### PR TITLE
Загрузка disk compartmentalizer через коробку, помимо сумки

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -145,7 +145,7 @@
 		user.visible_message("<span class='notice'>[user] has added \the [O] to \the [src].</span>", "<span class='notice'>You add \the [O] to \the [src].</span>")
 		SStgui.update_uis(src)
 		update_icon()
-	else if(istype(O, /obj/item/storage/bag))
+	else if(istype(O, /obj/item/storage/bag) || istype(O, /obj/item/storage/box))
 		var/obj/item/storage/bag/P = O
 		var/items_loaded = 0
 		for(var/obj/G in P.contents)


### PR DESCRIPTION
## Проблема
Сейчас **disk compartmentalizer** загружается вручную(по 1 предмету), в отличии от всех остальных машин типа **Smartfridge**.
Предлагаю добавить возможность загружать его и остальные машины так же и через коробки.

## Плюсы
Можно будет заполнять машины, используя не только специализированные сумки.

![image](https://user-images.githubusercontent.com/11385249/125054476-e96b8080-e0ae-11eb-9f67-f8948d7f0300.png)

