### PR TITLE
Исправление дюпа газа при замене пола

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -113,8 +113,33 @@
 
 
 /turf/simulated/ChangeTurf(path, defer_change = FALSE, keep_icon = TRUE, ignore_air = FALSE)
-	. = ..()
+	if(air && !defer_change && !ignore_air)
+		var/aoxy = air.oxygen
+		var/anitro = air.nitrogen
+		var/aco = air.carbon_dioxide
+		var/atox = air.toxins
+		var/asleep = air.sleeping_agent
+		var/ab = air.agent_b
+		var/atemp = air.temperature
+		. = ..()
+		var/turf/simulated/T = .
+		if(istype(T) && T.air)
+			T.air.oxygen = aoxy
+			T.air.nitrogen = anitro
+			T.air.carbon_dioxide = aco
+			T.air.toxins = atox
+			T.air.sleeping_agent = asleep
+			T.air.agent_b = ab
+			T.air.temperature = atemp
+	else
+		. = ..()
 	queue_smooth_neighbors(src)
+
+/turf/simulated/AfterChange(ignore_air = FALSE, keep_cabling = FALSE)
+	..()
+	RemoveLattice()
+	if(!ignore_air && air && SSair)
+		SSair.add_to_active(src)
 
 /turf/simulated/proc/is_shielded()
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -268,50 +268,6 @@
 		for(var/obj/structure/cable/C in contents)
 			qdel(C)
 
-/turf/simulated/AfterChange(ignore_air = FALSE, keep_cabling = FALSE)
-	..()
-	RemoveLattice()
-	if(!ignore_air)
-		Assimilate_Air()
-
-//////Assimilate Air//////
-/turf/simulated/proc/Assimilate_Air()
-	if(air)
-		var/aoxy = 0 //Holders to assimilate air from nearby turfs
-		var/anitro = 0
-		var/aco = 0
-		var/atox = 0
-		var/asleep = 0
-		var/ab = 0
-		var/atemp = 0
-		var/turf_count = 0
-
-		for(var/direction in GLOB.cardinal)//Only use cardinals to cut down on lag
-			var/turf/T = get_step(src, direction)
-			if(istype(T, /turf/space))//Counted as no air
-				turf_count++//Considered a valid turf for air calcs
-				continue
-			else if(istype(T, /turf/simulated/floor))
-				var/turf/simulated/S = T
-				if(S.air)//Add the air's contents to the holders
-					aoxy += S.air.oxygen
-					anitro += S.air.nitrogen
-					aco += S.air.carbon_dioxide
-					atox += S.air.toxins
-					asleep += S.air.sleeping_agent
-					ab += S.air.agent_b
-					atemp += S.air.temperature
-				turf_count++
-		air.oxygen = (aoxy / max(turf_count, 1)) //Averages contents of the turfs, ignoring walls and the like
-		air.nitrogen = (anitro / max(turf_count, 1))
-		air.carbon_dioxide = (aco / max(turf_count, 1))
-		air.toxins = (atox / max(turf_count, 1))
-		air.sleeping_agent = (asleep / max(turf_count, 1))
-		air.agent_b = (ab / max(turf_count, 1))
-		air.temperature = (atemp / max(turf_count, 1))
-		if(SSair)
-			SSair.add_to_active(src)
-
 /turf/proc/ReplaceWithLattice()
 	ChangeTurf(baseturf)
 	new /obj/structure/lattice(locate(x, y, z))


### PR DESCRIPTION
PR исправляет дюп газа в атмосе

Суть проблемы - при замене пола атмос вместо того чтобы скопировать газ который изначально был в тайле рассчитывал "усредненный" газ из 4 соседних тайлов, игнорируя при этом газопроницаемость. Это приводило к 2 странным эффектам: 
1. Замена пола в тайле окруженном стенками удаляла в нём весь газ
2. Замена пола в тайле без газа окруженном стеклом приводила к копированию окружающего газа в тайл

Некоторые инженеры повадились таким образом дюпать плазму

ПР заменяет логику на следующую
1. При замене пола он сохраняет тот газ который изначально был в тайле
2. При разборе стенки он заполняет тайл "газом по умолчанию" (turf.dm:12), для станции это кислород/азот 20/80. Для космоса скорее всего там будет вакуум (но я не проверял)
3. При установке стенки в тайл стенка удалит в ней весь газ (тут без изменений, это и раньше так работало)