### PR TITLE
fix: Изменение минимального значения проверки для смены иконки голода

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -602,7 +602,7 @@
 				becomeFat()
 
 		// nutrition decrease
-		if(nutrition > 0 && stat != DEAD)
+		if(nutrition >= 0 && stat != DEAD)
 			handle_nutrition_alerts()
 			// THEY HUNGER
 			var/hunger_rate = hunger_drain

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1456,11 +1456,11 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 
 ///Adjust the nutrition of a mob
 /mob/proc/adjust_nutrition(change)
-	nutrition = max(1, nutrition + change)
+	nutrition = max(0, nutrition + change)
 
 ///Force set the mob nutrition
 /mob/proc/set_nutrition(change)
-	nutrition = max(1, change)
+	nutrition = max(0, change)
 
 /mob/clean_blood(clean_hands = TRUE, clean_mask = TRUE, clean_feet = TRUE)
 	. = ..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1456,11 +1456,11 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 
 ///Adjust the nutrition of a mob
 /mob/proc/adjust_nutrition(change)
-	nutrition = max(0, nutrition + change)
+	nutrition = max(1, nutrition + change)
 
 ///Force set the mob nutrition
 /mob/proc/set_nutrition(change)
-	nutrition = max(0, change)
+	nutrition = max(1, change)
 
 /mob/clean_blood(clean_hands = TRUE, clean_mask = TRUE, clean_feet = TRUE)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Изменено условие проверки для запуска функции смены иконки сытости.
## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
fix: https://github.com/ss220-space/Paradise/issues/559
При установке значения 0 для переменной nutrition не обновлялась иконка голода на экране. 
Изменено условие проверки для смены иконки сытости.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
