### PR TITLE
AI Vocal Announcement fix

### DIFF
--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -143,7 +143,7 @@ GLOBAL_VAR_INIT(announcing_vox, 0) // Stores the time of the last announcement
 
 	var/i = 0
 	for(var/word in words)
-		addtimer(CALLBACK(GLOBAL_PROC, /proc/play_vox_word, word, src.z, null), i)
+		addtimer(CALLBACK(GLOBAL_PROC, .proc/play_vox_word, word, src.z, null), i)
 		i +=1
 
 	ai_voice_announcement_to_text(words)

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -141,8 +141,10 @@ GLOBAL_VAR_INIT(announcing_vox, 0) // Stores the time of the last announcement
 	log_game("[key_name(src)] made a vocal announcement: [message].")
 	message_admins("[key_name_admin(src)] made a vocal announcement: [message].")
 
+	var/i = 0
 	for(var/word in words)
-		play_vox_word(word, src.z, null)
+		addtimer(CALLBACK(GLOBAL_PROC, /proc/play_vox_word, word, src.z, null), i)
+		i +=1
 
 	ai_voice_announcement_to_text(words)
 

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -144,7 +144,7 @@ GLOBAL_VAR_INIT(announcing_vox, 0) // Stores the time of the last announcement
 	var/i = 0
 	for(var/word in words)
 		addtimer(CALLBACK(GLOBAL_PROC, .proc/play_vox_word, word, src.z, null), i)
-		i +=1
+		i++
 
 	ai_voice_announcement_to_text(words)
 


### PR DESCRIPTION
Порядок слов теперь воспроизводится в верном порядке

## Changelog
:cl:
fix: порядок слов в звуковом оповещении от ИИ
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
