### PR TITLE
Feat: Заполняемая барменская бочка с пивом

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -244,11 +244,28 @@
 	desc = "Beer is liquid bread, it's good for you..."
 	icon_state = "beer"
 	reagent_id = "beer"
+	var/has_lid = TRUE
 
 /obj/structure/reagent_dispensers/beerkeg/blob_act(obj/structure/blob/B)
 	explosion(loc, 0, 3, 5, 7, 10)
 	if(!QDELETED(src))
 		qdel(src)
+
+/obj/structure/reagent_dispensers/beerkeg/proc/add_lid()
+		container_type = DRAINABLE | AMOUNT_VISIBLE
+		has_lid = TRUE
+
+/obj/structure/reagent_dispensers/beerkeg/proc/remove_lid()
+		container_type = REFILLABLE | AMOUNT_VISIBLE
+		has_lid = FALSE
+
+/obj/structure/reagent_dispensers/beerkeg/attack_hand(mob/user)
+	if(has_lid)
+		to_chat(usr, "<span class='notice'>You take the lid off [src].</span>")
+		remove_lid()
+	else
+		to_chat(usr, "<span class='notice'>You put the lid on [src].</span>")
+		add_lid()
 
 /obj/structure/reagent_dispensers/beerkeg/nuke
 	name = "Nanotrasen-brand nuclear fission explosive"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Теперь кегу с пивом можно использовать как бочку объемом 1000 юнитов для смешивания напитков или хим реагентов.
На старте кега наполнена пивом, как и раньше.
У кеги теперь есть крышка через которую её можно заполнять различными веществами. 
Открутить или закрутить крышку можно рукой по аналогии с бутылкой, только здесь крышка нужна чтобы добавлять что-то в кегу, а не выливать оттуда.


## Why It's Good For The Game
Ссылка на обсуждение из "отчеты-по-предложениям"
https://discord.com/channels/617003227182792704/755125334097133628/914440220949225522

## Changelog
Feat: beerkeg can be Refillable


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
