### PR TITLE
Обновление интерфейса Chem Dispenser

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -407,7 +407,7 @@
 			to_chat(target, "<span class='danger'>You are pricked by [G]!</span>")
 
 /datum/plant_gene/trait/smoke
-	name = "gaseous decomposition"
+	name = "Gaseous Decomposition"
 	dangerous = TRUE
 
 /datum/plant_gene/trait/smoke/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target)

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -147,7 +147,7 @@
 	// update the ui if it exists, returns null if no ui is passed/found
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
-		ui = new(user, src, ui_key, "ChemDispenser", ui_title, 390, 655)
+		ui = new(user, src, ui_key, "ChemDispenser", ui_title, 477, 655)
 		ui.open()
 
 /obj/machinery/chem_dispenser/ui_data(mob/user)
@@ -191,8 +191,9 @@
 
 	. = TRUE
 	switch(actions)
+		//Chem dispenser dispense amount
 		if("amount")
-			amount = clamp(round(text2num(params["amount"]), 1), 0, 50) // round to nearest 1 and clamp to 0 - 50
+			amount = clamp(round(text2num(params["amount"]), 1), 0, 100) //Round to nearest 1 and clamp to 0 - 100
 		if("dispense")
 			if(!is_operational() || QDELETED(cell))
 				return

--- a/tgui/packages/tgui/interfaces/ChemDispenser.js
+++ b/tgui/packages/tgui/interfaces/ChemDispenser.js
@@ -4,7 +4,7 @@ import { Box, Button, Flex, LabeledList, ProgressBar, Section } from "../compone
 import { BeakerContents } from "../interfaces/common/BeakerContents";
 import { Window } from "../layouts";
 
-const dispenseAmounts = [1, 5, 10, 20, 30, 50];
+const dispenseAmounts = [1, 5, 10, 20, 30, 50, 100];
 const removeAmounts = [1, 5, 10];
 
 export const ChemDispenser = (props, context) => {
@@ -50,6 +50,7 @@ const ChemDispenserSettings = (properties, context) => {
                   icon="cog"
                   selected={amount === a}
                   content={a}
+                  align="center"
                   m="0"
                   width="100%"
                   onClick={() => act('amount', {


### PR DESCRIPTION
## What Does This PR Do
Обновление интерфейса химических раздатчиков

## Why It's Good For The Game
Очень душно вливать по 50u в бикеры на 300u. Теперь можно вливать по 100u.

## Images of changes
![image](https://user-images.githubusercontent.com/4831847/162665871-5b21e75b-8e05-45d6-a45c-89faadf58a87.png)

## Changelog
:cl:
add: Added 100u dispense amount to `chem_dispenser`
tweak: Tweaked labels content align. It's centered now
tweak: Tweaked base ui width to properly fit additional dispense amount
/:cl: