### PR TITLE
Добавление уязвимости к ЭМИ у станперчаток

### DIFF
--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -158,6 +158,15 @@
 		cell = null
 		update_icon()
 
+/obj/item/clothing/gloves/color/yellow/stun/emp_act()
+	if(!ishuman(loc))
+		return ..()
+	var/mob/living/carbon/human/H = loc
+	if(cell?.use(stun_cost))
+		H.Weaken(4)
+		H.adjustFireLoss(rand(10, 25))
+		H.apply_effect(STUTTER, 5 SECONDS)
+
 /obj/item/clothing/gloves/fingerless/rapid
 	name = "Gloves of the North Star"
 	desc = "Just looking at these fills you with an urge to beat the shit out of people."


### PR DESCRIPTION
Перчатки довольно сильное оружие позволяющее игнорировать блоки от даблы, щитов и обезоруживания. Так как нюка и предатели используют даблу и ЭМИ, была добавлена уязвимость к ЭМИ чтобы предотвратить односторонние конфликты в которых владелец перчаток имел бы беспройгрышное преимущество перед владельцем даблы. Теперь купив Эми имплант или взяв ЭМИ винтовку можно наказывать владельцев перчаток.