### PR TITLE
Letters to uppercase

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -407,7 +407,7 @@
 			to_chat(target, "<span class='danger'>You are pricked by [G]!</span>")
 
 /datum/plant_gene/trait/smoke
-	name = "gaseous decomposition"
+	name = "Gaseous Decomposition"
 	dangerous = TRUE
 
 /datum/plant_gene/trait/smoke/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Приводит название гена `Gaseous Decomposition` к общему виду.
В ботанике этот ген единственный целиком в lowercase по неизвестным причинам.

## Why It's Good For The Game
Так красивее.

## Images of changes
![image](https://user-images.githubusercontent.com/4831847/162068793-4fb45ca3-ffb3-4a17-91fe-2ca6e0ea0c35.png)
![image](https://user-images.githubusercontent.com/4831847/162070488-f0066186-ea76-426a-9456-3cc0a4653e9c.png)


## Changelog
:cl:
tweak: tweaked hydroponics trait gene name
/:cl: