### PR TITLE
Версия КПК `pda-clear` для SolGov и любителей аркад

### DIFF
--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -621,7 +621,7 @@
 	id = /obj/item/card/id/silver
 	r_pocket = /obj/item/lighter/zippo/blue
 	l_pocket = /obj/item/storage/fancy/cigarettes/cigpack_robustgold
-	pda = /obj/item/pda
+	pda = /obj/item/pda/clear
 	backpack_contents = list(
 		/obj/item/storage/box/responseteam = 1,
 		/obj/item/implanter/dust = 1,
@@ -653,7 +653,7 @@
 	id = /obj/item/card/id
 	l_hand = /obj/item/gun/projectile/automatic/ar
 	r_pocket = /obj/item/flashlight/seclite
-	pda = /obj/item/pda
+	pda = /obj/item/pda/clear
 	backpack_contents = list(
 		/obj/item/storage/box/responseteam = 1,
 		/obj/item/ammo_box/magazine/m556 = 3,
@@ -706,7 +706,7 @@
 	l_ear = /obj/item/radio/headset
 	glasses = /obj/item/clothing/glasses/sunglasses
 	id = /obj/item/card/id/supply
-	pda = /obj/item/pda
+	pda = /obj/item/pda/clear
 	backpack_contents = list(
 		/obj/item/storage/box/survival = 1,
 		/obj/item/hand_labeler = 1,

--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -33,8 +33,16 @@
 
 /obj/machinery/pdapainter/New()
 	..()
-	var/blocked = list(/obj/item/pda/silicon, /obj/item/pda/silicon/ai, /obj/item/pda/silicon/robot, /obj/item/pda/silicon/pai, /obj/item/pda/heads,
-						/obj/item/pda/clear, /obj/item/pda/syndicate, /obj/item/pda/chameleon, /obj/item/pda/chameleon/broken)
+	var/blocked = list(
+		/obj/item/pda/clear,
+		/obj/item/pda/silicon,
+		/obj/item/pda/silicon/ai,
+		/obj/item/pda/silicon/robot,
+		/obj/item/pda/silicon/pai,
+		/obj/item/pda/heads,
+		/obj/item/pda/syndicate,
+		/obj/item/pda/chameleon,
+		/obj/item/pda/chameleon/broken)
 
 	for(var/thing in typesof(/obj/item/pda) - blocked)
 		var/obj/item/pda/P = thing

--- a/code/modules/arcade/prize_datums.dm
+++ b/code/modules/arcade/prize_datums.dm
@@ -305,6 +305,12 @@ GLOBAL_DATUM_INIT(global_prizes, /datum/prizes, new())
 	typepath = /obj/item/stack/tile/arcade_carpet/loaded
 	cost = 150
 
+/datum/prize_item/headpat
+	name = "Gloves of Headpats"
+	desc = "Gloves that fill you with an irresistable urge to give headpats."
+	typepath = /obj/item/clothing/gloves/fingerless/rapid/headpat
+	cost = 150
+
 /datum/prize_item/tommygun
 	name = "Tommy Gun"
 	desc = "A replica tommy gun that fires foam darts."
@@ -323,11 +329,11 @@ GLOBAL_DATUM_INIT(global_prizes, /datum/prizes, new())
 	typepath = /obj/item/twohanded/toy/chainsaw
 	cost = 200
 
-/datum/prize_item/headpat
-	name = "Gloves of Headpats"
-	desc = "Gloves that fill you with an irresistable urge to give headpats."
-	typepath = /obj/item/clothing/gloves/fingerless/rapid/headpat
-	cost = 150
+/datum/prize_item/pdaclear
+	name = "PDA"
+	desc = "A personal digital assistent that looks exactly like SolGov's. Does not contain any useful information for the USSP."
+	typepath = /obj/item/pda/clear
+	cost = 1000
 
 /datum/prize_item/bike
 	name = "Awesome Bike!"

--- a/code/modules/pda/pdas.dm
+++ b/code/modules/pda/pdas.dm
@@ -168,7 +168,7 @@
 		M.notify_silent = 1 //Quiet in the library!
 
 /obj/item/pda/clear
-	icon_state = "pda-transp"
+	icon_state = "pda-clear"
 	desc = "A portable microcomputer by Thinktronic Systems, LTD. This is model is a special edition with a transparent case."
 	model_name = "Thinktronic 5230 Personal Data Assistant Deluxe Special Max Turbo Limited Edition"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Кто-то переименовал спрайт, исправил референсы
Добавил в список призов и в снаряжение некоторых представителей SolGov

UPD: произошёл обкак в ТЗ, КПК будет убран из снаряжения SolGov и добавлен в товары

По просьбе: Blenken#4002 (855461025280688128)

## Why It's Good For The Game
Теперь у торговцев SolGov будет лимитированная версия ПДА.
Стильно, престижно, богато.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![image](https://user-images.githubusercontent.com/4831847/165351685-3ee29ca8-d1d4-4d38-bbc8-cd2c5c0a2cae.png)


## Changelog
:cl: Luger
tweak: add `pda-clear` to TSF outfits and arcade prize machine
fix: `pda-clear` is now exist, lmao. It should be named `pda-transp`.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
