### PR TITLE
uplink implant fix

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1515,6 +1515,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "UI"
 	item = /obj/item/implanter/uplink
 	cost = 12
+	excludefrom = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 	surplus = 0
 	cant_discount = TRUE
 


### PR DESCRIPTION
SST and NUCLEAR shouldnt have access to traitor uplink shop in any case. 
Uplink implant has traitor shop as base shop. 
Removing uplink implant from SST and NUCLEAR uplinks solves the problem

## Changelog
:cl:
del: removed uplink implant from sst and nuclear uplink
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
