### PR TITLE
Ai blindcard fix

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1236,12 +1236,10 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 			return
 		new /obj/structure/AIcore/deactivated(loc)//Spawns a deactivated terminal at AI location.
 		aiRestorePowerRoutine = 0//So the AI initially has power.
+		update_blind_effects()
 		control_disabled = 1//Can't control things remotely if you're stuck in a card!
 		aiRadio.disabledAi = 1 	//No talking on the built-in radio for you either!
 		loc = card//Throw AI into the card.
-		aiRestorePowerRoutine = 0 //fix blind AI lacks power
-		update_blind_effects()
-		update_sight()
 		to_chat(src, "You have been downloaded to a mobile storage device. Remote device connection severed.")
 		to_chat(user, "<span class='boldnotice'>Transfer successful</span>: [name] ([rand(1000,9999)].exe) removed from host terminal and stored within local memory.")
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1239,6 +1239,9 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 		control_disabled = 1//Can't control things remotely if you're stuck in a card!
 		aiRadio.disabledAi = 1 	//No talking on the built-in radio for you either!
 		loc = card//Throw AI into the card.
+		aiRestorePowerRoutine = 0 //fix blind AI lacks power
+		update_blind_effects()
+		update_sight()
 		to_chat(src, "You have been downloaded to a mobile storage device. Remote device connection severed.")
 		to_chat(user, "<span class='boldnotice'>Transfer successful</span>: [name] ([rand(1000,9999)].exe) removed from host terminal and stored within local memory.")
 


### PR DESCRIPTION
Исправление вечно слепого ИИ, если был снят на интелкарту, когда АПЦ не был включен. Добавлено обновление слепого статуса при переходе на карту

## Changelog
:cl:
fix: добавлено обновление слепого статуса при переносе ИИ на интелкарту
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
