### PR TITLE
ХоСу добавлены боевые перчатки в шкафчик

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -113,6 +113,7 @@
 	new /obj/item/clothing/head/HoS/beret(src)
 	new /obj/item/clothing/suit/mantle/armor(src)
 	new /obj/item/clothing/glasses/hud/security/sunglasses(src)
+	new /obj/item/clothing/gloves/combat(src)
 	new /obj/item/storage/lockbox/mindshield(src)
 	new /obj/item/storage/box/flashbangs(src)
 	new /obj/item/holosign_creator/security(src)


### PR DESCRIPTION
По предложению **#ПерчаткиХОС** в ДС, добавил боевые перчатки в шкаф ГСБ.

![image](https://user-images.githubusercontent.com/20109643/126437262-50a6d8bd-32a1-4da6-8821-e0ee77294e90.png)