### PR TITLE
Tweak: Правки шведского акцента

### DIFF
--- a/code/game/dna/genes/goon_disabilities.dm
+++ b/code/game/dna/genes/goon_disabilities.dm
@@ -174,6 +174,18 @@
 
 /datum/dna/gene/disability/speech/swedish/OnSay(mob/M, message)
 	// svedish
+	message = replacetextEx(message,"W","V")
+	message = replacetextEx(message,"w","v")
+	message = replacetextEx(message,"J","Y")
+	message = replacetextEx(message,"j","y")
+	message = replacetextEx(message,"A",pick("Å","Ä","Æ","A"))
+	message = replacetextEx(message,"a",pick("å","ä","æ","a"))
+	message = replacetextEx(message,"BO","BJO")
+	message = replacetextEx(message,"Bo","Bjo")
+	message = replacetextEx(message,"bo","bjo")
+	message = replacetextEx(message,"O",pick("Ö","Ø","O"))
+	message = replacetextEx(message,"o",pick("ö","ø","o"))
+
 	message = replacetextEx_char(message,"А",pick("Å","Ä","А"))
 	message = replacetextEx_char(message,"а",pick("å","ä","а"))
 
@@ -196,7 +208,7 @@
 	message = replacetextEx_char(message,"оо","ꝏ")
 
 	if(prob(30) && !M.is_muzzled())
-		message += " Борк[pick("",", борк",", борк, борк")]!"
+		message += " Bork[pick("",", bork",", bork, bork")]!"
 	return message
 
 // WAS: /datum/bioEffect/unintelligable

--- a/code/game/dna/genes/goon_disabilities.dm
+++ b/code/game/dna/genes/goon_disabilities.dm
@@ -174,43 +174,28 @@
 
 /datum/dna/gene/disability/speech/swedish/OnSay(mob/M, message)
 	// svedish
-	message = replacetextEx_char(message,"Я",pick("А","Я"))
-	message = replacetextEx_char(message,"я",pick("а","я"))
+	message = replacetextEx_char(message,"А",pick("Å","Ä","А"))
+	message = replacetextEx_char(message,"а",pick("å","ä","а"))
 
-	message = replacetextEx_char(message,"Ю",pick("У","Ю"))
-	message = replacetextEx_char(message,"ю",pick("у","ю"))
+	message = replacetextEx_char(message,"О",pick("Ö","Ø","О"))
+	message = replacetextEx_char(message,"о",pick("ö","ø","о"))
 
-	message = replacetextEx_char(message,"Е",pick("Е","Э"))
-	message = replacetextEx_char(message,"е",pick("е","э"))
+	message = replacetextEx_char(message," и ",pick(" & "," и "))
+	message = replacetextEx_char(message," И ",pick(" & "," и "))
 
-	message = replacetextEx_char(message,"В",pick("Ф","В"))
-	message = replacetextEx_char(message,"в",pick("ф","в"))
+	message = replacetextEx_char(message,"АЕ","Æ")
+	message = replacetextEx_char(message,"ае","æ")
 
-	message = replacetextEx_char(message,"Т",pick("Д","Т"))
-	message = replacetextEx_char(message,"т",pick("д","т"))
+	message = replacetextEx_char(message,"ОЕ","Œ")
+	message = replacetextEx_char(message,"ое","œ")
 
-	message = replacetextEx_char(message,"Д",pick("Д","Т"))
-	message = replacetextEx_char(message,"д",pick("д","т"))
+	message = replacetextEx_char(message,"АУ","Ꜽ")
+	message = replacetextEx_char(message,"ау","ꜽ")
 
-	message = replacetextEx_char(message,"З",pick("Ж","З"))
-	message = replacetextEx_char(message,"з",pick("ж","з"))
+	message = replacetextEx_char(message,"ОО","Ꝏ")
+	message = replacetextEx_char(message,"оо","ꝏ")
 
-	message = replacetextEx_char(message,"С",pick("Ш","Щ","Ж","С"))
-	message = replacetextEx_char(message,"с",pick("ш","щ","ж","с"))
-
-	message = replacetextEx_char(message,"Ш",pick("Ш","Щ","Ж","С"))
-	message = replacetextEx_char(message,"ш",pick("ш","щ","ж","с"))
-
-	message = replacetextEx_char(message,"Щ",pick("Ш","Щ","Ж","С"))
-	message = replacetextEx_char(message,"щ",pick("ш","щ","ж","с"))
-
-	message = replacetextEx_char(message,"Ж",pick("Ш","Щ","Ж","С"))
-	message = replacetextEx_char(message,"ж",pick("ш","щ","ж","с"))
-
-	message = replacetextEx_char(message,"Ч",pick("Ш","Щ","Ч"))
-	message = replacetextEx_char(message,"ч",pick("ш","щ","ч"))
-
-	if(prob(10) && !M.is_muzzled())
+	if(prob(30) && !M.is_muzzled())
 		message += " Борк[pick("",", борк",", борк, борк")]!"
 	return message
 


### PR DESCRIPTION
## What Does This PR Do

Правки по голосовалке https://discord.com/channels/617003227182792704/755125334097133628/968515173692366918

## Why It's Good For The Game
- Борк-борк-борканье теперь снова имеет 30% вероятность (а не сниженную до 10%).
- Замена букв на схожие убрана, больше никакой *«Шлавы Шиндикату»*
- Добавлена периодическая замена букв на них же, но с умляутами и прочими смешными закорючками
- Некоторые буквосочетания иногда будут заменять соответствующими лигатурами («АЕ» → «Æ»).
- союз «и» иногда будет заменять амперсандом

## Images of changes
![изображение](https://user-images.githubusercontent.com/3854741/163654426-6d3921db-5613-4a37-9ec6-c2e6a51e3c8d.png)

## Changelog
:cl:
tweak: Шведский акцент: убраны бестолковые буквозамены и шепелявость, борканье возвращено к 30%
/:cl: