### PR TITLE
Fix: Teleportation Spell Doesn't Work

### DIFF
--- a/code/datums/spells/area_teleport.dm
+++ b/code/datums/spells/area_teleport.dm
@@ -11,7 +11,7 @@
 
 /obj/effect/proc_holder/spell/targeted/area_teleport/perform(list/targets, recharge = 1, mob/living/user = usr)
 	var/thearea = before_cast(targets)
-	if(!thearea || !cast_check(TRUE, FALSE, user))
+	if(!thearea || !cast_check(FALSE, FALSE, user))
 		revert_cast()
 		return
 	invocation(thearea)

--- a/code/datums/spells/area_teleport.dm
+++ b/code/datums/spells/area_teleport.dm
@@ -11,7 +11,7 @@
 
 /obj/effect/proc_holder/spell/targeted/area_teleport/perform(list/targets, recharge = 1, mob/living/user = usr)
 	var/thearea = before_cast(targets)
-	if(!thearea || !cast_check(FALSE, FALSE, user))
+	if(!thearea || cast_check(TRUE, TRUE, user))
 		revert_cast()
 		return
 	invocation(thearea)


### PR DESCRIPTION
## Список изменений
* Магическое заклинание телепортации вновь работает, как и должно было быть.