### PR TITLE
Fix: Large tweaks and fixes of ruin shuttle names in code and etc

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -3,13 +3,10 @@
 /turf/space,
 /area/space)
 "aac" = (
-/obj/docking_port/stationary{
+/obj/docking_port/stationary/whiteship{
 	dir = 8;
-	dwidth = 8;
-	height = 31;
 	id = "whiteship_home";
-	name = "north of Kerberos";
-	width = 17
+	name = "Near NSS Kerberos"
 	},
 /turf/space,
 /area/space)
@@ -185704,13 +185701,13 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aae
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa

--- a/_maps/map_files/RandomRuins/SpaceRuins/gasthelizards.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/gasthelizards.dmm
@@ -812,6 +812,13 @@
 	desc = "The name isn't descriptive enough? Safety lamp doesn't light!";
 	emagged = 1
 	},
+/obj/effect/decal/cleanable/blood{
+	pixel_x = -31
+	},
+/obj/effect/decal/cleanable/blood{
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -899,10 +906,10 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/space/gasthelizards/viewzone)
 "Dc" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/marker_beacon,
-/turf/template_noop,
-/area/template_noop)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/ruin/space/gasthelizards/viewzone)
 "Ds" = (
 /turf/simulated/floor/engine,
 /area/ruin/space/gasthelizards/viewzone)
@@ -1070,6 +1077,11 @@
 	icon_state = "dark"
 	},
 /area/ruin/space/gasthelizards/engineering)
+"Jf" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon,
+/turf/template_noop,
+/area/template_noop)
 "Ji" = (
 /obj/structure/rack,
 /obj/item/organ/external/tail/unathi,
@@ -1615,7 +1627,7 @@ lQ
 lQ
 lQ
 lQ
-lQ
+Jf
 "}
 (4,1,1) = {"
 lQ
@@ -1642,7 +1654,7 @@ lQ
 lQ
 lQ
 lQ
-Dc
+cm
 "}
 (5,1,1) = {"
 wM
@@ -1772,7 +1784,7 @@ SL
 dG
 by
 jx
-xA
+Dc
 ho
 ho
 ho
@@ -1912,7 +1924,7 @@ lQ
 lQ
 lQ
 lQ
-Dc
+cm
 "}
 (15,1,1) = {"
 lQ
@@ -1939,7 +1951,7 @@ lQ
 lQ
 lQ
 lQ
-lQ
+Jf
 "}
 (16,1,1) = {"
 lQ

--- a/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
@@ -32,10 +32,6 @@
 "ai" = (
 /turf/simulated/mineral,
 /area/ruin/powered)
-"ak" = (
-/obj/machinery/computer/shuttle/spacebarhotelpodv1,
-/turf/simulated/shuttle/floor,
-/area/shuttle/spacebar)
 "am" = (
 /turf/simulated/wall,
 /area/ruin/powered{
@@ -50,7 +46,7 @@
 "ao" = (
 /obj/structure/grille,
 /obj/structure/window/full/shuttle,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/asteroid/airless,
 /area/shuttle/spacebar)
 "ap" = (
 /turf/simulated/shuttle/wall{
@@ -87,7 +83,7 @@
 /obj/item/toy/figure/bartender,
 /obj/machinery/door_control{
 	desiredstate = 1;
-	id = "innerspacebardoors";
+	id = "sb_in";
 	in_use = 1;
 	name = "The Bar Entrance Airlocks Lock button";
 	normaldoorcontrol = 1;
@@ -97,7 +93,7 @@
 	},
 /obj/machinery/door_control{
 	desiredstate = 1;
-	id = "outerspacebardoors";
+	id = "sb_out";
 	in_use = 1;
 	name = "Outside Airlocks Lock button";
 	normaldoorcontrol = 1;
@@ -120,6 +116,13 @@
 /obj/structure/table,
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching camera near bar asteroid and inside its areas.";
+	dir = 8;
+	layer = 4;
+	name = "Camera Telescreen";
+	network = list("spacebar")
 	},
 /turf/simulated/floor/wood,
 /area/ruin/powered{
@@ -153,12 +156,6 @@
 /turf/simulated/shuttle/floor,
 /area/ruin/powered)
 "aC" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/space,
 /turf/simulated/shuttle/floor,
 /area/shuttle/spacebar)
@@ -170,9 +167,6 @@
 	name = "Space Bar"
 	})
 "aE" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/spacebar)
 "aF" = (
@@ -197,12 +191,12 @@
 	})
 "aI" = (
 /obj/machinery/door_control{
-	id = "podcycle1";
+	id = "blastdoorcycle1";
 	name = "Inner Blastdoors Switch";
 	pixel_x = 6;
 	pixel_y = 24
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/floor/plating,
 /area/ruin/powered)
 "aJ" = (
 /turf/simulated/wall,
@@ -264,19 +258,20 @@
 	dir = 8;
 	dwidth = 3;
 	height = 4;
-	id = spacebarpodv1;
-	name = "Regular Space Pod";
-	width = 7
+	id = "ruins_civil_shuttle";
+	name = "Regular Civilian Shuttle";
+	rebuildable = 1;
+	width = 6
 	},
 /obj/docking_port/stationary{
 	area_type = /area/ruin/powered;
 	dir = 8;
 	dwidth = 3;
 	height = 4;
-	id = "spacebarv1";
-	name = "Docking zone Space Bar";
+	id = "spacebar";
+	name = "Space Bar Landing zone";
 	turf_type = /turf/simulated/floor/plating/asteroid/airless;
-	width = 7
+	width = 6
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor3"
@@ -285,7 +280,7 @@
 "aS" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external/glass{
-	id_tag = innerspacebardoors
+	id_tag = "sb_in"
 	},
 /turf/simulated/floor/plating,
 /area/ruin/powered{
@@ -341,19 +336,6 @@
 /area/ruin/powered{
 	name = "Space Bar"
 	})
-"ba" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 1;
-	tag = "icon-heater (NORTH)"
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/shuttle/floor{
-	icon_state = "floor4"
-	},
-/area/shuttle/spacebar)
 "bb" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel,
@@ -392,19 +374,30 @@
 /turf/template_noop,
 /area/ruin/powered)
 "bh" = (
-/turf/simulated/shuttle/wall{
-	icon_state = "diagonalWall3"
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/coffee{
+	desc = "Its cold like the space outside noo!";
+	pixel_x = -6;
+	pixel_y = 8;
+	volume = 10
 	},
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = 6
+	},
+/turf/simulated/shuttle/floor,
 /area/shuttle/spacebar)
 "bi" = (
-/turf/simulated/shuttle/wall{
-	dir = 4;
-	icon_state = "diagonalWall3"
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
 	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor,
 /area/shuttle/spacebar)
 "bj" = (
 /obj/machinery/door/airlock/external/glass{
-	id_tag = innerspacebardoors
+	id_tag = "sb_in"
 	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/powered{
@@ -442,12 +435,13 @@
 	})
 "bm" = (
 /obj/machinery/door_control{
-	id = "pod cycle";
+	id = "blastdoorcycle";
 	name = "Outer Blastdoors Switch";
 	pixel_x = -6;
 	pixel_y = 24
 	},
-/turf/simulated/floor/plating/airless,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/ruin/powered)
 "bn" = (
 /obj/machinery/door/poddoor/preopen{
@@ -469,12 +463,11 @@
 	name = "Space Bar"
 	})
 "br" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/coffee{
-	desc = "Its cold like the space outside, noo!";
-	pixel_x = -6;
-	pixel_y = 8;
-	volume = 10
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/spacebar)
@@ -506,13 +499,13 @@
 /area/ruin/powered)
 "eb" = (
 /obj/machinery/door_control{
-	id = "podcycle1";
+	id = "blastdoorcycle1";
 	name = "Inner Blastdoors Switch";
 	pixel_x = 6;
 	pixel_y = 24
 	},
 /obj/machinery/door_control{
-	id = "pod cycle";
+	id = "blastdoorcycle";
 	name = "Outer Blastdoors Switch";
 	pixel_x = -6;
 	pixel_y = 24
@@ -527,6 +520,19 @@
 	icon_state = "swall_f10"
 	},
 /area/ruin/powered)
+"fi" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/airless,
+/area/ruin/powered)
+"fp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/ruin/powered{
+	name = "Space Bar"
+	})
 "ft" = (
 /obj/machinery/door/poddoor{
 	id_tag = "pod cycle";
@@ -547,6 +553,10 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/powered)
+"iH" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/ruin/powered)
 "jL" = (
 /obj/structure/grille,
 /obj/structure/window/full/shuttle,
@@ -563,6 +573,34 @@
 "kZ" = (
 /obj/structure/spacepoddoor,
 /turf/simulated/floor/plating/airless,
+/area/ruin/powered)
+"mH" = (
+/obj/machinery/camera{
+	c_tag = "Spacebar Shuttle and Pods LZ";
+	network = list("spacebar")
+	},
+/turf/simulated/floor/plating/asteroid/airless,
+/area/ruin/powered)
+"mN" = (
+/obj/machinery/camera{
+	c_tag = "Spacebar Toilets";
+	network = list("spacebar")
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/ruin/powered{
+	name = "Space Bar"
+	})
+"nz" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Outer Blastdoor View";
+	dir = 9;
+	network = list("spacebar")
+	},
+/turf/template_noop,
 /area/ruin/powered)
 "nM" = (
 /turf/simulated/shuttle/wall,
@@ -581,6 +619,11 @@
 /area/ruin/powered{
 	name = "Space Bar"
 	})
+"sF" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swall_f5"
+	},
+/area/shuttle/spacebar)
 "tK" = (
 /obj/machinery/light{
 	dir = 8
@@ -601,24 +644,25 @@
 	name = "Space Bar"
 	})
 "vV" = (
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/ruin/powered{
+	name = "Space Bar"
+	})
+"xt" = (
 /obj/structure/shuttle/engine/propulsion/burst,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/shuttle/floor{
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "dark"
 	},
 /area/shuttle/spacebar)
-"xt" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 1;
-	tag = "icon-heater (NORTH)"
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor4"
-	},
+"xM" = (
+/obj/machinery/computer/shuttle/ruins_civil_shuttle,
+/turf/simulated/shuttle/floor,
 /area/shuttle/spacebar)
 "yd" = (
 /obj/item/gps/ruin{
@@ -638,6 +682,11 @@
 /obj/structure/grille,
 /turf/simulated/shuttle/plating,
 /area/ruin/powered)
+"Ai" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swall_f9"
+	},
+/area/shuttle/spacebar)
 "Cm" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "swall3"
@@ -649,13 +698,21 @@
 	tag = "icon-swall12"
 	},
 /area/ruin/powered)
+"EM" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/airless,
+/area/ruin/powered)
 "Fz" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/spacebar)
 "Gj" = (
 /obj/machinery/door/airlock/external{
-	id_tag = "outerspacebardoors"
+	id_tag = "sb_out"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/airless,
 /area/ruin/powered)
 "Hg" = (
@@ -666,6 +723,23 @@
 /area/shuttle/spacebar)
 "Hi" = (
 /obj/structure/glowshroom/single,
+/turf/simulated/floor/plasteel,
+/area/ruin/powered{
+	name = "Space Bar"
+	})
+"JR" = (
+/obj/machinery/camera{
+	c_tag = "Indoor Blastdoor View";
+	dir = 1;
+	network = list("spacebar")
+	},
+/turf/simulated/floor/plating,
+/area/ruin/powered)
+"Ky" = (
+/obj/structure/urinal{
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/ruin/powered{
 	name = "Space Bar"
@@ -682,6 +756,17 @@
 /area/ruin/powered{
 	name = "Space Bar"
 	})
+"OO" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swall3"
+	},
+/area/shuttle/spacebar)
+"OY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/airless,
+/area/ruin/powered{
+	name = "Space Bar"
+	})
 "Sg" = (
 /obj/structure/urinal{
 	pixel_x = -32
@@ -692,17 +777,17 @@
 	})
 "Sx" = (
 /obj/machinery/light/small,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/floor/plating,
 /area/ruin/powered)
 "Sy" = (
 /obj/machinery/door_control{
-	id = "pod cycle";
+	id = "blastdoorcycle";
 	name = "Outer Blastdoors Switch";
 	pixel_x = -24;
 	pixel_y = -6
 	},
 /obj/machinery/door_control{
-	id = "podcycle1";
+	id = "blastdoorcycle1";
 	name = "Inner Blastdoors Switch";
 	pixel_x = -24;
 	pixel_y = 6
@@ -724,6 +809,27 @@
 	},
 /turf/simulated/shuttle/floor,
 /area/ruin/powered)
