### PR TITLE
Починить ящики

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -390,7 +390,7 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 	containertype = /obj/structure/closet/crate/secure/plasma
 	containername = "ablative armor crate"
 
-/datum/supply_packs/security/armory/laserarmor
+/datum/supply_packs/security/armory/sibyl
 	name = "Sibyl Attachments Crate"
 	contains = list(/obj/item/sibyl_system_mod,
 					/obj/item/sibyl_system_mod,


### PR DESCRIPTION
Ablative Armor Crate отсутствовал, т.к. ящик с Sibyl System повторял его путь и перезаписывал его.
https://github.com/ss220-space/Paradise/issues/54