### PR TITLE
fix: changeling can not humanize if monkeyized using DNA-Injector #458

### DIFF
--- a/code/game/gamemodes/changeling/powers/humanform.dm
+++ b/code/game/gamemodes/changeling/powers/humanform.dm
@@ -7,23 +7,29 @@
 	req_dna = 1
 	max_genetic_damage = 3
 
-//Transform into a human.
+// Transform into a human.
 /datum/action/changeling/humanform/sting_action(var/mob/living/carbon/human/user)
-	var/datum/changeling/changeling = user.mind.changeling
-	var/list/names = list()
-	for(var/datum/dna/DNA in (changeling.absorbed_dna+changeling.protected_dna))
-		names += "[DNA.real_name]"
-
-	var/chosen_name = input("Select the target DNA: ", "Target DNA", null) as null|anything in names
-	if(!chosen_name)
-		return
-
-	var/datum/dna/chosen_dna = changeling.GetDNA(chosen_name)
-	if(!chosen_dna)
-		return
 	if(!user)
 		return 0
+
+	var/datum/changeling/changeling = user.mind.changeling
+
+	// If you're human already, you can't use it.
+	if(!istype(user) || !user.dna.species.greater_form)
+		to_chat(user, "<span class='warning'>We cannot perform this ability in this form!</span>")
+		return
+
+	// DNA Selector
+	var/datum/dna/chosen_dna = changeling.select_dna("Select the target DNA: ", "Target DNA")
+
+	if(!chosen_dna)
+		return
+
+	// Notify players about transform.
+	user.visible_message("<span class='warning'>[user] transforms!</span>")
+
 	to_chat(user, "<span class='notice'>We transform our appearance.</span>")
+
 	user.dna.SetSEState(GLOB.monkeyblock,0,1)
 	genemutcheck(user,GLOB.monkeyblock,null,MUTCHK_FORCED)
 	if(istype(user))
@@ -37,8 +43,8 @@
 	user.sync_organ_dna(1)
 	user.UpdateAppearance()
 
-	changeling.purchasedpowers -= src
+	//changeling.purchasedpowers -= src // no longer needed as humanform now persistent.
 	//O.mind.changeling.purchasedpowers += new /datum/action/changeling/lesserform(null)
-	src.Remove(user)
+	//src.Remove(user) // no longer needed as humanform now persistent.
 	SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]"))
 	return 1

--- a/code/game/gamemodes/changeling/powers/lesserform.dm
+++ b/code/game/gamemodes/changeling/powers/lesserform.dm
@@ -8,29 +8,40 @@
 	genetic_damage = 3
 	req_human = 1
 
-//Transform into a monkey.
+// Transform into a monkey.
 /datum/action/changeling/lesserform/sting_action(var/mob/living/carbon/human/user)
-	var/datum/changeling/changeling = user.mind.changeling
 	if(!user)
 		return 0
+
+	var/datum/changeling/changeling = user.mind.changeling
+
 	if(user.has_brain_worms())
 		to_chat(user, "<span class='warning'>We cannot perform this ability at the present time!</span>")
 		return
 
-	var/mob/living/carbon/human/H = user
-
-	if(!istype(H) || !H.dna.species.primitive_form)
-		to_chat(H, "<span class='warning'>We cannot perform this ability in this form!</span>")
+	if(!istype(user) || !user.dna.species.primitive_form)
+		to_chat(user, "<span class='warning'>We cannot perform this ability in this form!</span>")
 		return
 
-	H.visible_message("<span class='warning'>[H] transforms!</span>")
+	user.visible_message("<span class='warning'>[user] transforms!</span>")
+
+	// Add genetic damage to add cooldown.
 	changeling.geneticdamage = 30
-	to_chat(H, "<span class='warning'>Our genes cry out!</span>")
-	H.monkeyize()
+
+	to_chat(user, "<span class='warning'>Our genes cry out!</span>")
+	user.monkeyize()
+
+	SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]"))
+	return 1
+
+
+// Grant human form on purchase. Required to humanize if monkeyized using DNA-Injector.
+/datum/action/changeling/lesserform/on_purchase(var/mob/user)
+	..()
+	var/datum/changeling/changeling = user.mind.changeling
 
 	var/datum/action/changeling/humanform/HF = new
 	changeling.purchasedpowers += HF
 	HF.Grant(user)
 
-	SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]"))
-	return 1
+	return

--- a/code/game/gamemodes/changeling/powers/transform.dm
+++ b/code/game/gamemodes/changeling/powers/transform.dm
@@ -10,7 +10,13 @@
 
 //Change our DNA to that of somebody we've absorbed.
 /datum/action/changeling/transform/sting_action(var/mob/living/carbon/human/user)
+	if(!user)
+		return 0
+
 	var/datum/changeling/changeling = user.mind.changeling
+
+	// DNA Selector.
+	// DNA is referenced directly here (careful). Changing DNA stats here will change stored DNA as well.
 	var/datum/dna/chosen_dna = changeling.select_dna("Select the target DNA: ", "Target DNA")
 
 	if(!chosen_dna)
@@ -28,8 +34,9 @@
 	for(var/datum/dna/DNA in (absorbed_dna+protected_dna))
 		names += "[DNA.real_name]"
 
-	var/chosen_name = input(prompt, title, null) as null|anything in names
+	var/chosen_name = input(prompt, title, null) as null|anything in sortList(names)
 	if(!chosen_name)
 		return
+
 	var/datum/dna/chosen_dna = GetDNA(chosen_name)
 	return chosen_dna

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -1,7 +1,28 @@
 /mob/living/carbon/human/proc/monkeyize()
 	var/mob/H = src
-	H.dna.SetSEState(GLOB.monkeyblock,1)
-	genemutcheck(H,GLOB.monkeyblock,null,MUTCHK_FORCED)
+
+	if (!H.dna.GetSEState(GLOB.monkeyblock)) // Monkey block NOT present.
+		H.dna.SetSEState(GLOB.monkeyblock,1)
+		genemutcheck(H,GLOB.monkeyblock,null,MUTCHK_FORCED)
+
+/mob/living/carbon/human/proc/is_monkeyized()
+	var/mob/H = src
+	if (H.dna.GetSEState(GLOB.monkeyblock))
+		return TRUE
+	return FALSE
+
+/mob/living/carbon/human/proc/humanize()
+	var/mob/H = src
+
+	if (H.dna.GetSEState(GLOB.monkeyblock)) // Monkey block present.
+		H.dna.SetSEState(GLOB.monkeyblock,0)
+		genemutcheck(H,GLOB.monkeyblock,null,MUTCHK_FORCED)
+
+/mob/living/carbon/human/proc/is_humanized()
+	var/mob/H = src
+	if (H.dna.GetSEState(GLOB.monkeyblock))
+		return FALSE
+	return TRUE
 
 /mob/new_player/AIize()
 	spawning = 1

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -4,9 +4,7 @@
 		genemutcheck(src,GLOB.monkeyblock,null,MUTCHK_FORCED)
 
 /mob/living/carbon/human/proc/is_monkeyized()
-	if (dna.GetSEState(GLOB.monkeyblock))
-		return TRUE
-	return FALSE
+	return dna.GetSEState(GLOB.monkeyblock)
 
 /mob/living/carbon/human/proc/humanize()
 	if (dna.GetSEState(GLOB.monkeyblock)) // Monkey block present.
@@ -14,9 +12,7 @@
 		genemutcheck(src,GLOB.monkeyblock,null,MUTCHK_FORCED)
 
 /mob/living/carbon/human/proc/is_humanized()
-	if (dna.GetSEState(GLOB.monkeyblock))
-		return FALSE
-	return TRUE
+	return !dna.GetSEState(GLOB.monkeyblock)
 
 /mob/new_player/AIize()
 	spawning = 1

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -1,26 +1,20 @@
 /mob/living/carbon/human/proc/monkeyize()
-	var/mob/H = src
-
-	if (!H.dna.GetSEState(GLOB.monkeyblock)) // Monkey block NOT present.
-		H.dna.SetSEState(GLOB.monkeyblock,1)
-		genemutcheck(H,GLOB.monkeyblock,null,MUTCHK_FORCED)
+	if (!dna.GetSEState(GLOB.monkeyblock)) // Monkey block NOT present.
+		dna.SetSEState(GLOB.monkeyblock,1)
+		genemutcheck(src,GLOB.monkeyblock,null,MUTCHK_FORCED)
 
 /mob/living/carbon/human/proc/is_monkeyized()
-	var/mob/H = src
-	if (H.dna.GetSEState(GLOB.monkeyblock))
+	if (dna.GetSEState(GLOB.monkeyblock))
 		return TRUE
 	return FALSE
 
 /mob/living/carbon/human/proc/humanize()
-	var/mob/H = src
-
-	if (H.dna.GetSEState(GLOB.monkeyblock)) // Monkey block present.
-		H.dna.SetSEState(GLOB.monkeyblock,0)
-		genemutcheck(H,GLOB.monkeyblock,null,MUTCHK_FORCED)
+	if (dna.GetSEState(GLOB.monkeyblock)) // Monkey block present.
+		dna.SetSEState(GLOB.monkeyblock,0)
+		genemutcheck(src,GLOB.monkeyblock,null,MUTCHK_FORCED)
 
 /mob/living/carbon/human/proc/is_humanized()
-	var/mob/H = src
-	if (H.dna.GetSEState(GLOB.monkeyblock))
+	if (dna.GetSEState(GLOB.monkeyblock))
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

**humanform.dm:**

- Больше не просит превратиться в человека и др, если вы НЕ находитесь в их меньшей форме.
- Абилка больше не удаляется при использовании (она постоянна и требуется для исправления бага).
- Удален код "SelectDNA", так как он дублирует метод select_dna в transform.dm.

**lesserform.dm:**

- Дает абилку "Human form" сразу при покупке, а не при активации.
(теперь ее можно было использовать, если обезьяна превратится в человека с помощью инжектора ДНК).
- Удалена лишняя переменная "var/mob/living/carbon/human/H = user", так как можно использовать "var/mob/living/carbon/human/user" напрямую.

**transform_procs.dm:**

- Метод monkeyize теперь проверяет, существует ли вообще блок monkey, чтобы избежать вызова "genemutcheck", когда это не требуется.
- Добавлен метод humanize, а также проверки is_monkeized и is_humanized для дальнейшего использования позже.

**transform.dm:**

- Диалог выбора ДНК теперь показывает отсортированный список.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Исправление бага, когда генокрад не превращается в макаку, после укола DNA инджектором. (т.к. Lesserform не использовалась, то humanform абилка не добавляется).

Небольшой рефактор для читаемости и качества кода.

## Changelog
:cl:
fix: changeling can not humanize if monkeyized using DNA-Injector #458
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
