### PR TITLE
Убран показ грин/ред текста у антагов в конце раунда.

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -591,7 +591,7 @@
 				var/new_target
 				if(length(possible_targets) > 0)
 					if(alert(usr, "Do you want to pick the objective yourself? No will randomise it", "Pick objective", "Yes", "No") == "Yes")
-						possible_targets += "Free objective"
+						possible_targets += "Free Objective."
 						new_target = input("Select target:", "Objective target", def_target) as null|anything in possible_targets
 					else
 						new_target = pick(possible_targets)
@@ -600,14 +600,14 @@
 						return
 				else
 					to_chat(usr, "<span class='warning'>No possible target found. Defaulting to a Free objective.</span>")
-					new_target = "Free objective"
+					new_target = "Free Objective."
 
 				var/objective_path = text2path("/datum/objective/[new_obj_type]")
-				if(new_target == "Free objective")
+				if(new_target == "Free Objective.")
 					new_objective = new objective_path
 					new_objective.owner = src
 					new_objective:target = null
-					new_objective.explanation_text = "Free objective"
+					new_objective.explanation_text = "Free Objective."
 				else
 					new_objective = new objective_path
 					new_objective.owner = src
@@ -691,7 +691,7 @@
 					if((possible_target != src) && ishuman(possible_target.current))
 						possible_targets += possible_target
 				possible_targets = sortAtom(possible_targets)
-				possible_targets += "Free objective"
+				possible_targets += "Free Objective."
 				var/new_target = input("Select target:", "Objective target") as null|anything in possible_targets
 				if(!new_target)
 					return

--- a/code/game/gamemodes/blob/blob_finish.dm
+++ b/code/game/gamemodes/blob/blob_finish.dm
@@ -11,20 +11,14 @@
 /datum/game_mode/blob/declare_completion()
 	if(blobwincount <= GLOB.blobs.len)
 		SSticker.mode_result = "blob win - blob took over"
-		to_chat(world, "<FONT size = 3><B>The blob has taken over the station!</B></FONT>")
-		to_chat(world, "<B>The entire station was eaten by the Blob</B>")
 		log_game("Blob mode completed with a blob victory.")
 
 	else if(station_was_nuked)
 		SSticker.mode_result = "blob halfwin - nuke"
-		to_chat(world, "<FONT size = 3><B>Partial Win: The station has been destroyed!</B></FONT>")
-		to_chat(world, "<B>Directive 7-12 has been successfully carried out preventing the Blob from spreading.</B>")
 		log_game("Blob mode completed with a tie (station destroyed).")
 
 	else if(!GLOB.blob_cores.len)
 		SSticker.mode_result = "blob loss - blob eliminated"
-		to_chat(world, "<FONT size = 3><B>The staff has won!</B></FONT>")
-		to_chat(world, "<B>The alien organism has been eradicated from the station</B>")
 		log_game("Blob mode completed with a crew victory.")
 		to_chat(world, "<span class='notice'>Rebooting in 30s</span>")
 	..()

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -207,19 +207,17 @@ GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","E
 				var/count = 1
 				for(var/datum/objective/objective in changeling.objectives)
 					if(objective.check_completion())
-						text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='green'><B>Success!</B></font>"
+						text += "<br><B>Objective #[count]</B>: [objective.explanation_text]"
 						SSblackbox.record_feedback("nested tally", "changeling_objective", 1, list("[objective.type]", "SUCCESS"))
 					else
-						text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='red'>Fail.</font>"
+						text += "<br><B>Objective #[count]</B>: [objective.explanation_text]"
 						SSblackbox.record_feedback("nested tally", "changeling_objective", 1, list("[objective.type]", "FAIL"))
 						changelingwin = 0
 					count++
 
 			if(changelingwin)
-				text += "<br><font color='green'><B>The changeling was successful!</B></font>"
 				SSblackbox.record_feedback("tally", "changeling_success", 1, "SUCCESS")
 			else
-				text += "<br><font color='red'><B>The changeling has failed.</B></font>"
 				SSblackbox.record_feedback("tally", "changeling_success", 1, "FAIL")
 
 		to_chat(world, text)

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -299,13 +299,10 @@ GLOBAL_LIST_EMPTY(all_cults)
 /datum/game_mode/cult/declare_completion()
 	if(cult_objs.cult_status == NARSIE_HAS_RISEN)
 		SSticker.mode_result = "cult win - cult win"
