### PR TITLE
Позволяет выгружать из БРПЕДА части нужного качества

### DIFF
--- a/code/game/objects/items/weapons/stock_parts.dm
+++ b/code/game/objects/items/weapons/stock_parts.dm
@@ -44,6 +44,21 @@
 	alt_sound = 'sound/items/pshoom_2.ogg'
 	usesound = 'sound/items/pshoom.ogg'
 	toolspeed = 0.5
+	var/empty_mode = 4 //То, что выгружаем. Если меньше или равно, то выгружаем
+
+/obj/item/storage/part_replacer/bluespace/drop_inventory(mob/user)
+	if(user.a_intent == INTENT_HARM) //Меняем режим выгрузки
+		empty_mode -= 1
+		if(empty_mode < 0)
+			empty_mode = 4
+		to_chat(user, "<span class='notice'>[src.name] будет выгружать предметы рангом [empty_mode] и ниже.</span>")
+	else
+		var/turf/T = get_turf(src)
+		hide_from(user)
+		for(var/obj/item/stock_parts/I in contents)
+			if(I.rating <= empty_mode)
+				remove_from_storage(I, T)
+				CHECK_TICK
 
 /obj/item/storage/part_replacer/proc/play_rped_sound()
 	//Plays the sound for RPED exchanging or installing parts.


### PR DESCRIPTION
Переработка без usr https://github.com/ss220-space/Paradise/pull/436

## What Does This PR Do
Позволяет установить уровень выгрузки для БРПЕДА в 4 режиме.
Все предметы с таким уровнем и ниже будут выгружены при использовании БРПЕДА в руке.
Сейчас в БРПЕД лезет 400 предметов, но они могут быть забиты.
Если выгружать предметы, то 400 предметов оказываются на полу.
А выкидывать по 1 предмету не удобно.

## Why It's Good For The Game
Позволяет выгружать устаревшие модули не по одному, а целой пачкой.

## Images of changes
https://user-images.githubusercontent.com/11385249/146299445-51de341a-85c8-457c-bb6f-0dc60439c6ef.mp4

## Changelog
:cl:
add: Позволяет выгружать из БРПЕДА части нужного качества
/:cl:

