### PR TITLE
Fix: Avoid timer scheduling too far events into short queue

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -3,7 +3,7 @@
 /// Helper for getting the correct bucket for a given timer
 #define BUCKET_POS(timer) (((round((timer.timeToRun - SStimer.head_offset) / world.tick_lag)+1) % BUCKET_LEN)||BUCKET_LEN)
 /// Gets the maximum time at which timers will be invoked from buckets, used for deferring to secondary queue
-#define TIMER_MAX (world.time + TICKS2DS(min(BUCKET_LEN-(SStimer.practical_offset-DS2TICKS(world.time - SStimer.head_offset))-1, BUCKET_LEN-1)))
+#define TIMER_MAX (SStimer.head_offset + TICKS2DS(BUCKET_LEN + SStimer.practical_offset - 1))
 /// Max float with integer precision
 #define TIMER_ID_MAX (2**24)
 


### PR DESCRIPTION
Previously it was possible for events to enter the short queue when the timer is offset by more than BUCKET_LEN

Now it is forced to schedule events into the second queue if the timer is processing slower then world time goes allowing the timer to keep up