+"TN" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/ruin/powered)
+"TZ" = (
+/turf/simulated/floor/plating,
+/area/ruin/powered)
+"Un" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/coffee{
+	desc = "Its cold like the space outside noo!";
+	pixel_x = -6;
+	pixel_y = 8;
+	volume = 10
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/powered{
+	name = "Space Bar"
+	})
 "Up" = (
 /obj/structure/shuttle/engine/propulsion/burst{
 	dir = 8
@@ -756,10 +862,18 @@
 /area/ruin/powered{
 	name = "Space Bar"
 	})
+"XG" = (
+/obj/machinery/camera{
+	c_tag = "Spacebar Outer Airlocks View";
+	network = list("spacebar")
+	},
+/turf/simulated/floor/plating/asteroid/airless,
+/area/space/nearstation)
 "YT" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/ruin/powered{
 	name = "Space Bar"
@@ -769,6 +883,7 @@
 	id_tag = "spacebartoilet";
 	name = "Toilet"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/ruin/powered{
 	name = "Space Bar"
@@ -799,7 +914,7 @@ aa
 aa
 aa
 aa
-bg
+nz
 aa
 aa
 aa
@@ -844,7 +959,7 @@ aa
 aJ
 aY
 aY
-aY
+EM
 aY
 aY
 aY
@@ -968,14 +1083,14 @@ ac
 ac
 ac
 KC
-dN
-aY
-aY
-aY
-aY
+TN
+TZ
+TZ
+TZ
+iH
 Sx
 aJ
-ac
+XG
 ac
 aa
 aa
@@ -1011,11 +1126,11 @@ ab
 ac
 KC
 bm
-aY
-aY
-aY
-aY
-aY
+TZ
+TZ
+TZ
+TZ
+JR
 aJ
 ac
 ac
@@ -1049,15 +1164,15 @@ ac
 ac
 ac
 ac
-ac
-ac
+af
+af
 KC
 aI
-aY
-aY
-aY
-aY
-aY
+TZ
+iH
+iH
+TZ
+TZ
 aJ
 ac
 be
@@ -1092,13 +1207,13 @@ af
 af
 aJ
 af
-ac
+ag
 KC
-dN
-aY
-aY
-aY
-aY
+TN
+TZ
+TZ
+TZ
+TZ
 Sx
 aJ
 ac
@@ -1133,8 +1248,8 @@ ac
 af
 ag
 ag
-af
-ac
+ag
+ag
 KC
 kZ
 kZ
@@ -1176,7 +1291,7 @@ ag
 ag
 ag
 ag
-af
+ag
 aJ
 bn
 bn
@@ -1187,7 +1302,7 @@ bn
 aJ
 ag
 aJ
-dN
+fi
 aJ
 af
 aJ
@@ -1299,11 +1414,11 @@ ag
 ag
 ap
 nM
-nM
 aP
 nM
-nM
-bh
+OO
+sF
+ag
 ag
 ag
 ag
@@ -1340,12 +1455,12 @@ aJ
 an
 bp
 ao
-ak
+xM
 aC
 Fz
-Hg
+bi
 xt
-vV
+ag
 ag
 ag
 ag
@@ -1384,10 +1499,10 @@ ag
 ao
 br
 aE
-Fz
+bh
 Hg
-ba
-vV
+xt
+ag
 ag
 ag
 ag
@@ -1425,11 +1540,11 @@ ag
 ag
 at
 nM
-nM
 aR
 nM
-nM
-bi
+OO
+Ai
+ag
 ag
 ag
 ag
@@ -1515,7 +1630,7 @@ ag
 am
 bj
 am
-ag
+mH
 ag
 CS
 fP
@@ -1555,7 +1670,7 @@ ai
 ag
 ag
 bf
-aT
+OY
 bf
 ag
 ag
@@ -1681,7 +1796,7 @@ as
 aK
 aN
 bq
-aO
+fp
 bq
 bs
 aW
@@ -1725,7 +1840,7 @@ aN
 aO
 aO
 aO
-aO
+fp
 aO
 aO
 aO
@@ -1805,10 +1920,10 @@ as
 as
 as
 aK
-aN
+vV
 aO
 aO
-aW
+Un
 aO
 aO
 aO
@@ -1897,7 +2012,7 @@ bt
 bc
 am
 Sg
-Sg
+Ky
 am
 bl
 am
@@ -1980,7 +2095,7 @@ aO
 aO
 rn
 am
-aO
+mN
 aO
 YT
 aO
@@ -2016,7 +2131,7 @@ as
 as
 aX
 aO
-aO
+fp
 bk
 aO
 aO
@@ -2024,7 +2139,7 @@ aO
 am
 aO
 aO
-aO
+fp
 Hi
 am
 ai

--- a/_maps/map_files/RandomRuins/SpaceRuins/spacehotelv1.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/spacehotelv1.dmm
@@ -121,6 +121,20 @@
 	},
 /turf/simulated/floor/wood,
 /area/ruin/space/spacehotelv1/centralhallway)
+"aF" = (
+/obj/machinery/door_control{
+	desiredstate = 1;
+	id = "ext_shuttle_door";
+	name = "Door Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = -25;
+	pixel_y = -24;
+	specialfunctions = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkblue"
+	},
+/area/ruin/space/spacehotelv1/entryhallway)
 "aH" = (
 /turf/simulated/wall,
 /area/ruin/space/spacehotelv1/engi2)
@@ -311,6 +325,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/foremaints)
 "bQ" = (
@@ -360,6 +375,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/evamaints)
 "ch" = (
@@ -513,7 +529,7 @@
 	height = 4;
 	id = "spacehotelv1";
 	name = "Docking port The Twin-Nexus Hotel";
-	width = 7
+	width = 6
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -584,6 +600,7 @@
 /area/ruin/space/spacehotelv1/reception)
 "dF" = (
 /obj/machinery/space_heater,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/forestarboardmaints)
 "dH" = (
@@ -607,6 +624,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/terminal,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/engi2)
 "dT" = (
@@ -694,6 +712,7 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/foremaints)
 "eF" = (
@@ -719,6 +738,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/forestarboardmaints)
 "eL" = (
@@ -873,6 +893,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/foremaints)
 "fM" = (
@@ -947,6 +968,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/foremaints)
 "gp" = (
@@ -1118,6 +1140,7 @@
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/forestarboardmaints)
 "hB" = (
@@ -1166,6 +1189,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/forestarboardmaints)
 "hO" = (
@@ -1539,11 +1563,11 @@
 /turf/simulated/floor/wood,
 /area/ruin/space/spacehotelv1/forehallway)
 "kh" = (
-/mob/living/simple_animal/crab,
-/turf/simulated/floor/beach/sand{
-	slowdown = 1
-	},
-/area/ruin/space/spacehotelv1/bar)
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/ruin/space/spacehotelv1/foremaints)
 "kj" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -1645,6 +1669,7 @@
 	dir = 8
 	},
 /obj/item/crowbar,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/engi2)
 "kK" = (
@@ -2263,6 +2288,7 @@
 	name = "scrubber to outside gas pump";
 	target_pressure = 4000
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/aftmaints)
 "pA" = (
@@ -2368,6 +2394,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/forestarboardmaints)
 "qq" = (
@@ -2420,6 +2447,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/forestarboardmaints)
 "qI" = (
@@ -2622,6 +2650,7 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/foremaints)
 "se" = (
@@ -2739,7 +2768,10 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/engi1)
 "sN" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external{
+	id_tag = "ext_sol1_door";
+	locked = 1
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -2821,6 +2853,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/evamaints)
 "tj" = (
@@ -2832,6 +2865,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/engi1)
 "tm" = (
@@ -3068,6 +3102,15 @@
 /obj/item/flashlight/lamp/green,
 /turf/simulated/floor/wood,
 /area/ruin/space/spacehotelv1/guestroom1)
+"uz" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/ruin/space/spacehotelv1/evamaints)
 "uA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3097,6 +3140,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/ruin/space/spacehotelv1/guestroom1)
+"uP" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/ruin/space/spacehotelv1/foremaints)
 "uQ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3194,6 +3241,7 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/aftmaints)
 "vl" = (
@@ -3604,6 +3652,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/foremaints)
 "ya" = (
@@ -3907,6 +3956,7 @@
 /area/ruin/space/spacehotelv1/forestarboardmaints)
 "As" = (
 /obj/structure/coatrack,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/evamaints)
 "Av" = (
@@ -3941,6 +3991,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/tcomms)
 "AF" = (
@@ -4031,6 +4082,16 @@
 	desc = "Труба ведёт газ на фильтрацию";
 	dir = 9;
 	name = "Труба на фильтрацию"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door_control{
+	desiredstate = 1;
+	id = "ext_sol2_door";
+	name = "Door Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = -8;
+	pixel_y = -24;
+	specialfunctions = 4
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/aftmaints)
@@ -4284,6 +4345,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/forestarboardmaints)
 "Dp" = (
@@ -4313,6 +4375,19 @@
 	},
 /turf/simulated/floor/plasteel/grimy,
 /area/ruin/space/spacehotelv1/forehallway)
+"Du" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door_control{
+	desiredstate = 1;
+	id = "ext_eva_door";
+	name = "Door Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 25;
+	pixel_y = -24;
+	specialfunctions = 4
+	},
+/turf/simulated/floor/plating,
+/area/ruin/space/spacehotelv1/evamaints)
 "Dz" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -4716,6 +4791,15 @@
 	},
 /turf/simulated/floor/plasteel/grimy,
 /area/ruin/space/spacehotelv1/restoraunt1)
+"Fx" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/ruin/space/spacehotelv1/foremaints)
 "Fy" = (
 /obj/structure/grille,
 /obj/structure/lattice,
@@ -4882,6 +4966,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/forestarboardmaints)
 "GG" = (
@@ -4895,7 +4980,10 @@
 /turf/simulated/floor/wood,
 /area/ruin/space/spacehotelv1/guestroom5)
 "GI" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external{
+	id_tag = "ext_eva_door";
+	locked = 1
+	},
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/evamaints)
 "GU" = (
@@ -5131,6 +5219,12 @@
 	tag = "icon-vault (WEST)"
 	},
 /area/ruin/space/spacehotelv1/entryhallway)
+"IK" = (
+/mob/living/simple_animal/crab,
+/turf/simulated/floor/beach/sand{
+	slowdown = 1
+	},
+/area/ruin/space/spacehotelv1/bar)
 "IO" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -5171,6 +5265,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/aftmaints)
 "IV" = (
@@ -5204,6 +5299,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/ruin/space/spacehotelv1/guestroom5)
+"Jg" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/ruin/space/spacehotelv1/forestarboardmaints)
 "Jh" = (
 /obj/machinery/door/airlock/multi_tile/glass,
 /obj/machinery/door/firedoor,
@@ -5521,6 +5625,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/engi1)
 "Ls" = (
@@ -5767,6 +5872,7 @@
 /area/ruin/space/spacehotelv1/forehallway)
 "MH" = (
 /obj/machinery/space_heater,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/foremaints)
 "MI" = (
@@ -6169,7 +6275,9 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/aftportmaints)
 "OL" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external{
+	id_tag = "ext_shuttle_door"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "dark"
@@ -6196,6 +6304,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/engi2)
 "OR" = (
@@ -6285,6 +6394,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/engi1)
 "Pq" = (
@@ -6632,6 +6742,15 @@
 	icon_state = "white"
 	},
 /area/ruin/space/spacehotelv1/kitchen)
+"RB" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/ruin/space/spacehotelv1/foremaints)
 "RG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -6839,6 +6958,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/evamaints)
 "Te" = (
@@ -6927,6 +7047,15 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/machinery/door_control{
+	desiredstate = 1;
+	id = "ext_sol1_door";
+	name = "Door Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = -25;
+	pixel_y = 24;
+	specialfunctions = 4
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/foremaints)
@@ -7043,6 +7172,13 @@
 	icon_state = "barber"
 	},
 /area/ruin/space/spacehotelv1/barber)
+"Up" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/closet/crate/can,
+/turf/simulated/floor/sepia,
+/area/ruin/space/spacehotelv1/bar)
 "Uv" = (
 /obj/structure/chair/barber{
 	dir = 4
@@ -7422,6 +7558,7 @@
 	name = "Push me";
 	pixel_x = 26
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/forestarboardmaints)
 "Xa" = (
@@ -7471,7 +7608,10 @@
 	dir = 4;
 	name = "Труба на фильтрацию"
 	},
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external{
+	id_tag = "ext_sol2_door";
+	locked = 1
+	},
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/aftmaints)
 "Xp" = (
@@ -7600,6 +7740,11 @@
 	icon_state = "dark"
 	},
 /area/ruin/space/spacehotelv1/janitor)
+"Yp" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/ruin/space/spacehotelv1/foremaints)
 "Yq" = (
 /obj/structure/sign/poster/random{
 	pixel_y = -32
@@ -7854,6 +7999,15 @@
 	icon_state = "white"
 	},
 /area/ruin/space/spacehotelv1/bar)
+"ZO" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/ruin/space/spacehotelv1/foremaints)
 "ZP" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -9213,7 +9367,7 @@ LE
 LE
 ai
 sd
