### PR TITLE
Revert "Ребаланс ксеносов"

### DIFF
--- a/code/modules/mob/living/carbon/human/species/tajaran.dm
+++ b/code/modules/mob/living/carbon/human/species/tajaran.dm
@@ -28,9 +28,6 @@
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = HAS_TAIL | HAS_HEAD_ACCESSORY | HAS_MARKINGS | HAS_SKIN_COLOR | TAIL_WAGGING
 	dietflags = DIET_OMNI
-	hunger_drain = 0.15
-	speed_mod = -0.4
-	burn_mod = 1.8
 	taste_sensitivity = TASTE_SENSITIVITY_SHARP
 	reagent_tag = PROCESS_ORG
 

--- a/code/modules/mob/living/carbon/human/species/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/unathi.dm
@@ -19,7 +19,6 @@
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = HAS_TAIL | HAS_HEAD_ACCESSORY | HAS_BODY_MARKINGS | HAS_HEAD_MARKINGS | HAS_SKIN_COLOR | HAS_ALT_HEADS | TAIL_WAGGING
 	dietflags = DIET_CARN
-	hunger_drain = 0.17
 	taste_sensitivity = TASTE_SENSITIVITY_SHARP
 
 	cold_level_1 = 280 //Default 260 - Lower is better
@@ -37,8 +36,7 @@
 	default_headacc = "Simple"
 	default_headacc_colour = "#404040"
 	butt_sprite = "unathi"
-	brute_mod = 0.8
-	speed_mod = 0.2
+	brute_mod = 1.05
 
 	has_organ = list(
 		"heart" =    /obj/item/organ/internal/heart/unathi,

--- a/code/modules/mob/living/carbon/human/species/vulpkanin.dm
+++ b/code/modules/mob/living/carbon/human/species/vulpkanin.dm
@@ -19,19 +19,9 @@
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = HAS_TAIL | TAIL_WAGGING | TAIL_OVERLAPPED | HAS_HEAD_ACCESSORY | HAS_MARKINGS | HAS_SKIN_COLOR
 	dietflags = DIET_OMNI
-	hunger_drain = 0.17
-	speed_mod = -0.5
-	burn_mod = 2
+	hunger_drain = 0.11
 	taste_sensitivity = TASTE_SENSITIVITY_SHARP
 	reagent_tag = PROCESS_ORG
-
-	cold_level_1 = 230
-	cold_level_2 = 170
-	cold_level_3 = 100
-
-	heat_level_1 = 330
-	heat_level_2 = 370
-	heat_level_3 = 430
 
 	flesh_color = "#966464"
 	base_color = "#CF4D2F"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Реверт старого ребаланса ксеносов от РВ.
Тому кто будет это мерджить нужно так же снизить скорость боргов (значение robot_delay 2.5) в конфигах сервера. 

## Ссылка на голосование
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
https://discord.com/channels/617003227182792704/755125334097133628/865205145573916723
![image](https://user-images.githubusercontent.com/59314481/125789039-94ea0803-7f83-4ad7-a823-d51b0a3f63c3.png)


## Changelog
:cl:
del: Удален старый ребаланс ксеносов.
tweak: <КОНФИГИ> Скорость боргов снижена до 2.5
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
