### PR TITLE
100% батарейки. Пока не пройдет авоут не мерджить.

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -28,10 +28,7 @@
 /obj/item/stock_parts/cell/New()
 	..()
 	START_PROCESSING(SSobj, src)
-	if(istype(loc,/obj/item) || istype(loc,/mob) || istype(loc,/obj/mecha)) //Если оружие, борг или экзоскелет, то полность заряжен
-		charge = maxcharge
-	else
-		charge = round(maxcharge/10,1)
+	charge = maxcharge
 
 	if(ratingdesc)
 		desc += " This one has a power rating of [DisplayPower(maxcharge)], and you should not swallow it."


### PR DESCRIPTION
Возвращает всем батарейкам их 100% заряд раундстартом и сразу после создания.



## What Does This PR Do
Все батарейки будут 100% заряженными сразу после создания.

## Why It's Good For The Game
Предложка: https://discord.com/channels/617003227182792704/618952559607939072/967569845237469266

## Changelog
:cl:
tweak: all roundstart and new created cells now fully charged.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
