### PR TITLE
Стартовый заряд боргов

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -28,8 +28,9 @@
 /obj/item/stock_parts/cell/New()
 	..()
 	START_PROCESSING(SSobj, src)
-	var/obj/item/I = loc
-	if(istype(I)) //Если находится в предмете, то полностью заряжен. Предназначено для оружия
+	var/obj/item/I = loc //Если находится в предмете - оружие
+	var/mob/M = loc //Если находится в монстре - роботы
+	if(istype(I) || istype(M)) //То полностью заряжена
 		charge = maxcharge
 	else
 		charge = round(maxcharge/10,1)


### PR DESCRIPTION
## What Does This PR Do
Борги с ЦК имеют полный заряд батареи. Собранные борги получают тот же заряд, что был у батареи, которую использовали для сборки

## Why It's Good For The Game
Возвращает стартовый заряд боргов

## Changelog
:cl:
fix: Борги с ЦК имеют полный заряд. Исправление https://github.com/ss220-space/Paradise/pull/434 
/:cl:

