### PR TITLE
Fix: airlock shielding dupe; fix: airlock_electronics spawn on airlock deconstruction

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1404,18 +1404,13 @@ About the new airlock wires panel:
 		if(user)
 			to_chat(user, "<span class='notice'>You remove the airlock electronics.</span>")
 		var/obj/item/airlock_electronics/ae
-		if(!electronics)
-			ae = new/obj/item/airlock_electronics(loc)
-			check_access()
-			if(req_access.len)
-				ae.selected_accesses = req_access
-			else if(req_one_access.len)
-				ae.selected_accesses = req_one_access
-				ae.one_access = 1
-		else
-			ae = electronics
-			electronics = null
-			ae.forceMove(loc)
+		ae = new/obj/item/airlock_electronics(loc)
+		check_access()
+		if(req_access.len)
+			ae.selected_accesses = req_access
+		else if(req_one_access.len)
+			ae.selected_accesses = req_one_access
+			ae.one_access = 1
 		if(emagged)
 			ae.icon_state = "door_electronics_smoked"
 			operating = 0

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -149,6 +149,12 @@ About the new airlock wires panel:
 		damage_deflection = AIRLOCK_DAMAGE_DEFLECTION_R
 	update_icon()
 
+/obj/machinery/door/airlock/on_construction()
+	// Remove shielding to prevent metal/plasteel duplication
+	security_level = AIRLOCK_SECURITY_NONE
+	modify_max_integrity(normal_integrity)
+	damage_deflection = AIRLOCK_DAMAGE_DEFLECTION_N
+
 /obj/machinery/door/airlock/proc/update_other_id()
 	for(var/obj/machinery/door/airlock/A in GLOB.airlocks)
 		if(A.closeOtherId == closeOtherId && A != src)

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -172,6 +172,7 @@
 		door = new glass_type(loc)
 	else
 		door = new airlock_type(loc)
+	door.on_construction()
 	door.setDir(dir)
 	door.electronics = electronics
 	door.unres_sides = electronics.unres_access_from


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Всем аирлокам убрана защита проводов при сборке из airlock_assembly, теперь не получится дюпать металл/пласталь, собирая vault door или high security airlock и срезая с них защиту проводов. Fixes #605

Также нашел баг: не выпадает плата airlock_electronics при разборке аирлока, в который плата была вставлена вручную (то есть если в переменной electronics есть ссылка на плату).
Плата выпадает, но почему-то невидимой (invisibility = 100), а при попытке взять её в руки удаляется. Шаги воспроизведения: собрать аирлок, разобрать аирлок, изменить переменную персонажа see_invisible на 100 или переменную платы invisibility на 0, взять плату в руку, переключить руки, плата удалится из неактивной руки.
Фикс: теперь при разборке аирлока в любом случае спавнится новая плата. Старая, если она была, удаляется вместе с аирлоком.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: airlock shielding duplication
fix: airlock_electronics spawn on airlock deconstruction
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
