### PR TITLE
Fix timers not removing from second queue on init

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -455,7 +455,7 @@ SUBSYSTEM_DEF(timer)
 	if(buckethead == src)
 		bucket_list[bucket_pos] = next
 		SStimer.bucket_count--
-	else if(timeToRun < TIMER_MAX)
+	else if(bucket_joined)
 		SStimer.bucket_count--
 	else
 		var/l = length(second_queue)


### PR DESCRIPTION
Properly eject timer from second queue on timer_max drift due timer not firing in init

See https://github.com/tgstation/tgstation/issues/56292
