### PR TITLE
Fix: martial arts exploit

### DIFF
--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -167,7 +167,7 @@
 	var/mob/living/M = loc
 
 	if(M.a_intent in accepted_intents)
-		if(istype(M.mind.martial_art, /datum/martial_art/cqc))
+		if(M.mind.martial_art)
 			M.changeNext_move(CLICK_CD_MELEE)//normal attack speed for hulk, CQC and Carp.
 		else
 			M.changeNext_move(click_speed_modifier)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Данный PR устраняет бонус к скорости атаки от "перчаток полярной звезды" при наличии искусства спящего карпа. Согласно комментариям в самом коде и описанию на Wiki.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Эксплойт позволял антагонистам получить безумные цифры к скорости и урону в ближнем бою, а вкупе с отражением прожектайлов это превращало их в ходячий мясокомбинат, непорядок.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