-		to_chat(world, "<span class='danger'> <FONT size = 3>The cult wins! It has succeeded in summoning [SSticker.cultdat.entity_name]!</FONT></span>")
 	else if(cult_objs.cult_status == NARSIE_HAS_FALLEN)
 		SSticker.mode_result = "cult draw - narsie died, nobody wins"
-		to_chat(world, "<span class='danger'> <FONT size = 3>Nobody wins! [SSticker.cultdat.entity_name] was summoned, but banished!</FONT></span>")
 	else
 		SSticker.mode_result = "cult loss - staff stopped the cult"
-		to_chat(world, "<span class='warning'> <FONT size = 3>The staff managed to stop the cult!</FONT></span>")
 
 	var/endtext
 	endtext += "<br><b>The cultists' objectives were:</b>"

--- a/code/game/gamemodes/devil/objectives.dm
+++ b/code/game/gamemodes/devil/objectives.dm
@@ -83,7 +83,7 @@
 	if(target)
 		explanation_text = "Purchase and retain the soul of [target.name], the [target.assigned_role]."
 	else
-		explanation_text = "Free objective."
+		explanation_text = "Free Objective.."
 
 /datum/objective/devil/buy_target/check_completion()
 	return target.soulOwner == owner

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -478,10 +478,7 @@
 	var/list/objective_parts = list()
 	var/count = 1
 	for(var/datum/objective/objective in ply.objectives)
-		if(objective.check_completion())
-			objective_parts += "<b>Objective #[count]</b>: [objective.explanation_text] <span class='greentext'>Success!</span>"
-		else
-			objective_parts += "<b>Objective #[count]</b>: [objective.explanation_text] <span class='redtext'>Fail.</span>"
+		objective_parts += "<b>Objective #[count]</b>: [objective.explanation_text]"
 		count++
 	return objective_parts.Join("<br>")
 

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -234,17 +234,15 @@ GLOBAL_LIST_EMPTY(cortical_stacks) //Stacks for 'leave nobody behind' objective.
 		else
 			win_msg += "<B>The Vox Raiders were repelled!</B>"
 
-	to_chat(world, "<span class='warning'><FONT size = 3><B>[win_type] [win_group] victory!</B></FONT></span>")
-	to_chat(world, "[win_msg]")
 	SSticker.mode_result = "heist - [win_type] [win_group]"
 
 	var/count = 1
 	for(var/datum/objective/objective in raid_objectives)
 		if(objective.check_completion())
-			to_chat(world, "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='green'><B>Success!</B></font>")
+			to_chat(world, "<br><B>Objective #[count]</B>: [objective.explanation_text]")
 			SSblackbox.record_feedback("nested tally", "traitor_objective", 1, list("[objective.type]", "SUCCESS"))
 		else
-			to_chat(world, "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='red'>Fail.</font>")
+			to_chat(world, "<br><B>Objective #[count]</B>: [objective.explanation_text]")
 			SSblackbox.record_feedback("nested tally", "traitor_objective", 1, list("[objective.type]", "FAIL"))
 		count++
 

--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -31,28 +31,17 @@
 	sendmeteors()
 
 /datum/game_mode/meteor/declare_completion()
-	var/text
-	var/survivors = 0
 	for(var/mob/living/player in GLOB.player_list)
 		if(player.stat != DEAD)
 			var/turf/location = get_turf(player.loc)
 			if(!location)	continue
 
 			if(location.loc.type == SSshuttle.emergency.areaInstance.type) //didn't work in the switch for some reason
-				text += "<br><b><font size=2>[player.real_name] escaped on the emergency shuttle</font></b>"
 
 			else
 				switch(location.loc.type)
 					if( /area/shuttle/escape_pod1/centcom, /area/shuttle/escape_pod2/centcom, /area/shuttle/escape_pod3/centcom, /area/shuttle/escape_pod5/centcom )
-						text += "<br><font size=2>[player.real_name] escaped in a life pod.</font>"
 					else
-						text += "<br><font size=1>[player.real_name] survived but is stranded without any hope of rescue.</font>"
-			survivors++
-
-	if(survivors)
-		to_chat(world, "<span class='boldnotice'>The following survived the meteor storm</span>:[text]")
-	else
-		to_chat(world, "<span class='boldnotice'>Nobody survived the meteor storm!</span>")
 
 	SSticker.mode_result = "meteor end - evacuation"
 

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -337,48 +337,30 @@
 
 	if(!disk_rescued && station_was_nuked && !syndies_didnt_escape)
 		SSticker.mode_result = "nuclear win - syndicate nuke"
-		to_chat(world, "<FONT size = 3><B>Syndicate Major Victory!</B></FONT>")
-		to_chat(world, "<B>[syndicate_name()] operatives have destroyed [station_name()]!</B>")
 
 	else if(!disk_rescued && station_was_nuked && syndies_didnt_escape)
 		SSticker.mode_result = "nuclear halfwin - syndicate nuke - did not evacuate in time"
-		to_chat(world, "<FONT size = 3><B>Total Annihilation</B></FONT>")
-		to_chat(world, "<B>[syndicate_name()] operatives destroyed [station_name()] but did not leave the area in time and got caught in the explosion.</B> Next time, don't lose the disk!")
 
 	else if(!disk_rescued && !station_was_nuked && nuke_off_station && !syndies_didnt_escape)
 		SSticker.mode_result = "nuclear halfwin - blew wrong station"
-		to_chat(world, "<FONT size = 3><B>Crew Minor Victory</B></FONT>")
-		to_chat(world, "<B>[syndicate_name()] operatives secured the authentication disk but blew up something that wasn't [station_name()].</B> Next time, don't lose the disk!")
 
 	else if(!disk_rescued && !station_was_nuked && nuke_off_station && syndies_didnt_escape)
 		SSticker.mode_result = "nuclear halfwin - blew wrong station - did not evacuate in time"
-		to_chat(world, "<FONT size = 3><B>[syndicate_name()] operatives have earned Darwin Award!</B></FONT>")
-		to_chat(world, "<B>[syndicate_name()] operatives blew up something that wasn't [station_name()] and got caught in the explosion.</B> Next time, don't lose the disk!")
 
 	else if(disk_rescued && is_operatives_are_dead())
 		SSticker.mode_result = "nuclear loss - evacuation - disk secured - syndi team dead"
-		to_chat(world, "<FONT size = 3><B>Crew Major Victory!</B></FONT>")
-		to_chat(world, "<B>The Research Staff has saved the disc and killed the [syndicate_name()] Operatives</B>")
 
 	else if(disk_rescued)
 		SSticker.mode_result = "nuclear loss - evacuation - disk secured"
-		to_chat(world, "<FONT size = 3><B>Crew Major Victory</B></FONT>")
-		to_chat(world, "<B>The Research Staff has saved the disc and stopped the [syndicate_name()] Operatives!</B>")
 
 	else if(!disk_rescued && is_operatives_are_dead())
 		SSticker.mode_result = "nuclear loss - evacuation - disk not secured"
-		to_chat(world, "<FONT size = 3><B>Syndicate Minor Victory!</B></FONT>")
-		to_chat(world, "<B>The Research Staff failed to secure the authentication disk but did manage to kill most of the [syndicate_name()] Operatives!</B>")
 
 	else if(!disk_rescued && crew_evacuated)
 		SSticker.mode_result = "nuclear halfwin - detonation averted"
-		to_chat(world, "<FONT size = 3><B>Syndicate Minor Victory!</B></FONT>")
-		to_chat(world, "<B>[syndicate_name()] operatives recovered the abandoned authentication disk but detonation of [station_name()] was averted.</B> Next time, don't lose the disk!")
 
 	else if(!disk_rescued && !crew_evacuated)
 		SSticker.mode_result = "nuclear halfwin - interrupted"
-		to_chat(world, "<FONT size = 3><B>Neutral Victory</B></FONT>")
-		to_chat(world, "<B>Round was mysteriously interrupted!</B>")
 	..()
 	return
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -83,7 +83,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 	if(target && target.current)
 		explanation_text = "Assassinate [target.current.real_name], the [target.assigned_role]."
 	else
-		explanation_text = "Free Objective"
+		explanation_text = "Free Objective."
 	return target
 
 /datum/objective/assassinate/check_completion()
@@ -106,7 +106,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 	if(target && target.current)
 		explanation_text = "Assassinate [target.current.real_name], the [target.assigned_role]."
 	else
-		explanation_text = "Free Objective"
+		explanation_text = "Free Objective."
 	return target
 
 /datum/objective/mutiny/check_completion()
@@ -132,7 +132,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 	if(target && target.current)
 		explanation_text = "Prevent [target.current.real_name], the [target.assigned_role] from escaping alive."
 	else
-		explanation_text = "Free Objective"
+		explanation_text = "Free Objective."
 	return target
 
 /datum/objective/maroon/check_completion()
@@ -160,7 +160,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 	if(target && target.current)
 		explanation_text = "Steal the brain of [target.current.real_name] the [target.assigned_role]."
 	else
-		explanation_text = "Free Objective"
+		explanation_text = "Free Objective."
 	return target
 
 
@@ -187,7 +187,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 	if(target && target.current)
 		explanation_text = "Protect [target.current.real_name], the [target.assigned_role]."
 	else
-		explanation_text = "Free Objective"
+		explanation_text = "Free Objective."
 	return target
 
 /datum/objective/protect/check_completion()
@@ -325,7 +325,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 		target_real_name = target.current.real_name
 		explanation_text = "Escape on the shuttle or an escape pod with the identity of [target_real_name], the [target.assigned_role] while wearing [target.p_their()] identification card."
 	else
-		explanation_text = "Free Objective"
+		explanation_text = "Free Objective."
 
 /datum/objective/escape/escape_with_identity/check_completion()
 	if(!target_real_name)
@@ -398,7 +398,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 		if(islist(O.protected_jobs) && O.protected_jobs.len)
 			explanation_text += "It may also be in the possession of the [jointext(O.protected_jobs, ", ")]."
 		return
-	explanation_text = "Free Objective."
+	explanation_text = "Free Objective.."
 
 
 /datum/objective/steal/proc/select_target()
@@ -423,7 +423,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 
 /datum/objective/steal/check_completion()
 	if(!steal_target)
-		return 1 // Free Objective
+		return 1 // Free Objective.
 
 	if(!owner.current)
 		return FALSE
@@ -525,7 +525,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 		target_real_name = target.current.real_name
 		explanation_text = "Destroy [target_real_name], the AI."
 	else
-		explanation_text = "Free Objective"
+		explanation_text = "Free Objective."
 	return target
 
 /datum/objective/destroy/check_completion()
@@ -632,7 +632,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 	if(target && target.current)
 		explanation_text = "The Shoal has a need for [target.current.real_name], the [target.assigned_role]. Take [target.current.p_them()] alive."
 	else
-		explanation_text = "Free Objective"
+		explanation_text = "Free Objective."
 	return target
 
 /datum/objective/heist/kidnap/check_completion()

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -368,10 +368,8 @@
 /datum/game_mode/revolution/declare_completion()
 	if(finished == 1)
 		SSticker.mode_result = "revolution win - heads killed"
-		to_chat(world, "<span class='redtext'>The heads of staff were killed or exiled! The revolutionaries win!</span>")
 	else if(finished == 2)
 		SSticker.mode_result = "revolution loss - rev heads killed"
-		to_chat(world, "<span class='redtext'>The heads of staff managed to stop the revolution!</span>")
 	..()
 	return TRUE
 

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -267,20 +267,12 @@ Made by Xhuis
 /datum/game_mode/shadowling/declare_completion()
 	if(check_shadow_victory() && SSshuttle.emergency.mode >= SHUTTLE_ESCAPE) //Doesn't end instantly - this is hacky and I don't know of a better way ~X
 		SSticker.mode_result = "shadowling win - shadowling ascension"
-		to_chat(world, "<FONT size = 3><B>Shadowling Victory</B></FONT>")
-		to_chat(world, "<span class='greentext'><b>The shadowlings have ascended and taken over the station!</b></span>")
 	else if(shadowling_dead && !check_shadow_victory()) //If the shadowlings have ascended, they can not lose the round
 		SSticker.mode_result = "shadowling loss - shadowling killed"
-		to_chat(world, "<FONT size = 3><B>Crew Major Victory</B></FONT>")
-		to_chat(world, "<span class='redtext'><b>The shadowlings have been killed by the crew!</b></span>")
 	else if(!check_shadow_victory() && SSshuttle.emergency.mode >= SHUTTLE_ESCAPE)
 		SSticker.mode_result = "shadowling loss - crew escaped"
-		to_chat(world, "<FONT size = 3><B>Crew Minor Victory</B></FONT>")
-		to_chat(world, "<span class='redtext'><b>The crew escaped the station before the shadowlings could ascend!</b></span>")
 	else
 		SSticker.mode_result = "shadowling loss - generic failure"
-		to_chat(world, "<FONT size = 3><B>Crew Major Victory</B></FONT>")
-		to_chat(world, "<span class='redtext'><b>The shadowlings have failed!</b></span>")
 	..()
 	return 1
 

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -117,19 +117,13 @@
 				var/count = 1
 				for(var/datum/objective/objective in traitor.objectives)
 					if(objective.check_completion())
-						text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='green'><B>Success!</B></font>"
+						text += "<br><B>Objective #[count]</B>: [objective.explanation_text]"
 						SSblackbox.record_feedback("nested tally", "traitor_objective", 1, list("[objective.type]", "SUCCESS"))
 					else
-						text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='red'>Fail.</font>"
+						text += "<br><B>Objective #[count]</B>: [objective.explanation_text]"
 						SSblackbox.record_feedback("nested tally", "traitor_objective", 1, list("[objective.type]", "FAIL"))
 						traitorwin = 0
 					count++
-
-			var/special_role_text
-			if(traitor.special_role)
-				special_role_text = lowertext(traitor.special_role)
-			else
-				special_role_text = "antagonist"
 
 			var/datum/antagonist/traitor/contractor/contractor = traitor.has_antag_datum(/datum/antagonist/traitor/contractor)
 			if(istype(contractor) && contractor.contractor_uplink)
@@ -154,10 +148,8 @@
 				text += "<br><font color='orange'><B>[earned_tc] TC were earned from the contracts.</B></font>"
 
 			if(traitorwin)
-				text += "<br><font color='green'><B>The [special_role_text] was successful!</B></font><br>"
 				SSblackbox.record_feedback("tally", "traitor_success", 1, "SUCCESS")
 			else
-				text += "<br><font color='red'><B>The [special_role_text] has failed!</B></font><br>"
 				SSblackbox.record_feedback("tally", "traitor_success", 1, "FAIL")
 
 		if(length(SSticker.mode.implanted))

--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -98,25 +98,17 @@
 				var/count = 1
 				for(var/datum/objective/objective in vampire.objectives)
 					if(objective.check_completion())
-						text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='green'><B>Success!</B></font>"
+						text += "<br><B>Objective #[count]</B>: [objective.explanation_text]"
 						SSblackbox.record_feedback("nested tally", "traitor_objective", 1, list("[objective.type]", "SUCCESS"))
 					else
-						text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='red'>Fail.</font>"
+						text += "<br><B>Objective #[count]</B>: [objective.explanation_text]"
 						SSblackbox.record_feedback("nested tally", "traitor_objective", 1, list("[objective.type]", "FAIL"))
 						traitorwin = 0
 					count++
 
-			var/special_role_text
-			if(vampire.special_role)
-				special_role_text = lowertext(vampire.special_role)
-			else
-				special_role_text = "antagonist"
-
 			if(traitorwin)
-				text += "<br><font color='green'><B>The [special_role_text] was successful!</B></font>"
 				SSblackbox.record_feedback("tally", "traitor_success", 1, "SUCCESS")
 			else
-				text += "<br><font color='red'><B>The [special_role_text] has failed!</B></font>"
 				SSblackbox.record_feedback("tally", "traitor_success", 1, "FAIL")
 		to_chat(world, text)
 	return 1

--- a/code/game/gamemodes/wizard/raginmages.dm
+++ b/code/game/gamemodes/wizard/raginmages.dm
@@ -158,5 +158,4 @@
 /datum/game_mode/wizard/raginmages/declare_completion()
 	if(finished)
 		SSticker.mode_result = "raging wizard loss - wizard killed"
-		to_chat(world, "<span class='warning'><FONT size = 3><B> The crew has managed to hold off the Wizard attack! The Space Wizard Federation has been taught a lesson they will not soon forget!</B></FONT></span>")
 	..(1)

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -201,7 +201,6 @@
 /datum/game_mode/wizard/declare_completion(var/ragin = 0)
 	if(finished && !ragin)
 		SSticker.mode_result = "wizard loss - wizard killed"
-		to_chat(world, "<span class='warning'><FONT size = 3><B> The wizard[(wizards.len>1)?"s":""] has been killed by the crew! The Space Wizards Federation has been taught a lesson they will not soon forget!</B></FONT></span>")
 	..()
 	return 1
 
@@ -227,19 +226,17 @@
 			var/wizardwin = 1
 			for(var/datum/objective/objective in wizard.objectives)
 				if(objective.check_completion())
-					text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='green'><B>Success!</B></font>"
+					text += "<br><B>Objective #[count]</B>: [objective.explanation_text]"
 					SSblackbox.record_feedback("nested tally", "wizard_objective", 1, list("[objective.type]", "SUCCESS"))
 				else
-					text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='red'>Fail.</font>"
+					text += "<br><B>Objective #[count]</B>: [objective.explanation_text]"
 					SSblackbox.record_feedback("nested tally", "wizard_objective", 1, list("[objective.type]", "FAIL"))
 					wizardwin = 0
 				count++
 
 			if(wizard.current && wizard.current.stat!=DEAD && wizardwin)
-				text += "<br><font color='green'><B>The wizard was successful!</B></font>"
 				SSblackbox.record_feedback("tally", "wizard_success", 1, "SUCCESS")
 			else
-				text += "<br><font color='red'><B>The wizard has failed!</B></font>"
 				SSblackbox.record_feedback("tally", "wizard_success", 1, "FAIL")
 			if(wizard.spell_list)
 				text += "<br><B>[wizard.name] used the following spells: </B>"

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -57,7 +57,7 @@
 				return
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/N = M
-			var/objective = "Free Objective"
+			var/objective = "Free Objective."
 			switch(rand(1,100))
 				if(1 to 50)
 					objective = "Steal [pick("a hand teleporter", "the Captain's antique laser gun", "a jetpack", "the Captain's ID", "the Captain's jumpsuit")]."

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -113,18 +113,11 @@ GLOBAL_LIST_EMPTY(antagonists)
 
 	report += printplayer(owner)
 
-	var/objectives_complete = TRUE
 	if(owner.objectives.len)
 		report += printobjectives(owner)
 		for(var/datum/objective/objective in owner.objectives)
 			if(!objective.check_completion())
-				objectives_complete = FALSE
 				break
-
-	if(owner.objectives.len == 0 || objectives_complete)
-		report += "<span class='greentext big'>The [name] was successful!</span>"
-	else
-		report += "<span class='redtext big'>The [name] has failed!</span>"
 
 	return report.Join("<br>")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Что этот ПР делает
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Полностью убирает показ грин/ред текста у антагов в конце раунда, а также любой текст, который говорит о победе/проигрыше антагонистов/станции, оставляя логирование последнего.

## Почему это хорошо для игры
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Без постоянного напоминания о проигрыше/победе антагов экипаж станции может наконец потерять некоторые ООС причины мешать антагам в тех ситуациях, когда это идет в разрез с получением fun'а для всех участников действий.
Без постоянного напоминания о проигрыше/победе антагов эти самые антаги могут наконец потерять некоторые ООС причины любой ценой завершить цели ради гринтекста, что может так же повысить общий уровень fun'а.

Также отсутствие необходимости в создании проверки успешного выполнения цели антагониста позволит добавлять новые цели, отследить выполнение которых игромеханически достаточно сложно. 
(например: Сломать несколько костей цели, заставить цель прогуляться в камеру (в тюрьму) на n-ное количество времени...)

## Ссылка на голосовалочку по этому изменению
![image](https://user-images.githubusercontent.com/59314481/119367848-0e509380-bcbb-11eb-8805-f414f6676293.png)
https://discord.com/channels/617003227182792704/757200958349377617/799437546534469632

## Changelog
:cl:
del: Показ гринтекста в конце раунда
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
