### PR TITLE
feat: Changes runechat_msg_location from mob onto atom level. add: Logs TTS.

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -54,6 +54,8 @@
 	var/chat_color
 	/// A luminescence-shifted value of the last color calculated for chatmessage overlays
 	var/chat_color_darkened
+	/// The location our runechat message should appear. Should be src by default.
+	var/atom/runechat_msg_location
 
 /atom/New(loc, ...)
 	SHOULD_CALL_PARENT(TRUE)
@@ -857,7 +859,7 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 			speech_bubble_hearers += M.client
 
 			if((M.client.prefs.toggles2 & PREFTOGGLE_2_RUNECHAT) && M.can_hear() && M.stat != UNCONSCIOUS)
-				M.create_chat_message(src, message, FALSE, TRUE)
+				M.create_chat_message(src.runechat_msg_location, message, FALSE, TRUE)
 
 	if(length(speech_bubble_hearers))
 		var/image/I = image('icons/mob/talk.dmi', src, "[bubble_icon][say_test(message)]", FLY_LAYER)
@@ -1020,3 +1022,9 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 		else
 			name = "[prefix][t]"
 	return t
+
+/**
+ * Updates the atom's runechat maptext display location.
+ */
+/atom/proc/update_runechat_msg_location()
+	return

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -279,6 +279,7 @@
 			onTransitZ(old_z, dest_z)
 
 	Moved(old_loc, NONE)
+	update_runechat_msg_location()
 
 	return 1
 
@@ -300,7 +301,6 @@
 	if(client)
 		reset_perspective(destination)
 	update_canmove() //if the mob was asleep inside a container and then got forceMoved out we need to make them fall.
-	update_runechat_msg_location()
 
 
 //Called whenever an object moves and by mobs when they attempt to move themselves through space

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -683,3 +683,8 @@ GLOBAL_DATUM_INIT(fire_overlay, /image, image("icon" = 'icons/goonstation/effect
 	if(flags & SLOT_PDA)
 		owner.update_inv_wear_pda()
 
+/obj/item/update_runechat_msg_location()
+	if(ismob(loc) || isobj(loc))
+		runechat_msg_location = loc
+	else
+		runechat_msg_location = src

--- a/code/game/objects/items/devices/tts.dm
+++ b/code/game/objects/items/devices/tts.dm
@@ -21,6 +21,7 @@
 		playsound(src, "terminal_type", 50, TRUE)
 		return
 	atom_say(input)
+	log_say("(TTS) [input]", user)
 
 /obj/item/ttsdevice/AltClick(mob/living/user)
 	var/noisechoice = input(user, "What noise would you like to make?", "Robot Noises") as null|anything in list("Beep","Buzz","Ping")
@@ -41,3 +42,4 @@
 		return
 	new_name = reject_bad_name(new_name)
 	name = "[new_name]'s [initial(name)]"
+

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -49,6 +49,8 @@
 		armor = getArmor()
 	else if(!istype(armor, /datum/armor))
 		stack_trace("Invalid type [armor.type] found in .armor during /obj Initialize()")
+	runechat_msg_location = src
+	update_runechat_msg_location()
 
 /obj/Topic(href, href_list, nowindow = FALSE, datum/ui_state/state = GLOB.default_state)
 	// Calling Topic without a corresponding window open causes runtime errors

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1490,8 +1490,3 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	update_icons()	//apply the now updated overlays to the mob
 
 
-/**
- * Updates the mob's runechat maptext display location.
- */
-/mob/proc/update_runechat_msg_location()
-	return

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -205,7 +205,3 @@
 	var/registered_z
 
 	var/obj/effect/proc_holder/ranged_ability //Any ranged ability the mob has, as a click override
-
-
-	/// The location our runechat message should appear. Should be src by default.
-	var/atom/runechat_msg_location


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Меняет runechat_msg_location с уровня mob на уровень atom дабы некоторые предметы(obj) тоже могли менять локации рунчатов а не орать в руках или в кармане людей.
Вдобавок TTS логирование дабы можно было отследить что человек болтает через TTS.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Часть предметов теперь будут показываться прямо на вид даже если в руках или кармашке. К примеру если кто-то запустит Orion Ship(бомба из емагнутого автомата).
(Мехи и ММИ всё ещё могут болтать как и раньше. Только теперь и сами предметы которые юзают atom_say тоже могут.
К примеру кассета(? не помню) )

## Changelog
:cl:
add: Adds logging for TTS for a mob who uses it.
feat: Changes runechat_msg_location onto atom level.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
