### PR TITLE
fix: /datum/language для русской клавиатуры

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -45,6 +45,9 @@
 			GLOB.language_keys[":[lowertext(L.key)]"] = L
 			GLOB.language_keys[".[lowertext(L.key)]"] = L
 			GLOB.language_keys["#[lowertext(L.key)]"] = L
+			GLOB.language_keys[":[sanitize_english_string_to_russian(L.key)]"] = L
+			GLOB.language_keys[".[sanitize_english_string_to_russian(L.key)]"] = L
+			GLOB.language_keys["#[sanitize_english_string_to_russian(L.key)]"] = L
 
 	var/rkey = 0
 	for(var/spath in subtypesof(/datum/species))

--- a/code/__HELPERS/russian.dm
+++ b/code/__HELPERS/russian.dm
@@ -1,0 +1,21 @@
+GLOBAL_LIST_INIT(enkeys, list(
+	"q" = "й", "w" = "ц", "e" = "у", "r" = "к", "t" = "е", "y" = "н",
+	"u" = "г", "i" = "ш", "o" = "щ", "p" = "з",
+	"a" = "ф", "s" = "ы", "d" = "в", "f" = "а", "g" = "п", "h" = "р",
+	"j" = "о", "k" = "л", "l" = "д", ";" = "ж", "'" = "э", "z" = "я",
+	"x" = "ч", "c" = "с", "v" = "м", "b" = "и", "n" = "т", "m" = "ь",
+	"," = "б", "." = "ю",
+))
+
+
+/proc/sanitize_english_key_to_russian(t)
+	t = lowertext(t)
+	if(t in GLOB.enkeys)
+		return GLOB.enkeys[t]
+	return t
+
+/proc/sanitize_english_string_to_russian(text)
+	. = ""
+	for(var/i in 1 to length_char(text))
+		. += sanitize_english_key_to_russian(copytext_char(text, i, i+1))
+	return .

--- a/code/__HELPERS/russian.dm
+++ b/code/__HELPERS/russian.dm
@@ -9,13 +9,10 @@ GLOBAL_LIST_INIT(enkeys, list(
 
 
 /proc/sanitize_english_key_to_russian(t)
-	t = lowertext(t)
-	if(t in GLOB.enkeys)
-		return GLOB.enkeys[t]
-	return t
+	var/new_char = GLOB.enkeys[lowertext(char)]
+	return (new_char != null) ? new_char : char
 
 /proc/sanitize_english_string_to_russian(text)
 	. = ""
 	for(var/i in 1 to length_char(text))
 		. += sanitize_english_key_to_russian(copytext_char(text, i, i+1))
-	return .

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -1144,6 +1144,25 @@
 		else
 			to_chat(usr, "Mob doesn't know that language.")
 
+	else if(href_list["grantalllanguage"])
+		if(!check_rights(R_SPAWN))	return
+
+		var/mob/H = locateUID(href_list["grantalllanguage"])
+
+		if(!istype(H))
+			to_chat(usr, "This can only be done to instances of type /mob")
+			return
+
+		if(!H)
+			to_chat(usr, "Mob doesn't exist anymore")
+			return
+
+		H.grant_all_languages()
+
+		to_chat(usr, "Added all languages to [H].")
+		message_admins("[key_name_admin(usr)] has given [key_name_admin(H)] all languages")
+		log_admin("[key_name(usr)] has given [key_name(H)] all languages")
+
 	else if(href_list["addverb"])
 		if(!check_rights(R_DEBUG))			return
 

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -1153,10 +1153,6 @@
 			to_chat(usr, "This can only be done to instances of type /mob")
 			return
 
-		if(!H)
-			to_chat(usr, "Mob doesn't exist anymore")
-			return
-
 		H.grant_all_languages()
 
 		to_chat(usr, "Added all languages to [H].")

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -2,6 +2,17 @@
 
 /*
 	Datum based languages. Easily editable and modular.
+
+	Busy letters for language:
+	a b d f g j k o q v x y
+	aa as bo db fa fm fn fs vu
+
+	Busy symbols for language:
+	0 1 2 3 4 5 6 7 8 9
+	% ? ^
+
+	CAUTION! The key must not repeat the key of the radio channel
+	and must not contain prohibited characters
 */
 
 /datum/language
@@ -482,7 +493,7 @@
 	ask_verb = "chitters"
 	exclaim_verbs = list("chitters")
 	colour = "terrorspider"
-	key = "ts"
+	key = "as"
 	flags = RESTRICTED | HIVEMIND | NOBABEL
 	follow = TRUE
 
@@ -527,7 +538,7 @@
 	ask_verb = "gibbers"
 	exclaim_verbs = list("gibbers")
 	colour = "abductor"
-	key = "zw" //doesn't matter, this is their default and only language
+	key = "aa" //doesn't matter, this is their default and only language
 	flags = RESTRICTED | HIVEMIND | NOBABEL
 	follow = TRUE
 
@@ -640,7 +651,7 @@
 	speech_verb = "states"
 	ask_verb = "queries"
 	exclaim_verbs = list("declares")
-	key = "]"
+	key = "db"
 	flags = RESTRICTED
 	follow = TRUE
 	syllables = list ("beep", "boop")
@@ -652,7 +663,7 @@
 	ask_verb = "tones"
 	exclaim_verbs = list("tones")
 	colour = "say_quote"
-	key = "z"//Zwarmer...Or Zerg!
+	key = "as"//Zwarmer...Or Zerg!
 	flags = RESTRICTED | HIVEMIND | NOBABEL
 	follow = TRUE
 
@@ -730,17 +741,17 @@
 	speech_verb = "chimpers"
 	ask_verb = "chimpers"
 	exclaim_verbs = list("screeches")
-	key = "mo"
+	key = "fm"
 
 /datum/language/skrell/monkey
 	name = "Neara"
 	desc = "Squik squik squik."
-	key = "ne"
+	key = "fn"
 
 /datum/language/unathi/monkey
 	name = "Stok"
 	desc = "Hiss hiss hiss."
-	key = "st"
+	key = "fs"
 
 /datum/language/tajaran/monkey
 	name = "Farwa"
@@ -758,5 +769,9 @@
 		if(new_language.flags & NOBABEL)
 			continue
 		languages |= new_language
+
+/mob/proc/grant_all_languages()
+	for(var/la in GLOB.all_languages)
+		add_language(la)
 
 #undef SCRAMBLE_CACHE_LEN

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1365,6 +1365,7 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	.["Regenerate Icons"] = "?_src_=vars;regenerateicons=[UID()]"
 	.["Add Language"] = "?_src_=vars;addlanguage=[UID()]"
 	.["Remove Language"] = "?_src_=vars;remlanguage=[UID()]"
+	.["Grant All Language"] = "?_src_=vars;grantalllanguage=[UID()]"
 	.["Add Organ"] = "?_src_=vars;addorgan=[UID()]"
 	.["Remove Organ"] = "?_src_=vars;remorgan=[UID()]"
 

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -157,11 +157,11 @@
 
 /mob/proc/find_valid_prefixes(message)
 	var/list/prefixes = list() // [["Common", start, end], ["Gutter", start, end]]
-	for(var/i in 1 to length(message))
-		var/selection = trim_right(lowertext(copytext(message, i, i + 3)))
+	for(var/i in 1 to length_char(message))
+		var/selection = trim_right(lowertext(copytext_char(message, i, i + 3)))
 		var/datum/language/L = GLOB.language_keys[selection]
 		if(L != null && can_speak_language(L)) // What the fuck... remove the L != null check if you ever find out what the fuck is adding `null` to the languages list on absolutely random mobs... seriously what the hell...
-			prefixes[++prefixes.len] = list(L, i, i + length(selection))
+			prefixes[++prefixes.len] = list(L, i, i + length_char(selection))
 		else if(!L && i == 1)
 			prefixes[++prefixes.len] = list(get_default_language(), i, i)
 		else
@@ -170,14 +170,14 @@
 /proc/strip_prefixes(message)
 	. = ""
 	var/last_index = 1
-	for(var/i in 1 to length(message))
-		var/selection = trim_right(lowertext(copytext(message, i, i + 3)))
+	for(var/i in 1 to length_char(message))
+		var/selection = trim_right(lowertext(copytext_char(message, i, i + 3)))
 		var/datum/language/L = GLOB.language_keys[selection]
 		if(L)
-			. += copytext(message, last_index, i)
+			. += copytext_char(message, last_index, i)
 			last_index = i + 3
-		if(i + 1 > length(message))
-			. += copytext(message, last_index)
+		if(i + 1 > length_char(message))
+			. += copytext_char(message, last_index)
 
 // this returns a structured message with language sections
 // list(/datum/multilingual_say_piece(common, "hi"), /datum/multilingual_say_piece(farwa, "squik"), /datum/multilingual_say_piece(common, "meow!"))
@@ -203,11 +203,11 @@
 			break
 
 		if(i + 1 > length(prefix_locations)) // We are out of lookaheads, that means the rest of the message is in cur lang
-			var/spoke_message = handle_autohiss(trim(copytext(message, current[3])), L)
+			var/spoke_message = handle_autohiss(trim(copytext_char(message, current[3])), L)
 			. += new /datum/multilingual_say_piece(current[1], spoke_message)
 		else
 			var/next = prefix_locations[i + 1] // We look ahead at the next message to see where we need to stop.
-			var/spoke_message = handle_autohiss(trim(copytext(message, current[3], next[2])), L)
+			var/spoke_message = handle_autohiss(trim(copytext_char(message, current[3], next[2])), L)
 			. += new /datum/multilingual_say_piece(current[1], spoke_message)
 
 /* These are here purely because it would be hell to try to convert everything over to using the multi-lingual system at once */

--- a/paradise.dme
+++ b/paradise.dme
@@ -108,6 +108,7 @@
 #include "code\__HELPERS\pronouns.dm"
 #include "code\__HELPERS\qdel.dm"
 #include "code\__HELPERS\sanitize_values.dm"
+#include "code\__HELPERS\russian.dm"
 #include "code\__HELPERS\text.dm"
 #include "code\__HELPERS\time.dm"
 #include "code\__HELPERS\tool_helpers.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Языки теперь могут использоваться на русской клавиатуре. К примеру, язык дион (:q) можно использовать на русской раскладке, т.е. с помощью :й

## Why It's Good For The Game
Fixes #228 

## Changelog
:cl:
fix: "Радио-канал" киборгов можно использовать с русской раскладки
fix: Некоторые языки не работали из-за коллизии с радио-каналами
add: В VV администратора добавлен пункт для добавления всех языков
/:cl: