### PR TITLE
Продолжение Фикса батареек

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -28,8 +28,9 @@
 /obj/item/stock_parts/cell/New()
 	..()
 	START_PROCESSING(SSobj, src)
-	var/obj/item/I = loc
-	if(istype(I)) //Если находится в предмете, то полностью заряжен. Предназначено для оружия
+	var/obj/item/I = loc //Если находится в предмете - оружие
+	var/mob/M = loc //Если находится в монстре - роботы
+	if(istype(I) || istype(M)) //То полностью заряжена
 		charge = maxcharge
 	else
 		charge = round(maxcharge/10,1)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -28,9 +28,7 @@
 /obj/item/stock_parts/cell/New()
 	..()
 	START_PROCESSING(SSobj, src)
-	var/obj/item/I = loc //Если находится в предмете - оружие
-	var/mob/M = loc //Если находится в монстре - роботы
-	if(istype(I) || istype(M)) //То полностью заряжена
+	if(istype(loc,/obj/item) || istype(loc,/mob) || istype(loc,/obj/mecha)) //Если оружие, борг или экзоскелет, то полность заряжен
 		charge = maxcharge
 	else
 		charge = round(maxcharge/10,1)


### PR DESCRIPTION
Продолжение - https://github.com/ss220-space/Paradise/pull/521

Оказывается, что Екзоскелеты с ЦК тоже получаются разряженными 10% (Торговцы-ЕРТ)
![image](https://user-images.githubusercontent.com/11385249/146290477-7bd157b1-be96-46e1-9a3f-9da4179a936e.png)
![image](https://user-images.githubusercontent.com/11385249/146290489-ba9be706-32fe-4796-b698-6a4e294e185a.png)
![image](https://user-images.githubusercontent.com/11385249/146290527-2642b2b7-99c6-4ade-a06b-93ee79b90022.png)

