### PR TITLE
Корректировка логики распределения урона

### DIFF
--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -224,17 +224,17 @@
 					forbidden_limbs += src
 			else
 				forbidden_limbs += src
-			if(forbidden_limbs.len)
+			if(length(forbidden_limbs))
 				possible_points -= forbidden_limbs
 			//If everything is damaged, no damage
 			var/can_distribute = TRUE
-			if(forbidden_limbs?.len == owner?.bodyparts_by_name.len)
+			if(owner && length(forbidden_limbs) == length(owner.bodyparts_by_name))
 				can_distribute = FALSE
 			//Return damage to upper body if nothing is available
-			if(!possible_points.len && parent)
+			if(parent && !length(possible_points))
 				possible_points += parent
 
-			if(possible_points.len && can_distribute)
+			if(can_distribute && length(possible_points))
 				//And pass the pain around
 				var/obj/item/organ/external/target = pick(possible_points)
 				target.receive_damage(brute, burn, sharp, used_weapon, forbidden_limbs, ignore_resists = TRUE) //If the damage was reduced before, don't reduce it again

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -161,15 +161,15 @@
 #define LIMB_THRESH_INT_DMG 10
 	// Probability of taking internal damage from sufficient force, while otherwise healthy
 #define LIMB_DMG_PROB 5
-	// High brute damage or sharp objects may damage internal organs
-	if(internal_organs && (brute_dam >= max_damage || (((sharp && brute >= LIMB_SHARP_THRESH_INT_DMG) || brute >= LIMB_THRESH_INT_DMG) && prob(LIMB_DMG_PROB))))
+	// High brute damage or sharp objects may damage internal organs; distributed damage doesn't inflict it
+	if(!ignore_resists && internal_organs && (brute_dam >= max_damage || (((sharp && brute >= LIMB_SHARP_THRESH_INT_DMG) || brute >= LIMB_THRESH_INT_DMG) && prob(LIMB_DMG_PROB))))
 		// Damage an internal organ
 		if(internal_organs && internal_organs.len)
-			var/obj/item/organ/internal/I = pick(internal_organs)
+			var/obj/item/organ/internal/internal_organ = pick(internal_organs)
 			//Pass full damage if an internal organ is dead
-			var/internal_damage = min(I.max_damage - I.damage, brute * 0.5)
+			var/internal_damage = min(internal_organ.max_damage - internal_organ.damage, brute * 0.5)
 			if(internal_damage)
-				I.receive_damage(internal_damage)
+				internal_organ.receive_damage(internal_damage)
 				brute -= internal_damage
 
 	if(status & ORGAN_BROKEN && prob(40) && brute)
@@ -183,11 +183,17 @@
 	else
 		add_autopsy_data(null, brute + burn)
 
+	// See if internal bleeding has place; distributed damage doesn't inflict it
+	if(!ignore_resists)
+		check_for_internal_bleeding(brute)
+	// See if bones need to break; distributed damage doesn't inflict it
+	if(!ignore_resists)
+		check_fracture(brute)
+
 	// Make sure we don't exceed the maximum damage a limb can take before dismembering
 	if((brute_dam + burn_dam + brute + burn) < max_damage)
 		brute_dam += brute
 		burn_dam += burn
-		check_for_internal_bleeding(brute)
 	else
 		//If we can't inflict the full amount of damage, spread the damage in other ways
 		//How much damage can we actually cause?
@@ -201,7 +207,6 @@
 				can_inflict = max(0, can_inflict - brute)
 				//How much brute damage is left to inflict
 				brute = max(0, brute - temp)
-				check_for_internal_bleeding(brute)
 
 			if(burn > 0 && can_inflict)
 				//Inflict all burn damage we can
@@ -242,8 +247,6 @@
 			if(dismember_at_max_damage && body_part != UPPER_TORSO && body_part != LOWER_TORSO) // We've ensured all damage to the mob is retained, now let's drop it, if necessary.
 				droplimb(1) //Clean loss, just drop the limb and be done
 
-	// See if bones need to break
-	check_fracture(brute)
 	var/mob/living/carbon/owner_old = owner //Need to update health, but need a reference in case the below check cuts off a limb.
 	//If limb took enough damage, try to cut or tear it off
 	if(owner && loc == owner)
@@ -419,18 +422,19 @@ Note that amputating the affected organ does in fact remove the infection from t
 		owner.adjustToxLoss(1)
 
 //Updates brute_damn and burn_damn from wound damages. Updates BLEEDING status.
-/obj/item/organ/external/proc/check_fracture(var/damage_inflicted)
-	if(config.bones_can_break && brute_dam > min_broken_damage && !is_robotic())
-		if(prob(damage_inflicted))
+/obj/item/organ/external/proc/check_fracture(damage)
+	if(config.bones_can_break && brute_dam + burn_dam + damage > min_broken_damage && !is_robotic())
+		if(prob(damage))
 			fracture()
 
 /obj/item/organ/external/proc/check_for_internal_bleeding(damage)
 	if(owner && (NO_BLOOD in owner.dna.species.species_traits))
 		return
-	var/local_damage = brute_dam + damage
-	if(damage > 15 && local_damage > 30 && prob(damage) && !is_robotic())
-		internal_bleeding = TRUE
-		owner.custom_pain("You feel something rip in your [name]!")
+	var/min_internal_bleeding_damage = 30
+	if(damage > 15 && brute_dam + burn_dam + damage > min_internal_bleeding_damage && !is_robotic())
+		if(prob(damage))
+			internal_bleeding = TRUE
+			owner.custom_pain("You feel something rip in your [name]!")
 
 // new damage icon system
 // returns just the brute/burn damage code

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -214,20 +214,27 @@
 			var/list/obj/item/organ/external/possible_points = list()
 			if(parent)
 				possible_points += parent
-				if(parent.max_damage - parent.damage)
-					forbidden_limbs += parent
 			if(children)
+				var/all_child_forbidden = TRUE
 				for(var/organ in children)
-					if(organ)
+					if(organ && !(organ in forbidden_limbs))
+						all_child_forbidden = FALSE
 						possible_points += organ
+				if(all_child_forbidden)
+					forbidden_limbs += src
 			else
 				forbidden_limbs += src
 			if(forbidden_limbs.len)
 				possible_points -= forbidden_limbs
+			//If everything is damaged, no damage
+			var/can_distribute = TRUE
+			if(forbidden_limbs?.len == owner?.bodyparts_by_name.len)
+				can_distribute = FALSE
 			//Return damage to upper body if nothing is available
 			if(!possible_points.len && parent)
 				possible_points += parent
-			if(possible_points.len)
+
+			if(possible_points.len && can_distribute)
 				//And pass the pain around
 				var/obj/item/organ/external/target = pick(possible_points)
 				target.receive_damage(brute, burn, sharp, used_weapon, forbidden_limbs, ignore_resists = TRUE) //If the damage was reduced before, don't reduce it again


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Корректировка логики распределения урона по телу. На текущий момент, урон может быть поглощен мертвыми внутренними органами (которые уже не могут получать больше урона) или же просто быть потерян в поиске подходящего соседа для распределения урона.

На текущий момент логика такая.
Если конечность получает полный урон, она заносится в ЧС. Урон распределяется между парентом (вышестоящей конечности) и чайлдом (нижестоящей конечности).
Если правая рука получила максимальный урон, она переносит оставшийся урон либо в торс, либо в лапку. Если урон уходит в лапку, то урон уже не может вернуться через руку в сторону торса. Таким образом, весь урон, который был свыше здоровья лапки попросту пропадает. Если в правую руку прилетел снаряд на 50 урона, урон с правой руки ушел на правую лапку, а на правой руке и правой лапке уже нет здоровья, то кукла не получит урона, так как у урона нет соседа.

Этот ПР меняет логику таким образом, что конечность заносится в ЧС только в том случае, если она конечная (лапки/хвост/голова), или если ~~парент-конечность не имеет здоровья~~ [EDIT 
2318e2c] все дети находятся в ЧС

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Больше летальности оружия и фикс бага, который уменьшал вероятную летальность.
Теперь куклам не так безразлично на то, что ее избивают минуту, так как урон "терялся".

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
https://www.youtube.com/watch?v=vO6b0qvtWfA

## Changelog
:cl:
fix: Корректировка логики распределения урона
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
