### PR TITLE
Игрушку в разгрузку

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -506,7 +506,8 @@
 	max_w_class = WEIGHT_CLASS_NORMAL
 	can_hold = list(
 		/obj/item/gun/projectile/automatic/pistol,
-		/obj/item/gun/projectile/revolver/detective
+		/obj/item/gun/projectile/revolver/detective,
+		/obj/item/gun/projectile/automatic/toy/pistol
 		)
 
 /obj/item/storage/belt/wands

--- a/code/modules/projectiles/guns/projectile/toy.dm
+++ b/code/modules/projectiles/guns/projectile/toy.dm
@@ -21,6 +21,7 @@
 	desc = "A small, easily concealable toy handgun. Ages 8 and up."
 	icon_state = "pistol"
 	w_class = WEIGHT_CLASS_SMALL
+	can_holster = TRUE
 	mag_type = /obj/item/ammo_box/magazine/toy/pistol
 	fire_sound = 'sound/weapons/gunshots/gunshot.ogg'
 	can_suppress = 0


### PR DESCRIPTION
## What Does This PR Do
Позволяет засунуть игрушечные пистолеты в разгрузку обычную и детектива

## Why It's Good For The Game
Реплики пытаются сделать максимально похожими на настоящие образцы, те совпадают по размеру и форме.
Почему же их нельзя засунуть в разгрузку?

## Changelog
:cl:
fix: Позволяет засунуть игрушечные пистолеты(foam) в разгрузку обычную и детектива
/:cl:
