### PR TITLE
Tweak: SSU Drops Their Contents When Destroyed

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -256,11 +256,6 @@
 
 /obj/machinery/suit_storage_unit/Destroy()
 	SStgui.close_uis(wires)
-	QDEL_NULL(suit)
-	QDEL_NULL(helmet)
-	QDEL_NULL(mask)
-	QDEL_NULL(magboots)
-	QDEL_NULL(storage)
 	QDEL_NULL(wires)
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Что привносит данный PR:
После уничтожения хранилища ригов его содержимое остаётся на полу, а не исчезает в вечности.
Включает в себя оригинальный коммит:
- https://github.com/ParadiseSS13/Paradise/pull/16733
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Почему это должно быть в игре:
Теперь можно не опасаться внезапного уничтожения некоторых хай-риск предметов или ценного снаряжения.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Отображение изменений:
https://user-images.githubusercontent.com/67621641/134515228-e0969589-9ed5-4763-a750-cf043b78aace.mp4
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->