### PR TITLE
Fix: airlock shielding dupe

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -149,6 +149,12 @@ About the new airlock wires panel:
 		damage_deflection = AIRLOCK_DAMAGE_DEFLECTION_R
 	update_icon()
 
+/obj/machinery/door/airlock/on_construction()
+	// Remove shielding to prevent metal/plasteel duplication
+	security_level = AIRLOCK_SECURITY_NONE
+	modify_max_integrity(normal_integrity)
+	damage_deflection = AIRLOCK_DAMAGE_DEFLECTION_N
+
 /obj/machinery/door/airlock/proc/update_other_id()
 	for(var/obj/machinery/door/airlock/A in GLOB.airlocks)
 		if(A.closeOtherId == closeOtherId && A != src)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -149,8 +149,8 @@ About the new airlock wires panel:
 		damage_deflection = AIRLOCK_DAMAGE_DEFLECTION_R
 	update_icon()
 
-/obj/machinery/door/airlock/on_construction()
-	// Remove shielding to prevent metal/plasteel duplication
+// Remove shielding to prevent metal/plasteel duplication
+/obj/machinery/door/airlock/proc/remove_shielding()
 	security_level = AIRLOCK_SECURITY_NONE
 	modify_max_integrity(normal_integrity)
 	damage_deflection = AIRLOCK_DAMAGE_DEFLECTION_N

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -172,7 +172,7 @@
 		door = new glass_type(loc)
 	else
 		door = new airlock_type(loc)
-	door.on_construction()
+	door.remove_shielding()
 	door.setDir(dir)
 	door.electronics = electronics
 	door.unres_sides = electronics.unres_access_from

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -172,6 +172,7 @@
 		door = new glass_type(loc)
 	else
 		door = new airlock_type(loc)
+	door.on_construction()
 	door.setDir(dir)
 	door.electronics = electronics
 	door.unres_sides = electronics.unres_access_from


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Всем аирлокам убрана защита проводов при сборке из airlock_assembly, теперь не получится дюпать металл/пласталь, собирая vault door или high security airlock и срезая с них защиту проводов. Fixes #605
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: airlock shielding duplication
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
