### PR TITLE
Fix: paralyzer damage

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -193,7 +193,7 @@
 /obj/item/projectile/beam/dominator/paralyzer
 	name = "paralyzer beam"
 	icon_state = "omnilaser"
-	damage = 33
+	damage = 25
 	shockbull = TRUE
 	damage_type = STAMINA
 	flag = "energy"


### PR DESCRIPTION
-Стамина урон парализатора снижен для соответствия дизейблеру.

Доминатор использует отдельный тип дизейблера который был пропущен при последних правках баланса, в результате чего доминатор наносит повышенный урон по сравнению с другими типами нелетального вооружения. Это изменение уравнивает парализатор доминатора с дизейблером.
