### PR TITLE
Твики баланса коммитов Джордана

### DIFF
--- a/code/datums/diseases/advance/symptoms/blood.dm
+++ b/code/datums/diseases/advance/symptoms/blood.dm
@@ -18,7 +18,7 @@ Bonus
 	name = "Viral Hematopoiesis"
 	stealth = -2
 	resistance = -2
-	stage_speed = -6
+	stage_speed = -4
 	transmittable = -1
 	level = 5
 	var/check = FALSE

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -417,7 +417,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A highly illegal compound contained within a compact auto-injector; when injected it makes the user extremely resistant to incapacitation and greatly enhances the body's ability to repair itself."
 	reference = "ST"
 	item = /obj/item/reagent_containers/hypospray/autoinjector/stimulants
-	cost = 4
+	cost = 5
 	job = list("Scientist", "Research Director", "Geneticist", "Chief Medical Officer", "Medical Doctor", "Psychiatrist", "Chemist", "Paramedic", "Coroner", "Virologist")
 
 //Tator Poison Bottles
@@ -844,7 +844,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			will instantly put them in your grasp and silence them, as well as causing rapid suffocation. Does not work on those who do not need to breathe."
 	reference = "GAR"
 	item = /obj/item/twohanded/garrote
-	cost = 6
+	cost = 8
 
 /datum/uplink_item/stealthy_weapons/martialarts
 	name = "Martial Arts Scroll"
@@ -1038,7 +1038,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A pizza box with a bomb taped inside of it. The timer needs to be set by opening the box; afterwards, opening the box again will trigger the detonation."
 	reference = "PB"
 	item = /obj/item/pizza_bomb
-	cost = 2
+	cost = 3
 	surplus = 80
 
 /datum/uplink_item/explosives/grenadier

--- a/code/game/objects/items/devices/pizza_bomb.dm
+++ b/code/game/objects/items/devices/pizza_bomb.dm
@@ -3,6 +3,7 @@
 	desc = "A box suited for pizzas."
 	icon = 'icons/obj/food/pizza.dmi'
 	icon_state = "pizzabox1"
+	throw_range = 1
 	var/timer = 10 //Adjustable timer
 	var/timer_set = 0
 	var/primed = 0


### PR DESCRIPTION
-Stage speed кроветворного вируса повышена с -6 до -4 для 
баланса и корректной работы с симптомом фильтра токсинов. -6 скорости вызывает отключение симптома toxic filter, что обычно возможно только в случае если специально подбирать симптомы с минимальной скоростью. Однаки из-за крайне низкой скорости кроветворного вируса вполне вероятно получить нерабочий фильтр токсинов случайным образом.

-Стоимость гарроты повышена с 6 до 8 и таким образом уравнена с сонной ручкой как предмет схожего назначения и силы.

-Стоимость стимуляторов повышена с 4 до 5 для баланса (больше невозможно одновременно купить двойной меч и стимуляторы без скидки на что либо из них.)

-Стоимость пиццы-бомбы повышена с 2 до 3 для того чтобы не подталкивать к бессмысленному шахидизму из-за смешной стоимости.

-Дальность броска пиццы бомбы урезана до единицы во избежание использования ее как ракеты и прямого  апгрейда минибомбы синдиката за меньшую цену. Неизвестно было ли так задумано, но таймер на этой бомбе это не время до взвода, а время до взрыва, который будучи установленным на 1 является одним одним из редких видов взрывчатки которую нет нужды держать перед броском взведенной чтобы противник не успел убежать из зоны поражения.
