### PR TITLE
ОбновлениеАнтагонистов 2.0

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -116,7 +116,7 @@
 
 /datum/status_effect/stamina_dot
 	id = "stamina_dot"
-	duration = 100
+	duration = 130
 	alert_type = null
 
 /datum/status_effect/stamina_dot/tick()

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -194,7 +194,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A specialised, one shell shotgun with a built-in cloaking device to mimic a cane. The shotgun is capable of hiding it's contents and the pin alongside being supressed. Comes boxed with 6 specialised shrapnel rounds laced with a silencing toxin and 1 preloaded in the shotgun's chamber."
 	reference = "MCS"
 	item = /obj/item/storage/box/syndie_kit/caneshotgun
-	cost = 10
+	cost = 5
 	job = list("Mime")
 
 /datum/uplink_item/jobspecific/mimery
@@ -202,7 +202,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "Contains two manuals to teach you advanced Mime skills. You will be able to shoot stunning bullets out of your fingers, and create large walls that can block an entire hallway!"
 	reference = "AM"
 	item = /obj/item/storage/box/syndie_kit/mimery
-	cost = 10
+	cost = 6
 	job = list("Mime")
 
 /datum/uplink_item/jobspecific/pressure_mod
@@ -210,7 +210,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A modification kit which allows Kinetic Accelerators to do greatly increased damage while indoors. Occupies 35% mod capacity."
 	reference = "KPM"
 	item = /obj/item/borg/upgrade/modkit/indoors
-	cost = 5 //you need two for full damage, so total of 10 for maximum damage
+	cost = 4 //you need two for full damage, so total of 8 for maximum damage
 	job = list("Shaft Miner")
 
 //Chef
@@ -273,7 +273,16 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "An Anti-Personnel proximity mine cleverly disguised as a wet floor caution sign that is triggered by running past it, activate it to start the 15 second timer and activate again to disarm."
 	reference = "PM"
 	item = /obj/item/caution/proximity_sign
-	cost = 4
+	cost = 3
+	job = list("Janitor")
+	surplus = 0
+
+/datum/uplink_item/jobspecific/holomine
+	name = "Holomine Projector"
+	desc = "Projector that can set up to 5 stun mines with additional EMP effect."
+	reference = "HM"
+	item = /obj/item/holosign_creator/syndie
+	cost = 8
 	job = list("Janitor")
 	surplus = 0
 
@@ -286,6 +295,23 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/rad_laser
 	cost = 5
 	job = list("Chief Medical Officer", "Medical Doctor", "Geneticist", "Psychiatrist",	"Chemist", "Paramedic", "Coroner", "Virologist")
+
+/datum/uplink_item/jobspecific/batterer
+	name = "Mind Batterer"
+	desc = "A device that has a chance of knocking down people around you for a long amount of time or slowing them down. The user is unaffected. Each charge takes 2 minutes to recharge."
+	reference = "BTR"
+	item = /obj/item/batterer
+	cost = 5
+	job = list("Chief Medical Officer", "Psychiatrist")
+
+/datum/uplink_item/jobspecific/genekit
+	name = "Genetic Superiority Bundle"
+	desc = "A set of injectors containing extremely powerful mutations brought to you by recently established Syndicate research station. This set is designed for teamwork"
+	reference = "GS"
+	item = /obj/item/storage/box/syndie_kit/genes
+	cost = 15
+	job = list("Chief Medical Officer", "Geneticist")
+	surplus = 0
 
 //Virology
 
@@ -314,6 +340,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/clothing/gloves/color/black/thief
 	cost = 6
 	job = list("Civilian")
+
+/datum/uplink_item/jobspecific/stungloves
+	name = "Stungloves"
+	desc = "A pair of sturdy shock gloves with insulated layer. Protects user from electric shock and allows to shock enemies."
+	reference = "SG"
+	item = /obj/item/storage/box/syndie_kit/stungloves
+	cost = 2
+	job = list("Civilian", "Mechanic", "Station Engineer", "Chief Engineer")
 
 //Bartender
 
@@ -352,7 +386,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "Insulated gloves that can utilize the power of the station to deliver a short arc of electricity at a target. Must be standing on a powered cable to use."
 	reference = "PG"
 	item = /obj/item/clothing/gloves/color/yellow/power
-	cost = 10
+	cost = 8
 	job = list("Station Engineer", "Chief Engineer")
 
 //RD
@@ -557,12 +591,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/twohanded/chainsaw
 	cost = 12
 
-/datum/uplink_item/dangerous/batterer
-	name = "Mind Batterer"
-	desc = "A device that has a chance of knocking down people around you for a long amount of time. 50% chance per person. The user is unaffected. Has 5 charges."
-	reference = "BTR"
-	item = /obj/item/batterer
-	cost = 5
 
 // SUPPORT AND MECHAS
 
@@ -844,7 +872,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			will instantly put them in your grasp and silence them, as well as causing rapid suffocation. Does not work on those who do not need to breathe."
 	reference = "GAR"
 	item = /obj/item/twohanded/garrote
-	cost = 8
+	cost = 6
 
 /datum/uplink_item/stealthy_weapons/martialarts
 	name = "Martial Arts Scroll"
