### PR TITLE
tweak: thrown knifes and etc have possibilities to be embed in player's body

### DIFF
--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -15,6 +15,9 @@
 	hitsound = 'sound/items/wirecutter.ogg'
 	usesound = 'sound/items/wirecutter.ogg'
 	sharp = 1
+	embed_chance = 15
+	embedded_fall_chance = 5
+	embedded_ignore_throwspeed_threshold = TRUE
 	toolspeed = 1
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 30)
 	tool_behaviour = TOOL_WIRECUTTER

--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -16,7 +16,6 @@
 	usesound = 'sound/items/wirecutter.ogg'
 	sharp = 1
 	embed_chance = 15
-	embedded_fall_chance = 5
 	embedded_ignore_throwspeed_threshold = TRUE
 	toolspeed = 1
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 30)

--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -15,7 +15,7 @@
 	hitsound = 'sound/items/wirecutter.ogg'
 	usesound = 'sound/items/wirecutter.ogg'
 	sharp = 1
-	embed_chance = 15
+	embed_chance = 5
 	embedded_ignore_throwspeed_threshold = TRUE
 	toolspeed = 1
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 30)

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -145,6 +145,9 @@
 	slot_flags = SLOT_BACK|SLOT_BELT
 	block_chance = 30
 	sharp = TRUE
+	embed_chance = 40
+	embedded_fall_chance = 0
+	embedded_ignore_throwspeed_threshold = TRUE
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 
@@ -231,6 +234,9 @@
 	armour_penetration = 35
 	slot_flags = SLOT_BACK
 	sharp = TRUE
+	embed_chance = 20
+	embedded_fall_chance = 10
+	embedded_ignore_throwspeed_threshold = TRUE
 	attack_verb = list("chopped", "sliced", "cut", "reaped")
 	hitsound = 'sound/weapons/rapierhit.ogg'
 
@@ -320,6 +326,9 @@
 	desc = "Used for absolutely hilarious sacrifices."
 	hitsound = 'sound/items/bikehorn.ogg'
 	sharp = TRUE
+	embed_chance = 45
+	embedded_fall_chance = 0
+	embedded_ignore_throwspeed_threshold = TRUE
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut", "honked")
 
 /obj/item/nullrod/whip
@@ -406,6 +415,9 @@
 	w_class = WEIGHT_CLASS_HUGE
 	desc = "They say fear is the true mind killer, but stabbing them in the head works too. Honour compels you to not sheathe it once drawn."
 	sharp = TRUE
+	embed_chance = 45
+	embedded_fall_chance = 0
+	embedded_ignore_throwspeed_threshold = TRUE
 	slot_flags = null
 	flags = HANDSLOW
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -145,8 +145,7 @@
 	slot_flags = SLOT_BACK|SLOT_BELT
 	block_chance = 30
 	sharp = TRUE
-	embed_chance = 40
-	embedded_fall_chance = 0
+	embed_chance = 20
 	embedded_ignore_throwspeed_threshold = TRUE
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
@@ -235,7 +234,6 @@
 	slot_flags = SLOT_BACK
 	sharp = TRUE
 	embed_chance = 20
-	embedded_fall_chance = 10
 	embedded_ignore_throwspeed_threshold = TRUE
 	attack_verb = list("chopped", "sliced", "cut", "reaped")
 	hitsound = 'sound/weapons/rapierhit.ogg'
@@ -327,7 +325,6 @@
 	hitsound = 'sound/items/bikehorn.ogg'
 	sharp = TRUE
 	embed_chance = 45
-	embedded_fall_chance = 0
 	embedded_ignore_throwspeed_threshold = TRUE
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut", "honked")
 
@@ -416,7 +413,6 @@
 	desc = "They say fear is the true mind killer, but stabbing them in the head works too. Honour compels you to not sheathe it once drawn."
 	sharp = TRUE
 	embed_chance = 45
-	embedded_fall_chance = 0
 	embedded_ignore_throwspeed_threshold = TRUE
 	slot_flags = null
 	flags = HANDSLOW

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -115,6 +115,9 @@
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	sharp = TRUE
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
+	embed_chance = 45
+	embedded_fall_chance = 0
+	embedded_ignore_throwspeed_threshold = TRUE
 	var/bayonet = FALSE	//Can this be attached to a gun?
 
 /obj/item/kitchen/knife/suicide_act(mob/user)

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -116,7 +116,6 @@
 	sharp = TRUE
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 	embed_chance = 45
-	embedded_fall_chance = 0
 	embedded_ignore_throwspeed_threshold = TRUE
 	var/bayonet = FALSE	//Can this be attached to a gun?
 

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -167,6 +167,7 @@
 	origin_tech = "materials=3;combat=4"
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "cut")
 	bayonet = TRUE
+	embed_chance = 90
 
 /obj/item/kitchen/knife/combat/survival
 	name = "survival knife"

--- a/code/game/objects/items/weapons/scissors.dm
+++ b/code/game/objects/items/weapons/scissors.dm
@@ -5,8 +5,7 @@
 	item_state = "scissor"
 	force = 5
 	sharp = 1
-	embed_chance = 25
-	embedded_fall_chance = 0
+	embed_chance = 10
 	embedded_ignore_throwspeed_threshold = TRUE
 	w_class = WEIGHT_CLASS_SMALL
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/game/objects/items/weapons/scissors.dm
+++ b/code/game/objects/items/weapons/scissors.dm
@@ -5,6 +5,9 @@
 	item_state = "scissor"
 	force = 5
 	sharp = 1
+	embed_chance = 25
+	embedded_fall_chance = 0
+	embedded_ignore_throwspeed_threshold = TRUE
 	w_class = WEIGHT_CLASS_SMALL
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("slices", "cuts", "stabs", "jabs")

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -180,8 +180,7 @@
 	force = 5
 	throwforce = 15
 	sharp = TRUE
-	embed_chance = 40
-	embedded_fall_chance = 15
+	embed_chance = 25
 	embedded_ignore_throwspeed_threshold = TRUE
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = SLOT_BACK
@@ -383,7 +382,6 @@
 	attack_verb = list("attacked", "poked", "jabbed", "torn", "gored")
 	sharp = TRUE
 	embed_chance = 50
-	embedded_fall_chance = 10
 	embedded_ignore_throwspeed_threshold = TRUE
 	no_spin_thrown = TRUE
 	var/obj/item/grenade/explosive = null
@@ -527,8 +525,7 @@
 	attack_verb = list("sawed", "cut", "hacked", "carved", "cleaved", "butchered", "felled", "timbered")
 	hitsound = "swing_hit"
 	sharp = TRUE
-	embed_chance = 20
-	embedded_fall_chance = 20
+	embed_chance = 10
 	embedded_ignore_throwspeed_threshold = TRUE
 	actions_types = list(/datum/action/item_action/startchainsaw)
 	var/on = FALSE
@@ -597,8 +594,7 @@
 	origin_tech = "materials=6;syndicate=4"
 	attack_verb = list("sawed", "cut", "hacked", "carved", "cleaved", "butchered", "felled", "timbered")
 	sharp = TRUE
-	embed_chance = 20
-	embedded_fall_chance = 20
+	embed_chance = 10
 	embedded_ignore_throwspeed_threshold = TRUE
 
 /obj/item/twohanded/chainsaw/update_icon()
@@ -896,7 +892,6 @@
 	attack_verb = list("attacked", "poked", "jabbed", "tore", "gored")
 	sharp = TRUE
 	embed_chance = 50
-	embedded_fall_chance = 5
 	embedded_ignore_throwspeed_threshold = TRUE
 
 /obj/item/twohanded/bamboospear/update_icon()

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -180,6 +180,9 @@
 	force = 5
 	throwforce = 15
 	sharp = TRUE
+	embed_chance = 40
+	embedded_fall_chance = 15
+	embedded_ignore_throwspeed_threshold = TRUE
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = SLOT_BACK
 	force_unwielded = 5
@@ -379,6 +382,9 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "poked", "jabbed", "torn", "gored")
 	sharp = TRUE
+	embed_chance = 50
+	embedded_fall_chance = 10
+	embedded_ignore_throwspeed_threshold = TRUE
 	no_spin_thrown = TRUE
 	var/obj/item/grenade/explosive = null
 	max_integrity = 200
@@ -521,6 +527,9 @@
 	attack_verb = list("sawed", "cut", "hacked", "carved", "cleaved", "butchered", "felled", "timbered")
 	hitsound = "swing_hit"
 	sharp = TRUE
+	embed_chance = 20
+	embedded_fall_chance = 20
+	embedded_ignore_throwspeed_threshold = TRUE
 	actions_types = list(/datum/action/item_action/startchainsaw)
 	var/on = FALSE
 
@@ -588,6 +597,9 @@
 	origin_tech = "materials=6;syndicate=4"
 	attack_verb = list("sawed", "cut", "hacked", "carved", "cleaved", "butchered", "felled", "timbered")
 	sharp = TRUE
+	embed_chance = 20
+	embedded_fall_chance = 20
+	embedded_ignore_throwspeed_threshold = TRUE
 
 /obj/item/twohanded/chainsaw/update_icon()
 	if(wielded)
@@ -883,6 +895,9 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "poked", "jabbed", "tore", "gored")
 	sharp = TRUE
+	embed_chance = 50
+	embedded_fall_chance = 5
+	embedded_ignore_throwspeed_threshold = TRUE
 
 /obj/item/twohanded/bamboospear/update_icon()
 	icon_state = "bamboo_spear[wielded]"

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -53,8 +53,7 @@
 	force = 40
 	throwforce = 10
 	sharp = 1
