### PR TITLE
fix: nutriment pump exploit

### DIFF
--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -292,6 +292,10 @@
 		return
 	if(owner.stat == DEAD)
 		return
+	if(owner.mind != null && owner.mind.vampire != null)
+		return
+	if(ismachineperson(owner))
+		return
 	if(owner.nutrition <= hunger_threshold)
 		synthesizing = TRUE
 		to_chat(owner, "<span class='notice'>You feel less hungry...</span>")


### PR DESCRIPTION
## What Does This PR Do
Не позволяет получить голод/энергию из нутримент помпы вампирам и кпб. Помпу всё ещё можно установить, но уменьшать голод она не будет.

## Why It's Good For The Game
Не позволяет с лёгкостью избавиться от голода вампирам и устраняет нелогичную возможность получать бесконечную энергию для кпб.