@@ -864,7 +892,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A manual that teaches a single user tactical Close-Quarters Combat before self-destructing. Does not restrict weapon usage, but cannot be used alongside Gloves of the North Star."
 	reference = "CQC"
 	item = /obj/item/CQC_manual
-	cost = 14
+	cost = 10
 	cant_discount = TRUE
 
 /datum/uplink_item/stealthy_weapons/cameraflash
@@ -1119,7 +1147,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "These glasses are thermals with Syndicate chameleon technology built into them. They allow you to see organisms through walls by capturing the upper portion of the infra-red light spectrum, emitted as heat and light by objects. Hotter objects, such as warm bodies, cybernetic organisms and artificial intelligence cores emit more of this light than cooler objects like walls and airlocks."
 	reference = "THIG"
 	item = /obj/item/clothing/glasses/chameleon/thermal
-	cost = 6
+	cost = 4
 
 /datum/uplink_item/stealthy_tools/traitor_belt
 	name = "Traitor's Toolbelt"
@@ -1418,7 +1446,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "When screwed to wiring attached to an electric grid, then activated, this large device places excessive load on the grid, causing a stationwide blackout. The sink cannot be carried because of its excessive size. Ordering this sends you a small beacon that will teleport the power sink to your location on activation."
 	reference = "PS"
 	item = /obj/item/powersink
-	cost = 10
+	cost = 8
 
 /datum/uplink_item/device_tools/singularity_beacon
 	name = "Power Beacon"
@@ -1509,7 +1537,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "An implant injected into the body and later activated manually to break out of any restraints. Can be activated up to 4 times."
 	reference = "FI"
 	item = /obj/item/implanter/freedom
-	cost = 5
+	cost = 4
 
 /datum/uplink_item/implants/uplink
 	name = "Uplink Implant"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -301,7 +301,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A device that has a chance of knocking down people around you for a long amount of time or slowing them down. The user is unaffected. Each charge takes 2 minutes to recharge."
 	reference = "BTR"
 	item = /obj/item/batterer
-	cost = 5
+	cost = 10
 	job = list("Chief Medical Officer", "Psychiatrist")
 
 /datum/uplink_item/jobspecific/genekit

--- a/code/game/gamemodes/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/changeling/powers/mutations.dm
@@ -261,6 +261,7 @@
 		var/obj/item/grab/G = C.grabbedby(src,1)
 		if(istype(G))
 			G.state = GRAB_PASSIVE //Instant aggressive grab
+			C.Weaken(2)
 
 /mob/proc/tentacle_stab(mob/living/carbon/C)
 	if(Adjacent(C))

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -49,13 +49,13 @@ effective or pretty fucking useless.
 			to_chat(M, "<span class='danger'>You feel a tremendous, paralyzing wave flood your mind.</span>")
 		else
 			to_chat(M, "<span class='danger'>You feel a sudden, electric jolt travel through your head.</span>")
-			M.Slowed(10)
-			M.Confused(5)
+			M.Slowed(5)
+			M.Confused(3)
 
 	playsound(loc, 'sound/misc/interference.ogg', 50, 1)
 	charges--
 	to_chat(user, "<span class='notice'>You trigger [src]. It has [charges] charges left.</span>")
-	addtimer(CALLBACK(src, .proc/recharge), 2 MINUTES)
+	addtimer(CALLBACK(src, .proc/recharge), 3 MINUTES)
 
 /obj/item/batterer/proc/recharge()
 	charges++

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -27,38 +27,39 @@ effective or pretty fucking useless.
 	item_state = "electronic"
 	origin_tech = "magnets=3;combat=3;syndicate=3"
 
-	var/times_used = 0 //Number of times it's been used.
-	var/max_uses = 5
+	var/charges = 3
 
 /obj/item/batterer/examine(mob/user)
 	. = ..()
-	if(times_used >= max_uses)
-		. += "<span class='notice'>[src] is out of charge.</span>"
-	if(times_used < max_uses)
-		. += "<span class='notice'>[src] has [max_uses-times_used] charges left.</span>"
+	. += "<span class='notice'>[src] has [charges] charges left.</span>"
 
 /obj/item/batterer/attack_self(mob/living/carbon/user, flag = 0, emp = 0)
 	if(!user)
 		return
-	if(times_used >= max_uses)
-		to_chat(user, "<span class='danger'>The mind batterer has been burnt out!</span>")
+	if(charges == 0)
+		to_chat(user, "<span class='danger'>The mind batterer is out of charge!</span>")
 		return
 
 
-	for(var/mob/living/carbon/human/M in oview(7, user))
+	for(var/mob/living/carbon/human/M in orange (10, user))
 		if(prob(50))
 			M.Weaken(rand(1,3))
-			M.adjustStaminaLoss(rand(25, 60))
+			M.adjustStaminaLoss(rand(35, 60))
 			add_attack_logs(user, M, "Stunned with [src]")
 			to_chat(M, "<span class='danger'>You feel a tremendous, paralyzing wave flood your mind.</span>")
 		else
 			to_chat(M, "<span class='danger'>You feel a sudden, electric jolt travel through your head.</span>")
