### PR TITLE
Исправление форматирования профессий в ПДА при использовании кастомного имени

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -151,6 +151,7 @@ GLOBAL_LIST_EMPTY(PDA_Manifest)
 	if(GLOB.PDA_Manifest.len)
 		return
 	var/heads[0]
+	var/pro[0]
 	var/sec[0]
 	var/eng[0]
 	var/med[0]
@@ -173,6 +174,12 @@ GLOBAL_LIST_EMPTY(PDA_Manifest)
 			depthead = 1
 			if(real_rank == "Captain" && heads.len != 1)
 				heads.Swap(1,  heads.len)
+
+		if((real_rank == "Magistrate") || (real_rank == "Internal Affairs Agent") || (real_rank == "Nanotrasen Representative"))
+			pro[++pro.len] = list("name" = name, "rank" = rank, "active" = isactive)
+			department = 1
+			if((real_rank == "Magistrate") && pro.len != 1)
+				pro.Swap(1,  pro.len)
 
 		if(real_rank in GLOB.security_positions)
 			sec[++sec.len] = list("name" = name, "rank" = rank, "active" = isactive)
@@ -220,6 +227,7 @@ GLOBAL_LIST_EMPTY(PDA_Manifest)
 
 	GLOB.PDA_Manifest = list(\
 		"heads" = heads,\
+		"pro" = pro,\
 		"sec" = sec,\
 		"eng" = eng,\
 		"med" = med,\

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -171,7 +171,7 @@ GLOBAL_LIST_EMPTY(PDA_Manifest)
 			heads[++heads.len] = list("name" = name, "rank" = rank, "active" = isactive)
 			department = 1
 			depthead = 1
-			if(rank == "Captain" && heads.len != 1)
+			if(real_rank == "Captain" && heads.len != 1)
 				heads.Swap(1,  heads.len)
 
 		if(real_rank in GLOB.security_positions)
@@ -237,11 +237,10 @@ GLOBAL_LIST_EMPTY(PDA_Manifest)
 	for(var/mob/living/carbon/human/H in GLOB.player_list)
 		manifest_inject(H)
 
-/datum/datacore/proc/manifest_modify(name, assignment)
+/datum/datacore/proc/manifest_modify(name, rank, assignment)
 	if(GLOB.PDA_Manifest.len)
 		GLOB.PDA_Manifest.Cut()
 	var/datum/data/record/foundrecord
-	var/real_title = assignment
 
 	for(var/datum/data/record/t in GLOB.data_core.general)
 		if(t)
@@ -249,18 +248,9 @@ GLOBAL_LIST_EMPTY(PDA_Manifest)
 				foundrecord = t
 				break
 
-	var/list/all_jobs = get_job_datums()
-
-	for(var/datum/job/J in all_jobs)
-		var/list/alttitles = get_alternate_titles(J.title)
-		if(!J)	continue
-		if(assignment in alttitles)
-			real_title = J.title
-			break
-
 	if(foundrecord)
 		foundrecord.fields["rank"] = assignment
-		foundrecord.fields["real_rank"] = real_title
+		foundrecord.fields["real_rank"] = rank
 
 GLOBAL_VAR_INIT(record_id_num, 1001)
 /datum/datacore/proc/manifest_inject(mob/living/carbon/human/H)

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -411,7 +411,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 			return
 		if("modify") // inserting or removing the ID you plan to modify
 			if(modify)
-				GLOB.data_core.manifest_modify(modify.registered_name, modify.assignment)
+				GLOB.data_core.manifest_modify(modify.registered_name, modify.rank, modify.assignment)
 				regenerate_id_name()
 				if(ishuman(usr))
 					modify.forceMove(get_turf(src))

--- a/tgui/packages/tgui/interfaces/common/CrewManifest.js
+++ b/tgui/packages/tgui/interfaces/common/CrewManifest.js
@@ -88,6 +88,7 @@ export const CrewManifest = (props, context) => {
 
   const {
     heads,
+    pro,
     sec,
     eng,
     med,
@@ -120,15 +121,7 @@ export const CrewManifest = (props, context) => {
           </Box>
         )}
         level={2}>
-        {ManifestTable(ser.filter(character => {
-          switch (character.rank) {
-            case "Magistrate": return true;
-            case "Internal Affairs Agent": return true;
-            case "Nanotrasen Representative": return true;
-            case "Human Resources Agent": return true;
-            default: return false;
-          }
-        }))}
+        {ManifestTable(pro)}
       </Section>
 
       <Section


### PR DESCRIPTION
Теперь при использовании кастомного имени для профы они не будут улетать в misc а будут находится в том департаменте в котором и должны, если это глава то он также будет отображаться в списке командования