### PR TITLE
sibyl-deattach-fix

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -74,16 +74,18 @@
 			to_chat(user, "<span class='notice'>Вы начинаете заваривать болты мода Sibyl System от [src]...</span>")
 			if(!I.use_tool(src, user, 160, volume = I.tool_volume))
 				return
-			sibyl_mod.install(src, user)
-			to_chat(user, "<span class='notice'>Вы заварили болты мода Sibyl System в [src].</span>")
+			if(sibyl_mod.integrity == 1)
+				sibyl_mod.install(src, user)
+				to_chat(user, "<span class='notice'>Вы заварили болты мода Sibyl System в [src].</span>")
 			return
 		if(sibyl_mod.integrity == 2)
 			to_chat(user, "<span class='notice'>Вы начинаете разваривать болты мода Sibyl System от [src]...</span>")
 			if(!I.use_tool(src, user, 160, volume = I.tool_volume))
 				return
 			if(prob(70))
-				sibyl_mod.uninstall(src, user)
-				to_chat(user, "<span class='notice'>Вы успешно разварили болты мода Sibyl System от [src].</span>")
+				if(sibyl_mod.integrity == 2)
+					sibyl_mod.uninstall(src, user)
+					to_chat(user, "<span class='notice'>Вы успешно разварили болты мода Sibyl System от [src].</span>")
 			else
 				var/mob/living/carbon/human/H = user
 				var/obj/item/organ/external/affecting = H.get_organ(user.r_hand == I ? "l_hand" : "r_hand")
@@ -100,8 +102,9 @@
 			if(!I.use_tool(src, user, 160, volume = I.tool_volume))
 				return
 			if(prob(95))
-				sibyl_mod.uninstall(src, user)
-				to_chat(user, "<span class='notice'>Вы успешно отковыряли болты мода Sibyl System от [src].</span>")
+				if(sibyl_mod.integrity == 1)
+					sibyl_mod.uninstall(src, user)
+					to_chat(user, "<span class='notice'>Вы успешно отковыряли болты мода Sibyl System от [src].</span>")
 			else
 				var/mob/living/carbon/human/H = user
 				var/obj/item/organ/external/affecting = H.get_organ(user.r_hand == I ? "l_hand" : "r_hand")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Исправление логики отсоединения-присоединения модуля Sibyl
Сейчас если ты открутишь отвёрткой модуль и два раза успешно разваришь - он снимется. 
Соответственно, если два раза успешно заваришь - он сам закрутится.
В данном ПР это исправлено

## Changelog
:cl:
fix: fixed sibyl deattach
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