+			M.Slowed(10)
+			M.Confused(5)
 
 	playsound(loc, 'sound/misc/interference.ogg', 50, 1)
-	times_used++
-	to_chat(user, "<span class='notice'>You trigger [src]. It has [max_uses-times_used] charges left.</span>")
-	if(times_used >= max_uses)
-		icon_state = "battererburnt"
+	charges--
+	to_chat(user, "<span class='notice'>You trigger [src]. It has [charges] charges left.</span>")
+	addtimer(CALLBACK(src, .proc/recharge), 2 MINUTES)
+
+/obj/item/batterer/proc/recharge()
+	charges++
+
 
 
 /*

--- a/code/game/objects/items/weapons/holosign.dm
+++ b/code/game/objects/items/weapons/holosign.dm
@@ -82,6 +82,11 @@
 	creation_time = 0
 	max_signs = 3
 
+/obj/item/holosign_creator/syndie
+	holosign_type = /obj/structure/holosign/wetsign/mine
+	creation_time = 5
+	max_signs = 5
+
 /obj/item/holosign_creator/cyborg
 	name = "Energy Barrier Projector"
 	desc = "A holographic projector that creates fragile energy fields."

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -358,3 +358,25 @@ To apply, hold the injector a short distance away from the outer thigh before ap
 	new /obj/item/reagent_containers/syringe/sarin(src)
 	new /obj/item/reagent_containers/syringe/pancuronium(src)
 
+/obj/item/storage/box/syndie_kit/genes
+	name = "Genetic superiority bundle"
+	desc = "Fun for the whole family"
+
+/obj/item/storage/box/syndie_kit/genes/New()
+	..()
+	new /obj/item/dnainjector/hulkmut(src)
+	new /obj/item/dnainjector/xraymut(src)
+	new /obj/item/dnainjector/telemut(src)
+	new /obj/item/dnainjector/runfast(src)
+	new /obj/item/dnainjector/insulation(src)
+
+/obj/item/storage/box/syndie_kit/stungloves
+	name = "Stungloves"
+
+/obj/item/storage/box/syndie_kit/stungloves/New()
+	..()
+	new /obj/item/clothing/gloves/color/yellow/stun(src)
+	new /obj/item/stock_parts/cell/high/plus(src)
+	new /obj/item/toy/crayon/white(src)
+	new /obj/item/toy/crayon/yellow(src)
+	new /obj/item/toy/crayon/rainbow(src)

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -41,6 +41,21 @@
 	desc = "The words flicker as if they mean nothing."
 	icon_state = "holosign"
 
+/obj/structure/holosign/wetsign/mine
+	desc = "The words flicker as if they mean something."
+
+/obj/structure/holosign/wetsign/mine/Crossed(atom/movable/AM, oldloc)
+	. = ..()
+	if(!isliving(AM))
+		return
+	triggermine(AM)
+
+/obj/structure/holosign/wetsign/mine/proc/triggermine(mob/living/victim)
+	empulse(src, 1, 1)
+	if(ishuman(victim))
+		victim.adjustStaminaLoss(100)
+	qdel(src)
+
 /obj/structure/holosign/barrier
 	name = "holo barrier"
 	desc = "A short holographic barrier which can only be passed by walking."


### PR DESCRIPTION
Предметы предателя
Трость дробовик мима
 -Цена уменьшена с 10 до 5
Мануал мима
 -Цена уменьшена с 10 до 5
Мод для КА предателя
 -Цена уменьшена с 5 до 4
Мины уборщика
 -Цена уменьшена  с 4 до 3
Силовые перчатки
 -Цена уменьшена с 10 до 8
Гаррота
 -Цена уменьшена с 8 до 6
CQC
 -Цена уменьшена с 14 до 10
Термалы
 -Цена уменьшена с 6 до 4
Powersink
 -Цена уменьшена с 10 до 8
Имплант свободы
 -Цена уменьшена с 5 до 4
 
 Добавлено
 -Проектор стан мин для уборщика. Устанавливает до 5 оглушающих мин одновременно. При наступании создают ЭМИ импульс и вводят в стаминакрит. Стоит 8ТК
 -Станперчатки для инжинеров и ассистентов. Станпрод в виде перчаток. 20 стамина урона, заряда в поставляемой батарее хватит на 10 ударов. Стоит 2 ТК
 -Набор генов для генетика и СМО. Содержит икс-рей, халка, телекинез, бег и защиту от шока. Стоит 15 ТК.
 
 Переработано
Мозгодавка 
 -больше недоступна для всех предателей. Теперь этот предмет является эксклюзивным для СМО и психолога.
 -Теперь заряды восстанавливаются через 3 минуты после использования
 -Минимальный стамина урон повышен до 35
 -В случае неудачи, вместо оглушения и стамина урона накладывает 5 тиков замедления и 3 тика смятения
 
 Стан культа, глейр вампира и тенеморфа
  -Длительность дебаффа наносящего урон стамине повышена с 10 до 13 секунд
 Щупальце генокрада
  -Теперь оглушает на 2.5 секунды при захвате цели