### PR TITLE
fix: intercoms not working when in a comms blackouts

### DIFF
--- a/code/game/machinery/tcomms/_base.dm
+++ b/code/game/machinery/tcomms/_base.dm
@@ -275,7 +275,7 @@ GLOBAL_LIST_EMPTY(tcomms_machines)
 	var/bad_connection = FALSE
 	var/datum/radio_frequency/new_connection = tcm.connection
 
-	if(tcm?.connection?.frequency != display_freq)
+	if(tcm.connection.frequency != display_freq)
 		bad_connection = is_bad_connection(tcm.connection.frequency, display_freq)
 		new_connection = SSradio.return_frequency(display_freq)
 

--- a/code/game/machinery/tcomms/_base.dm
+++ b/code/game/machinery/tcomms/_base.dm
@@ -275,7 +275,7 @@ GLOBAL_LIST_EMPTY(tcomms_machines)
 	var/bad_connection = FALSE
 	var/datum/radio_frequency/new_connection = tcm.connection
 
-	if(tcm.connection.frequency != display_freq)
+	if(tcm?.connection?.frequency != display_freq)
 		bad_connection = is_bad_connection(tcm.connection.frequency, display_freq)
 		new_connection = SSradio.return_frequency(display_freq)
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -462,8 +462,7 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 		tcm.zlevels = list(position.z)
 		if(!instant)
 			// Simulate two seconds of lag
-			addtimer(CALLBACK(GLOBAL_PROC, .proc/broadcast_message, tcm), 20)
-			QDEL_IN(tcm, 20)
+			addtimer(CALLBACK(src, .proc/broadcast_callback, tcm), 2 SECONDS)
 		else
 			// Nukeops + Deathsquad headsets are instant and should work the same, whether there is comms or not
 			broadcast_message(tcm)
@@ -480,6 +479,13 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 		if(get_dist(src, M) <= canhear_range)
 			talk_into(M, message_pieces, null, verb)
 
+// To the person who asks "Why is this in a callback?"
+// You see, if you use QDEL_IN on the tcm and on broadcast_message()
+// The timer SS races itself and the message can be deleted before its sent
+// Having both in this callback removes that risk
+/obj/item/radio/proc/broadcast_callback(datum/tcomms_message/tcm)
+	broadcast_message(tcm)
+	qdel(tcm) // Delete the message datum
 
 /*
 /obj/item/radio/proc/accept_rad(obj/item/radio/R as obj, message)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Фиксит давно старое радио в ручках и интеркомчики дабы они снова звенели во время аномалии ионосферки.
Спасибо людям из оффов( https://github.com/ParadiseSS13/Paradise/pull/17208 ) мы смогли вернуть радио И интеркомы в рабочее состояние!

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Радио и интеркомы снова имеют смысл! И даже большой!

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![image](https://user-images.githubusercontent.com/32985153/145731045-07ce9c4c-bfa4-4ee8-a54e-f2615aacc1e0.png)

## Changelog
:cl:
fix: fixes radio during tcomms blackout
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
