### PR TITLE
Tweak: player ready number is visible to everyone now

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -100,8 +100,8 @@
 
 		if(SSticker.current_state == GAME_STATE_PREGAME)
 			stat("Players:", "[totalPlayers]")
-			if(check_rights(R_ADMIN, 0, src))
-				stat("Players Ready:", "[totalPlayersReady]")
+			//if(check_rights(R_ADMIN, 0, src))
+			stat("Players Ready:", "[totalPlayersReady]")
 			totalPlayers = 0
 			totalPlayersReady = 0
 			for(var/mob/new_player/player in GLOB.player_list)


### PR DESCRIPTION
## Что делает этот PR
Количество готовых игроков видно всем, а не только админам.
Не вижу ни одной причины почему оно должно быть скрыто.

## Почему это хорошо для игры
Возможно это будет полезно специфично для WL/Prime серверов. В любом другом случаи никаких минусов не дает (?).

## Changelog
tweak: player ready number is visible to everyone now