### PR TITLE
Доработка инвентаря SeedExtractor и итерфейс на TGUI 

### DIFF
--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -136,7 +136,10 @@
 /obj/machinery/seed_extractor/interact(mob/user)
 	if(stat)
 		return 0
-
+	
+	ui_interact(user) //Перенаправление: Расширенный инвентарь и tgui
+	return
+	
 	add_fingerprint(user)
 	user.set_machine(src)
 
@@ -188,6 +191,8 @@
 	return
 
 /obj/machinery/seed_extractor/proc/add_seed(obj/item/seeds/O)
+	return add_seedExt(O) //Перенаправление: Расширенный инвентарь и tgui
+	
 	if(contents.len >= 999)
 		to_chat(usr, "<span class='notice'>\The [src] is full.</span>")
 		return 0
@@ -209,3 +214,145 @@
 
 	piles += new /datum/seed_pile(O.plantname, O.lifespan, O.endurance, O.maturation, O.production, O.yield, O.potency)
 	return
+	
+	//Расширенный инвентарь и tgui
+/datum/seed_pile/extended
+	var/id_string = ""
+	var/list/seeds = list() //Храним список объектов, чтобы не искать циклом по contents
+
+/datum/seed_pile/extended/New(obj/item/seeds/O)
+	..(O.plantname, O.lifespan, O.endurance, O.maturation, O.production, O.yield, O.potency)
+	src.id_string = generate_seedId(O)
+	src.seeds += O
+
+/proc/generate_seedId(obj/item/seeds/O) //Генерация строки-идентификатора для поиска
+	var/id_string = copytext("[O.type]",16)
+
+	id_string += "[O.lifespan]_[O.endurance]_[O.maturation]_[O.production]_[O.yield]_[O.potency]_[O.weed_rate]_[O.weed_chance]"
+
+	for (var/datum/plant_gene/reagent/G in O.genes)
+		id_string += "_[G.reagent_id]_[G.rate*100]"
+
+	for (var/datum/plant_gene/trait/G in O.genes)
+		if (istype(G,/datum/plant_gene/trait/plant_type))
+			id_string += "_"+copytext("[G.type]",36)
+		else
+			id_string += "_"+copytext("[G.type]",25)
+
+	return id_string
+
+/proc/generate_strainText(obj/item/seeds/O) //Генерация отображаемого текста описания
+	var/strain_text = ""
+
+	for (var/datum/plant_gene/reagent/G in O.genes)
+		if (strain_text !="")
+			strain_text += ", "
+		strain_text += "[G.get_name()]"
+
+	for (var/datum/plant_gene/trait/G in O.genes)
+		if (strain_text !="")
+			strain_text += ", "
+		strain_text += "[G.get_name()]"
+
+	return strain_text
+
+/obj/machinery/seed_extractor/proc/add_seedExt(obj/item/seeds/O)
+	if(istype(O.loc,/mob))
+		var/mob/M = O.loc
+		if(!M.drop_item())
+			return 0
+	else if(istype(O.loc,/obj/item/storage))
+		var/obj/item/storage/S = O.loc
+		S.remove_from_storage(O,src)
+
+	O.forceMove(src)
+	. = 1
+
+	var/id_string = generate_seedId(O)
+	for (var/datum/seed_pile/extended/N in piles)
+		if (N.id_string == id_string)
+			++N.amount
+			N.seeds += O
+			return
+
+	piles += new /datum/seed_pile/extended(O)
+	return
+
+/obj/machinery/seed_extractor/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = TRUE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)
+
+	add_fingerprint(user)
+	user.set_machine(src)
+
+	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
+	if(!ui)
+		ui = new(user, src, ui_key, "SeedExtractor", name, 900, 600)
+		ui.open()
+
+/obj/machinery/seed_extractor/ui_data(mob/user)
+	var/list/data = list()
+
+	data["contents"] = null
+	data["total"] = contents.len
+	data["capacity"] = max_seeds
+
+	var/list/items = list()
+	for(var/i in 1 to length(piles))
+		var/datum/seed_pile/extended/P = piles[i]
+		var/list/obj/item/seeds/Sl = P.seeds
+
+		if (length(Sl) == 0)
+			continue //Пустых куч быть не должно, но проверка не помешает
+
+		var/strain_text=generate_strainText(Sl[1])
+		items.Add(list(list("display_name" = html_encode(capitalize(P.name)), "vend" = i, "quantity" = P.amount,"life"=P.lifespan,"endr"=P.endurance,"matr" = P.maturation,"prod" = P.production,"yld" = P.yield,"potn" = P.potency,"strain_text" = strain_text )))
+
+	if(length(items))
+		data["contents"] = items
+
+	return data
+
+/obj/machinery/seed_extractor/ui_act(action, params)
+	if(..())
+		return
+
+	. = TRUE
+
+	var/mob/user = usr
+
+	switch(action)
+		if("vend")
+			var/index = text2num(params["index"])
+			var/amount = text2num(params["amount"])
+
+			if(isnull(index) || !ISINDEXSAFE(piles, index) || isnull(amount))
+				return TRUE
+
+			var/datum/seed_pile/extended/P = piles[index]
+			var/list/Sl = P.seeds
+
+			if (length(Sl)==0)
+				piles.Remove(P)
+				return TRUE
+
+			var/i = amount
+
+			if(i == 1 && Adjacent(user) && !issilicon(user))
+				var/obj/item/seeds/O = Sl[1]
+
+				if(!user.put_in_hands(O))
+					O.forceMove(loc)
+					adjust_item_drop_location(O)
+
+				Sl.Remove(O)
+
+			else
+				for(var/cntr in 1 to i)
+					var/obj/item/seeds/O = Sl[1]
+					O.forceMove(loc)
+					adjust_item_drop_location(O)
+					Sl.Remove(O)
+
+			if (length(Sl)==0)
+				piles.Remove(P)
+			else
+				P.amount = length(Sl)

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -260,7 +260,7 @@
 	if(istype(O.loc,/mob))
 		var/mob/M = O.loc
 		if(!M.drop_item())
-			return 0
+			return FALSE
 	else if(istype(O.loc,/obj/item/storage))
 		var/obj/item/storage/S = O.loc
 		S.remove_from_storage(O,src)

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -222,11 +222,10 @@
 
 /datum/seed_pile/extended/New(obj/item/seeds/O)
 	..(O.plantname, O.lifespan, O.endurance, O.maturation, O.production, O.yield, O.potency)
-	src.id_string = generate_seedId(O)
 	src.seeds += O
 
 /obj/machinery/seed_extractor/proc/generate_seedId(obj/item/seeds/O) //Генерация строки-идентификатора для поиска
-	var/id_string = copytext("[O.type]",16)
+	var/id_string = copytext("[O.type]",17)
 
 	id_string += "[O.lifespan]_[O.endurance]_[O.maturation]_[O.production]_[O.yield]_[O.potency]_[O.weed_rate]_[O.weed_chance]"
 
@@ -275,7 +274,9 @@
 			N.seeds += O
 			return
 
-	piles += new /datum/seed_pile/extended(O)
+	var/datum/seed_pile/extended/NP = new(O)
+	NP.id_string = id_string
+	piles += NP
 	return
 
 /obj/machinery/seed_extractor/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = TRUE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -241,7 +241,7 @@
 
 	return id_string
 
-/proc/generate_strainText(obj/item/seeds/O) //Генерация отображаемого текста описания
+/obj/machinery/seed_extractor/proc/generate_strainText(obj/item/seeds/O) //Генерация отображаемого текста описания
 	var/strain_text = ""
 
 	for (var/datum/plant_gene/reagent/G in O.genes)

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -225,7 +225,7 @@
 	src.id_string = generate_seedId(O)
 	src.seeds += O
 
-/proc/generate_seedId(obj/item/seeds/O) //Генерация строки-идентификатора для поиска
+/obj/machinery/seed_extractor/proc/generate_seedId(obj/item/seeds/O) //Генерация строки-идентификатора для поиска
 	var/id_string = copytext("[O.type]",16)
 
 	id_string += "[O.lifespan]_[O.endurance]_[O.maturation]_[O.production]_[O.yield]_[O.potency]_[O.weed_rate]_[O.weed_chance]"

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -266,7 +266,7 @@
 		S.remove_from_storage(O,src)
 
 	O.forceMove(src)
-	. = 1
+	. = TRUE
 
 	var/id_string = generate_seedId(O)
 	for (var/datum/seed_pile/extended/N in piles)

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -215,7 +215,7 @@
 	piles += new /datum/seed_pile(O.plantname, O.lifespan, O.endurance, O.maturation, O.production, O.yield, O.potency)
 	return
 	
-	//Расширенный инвентарь и tgui
+//Расширенный инвентарь и tgui
 /datum/seed_pile/extended
 	var/id_string = ""
 	var/list/seeds = list() //Храним список объектов, чтобы не искать циклом по contents

--- a/tgui/packages/tgui/interfaces/SeedExtractor.js
+++ b/tgui/packages/tgui/interfaces/SeedExtractor.js
@@ -1,0 +1,296 @@
+import { createSearch } from 'common/string';
+import { Fragment } from 'inferno';
+import { useBackend, useLocalState } from '../backend';
+import { Box, Section, Button, NumberInput, Input, Divider, Flex, NoticeBox, Icon } from '../components';
+import { Window } from '../layouts';
+
+const localeStrings ={
+  'title': 'Seeds',
+
+  'plantName': 'Plant',
+  'lifespan': 'Lifespan',
+  'endurance': 'Endurance',
+  'maturation': 'Maturation',
+  'production': 'Production',
+  'yield': 'Yield',
+  'potency': 'Potency',
+
+  'searchTooltip': 'Search..',
+  'sortByTooltip': 'Sort by',
+
+  'dispOneTooltip': 'Dispense one',
+  'dispAllTooltip': 'Dispense all',
+
+  'inStock': 'in stock',
+
+  'noContents': 'No seeds loaded.',
+  'emptySearchResult': 'No items matching your criteria was found!',
+};
+
+const sortTypes = {
+  'plantName': (a, b) => (a.display_name!==b.display_name ? (a.display_name>b.display_name? 1 : -1) : 0),
+  'lifespan': (a, b) => a.life - b.life,
+  'endurance': (a, b) => a.endr - b.endr,
+  'maturation': (a, b) => a.matr - b.matr,
+  'production': (a, b) => a.prod - b.prod,
+  'yield': (a, b) => a.yld - b.yld,
+  'potency': (a, b) => a.potn - b.potn,
+};
+
+export const SeedExtractor = (props, context) => {
+  const { act, data } = useBackend(context);
+  const {
+    total,
+    capacity,
+    contents,
+  } = data;
+
+  return (
+    <Window>
+      <Window.Content className="Layout__content--flexColumn">
+        <Section title={localeStrings["title"]} buttons={(<SeedVaultSearch />)} m={0} p={0}>
+          <SeedVaultHeader seedsTotal={total} seedsCapacity={capacity} />
+        </Section>
+        {!contents
+          ? <NoticeBox m={0}> {localeStrings["noContents"]} </NoticeBox>
+          : <div class="Divider Divider__noMargin" />}
+        <Section flexGrow={1} stretchContents mt={0}>
+          {!!contents && (<SeedVaultContents />)}
+        </Section>
+      </Window.Content>
+    </Window>
+  );
+};
+
+const SeedVaultHeaderField = (props, context) => {
+  const {
+    name,
+    alpha,
+  } = props;
+
+  const [
+    _sortOrder,
+    setSortOrder,
+  ] = useLocalState(context, 'sort', { "field": "plantName", "desc": false });
+
+  return (
+    <Button fluid iconRight
+      icon={_sortOrder.field!==name ? "" : (_sortOrder.desc ? (!alpha ? "sort-amount-down" : "sort-alpha-down") : (!alpha ? "sort-amount-up" : "sort-alpha-up"))}
+      color="transparent"
+      textColor="white"
+      content={localeStrings[name]}
+      tooltip={localeStrings["sortByTooltip"]+" "+name.toLowerCase()}
+      tooltipPosition="bottom"
+      onClick={() => { (_sortOrder.field!==props.name ? setSortOrder({ "field": name, "desc": false }) : setSortOrder({ "field": name, "desc": !_sortOrder.desc })); }}
+    />
+  );
+};
+
+const SeedVaultSearch = (props, context) => {
+  const [
+    _searchText,
+    setSearchText,
+  ] = useLocalState(context, 'search', '');
+  return (
+    <Box mb="0.5rem" width="50vw" style={{ display: 'block' }}>
+      <Flex width="100%">
+        <Flex.Item mx={1} align="center"><Icon name="filter" /></Flex.Item>
+        <Flex.Item grow="1" mr="0.5rem">
+          <Input
+            placeholder={localeStrings["searchTooltip"]}
+            width="100%"
+            onInput={(_e, value) => setSearchText(value)}
+          />
+        </Flex.Item>
+      </Flex>
+    </Box>
+  );
+};
+
+const SeedVaultHeader = (props, context) => {
+  const {
+    seedsTotal,
+    seedsCapacity,
+  } = props;
+
+  return (
+    <Flex direction="row" textAlign="center" bold align="baseline" mt={0}>
+      <Flex.Item basis={"15vw"}>
+        <SeedVaultHeaderField name="plantName" alpha />
+      </Flex.Item>
+      <Flex.Item basis={"65vw"}>
+        <Flex direction="row">
+          <Flex.Item basis={0} grow={1} shrink={1}>
+            <SeedVaultHeaderField name="lifespan" />
+          </Flex.Item>
+          <Flex.Item basis={0} grow={1} shrink={1}>
+            <SeedVaultHeaderField name="endurance" />
+          </Flex.Item>
+          <Flex.Item basis={0} grow={1} shrink={1}>
+            <SeedVaultHeaderField name="maturation" />
+          </Flex.Item>
+          <Flex.Item basis={0} grow={1} shrink={1}>
+            <SeedVaultHeaderField name="production" />
+          </Flex.Item>
+          <Flex.Item basis={0} grow={1} shrink={1}>
+            <SeedVaultHeaderField name="yield" />
+          </Flex.Item>
+          <Flex.Item basis={0} grow={1} shrink={1}>
+            <SeedVaultHeaderField name="potency" />
+          </Flex.Item>
+        </Flex>
+      </Flex.Item>
+      <Flex.Item basis={0} grow={1} shrink={1} color="average">
+        {seedsTotal}/{seedsCapacity}
+      </Flex.Item>
+    </Flex>
+  );
+};
+
+const SeedVaultContents = (props, context) => {
+  const { act, data } = useBackend(context);
+  const {
+    contents,
+  } = data;
+
+  const [
+    searchText,
+    _setSearchText,
+  ] = useLocalState(context, 'search', '');
+
+  const [
+    sortOrder,
+    _setSortOrder,
+  ] = useLocalState(context, 'sort', { "field": "plantName", "desc": false });
+
+  const nameSearch = createSearch(searchText, pile => pile.display_name + pile.strain_text);
+
+  let piles = contents.filter(nameSearch).sort(sortTypes[sortOrder.field]);
+
+  if (sortOrder.desc) {
+    piles = piles.reverse();
+  }
+
+  let no_results = (piles.length === 0);
+
+  return (
+    <Flex.Item grow={1} >
+      {!!no_results && (
+        <Box color="average"> {localeStrings["emptySearchResult"]} </Box>
+      )}
+      {!no_results && (
+        <Box className="SeedExtractor__Contents">
+          {piles.map(item => (
+            <SeedVaultContentsRow
+              key={item.vend}
+              displayName={item.display_name}
+              descriptionText={item.strain_text}
+              lifespanVal={item.life}
+              enduranceVal={item.endr}
+              maturationVal={item.life}
+              productionVal={item.prod}
+              yieldVal={item.yld}
+              potencyVal={item.potn}
+              vendIdx={item.vend}
+              pileStock={item.quantity} />
+          ))}
+        </Box>
+      )}
+    </Flex.Item>
+  );
+
+};
+
+const SeedVaultContentsRow = (props, context) => {
+  const { act, data } = useBackend(context);
+  const {
+    key,
+    displayName,
+    descriptionText,
+    lifespanVal,
+    enduranceVal,
+    maturationVal,
+    productionVal,
+    yieldVal,
+    potencyVal,
+    vendIdx,
+    pileStock,
+  } = props;
+  return (
+    <Fragment>
+      <Flex direction="row" textAlign="center" className="SeedExtractor__contents--row">
+        <Flex.Item basis={"15vw"} textAlign="left" bold>
+          <Box m={1}>
+            {displayName}
+          </Box>
+        </Flex.Item>
+        <Flex.Item basis={"65vw"} py={1}>
+          <table style={{ "width": "100%", "border": "0" }}>
+            <tr>
+              <td>
+                <Flex direction="row" textAlign="center">
+                  <Flex.Item basis={0} grow={1} shrink={1}>
+                    {lifespanVal}
+                  </Flex.Item>
+                  <Flex.Item basis={0} grow={1} shrink={1}>
+                    {enduranceVal}
+                  </Flex.Item>
+                  <Flex.Item basis={0} grow={1} shrink={1}>
+                    {maturationVal}
+                  </Flex.Item>
+                  <Flex.Item basis={0} grow={1} shrink={1}>
+                    {productionVal}
+                  </Flex.Item>
+                  <Flex.Item basis={0} grow={1} shrink={1}>
+                    {yieldVal}
+                  </Flex.Item>
+                  <Flex.Item basis={0} grow={1} shrink={1}>
+                    {potencyVal}
+                  </Flex.Item>
+                </Flex>
+              </td>
+            </tr>
+            <tr>
+              <td style={{ "font-size": "90%", "padding-top": "0.5em" }} >
+                {descriptionText}
+              </td>
+            </tr>
+          </table>
+        </Flex.Item>
+        <Flex.Item basis={0} grow={1} shrink={1} py={1}>
+          <Flex direction="column">
+            <Flex.Item color="good">
+              {pileStock} {localeStrings["inStock"]}
+            </Flex.Item>
+            <Flex.Item minHeight="25px" pt={1}>
+              <Button
+                icon="arrow-down"
+                content="1"
+                tooltip="Dispense one"
+                tooltipPosition="bottom-left"
+                onClick={() => act('vend',
+                  { index: vendIdx, amount: 1 })} />
+              <NumberInput
+                width="40px"
+                minValue={0}
+                value={0}
+                maxValue={pileStock}
+                step={1}
+                stepPixelSize={3}
+                onChange={(e, value) => act('vend',
+                  { index: vendIdx, amount: value })} />
+              <Button
+                icon="arrow-down"
+                content="All"
+                tooltip="Dispense all"
+                tooltipPosition="bottom-left"
+                onClick={() => act('vend',
+                  { index: vendIdx, amount: pileStock })} />
+            </Flex.Item>
+          </Flex>
+        </Flex.Item>
+      </Flex>
+      <Divider />
+    </Fragment>
+  );
+};

--- a/tgui/packages/tgui/styles/interfaces/SeedExtractor.scss
+++ b/tgui/packages/tgui/styles/interfaces/SeedExtractor.scss
@@ -1,0 +1,14 @@
+$background-color: rgba(0, 0, 0, 1) !default;
+$color-divider: rgba(255, 255, 255, 0.1) !default;
+$thickness: 2px !default;
+
+.Divider__noMargin {
+  border-bottom: $thickness solid $color-divider;
+}
+
+.SeedExtractor__contents--row {
+  &:hover,
+  &:focus {
+    background-color: lighten($background-color, 15%);
+  }
+}

--- a/tgui/packages/tgui/styles/main.scss
+++ b/tgui/packages/tgui/styles/main.scss
@@ -53,6 +53,7 @@
 @include meta.load-css('./interfaces/Roulette.scss');
 @include meta.load-css('./interfaces/Safe.scss');
 @include meta.load-css('./interfaces/SecurityRecords.scss');
+@include meta.load-css('./interfaces/SeedExtractor.scss');
 
 // Layouts
 @include meta.load-css('./layouts/Layout.scss');


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Исправляет проблемы с хранением семян в экстракторе и добавляет новый интерфейс
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Изначально экстрактор семян хранит семена в группах по виду растения и основным характеристикам, при этом в одной группе могут находиться семена с разными генами веществ/черт/уязвимостью к сорнякам, если совпадает их вид и основные характеристики. В результате без дополнительной проверки не понять что именно за семечко из экстрактора вытащили.

Данный ПР расширяет систему хранения до группировки семян с учетом всех генов. И дает стильный интерфейс в комплекте для навигации по всему этому разнообразию.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![изображение](https://user-images.githubusercontent.com/85953769/122100278-33a96b00-ce3d-11eb-99bb-f8f338db1034.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: Новый интерфейс экстрактора семян
tweak: Доработано хранение семян в экстракторе с учетом генов веществ/черт
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
