### PR TITLE
Фикс бага со множеством порталов

### DIFF
--- a/code/game/machinery/computer/depot.dm
+++ b/code/game/machinery/computer/depot.dm
@@ -452,7 +452,7 @@
 /obj/machinery/computer/syndicate_depot/teleporter/proc/update_portal()
 	if(portal_enabled && !myportal)
 		var/turf/tele_target = choosetarget()
-		if(!tele_target)
+		if(!tele_target || myportal || myportal2)
 			return
 		var/turf/portal_turf = get_step(src, portaldir)
 		var/obj/effect/portal/redspace/P = new(portal_turf, tele_target, src, 0)
@@ -462,9 +462,10 @@
 		var/obj/effect/portal/redspace/P2 = new(get_turf(tele_target), portal_turf, src, 0)
 		myportal2 = P2
 		P2.name = "mysterious portal"
-	else if(!portal_enabled && myportal)
-		qdel(myportal)
-		myportal = null
+	else if(!portal_enabled)
+		if(myportal)
+			qdel(myportal)
+			myportal = null
 		if(myportal2)
 			qdel(myportal2)
 			myportal2 = null

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -24,6 +24,11 @@
 	src.target = target
 	src.creator = creator
 
+	for(var/obj/effect/portal/P in loc)
+		if(P != src)
+			QDEL_IN(P, 0)
+			stack_trace("More than one portal has been opened in [atom_loc_line(loc)]")
+
 	if(lifespan > 0)
 		spawn(lifespan)
 			qdel(src)
@@ -51,6 +56,12 @@
 
 	if(target && (get_turf(oldloc) == get_turf(target)))
 		return ..()
+
+	if(istype(AM, /obj/effect/portal))
+		qdel(AM)
+		qdel(src)
+		log_debug("Portal [src] crossed by another portal [AM]")
+		return
 
 	if(!teleport(AM))
 		return ..()


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
* Убирает возможность поставить больше одного портала на клетку.
Клетки с 2-мя и более порталов при применении имели шанс сломать к чертям игру. Иногда происходил рассинхрон между персонажем и куклой из-за чего персонаж не мог ходить. В худших случаях DM-у приходили кривые и пустые данные, что ломало весь сервер. Отдельное спасибо @semoro за помощь с фиксом. 

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
* Убирает отвратительный баг способный сломать всю игру. Меньше багов лучше жизнь
