### PR TITLE
Починка ботаники

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -7,6 +7,7 @@
 /obj/item/reagent_containers/food/snacks/grown
 	icon = 'icons/obj/hydroponics/harvest.dmi'
 	var/obj/item/seeds/seed = null // type path, gets converted to item on New(). It's safe to assume it's always a seed item.
+	volume = 100
 	var/plantname = ""
 	var/bitesize_mod = 0 	// If set, bitesize = 1 + round(reagents.total_volume / bitesize_mod)
 	var/splat_type = /obj/effect/decal/cleanable/plant_smudge

--- a/code/modules/hydroponics/grown/cannabis.dm
+++ b/code/modules/hydroponics/grown/cannabis.dm
@@ -1,5 +1,5 @@
 
-      
+
 // Cannabis
 /obj/item/seeds/cannabis
 	name = "pack of cannabis seeds"
@@ -125,4 +125,5 @@
 	name = "omega cannibas leaf"
 	desc = "You feel dizzy looking at it. What the fuck?"
 	icon_state = "ocannabis"
+	volume = 125
 	wine_power = 0.9

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -136,7 +136,6 @@
 	seed = /obj/item/seeds/cherry/bomb
 	bitesize_mod = 2
 	tastes = list("cherry" = 1, "explosion" = 1)
-	volume = 125 //Gives enough room for the black powder at max potency
 	max_integrity = 40
 	wine_power = 0.8
 


### PR DESCRIPTION
Исправил ботанику по собственному багрепорту #264, где и расписал всю проблему (в том числе и в комментариях)
1) Добавил в определение базового фрукта строку о максимальном хранилище веществ на 100u, протестировал на локали, работает как надо, багов не заметил.
2) Откровенно не понимаю за что черри бомбе максимум на 125u, пошарив по истокам, выяснил, что так было и в 2017, но вещества в неё все влезают. В общем, чего это она выделяется просто так? Опустил на 100u
3) Омега конопля, 10 Месяцев назад она имела в себе максимум 420u и хранила значительно больше веществ, но #14584 (кстати, ещё одно подтверждение того, что растения ДОЛЖНЫ иметь максимум в 100u), был нерф. Вот только всё равно не хватает 8u для умещения родных веществ. Вот ей в качестве особенности хорошо подходит +25u с черри бомбы. Поставил максимум омега конопле на 125u.

Считаю данные изменения необходимыми и не портящими баланс, а наоборот только чинящими сломанную ботанику.

P.s. Совершенно не программист и пользуюсь гитхабом в первый раз, надеюсь тут всё правильно сделал