### PR TITLE
Fix: airlock_electronics return on airlock deconstruction

### DIFF
--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -186,10 +186,8 @@
 	else
 		door.name = base_name
 	door.previous_airlock = previous_assembly
-	var/obj/item/airlock_electronics/ae
-	ae = electronics
+	electronics.forceMove(door)
 	electronics = null
-	ae.forceMove(door)
 	qdel(src)
 	update_icon()
 

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -186,7 +186,10 @@
 	else
 		door.name = base_name
 	door.previous_airlock = previous_assembly
-	electronics.forceMove(door)
+	var/obj/item/airlock_electronics/ae
+	ae = electronics
+	electronics = null
+	ae.forceMove(door)
 	qdel(src)
 	update_icon()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Баг: не выпадает плата airlock_electronics при разборке аирлока, собранного из airlock_assembly.
Насколько я понял, проблема в том, что плата некрасиво переносится из airlock_assembly в airlock. Вроде починил.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: airlock_electronics return on airlock deconstruction
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
