### PR TITLE
feat: PDA painting machine now has TGUI

### DIFF
--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -8,6 +8,10 @@
 	max_integrity = 200
 	var/obj/item/pda/storedpda = null
 	var/list/colorlist = list()
+	var/statusLabel
+	var/statusLabelCooldownTime = 0
+	var/statusLabelCooldownTimeSecondsToAdd = 20 // 20 deciseconds = 2 seconds, 1sec = 0.1 decisecond
+	var/allowErasePda = TRUE
 
 
 /obj/machinery/pdapainter/update_icon()
@@ -29,12 +33,20 @@
 
 /obj/machinery/pdapainter/New()
 	..()
-	var/blocked = list(/obj/item/pda/silicon/ai, /obj/item/pda/silicon/robot, /obj/item/pda/silicon/pai, /obj/item/pda/heads,
+	var/blocked = list(/obj/item/pda/silicon, /obj/item/pda/silicon/ai, /obj/item/pda/silicon/robot, /obj/item/pda/silicon/pai, /obj/item/pda/heads,
 						/obj/item/pda/clear, /obj/item/pda/syndicate, /obj/item/pda/chameleon, /obj/item/pda/chameleon/broken)
 
 	for(var/thing in typesof(/obj/item/pda) - blocked)
 		var/obj/item/pda/P = thing
-		colorlist[initial(P.icon_state)] = initial(P.desc)
+
+		// Get Base64 version of an icon for our TGUI needs.
+		// Always try to get first frame as it can be animation resulting in all frames in single image.
+		// pda-library as an example has 4 frames
+		var/iconImage = "[icon2base64(icon(initial(P.icon), initial(P.icon_state), frame = 1))]"
+		colorlist[initial(P.icon_state)] = list(iconImage, initial(P.desc))
+
+	// TODO: Sorting breaks the list. Need method.
+	//colorlist = sortList(colorlist)
 
 /obj/machinery/pdapainter/Destroy()
 	QDEL_NULL(storedpda)
@@ -61,7 +73,7 @@
 		return
 	if(istype(I, /obj/item/pda))
 		if(storedpda)
-			to_chat(user, "There is already a PDA inside.")
+			to_chat(user, "В аппарате уже есть PDA.")
 			return
 		else
 			var/obj/item/pda/P = user.get_active_hand()
@@ -90,39 +102,120 @@
 	if(..())
 		return 1
 
-	src.add_fingerprint(user)
+	// Do not let click buttons if you're ghost unless you're an admin.
+	// TODO: To parent class or separate helper method?
+	if (isobserver(usr) && !is_admin(usr))
+		return FALSE
 
-	if(storedpda)
-		var/obj/item/pda/P
-		P = input(user, "Select your color!", "PDA Painting") as null|anything in colorlist
-		if(!P)
-			return
-		if(!in_range(src, user))
-			return
-
-		storedpda.icon_state = P
-		storedpda.desc = colorlist[P]
-
-	else
-		to_chat(user, "<span class='notice'>The [src] is empty.</span>")
-
-
-/obj/machinery/pdapainter/verb/ejectpda()
-	set name = "Eject PDA"
-	set category = "Object"
-	set src in oview(1)
-
-	if(usr.incapacitated())
-		return
-
-	if(storedpda)
-		storedpda.loc = get_turf(src.loc)
-		storedpda = null
-		update_icon()
-	else
-		to_chat(usr, "<span class='notice'>The [src] is empty.</span>")
-
+	ui_interact(user)
 
 /obj/machinery/pdapainter/power_change()
 	..()
 	update_icon()
+
+
+
+// TGUI Related.
+
+/obj/machinery/pdapainter/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = TRUE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)
+	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
+	if(!ui)
+		ui = new(user, src, ui_key, "PDAPainter",  "PDA painting machine", 545, 350, master_ui, state)
+		ui.open()
+
+/obj/machinery/pdapainter/ui_data(mob/user)
+	var/data = list()
+
+	if(storedpda)
+		data["hasPDA"] = TRUE
+		data["pdaIcon"] = storedpda.iconImage
+		data["pdaOwnerName"] = storedpda.owner
+		data["pdaJobName"] = storedpda.ownjob
+	else
+		data["hasPDA"] = FALSE
+		data["pdaIcon"] = null
+		data["pdaOwnerName"]  = null
+		data["pdaJobName"] = null
+
+	if(canUpdateStatusLabel())
+		data["statusLabel"] = storedpda ? "OK" : "PDA не найден"
+	else
+		data["statusLabel"] = statusLabel
+
+	return data
+
+/obj/machinery/pdapainter/ui_static_data(mob/user)
+	var/data = list()
+	data["pdaTypes"] = colorlist
+	data["allowErasePda"] = allowErasePda
+	return data
+
+/obj/machinery/pdapainter/ui_act(action, params)
+	if(..())
+		return
+
+	. = TRUE
+
+	switch(action)
+		if("insert_pda")
+			insert_pda()
+		if("eject_pda")
+			eject_pda()
+		if("choose_pda")
+			// choose_pda()
+			if(storedpda)
+				storedpda.icon_state = params["selectedPda"]
+				storedpda.desc = colorlist[storedpda.icon_state][2]
+				storedpda.iconImage = colorlist[storedpda.icon_state][1]
+				playsound(loc, 'sound/goonstation/machines/printer_thermal.ogg', 15, 1, extrarange = -6, falloff = 10)
+				statusLabel = "Покраска завершена"
+				statusLabelCooldownTime = world.time + statusLabelCooldownTimeSecondsToAdd
+		if("erase_pda")
+			erase_pda()
+
+	if(.)
+		add_fingerprint(usr)
+
+/obj/machinery/pdapainter/proc/insert_pda()
+	if(!storedpda) // PDA is NOT in the machine.
+		if(ishuman(usr))
+			var/obj/item/pda/P = usr.get_active_hand()
+
+			if(istype(P)) // If it is really PDA.
+				if(usr.drop_item())
+					storedpda = P
+					P.forceMove(src)
+					P.add_fingerprint(usr)
+					update_icon()
+					SStgui.update_uis(src)
+					return TRUE
+
+/obj/machinery/pdapainter/proc/erase_pda()
+	if(storedpda) // PDA is in machine.
+		if(ishuman(usr))
+			if (storedpda.id || storedpda.cartridge)
+				to_chat(usr, "<span class='notice'>Уберите карту и картридж из PDA.</span>")
+				statusLabel = "Уберите карту и картридж"
+				statusLabelCooldownTime = world.time + statusLabelCooldownTimeSecondsToAdd
+			else
+				storedpda = new /obj/item/pda(src)
+				to_chat(usr, "<span class='notice'>Данные на PDA полностью стерты.</span>")
+				statusLabel = "PDA очищен"
+				statusLabelCooldownTime = world.time + statusLabelCooldownTimeSecondsToAdd
+
+/obj/machinery/pdapainter/proc/eject_pda(var/obj/item/pda/pda = null)
+	if(storedpda) // PDA is in machine.
+		if(ishuman(usr))
+			storedpda.forceMove(get_turf(src))
+			if(!usr.get_active_hand() && Adjacent(usr))
+				usr.put_in_hands(storedpda)
+			storedpda = null
+		else
+			storedpda.forceMove(get_turf(src))
+			storedpda = null
+		update_icon()
+	SStgui.update_uis(src)
+	// SStgui.close_uis(src) // this  can close window on its own, nice
+
+/obj/machinery/pdapainter/proc/canUpdateStatusLabel()
+	return (statusLabelCooldownTime < world.time)

