### PR TITLE
Fix: Implanted Agents Not Detonating on Death

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -1,7 +1,7 @@
 /mob/living/carbon/human/emote(act, m_type = 1, message = null, force)
 
-	if((stat != CONSCIOUS) || (status_flags & FAKEDEATH))
-		return // You can't just scream if you dead or sleeping
+	if((stat == DEAD) || (status_flags & FAKEDEATH))
+		return // You can't just scream if you dead
 
 	var/param = null
 	if(findtext(act, "-", 1, null))


### PR DESCRIPTION
## Почему это должно быть в игре
Ошибки это плохо. Не допускайте ошибок.

## Список изменений
Исправление отсутствия подрыва агентов с имплантом при смерти.