-	embed_chance = 40
-	embedded_fall_chance = 0
+	embed_chance = 20
 	embedded_ignore_throwspeed_threshold = TRUE
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
@@ -82,8 +81,7 @@
 	force = 40
 	throwforce = 10
 	sharp = 1
-	embed_chance = 40
-	embedded_fall_chance = 0
+	embed_chance = 20
 	embedded_ignore_throwspeed_threshold = TRUE
 	w_class = WEIGHT_CLASS_NORMAL
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -105,7 +103,6 @@
 	name = "harpoon"
 	sharp = 1
 	embed_chance = 70
-	embedded_fall_chance = 15
 	embedded_ignore_throwspeed_threshold = TRUE
 	desc = "Tharr she blows!"
 	icon_state = "harpoon"

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -53,6 +53,9 @@
 	force = 40
 	throwforce = 10
 	sharp = 1
+	embed_chance = 40
+	embedded_fall_chance = 0
+	embedded_ignore_throwspeed_threshold = TRUE
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	block_chance = 50
@@ -79,6 +82,9 @@
 	force = 40
 	throwforce = 10
 	sharp = 1
+	embed_chance = 40
+	embedded_fall_chance = 0
+	embedded_ignore_throwspeed_threshold = TRUE
 	w_class = WEIGHT_CLASS_NORMAL
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
@@ -98,6 +104,9 @@
 /obj/item/harpoon
 	name = "harpoon"
 	sharp = 1
+	embed_chance = 70
+	embedded_fall_chance = 15
+	embedded_ignore_throwspeed_threshold = TRUE
 	desc = "Tharr she blows!"
 	icon_state = "harpoon"
 	item_state = "harpoon"

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -147,6 +147,9 @@
 	attack_verb = list("stabbed", "slashed", "attacked")
 	var/icon/broken_outline = icon('icons/obj/drinks.dmi', "broken")
 	sharp = 1
+	embed_chance = 10
+	embedded_fall_chance = 0
+	embedded_ignore_throwspeed_threshold = TRUE
 
 /obj/item/broken_bottle/decompile_act(obj/item/matter_decompiler/C, mob/user)
 	C.stored_comms["glass"] += 3

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -148,7 +148,6 @@
 	var/icon/broken_outline = icon('icons/obj/drinks.dmi', "broken")
 	sharp = 1
 	embed_chance = 10
-	embedded_fall_chance = 0
 	embedded_ignore_throwspeed_threshold = TRUE
 
 /obj/item/broken_bottle/decompile_act(obj/item/matter_decompiler/C, mob/user)

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -93,7 +93,6 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharp = 1
 	embed_chance = 70
-	embedded_fall_chance = 10
 	embedded_ignore_throwspeed_threshold = TRUE
 
 /obj/item/hatchet/suicide_act(mob/user)
@@ -130,7 +129,6 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharp = 1
 	embed_chance = 15
-	embedded_fall_chance = 5
 	embedded_ignore_throwspeed_threshold = TRUE
 	var/extend = 1
 	var/swiping = FALSE

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -92,6 +92,9 @@
 	attack_verb = list("chopped", "torn", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharp = 1
+	embed_chance = 70
+	embedded_fall_chance = 10
+	embedded_ignore_throwspeed_threshold = TRUE
 
 /obj/item/hatchet/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is chopping at [user.p_them()]self with the [name]! It looks like [user.p_theyre()] trying to commit suicide.</span>")
@@ -126,6 +129,9 @@
 	attack_verb = list("chopped", "sliced", "cut", "reaped")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharp = 1
+	embed_chance = 15
+	embedded_fall_chance = 5
+	embedded_ignore_throwspeed_threshold = TRUE
 	var/extend = 1
 	var/swiping = FALSE
 

--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -15,8 +15,7 @@
 	var/list/digsound = list('sound/effects/picaxe1.ogg','sound/effects/picaxe2.ogg','sound/effects/picaxe3.ogg')
 	var/drill_verb = "picking"
 	sharp = 1
-	embed_chance = 25
-	embedded_fall_chance = 10
+	embed_chance = 15
 	embedded_ignore_throwspeed_threshold = TRUE
 	var/excavation_amount = 100
 	usesound = 'sound/effects/picaxe1.ogg'

--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -15,6 +15,9 @@
 	var/list/digsound = list('sound/effects/picaxe1.ogg','sound/effects/picaxe2.ogg','sound/effects/picaxe3.ogg')
 	var/drill_verb = "picking"
 	sharp = 1
+	embed_chance = 25
+	embedded_fall_chance = 10
+	embedded_ignore_throwspeed_threshold = TRUE
 	var/excavation_amount = 100
 	usesound = 'sound/effects/picaxe1.ogg'
 	toolspeed = 1

--- a/code/modules/mining/lavaland/loot/ashdragon_loot.dm
+++ b/code/modules/mining/lavaland/loot/ashdragon_loot.dm
@@ -35,6 +35,9 @@
 	w_class = WEIGHT_CLASS_BULKY
 	force = 1
 	throwforce = 1
+	embed_chance = 25
+	embedded_fall_chance = 0
+	embedded_ignore_throwspeed_threshold = TRUE
 	hitsound = 'sound/effects/ghost2.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "rended")
 	var/summon_cooldown = 0

--- a/code/modules/mining/lavaland/loot/ashdragon_loot.dm
+++ b/code/modules/mining/lavaland/loot/ashdragon_loot.dm
@@ -36,7 +36,6 @@
 	force = 1
 	throwforce = 1
 	embed_chance = 25
-	embedded_fall_chance = 0
 	embedded_ignore_throwspeed_threshold = TRUE
 	hitsound = 'sound/effects/ghost2.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "rended")

--- a/code/modules/ruins/lavalandruin_code/dead_ratvar.dm
+++ b/code/modules/ruins/lavalandruin_code/dead_ratvar.dm
@@ -255,7 +255,6 @@
 	armour_penetration = 10
 	sharp = TRUE
 	embed_chance = 70
-	embedded_fall_chance = 5
 	embedded_ignore_throwspeed_threshold = TRUE
 	attack_verb = list("stabbed", "poked", "slashed")
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/modules/ruins/lavalandruin_code/dead_ratvar.dm
+++ b/code/modules/ruins/lavalandruin_code/dead_ratvar.dm
@@ -254,6 +254,9 @@
 	throwforce = 25
 	armour_penetration = 10
 	sharp = TRUE
+	embed_chance = 70
+	embedded_fall_chance = 5
+	embedded_ignore_throwspeed_threshold = TRUE
 	attack_verb = list("stabbed", "poked", "slashed")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	w_class = WEIGHT_CLASS_BULKY

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -82,6 +82,9 @@
 	throwforce = 5.0
 	throw_speed = 3
 	throw_range = 5
+	embed_chance = 10
+	embedded_fall_chance = 0
+	embedded_ignore_throwspeed_threshold = TRUE
 	materials = list(MAT_METAL=4000, MAT_GLASS=1000)
 	origin_tech = "materials=1;biotech=1"
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
@@ -146,6 +149,9 @@
 	throwforce = 9.0
 	throw_speed = 3
 	throw_range = 5
+	embed_chance = 45
+	embedded_fall_chance = 5
+	embedded_ignore_throwspeed_threshold = TRUE
 	materials = list(MAT_METAL=10000, MAT_GLASS=6000)
 	origin_tech = "biotech=1;combat=1"
 	attack_verb = list("attacked", "slashed", "sawed", "cut")

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -83,7 +83,6 @@
 	throw_speed = 3
 	throw_range = 5
 	embed_chance = 10
-	embedded_fall_chance = 0
 	embedded_ignore_throwspeed_threshold = TRUE
 	materials = list(MAT_METAL=4000, MAT_GLASS=1000)
 	origin_tech = "materials=1;biotech=1"
@@ -149,8 +148,7 @@
 	throwforce = 9.0
 	throw_speed = 3
 	throw_range = 5
-	embed_chance = 45
-	embedded_fall_chance = 5
+	embed_chance = 20
 	embedded_ignore_throwspeed_threshold = TRUE
 	materials = list(MAT_METAL=10000, MAT_GLASS=6000)
 	origin_tech = "biotech=1;combat=1"


### PR DESCRIPTION
## Что делает этот ПР

Теперь острые предметы имеют шанс вонзиться в игрока при броске и нанести урон, зависящий от веса предмета, открыть кровотечение и выпасть с 5% шансом.

Шансы вонзиться в тело:
Arrhythmic Knife - 45%
Bamboo Spear - 50%
Broken Bottle - 10%
Claymore - 20%
Clown Dagger - 45%
Chainsaw - 10%
Fireaxe - 25%
Holy Claymore - 20%
Harpoon - 70%
Hatchet - 70%
Kitchen Knife - 45% (Combat и Survival - 90%)
Katana - 20%
Pickaxe - 15%
Reaper Scythe - 20%
Ratvarian Spear - 70%
Spectral Blade - 25%
Scythe - 15%
Scissors - 10%
Spear - 50%
Scalpel - 10%
Wirecutters - 5%

## Почему это хорошо для игры

https://clips.twitch.tv/SmoggyPolishedLasagnaRiPepperonis-QH1IkDboIBKh6lVp

## Changelog
:cl:
tweak: knife can be embed in player's body
tweak: combat knife has upper chances to be embedeed
tweak: more embeddable weapons
:cl:
