### PR TITLE
AI: бинды для сохраненных локаций (Shift + цифра)

### DIFF
--- a/code/modules/keybindings/bindings_ai.dm
+++ b/code/modules/keybindings/bindings_ai.dm
@@ -1,6 +1,52 @@
+/mob/living/silicon/ai/var/current_camera = 0
 /mob/living/silicon/ai/key_down(_key, client/user)
-	switch(_key)
-		if("4")
-			a_intent_change(INTENT_HOTKEY_LEFT)
+	if(user.keys_held["Shift"])
+		if(text2num(_key) != null)
+			if(set_camera_by_index(user, text2num(_key)))
+				update_binded_camera(user)
 			return
-	return ..()
+		return ..()
+	else
+		switch(_key)
+			if("4")
+				a_intent_change(INTENT_HOTKEY_LEFT)
+				return
+			if("N")
+				if(check_for_binded_cameras(user))
+					current_camera++
+					update_binded_camera(user)
+					return
+			if("B")
+				if(check_for_binded_cameras(user))
+					current_camera--
+					update_binded_camera(user)
+					return
+		return ..()
+/mob/living/silicon/ai/proc/check_for_binded_cameras(client/user)
+	if(!length(stored_locations))
+		to_chat(user, "<span class='warning'>You have no stored camera positions</span>")
+		return 0
+	return 1
+/mob/living/silicon/ai/proc/set_camera_by_index(client/user, var/camnum)
+	var/camnum_lenght = length(stored_locations)
+	if(camnum > camnum_lenght || (camnum == 0 && camnum_lenght != 10))
+		to_chat(user, "<span class='warning'>You have no stored camera on [camnum] position</span>")
+		return 0
+	if(!camnum)
+		camnum = 10
+	current_camera = camnum
+	return 1
+/mob/living/silicon/ai/proc/update_binded_camera(client/user)
+	var/camname
+	var/camnummax = length(stored_locations)
+	if(current_camera > camnummax)
+		current_camera = 1
+	else if(!current_camera)
+		current_camera = camnummax
+	camname = stored_locations[current_camera]
+	ai_goto_location(stored_locations[current_camera])
+	to_chat(user, "<span class='warning'>Now you on position: [camname] | Number [current_camera] | All cameras value: [camnummax]</span>")
+
+
+
+

--- a/code/modules/keybindings/bindings_ai.dm
+++ b/code/modules/keybindings/bindings_ai.dm
@@ -44,7 +44,7 @@
 	var/camname
 	camname = stored_locations[current_camera]
 	ai_goto_location(camname)
-	to_chat(user, "<span class='warning'>Now you on camera position: [camname]</span>")
+	to_chat(user, "<span class='notice'>Now you on camera position: [camname]</span>")
 
 /mob/living/silicon/ai/proc/current_camera_next(client/user)
 	current_camera++

--- a/code/modules/keybindings/bindings_ai.dm
+++ b/code/modules/keybindings/bindings_ai.dm
@@ -48,7 +48,7 @@
 	else if(!current_camera)
 		current_camera = camnummax
 	camname = stored_locations[current_camera]
-	ai_goto_location(stored_locations[current_camera])
+	ai_goto_location(camname)
 	to_chat(user, "<span class='warning'>Now you on position: [camname] | Number [current_camera] | All cameras value: [camnummax]</span>")
 
 

--- a/code/modules/keybindings/bindings_ai.dm
+++ b/code/modules/keybindings/bindings_ai.dm
@@ -23,6 +23,7 @@
 					update_binded_camera(user)
 					return
 		return ..()
+
 /mob/living/silicon/ai/proc/check_for_binded_cameras(client/user)
 	if(!length(stored_locations))
 		to_chat(user, "<span class='warning'>You have no stored camera positions</span>")

--- a/code/modules/keybindings/bindings_ai.dm
+++ b/code/modules/keybindings/bindings_ai.dm
@@ -31,11 +31,11 @@
 	return 1
 
 /mob/living/silicon/ai/proc/set_camera_by_index(client/user, var/camnum)
-	var/camnum_lenght = length(stored_locations)
-	if(camnum > camnum_lenght || (camnum == 0 && camnum_lenght != 10))
+	var/camnum_length = length(stored_locations)
+	if(camnum > camnum_length || (camnum == 0 && camnum_length < 10))
 		to_chat(user, "<span class='warning'>You have no stored camera on [camnum] position</span>")
 		return 0
-	if(!camnum)
+	if(camnum == 0)
 		camnum = 10
 	current_camera = camnum
 	return 1

--- a/code/modules/keybindings/bindings_ai.dm
+++ b/code/modules/keybindings/bindings_ai.dm
@@ -53,8 +53,3 @@
 /mob/living/silicon/ai/proc/current_camera_back(client/user)
 	if(current_camera <= 1)
 		current_camera = length(stored_locations)
-
-
-
-
-

--- a/code/modules/keybindings/bindings_ai.dm
+++ b/code/modules/keybindings/bindings_ai.dm
@@ -37,6 +37,7 @@
 		camnum = 10
 	current_camera = camnum
 	return 1
+
 /mob/living/silicon/ai/proc/update_binded_camera(client/user)
 	var/camname
 	var/camnummax = length(stored_locations)

--- a/code/modules/keybindings/bindings_ai.dm
+++ b/code/modules/keybindings/bindings_ai.dm
@@ -27,6 +27,7 @@
 		to_chat(user, "<span class='warning'>You have no stored camera positions</span>")
 		return 0
 	return 1
+
 /mob/living/silicon/ai/proc/set_camera_by_index(client/user, var/camnum)
 	var/camnum_lenght = length(stored_locations)
 	if(camnum > camnum_lenght || (camnum == 0 && camnum_lenght != 10))

--- a/code/modules/keybindings/bindings_ai.dm
+++ b/code/modules/keybindings/bindings_ai.dm
@@ -1,4 +1,5 @@
 /mob/living/silicon/ai/var/current_camera = 0
+
 /mob/living/silicon/ai/key_down(_key, client/user)
 	if(user.keys_held["Shift"])
 		if(text2num(_key) != null)

--- a/code/modules/keybindings/bindings_ai.dm
+++ b/code/modules/keybindings/bindings_ai.dm
@@ -14,12 +14,12 @@
 				return
 			if("N")
 				if(check_for_binded_cameras(user))
-					current_camera++
+					current_camera_next(user)
 					update_binded_camera(user)
 					return
 			if("B")
 				if(check_for_binded_cameras(user))
-					current_camera--
+					current_camera_back(user)
 					update_binded_camera(user)
 					return
 		return ..()
@@ -42,14 +42,20 @@
 
 /mob/living/silicon/ai/proc/update_binded_camera(client/user)
 	var/camname
-	var/camnummax = length(stored_locations)
-	if(current_camera > camnummax)
-		current_camera = 1
-	else if(!current_camera)
-		current_camera = camnummax
 	camname = stored_locations[current_camera]
 	ai_goto_location(camname)
-	to_chat(user, "<span class='warning'>Now you on position: [camname] | Number [current_camera] | All cameras value: [camnummax]</span>")
+	to_chat(user, "<span class='warning'>Now you on camera position: [camname]</span>")
+
+/mob/living/silicon/ai/proc/current_camera_next(client/user)
+	current_camera++
+	if(current_camera > length(stored_locations))
+		current_camera = 1
+
+/mob/living/silicon/ai/proc/current_camera_back(client/user)
+	current_camera--
+	if(!current_camera)
+		current_camera = length(stored_locations)
+
 
 
 

--- a/code/modules/keybindings/bindings_ai.dm
+++ b/code/modules/keybindings/bindings_ai.dm
@@ -47,13 +47,11 @@
 	to_chat(user, "<span class='notice'>Now you on camera position: [camname]</span>")
 
 /mob/living/silicon/ai/proc/current_camera_next(client/user)
-	current_camera++
-	if(current_camera > length(stored_locations))
+	if(current_camera >= length(stored_locations))
 		current_camera = 1
 
 /mob/living/silicon/ai/proc/current_camera_back(client/user)
-	current_camera--
-	if(!current_camera)
+	if(current_camera <= 1)
 		current_camera = length(stored_locations)
 
 


### PR DESCRIPTION
Итого, теперь при нажатии клавиш B и N будет перемещение между камерами, начиная с 1-й или 10-й.
B(ack) - назад, N(ext) - вперёд.

Помимо этого, можно не кликать много раз, а просто нажать Shift + номер камеры, и так вплоть до десяти(их максимум таким и был).

Делал из To-Do. Вариант с минимапой посчитал не столько нужным, ведь позиции задает сам игрок, и ему проще нажать две кнопки и попасть на нужную локу, чем смотреть её на карте, ну и еще с лавалендом это надо было бы устроить...