### PR TITLE
Fix: Removed baguse Sorium chemical reaction

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -89,30 +89,24 @@
 	name = "Sorium"
 	id = "sorium"
 	result = "sorium"
-	required_reagents = list("mercury" = 1, "carbon" = 1, "nitrogen" = 1, "oxygen" = 1, "stabilizing_agent" = 1)
+	required_reagents = list("mercury" = 1, "carbon" = 1, "nitrogen" = 1, "oxygen" = 1)
 	result_amount = 4
 	mix_message = "The mixture pops and crackles before settling down."
 
 /datum/chemical_reaction/sorium_explosion
 	name = "Sorium Explosion"
 	id = "sorium_explosion"
-	required_reagents = list("mercury" = 1, "carbon" = 1, "nitrogen" = 1, "oxygen" = 1)
+	required_reagents = list("sorium" = 1)
 	result_amount = 1
-	mix_message = "The mixture explodes with a big bang."
+	min_temp = T0C + 200
+	mix_sound = null
+ 	mix_message = "The mixture explodes with a big bang."
 
 /datum/chemical_reaction/sorium_explosion/on_reaction(datum/reagents/holder, created_volume)
 	var/turf/T = get_turf(holder.my_atom)
 	if(!T)
 		return
 	goonchem_vortex(T, 0, created_volume)
-
-/datum/chemical_reaction/sorium_explosion/sorium
-	name = "sorium_vortex"
-	id = "sorium_vortex"
-	required_reagents = list("sorium" = 1)
-	min_temp = T0C + 200
-	mix_sound = null
-	mix_message = null
 
 /datum/chemical_reaction/liquid_dark_matter
 	name = "Liquid Dark Matter"


### PR DESCRIPTION
## What Does This PR Do
Убрана возможность получения химической реакции - взрыва(отбрасывает предметы и персонажей от эпицентра)
путем возникновении вещества Sorium при смешивании данного рецепта:
[1 часть Mercury + 1 часть Oxygen + 1 часть Nitrogen + 1 часть Carbon];
Теперь, что бы получить хим. реакцию вещества Sorium, нужно сначала изготовить данное вещество по рецепту и нагреть до 473,15 К.
Так же удалена возможность стабилизировать вещество при помощи Stabilizing Agent, так как в этом теперь нет необходимости.

## Why It's Good For The Game
Данная хим. реакция является несбалансированной и недоработанной - она проста и дешева в изготовлении, так как требует основные реагенты из хим. раздатчика.
Этим пользуются многие игроки, чтобы за считанные секунды убивать любого моба, будь то минорный вампир или мажорный блоб (некоторые игроки убивают этим багоюзом мегафауну, тем самым легко получая с нее лут).
Новый способ получения реакции увеличит её стоимость - теперь игрок должен нагреть вещество вручную (что занимает время), используя другие хим. вещества (что увеличивает затраты), используя Pyro Grenade Casing или что-то иное.

## Changelog
:cl:
fix: Sorium reaction
/:cl: