### PR TITLE
Fix: Bug with disappearing posters

### DIFF
--- a/code/game/objects/effects/decals/contraband.dm
+++ b/code/game/objects/effects/decals/contraband.dm
@@ -88,6 +88,9 @@
 	poster_item_icon_state = initial(selected.poster_item_icon_state)
 	ruined = initial(selected.ruined)
 
+/obj/structure/sign/poster/screwdriver_act()
+	return
+
 /obj/structure/sign/poster/wirecutter_act(mob/user, obj/item/I)
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))


### PR DESCRIPTION
## What Does This PR Do

Исправлена ошибка появляющаяся при использовании объекта Screwdriver на объект Poster, при которой Poster удалялся и заменялся на несуществующий Sign.

## Why It's Good For The Game

Данный баг оказался критически опасным, так как привносил в игру дизбалансный багоюз, который позволял игрокам с объектом Chameleon-Projector становится полностью невидимыми. 

Теперь же, при использовании отвертки на любой постер она будет его дамажить, а не пытаться откручивать.

## Changelog
:cl:
fix: invisible poster
/:cl: