### PR TITLE
Feat: корректировка возврата средств за боеприпасы в автолат

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -42,6 +42,8 @@
 	..()
 	icon_state = "[initial(icon_state)][BB ? "-live" : ""]"
 	desc = "[initial(desc)][BB ? "" : " This one is spent."]"
+	if (!BB)
+		materials = list(MAT_METAL=0)
 
 /obj/item/ammo_casing/proc/newshot(params) //For energy weapons, shotgun shells and wands (!).
 	if(!BB)

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -42,8 +42,6 @@
 	..()
 	icon_state = "[initial(icon_state)][BB ? "-live" : ""]"
 	desc = "[initial(desc)][BB ? "" : " This one is spent."]"
-	if (!BB)
-		materials = list(MAT_METAL=0)
 
 /obj/item/ammo_casing/proc/newshot(params) //For energy weapons, shotgun shells and wands (!).
 	if(!BB)

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -1,6 +1,7 @@
 /obj/item/ammo_casing/a357
 	desc = "A .357 bullet casing."
 	caliber = ".357"
+	materials = list(MAT_METAL=4285.7)
 	projectile_type = /obj/item/projectile/bullet
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_STRONG
@@ -9,6 +10,7 @@
 	desc = "A 9mm rubber bullet casing."
 	caliber = "9mm"
 	icon_state = "r-casing"
+	materials = list(MAT_METAL=650)
 	projectile_type = /obj/item/projectile/bullet/weakbullet4
 
 /obj/item/ammo_casing/a762
@@ -33,6 +35,7 @@
 	desc = "A .38 bullet casing."
 	caliber = ".38"
 	icon_state = "r-casing"
+	materials = list(MAT_METAL=5000)
 	projectile_type = /obj/item/projectile/bullet/weakbullet2
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
@@ -50,6 +53,7 @@
 	projectile_type = /obj/item/projectile/bullet/midbullet3
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
+	materials = list(MAT_METAL=1500)
 
 /obj/item/ammo_casing/c10mm/ap
 	projectile_type = /obj/item/projectile/bullet/midbullet3/ap
@@ -64,6 +68,7 @@
 /obj/item/ammo_casing/c9mm
 	desc = "A 9mm bullet casing."
 	caliber = "9mm"
+	materials = list(MAT_METAL=1000)
 	projectile_type = /obj/item/projectile/bullet/weakbullet3
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_WEAK
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
@@ -109,6 +114,7 @@
 	projectile_type = /obj/item/projectile/bullet/midbullet
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
+	materials = list(MAT_METAL=1500)
 
 /obj/item/ammo_casing/c45/nostamina
 	projectile_type = /obj/item/projectile/bullet/midbullet3
@@ -157,7 +163,6 @@
 	projectile_type = /obj/item/projectile/bullet/pellet/rubber
 	pellets = 6
 	variance = 25
-	materials = list(MAT_METAL=4000)
 
 
 /obj/item/ammo_casing/shotgun/beanbag
@@ -370,6 +375,7 @@
 	caliber = "foam_force"
 	icon = 'icons/obj/guns/toy.dmi'
 	icon_state = "foamdart"
+	materials = list(MAT_METAL=12.5)
 	var/modified = 0
 	harmful = FALSE
 
@@ -418,6 +424,7 @@
 	desc = "Whose smart idea was it to use toys as crowd control? Ages 18 and up."
 	projectile_type = /obj/item/projectile/bullet/reusable/foam_dart/riot
 	icon_state = "foamdart_riot"
+	materials = list(MAT_METAL=1000)
 
 /obj/item/ammo_casing/caseless/foam_dart/sniper
 	name = "foam sniper dart"
@@ -425,6 +432,7 @@
 	caliber = "foam_force_sniper"
 	projectile_type = /obj/item/projectile/bullet/reusable/foam_dart/sniper
 	icon_state = "foamdartsniper"
+	materials = list(MAT_METAL=22.5)
 
 /obj/item/ammo_casing/caseless/foam_dart/sniper/update_icon()
 	..()
@@ -442,6 +450,7 @@
 	name = "riot foam sniper dart"
 	desc = "For the bigger brother of the crowd control toy. Ages 18 and up."
 	caliber = "foam_force_sniper"
+	materials = list(MAT_METAL=1800)
 	projectile_type = /obj/item/projectile/bullet/reusable/foam_dart/sniper/riot
 	icon_state = "foamdartsniper_riot"
 

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -29,6 +29,7 @@
 	icon_state = "9mmbox"
 	origin_tech = "combat=2"
 	ammo_type = /obj/item/ammo_casing/rubber9mm
+	materials = list(MAT_METAL=19500)
 	max_ammo = 30
 
 /obj/item/ammo_box/c10mm

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -230,6 +230,7 @@
 	icon_state = "enforcer"
 	ammo_type = /obj/item/ammo_casing/rubber9mm
 	max_ammo = 8
+	materials = list(MAT_METAL=7200)
 	multiple_sprites = 1
 	caliber = "9mm"
 
@@ -257,6 +258,7 @@
 /obj/item/ammo_box/magazine/enforcer/lethal
 	name = "handgun magazine (9mm)"
 	ammo_type = /obj/item/ammo_casing/c9mm
+	materials = list(MAT_METAL=10000)
 
 /obj/item/ammo_box/magazine/wt550m9
 	name = "wt550 magazine (4.6x30mm)"

--- a/code/modules/projectiles/firing.dm
+++ b/code/modules/projectiles/firing.dm
@@ -57,6 +57,7 @@
 	BB.preparePixelProjectile(target, targloc, user, params, spread)
 	if(BB)
 		BB.fire()
+	materials = list(MAT_METAL=0)
 	BB = null
 	return 1
 


### PR DESCRIPTION
## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
+ Автолат теперь принимает одиночные патроны: .357, 9мм резина, .38, 10мм, 9мм, .45, пенный дротик, усиленный пенный дротик, снайперский пенный дротик, усиленный снайперский пенный дротик
- Автолат более не принимает использованные боеприпасы;
* Исправлена цена при возврате в автолат: коробка 9мм резины, магазин 9мм, магазин 9мм резины;
* Удалено лишнее повторение цены резинового патрона для дробовика.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Исправление дюпа металла, добавление возможности реутилизации неиспользованных стандартных боеприпасов.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: Автолат теперь принимает одиночные патроны: .357, 9мм резина, .38, 10мм, 9мм, .45, пенный дротик, усиленный пенный дротик, снайперский пенный дротик, усиленный снайперский пенный дротик;
tweak: Автолат более не принимает использованные боеприпасы;
fix: Исправлена цена при возврате в автолат: коробка 9мм резины, магазин 9мм, магазин 9мм резины;
del: Удалено лишнее повторение цены резинового патрона для дробовика.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