-vl
+uP
 uW
 Gq
 Gi
@@ -9285,8 +9439,8 @@ LE
 LE
 LE
 ai
-MI
-vl
+Yp
+uP
 uW
 sX
 NM
@@ -9648,10 +9802,10 @@ LE
 LE
 JW
 rp
-kk
+kh
 eE
 MO
-Bk
+Fx
 BT
 lT
 RQ
@@ -9722,7 +9876,7 @@ LE
 JW
 rp
 EX
-nf
+RB
 rp
 rp
 BT
@@ -9795,7 +9949,7 @@ LE
 JW
 rp
 yH
-nf
+RB
 rp
 nd
 pU
@@ -9917,7 +10071,7 @@ GU
 SH
 SH
 VY
-VY
+Up
 Ea
 YC
 YC
@@ -9989,7 +10143,7 @@ GU
 GU
 Ew
 Ew
-kh
+Ew
 OD
 XP
 BR
@@ -10135,7 +10289,7 @@ zQ
 GU
 Ew
 xx
-Ew
+IK
 OD
 XP
 BR
@@ -10160,7 +10314,7 @@ LE
 JW
 SM
 ai
-nf
+RB
 rp
 On
 On
@@ -10525,7 +10679,7 @@ LE
 JW
 rp
 cr
-vl
+uP
 rp
 On
 On
@@ -10671,7 +10825,7 @@ SM
 JW
 SM
 rp
-vl
+uP
 rp
 om
 FJ
@@ -10890,7 +11044,7 @@ LE
 JW
 SM
 rp
-vl
+uP
 rp
 pf
 XR
@@ -11208,12 +11362,12 @@ zZ
 os
 WJ
 Dk
-WJ
+Jg
 WJ
 qC
 un
 jh
-jU
+aF
 jr
 Tw
 OL
@@ -11255,7 +11409,7 @@ LE
 JW
 rp
 dq
-vl
+uP
 rp
 rp
 rp
@@ -11275,7 +11429,7 @@ Te
 fz
 zZ
 dt
-jl
+uz
 Rf
 zZ
 Te
@@ -11329,7 +11483,7 @@ JW
 rp
 TA
 vl
-vl
+uP
 vl
 MI
 rp
@@ -11342,8 +11496,8 @@ Gm
 rt
 qC
 WJ
-WJ
-WJ
+Jg
+Jg
 WJ
 mx
 zZ
@@ -11404,7 +11558,7 @@ rp
 gN
 rp
 fI
-MO
+ZO
 OH
 Bk
 rp
@@ -11567,7 +11721,7 @@ Av
 Wu
 zZ
 tB
