### PR TITLE
fix: fixed nanomaps not rendering

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -6962,11 +6962,7 @@
 	icon_state = "black";
 	name = "Mineral's"
 	},
-/obj/effect/spawner/lootdrop/trade_sol/minerals{
-	loot = list(/obj/item/stack/sheet/mineral/silver = 50, /obj/item/stack/sheet/mineral/silver {amount = 10} = 50, /obj/item/stack/sheet/mineral/silver {amount = 30} = 50, /obj/item/stack/sheet/mineral/gold = 50, /obj/item/stack/sheet/mineral/gold {amount = 10} = 50, /obj/item/stack/sheet/mineral/gold {amount = 30} = 50, /obj/item/stack/sheet/mineral/uranium = 50, /obj/item/stack/sheet/mineral/uranium {amount = 10} = 50, /obj/item/stack/sheet/mineral/uranium {amount = 30} = 50, /obj/item/stack/sheet/mineral/diamond = 50, /obj/item/stack/sheet/mineral/diamond {amount = 10} = 50, /obj/item/stack/sheet/mineral/diamond {amount = 30} = 50, /obj/item/stack/sheet/mineral/titanium = 50, /obj/item/stack/sheet/mineral/titanium {amount = 10} = 50, /obj/item/stack/sheet/mineral/titanium {amount = 30} = 50, /obj/item/stack/sheet/plasteel = 50, /obj/item/stack/sheet/plasteel {amount = 10} = 50, /obj/item/stack/sheet/plasteel {amount = 30} = 50, /obj/item/stack/sheet/titaniumglass = 50, /obj/item/stack/sheet/titaniumglass {amount = 10} = 50, /obj/item/stack/sheet/titaniumglass {amount = 30} = 50, /obj/item/stack/sheet/mineral/tranquillite = 50, /obj/item/stack/sheet/mineral/tranquillite {amount = 10} = 50, /obj/item/stack/sheet/mineral/tranquillite {amount = 30} = 50, /obj/item/stack/sheet/mineral/bananium = 50, /obj/item/stack/sheet/mineral/bananium {amount = 10} = 50, /obj/item/stack/sheet/mineral/bananium {amount = 30} = 50, /obj/item/stack/sheet/wood = 50, /obj/item/stack/sheet/wood {amount = 10} = 50, /obj/item/stack/sheet/wood {amount = 30} = 50, /obj/item/stack/sheet/plastic = 50, /obj/item/stack/sheet/plastic {amount = 10} = 50, /obj/item/stack/sheet/plastic {amount = 30} = 50, /obj/item/stack/sheet/mineral/sandstone = 50, /obj/item/stack/sheet/mineral/sandstone {amount = 10} = 50, /obj/item/stack/sheet/mineral/sandstone {amount = 30} = 50);
-	lootcount = 15;
-	name = "9. Minerals"
-	},
+/obj/effect/spawner/lootdrop/trade_sol/minerals,
 /turf/simulated/floor/wood,
 /area/shuttle/trade/sol)
 "aKd" = (

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -54790,11 +54790,7 @@
 	icon_state = "black";
 	name = "Mineral's"
 	},
-/obj/effect/spawner/lootdrop/trade_sol/minerals{
-	loot = list(/obj/item/stack/sheet/mineral/silver = 50, /obj/item/stack/sheet/mineral/silver {amount = 10} = 50, /obj/item/stack/sheet/mineral/silver {amount = 30} = 50, /obj/item/stack/sheet/mineral/gold = 50, /obj/item/stack/sheet/mineral/gold {amount = 10} = 50, /obj/item/stack/sheet/mineral/gold {amount = 30} = 50, /obj/item/stack/sheet/mineral/uranium = 50, /obj/item/stack/sheet/mineral/uranium {amount = 10} = 50, /obj/item/stack/sheet/mineral/uranium {amount = 30} = 50, /obj/item/stack/sheet/mineral/diamond = 50, /obj/item/stack/sheet/mineral/diamond {amount = 10} = 50, /obj/item/stack/sheet/mineral/diamond {amount = 30} = 50, /obj/item/stack/sheet/mineral/titanium = 50, /obj/item/stack/sheet/mineral/titanium {amount = 10} = 50, /obj/item/stack/sheet/mineral/titanium {amount = 30} = 50, /obj/item/stack/sheet/plasteel = 50, /obj/item/stack/sheet/plasteel {amount = 10} = 50, /obj/item/stack/sheet/plasteel {amount = 30} = 50, /obj/item/stack/sheet/titaniumglass = 50, /obj/item/stack/sheet/titaniumglass {amount = 10} = 50, /obj/item/stack/sheet/titaniumglass {amount = 30} = 50, /obj/item/stack/sheet/mineral/tranquillite = 50, /obj/item/stack/sheet/mineral/tranquillite {amount = 10} = 50, /obj/item/stack/sheet/mineral/tranquillite {amount = 30} = 50, /obj/item/stack/sheet/mineral/bananium = 50, /obj/item/stack/sheet/mineral/bananium {amount = 10} = 50, /obj/item/stack/sheet/mineral/bananium {amount = 30} = 50, /obj/item/stack/sheet/wood = 50, /obj/item/stack/sheet/wood {amount = 10} = 50, /obj/item/stack/sheet/wood {amount = 30} = 50, /obj/item/stack/sheet/plastic = 50, /obj/item/stack/sheet/plastic {amount = 10} = 50, /obj/item/stack/sheet/plastic {amount = 30} = 50, /obj/item/stack/sheet/mineral/sandstone = 50, /obj/item/stack/sheet/mineral/sandstone {amount = 10} = 50, /obj/item/stack/sheet/mineral/sandstone {amount = 30} = 50);
-	lootcount = 15;
-	name = "9. Minerals"
-	},
+/obj/effect/spawner/lootdrop/trade_sol/minerals,
 /turf/simulated/floor/wood,
 /area/shuttle/trade/sol)
 "cbB" = (


### PR DESCRIPTION
### мержить после PRов с картами, а то merge conflict)😂😂😂😂😂👌👌👌👌
### мержить после PRов с картами, а то merge conflict))) 😂😂😂😂😂👌👌👌👌
### мержить после PRов с картами, а то merge conflict))😂😂😂😂😂👌👌👌👌

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Это настолько же смешно, насколько хуево
фикс рендера наномап, [#299](https://github.com/ss220-space/Paradise/pull/299), помним, любим, скорбим. Ты был хорошей ошибкой, _1:98:got '', expected one of: operator, field access, '}', ';'_

## Images of changes
![image](https://user-images.githubusercontent.com/20109643/162879180-965de399-f741-4160-85da-e5ea74829860.png)
![spunch-bop-mr-krabs](https://user-images.githubusercontent.com/20109643/162880318-9946133e-3f3e-48e7-95d7-0de87334f14e.gif)



## Changelog
:cl:
[fix: fix nanomaps not rendering](https://github.com/ss220-space/Paradise/commit/b6139a50dd4a26f36dd27caf2abfd6c1d9d1998e)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
