### PR TITLE
Неофициальный патч Тайпана v1.01

### DIFF
--- a/_maps/map_files/generic/syndicatebase.dmm
+++ b/_maps/map_files/generic/syndicatebase.dmm
@@ -19011,12 +19011,12 @@
 "pKJ" = (
 /obj/machinery/r_n_d/server{
 	icon_state = "syndie_server";
-	id_with_download_string = "0027";
-	id_with_upload_string = "0027;1";
+	id_with_download_string = "27";
+	id_with_upload_string = "27;1";
 	name = "ERR#UNKWN";
 	req_access = null;
 	req_access_txt = "155";
-	server_id = 0027;
+	server_id = 404;
 	syndicate = 1
 	},
 /turf/simulated/floor/bluegrid{
@@ -19877,7 +19877,7 @@
 /obj/item/radio/intercom/syndicate{
 	pixel_x = 30
 	},
-/obj/machinery/computer/rdconsole/core,
+/obj/machinery/computer/rdconsole/syndie,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault";

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -242,6 +242,7 @@
 	build_path = /obj/machinery/computer/rdconsole/core
 	req_access = list(ACCESS_TOX) // This is for adjusting the type of computer we're building - in case something messes up the pre-existing robotics or mechanics consoles
 	var/access_types = list("R&D Core", "Robotics", "E.X.P.E.R.I-MENTOR", "Mechanics", "Public")
+	var/emag_types = list("R&D Core", "Syndicate") //For a Taipan.
 	id = 1
 /obj/item/circuitboard/rdconsole/robotics
 	name = "Circuit Board (RD Console - Robotics)"
@@ -259,6 +260,10 @@
 	name = "Circuit Board (RD Console - Public)"
 	build_path = /obj/machinery/computer/rdconsole/public
 	id = 5
+/obj/item/circuitboard/rdconsole/syndie
+	name = "Circuit Board (RD Console - Syndicate)"
+	build_path = /obj/machinery/computer/rdconsole/syndie	//For Taipan
+	id = 27
 
 
 /obj/item/circuitboard/mecha_control
@@ -409,6 +414,21 @@ obj/item/circuitboard/syndicatesupplycomp/public
 				to_chat(user, "DERP! BUG! Report this (And what you were doing to cause it) to Agouri")
 		return
 	return ..()
+
+/obj/item/circuitboard/rdconsole/emag_act(user as mob)
+	var/console_choice = input(user, "What do you want to configure the access to?", "Access Modification", "R&D Core") as null|anything in emag_types
+	if(console_choice == null)
+		return
+	switch(console_choice)
+		if("R&D Core")
+			name = "Circuit Board (RD Console)"
+			build_path = /obj/machinery/computer/rdconsole/core
+			id = 1
+		if("Syndicate")
+			name = "Circuit Board (RD Console - Syndicate)"
+			build_path = /obj/machinery/computer/rdconsole/syndie	//This prevent traitors from emaging circuit and steal syndie stuff
+			id = 1
+	return
 
 /obj/item/circuitboard/rdconsole/attackby(obj/item/I as obj, mob/user as mob, params)
 	if(istype(I,/obj/item/card/id)||istype(I, /obj/item/pda))

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -225,6 +225,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		emagged = TRUE
 		to_chat(user, "<span class='notice'>You disable the security protocols</span>")
 		if(is_taipan(z))
+			syndicate = 1
 			id = 27		//so Taipan can build more consoles, that connected to server
 			//Its does not change icon of the console, only ID
 			//It is nulling access, but I think this is fair price for more consoles

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -225,7 +225,6 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		emagged = TRUE
 		to_chat(user, "<span class='notice'>You disable the security protocols</span>")
 		if(is_taipan(z))
-			syndicate = 1
 			id = 27		//so Taipan can build more consoles, that connected to server
 			//Its does not change icon of the console, only ID
 			//It is nulling access, but I think this is fair price for more consoles

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -172,11 +172,9 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	matching_designs = list()
 	if(is_taipan(z))
 		syndicate = 1
-		ui_theme = "syndicate"
-		icon_screen = "syndie_rdcomp"
-		icon_keyboard = "syndie_key"
+		id = 27
 		req_access = list(ACCESS_SYNDICATE_SCIENTIST)
-		id = 0027
+		//Tajaran deleted ID, because he made a separate console for that. Need to emag normal circuit for that
 		update_icon()
 	if(!id)
 		for(var/obj/machinery/r_n_d/server/centcom/S in GLOB.machines)
@@ -226,6 +224,10 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		req_access = list()
 		emagged = TRUE
 		to_chat(user, "<span class='notice'>You disable the security protocols</span>")
+		if(is_taipan(z))
+			id = 27		//so Taipan can build more consoles, that connected to server
+			//Its does not change icon of the console, only ID
+			//It is nulling access, but I think this is fair price for more consoles
 
 /obj/machinery/computer/rdconsole/proc/valid_nav(next_menu, next_submenu)
 	switch(next_menu)
@@ -276,9 +278,10 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		var/server_processed = FALSE
 		if(S.disabled)
 			continue
-		if(syndicate != S.syndicate) // То самое злосчастное место куда я не добавила проверку сразу!
+		/*if(syndicate != S.syndicate) // То самое злосчастное место куда я не добавила проверку сразу!
 			log_debug("[src.name] ([COORD(src)]) and [S.name]([COORD(S)]) don't have the same\"Syndicate\" flag. Skipped synchronizing data.")	//На всякий
 			continue	//По идее должно блочить скачивание и загрузку на синди/не синди сервера в зависимости от того синди или не синди эта консоль @_@
+		*/ // We need allow NT to share research with Syndicate -Taj
 		if((id in S.id_with_upload) || istype(S, /obj/machinery/r_n_d/server/centcom))
 			files.push_data(S.files)
 			server_processed = TRUE
@@ -972,6 +975,17 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	id = 5
 	req_access = list()
 	circuit = /obj/item/circuitboard/rdconsole/public
+
+/obj/machinery/computer/rdconsole/syndie
+	name = "syndicate R&D console"
+	desc = "A console that makes weapon against NT. <span class='warning'> Death to NT!</span>"
+	id = 1 //Changes upon emaging. Yes, no free stuff for traitors
+	ui_theme = "syndicate"
+	icon_screen = "syndie_rdcomp"
+	icon_keyboard = "syndie_key"
+	req_access = list(ACCESS_SYNDICATE_SCIENTIST)
+	circuit = /obj/item/circuitboard/rdconsole/syndie //you need to emag circuit to build this
+	//So basically... Red RD console on the station(s)
 
 #undef TECH_UPDATE_DELAY
 #undef DESIGN_UPDATE_DELAY

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -985,6 +985,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	icon_keyboard = "syndie_key"
 	req_access = list(ACCESS_SYNDICATE_SCIENTIST)
 	circuit = /obj/item/circuitboard/rdconsole/syndie //you need to emag circuit to build this
+	light_color = LIGHT_COLOR_RED
 	//So basically... Red RD console on the station(s)
 
 #undef TECH_UPDATE_DELAY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
## Мотивации и причины
Тайпан сейчас является гост ролью, хотя все механики, включая РнД, которое я затрону данным ПРом, больше подходят для раундстарт профы и с большим уклоном в работку.
С данными изменениями я хочу упростить жизнь Тайпану, сделав её более "гост ролью". Чтобы в любом моменте раунда мог зайти первый Тайпановец и сразу начать помогать агентам.
Тайпановцам, что заходят раундстартом, этот ПР никак не поможет, только мидраундом.

## What Does This PR Do
(~~Комментирует проверку от Фуры~~) Позволяет синди пользоваться сервером на Тайпане
Добавляет консоли для синдиката.
Чтобы получить их платы - нужно емагнуть обычную плату консоли РнД.
Собрав консоль и емагнув их на Тайпане - они подключаться к серверу на Тайпане и смогут скачивать данные с него. (Доступ ученого потеряется)
(Взломав емагом на станции НТ, просто получиться красная консоль (не подключиться к серверам Синди), это не даст никакого примущества)

## Why It's Good For The Game
Тайпан, как гост роль в середине раунда, может спокойно играться, без нужды изучать все сначала, когда НТ уже и так сделали это.

## Changelog
:cl:
add: new console for Taipan
add: circuit for new console
fix: a server on Taipan now works; now it can sync with Taipan rnd
tweak: a taipan server's settings
experiment: changed light color from purple to red for syndie console
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
