### PR TITLE
Fix: Exploit With Duping Martial Arts Through Gloves

### DIFF
--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -144,6 +144,7 @@
 	H.verbs -= /mob/living/carbon/human/proc/martial_arts_help
 	if(base)
 		base.teach(H)
+		base = null
 
 /mob/living/carbon/human/proc/martial_arts_help()
 	set name = "Show Info"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Что привносит данный PR:
Исправлен эксплойт, позволяющий дюпать боевые искусства через boxing gloves и krav-maga gloves.
Включает в себя оригинальный коммит:
- https://github.com/ParadiseSS13/Paradise/pull/15711
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Почему это должно быть в игре:
Теперь нельзя получить несколько боевых искусств по цене одного, меньше возможностей для багоюза.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->