### PR TITLE
Все новые батарейки частично заряжены

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -28,7 +28,7 @@
 /obj/item/stock_parts/cell/New()
 	..()
 	START_PROCESSING(SSobj, src)
-	charge = maxcharge
+	charge = round(maxcharge/10,1)
 	if(ratingdesc)
 		desc += " This one has a power rating of [DisplayPower(maxcharge)], and you should not swallow it."
 	update_icon()

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -29,7 +29,7 @@
 	..()
 	START_PROCESSING(SSobj, src)
 	var/obj/item/I = loc
-	if(I) //Если находится в предмете, то полностью заряжен. Предназначено для оружия
+	if(istype(I)) //Если находится в предмете, то полностью заряжен. Предназначено для оружия
 		charge = maxcharge
 	else
 		charge = round(maxcharge/10,1)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -28,7 +28,12 @@
 /obj/item/stock_parts/cell/New()
 	..()
 	START_PROCESSING(SSobj, src)
-	charge = round(maxcharge/10,1)
+	var/obj/item/I = loc
+	if(I) //Если находится в предмете, то полностью заряжен. Предназначено для оружия
+		charge = maxcharge
+	else
+		charge = round(maxcharge/10,1)
+
 	if(ratingdesc)
 		desc += " This one has a power rating of [DisplayPower(maxcharge)], and you should not swallow it."
 	update_icon()


### PR DESCRIPTION
## What Does This PR Do
Изменяет начальный заряд батареек до 1/10 от максимального
- Все стартовые машины имеют заряд 1/10
- Все стартовое оружие имеет полный заряд
- Все стартовые батарейки имеют заряд 1/10
- Все батарейки из автолата и протолата имеют заряд 1/10
- Слайм-батарейки при создании имеют заряд 1/10
- Ботанические батарейки при создании имеют полный заряд

## Why It's Good For The Game
Сейчас все батарейки получают полный заряд при создании, делая зарядные станции по сути бесполезными

## Changelog
:cl:
fix: Изменяет начальный заряд батареек до 1/10 от максимального
/:cl:
