### PR TITLE
Ребаланс новых симптомов

### DIFF
--- a/code/datums/diseases/advance/symptoms/epinephrine.dm
+++ b/code/datums/diseases/advance/symptoms/epinephrine.dm
@@ -35,4 +35,7 @@ Bonus
 				check = TRUE
 	if(check == TRUE && M.health <= HEALTH_THRESHOLD_CRIT)
 		M.reagents.add_reagent("epinephrine", 0.6)
+	if(M.reagents.get_reagent_amount("epinephrine") > 20)
+		var/obj/item/organ/internal/heart/heart = M.get_int_organ(/obj/item/organ/internal/heart)
+		heart.receive_damage(1)
 	return

--- a/code/datums/diseases/advance/symptoms/epinephrine.dm
+++ b/code/datums/diseases/advance/symptoms/epinephrine.dm
@@ -37,5 +37,5 @@ Bonus
 		M.reagents.add_reagent("epinephrine", 0.6)
 	if(M.reagents.get_reagent_amount("epinephrine") > 20)
 		var/obj/item/organ/internal/heart/heart = M.get_int_organ(/obj/item/organ/internal/heart)
-		heart.receive_damage(1)
+		heart?.receive_damage(1)
 	return

--- a/code/datums/diseases/advance/symptoms/painkiller.dm
+++ b/code/datums/diseases/advance/symptoms/painkiller.dm
@@ -29,8 +29,8 @@ Bonus
 		var/mob/living/M = A.affected_mob
 		switch(A.stage)
 			if(4, 5)
-				if(M.reagents.get_reagent_amount("hydrocodone") < 20)
-					M.reagents.add_reagent("hydrocodone", 10)
+				if(M.reagents.get_reagent_amount("hydrocodone") < 8 && M.getToxLoss() < 13)
+					M.reagents.add_reagent("hydrocodone", 2)
 			else
 				if(prob(SYMPTOM_ACTIVATION_PROB * 5))
 					to_chat(M, "<span class='notice'>[pick("Your body feels numb.", "You realize you feel nothing.", "You can't feel your body.")]</span>")


### PR DESCRIPTION
Обезболивающий симптом
--Уменьшено количество генерируемого гидрокодона до 2u за смену стадии.
--Уменьшен порог генерации гидрокодона до 8u
--Теперь не генерирует гидрокодон если носитель имеет более 13 токсического урона
Эпинефриновый симптом
--Добавлено повреждение сердца при передозировке эпинефрина: Если в организме присутствует данный вирус и более 20u эпинефрина, то сердце носителя получает единицу урона каждый тик

Гидрокодон резко режет шансы милишным антагам. Пауки и блоб очень сильно зависят от боли. Боль дает замедление. Тот же самый террор куснув человека раза 3-4 даст ему замедлу и человек убежать уже не сможет. Терроры сами по себе очень медленные, а люди под гидрокодоном даже с 150 урона могут обгонять их и убегать. дальнего боя у них нет.То же самое в меньшей степени касается блоба и демонов резни, вообще очень многих милишных симплов. Да и остальным антагам плохо когда отлеталенные челы настолько боеспособны. Так же страдают нюкеры которые на летале и живут(хотя они сейчас поломанные из-за скейла ТК.

Эпинефрин просто... ну он убирает из игры аспект софт крита. Сильно раненный человек не нуждается в стабилизации и может просто переждать крит. Для многих антагов также проблема в том что ты вроде как влил 150-180 урона, оставляешь чела умирать, а он за ~320 секунд стабилизировался и пополз в мед зашивать внутряк и переломы.

Эпинефрин еще терпимый, просто нуждается в более ощутимом минусе, а вот гидра уж больно весомое преимущество в бою дает.

Оба вируса проблемы в том что они требуют очень мало скила. Наниты с ТГ выпилили по той же причине, пассивный бонус навсегда без особых усилий.

Решать это можно двумя вещами, либо усложнять виро чтобы на создание вируса уходила прорва времени, либо делать симптомы обоюдоострым лезвием, чтобы они при неосторожном обращении представляли опасность для владельца либо были бесполезными. Соответственно усилие окупающее бонусы будет в том чтобы не попадать в ситуации в которых от вирусов будет вред.

Моё нерф состоит в том чтобы эпинефриновый вирус давал урон сердцу при передозе - то есть долго валятся в крите опасно, начнет умирать сердце
Для гидрокодона я просто ввел остановку выработки от яда - так как часто вирусу делают симптом переводящий урон в яд, то на практике это будет значить что человек получив много урона будет быстро бегать только пока этот вирус не перекидал урон в яд и не выветрился гидрокодон а потом боль вернется.
Также врачи-палачи вливающие эпинефрин не глядя теперь будут убивать сердце челам с вирусом

