### PR TITLE
 Tweak: Перевод интерфейса медицинской криокапсулы

### DIFF
--- a/code/__HELPERS/pronouns.dm
+++ b/code/__HELPERS/pronouns.dm
@@ -1,5 +1,21 @@
 //pronoun procs, for getting pronouns without using the text macros that only work in certain positions
 //datums don't have gender, but most of their subtypes do!
+
+/proc/declension_ru(num, single_name, double_name, multiple_name)
+	if(!isnum(num) || round(num) != num)
+		return double_name // fractional numbers
+	if(((num % 10) == 1) && ((num % 100) != 11)) // 1, not 11
+		return single_name
+	if(((num % 10) in 2 to 4) && !((num % 100) in 12 to 14)) // 2, 3, 4, not 12, 13, 14
+		return double_name
+	return multiple_name // 5, 6, 7, 8, 9, 0
+
+/proc/genderize_ru(gender, male_word, female_word, neuter_word, multiple_word)
+	return gender == MALE ? male_word : (gender == FEMALE ? female_word : (gender == NEUTER ? neuter_word : multiple_word))
+
+/proc/pluralize_ru(gender, single_word, plural_word)
+	return gender == PLURAL ? plural_word : single_word
+
 /datum/proc/p_they(capitalized, temp_gender)
 	. = "it"
 	if(capitalized)
@@ -41,18 +57,6 @@
 	. = p_s(temp_gender)
 	if(.)
 		. = "e[.]"
-
-/proc/declension_ru(num, single_name, double_name, multiple_name)
-	if(!isnum(num) || round(num) != num)
-		return double_name // fractional numbers
-	if(((num % 10) == 1) && ((num % 100) != 11)) // 1, not 11
-		return single_name
-	if(((num % 10) in 2 to 4) && !((num % 100) in 12 to 14)) // 2, 3, 4, not 12, 13, 14
-		return double_name
-	return multiple_name // 5, 6, 7, 8, 9, 0
-
-/proc/genderize_ru(gender, male_word, female_word, neuter_word, multiple_word)
-	return gender == MALE ? male_word : (gender == FEMALE ? female_word : (gender == NEUTER ? neuter_word : multiple_word))
 
 //like clients, which do have gender.
 /client/p_they(capitalized, temp_gender)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -2,8 +2,8 @@
 #define AUTO_EJECT_HEALTHY	(1<<1)
 
 /obj/machinery/atmospherics/unary/cryo_cell
-	name = "cryo cell"
-	desc = "Lowers the body temperature so certain medications may take effect."
+	name = "криокапсула"
+	desc = "Понижает температуру тела, позволяя применять определённые лекарства."
 	icon = 'icons/obj/cryogenics.dmi'
 	icon_state = "pod0"
 	density = 1
@@ -123,22 +123,22 @@
 	if(!istype(user.loc, /turf) || !istype(O.loc, /turf)) // are you in a container/closet/pod/etc?
 		return
 	if(occupant)
-		to_chat(user, "<span class='boldnotice'>The cryo cell is already occupied!</span>")
+		to_chat(user, "<span class='boldnotice'>Криокапсула уже занята!</span>")
 		return
 	var/mob/living/L = O
 	if(!istype(L) || L.buckled)
 		return
 	if(L.abiotic())
-		to_chat(user, "<span class='danger'>Subject cannot have abiotic items on.</span>")
+		to_chat(user, "<span class='danger'>Субъект не должен держать в руках абиотические предметы.</span>")
 		return
 	if(L.has_buckled_mobs()) //mob attached to us
-		to_chat(user, "<span class='warning'>[L] will not fit into [src] because [L.p_they()] [L.p_have()] a slime latched onto [L.p_their()] head.</span>")
+		to_chat(user, "<span class='warning'>[L] нельзя поместить в [src], поскольку к [genderize_ru(L.gender,"его","её","его","их")] голове прилеплен слайм.</span>")
 		return
 	if(put_mob(L))
 		if(L == user)
-			visible_message("[user] climbs into the cryo cell.")
+			visible_message("[user] залеза[pluralize_ru(user.gender,"ет","ют")] в криокапсулу.")
 		else
-			visible_message("[user] puts [L.name] into the cryo cell.")
+			visible_message("[user] помеща[pluralize_ru(user.gender,"ет","ют")] [L.name] в криокапсулу.")
 			add_attack_logs(user, L, "put into a cryo cell at [COORD(src)].", ATKLOG_ALL)
 			if(user.pulling == L)
 				user.stop_pulling()
@@ -194,7 +194,7 @@
 		return
 
 	if(panel_open)
-		to_chat(usr, "<span class='boldnotice'>Close the maintenance panel first.</span>")
+		to_chat(usr, "<span class='boldnotice'>Сначала закройте панель техобслуживания.</span>")
 		return
 
 	ui_interact(user)
@@ -202,7 +202,7 @@
 /obj/machinery/atmospherics/unary/cryo_cell/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
-		ui = new(user, src, ui_key, "Cryo", "Cryo Cell", 520, 490)
+		ui = new(user, src, ui_key, "Cryo", "Криокапсула", 520, 490)
 		ui.open()
 
 /obj/machinery/atmospherics/unary/cryo_cell/ui_data(mob/user)
@@ -285,15 +285,15 @@
 	if(istype(G, /obj/item/reagent_containers/glass))
 		var/obj/item/reagent_containers/B = G
 		if(beaker)
-			to_chat(user, "<span class='warning'>A beaker is already loaded into the machine.</span>")
+			to_chat(user, "<span class='warning'>В криокамеру уже загружена мензурка.</span>")
 			return
 		if(!user.drop_item())
-			to_chat(user, "[B] is stuck to you!")
+			to_chat(user, "Вы не можете бросить [B]!")
 			return
 		B.forceMove(src)
 		beaker =  B
 		add_attack_logs(user, null, "Added [B] containing [B.reagents.log_list()] to a cryo cell at [COORD(src)]")
-		user.visible_message("[user] adds \a [B] to [src]!", "You add \a [B] to [src]!")
+		user.visible_message("[user] загружа[pluralize_ru(user.gender,"ет","ют")] [B] в [src]!", "Вы загружаете [B] в [src]!")
 		SStgui.update_uis(src)
 		return
 
@@ -303,12 +303,12 @@
 	if(istype(G, /obj/item/grab))
 		var/obj/item/grab/GG = G
 		if(panel_open)
-			to_chat(user, "<span class='boldnotice'>Close the maintenance panel first.</span>")
+			to_chat(user, "<span class='boldnotice'>Сначала закройте панель техобслуживания.</span>")
 			return
 		if(!ismob(GG.affecting))
 			return
 		if(GG.affecting.has_buckled_mobs()) //mob attached to us
-			to_chat(user, "<span class='warning'>[GG.affecting] will not fit into [src] because [GG.affecting.p_they()] [GG.affecting.p_have()] a slime latched onto [GG.affecting.p_their()] head.</span>")
+			to_chat(user, "<span class='warning'>[GG.affecting] не влеза[pluralize_ru(GG.affecting.gender,"ет","ют")] в [src] потому что к [genderize_ru(GG.affecting.gender,"его","её","его","их")] голове прилеплен слайм.</span>")
 			return
 		var/mob/M = GG.affecting
 		if(put_mob(M))
@@ -322,7 +322,7 @@
 
 /obj/machinery/atmospherics/unary/cryo_cell/screwdriver_act(mob/user, obj/item/I)
 	if(occupant || on)
-		to_chat(user, "<span class='notice'>The maintenance panel is locked.</span>")
+		to_chat(user, "<span class='notice'>Панель техобслуживания закрыта.</span>")
 		return TRUE
 	if(default_deconstruction_screwdriver(user, "pod0-o", "pod0", I))
 		return TRUE
@@ -446,21 +446,21 @@
 
 /obj/machinery/atmospherics/unary/cryo_cell/proc/put_mob(mob/living/carbon/M)
 	if(!istype(M))
-		to_chat(usr, "<span class='danger'>The cryo cell cannot handle such a lifeform!</span>")
+		to_chat(usr, "<span class='danger'>Подобную форму жизни в криокапсулу не удаётся поместить!</span>")
 		return
 	if(occupant)
-		to_chat(usr, "<span class='danger'>The cryo cell is already occupied!</span>")
+		to_chat(usr, "<span class='danger'>Криокапсула уже занята!</span>")
 		return
 	if(M.abiotic())
-		to_chat(usr, "<span class='warning'>Subject may not have abiotic items on.</span>")
+		to_chat(usr, "<span class='warning'>Субъект не должен держать в руках абиотические предметы.</span>")
 		return
 	if(!node)
-		to_chat(usr, "<span class='warning'>The cell is not correctly connected to its pipe network!</span>")
+		to_chat(usr, "<span class='warning'>Криокапсула не подключена к трубам!</span>")
 		return
 	M.stop_pulling()
 	M.forceMove(src)
 	if(M.health > -100 && (M.health < 0 || M.sleeping))
-		to_chat(M, "<span class='boldnotice'>You feel a cold liquid surround you. Your skin starts to freeze up.</span>")
+		to_chat(M, "<span class='boldnotice'>Вас окружает холодная жидкость. Кожа начинает замерзать.</span>")
 	occupant = M
 //	M.metabslow = 1
 	add_fingerprint(usr)
@@ -469,14 +469,14 @@
 	return 1
 
 /obj/machinery/atmospherics/unary/cryo_cell/verb/move_eject()
-	set name = "Eject occupant"
+	set name = "Извлечь пациента"
 	set category = "Object"
 	set src in oview(1)
 
 	if(usr == occupant)//If the user is inside the tube...
 		if(usr.stat == DEAD)
 			return
-		to_chat(usr, "<span class='notice'>Release sequence activated. This will take two minutes.</span>")
+		to_chat(usr, "<span class='notice'>Активирована высвобождающая последовательность. Время ожидания: две минуты.</span>")
 		sleep(600)
 		if(!src || !usr || !occupant || (occupant != usr)) //Check if someone's released/replaced/bombed him already
 			return
@@ -496,12 +496,12 @@
 	light_color = LIGHT_COLOR_RED
 
 /obj/machinery/atmospherics/unary/cryo_cell/verb/move_inside()
-	set name = "Move Inside"
+	set name = "Залезть внутрь"
 	set category = "Object"
 	set src in oview(1)
 
 	if(usr.has_buckled_mobs()) //mob attached to us
-		to_chat(usr, "<span class='warning'>[usr] will not fit into [src] because [usr.p_they()] [usr.p_have()] a slime latched onto [usr.p_their()] head.</span>")
+		to_chat(usr, "<span class='warning'>[usr] не влез[pluralize_ru(usr.gender,"ет","ут")] в [src], потому что к [genderize_ru(usr.gender,"его","её","его","их")] голове прилеплен слайм.</span>")
 		return
 
 	if(stat & (NOPOWER|BROKEN))

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -285,7 +285,7 @@
 	if(istype(G, /obj/item/reagent_containers/glass))
 		var/obj/item/reagent_containers/B = G
 		if(beaker)
-			to_chat(user, "<span class='warning'>В криокамеру уже загружена мензурка.</span>")
+			to_chat(user, "<span class='warning'>В криокапсулу уже загружена другая ёмкость.</span>")
 			return
 		if(!user.drop_item())
 			to_chat(user, "Вы не можете бросить [B]!")

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -293,7 +293,7 @@
 		B.forceMove(src)
 		beaker =  B
 		add_attack_logs(user, null, "Added [B] containing [B.reagents.log_list()] to a cryo cell at [COORD(src)]")
-		user.visible_message("[user] загружа[pluralize_ru(user.gender,"ет","ют")] [B] в [src]!", "Вы загружаете [B] в [src]!")
+		user.visible_message("[user] загружа[pluralize_ru(user.gender,"ет","ют")] [B] в криокапсулу!", "Вы загружаете [B] в криокапсулу!")
 		SStgui.update_uis(src)
 		return
 

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -446,7 +446,7 @@
 
 /obj/machinery/atmospherics/unary/cryo_cell/proc/put_mob(mob/living/carbon/M)
 	if(!istype(M))
-		to_chat(usr, "<span class='danger'>Подобную форму жизни в криокапсулу не удаётся поместить!</span>")
+		to_chat(usr, "<span class='danger'>Подобную форму жизни не удастся поместить в криокапсулу!</span>")
 		return
 	if(occupant)
 		to_chat(usr, "<span class='danger'>Криокапсула уже занята!</span>")

--- a/tgui/packages/common/l10n.js
+++ b/tgui/packages/common/l10n.js
@@ -9,7 +9,7 @@ export const declensionRu = (num, single_name, double_name, multiple_name) => {
 
   if (lastDigit === 1) {
     return single_name;
-  } else if (lastDigit >= 2 && shorten <= 4) {
+  } else if (lastDigit >= 2 && lastDigit <= 4) {
     return double_name;
   } else {
     return multiple_name;

--- a/tgui/packages/common/l10n.js
+++ b/tgui/packages/common/l10n.js
@@ -1,0 +1,17 @@
+export const declensionRu = (num, single_name, double_name, multiple_name) => {
+  const shorten = num % 100;
+
+  if (shorten >= 10 && shorten <= 20) {
+    return multiple_name;
+  }
+
+  const lastDigit = shorten % 10;
+
+  if (lastDigit === 1) {
+    return single_name;
+  } else if (lastDigit >= 2 && shorten <= 4) {
+    return double_name;
+  } else {
+    return multiple_name;
+  }
+};

--- a/tgui/packages/tgui/interfaces/Cryo.js
+++ b/tgui/packages/tgui/interfaces/Cryo.js
@@ -5,27 +5,27 @@ import { Window } from "../layouts";
 
 const damageTypes = [
   {
-    label: "Resp.",
+    label: "Асфиксия",
     type: "oxyLoss",
   },
   {
-    label: "Toxin",
+    label: "Интоксикация",
     type: "toxLoss",
   },
   {
-    label: "Brute",
+    label: "Раны",
     type: "bruteLoss",
   },
   {
-    label: "Burn",
+    label: "Ожоги",
     type: "fireLoss",
   },
 ];
 
 const statNames = [
-  ["good", "Conscious"],
-  ["average", "Unconscious"],
-  ["bad", "DEAD"],
+  ["good", "В сознании"],
+  ["average", "Без сознания"],
+  ["bad", "ТРУП"],
 ];
 
 export const Cryo = (props, context) => {
@@ -53,7 +53,7 @@ const CryoContent = (props, context) => {
   return (
     <Fragment>
       <Section
-        title="Occupant"
+        title="Пациент"
         flexGrow="1"
         buttons={(
           <Button
@@ -65,10 +65,10 @@ const CryoContent = (props, context) => {
         )}>
         {hasOccupant ? (
           <LabeledList>
-            <LabeledList.Item label="Occupant">
-              {occupant.name || "Unknown"}
+            <LabeledList.Item label="Пациент">
+              {occupant.name || "Неизвестное"}
             </LabeledList.Item>
-            <LabeledList.Item label="Health">
+            <LabeledList.Item label="Здоровье">
               <ProgressBar
                 min={occupant.health}
                 max={occupant.maxHealth}
@@ -79,14 +79,14 @@ const CryoContent = (props, context) => {
               </ProgressBar>
             </LabeledList.Item>
             <LabeledList.Item
-              label="Status"
+              label="Статус"
               color={statNames[occupant.stat][0]}>
               {statNames[occupant.stat][1]}
             </LabeledList.Item>
-            <LabeledList.Item label="Temperature">
+            <LabeledList.Item label="Температура">
               <AnimatedNumber
                 value={Math.round(occupant.bodyTemperature)} />
-              {' K'}
+              {' °K'}
             </LabeledList.Item>
             <LabeledList.Divider />
             {(damageTypes.map(damageType => (
@@ -110,38 +110,38 @@ const CryoContent = (props, context) => {
                 mb="0.5rem"
                 size="5"
               /><br />
-              No occupant detected.
+              Пациент не обнаружен.
             </Flex.Item>
           </Flex>
         )}
       </Section>
       <Section
-        title="Cell"
+        title="Криокапсула"
         buttons={(
           <Button
             icon="eject"
             onClick={() => act('ejectBeaker')}
             disabled={!isBeakerLoaded}>
-            Eject Beaker
+            Извлечь мензурку
           </Button>
         )}>
         <LabeledList>
-          <LabeledList.Item label="Power">
+          <LabeledList.Item label="Питание">
             <Button
               icon="power-off"
               onClick={() => act(isOperating ? 'switchOff' : 'switchOn')}
               selected={isOperating}>
-              {isOperating ? "On" : "Off"}
+              {isOperating ? "Вкл" : "Выкл"}
             </Button>
           </LabeledList.Item>
-          <LabeledList.Item label="Temperature" color={cellTemperatureStatus}>
+          <LabeledList.Item label="Температура" color={cellTemperatureStatus}>
             <AnimatedNumber value={cellTemperature} /> K
           </LabeledList.Item>
-          <LabeledList.Item label="Beaker">
+          <LabeledList.Item label="Мензурка">
             <CryoBeaker />
           </LabeledList.Item>
           <LabeledList.Divider />
-          <LabeledList.Item label="Auto-eject healthy occupants">
+          <LabeledList.Item label="Автоизвлечение здоровых пациентов">
             <Button
               icon={auto_eject_healthy ? "toggle-on" : "toggle-off"}
               selected={auto_eject_healthy}
@@ -149,10 +149,10 @@ const CryoContent = (props, context) => {
                 ? 'auto_eject_healthy_off'
                 : 'auto_eject_healthy_on'
               )}>
-              {auto_eject_healthy ? "On" : "Off"}
+              {auto_eject_healthy ? "Вкл" : "Выкл"}
             </Button>
           </LabeledList.Item>
-          <LabeledList.Item label="Auto-eject dead occupants">
+          <LabeledList.Item label="Автоизвлечение мёртвых пациентов">
             <Button
               icon={auto_eject_dead ? "toggle-on" : "toggle-off"}
               selected={auto_eject_dead}
@@ -160,7 +160,7 @@ const CryoContent = (props, context) => {
                 ? 'auto_eject_dead_off'
                 : 'auto_eject_dead_on'
               )}>
-              {auto_eject_dead ? "On" : "Off"}
+              {auto_eject_dead ? "Вкл" : "Выкл"}
             </Button>
           </LabeledList.Item>
         </LabeledList>
@@ -190,16 +190,16 @@ const CryoBeaker = (props, context) => {
           {beakerVolume ? (
             <AnimatedNumber
               value={beakerVolume}
-              format={v => Math.round(v) + " units remaining"}
+              format={v => Math.round(v) + " единиц осталось"}
             />
-          ) : "Beaker is empty"}
+          ) : "Мензурка пуста"}
         </Box>
       </Fragment>
     );
   } else {
     return (
       <Box color="average">
-        No beaker loaded
+        Мензурка не установлена
       </Box>
     );
   }

--- a/tgui/packages/tgui/interfaces/Cryo.js
+++ b/tgui/packages/tgui/interfaces/Cryo.js
@@ -60,7 +60,7 @@ const CryoContent = (props, context) => {
             icon="user-slash"
             onClick={() => act('ejectOccupant')}
             disabled={!hasOccupant}>
-            Eject
+            Извлечь
           </Button>
         )}>
         {hasOccupant ? (
@@ -183,7 +183,7 @@ const CryoBeaker = (props, context) => {
           ? beakerLabel
           : (
             <Box color="average">
-              No label
+              Мензурка не подписана
             </Box>
           )}
         <Box color={!beakerVolume && "bad"}>

--- a/tgui/packages/tgui/interfaces/Cryo.js
+++ b/tgui/packages/tgui/interfaces/Cryo.js
@@ -122,7 +122,7 @@ const CryoContent = (props, context) => {
             icon="eject"
             onClick={() => act('ejectBeaker')}
             disabled={!isBeakerLoaded}>
-            Извлечь мензурку
+            Извлечь ёмкость
           </Button>
         )}>
         <LabeledList>
@@ -135,9 +135,9 @@ const CryoContent = (props, context) => {
             </Button>
           </LabeledList.Item>
           <LabeledList.Item label="Температура" color={cellTemperatureStatus}>
-            <AnimatedNumber value={cellTemperature} /> K
+            <AnimatedNumber value={cellTemperature} /> °K
           </LabeledList.Item>
-          <LabeledList.Item label="Мензурка">
+          <LabeledList.Item label="Ёмкость">
             <CryoBeaker />
           </LabeledList.Item>
           <LabeledList.Divider />
@@ -180,26 +180,26 @@ const CryoBeaker = (props, context) => {
     return (
       <Fragment>
         {beakerLabel
-          ? beakerLabel
+          ? `«${beakerLabel}»`
           : (
             <Box color="average">
-              Мензурка не подписана
+              Ёмкость не подписана
             </Box>
           )}
         <Box color={!beakerVolume && "bad"}>
           {beakerVolume ? (
             <AnimatedNumber
               value={beakerVolume}
-              format={v => Math.round(v) + " единиц осталось"}
+              format={v => `Содержит ${Math.round(v)} сл`}
             />
-          ) : "Мензурка пуста"}
+          ) : "Ёмкость пуста"}
         </Box>
       </Fragment>
     );
   } else {
     return (
       <Box color="average">
-        Мензурка не установлена
+        Ёмкость не установлена
       </Box>
     );
   }

--- a/tgui/packages/tgui/interfaces/Cryo.js
+++ b/tgui/packages/tgui/interfaces/Cryo.js
@@ -66,7 +66,7 @@ const CryoContent = (props, context) => {
         {hasOccupant ? (
           <LabeledList>
             <LabeledList.Item label="Пациент">
-              {occupant.name || "Неизвестное"}
+              {occupant.name || "Имя неизвестно"}
             </LabeledList.Item>
             <LabeledList.Item label="Здоровье">
               <ProgressBar

--- a/tgui/packages/tgui/interfaces/Cryo.js
+++ b/tgui/packages/tgui/interfaces/Cryo.js
@@ -193,7 +193,7 @@ const CryoBeaker = (props, context) => {
                 const num = Math.round(v);
                 const leftText = declensionRu(num, 'Осталась', 'Остались', 'Осталось');
                 const unitText = declensionRu(num, 'единица', 'единицы', 'единиц');
-                return `${leftText} ${num}&nbsp;${unitText}`;
+                return `${leftText} ${num} ${unitText}`;
               }}
             />
           ) : "Ёмкость пуста"}

--- a/tgui/packages/tgui/interfaces/Cryo.js
+++ b/tgui/packages/tgui/interfaces/Cryo.js
@@ -1,4 +1,5 @@
 import { Fragment } from 'inferno';
+import { declensionRu } from 'common/l10n';
 import { useBackend } from "../backend";
 import { AnimatedNumber, Box, Button, Flex, Icon, LabeledList, ProgressBar, Section } from "../components";
 import { Window } from "../layouts";
@@ -188,7 +189,12 @@ const CryoBeaker = (props, context) => {
           {beakerVolume ? (
             <AnimatedNumber
               value={beakerVolume}
-              format={v => `Содержит ${Math.round(v)} сл`}
+              format={v => {
+                const num = Math.round(v);
+                const leftText = declensionRu(num, 'Осталась', 'Остались', 'Осталось');
+                const unitText = declensionRu(num, 'единица', 'единицы', 'единиц');
+                return `${leftText} ${num}&nbsp;${unitText}`;
+              }}
             />
           ) : "Ёмкость пуста"}
         </Box>

--- a/tgui/packages/tgui/interfaces/Cryo.js
+++ b/tgui/packages/tgui/interfaces/Cryo.js
@@ -84,9 +84,7 @@ const CryoContent = (props, context) => {
               {statNames[occupant.stat][1]}
             </LabeledList.Item>
             <LabeledList.Item label="Температура">
-              <AnimatedNumber
-                value={Math.round(occupant.bodyTemperature)} />
-              {' °K'}
+              <AnimatedNumber value={Math.round(occupant.bodyTemperature)} /> K
             </LabeledList.Item>
             <LabeledList.Divider />
             {(damageTypes.map(damageType => (
@@ -135,7 +133,7 @@ const CryoContent = (props, context) => {
             </Button>
           </LabeledList.Item>
           <LabeledList.Item label="Температура" color={cellTemperatureStatus}>
-            <AnimatedNumber value={cellTemperature} /> °K
+            <AnimatedNumber value={cellTemperature} /> K
           </LabeledList.Item>
           <LabeledList.Item label="Ёмкость">
             <CryoBeaker />


### PR DESCRIPTION
## Changelog
:cl:
tweak: Перевод интерфейса криокапсулы
/:cl:

## Скриншоты
![изображение](https://user-images.githubusercontent.com/3854741/165832191-79c3f294-cf3d-4157-9489-c82952bf3259.png)
![изображение](https://user-images.githubusercontent.com/3854741/165838866-e8fc7194-fadb-4884-ba01-553a14c02e24.png)
![изображение](https://user-images.githubusercontent.com/3854741/165839546-28253f88-c7c8-422d-8d10-36662807744f.png)

В процессе подготовки скриншотов были убиты одна таяра и три дионы.

~~Вас может смутить что объём ёмкости указан не в единицах, а в сантилитрах (сл). 
Дело в том что объём жидкостей действительно меряется в сантилитрах, и это хорошо видно на медицинском сканере, который показывает что в здоровом пациенте находится 560 сл крови (то есть 5,6 литра). Единицы объёма и есть сантилитры.~~
Возвращены единицы