### PR TITLE
Fix: TestCI edited the global vars

### DIFF
--- a/code/modules/client/geoip.dm
+++ b/code/modules/client/geoip.dm
@@ -1,7 +1,3 @@
-var/global/geoip_query_counter = 0
-var/global/geoip_next_counter_reset = 0
-var/global/list/geoip_ckey_updated = list()
-
 /datum/geoip_data
 	var/holder = null
 	var/status = null
@@ -20,6 +16,7 @@ var/global/list/geoip_ckey_updated = list()
 	INVOKE_ASYNC(src, .proc/get_geoip_data, C, addr)
 
 /datum/geoip_data/proc/get_geoip_data(client/C, addr)
+	var/global/list/geoip_ckey_updated = list()
 
 	if(!C || !addr)
 		return
@@ -210,6 +207,9 @@ var/global/list/geoip_ckey_updated = list()
 	return TRUE
 
 /proc/geoip_check(addr)
+	var/global/geoip_query_counter = 0
+	var/global/geoip_next_counter_reset = 0
+
 	if(world.time > geoip_next_counter_reset)
 		geoip_next_counter_reset = world.time + 900
 		geoip_query_counter = 0

--- a/code/modules/detectivework/forensics.dm
+++ b/code/modules/detectivework/forensics.dm
@@ -2,8 +2,8 @@
 
 //This is the output of the stringpercent(print) proc, and means about 80% of
 //the print must be there for it to be complete.  (Prints are 32 digits)
-var/const/FINGERPRINT_COMPLETE = 6
-proc/is_complete_print(print)
+/proc/is_complete_print(print)
+	var/const/FINGERPRINT_COMPLETE = 6
 	return stringpercent(print) <= FINGERPRINT_COMPLETE
 
 atom/var/list/suit_fibers

--- a/code/modules/detectivework/microscope/microscope.dm
+++ b/code/modules/detectivework/microscope/microscope.dm
@@ -1,7 +1,7 @@
 //This is the output of the stringpercent(print) proc, and means about 80% of
 //the print must be there for it to be complete.  (Prints are 32 digits)
-var/const/FINGERPRINT_COMPLETE = 6
-proc/is_complete_print(print)
+/proc/is_complete_print(print)
+	var/const/FINGERPRINT_COMPLETE = 6
 	return stringpercent(print) <= FINGERPRINT_COMPLETE
 
 //microscope code itself

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -2,7 +2,6 @@
 #define ION_RANDOM 0
 #define ION_ANNOUNCE 1
 
-var/iondepartment = pick_list("ion_laws.json", "отделы")
 /datum/event/ion_storm
 	var/botEmagChance = 10
 	var/announceEvent = ION_NOANNOUNCEMENT // -1 means don't announce, 0 means have it randomly announce, 1 means
@@ -46,6 +45,7 @@ var/iondepartment = pick_list("ion_laws.json", "отделы")
 	return message
 
 /proc/generate_static_ion_law()
+	var/iondepartment = pick_list("ion_laws.json", "отделы")
 	var/list/players = list()
 	for(var/mob/living/carbon/human/player in GLOB.player_list)
 		if(	!player.mind || player.mind.assigned_role == player.mind.special_role || player.client.inactivity > 10 MINUTES)


### PR DESCRIPTION
## What Does This PR Do
НЕ МЕРЖИТЬ
Изменено расположение глобальных var, которые не проходили тесты CI:
code/modules/client/geoip.dm:var/global/geoip_query_counter = 0
code/modules/client/geoip.dm:var/global/geoip_next_counter_reset = 0
code/modules/client/geoip.dm:var/global/list/geoip_ckey_updated = list()
code/modules/detectivework/forensics.dm:var/const/FINGERPRINT_COMPLETE = 6
code/modules/detectivework/microscope/microscope.dm:var/const/FINGERPRINT_COMPLETE = 6
code/modules/events/ion_storm.dm:var/iondepartment = pick_list("ion_laws.json", "отделы")
## Changelog
:cl:
fix: TestCI_globalvar
/:cl: