### PR TITLE
Feat: Emote refactor

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -169,6 +169,18 @@
 
 	log_emote(message, src)
 
+	// Coloring text for runechat
+	var/speaker_name = src.name
+	if(ishuman(src))
+		var/mob/living/carbon/human/H = src
+		speaker_name = H.GetVoice()
+
+	if(isobserver(src))
+		if(speaker_name != src.real_name && src.real_name)
+			speaker_name = "[src.real_name] ([speaker_name])"
+
+	colorize_name(src, speaker_name)
+
 	for(var/mob/M in GLOB.dead_mob_list)
 		if(!M.client)
 			continue //skip monkeys and leavers

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -188,7 +188,7 @@
 					continue
 				if(!M.has_vision(information_only=TRUE))
 					continue
-				to_chat(src, message)
+				to_chat(M, message)
 				if(M.client?.prefs.toggles2 & PREFTOGGLE_2_RUNECHAT)
 					M.create_chat_message(src, input, FALSE, TRUE, TRUE)
 			return 1
@@ -198,13 +198,14 @@
 					continue
 				if(!M.can_hear())
 					continue
-				if(stat == UNCONSCIOUS || (sleeping > 0 && stat != DEAD))
-					to_chat(src, "<I>... You can almost hear something ...</I>")
+				if(M.stat == UNCONSCIOUS || (M.sleeping > 0 && M.stat != DEAD))
+					to_chat(M, "<I>... You can almost hear something ...</I>")
 				else
-					to_chat(src, message)
+					to_chat(M, message)
 					if(M.client?.prefs.toggles2 & PREFTOGGLE_2_RUNECHAT)
 						M.create_chat_message(src, input, FALSE, TRUE, TRUE)
 
+			// Gives the ability to be heard by atoms(For example: recorder)
 			// based on say code
 			var/list/listening_obj = new
 			for(var/atom/movable/A in view(7, src))

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -160,3 +160,62 @@
 
 			else if(M.stat == DEAD && M.get_preference(PREFTOGGLE_CHAT_DEAD)) // Show the emote to regular ghosts with deadchat toggled on
 				M.show_message(message, 2)
+
+/mob/proc/show_emote(var/m_type = EMOTE_VISUAL, var/input = null)
+	if(!input)
+		return
+
+	var/message = "<B>[src]</b> [input]"
+
+	log_emote(message, src)
+
+	for(var/mob/M in GLOB.dead_mob_list)
+		if(!M.client)
+			continue //skip monkeys and leavers
+
+		if(isnewplayer(M))
+			continue
+
+		if(isobserver(M) && M.get_preference(PREFTOGGLE_CHAT_GHOSTSIGHT) && !(M in viewers(src, null)) && client) // The client check makes sure people with ghost sight don't get spammed by simple mobs emoting.
+			M.show_message(message)
+
+	switch(m_type)
+		if(EMOTE_VISUAL) //Visible
+			for(var/mob/M in get_mobs_in_view(7, src))
+				if(!M.client)
+					continue
+				if(M.see_invisible < invisibility)
+					continue
+				if(!M.has_vision(information_only=TRUE))
+					continue
+				to_chat(src, message)
+				if(M.client?.prefs.toggles2 & PREFTOGGLE_2_RUNECHAT)
+					M.create_chat_message(src, input, FALSE, TRUE, TRUE)
+			return 1
+		if(EMOTE_SOUND) //Audible
+			for(var/mob/M in get_mobs_in_view(7, src))
+				if(!M.client)
+					continue
+				if(!M.can_hear())
+					continue
+				if(stat == UNCONSCIOUS || (sleeping > 0 && stat != DEAD))
+					to_chat(src, "<I>... You can almost hear something ...</I>")
+				else
+					to_chat(src, message)
+					if(M.client?.prefs.toggles2 & PREFTOGGLE_2_RUNECHAT)
+						M.create_chat_message(src, input, FALSE, TRUE, TRUE)
+
+			// based on say code
+			var/list/listening_obj = new
+			for(var/atom/movable/A in view(7, src))
+				if(istype(A, /mob))
+					var/mob/M = A
+					for(var/obj/O in M.contents)
+						listening_obj |= O
+				else if(istype(A, /obj))
+					var/obj/O = A
+					listening_obj |= O
+			for(var/obj/O in listening_obj)
+				O.hear_message(src, input)
+			return 1
+	return

--- a/code/modules/mob/living/carbon/alien/humanoid/emote.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/emote.dm
@@ -29,102 +29,99 @@
 		return
 
 	switch(act)
-
-
-
 		if("sign")
 			if(!restrained())
 				var/num = null
 				if(text2num(param))
 					num = "the number [text2num(param)]"
 				if(num)
-					message = "<B>\The [src]</B> signs [num]."
+					message = "signs [num]."
 					m_type = 1
 		if("burp")
 			if(!muzzled)
-				message = "<B>\The [src]</B> burps."
+				message = "burps."
 				m_type = 2
 		if("deathgasp")
-			message = "<B>\The [src]</B> lets out a waning guttural screech, green blood bubbling from its maw..."
+			message = "lets out a waning guttural screech, green blood bubbling from its maw..."
 			m_type = 2
 		if("scratch")
 			if(!restrained())
-				message = "<B>\The [src]</B> scratches."
+				message = "scratches."
 				m_type = 1
 		if("whimper")
 			if(!muzzled)
-				message = "<B>\The [src]</B> whimpers."
+				message = "whimpers."
 				m_type = 2
 		if("roar")
 			if(!muzzled)
-				message = "<B>\The [src]</B> roars."
+				message = "roars."
 				m_type = 2
 		if("hiss")
 			if(!muzzled)
-				message = "<B>\The [src]</B> hisses."
+				message = "hisses."
 				m_type = 2
 		if("tail")
-			message = "<B>\The [src]</B> waves its tail."
+			message = "waves its tail."
 			m_type = 1
 		if("gasp")
-			message = "<B>\The [src]</B> gasps."
+			message = "gasps."
 			m_type = 2
 		if("shiver")
-			message = "<B>\The [src]</B> shivers."
+			message = "shivers."
 			m_type = 2
 		if("drool")
-			message = "<B>\The [src]</B> drools."
+			message = "drools."
 			m_type = 1
 		if("scretch")
 			if(!muzzled)
-				message = "<B>\The [src]</B> scretches."
+				message = "scretches."
 				m_type = 2
 		if("choke")
-			message = "<B>\The [src]</B> chokes."
+			message = "chokes."
 			m_type = 2
 		if("moan")
-			message = "<B>\The [src]</B> moans!"
+			message = "moans!"
 			m_type = 2
 		if("nod")
-			message = "<B>\The [src]</B> nods its head."
+			message = "nods its head."
 			m_type = 1
 		if("sit")
-			message = "<B>\The [src]</B> sits down."
+			message = "sits down."
 			m_type = 1
 		if("sway")
-			message = "<B>\The [src]</B> sways around dizzily."
+			message = "sways around dizzily."
 			m_type = 1
 		if("sulk")
-			message = "<B>\The [src]</B> sulks down sadly."
+			message = "sulks down sadly."
 			m_type = 1
 		if("twitch")
-			message = "<B>\The [src]</B> twitches violently."
+			message = "twitches violently."
 			m_type = 1
 		if("dance")
 			if(!restrained())
-				message = "<B>\The [src]</B> dances around happily."
+				message = "dances around happily."
 				m_type = 1
 		if("roll")
 			if(!restrained())
-				message = "<B>\The [src]</B> rolls."
+				message = "rolls."
 				m_type = 1
 		if("shake")
-			message = "<B>\The [src]</B> shakes its head."
+			message = "shakes its head."
 			m_type = 1
 		if("gnarl")
 			if(!muzzled)
-				message = "<B>\The [src]</B> gnarls and shows its teeth.."
+				message = "gnarls and shows its teeth.."
 				m_type = 2
 		if("jump")
-			message = "<B>\The [src]</B> jumps!"
+			message = "jumps!"
 			m_type = 1
 		if("collapse")
 			Paralyse(2)
-			message = "<B>\The [src]</B> collapses!"
+			message = "collapses!"
 			m_type = 2
 		if("flip")
 			m_type = 1
-			message = "<B>\The [src]</B> does a flip!"
+			message = "does a flip!"
 			SpinAnimation(5,1)
 		if("help")
 			to_chat(src, "burp, flip, deathgasp, choke, collapse, dance, drool, gasp, shiver, gnarl, jump, moan, nod, roar, roll, scratch,\nscretch, shake, sign-#, sit, sulk, sway, tail, twitch, whimper")

--- a/code/modules/mob/living/carbon/alien/larva/emote.dm
+++ b/code/modules/mob/living/carbon/alien/larva/emote.dm
@@ -107,7 +107,7 @@
 			m_type = 1
 		if("collapse")
 			Paralyse(2)
-			message = text("collapses!", src)
+			message = "collapses!"
 			m_type = 2
 		if("help")
 			to_chat(src, "burp, choke, collapse, dance, drool, gasp, shiver, gnarl, jump, moan, nod, roll, scratch,\nscretch, shake, sign-#, sulk, sway, tail, twitch, whimper")

--- a/code/modules/mob/living/carbon/alien/larva/emote.dm
+++ b/code/modules/mob/living/carbon/alien/larva/emote.dm
@@ -29,85 +29,85 @@
 			return custom_emote(m_type, message)
 		if("sign")
 			if(!src.restrained())
-				message = text("<B>The alien</B> signs[].", (text2num(param) ? text(" the number []", text2num(param)) : null))
+				message = text("signs[].", (text2num(param) ? text(" the number []", text2num(param)) : null))
 				m_type = 1
 		if("burp")
 			if(!muzzled)
-				message = "<B>[src]</B> burps."
+				message = "burps."
 				m_type = 2
 		if("scratch")
 			if(!src.restrained())
-				message = "<B>The [src.name]</B> scratches."
+				message = "scratches."
 				m_type = 1
 		if("whimper")
 			if(!muzzled)
-				message = "<B>The [src.name]</B> whimpers."
+				message = "whimpers."
 				m_type = 2
 //		if("roar")
 //			if(!muzzled)
-//				message = "<B>The [src.name]</B> roars." Commenting out since larva shouldn't roar /N
+//				message = "roars." Commenting out since larva shouldn't roar /N
 //				m_type = 2
 		if("tail")
-			message = "<B>The [src.name]</B> waves its tail."
+			message = "waves its tail."
 			m_type = 1
 		if("gasp")
-			message = "<B>The [src.name]</B> gasps."
+			message = "gasps."
 			m_type = 2
 		if("shiver")
-			message = "<B>The [src.name]</B> shivers."
+			message = "shivers."
 			m_type = 2
 		if("drool")
-			message = "<B>The [src.name]</B> drools."
+			message = "drools."
 			m_type = 1
 		if("scretch")
 			if(!muzzled)
-				message = "<B>The [src.name]</B> scretches."
+				message = "scretches."
 				m_type = 2
 		if("choke")
-			message = "<B>The [src.name]</B> chokes."
+			message = "chokes."
 			m_type = 2
 		if("moan")
-			message = "<B>The [src.name]</B> moans!"
+			message = "moans!"
 			m_type = 2
 		if("nod")
-			message = "<B>The [src.name]</B> nods its head."
+			message = "nods its head."
 			m_type = 1
 //		if("sit")
-//			message = "<B>The [src.name]</B> sits down." //Larvan can't sit down, /N
+//			message = "sits down." //Larvan can't sit down, /N
 //			m_type = 1
 		if("sway")
-			message = "<B>The [src.name]</B> sways around dizzily."
+			message = "sways around dizzily."
 			m_type = 1
 		if("sulk")
-			message = "<B>The [src.name]</B> sulks down sadly."
+			message = "sulks down sadly."
 			m_type = 1
 		if("twitch")
-			message = "<B>The [src.name]</B> twitches violently."
+			message = "twitches violently."
 			m_type = 1
 		if("dance")
 			if(!src.restrained())
-				message = "<B>The [src.name]</B> dances around happily."
+				message = "dances around happily."
 				m_type = 1
 		if("roll")
 			if(!src.restrained())
-				message = "<B>The [src.name]</B> rolls."
+				message = "rolls."
 				m_type = 1
 		if("shake")
-			message = "<B>The [src.name]</B> shakes its head."
+			message = "shakes its head."
 			m_type = 1
 		if("gnarl")
 			if(!muzzled)
-				message = "<B>The [src.name]</B> gnarls and shows its teeth.."
+				message = "gnarls and shows its teeth.."
 				m_type = 2
 		if("jump")
-			message = "<B>The [src.name]</B> jumps!"
+			message = "jumps!"
 			m_type = 1
 		if("hiss_")
-			message = "<B>The [src.name]</B> hisses softly."
+			message = "hisses softly."
 			m_type = 1
 		if("collapse")
 			Paralyse(2)
-			message = text("<B>[]</B> collapses!", src)
+			message = text("collapses!", src)
 			m_type = 2
 		if("help")
 			to_chat(src, "burp, choke, collapse, dance, drool, gasp, shiver, gnarl, jump, moan, nod, roll, scratch,\nscretch, shake, sign-#, sulk, sway, tail, twitch, whimper")

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -1053,13 +1053,7 @@
 			to_chat(src, emotelist)
 		else
 			to_chat(src, "<span class='notice'>Неизвестный эмоут '[act]'. Введи *help для отображения списка.</span>")
-
-	if(message) //Humans are special fucking snowflakes and have 800 lines of emotes, they get to handle their own emotes, not call the parent.
-		switch(m_type)
-			if(1)
-				custom_emote(EMOTE_VISUAL, message)
-			if(2)
-				custom_emote(EMOTE_SOUND, message)
+	..()
 
 /mob/living/carbon/human/verb/pose()
 	set name = "Set Pose"

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -341,25 +341,7 @@ GLOBAL_LIST_EMPTY(channel_to_radio_key)
 		return 1
 
 	if(act && type && message) //parent call
-		log_emote(message, src)
-
-		for(var/mob/M in GLOB.dead_mob_list)
-			if(!M.client)
-				continue //skip monkeys and leavers
-
-			if(isnewplayer(M))
-				continue
-
-			if(isobserver(M) && M.get_preference(PREFTOGGLE_CHAT_GHOSTSIGHT) && !(M in viewers(src, null)) && client) // The client check makes sure people with ghost sight don't get spammed by simple mobs emoting.
-				M.show_message(message)
-
-		switch(type)
-			if(1) //Visible
-				visible_message(message)
-				return 1
-			if(2) //Audible
-				audible_message(message)
-				return 1
+		show_emote(type, message)
 
 	else //everything else failed, emote is probably invalid
 		if(act == "help")

--- a/code/modules/mob/living/silicon/emote.dm
+++ b/code/modules/mob/living/silicon/emote.dm
@@ -28,49 +28,49 @@
 		if("ping","pings")
 			var/M = handle_emote_param(param)
 
-			message = "<B>[src]</B> pings[M ? " at [M]" : ""]."
+			message = "pings[M ? " at [M]" : ""]."
 			playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)
 			m_type = 2
 
 		if("buzz","buzzs","buzzes")
 			var/M = handle_emote_param(param)
 
-			message = "<B>[src]</B> buzzes[M ? " at [M]" : ""]."
+			message = "buzzes[M ? " at [M]" : ""]."
 			playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
 			m_type = 2
 
 		if("beep","beeps")
 			var/M = handle_emote_param(param)
 
-			message = "<B>[src]</B> beeps[M ? " at [M]" : ""]."
+			message = "beeps[M ? " at [M]" : ""]."
 			playsound(src.loc, 'sound/machines/twobeep.ogg', 50, 0)
 			m_type = 2
 
 		if("yes")
 			var/M = handle_emote_param(param)
 
-			message = "<B>[src]</B> emits an affirmative blip[M ? " at [M]" : ""]."
+			message = "emits an affirmative blip[M ? " at [M]" : ""]."
 			playsound(src.loc, 'sound/machines/synth_yes.ogg', 50, 0)
 			m_type = 2
 
 		if("no")
 			var/M = handle_emote_param(param)
 
-			message = "<B>[src]</B> emits a negative blip[M ? " at [M]" : ""]."
+			message = "emits a negative blip[M ? " at [M]" : ""]."
 			playsound(src.loc, 'sound/machines/synth_no.ogg', 50, 0)
 			m_type = 2
 
 		if("scream", "screams")
 			var/M = handle_emote_param(param)
 
-			message = "<B>[src]</B> screams[M ? " at [M]" : ""]!"
+			message = "screams[M ? " at [M]" : ""]!"
 			playsound(src.loc, 'sound/goonstation/voice/robot_scream.ogg', 80, 0)
 			m_type = 2
 
 		if("buzz2")
 			var/M = handle_emote_param(param)
 
-			message = "<B>[src]</B> emits an irritated buzzing sound[M ? " at [M]" : ""]."
+			message = "emits an irritated buzzing sound[M ? " at [M]" : ""]."
 			playsound(src.loc, 'sound/machines/buzz-two.ogg', 50, 0)
 			m_type = 2
 

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -35,9 +35,9 @@
 					param = null
 
 				if(param)
-					message = "<B>[src]</B> salutes to [param]."
+					message = "salutes to [param]."
 				else
-					message = "<B>[src]</b> salutes."
+					message = "salutes."
 			m_type = 1
 		if("bow","bows")
 			if(!src.buckled)
@@ -51,39 +51,39 @@
 					param = null
 
 				if(param)
-					message = "<B>[src]</B> bows to [param]."
+					message = "bows to [param]."
 				else
-					message = "<B>[src]</B> bows."
+					message = "bows."
 			m_type = 1
 
 		if("clap","claps")
 			if(!src.restrained())
-				message = "<B>[src]</B> claps."
+				message = "claps."
 				m_type = 2
 		if("flap","flaps")
 			if(!src.restrained())
-				message = "<B>[src]</B> flaps its wings."
+				message = "flaps its wings."
 				m_type = 2
 
 		if("aflap","aflaps")
 			if(!src.restrained())
-				message = "<B>[src]</B> flaps its wings ANGRILY!"
+				message = "flaps its wings ANGRILY!"
 				m_type = 2
 
 		if("twitch")
-			message = "<B>[src]</B> twitches violently."
+			message = "twitches violently."
 			m_type = 1
 
 		if("twitch_s","twitches")
-			message = "<B>[src]</B> twitches."
+			message = "twitches."
 			m_type = 1
 
 		if("nod","nods")
-			message = "<B>[src]</B> nods."
+			message = "nods."
 			m_type = 1
 
 		if("deathgasp")
-			message = "<B>[src]</B> shudders violently for a moment, then becomes motionless, its eyes slowly darkening."
+			message = "shudders violently for a moment, then becomes motionless, its eyes slowly darkening."
 			m_type = 1
 
 		if("glare","glares")
@@ -97,9 +97,9 @@
 				param = null
 
 			if(param)
-				message = "<B>[src]</B> glares at [param]."
+				message = "glares at [param]."
 			else
-				message = "<B>[src]</B> glares."
+				message = "glares."
 
 		if("stare","stares")
 			var/M = null
@@ -112,9 +112,9 @@
 				param = null
 
 			if(param)
-				message = "<B>[src]</B> stares at [param]."
+				message = "stares at [param]."
 			else
-				message = "<B>[src]</B> stares."
+				message = "stares."
 
 		if("look","looks")
 			var/M = null
@@ -128,15 +128,15 @@
 				param = null
 
 			if(param)
-				message = "<B>[src]</B> looks at [param]."
+				message = "looks at [param]."
 			else
-				message = "<B>[src]</B> looks."
+				message = "looks."
 			m_type = 1
 
 
 		if("law")
 			if(istype(module,/obj/item/robot_module/security))
-				message = "<B>[src]</B> shows its legal authorization barcode."
+				message = "shows its legal authorization barcode."
 
 				playsound(src.loc, 'sound/voice/biamthelaw.ogg', 50, 0)
 				m_type = 2
@@ -145,7 +145,7 @@
 
 		if("halt")
 			if(istype(module,/obj/item/robot_module/security))
-				message = "<B>[src]</B>'s speakers skreech, \"Halt! Security!\"."
+				message = "'s speakers skreech, \"Halt! Security!\"."
 
 				playsound(src.loc, 'sound/voice/halt.ogg', 50, 0)
 				m_type = 2
@@ -154,7 +154,7 @@
 
 		if("flip","flips")
 			m_type = 1
-			message = "<B>[src]</B> does a flip!"
+			message = "does a flip!"
 			src.SpinAnimation(5,1)
 
 		if("help")

--- a/code/modules/mob/living/simple_animal/bot/emote.dm
+++ b/code/modules/mob/living/simple_animal/bot/emote.dm
@@ -30,42 +30,42 @@
 		if("ping")
 			var/M = handle_emote_param(param)
 
-			message = "<B>[src]</B> pings[M ? " at [M]" : ""]."
+			message = "pings[M ? " at [M]" : ""]."
 			playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)
 			m_type = 2
 
 		if("buzz")
 			var/M = handle_emote_param(param)
 
-			message = "<B>[src]</B> buzzes[M ? " at [M]" : ""]."
+			message = "buzzes[M ? " at [M]" : ""]."
 			playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
 			m_type = 2
 
 		if("beep")
 			var/M = handle_emote_param(param)
 
-			message = "<B>[src]</B> beeps[M ? " at [M]" : ""]."
+			message = "beeps[M ? " at [M]" : ""]."
 			playsound(src.loc, 'sound/machines/twobeep.ogg', 50, 0)
 			m_type = 2
 
 		if("yes")
 			var/M = handle_emote_param(param)
 
-			message = "<B>[src]</B> emits an affirmative blip[M ? " at [M]" : ""]."
+			message = "emits an affirmative blip[M ? " at [M]" : ""]."
 			playsound(src.loc, 'sound/machines/synth_yes.ogg', 50, 0)
 			m_type = 2
 
 		if("no")
 			var/M = handle_emote_param(param)
 
-			message = "<B>[src]</B> emits an negative blip[M ? " at [M]" : ""]."
+			message = "emits an negative blip[M ? " at [M]" : ""]."
 			playsound(src.loc, 'sound/machines/synth_no.ogg', 50, 0)
 			m_type = 2
 
 		if("scream", "screams")
 			var/M = handle_emote_param(param)
 
-			message = "<B>[src]</B> screams[M ? " at [M]" : ""]!"
+			message = "screams[M ? " at [M]" : ""]!"
 			playsound(src.loc, 'sound/goonstation/voice/robot_scream.ogg', 80, 0)
 			m_type = 2
 

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -172,14 +172,14 @@
 
 	switch(act)
 		if("meow")
-			message = "<B>[src]</B> [pick(emote_hear)]!"
+			message = "[pick(emote_hear)]!"
 			m_type = 2 //audible
 			playsound(src, meow_sound, 50, 0.75)
 		if("hiss")
-			message = "<B>[src]</B> hisses!"
+			message = "hisses!"
 			m_type = 2
 		if("purr")
-			message = "<B>[src]</B> purrs."
+			message = "purrs."
 			m_type = 2
 		if("help")
 			to_chat(src, "scream, meow, hiss, purr")

--- a/code/modules/mob/living/simple_animal/friendly/diona.dm
+++ b/code/modules/mob/living/simple_animal/friendly/diona.dm
@@ -291,7 +291,7 @@
 
 	switch(act) //IMPORTANT: Emotes MUST NOT CONFLICT anywhere along the chain.
 		if("chirp")
-			message = "<B>\The [src]</B> chirps!"
+			message = "chirps!"
 			m_type = 2 //audible
 			playsound(src, chirp_sound, 40, 1, 1)
 		if("help")

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -55,15 +55,15 @@
 
 	switch(act)
 		if("bark")
-			message = "<B>[src]</B> [pick(src.speak_emote)]!"
+			message = "[pick(src.speak_emote)]!"
 			m_type = 2 //audible
 			playsound(src, pick(src.bark_sound), 50, TRUE)
 		if("yelp")
-			message = "<B>[src]</B> yelps!"
+			message = "yelps!"
 			m_type = 2 //audible
 			playsound(src, yelp_sound, 75, TRUE)
 		if("growl")
-			message = "<B>[src]</B> growls!"
+			message = "growls!"
 			m_type = 2 //audible
 		if("help")
 			to_chat(src, "scream, bark, growl")

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -135,7 +135,7 @@
 
 	switch(act)
 		if("squeak")
-			message = "<B>\The [src]</B> [pick(emote_hear)]!"
+			message = "[pick(emote_hear)]!"
 			m_type = 2 //audible
 			playsound(src, squeak_sound, 40, 1)
 		if("help")

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -309,7 +309,7 @@
 	act = lowertext(act)
 	switch(act) //IMPORTANT: Emotes MUST NOT CONFLICT anywhere along the chain.
 		if("scream")
-			message = "<B>\The [src]</B> whimpers."
+			message = "whimpers."
 			m_type = 2
 		if("help")
 			to_chat(src, "scream")


### PR DESCRIPTION
## What Does This PR Do
Удаляет все [src] в начале сообщений эмоутов и добавляет функцию show_emote, задача которой - отправка эмоута всем рядом с поддержкой рунчата. Эмоуты людей теперь также передают сообщение в родительский метод.

## Why It's Good For The Game
Правит некоторые баги связанные с эмоутами людей, добавляет рунчат всем остальным существам(кроме слизней).

## Images of changes
![image](https://user-images.githubusercontent.com/59798256/143393690-8a57880b-aba9-4b19-b5d2-203c80c9f9a0.png)
![image](https://user-images.githubusercontent.com/59798256/143393706-f76b7679-88d7-4aac-b8c8-c8cde8e0dd19.png)
![image](https://user-images.githubusercontent.com/59798256/143394673-6bf25f39-eded-4bb3-bc7b-7705f2efcf57.png)

