### PR TITLE
Feat: unica as target for antagonists

### DIFF
--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -123,6 +123,11 @@
 	typepath = /obj/item/clothing/gloves/color/black/krav_maga/sec
 	protected_jobs = list("Head Of Security", "Warden")
 
+/datum/theft_objective/unica
+	name = "Unica 6 auto-revolver"
+	typepath = /obj/item/gun/projectile/revolver/mateba
+	protected_jobs = list("Head Of Security")
+
 /datum/theft_objective/number
 	var/min=0
 	var/max=0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Добавляет унику в список предметов для кражи.

## Why It's Good For The Game
Уника добавлена очень давно, и для нее собирались сделать и срп и все соотвествующее, первым шагом будет добавление ее в список предметов для кражи, что логично, ведь она уникальна и принадлежит главе. (Админам придется редачить цельку, если она выпадет влышам у которых  сегодня коробка, но я не думаю, что это большая проблема, ведь на вле играет 30 человек, а на остальных серверах 200+, и этот твик для большинства)

## Changelog
:cl:
tweak: now unica is a steal target for antags
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
