### PR TITLE
Fix: Blobbernauts Can't Attack Airlocks

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -722,6 +722,7 @@ About the new airlock wires panel:
 		shock(user, 100)
 
 /obj/machinery/door/airlock/attack_animal(mob/user)
+	. = ..()
 	if(istype(user, /mob/living/simple_animal/hulk))
 		var/mob/living/simple_animal/hulk/H = user
 		H.attack_hulk(src)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -186,6 +186,7 @@
 	open()
 
 /obj/machinery/door/firedoor/attack_animal(mob/user)
+	. = ..()
 	if(istype(user, /mob/living/simple_animal/hulk))
 		var/mob/living/simple_animal/hulk/H = user
 		H.attack_hulk(src)


### PR DESCRIPTION
## Список изменений
Блоббернауты снова могут ломать шлюзы, как в старые-добрые времена до халков.