--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -45,8 +45,7 @@
 		var/iconImage = "[icon2base64(icon(initial(P.icon), initial(P.icon_state), frame = 1))]"
 		colorlist[initial(P.icon_state)] = list(iconImage, initial(P.desc))
 
-	// TODO: Sorting breaks the list. Need method.
-	//colorlist = sortList(colorlist)
+	colorlist = sortAssoc(colorlist)
 
 /obj/machinery/pdapainter/Destroy()
 	QDEL_NULL(storedpda)
@@ -162,7 +161,6 @@
 		if("eject_pda")
 			eject_pda()
 		if("choose_pda")
-			// choose_pda()
 			if(storedpda)
 				storedpda.icon_state = params["selectedPda"]
 				storedpda.desc = colorlist[storedpda.icon_state][2]

--- a/code/modules/pda/PDA.dm
+++ b/code/modules/pda/PDA.dm
@@ -60,6 +60,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 
 	var/obj/item/paicard/pai = null	// A slot for a personal AI device
 	var/retro_mode = 0
+	var/iconImage
 
 
 /*
@@ -69,6 +70,10 @@ GLOBAL_LIST_EMPTY(PDAs)
 	. = ..()
 	GLOB.PDAs += src
 	GLOB.PDAs = sortAtom(GLOB.PDAs)
+
+	// Generate image for the pda for TGUI.
+	iconImage = "[icon2base64(icon(icon, icon_state, frame = 1))]"
+
 	update_programs()
 	if(default_cartridge)
 		cartridge = new default_cartridge(src)

--- a/tgui/packages/tgui/interfaces/PDAPainter.js
+++ b/tgui/packages/tgui/interfaces/PDAPainter.js
@@ -1,0 +1,168 @@
+import { useBackend, useSharedState } from '../backend';
+import { Window } from '../layouts';
+import { Button, LabeledList, Flex, Box, Section, Table } from '../components';
+
+export const PDAPainter = (props, context) => {
+  const { act, data } = useBackend(context);
+
+  const {
+    statusLabel,
+    pdaTypes,
+    hasPDA,
+    pdaIcon,
+    pdaOwnerName,
+    pdaJobName,
+  } = data;
+
+  return (
+    <Window>
+      <Window.Content>
+        <Flex
+          spacing={1}
+          direction="row"
+          height="100%" flex="1">
+          <Flex.Item
+            width={24}
+            shrink={0}>
+            <Section title="Общее"
+              buttons={
+                <Button fluid
+                  icon={hasPDA ? 'eject' : 'exclamation-triangle'}
+                  selected={hasPDA}
+                  content={hasPDA ? 'Извлечь' : '-----'}
+                  tooltip={hasPDA ? "Извлечь PDA" : "Вставить PDA"}
+                  tooltipPosition="left"
+                  onClick={() => act(hasPDA ? 'eject_pda' : 'insert_pda')} />
+              }>
+              <LabeledList>
+                <LabeledList.Item label="Имя">
+                  {pdaOwnerName ? pdaOwnerName : 'Н/Д'}
+                </LabeledList.Item>
+                <LabeledList.Item label="Должность">
+                  {pdaJobName ? pdaJobName : 'Н/Д'}
+                </LabeledList.Item>
+              </LabeledList>
+            </Section>
+            <Section>
+              <Flex height="100%"
+                direction="column" flex="1">
+                <Flex.Item>
+                  <Box
+                    textAlign="center">
+                    <Box as="img"
+                      height="160px" // Set image size here.
+                      src={hasPDA ? `data:image/png;base64,${pdaIcon}`: ""}
+                      style={{
+                        '-ms-interpolation-mode': 'nearest-neighbor',
+                      }}
+                      align="middle" />
+                  </Box>
+                  <LabeledList m="5px">
+                    <LabeledList.Item label="Статус">
+                      {statusLabel}
+                    </LabeledList.Item>
+                  </LabeledList>
+
+                  <Button.Confirm m="5px"
+                    fluid
+                    disabled={!hasPDA}
+                    content="Стереть PDA"
+                    confirmContent="Подтвердить?"
+                    textAlign="left"
+                    color="red"
+                    tooltip={"Cбросить телефон на заводские настройки"}
+                    tooltipPosition="top"
+                    onClick={() => act("erase_pda")}
+                  />
+                </Flex.Item>
+              </Flex>
+            </Section>
+          </Flex.Item>
+          <Flex.Item
+            width={27}>
+            <Flex direction="column" height="100%" flex="1">
+              <Section title="Цвет PDA" flexGrow="1">
+                <Table>
+                  {Object.keys(pdaTypes).map(key => (
+                    <PDAColorRow
+                      key={key}
+                      selectedPda={key}
+                      selectedPdaImage={pdaTypes[key][0]} />
+                  ))}
+
+                  {/* Logic explanation for dummies.
+                    PDApainter.dm:
+                      data["pdaTypes"] = colorlist << all pda colors here
+                      colorlist is a list(list()):
+                        example: colorlist[initial(P.icon_state)] = list(iconImage, initial(P.desc))
+
+                        to get data:
+                          colorlist[pda-clown] - yields a list that has image and description.
+                          colorlist[pda-clown][1] - to get image
+                          colorlist[pda-clown][2] - to get description
+
+                    [!] in DM an array starts from 1
+
+                      then it goes as:
+                        var/data = list()
+                        data["pdaTypes"] = colorlist
+
+                    in PDAPainter.js
+                      pdaTypes[key]
+                      pdaTypes[pda-clown] - yields a list that has image and description.
+                      pdaTypes[pda-clown][0] - to get image
+                      pdaTypes[pda-clown][1] - to get description
+
+                      [!] in JS an array start from 0
+                  */}
+                </Table>
+              </Section>
+            </Flex>
+          </Flex.Item>
+        </Flex>
+      </Window.Content>
+    </Window>
+  );
+};
+
+export const PDAColorRow = (props, context) => {
+  const { act, data } = useBackend(context);
+
+  const {
+    hasPDA,
+  } = data;
+
+  const {
+    selectedPda,
+    selectedPdaImage,
+  } = props;
+
+  return (
+    <Table.Row>
+      <Table.Cell collapsing>
+        <img
+          src={`data:image/png;base64,${selectedPdaImage}`}
+          style={{
+            'vertical-align': 'middle',
+            width: '32px',
+            margin: '0px',
+            'margin-left': '0px',
+          }} />
+      </Table.Cell>
+      <Table.Cell bold>
+        <Button.Confirm
+          fluid
+          disabled={!hasPDA}
+          icon={selectedPdaImage}
+          content={selectedPda}
+          confirmContent="Покрасить?"
+          textAlign="left"
+          onClick={() => act("choose_pda", {
+            selectedPda: selectedPda,
+            selectedPdaImage: selectedPdaImage,
+          })} />
+      </Table.Cell>
+    </Table.Row>
+  );
+};
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

Добавляет TGUI меню для принтера PDA у ГП.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Теперь не нужно мучаться с выбором типа PDA для покраски, есть превью, удобный выбор, TGUI-like функционал, возможность стирать PDA для повторного использования.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->


https://user-images.githubusercontent.com/54457203/144940516-044605da-e60c-4f40-b118-054990c97159.mp4

## Changelog
:cl:
PDApainter.dm:
  fix: Blacklist another silicon pda (was shown as NONE).
  tweak: Colorlist is now list(list())
  tweak: Get base64 version of an icon to iconImage var for colorlist on init.
  tweak: attack_hand method rewritten to work with TGUI.
  add: Added TGUI related methods.
  add: Russian text
  del: ejectpda (old one) removed
  del: Removed old code

PDAPainter.js:
  add: Added TGUI related file

PDA.dm:
  add: iconImage var for base64 icon version
  add: Generate image for TGUI when new PDA is made.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
