### PR TITLE
Мелкие фиксы: Починка status у shock_kit и IED на капкане

### DIFF
--- a/code/game/objects/items/weapons/legcuffs.dm
+++ b/code/game/objects/items/weapons/legcuffs.dm
@@ -52,6 +52,7 @@
 		if(sig)
 			to_chat(user, "<span class='warning'>This beartrap already has a signaler hooked up to it!</span>")
 			return
+		IED = I
 		user.drop_item()
 		I.forceMove(src)
 		message_admins("[key_name_admin(user)] has rigged a beartrap with an IED.")

--- a/code/modules/assembly/shock_kit.dm
+++ b/code/modules/assembly/shock_kit.dm
@@ -27,11 +27,19 @@
 		part2 = null
 		qdel(src)
 		return
-	if(istype(W, /obj/item/screwdriver))
-		status = !status
-		to_chat(user, "<span class='notice'>[src] is now [status ? "secured" : "unsecured"]!</span>")
 	add_fingerprint(user)
 	return
+
+/obj/item/assembly/shock_kit/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	if(!status)
+		status = !status
+		to_chat(user, "<span class='notice'>[src] is now ready to be attached to a chair!</span>")
+	else
+		status = !status
+		to_chat(user, "<span class='notice'>[src] is now ready!</span>")
 
 /obj/item/assembly/shock_kit/attack_self(mob/user as mob)
 	part1.attack_self(user, status)

--- a/code/modules/assembly/shock_kit.dm
+++ b/code/modules/assembly/shock_kit.dm
@@ -34,11 +34,10 @@
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-	if(!status)
-		status = !status
+	status = !status
+	if(status)
 		to_chat(user, "<span class='notice'>[src] is now ready to be attached to a chair!</span>")
 	else
-		status = !status
 		to_chat(user, "<span class='notice'>[src] is now ready!</span>")
 
 /obj/item/assembly/shock_kit/attack_self(mob/user as mob)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Чинит код, который не работал.
shock_kit теперь нормально меняет свой статус, теперь можно сделать из него электрический стул, как и было задумано.
IED теперь корректно крепиться к капкану.

## Why It's Good For The Game
Можно будет собрать стул для казни, если прошлый сломается.
IED не будет вечно копиться в капкане, а будет использоваться по назначению.
Код будет работать.

## Changelog
:cl:
fix: shock_kit's status, now it works
fix: IED on beartraps now works!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
