### PR TITLE
Фикс/доработка миксера газа

### DIFF
--- a/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
@@ -111,7 +111,7 @@
 
 	/*
 	Pump mode:
-	If mix ratio is set to 100:0 or 0:100, mixer will act like a gas pump, avoiding unnecessary checks for acutal mixing process
+	If mixing ratio is set to 100:0 or 0:100, mixer will act like a gas pump, avoiding unnecessary checks for actual mixing process
 	pump = 0 - pump mode is OFF
 	pump = 1 - pump mode is ON, transfers gas from intake 1 to outlet (node 1 -> node 3)
 	pump = 2 - pump mode is ON, transfers gas from intake 2 to outlet (node 2 -> node 3)

--- a/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
@@ -109,27 +109,44 @@
 		//No need to mix if target is already full!
 		return 1
 
+	/*
+	Pump mode:
+	If mix ratio is set to 100:0 or 0:100, mixer will act like a gas pump, avoiding unnecessary checks for acutal mixing process
+	pump = 0 - pump mode is OFF
+	pump = 1 - pump mode is ON, transfers gas from intake 1 to outlet (node 1 -> node 3)
+	pump = 2 - pump mode is ON, transfers gas from intake 2 to outlet (node 2 -> node 3)
+	*/
+
+	var/pump = 0
+
+	if(!node1_concentration)
+		pump = 2
+
+	if(!node2_concentration)
+		pump = 1
+
 	//Calculate necessary moles to transfer using PV=nRT
 
 	var/pressure_delta = target_pressure - output_starting_pressure
 	var/transfer_moles1 = 0
 	var/transfer_moles2 = 0
 
-	if(air1.temperature > 0)
+	if((air1.temperature > 0) && ((pump == 0) || (pump == 1)))
 		transfer_moles1 = (node1_concentration*pressure_delta)*air3.volume/(air1.temperature * R_IDEAL_GAS_EQUATION)
 
-	if(air2.temperature > 0)
+	if((air2.temperature > 0) && ((pump == 0) || (pump == 2)))
 		transfer_moles2 = (node2_concentration*pressure_delta)*air3.volume/(air2.temperature * R_IDEAL_GAS_EQUATION)
 
-	var/air1_moles = air1.total_moles()
-	var/air2_moles = air2.total_moles()
+	if(pump == 0)
+		var/air1_moles = air1.total_moles()
+		var/air2_moles = air2.total_moles()
 
-	if((air1_moles < transfer_moles1) || (air2_moles < transfer_moles2))
-		if(!transfer_moles1 || !transfer_moles2) return
-		var/ratio = min(air1_moles/transfer_moles1, air2_moles/transfer_moles2)
+		if((air1_moles < transfer_moles1) || (air2_moles < transfer_moles2))
+			if(!transfer_moles1 || !transfer_moles2) return
+			var/ratio = min(air1_moles/transfer_moles1, air2_moles/transfer_moles2)
 
-		transfer_moles1 *= ratio
-		transfer_moles2 *= ratio
+			transfer_moles1 *= ratio
+			transfer_moles2 *= ratio
 
 	//Actually transfer the gas
 


### PR DESCRIPTION
### Проблема
На карте Delta в Атмосе основу смесительного контура (все желтые трубы) составляют миксеры, что является крайне хорошим решением на мой взгляд, поскольку они обеспечивают наибольшую гибкость всей системы. Но есть один огромный недостаток: они не могут нормально работать, когда в них выставляется смесь 100/0 или 0/100 (т.е. просто пропустить один газ из одного из входов на выход, без смешивания), а такой способ довольно часто используется, например когда требуется просто заполнить канистру каким-либо определенным газом.

### Решение
Я попробовал сделать некий "режим помпы", имеющий место быть при выставлении отношения в миксере 100 к 0 или наоборот, работает собственно как обычная помпа, пропуская нужный газ и пропуская манипуляции для правильной регулировки смеси (эти самые манипуляции и ломали функционал при 100/0, видимо изначально миксер был рассчитан исключительно на работу со смешиванием). Если смешивание таки происходит, то ничего не скипается и работает как и было задумано.