-og
+Du
 xv
 zZ
 SM

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndiecakesfactory.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndiecakesfactory.dmm
@@ -1,30 +1,163 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aM" = (
-/obj/item/stack/rods,
 /obj/item/stack/sheet/metal,
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "bb" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/ruin/unpowered)
+"bk" = (
+/turf/unsimulated,
+/area/space)
+"dy" = (
+/obj/structure/lattice,
+/obj/item/stack/sheet/metal,
+/turf/template_noop,
+/area/template_noop)
+"es" = (
+/obj/machinery/conveyor/northeast{
+	id = null
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"fq" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/dispenser/oxygen,
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"fU" = (
+/obj/machinery/conveyor/east{
+	id = null
+	},
+/obj/machinery/gibber/autogibber,
+/obj/structure/plasticflaps{
+	canmove = 0
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"fY" = (
+/obj/machinery/conveyor/east{
+	id = null
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin)
+"hm" = (
+/obj/structure/lattice,
+/turf/unsimulated,
+/area/template_noop)
+"ho" = (
+/mob/living/simple_animal/pet/dog/corgi,
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"iK" = (
+/mob/living/simple_animal/pet/dog/corgi,
+/mob/living/simple_animal/pet/dog/corgi,
+/obj/machinery/conveyor/east{
+	id = null
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"jf" = (
+/obj/machinery/conveyor/north/ccw{
+	id = null
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"jv" = (
+/turf/unsimulated/wall/fakeglass{
+	dir = 4
+	},
+/area/ruin/unpowered)
+"jR" = (
+/obj/item/stack/cable_coil/random,
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"ke" = (
+/turf/unsimulated/floor/plating/airless,
+/area/space)
+"kh" = (
+/obj/machinery/conveyor/east{
+	dir = 2;
+	id = null
+	},
+/turf/simulated/floor/plasteel,
+/area/space)
+"ky" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/syndicate,
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"ls" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/space)
+"lK" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/mineral/plasma,
 /obj/item/stack/sheet/mineral/plasma,
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
-"bk" = (
-/obj/structure/grille/broken,
+"mu" = (
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 2;
+	height = 5;
+	id = "sindiecake_dock";
+	name = "Docking port Syndicake Factory";
+	width = 8
+	},
 /turf/template_noop,
 /area/space)
-"cc" = (
-/obj/item/reagent_containers/food/snacks/syndicake,
-/obj/item/reagent_containers/food/snacks/syndicake,
-/obj/item/reagent_containers/food/snacks/syndicake,
-/turf/simulated/floor/plating,
-/area/space)
-"dy" = (
+"mx" = (
 /obj/structure/lattice,
+/obj/item/stack/rods,
+/turf/template_noop,
+/area/space)
+"nV" = (
+/obj/structure/grille/broken,
+/turf/space,
+/area/ruin/space)
+"ob" = (
+/obj/effect/spawner/random_spawners/syndicate/loot,
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"om" = (
+/obj/item/trash/syndi_cakes,
+/turf/template_noop,
+/area/space)
+"oJ" = (
+/obj/item/stack/rods,
+/turf/template_noop,
+/area/space)
+"oO" = (
+/turf/simulated/floor/plating/burnt,
+/area/ruin)
+"pb" = (
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/space)
+"pd" = (
+/turf/template_noop,
+/area/space)
+"pp" = (
 /turf/unsimulated,
 /area/template_noop)
-"es" = (
+"pR" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/trash/syndi_cakes,
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"qA" = (
+/obj/item/stack/sheet/metal,
+/obj/item/stack/sheet/metal,
+/turf/space,
+/area/space)
+"qS" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -32,81 +165,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
-"eY" = (
-/turf/simulated/floor/plating,
-/area/ruin)
-"fq" = (
-/obj/machinery/autolathe,
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"fU" = (
-/obj/machinery/door/airlock/mining/glass{
-	locked = 1;
-	name = "Egg processing"
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"fY" = (
-/obj/item/stack/sheet/metal,
-/turf/template_noop,
-/area/template_noop)
-"hm" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"ho" = (
+"rJ" = (
+/obj/structure/lattice,
 /turf/space,
 /area/ruin/space)
-"hs" = (
-/turf/unsimulated/wall/fakeglass{
+"rL" = (
+/obj/structure/rack{
 	dir = 4
 	},
-/area/ruin/unpowered)
-"iK" = (
-/obj/item/stack/sheet/metal,
-/obj/item/stack/sheet/metal,
-/turf/space,
-/area/ruin/space)
-"jf" = (
-/obj/item/trash/syndi_cakes,
-/turf/template_noop,
-/area/template_noop)
-"jv" = (
-/obj/item/stack/cable_coil/cut,
-/turf/template_noop,
-/area/space)
-"jR" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/fancy/cigarettes/cigpack_random,
+/obj/random/tool,
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
-"ke" = (
-/obj/structure/lattice,
-/turf/space,
-/area/ruin)
-"kh" = (
-/obj/structure/lattice,
-/obj/item/stack/rods,
-/turf/template_noop,
-/area/space)
-"ky" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/turf/simulated/wall,
+"rU" = (
+/obj/effect/spawner/random_spawners/oil_maybe,
+/turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
-"ls" = (
-/obj/structure/lattice,
-/turf/template_noop,
-/area/space)
-"lK" = (
+"sd" = (
 /obj/machinery/power/apc/noalarm{
 	area = null;
 	dir = 8;
@@ -125,356 +199,75 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
-"mc" = (
-/obj/structure/grille/broken,
-/turf/space,
-/area/ruin/space)
-"mx" = (
-/obj/item/trash/syndi_cakes,
-/turf/template_noop,
-/area/space)
-"nV" = (
-/obj/machinery/conveyor/east{
-	id = null
-	},
-/turf/simulated/floor/plasteel,
-/area/space)
-"ob" = (
-/obj/structure/lattice,
-/turf/template_noop,
-/area/ruin/unpowered)
-"om" = (
-/obj/item/reagent_containers/food/snacks/syndicake,
-/obj/item/reagent_containers/food/snacks/syndicake,
-/obj/item/reagent_containers/food/snacks/syndicake,
-/obj/item/reagent_containers/food/snacks/syndicake,
-/obj/item/reagent_containers/food/snacks/syndicake,
-/obj/item/reagent_containers/food/snacks/syndicake,
-/turf/simulated/floor/plasteel,
-/area/space)
-"oJ" = (
-/obj/item/stack/rods,
-/turf/template_noop,
-/area/space)
-"oO" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Nexus"
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"pb" = (
-/obj/structure/lattice/catwalk,
-/turf/template_noop,
-/area/space)
-"pd" = (
-/turf/template_noop,
-/area/space)
-"pp" = (
-/turf/unsimulated,
-/area/space)
-"pR" = (
-/obj/machinery/conveyor/northeast{
-	id = null
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"qS" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "EVA Storage"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0;
-	tag = ""
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"rJ" = (
-/obj/structure/lattice,
-/turf/space,
-/area/ruin/space)
-"rL" = (
-/obj/item/reagent_containers/food/snacks/syndicake,
-/turf/simulated/floor/plasteel/airless,
-/area/ruin)
-"rU" = (
-/obj/machinery/space_heater,
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"sd" = (
-/turf/simulated/floor/plating,
-/area/space)
 "sN" = (
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
+"tz" = (
+/obj/item/stack/cable_coil/cut,
+/turf/template_noop,
+/area/space)
 "ub" = (
-/obj/item/stack/rods,
-/turf/space,
+/obj/structure/grille/broken,
+/turf/template_noop,
 /area/space)
 "uA" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/snacks/syndicake,
+/obj/machinery/door/airlock/mining/glass{
+	locked = 1;
+	name = "Egg processing"
+	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
 "uF" = (
-/obj/machinery/conveyor/east{
-	id = null
-	},
-/obj/machinery/gibber/autogibber,
-/obj/structure/plasticflaps{
-	canmove = 0
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"wB" = (
-/obj/item/trash/syndi_cakes,
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"xT" = (
-/turf/unsimulated/floor/plating/airless,
-/area/space)
-"yU" = (
-/obj/item/stack/sheet/metal,
-/obj/item/stack/sheet/metal,
-/turf/space,
-/area/space)
-"zd" = (
-/obj/machinery/power/apc/noalarm{
-	area = null;
-	dir = 8;
-	keep_preset_name = 1;
-	locked = 0;
-	name = "EVA room APC";
-	pixel_x = -24;
-	start_charge = -1
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"zo" = (
-/turf/simulated/wall,
-/area/space)
-"zt" = (
-/obj/item/stack/sheet/metal,
-/turf/template_noop,
-/area/space)
-"zF" = (
-/turf/unsimulated/wall/fakeglass{
-	dir = 8
-	},
-/area/ruin/unpowered)
-"zP" = (
-/obj/structure/rack{
-	dir = 4
-	},
-/obj/random/tool,
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"zY" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light,
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"AH" = (
-/obj/structure/lattice,
-/obj/item/stack/sheet/metal,
-/turf/template_noop,
-/area/template_noop)
-"AJ" = (
-/obj/effect/spawner/random_spawners/wall_rusted_probably,
-/turf/simulated/wall,
-/area/space)
-"BG" = (
-/obj/machinery/door/airlock/mining/glass{
-	locked = 1;
-	name = "Manufacturing Control Room"
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"BI" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"Cp" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
 	tag = ""
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/wall,
 /area/ruin/unpowered)
-"CY" = (
-/obj/item/stack/rods,
-/turf/template_noop,
-/area/template_noop)
-"Da" = (
-/turf/space,
-/area/space)
-"Dz" = (
-/mob/living/simple_animal/pet/dog/corgi,
-/obj/machinery/conveyor/east{
-	id = null
+"xT" = (
+/obj/machinery/door/airlock/mining/glass{
+	locked = 1;
+	name = "Manufacturing Control Room"
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
-"Ej" = (
-/obj/structure/closet/emcloset,
+"yS" = (
+/obj/item/trash/syndi_cakes,
+/turf/space,
+/area/space)
+"yU" = (
+/turf/simulated/floor/plasteel,
+/area/ruin)
+"zd" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = "90Curve"
+	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
-"EJ" = (
+"zo" = (
+/obj/structure/lattice,
+/turf/space,
+/area/ruin)
+"zt" = (
+/obj/effect/spawner/random_spawners/wall_rusted_probably,
 /turf/simulated/wall,
-/area/ruin/unpowered)
-"Fw" = (
+/area/space)
+"zF" = (
 /obj/item/stack/cable_coil/cut,
 /turf/template_noop,
 /area/template_noop)
-"FO" = (
-/obj/machinery/suit_storage_unit/syndicate,
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"Gm" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0;
-	tag = ""
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"GB" = (
-/mob/living/simple_animal/pet/dog/corgi,
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"Hx" = (
-/mob/living/simple_animal/pet/dog/corgi,
-/mob/living/simple_animal/pet/dog/corgi,
-/obj/machinery/conveyor/east{
-	id = null
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"Hy" = (
-/turf/template_noop,
-/area/template_noop)
-"HQ" = (
-/obj/structure/table/reinforced,
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"Ic" = (
-/turf/simulated/floor/plating/burnt,
-/area/ruin)
-"Id" = (
-/obj/effect/spawner/random_spawners/oil_maybe,
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"IB" = (
-/obj/structure/lattice,
-/turf/space,
-/area/ruin/unpowered)
-"JI" = (
-/obj/effect/spawner/random_spawners/syndicate/loot,
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"Ki" = (
-/obj/structure/lattice,
-/turf/template_noop,
-/area/template_noop)
-"Kr" = (
-/obj/structure/girder,
-/turf/simulated/floor/plating,
-/area/ruin/unpowered)
-"KD" = (
-/turf/simulated/floor/plating,
-/area/ruin/unpowered)
-"KS" = (
-/turf/unsimulated/floor/plating/airless,
-/area/ruin)
-"Le" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/port_gen/pacman,
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"Mi" = (
-/turf/unsimulated,
-/area/template_noop)
-"Mz" = (
-/turf/simulated/floor/plasteel,
-/area/ruin)
-"Nw" = (
-/obj/machinery/power/smes,
-/obj/structure/cable/blue{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"NQ" = (
-/obj/structure/lattice,
-/turf/space,
-/area/space)
-"OA" = (
-/obj/structure/computerframe,
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"OK" = (
-/obj/item/reagent_containers/food/snacks/syndicake,
-/turf/space,
-/area/space)
-"OU" = (
-/turf/simulated/floor/plasteel/airless,
-/area/ruin)
-"Qv" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/trash/syndi_cakes,
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"QF" = (
-/obj/machinery/conveyor/east{
-	dir = 2;
-	id = null
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin)
-"QI" = (
-/obj/effect/spawner/random_spawners/wall_rusted_probably,
-/turf/simulated/wall,
-/area/ruin)
-"Ra" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"Rg" = (
-/obj/machinery/door/airlock/mining/glass{
-	locked = 1;
-	max_integrity = 300000;
-	name = "Corgi processing";
-	normal_integrity = 300000
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"Ry" = (
-/obj/item/stack/cable_coil/random,
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"RB" = (
+"zP" = (
 /mob/living/simple_animal/hostile/alien/sentinel{
 	animal_species = /mob/living/simple_animal/pet/dog;
 	attack_sound = 'sound/weapons/bite.ogg';
@@ -491,35 +284,248 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
-"Tj" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/syndicate,
+"zY" = (
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/port_gen/pacman,
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
-"Tt" = (
-/obj/machinery/door/airlock/external,
-/turf/simulated/floor/plating,
-/area/ruin/powered)
-"TM" = (
+"At" = (
+/obj/item/reagent_containers/food/snacks/syndicake,
+/obj/item/reagent_containers/food/snacks/syndicake,
+/obj/item/reagent_containers/food/snacks/syndicake,
+/obj/item/reagent_containers/food/snacks/syndicake,
+/obj/item/reagent_containers/food/snacks/syndicake,
+/obj/item/reagent_containers/food/snacks/syndicake,
+/turf/simulated/floor/plasteel,
+/area/space)
+"AH" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"AJ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"BG" = (
+/turf/space,
+/area/ruin/unpowered)
+"BI" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"Cp" = (
+/obj/structure/lattice,
+/turf/space,
+/area/ruin/unpowered)
+"CY" = (
+/obj/item/stack/rods,
+/turf/template_noop,
+/area/template_noop)
+"Da" = (
+/turf/space,
+/area/space)
+"Dz" = (
+/obj/item/trash/syndi_cakes,
+/turf/template_noop,
+/area/template_noop)
+"Ec" = (
+/obj/structure/lattice,
+/obj/random/tool,
+/turf/space,
+/area/space)
+"EJ" = (
+/turf/simulated/wall,
+/area/ruin/unpowered)
+"Fw" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"FO" = (
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"GB" = (
+/mob/living/simple_animal/pet/dog/corgi,
+/obj/machinery/conveyor/east{
+	id = null
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"Hx" = (
+/obj/item/stack/rods,
+/turf/space,
+/area/space)
+"Hy" = (
+/turf/template_noop,
+/area/template_noop)
+"Ic" = (
+/obj/item/stack/sheet/metal,
+/turf/template_noop,
+/area/space)
+"Id" = (
+/obj/machinery/door/airlock/mining/glass{
+	locked = 1;
+	max_integrity = 300000;
+	name = "Corgi processing";
+	normal_integrity = 300000
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"IB" = (
+/obj/machinery/power/apc/noalarm{
+	area = null;
+	dir = 8;
+	keep_preset_name = 1;
+	locked = 0;
+	name = "EVA room APC";
+	pixel_x = -24;
+	start_charge = -1
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"JI" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "EVA Storage"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"Ki" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"Kr" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "Nexus"
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"KD" = (
+/obj/machinery/space_heater,
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"KS" = (
+/turf/unsimulated/floor/plating/airless,
+/area/ruin)
+"Le" = (
+/obj/machinery/power/smes,
+/obj/structure/cable/blue{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"Mi" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/syndicake,
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"Mz" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"Nw" = (
+/obj/machinery/autolathe,
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"NQ" = (
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"OA" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/cigarettes/cigpack_random,
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"OK" = (
+/obj/item/reagent_containers/food/snacks/syndicake,
+/turf/space,
+/area/space)
+"OU" = (
+/turf/simulated/floor/plasteel/airless,
+/area/ruin)
+"QF" = (
+/obj/machinery/conveyor/east{
+	dir = 2;
+	id = null
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin)
+"QI" = (
+/obj/structure/chair/office/dark,
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"Ra" = (
+/obj/machinery/tcomms/relay/ruskie{
+	network_id = "SYNDICAKES-FACTORY"
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"Rg" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"Ry" = (
+/obj/structure/table/reinforced,
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"RB" = (
+/obj/machinery/suit_storage_unit/syndicate,
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"Tj" = (
 /obj/structure/chair/office/dark{
 	dir = 4;
-	icon_state = "officechair_dark";
 	tag = "icon-officechair_dark (EAST)"
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
+"Tt" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light,
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered)
+"TM" = (
+/obj/effect/spawner/random_spawners/wall_rusted_probably,
+/turf/simulated/wall,
+/area/ruin)
 "TT" = (
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8";
+	icon_state = "4-8";
 	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
@@ -528,64 +534,63 @@
 	id = null
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin)
-"UC" = (
-/obj/machinery/tcomms/relay/ruskie{
-	network_id = "SYNDICAKES-FACTORY"
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
-"UR" = (
-/obj/item/trash/syndi_cakes,
-/turf/space,
 /area/space)
+"UC" = (
+/obj/item/stack/rods,
+/obj/item/stack/sheet/metal,
+/turf/template_noop,
+/area/space)
+"UR" = (
+/obj/machinery/door/airlock/external,
+/turf/simulated/floor/plating,
+/area/ruin/powered)
 "Vf" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
 "Vt" = (
-/obj/machinery/conveyor/north/ccw{
-	id = null
+/turf/unsimulated/wall/fakeglass{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
 "VH" = (
-/obj/structure/lattice,
-/obj/random/tool,
-/turf/space,
+/turf/simulated/wall,
 /area/space)
 "VR" = (
-/obj/structure/lattice,
-/turf/unsimulated,
-/area/space)
+/obj/structure/girder,
+/turf/simulated/floor/plating,
+/area/ruin/unpowered)
 "WL" = (
 /turf/space,
-/area/ruin/unpowered)
+/area/ruin/space)
 "Xd" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
+/obj/item/trash/syndi_cakes,
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
+"Xn" = (
+/obj/item/reagent_containers/food/snacks/syndicake,
+/turf/simulated/floor/plasteel/airless,
+/area/ruin)
 "XZ" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/dispenser/oxygen,
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
+/obj/item/stack/sheet/metal,
+/obj/item/stack/sheet/metal,
+/turf/space,
+/area/ruin/space)
 "YR" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
 /area/ruin/unpowered)
+"YT" = (
+/obj/item/reagent_containers/food/snacks/syndicake,
+/obj/item/reagent_containers/food/snacks/syndicake,
+/obj/item/reagent_containers/food/snacks/syndicake,
+/turf/unsimulated/floor/plating/airless,
+/area/space)
 "YU" = (
-/obj/structure/chair/office/dark,
+/obj/structure/computerframe,
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
 "Zs" = (
@@ -595,11 +600,8 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
 "Zt" = (
-/obj/machinery/conveyor/east{
-	dir = 2;
-	id = null
-	},
-/turf/simulated/floor/plasteel,
+/obj/structure/lattice,
+/turf/unsimulated,
 /area/space)
 
 (1,1,1) = {"
@@ -608,25 +610,23 @@ Hy
 Hy
 Hy
 Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
+bb
+bb
+bb
+bb
+bb
+bb
+EJ
+EJ
+EJ
+EJ
+EJ
+EJ
+EJ
+EJ
+Ki
+Ki
+Ki
 Hy
 Hy
 Hy
@@ -650,26 +650,24 @@ Hy
 Hy
 Hy
 Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
+EJ
+EJ
+EJ
+EJ
+EJ
+EJ
+EJ
+zY
+BI
+IB
+KD
+sN
+RB
+EJ
+EJ
+EJ
+pb
+pd
 Hy
 Hy
 Hy
@@ -692,26 +690,24 @@ Hy
 Hy
 Hy
 Hy
-Hy
-Hy
+EJ
 ob
-ob
-ob
-ob
-ob
-ob
+ho
+BI
+sN
+sN
 EJ
-EJ
-EJ
-EJ
-EJ
-EJ
-EJ
-EJ
-Ki
-Ki
-Ki
-Hy
+AH
+sN
+TT
+sN
+sN
+sN
+UR
+YR
+UR
+pb
+pb
 Hy
 Hy
 Hy
@@ -734,14 +730,12 @@ Hy
 Hy
 Hy
 Hy
-Hy
-Hy
 EJ
-EJ
-EJ
-EJ
-EJ
-EJ
+sN
+iK
+ho
+GB
+sN
 EJ
 Le
 Vf
@@ -776,26 +770,24 @@ Hy
 Hy
 Hy
 Hy
-Hy
-Hy
 EJ
-JI
-GB
-Vf
 sN
+GB
+sN
+GB
 sN
 EJ
 Ra
 sN
-Gm
-sN
+TT
 sN
 sN
 Tt
-KD
-Tt
-pb
-pb
+EJ
+pd
+pd
+ls
+pd
 Hy
 Hy
 Hy
@@ -818,25 +810,23 @@ Hy
 Hy
 Hy
 Hy
-Hy
-Hy
 EJ
 sN
-Hx
-GB
-Dz
+Zs
+sN
+Zs
 sN
 EJ
 Nw
-hm
-TT
-Id
 sN
-Ej
+TT
+sN
+QI
+YU
 EJ
-EJ
-EJ
-pb
+pd
+pd
+ls
 pd
 Hy
 Hy
@@ -860,21 +850,19 @@ Hy
 Hy
 Hy
 Hy
-Hy
-Hy
 EJ
 sN
-Dz
+Zs
 sN
-Dz
-sN
+Zs
+rU
 EJ
-UC
 sN
-Gm
+ho
+TT
+Tj
 sN
 sN
-zY
 EJ
 pd
 pd
@@ -902,19 +890,17 @@ Hy
 Hy
 Hy
 Hy
-Hy
-Hy
 EJ
-sN
-Zs
-sN
-Zs
+es
+jf
+jf
+jf
 sN
 EJ
 fq
-sN
-Gm
-sN
+Fw
+TT
+Mi
 YU
 OA
 EJ
@@ -922,7 +908,7 @@ pd
 pd
 ls
 pd
-Hy
+pd
 Hy
 Hy
 Hy
@@ -944,29 +930,27 @@ Hy
 Hy
 Hy
 Hy
-Hy
-Hy
 EJ
-sN
 Zs
-sN
-Zs
+EJ
+EJ
+EJ
 Id
 EJ
-sN
-GB
-Gm
-TM
-sN
-sN
+EJ
+EJ
+JI
+EJ
+EJ
+EJ
+EJ
+EJ
+EJ
+EJ
 EJ
 pd
 pd
-ls
 pd
-Hy
-Hy
-Hy
 Hy
 Hy
 Hy
@@ -986,30 +970,28 @@ Hy
 Hy
 Hy
 Hy
-Hy
-Hy
 EJ
+Zs
+Vt
+Tj
 pR
-Vt
-Vt
-Vt
+sd
+EJ
 sN
-EJ
-XZ
 BI
-Gm
-uA
-OA
+TT
+sN
+sN
 jR
+VR
+OU
+OU
+OU
 EJ
 pd
 pd
-ls
 pd
-pd
-Hy
-Hy
-Hy
+OK
 Hy
 Hy
 Hy
@@ -1028,30 +1010,28 @@ Hy
 Hy
 Hy
 Hy
-Hy
-Hy
 EJ
 Zs
-EJ
-EJ
-EJ
+jv
+ky
+rL
 Rg
-EJ
-EJ
-EJ
+uF
+AJ
+AJ
 qS
-EJ
-EJ
-EJ
-EJ
-EJ
-EJ
-EJ
+sN
+rJ
+rJ
+VR
+Xn
+KS
+OU
 EJ
 pd
 pd
 pd
-Hy
+pd
 Hy
 Hy
 Hy
@@ -1070,37 +1050,35 @@ Hy
 Hy
 Hy
 Hy
-Hy
-Hy
 EJ
 Zs
-zF
-TM
-Qv
-lK
 EJ
 sN
-Vf
-Gm
+Xd
+sN
+xT
 sN
 sN
-Ry
+sN
+sN
+sN
+sN
 Kr
 OU
-OU
-OU
+KS
+KS
 EJ
 pd
 pd
 pd
-OK
+pd
+oJ
 Hy
 Hy
 Hy
 Hy
 Hy
-Hy
-Hy
+aM
 Hy
 Hy
 Hy
@@ -1112,34 +1090,32 @@ Hy
 Hy
 Hy
 Hy
-Hy
-Hy
 EJ
 Zs
-hs
+Vt
 Tj
 zP
 Xd
-ky
+EJ
 Cp
-Cp
-es
 sN
+sN
+sN
+sN
+sN
+EJ
+KS
+KS
 rJ
-rJ
-Kr
-rL
-eY
-OU
 EJ
 pd
 pd
+om
 pd
 pd
+pd
 Hy
-Hy
-Hy
-Hy
+aM
 Hy
 Hy
 Hy
@@ -1154,37 +1130,35 @@ Hy
 Hy
 Hy
 Hy
-Hy
-Hy
 EJ
 Zs
+jv
+lK
+YU
+sN
 EJ
-sN
-wB
-sN
 BG
+Cp
 sN
-sN
-sN
-sN
-sN
-sN
-oO
-OU
-eY
-eY
+Mz
+Ry
+Ry
 EJ
-pd
-pd
-pd
-pd
+OU
+KS
+rJ
+EJ
+Ic
 oJ
+pd
+pd
+pd
+tz
 Hy
 Hy
 Hy
 Hy
 Hy
-fY
 Hy
 Hy
 Hy
@@ -1196,34 +1170,32 @@ Hy
 Hy
 Hy
 Hy
+EJ
+fU
+EJ
+EJ
+EJ
+uA
+EJ
+EJ
+EJ
+Kr
+EJ
+EJ
+EJ
+EJ
+OU
+KS
+OK
+Da
+pd
+pd
+NQ
+Ic
+pd
+pd
+pd
 Hy
-Hy
-EJ
-Zs
-zF
-TM
-RB
-wB
-EJ
-IB
-sN
-sN
-sN
-sN
-sN
-EJ
-eY
-eY
-rJ
-EJ
-pd
-pd
-mx
-pd
-pd
-pd
-Hy
-fY
 Hy
 Hy
 Hy
@@ -1238,38 +1210,36 @@ Hy
 Hy
 Hy
 Hy
-Hy
-Hy
-EJ
-Zs
-hs
-bb
-OA
-sN
-EJ
-WL
-IB
-sN
-YR
-HQ
-HQ
-EJ
+Zt
+fY
 OU
-eY
-rJ
-EJ
-zt
-oJ
+OU
+KS
+KS
+yU
+WL
+OU
+OU
+OU
+OU
+WL
+XZ
+KS
+Da
+OK
+OK
+pd
+pd
+NQ
+VH
 pd
 pd
 pd
-jv
+pd
+OK
 Hy
 Hy
-Hy
-Hy
-Hy
-Hy
+aM
 Hy
 Hy
 Hy
@@ -1280,35 +1250,33 @@ Hy
 Hy
 Hy
 Hy
-Hy
-Hy
-EJ
-uF
-EJ
-EJ
-EJ
-fU
-EJ
-EJ
-EJ
-oO
-EJ
-EJ
-EJ
-EJ
+pd
+rJ
+rJ
+rJ
+KS
+rJ
+KS
+rJ
+KS
+KS
+Hx
+NQ
 OU
-eY
-OK
+KS
+NQ
+NQ
 Da
-pd
-pd
+OK
+qA
+Da
 NQ
 zt
 pd
+OK
 pd
 pd
-Hy
-Hy
+pd
 Hy
 Hy
 Hy
@@ -1322,38 +1290,36 @@ Hy
 Hy
 Hy
 Hy
-Hy
-Hy
-VR
+pd
 Uq
-OU
-OU
+ke
+nV
+KS
+nV
 KS
 KS
-Mz
-ho
-OU
-OU
-OU
-OU
-ho
-iK
-eY
 Da
-OK
-OK
+NQ
+Da
+NQ
+Da
+Da
+yS
+Hx
+Da
+Da
 pd
 pd
 NQ
-zo
+NQ
 pd
 pd
 pd
+Ic
 pd
-OK
+pd
 Hy
 Hy
-fY
 Hy
 Hy
 Hy
@@ -1363,80 +1329,76 @@ Hy
 Hy
 Hy
 Hy
-Hy
-Hy
-Hy
+Ki
+bk
 pd
+kh
 rJ
-rJ
-rJ
-KS
-rJ
-KS
-rJ
-Ic
-Ic
-ub
+kh
+kh
 NQ
-OU
-eY
-NQ
-NQ
+oO
+Da
+Da
+Da
 Da
 OK
-yU
 Da
-NQ
-AJ
-pd
+Da
 OK
+OK
+Da
+pd
+NQ
+Da
+Da
 pd
 pd
 pd
+pd
+pd
+pd
+pd
 Hy
-Hy
-Hy
-Hy
+Ki
 Hy
 Hy
 "}
 (20,1,1) = {"
+CY
 Hy
 Hy
 Hy
 Hy
-Hy
-Hy
-Hy
+bk
 pd
-nV
-xT
-mc
-KS
-mc
-KS
-KS
-Da
+pd
+VH
+pd
+VH
+VH
 NQ
-Da
-NQ
-Da
-Da
-UR
-ub
+Hx
 Da
 Da
+Da
+Da
+Da
+Da
+Da
+Da
+Da
+Hx
+Ic
 pd
 pd
-NQ
-NQ
+pd
+om
 pd
 pd
 pd
-zt
 pd
-pd
-Hy
+OK
 Hy
 Hy
 Hy
@@ -1447,80 +1409,76 @@ Hy
 Hy
 Hy
 Hy
-Hy
-Hy
 Ki
 pp
+hm
+Zt
 pd
-Zt
-rJ
-Zt
-Zt
-NQ
+pd
+pd
+pd
+pd
 Ic
-Da
-Da
-Da
-Da
-OK
-Da
-Da
-OK
-OK
-Da
 pd
+pd
+KS
+OU
+OU
+Da
 NQ
-Da
-Da
 pd
 pd
 pd
 pd
+pd
+pd
+oJ
+pd
+Ic
+ls
 pd
 pd
 pd
 Hy
-Ki
+Hy
 Hy
 Hy
 "}
 (22,1,1) = {"
 Hy
 Hy
-CY
+Ki
 Hy
 Hy
 Hy
+Ki
 Hy
-pp
 pd
-pd
-zo
-pd
-zo
-zo
-NQ
-ub
-Da
-Da
-Da
-Da
-Da
-Da
-Da
-Da
-Da
-ub
-zt
-pd
-pd
-pd
-mx
-pd
-pd
-pd
-pd
+oJ
 OK
+pd
+pd
+ub
+NQ
+QF
+QF
+QF
+QF
+Da
+ke
+oJ
+pd
+pd
+pd
+YT
+Ec
+pd
+pd
+pd
+pd
+pd
+pd
+ls
 Hy
 Hy
 Hy
@@ -1531,38 +1489,36 @@ Hy
 Hy
 Hy
 Hy
+CY
 Hy
 Hy
-Ki
-Mi
-dy
-VR
+Hy
+Hy
 pd
 pd
+zo
+OK
 pd
-pd
-pd
-zt
-pd
-pd
-Ic
-OU
-OU
-Da
+VH
+NQ
+NQ
+TM
+NQ
 NQ
 pd
 pd
+Ic
+NQ
+NQ
+At
+VH
 pd
-pd
-pd
+OK
 pd
 oJ
 pd
-zt
-ls
 pd
-pd
-pd
+Ic
 Hy
 Hy
 Hy
@@ -1572,81 +1528,77 @@ Hy
 Hy
 Hy
 Hy
-Hy
 Ki
 Hy
 Hy
 Hy
-Ki
+Hy
+Hy
 Hy
 pd
-oJ
-OK
 pd
 pd
-bk
+pd
+pd
+pd
+pd
+pd
 NQ
-QF
-QF
-QF
-QF
+ls
+pd
+pd
+pd
+pd
+pd
+VH
+VH
 Da
-sd
+Da
+pd
 oJ
 pd
 pd
 pd
-cc
-VH
-pd
-pd
-pd
-pd
-pd
-pd
-ls
 Hy
 Hy
 Hy
 Hy
 "}
 (25,1,1) = {"
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
 CY
 Hy
 Hy
 Hy
 Hy
+dy
+CY
+CY
+Hy
+aM
+Hy
 pd
 pd
-ke
-OK
-pd
-zo
-NQ
-NQ
-QI
-NQ
-NQ
 pd
 pd
-zt
-NQ
-NQ
-om
-zo
+pd
+pd
+pd
+pd
+pd
 pd
 OK
 pd
 oJ
 pd
+om
 pd
-zt
+pd
+OK
+pd
+pd
+pd
+pd
+pd
 Hy
 Hy
 Hy
@@ -1658,41 +1610,39 @@ Hy
 Hy
 Hy
 Hy
-Ki
 Hy
 Hy
 Hy
 Hy
 Hy
 Hy
-pd
-pd
-pd
-pd
-pd
-pd
-pd
+Hy
 pd
 NQ
-ls
+OK
 pd
 pd
+UC
+pd
+om
 pd
 pd
-pd
-zo
-zo
-Da
-Da
 pd
 oJ
 pd
 pd
 pd
+pd
+pd
+pd
+UC
+pd
+pd
 Hy
 Hy
 Hy
 Hy
+Dz
 "}
 (27,1,1) = {"
 Hy
@@ -1702,15 +1652,14 @@ Hy
 Hy
 Hy
 Hy
-AH
-CY
 CY
 Hy
-fY
+Hy
+Hy
+zF
 Hy
 pd
-pd
-pd
+oJ
 pd
 pd
 pd
@@ -1719,20 +1668,19 @@ pd
 pd
 pd
 OK
-pd
 oJ
 pd
 mx
 pd
 pd
-OK
-pd
 pd
 pd
 pd
 pd
 Hy
 Hy
+Hy
+aM
 Hy
 Hy
 "}
@@ -1747,76 +1695,72 @@ Hy
 Hy
 Hy
 Hy
-Hy
-Hy
-Hy
+CY
+CY
 Hy
 pd
-NQ
+pd
+pd
+pd
+ls
+pd
 OK
 pd
 pd
-aM
+mu
 pd
-mx
 pd
 pd
 pd
 oJ
-pd
-pd
-pd
-pd
-pd
-pd
-aM
+Ic
 pd
 pd
 Hy
 Hy
 Hy
 Hy
-jf
+Hy
+Hy
+Hy
 "}
 (29,1,1) = {"
 Hy
+aM
 Hy
 Hy
+Ki
+Hy
+Hy
+Hy
+Ki
 Hy
 CY
 Hy
 Hy
 Hy
 Hy
-CY
-Hy
-Hy
-Hy
-Fw
-Hy
+pd
+pd
+pd
+pd
+pd
+ls
+pd
 pd
 oJ
 pd
 pd
-pd
-pd
-pd
-pd
-pd
-OK
-oJ
-pd
-kh
-pd
-pd
-pd
+UC
 pd
 pd
 pd
 Hy
 Hy
 Hy
-fY
+Hy
+Hy
+Hy
 Hy
 Hy
 "}
@@ -1832,29 +1776,27 @@ Hy
 Hy
 Hy
 Hy
+aM
 Hy
-CY
-CY
 Hy
+Hy
+Hy
+mx
 pd
 pd
+Ic
 pd
 pd
 ls
 pd
-OK
 pd
 pd
 pd
-pd
-pd
-pd
-pd
-oJ
-zt
 pd
 pd
 Hy
+Hy
+zF
 Hy
 Hy
 Hy
@@ -1865,36 +1807,34 @@ Hy
 (31,1,1) = {"
 Hy
 Hy
-Hy
-fY
-Hy
-Hy
-Ki
-Hy
-Hy
-Hy
-Ki
+CY
 Hy
 CY
 Hy
+aM
 Hy
 Hy
 Hy
+Hy
+Hy
+Dz
+Hy
+Hy
+Hy
+Hy
 pd
 pd
 pd
 pd
 pd
-ls
+NQ
+Ic
 pd
 pd
 oJ
 pd
-pd
 aM
-pd
-pd
-pd
+Hy
 Hy
 Hy
 Hy
@@ -1913,32 +1853,30 @@ Hy
 Hy
 Hy
 Hy
+CY
 Hy
 Hy
 Hy
+CY
+Hy
+aM
+Hy
+CY
 Hy
 Hy
-fY
-Hy
-Hy
-Hy
-Hy
-kh
+pd
+oJ
 pd
 pd
-zt
-pd
-pd
-ls
-pd
-pd
-pd
+OK
 pd
 pd
 pd
 Hy
 Hy
-Fw
+Hy
+Hy
+Hy
 Hy
 Hy
 Hy
@@ -1951,37 +1889,35 @@ Hy
 Hy
 Hy
 Hy
+Hy
+Hy
+Ki
+Hy
+Hy
+Hy
+CY
 CY
 Hy
-CY
-Hy
-fY
 Hy
 Hy
 Hy
-Hy
-Hy
-jf
 Hy
 Hy
 Hy
 Hy
 pd
 pd
+ls
 pd
 pd
 pd
-NQ
-zt
-pd
-pd
-oJ
-pd
-fY
 Hy
 Hy
 Hy
 Hy
+Hy
+Hy
+aM
 Hy
 Hy
 Hy
@@ -1999,25 +1935,23 @@ Hy
 Hy
 Hy
 Hy
-CY
+Hy
+Hy
+Hy
+Hy
+Hy
+Hy
 Hy
 Hy
 Hy
 CY
 Hy
-fY
-Hy
-CY
 Hy
 Hy
-pd
-oJ
-pd
-pd
-OK
-pd
-pd
-pd
+Hy
+aM
+Hy
+Hy
 Hy
 Hy
 Hy
@@ -2039,12 +1973,6 @@ Hy
 Hy
 Hy
 Hy
-Ki
-Hy
-Hy
-Hy
-CY
-CY
 Hy
 Hy
 Hy
@@ -2053,19 +1981,23 @@ Hy
 Hy
 Hy
 Hy
-pd
-pd
-ls
-pd
-pd
-pd
+Hy
+Hy
+Hy
+Hy
+zF
 Hy
 Hy
 Hy
 Hy
 Hy
 Hy
-fY
+Hy
+Hy
+Hy
+Hy
+Hy
+Hy
 Hy
 Hy
 Hy
@@ -2094,12 +2026,10 @@ Hy
 Hy
 Hy
 Hy
-CY
 Hy
 Hy
 Hy
 Hy
-fY
 Hy
 Hy
 Hy
@@ -2133,140 +2063,12 @@ Hy
 Hy
 Hy
 Hy
+Dz
 Hy
 Hy
 Hy
 Hy
-Fw
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-"}
-(38,1,1) = {"
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-"}
-(39,1,1) = {"
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-jf
-Hy
-Hy
-Hy
-Hy
-fY
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-"}
-(40,1,1) = {"
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
-Hy
+aM
 Hy
 Hy
 Hy

--- a/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
@@ -156,8 +156,8 @@
 "ax" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "s_docking_airlock";
-	locked = 1;
-	name = "Shuttle Airlock"
+	name = "Shuttle Airlock";
+	req_access_txt = "150"
 	},
 /obj/structure/fans/tiny,
 /obj/docking_port/stationary{
@@ -172,8 +172,8 @@
 	dir = 8;
 	dwidth = 2;
 	height = 5;
-	id = ussppod;
-	name = "USSP Pod";
+	id = "ruins_transport_shuttle";
+	name = "USSP Cargo Shuttle";
 	width = 8
 	},
 /turf/simulated/shuttle/floor{
@@ -4329,7 +4329,7 @@
 	},
 /area/shuttle/ussp)
 "iP" = (
-/obj/machinery/computer/shuttle/ussp_pod,
+/obj/machinery/computer/shuttle/ruins_transport_shuttle,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
 	},
@@ -4546,8 +4546,8 @@
 "jl" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "s_docking_airlock";
-	locked = 1;
-	name = "Shuttle Airlock"
+	name = "Shuttle Airlock";
+	req_access_txt = "150"
 	},
 /obj/structure/fans/tiny,
 /turf/simulated/shuttle/floor{
@@ -5566,9 +5566,9 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	d1 = 4;
+	d1 = 1;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -5718,8 +5718,9 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
+/obj/structure/closet/crate{
+	icon_state = "crateopen";
+	opened = 1
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -7399,7 +7400,7 @@
 /obj/docking_port/stationary/whiteship{
 	dir = 8;
 	id = "whiteship_ussp";
-	name = "USSP"
+	name = "Near USSP"
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -8885,7 +8886,7 @@
 /turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
 /area/derelict/bridge)
 "tI" = (
-/obj/machinery/computer/shuttle/ussp_pod,
+/obj/machinery/computer/shuttle/ruins_transport_shuttle,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkblue"
@@ -9135,6 +9136,9 @@
 	icon_state = "solarpanel"
 	},
 /area/space/nearstation)
+"AA" = (
+/turf/simulated/shuttle/wall,
+/area/ruin/unpowered/no_grav)
 "AB" = (
 /obj/structure/grille,
 /obj/structure/window/full/shuttle,
@@ -13334,7 +13338,7 @@ rZ
 bn
 bn
 bn
-Ue
+AA
 QH
 so
 GG
@@ -13518,7 +13522,7 @@ bn
 bn
 bn
 NP
-Ue
+AA
 RN
 ac
 ul
@@ -13702,7 +13706,7 @@ rZ
 bn
 bn
 bn
-Ue
+AA
 lH
 ag
 ag

--- a/_maps/map_files/RandomRuins/SpaceRuins/whiteship.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/whiteship.dmm
@@ -11,6 +11,11 @@
 	tag = "icon-whitehall (WEST)"
 	},
 /area/shuttle/abandoned)
+"ae" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swall_f9"
+	},
+/area/shuttle/abandoned)
 "aN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
@@ -204,6 +209,12 @@
 	tag = "icon-whiteblue (NORTHWEST)"
 	},
 /area/shuttle/abandoned)
+"dn" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swall15";
+	tag = "icon-swall15"
+	},
+/area/shuttle/abandoned)
 "dA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
@@ -362,6 +373,11 @@
 	tag = "icon-whitebluefull"
 	},
 /area/shuttle/abandoned)
+"gF" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swallc2"
+	},
+/area/shuttle/abandoned)
 "gP" = (
 /obj/machinery/door/airlock/medical/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -445,6 +461,16 @@
 	icon_state = "darkblue"
 	},
 /area/shuttle/abandoned)
+"hJ" = (
+/obj/structure/sign/redcross{
+	desc = "The Star of Life, a symbol of Medical Aid.";
+	icon_state = "lifestar";
+	name = "Medbay"
+	},
+/turf/simulated/shuttle/wall{
+	icon_state = "swall12"
+	},
+/area/shuttle/abandoned)
 "ij" = (
 /obj/structure/grille,
 /obj/structure/window/full/shuttle,
@@ -518,6 +544,22 @@
 	icon_state = "barber"
 	},
 /area/shuttle/abandoned)
+"kc" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swall12"
+	},
+/area/shuttle/abandoned)
+"kg" = (
+/obj/structure/sign/redcross{
+	desc = "The Star of Life, a symbol of Medical Aid.";
+	icon_state = "lifestar";
+	name = "Medbay"
+	},
+/turf/simulated/shuttle/wall{
+	dir = 3;
+	icon_state = "swall1"
+	},
+/area/shuttle/abandoned)
 "kM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -573,16 +615,6 @@
 	icon_state = "darkblue"
 	},
 /area/shuttle/abandoned)
-"lE" = (
-/obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion (NORTH)"
-	},
-/obj/structure/shuttle/engine/heater{
-	pixel_y = 32;
-	tag = "icon-heater (NORTH)"
-	},
-/turf/simulated/wall/mineral/titanium/nodecon,
-/area/shuttle/abandoned)
 "lJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -599,6 +631,11 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue";
 	tag = "icon-whiteblue"
+	},
+/area/shuttle/abandoned)
+"lK" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swall14"
 	},
 /area/shuttle/abandoned)
 "lZ" = (
@@ -636,15 +673,12 @@
 /area/shuttle/abandoned)
 "mA" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
+	dir = 1;
 	tag = "icon-propulsion (NORTH)"
 	},
-/obj/structure/shuttle/engine/heater{
-	dir = 8;
-	pixel_x = 32;
-	tag = "icon-heater (NORTH)"
+/turf/simulated/shuttle/wall{
+	icon_state = "swall_f6"
 	},
-/turf/simulated/wall/mineral/titanium/nodecon,
 /area/shuttle/abandoned)
 "mM" = (
 /obj/structure/table,
@@ -656,6 +690,11 @@
 /obj/item/reagent_containers/glass/bottle/reagent/formaldehyde,
 /turf/simulated/floor/plasteel{
 	icon_state = "barber"
+	},
+/area/shuttle/abandoned)
+"mS" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swallc3"
 	},
 /area/shuttle/abandoned)
 "mU" = (
@@ -1013,6 +1052,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/abandoned)
+"uk" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swall_f10"
+	},
+/area/shuttle/abandoned)
 "ut" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -1079,7 +1123,7 @@
 	desc = "The undead. Its good time to RUN!";
 	faction = list("zombie");
 	harm_intent_damage = 10;
-	health = 85;
+	health = 65;
 	icon = 'icons/mob/human.dmi';
 	icon_living = "zombie2_s";
 	icon_state = "zombie2_s";
@@ -1115,6 +1159,7 @@
 /obj/machinery/door/window/brigdoor/southright{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/vomit,
 /mob/living/simple_animal/hostile/creature{
 	del_on_death = 1;
 	desc = "The undead! Its good time to RUN!";
@@ -1135,7 +1180,6 @@
 	speak_emote = list("growls","roars");
 	speed = -1
 	},
-/obj/effect/decal/cleanable/vomit,
 /turf/simulated/floor/plasteel{
 	icon_state = "barber"
 	},
@@ -1169,12 +1213,18 @@
 /obj/machinery/light/small/built{
 	dir = 8
 	},
+/obj/machinery/door_control{
+	id = "whiteshiproom1";
+	name = "Room 1 Shutters Control";
+	pixel_x = 26;
+	pixel_y = -2
+	},
 /mob/living/simple_animal/hostile/creature{
 	del_on_death = 1;
 	desc = "The undead! Its good time to RUN!";
 	faction = list("zombie");
 	harm_intent_damage = 10;
-	health = 60;
+	health = 45;
 	icon = 'icons/mob/human.dmi';
 	icon_living = "zombie_s";
 	icon_state = "zombie_s";
@@ -1188,12 +1238,6 @@
 	speak_chance = 1;
 	speak_emote = list("growls","roars");
 	speed = -1
-	},
-/obj/machinery/door_control{
-	id = "whiteshiproom1";
-	name = "Room 1 Shutters Control";
-	pixel_x = 26;
-	pixel_y = -2
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -1227,6 +1271,12 @@
 	name = "Room 1 Shutters"
 	},
 /turf/simulated/floor/plating,
+/area/shuttle/abandoned)
+"xn" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swall14";
+	tag = "icon-swall14"
+	},
 /area/shuttle/abandoned)
 "xC" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1281,7 +1331,10 @@
 	icon_state = "lifestar";
 	name = "Medbay"
 	},
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/shuttle/wall{
+	icon_state = "swall11";
+	tag = "icon-swall11"
+	},
 /area/shuttle/abandoned)
 "ys" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1311,7 +1364,7 @@
 	desc = "The undead! Its good time to RUN!";
 	faction = list("zombie");
 	harm_intent_damage = 10;
-	health = 60;
+	health = 20;
 	icon = 'icons/mob/human.dmi';
 	icon_living = "zombie_s";
 	icon_state = "zombie_s";
@@ -1388,6 +1441,11 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/plasteel,
 /area/shuttle/abandoned)
+"zB" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swall4"
+	},
+/area/shuttle/abandoned)
 "zF" = (
 /obj/structure/grille,
 /obj/structure/window/full/shuttle,
@@ -1455,15 +1513,18 @@
 /obj/docking_port/mobile{
 	dir = 8;
 	dwidth = 8;
-	height = 30;
+	height = 31;
 	id = "whiteship";
 	name = "NT Medical Ship";
+	rebuildable = 1;
 	width = 17
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/abandoned)
 "Aa" = (
-/turf/simulated/wall/mineral/titanium/nodecon,
+/turf/simulated/shuttle/wall{
+	icon_state = "swall_f6"
+	},
 /area/shuttle/abandoned)
 "Aq" = (
 /obj/machinery/door/airlock/medical,
@@ -1472,6 +1533,17 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
+/area/shuttle/abandoned)
+"AC" = (
+/obj/structure/sign/redcross{
+	desc = "The Star of Life, a symbol of Medical Aid.";
+	icon_state = "lifestar";
+	name = "Medbay"
+	},
+/turf/simulated/shuttle/wall{
+	dir = 3;
+	icon_state = "swall2"
+	},
 /area/shuttle/abandoned)
 "Bb" = (
 /obj/structure/sign/nosmoking_2{
@@ -1515,6 +1587,11 @@
 	icon_state = "barber"
 	},
 /area/shuttle/abandoned)
+"Bu" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swall_f5"
+	},
+/area/shuttle/abandoned)
 "BG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -1527,6 +1604,12 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull";
 	tag = "icon-whitebluefull"
+	},
+/area/shuttle/abandoned)
+"Cf" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swall8";
+	tag = "icon-swall12"
 	},
 /area/shuttle/abandoned)
 "CD" = (
@@ -1544,17 +1627,16 @@
 	icon_state = "darkblue"
 	},
 /area/shuttle/abandoned)
-"CM" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 1;
-	tag = "icon-propulsion (NORTH)"
+"CI" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swall11";
+	tag = "icon-swall11"
 	},
-/obj/structure/shuttle/engine/heater{
-	dir = 1;
-	pixel_y = -32;
-	tag = "icon-heater (NORTH)"
+/area/shuttle/abandoned)
+"CW" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swall7"
 	},
-/turf/simulated/wall/mineral/titanium/nodecon,
 /area/shuttle/abandoned)
 "Dc" = (
 /obj/machinery/computer/med_data,
@@ -1660,12 +1742,21 @@
 	icon_state = "barber"
 	},
 /area/shuttle/abandoned)
-"Fw" = (
-/obj/structure/sign/poster/official/nanotrasen_logo{
-	pixel_y = -32
+"Fq" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swall13"
 	},
-/turf/template_noop,
-/area/template_noop)
+/area/shuttle/abandoned)
+"Fw" = (
+/obj/structure/sign/redcross{
+	desc = "The Star of Life, a symbol of Medical Aid.";
+	icon_state = "lifestar";
+	name = "Medbay"
+	},
+/turf/simulated/shuttle/wall{
+	icon_state = "swall14"
+	},
+/area/shuttle/abandoned)
 "Fz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1774,6 +1865,18 @@
 	tag = "icon-whitebluefull"
 	},
 /area/shuttle/abandoned)
+"Im" = (
+/turf/simulated/shuttle/wall{
+	dir = 3;
+	icon_state = "swall1"
+	},
+/area/shuttle/abandoned)
+"Is" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swall7";
+	tag = "icon-swall7"
+	},
+/area/shuttle/abandoned)
 "IA" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "whiteshipouterairlock2";
@@ -1851,12 +1954,19 @@
 	icon_state = "darkbluefull"
 	},
 /area/shuttle/abandoned)
-"JT" = (
-/obj/structure/sign/poster/official/nanotrasen_logo{
-	pixel_y = 32
+"JI" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	tag = "icon-propulsion (NORTH)"
 	},
-/turf/template_noop,
-/area/template_noop)
+/turf/simulated/floor/plating/airless,
+/area/shuttle/abandoned)
+"JT" = (
+/obj/structure/sign/poster/official/nanotrasen_logo,
+/turf/simulated/shuttle/wall{
+	icon_state = "swall12"
+	},
+/area/shuttle/abandoned)
 "JX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -1869,7 +1979,7 @@
 	desc = "The undead. Its good time to RUN!";
 	faction = list("zombie");
 	harm_intent_damage = 10;
-	health = 85;
+	health = 65;
 	icon = 'icons/mob/human.dmi';
 	icon_living = "zombie2_s";
 	icon_state = "zombie2_s";
@@ -1928,7 +2038,7 @@
 	desc = "The undead! Its good time to RUN!";
 	faction = list("zombie");
 	harm_intent_damage = 10;
-	health = 60;
+	health = 20;
 	icon = 'icons/mob/human.dmi';
 	icon_living = "zombie_s";
 	icon_state = "zombie_s";
@@ -2121,6 +2231,14 @@
 	icon_state = "darkbluefull"
 	},
 /area/shuttle/abandoned)
+"Op" = (
+/obj/structure/shuttle/engine/propulsion{
+	tag = "icon-propulsion (NORTH)"
+	},
+/turf/simulated/shuttle/wall{
+	icon_state = "swall_f5"
+	},
+/area/shuttle/abandoned)
 "Oq" = (
 /obj/structure/rack,
 /obj/item/clothing/under/rank/medical/blue,
@@ -2178,15 +2296,22 @@
 	},
 /area/shuttle/abandoned)
 "Pv" = (
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/shuttle/wall{
+	dir = 3;
+	icon_state = "swall2"
+	},
 /area/shuttle/abandoned)
 "PB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/under/retro/medical{
+	name = "old medical officer's uniform"
+	},
 /mob/living/simple_animal/hostile/creature{
 	del_on_death = 1;
 	desc = "The undead! Its good time to RUN!";
 	faction = list("zombie");
 	harm_intent_damage = 10;
-	health = 60;
+	health = 45;
 	icon = 'icons/mob/human.dmi';
 	icon_living = "zombie_s";
 	icon_state = "zombie_s";
@@ -2200,10 +2325,6 @@
 	speak_chance = 1;
 	speak_emote = list("growls","roars");
 	speed = -1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/under/retro/medical{
-	name = "old medical officer's uniform"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -2245,12 +2366,7 @@
 	dir = 4;
 	tag = "icon-propulsion (NORTH)"
 	},
-/obj/structure/shuttle/engine/heater{
-	dir = 4;
-	pixel_x = -32;
-	tag = "icon-heater (NORTH)"
-	},
-/turf/simulated/wall/mineral/titanium/nodecon,
+/turf/simulated/floor/plating/airless,
 /area/shuttle/abandoned)
 "Sc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2307,6 +2423,11 @@
 	icon_state = "dark"
 	},
 /area/shuttle/abandoned)
+"SP" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swallc4"
+	},
+/area/shuttle/abandoned)
 "Ta" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
@@ -2343,6 +2464,31 @@
 /area/shuttle/abandoned)
 "Td" = (
 /turf/simulated/floor/plating,
+/area/shuttle/abandoned)
+"To" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swall3"
+	},
+/area/shuttle/abandoned)
+"Ty" = (
+/obj/structure/sign/redcross{
+	desc = "The Star of Life, a symbol of Medical Aid.";
+	icon_state = "lifestar";
+	name = "Medbay"
+	},
+/turf/simulated/shuttle/wall{
+	icon_state = "swall11"
+	},
+/area/shuttle/abandoned)
+"TU" = (
+/obj/structure/sign/redcross{
+	desc = "The Star of Life, a symbol of Medical Aid.";
+	icon_state = "lifestar";
+	name = "Medbay"
+	},
+/turf/simulated/shuttle/wall{
+	icon_state = "swall13"
+	},
 /area/shuttle/abandoned)
 "Uq" = (
 /obj/structure/bed/roller,
@@ -2390,6 +2536,11 @@
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "dark"
+	},
+/area/shuttle/abandoned)
+"VJ" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swallc1"
 	},
 /area/shuttle/abandoned)
 "We" = (
@@ -2468,7 +2619,7 @@
 	desc = "The undead! Its good time to RUN!";
 	faction = list("zombie");
 	harm_intent_damage = 10;
-	health = 60;
+	health = 45;
 	icon = 'icons/mob/human.dmi';
 	icon_living = "zombie_s";
 	icon_state = "zombie_s";
@@ -2497,6 +2648,24 @@
 /area/shuttle/abandoned)
 "XK" = (
 /obj/structure/chair/comfy/shuttle,
+/mob/living/simple_animal/hostile/creature{
+	del_on_death = 1;
+	desc = "The undead. Its good time to RUN!";
+	faction = list("zombie");
+	harm_intent_damage = 10;
+	health = 65;
+	icon = 'icons/mob/human.dmi';
+	icon_living = "zombie2_s";
+	icon_state = "zombie2_s";
+	loot = list(/obj/effect/decal/cleanable/blood/gibs);
+	maxHealth = 100;
+	name = "Zombie";
+	response_help = "gently probs";
+	speak = list("RAWR!","Rawr!","GRR!","Growl!");
+	speak_chance = 1;
+	speak_emote = list("growls","roars");
+	speed = 0
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "dark"
@@ -2536,7 +2705,7 @@
 	desc = "The undead. Its good time to RUN!";
 	faction = list("zombie");
 	harm_intent_damage = 10;
-	health = 85;
+	health = 35;
 	icon = 'icons/mob/human.dmi';
 	icon_living = "zombie2_s";
 	icon_state = "zombie2_s";
@@ -2588,24 +2757,6 @@
 	},
 /area/shuttle/abandoned)
 "Zr" = (
-/mob/living/simple_animal/hostile/creature{
-	del_on_death = 1;
-	desc = "The undead. Its good time to RUN!";
-	faction = list("zombie");
-	harm_intent_damage = 10;
-	health = 85;
-	icon = 'icons/mob/human.dmi';
-	icon_living = "zombie2_s";
-	icon_state = "zombie2_s";
-	loot = list(/obj/effect/decal/cleanable/blood/gibs);
-	maxHealth = 100;
-	name = "Zombie";
-	response_help = "gently probs";
-	speak = list("RAWR!","Rawr!","GRR!","Growl!");
-	speak_chance = 1;
-	speak_emote = list("growls","roars");
-	speed = 0
-	},
 /obj/item/gun/energy/gun/mini,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -2664,11 +2815,11 @@ GK
 GK
 GK
 GK
-mA
-mA
+JI
+JI
 GK
-mA
-mA
+JI
+JI
 GK
 GK
 GK
@@ -2683,12 +2834,12 @@ GK
 GK
 GK
 Aa
-Pv
-Pv
+CI
+Fq
 GK
-Pv
-Pv
-Aa
+lK
+CI
+Bu
 GK
 GK
 GK
@@ -2701,13 +2852,13 @@ GK
 GK
 GK
 GK
-Pv
+Cf
 fT
-Pv
+kc
 GK
-Pv
+kc
 il
-Pv
+Cf
 GK
 GK
 GK
@@ -2722,9 +2873,9 @@ GK
 GK
 tQ
 DP
-Pv
+kc
 GK
-Pv
+kc
 jQ
 Ep
 GK
@@ -2739,13 +2890,13 @@ GK
 GK
 GK
 GK
-Pv
+zB
 uR
-Pv
+kc
 GK
-Pv
+kc
 su
-Pv
+zB
 GK
 GK
 GK
@@ -2758,13 +2909,13 @@ GK
 GK
 GK
 GK
-yh
+hJ
 Td
-Pv
+kc
 GK
-Pv
+kc
 ux
-yh
+hJ
 GK
 GK
 GK
@@ -2777,13 +2928,13 @@ GK
 rA
 GK
 GK
-Pv
+kc
 nv
-Pv
+kc
 GK
-Pv
+kc
 yA
-Pv
+kc
 GK
 GK
 GK
@@ -2795,15 +2946,15 @@ GK
 GK
 GK
 GK
-Fw
-Pv
+JI
+kc
 XL
-Pv
+kc
 GK
-Pv
+kc
 Td
-Pv
-JT
+kc
+JI
 GK
 GK
 GK
@@ -2814,15 +2965,15 @@ GK
 GK
 GK
 GK
-Aa
-Pv
+lK
+SP
 Sh
-Pv
+kc
 GK
-Pv
+kc
 Il
-Pv
-Aa
+VJ
+Fq
 GK
 GK
 GK
@@ -2832,17 +2983,17 @@ GK
 GK
 GK
 GK
-mA
-Pv
+JI
+Fq
 Tb
 Hf
-Pv
+kc
 GK
-Pv
+kc
 MM
 oY
-Pv
-mA
+lK
+JI
 GK
 GK
 GK
@@ -2851,17 +3002,17 @@ GK
 GK
 GK
 GK
-Pv
-Pv
+lK
+SP
 ys
 bE
-Pv
+kc
 GK
-Pv
+kc
 sT
 fJ
-Pv
-Pv
+VJ
+Fq
 GK
 GK
 GK
@@ -2869,65 +3020,65 @@ GK
 (12,1,1) = {"
 GK
 GK
-mA
-Pv
+Aa
+SP
 WM
 zf
 xi
-Pv
+kc
 Jw
-Pv
+kc
 JB
 dT
 Ou
-Pv
-mA
+VJ
+Bu
 GK
 GK
 "}
 (13,1,1) = {"
 GK
 GK
-Pv
+JT
 Ju
 xJ
 lm
 Bb
-Pv
+kc
 Hu
-Pv
+kc
 st
 PS
 WZ
 qI
-Pv
+JT
 GK
 GK
 "}
 (14,1,1) = {"
 GK
-GK
-Pv
-Pv
-yh
+mA
+lK
+CW
+kg
 ZB
 Pv
-Pv
+SP
 mi
-Pv
-Pv
+VJ
+Im
 Aq
-yh
-Pv
-Pv
-GK
+AC
+CW
+Fq
+Op
 GK
 "}
 (15,1,1) = {"
 GK
-CM
-Pv
-Pv
+Fw
+dn
+SP
 EF
 YJ
 Dv
@@ -2937,28 +3088,28 @@ gt
 XH
 zJ
 xC
-Pv
-Pv
-lE
+VJ
+dn
+TU
 GK
 "}
 (16,1,1) = {"
 GK
-Pv
-Pv
+VJ
+SP
 eC
 rk
 jD
-Pv
+zB
 lZ
 aW
 pJ
-Pv
+zB
 Uq
 En
 aT
-Pv
-Pv
+VJ
+SP
 GK
 "}
 (17,1,1) = {"
@@ -2968,11 +3119,11 @@ qH
 Bp
 qp
 uZ
-Pv
-yh
+lK
+kg
 or
 Pv
-Pv
+Fq
 sU
 jT
 Zn
@@ -2982,22 +3133,22 @@ GK
 "}
 (18,1,1) = {"
 Aa
-Pv
-Pv
+To
+Im
 uB
 Pv
-Pv
-Pv
+CW
+SP
 aa
 Sc
 tv
-Pv
+kc
 UT
 vv
 Fz
 nP
-Pv
-Aa
+VJ
+Bu
 "}
 (19,1,1) = {"
 xm
@@ -3005,37 +3156,37 @@ xd
 gP
 xG
 Dt
-Pv
+kc
 hl
 Sm
 Jr
 lJ
-Pv
-Pv
-Pv
+lK
+To
+mS
 tu
 vM
 YK
-Pv
+kc
 "}
 (20,1,1) = {"
 Pv
-Pv
-Pv
+To
+Im
 xS
 Oq
-Pv
+kc
 ZO
 Lh
 re
 ZU
-Pv
+kc
 hb
-Pv
+Cf
 LP
 QN
 vI
-Pv
+kc
 "}
 (21,1,1) = {"
 zF
@@ -3043,37 +3194,37 @@ FI
 Nw
 Ha
 Nx
-Pv
+kc
 zQ
 UZ
 aN
 ci
-Pv
+kc
 aO
 mU
 Od
 wG
 mM
-Pv
+kc
 "}
 (22,1,1) = {"
 Pv
-Pv
-Pv
+To
+Im
 ms
 Pv
-Pv
+Fq
 nd
 yU
 bQ
 Gc
-Pv
+kc
 zO
-Pv
+zB
 sQ
 Pv
-Pv
-Pv
+To
+SP
 "}
 (23,1,1) = {"
 IA
@@ -3081,37 +3232,37 @@ MY
 es
 Og
 yK
-Pv
-Pv
-Pv
+VJ
+Is
+Im
 ut
 Pv
-Pv
-Pv
-Pv
+dn
+To
+SP
 zS
 PO
 sE
 fM
 "}
 (24,1,1) = {"
-Aa
-Pv
-Pv
+uk
+To
+Im
 rt
 Sz
 gT
-Pv
+Cf
 Kv
 JX
 dA
-Pv
+Cf
 CD
 kM
 DO
 Pv
-Pv
-Aa
+To
+ae
 "}
 (25,1,1) = {"
 GK
@@ -3134,39 +3285,39 @@ vF
 "}
 (26,1,1) = {"
 GK
-Aa
-Pv
+uk
+mS
 xk
 VD
 vG
-Pv
-Pv
+gF
+Im
 Oh
 Pv
-Pv
+mS
 Ji
 WD
 eg
-Pv
-Aa
+gF
+ae
 GK
 "}
 (27,1,1) = {"
 GK
 GK
-Pv
-Pv
+xn
+mS
 oy
-Pv
-Pv
+gF
+SP
 lv
 IV
 hn
-Pv
-Pv
+VJ
+mS
 Oy
-Pv
-Pv
+gF
+Fq
 GK
 GK
 "}
@@ -3175,16 +3326,16 @@ GK
 GK
 RU
 yh
-Pv
-Pv
+Is
+SP
 OP
 dS
 yE
 iz
 hj
-Pv
-Pv
-yh
+VJ
+Is
+Ty
 RU
 GK
 GK
@@ -3194,7 +3345,7 @@ GK
 GK
 GK
 GK
-Pv
+Cf
 wo
 XK
 Zr
@@ -3202,7 +3353,7 @@ bS
 PB
 sO
 Ne
-Pv
+Cf
 GK
 GK
 GK

--- a/_maps/map_files/cyberiad/z2.dmm
+++ b/_maps/map_files/cyberiad/z2.dmm
@@ -28302,11 +28302,6 @@
 	icon_state = "darkred"
 	},
 /area/centcom/specops)
-"vlE" = (
-/obj/structure/lattice/catwalk,
-/mob/living/carbon/human/monkey,
-/turf/space,
-/area/space/nearstation)
 "vlY" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/unsimulated/floor{
@@ -28694,8 +28689,8 @@
 	dir = 8;
 	dwidth = 2;
 	height = 5;
-	id = "spacebarpodv1_transit";
-	name = "Regular Space Pod in transit";
+	id = "ruins_civil_shuttle_transit";
+	name = "Regular Civilian Shuttle in transit";
 	width = 8
 	},
 /turf/space/transit,
@@ -31029,8 +31024,8 @@
 	dir = 8;
 	dwidth = 2;
 	height = 5;
-	id = "ussppod_transit";
-	name = "USSP Pod in transit";
+	id = "ruins_transport_shuttle_transit";
+	name = "Transport Shuttle in transit";
 	width = 8
 	},
 /turf/space/transit,
@@ -90377,7 +90372,7 @@ jyD
 jyD
 jyD
 jyD
-vlE
+moX
 jyD
 jyD
 jyD

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -146,6 +146,7 @@
 		engine is somewhere in the area. We'd like to request a patrol vessel \
 		to investigate."
 	cost = 2
+	allow_duplicates = FALSE // has sercet documents, should dup in space
 
 /datum/map_template/ruin/space/turreted_outpost
 	id = "turreted-outpost"

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -329,12 +329,12 @@ obj/item/circuitboard/syndicatesupplycomp/public
 /obj/item/circuitboard/mining_shuttle
 	name = "circuit Board (Mining Shuttle)"
 	build_path = /obj/machinery/computer/shuttle/mining
-/obj/item/circuitboard/ussp_pod
-	name = "circuit Board (USSP Shuttle)"
-	build_path = /obj/machinery/computer/shuttle/ussp_pod
-/obj/item/circuitboard/spacebarhotelpodv1
-	name = "circuit Board (Regular Space Shuttle)"
-	build_path = /obj/machinery/computer/shuttle/spacebarhotelpodv1
+/obj/item/circuitboard/ruins_transport_shuttle
+	name = "circuit Board (Transport Shuttle)"
+	build_path = /obj/machinery/computer/shuttle/ruins_transport_shuttle
+/obj/item/circuitboard/ruins_civil_shuttle
+	name = "circuit Board (Regular Civilian Shuttle)"
+	build_path = /obj/machinery/computer/shuttle/ruins_civil_shuttle
 /obj/item/circuitboard/white_ship
 	name = "circuit Board (White Ship)"
 	build_path = /obj/machinery/computer/shuttle/white_ship

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -865,19 +865,22 @@
 		message_admins("<b>FERRY: <font color='blue'>[key_name_admin(usr)] (<A HREF='?_src_=holder;secretsfun=moveferry'>Move Ferry</a>)</b> is requesting to move the transport ferry to Centcom.</font>")
 		return TRUE
 
-/obj/machinery/computer/shuttle/ussp_pod // this shuttle made for station and listening post of ussp since they have lore connection between eachother, btw the shuttle existed before the change but was deleted for some reason.
-	name = "USSP Shuttle Console"
-	desc = "Used to control the USSP Shuttle."
-	circuit = /obj/item/circuitboard/ussp_pod
-	shuttleId = "ussppod"
-	possible_destinations = "ussp_dock;dj_post"
 
-/obj/machinery/computer/shuttle/spacebarhotelpodv1 // made another shuttle, this one will fly between spacebar and twin nexus hotel. just another way to get to it.
-	name = "Regular Space Shuttle Console"
-	desc = "Used to control the Regular Shuttle."
-	circuit = /obj/item/circuitboard/spacebarhotelpodv1
-	shuttleId = "spacebarpodv1"
-	possible_destinations = "spacebarv1;spacehotelv1" // v1 for the mark that they connected and for ensure that no space hotels or bars will interference with these docks
+/obj/machinery/computer/shuttle/ruins_transport_shuttle // this shuttle made for station and listening post of ussp since they have lore connection between eachother, btw the shuttle existed before the change but was deleted for some reason.
+	name = "Transport Shuttle Console"
+	desc = "Used to control the Transport Shuttle."
+	circuit = /obj/item/circuitboard/ruins_transport_shuttle
+	shuttleId = "ruins_transport_shuttle"
+	possible_destinations = "ussp_dock;dj_post;sindiecake_dock"
+
+
+/obj/machinery/computer/shuttle/ruins_civil_shuttle // made another shuttle, this one will fly between spacebar and twin nexus hotel. just another way to get to it.
+	name = "Regular Civilian Shuttle Console"
+	desc = "Used to control the Regular Civilian Shuttle."
+	circuit = /obj/item/circuitboard/ruins_civil_shuttle
+	shuttleId = "ruins_civil_shuttle"
+	possible_destinations = "spacebar;spacehotelv1"
+
 
 /obj/machinery/computer/shuttle/white_ship
 	name = "White Ship Console"


### PR DESCRIPTION
Фиксы руин. Лью. Как и хотел, как и просили те кто дал знать о косяках, ну и не только. Как обычно опять что-то мелкое пропустил, снова. Увижу поправлю. Всё измененное ниже.

## Changelog

NT Med Shuttle: walls fixed, tweaked zombies hp to lower level, fixed shuttle size in map entity;

Delta: fixed NT Med Shuttle LZ size;

Spacebar: tweak uppon shuttle size, changed the name, placed few cameras with own network with screen in bar;

Spacehotelv1: added some dirt in maints, fixed new shuttle size, added buttons and lock on external airlocks except shuttle one;

GasTheLizards: cosmetic changes on catwalks;

Onehalf.dmm aka DK Excavator 453: changed dup status to false because of secret docs on the map;

z2.dmm aka CC level: deleted monkey on escape shuttle LZ in space area (who placed it here?), fixed spacebar shuttle, fixed ussp cargo shuttle;

Syndiecakesfactory.dmm: replaced floor plates(maybe not all of them) in space with wrong type of the plates, added exit point for ussp cargo shuttle in the area;

USSP Station: Renamed console in code and in game, replaced one seat in the shuttle with opened crate, old access returned back to its airlocks on the shuttle - 150. Why not? No one cares about it anyway :/ .

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Балансировка, косметика, пару изменений на космо-картах, исправление имён и размеров шатлов.

## Why It's Good For The Game
- Камеры будут в тему для бара, раз бармен в целом занимался приёмом шатлов и подов на площадку, ему не хватало лишь камер для наблюдения и теперь они там стоят, никому мешать не будут.
- На счет точки выхода на синди фабрике - посмотрим что выйдет, шатл мог и на эту фабрику летать за провизией. Потом, раньше у того него был доступ кеков - вернул назад, пусть придумывают что хотят по лору. Наверно позже выпилю рабочую консоль с шатла и поставть её на шатл можно будет лишь разобрав консоль на мостике и перенеся её на шатл, а то слишком просто получается.
- Зомби были толстоваты на мед шатле, теперь чуть картоннее, но может ещё придётся снизить.
- Остальное и так понятно - мелкие фиксы, косметика, твики того что сам налопатил.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

