### PR TITLE
Вирусы на ранней стадии больше не отображаются на медхуде

### DIFF
--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -50,6 +50,10 @@ GLOBAL_LIST_INIT(diseases, subtypesof(/datum/disease))
 	var/stage = 1
 	var/max_stages = 0
 	var/stage_prob = 4
+	/// The fraction of stages the virus must at least be at to show up on medical HUDs. Rounded up.
+	var/discovery_threshold = 0.5
+	/// If TRUE, this virus will show up on medical HUDs. Automatically set when it reaches mid-stage.
+	var/discovered = FALSE
 
 	//Other
 	var/list/viable_mobtypes = list() //typepaths of viable mobs
@@ -78,7 +82,9 @@ GLOBAL_LIST_INIT(diseases, subtypesof(/datum/disease))
 		return TRUE
 
 	stage = min(stage, max_stages)
-
+	if(!discovered && stage >= CEILING(max_stages * discovery_threshold, 1)) // Once we reach a late enough stage, medical HUDs can pick us up even if we regress
+			discovered = TRUE
+			affected_mob.med_hud_set_status()
 	if(!cure)
 		if(prob(stage_prob))
 			stage = min(stage + 1,max_stages)

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -90,6 +90,8 @@
 /mob/living/carbon/proc/has_virus()
 	for(var/thing in viruses)
 		var/datum/disease/D = thing
+		if(!D.discovered) // Early-stage viruses should not show up on med HUD (though health analywers can still pick them up)
+			continue
 		if((!(D.visibility_flags & HIDDEN_SCANNER)) && (D.severity != NONTHREAT))
 			return TRUE
 	return FALSE


### PR DESCRIPTION
Прямиком с оригинала https://github.com/ParadiseSS13/Paradise/pull/16307

### Что делает этот PR
Делает так, что вирусы больше не отображаются на медицинских HUD, пока они не достигнут середины своей максимальной стадии. Анализаторы здоровья и сканеры тела по-прежнему обнаруживают вирусы независимо от стадии.

### Почему это хорошо для игры
Событие Biohazard 7 (и преднамеренные выбросы вирусов) обычно не вызывают большого впечатления, поскольку пациенты с вирусом могут быть мгновенно обнаружены любым, у кого есть медицинский HUD. Первоначально скрывая вирус, пока он не достигнет более поздней стадии, этот PR позволяет вирусам распространяться, даже если немного, чтобы усложнить вспышки, а борьбу с вирусами сделать настоящей задачей.
Кроме того, у большинства вирусов есть симптомы на ранней стадии, и это должно мотивировать людей пройти обследование :)

**Улучшено**: Вирусы больше не отображаются на медицинских HUD, пока они не достигнут средней стадии.