### PR TITLE
fix: human names on spawn as translocated vet on lavaland #404

### DIFF
--- a/code/modules/ruins/lavalandruin_code/animal_hospital.dm
+++ b/code/modules/ruins/lavalandruin_code/animal_hospital.dm
@@ -13,6 +13,10 @@
 	assignedrole = "Translocated Vet"
 	allow_species_pick = TRUE
 
+/obj/effect/mob_spawn/human/doctor/alive/lavaland/equip(mob/living/carbon/human/H)
+	..()
+	H.rename_self(assignedrole)
+
 /obj/effect/mob_spawn/human/doctor/alive/lavaland/Destroy()
 	var/obj/structure/fluff/empty_sleeper/S = new(drop_location())
 	S.setDir(dir)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

Добавляет возможность выбрать имя при спавне за ветеринара на лаваленде.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Убираем баг, когда например вульпаканин имеет человеческое имя.
(не фикс, больше костыль, но в текущей ситуации качество кода не страдает, все происходит в наследованном классе и мы просто даем возможность написать свое имя)

## Changelog
:cl:
fix: human names on spawn as translocated vet on lavaland #404
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
