### PR TITLE
clown empty talking fix

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -169,7 +169,7 @@
 				S.message = uppertext(S.message)
 				verb = "yells loudly"
 
-		if(span)
+		if(span && (length(S.message) > 0))
 			S.message = "<span class='[span]'>[S.message]</span>"
 	return list("verb" = verb)
 


### PR DESCRIPTION
ранее модификатор <span> </span> применялся к любым частям сообщения, даже к пустым. В связи с этим если клоун получал много оксиурона и пытался что-то сказать, его сообщение преобразовывалось в кучу пустых тегов <span>. Игра считает, что это не пустое сообщение и выводит его в текст, получаем "", когда сообщения вообще не должно быть. Сделал проверку на длину сообщения при применении тега <span>
