### PR TITLE
Fix: Spell now checks phasing or user in rod

### DIFF
--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -99,6 +99,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell))
 	var/human_req = 0 //spell can only be cast by humans
 	var/nonabstract_req = 0 //spell can only be cast by mobs that are physical entities
 	var/stat_allowed = 0 //see if it requires being conscious/alive, need to set to 1 for ghostpells
+	var/phase_allowed = 0 // If true, the spell can be cast while phased, eg. blood crawling, ethereal jaunting
 	var/invocation = "HURP DURP" //what is uttered when the wizard casts the spell
 	var/invocation_emote_self = null
 	var/invocation_type = "none" //can be none, whisper and shout
@@ -577,6 +578,10 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell))
 		if(user.stat && !stat_allowed)
 			if(show_message)
 				to_chat(user, "<span class='notice'>You can't cast this spell while incapacitated.</span>")
+			return 0
+		if(!phase_allowed && istype(user.loc, /obj/effect/dummy) || istype(user.loc, /obj/effect/immovablerod/wizard))
+			if(show_message)
+				to_chat(user, "<span class='notice'>[name] cannot be cast unless you are completely manifested in the material plane!</span>")
 			return 0
 		if(ishuman(user) && (invocation_type == "whisper" || invocation_type == "shout") && user.is_muzzled())
 			if(show_message)

--- a/code/datums/spells/bloodcrawl.dm
+++ b/code/datums/spells/bloodcrawl.dm
@@ -3,6 +3,7 @@
 	desc = "Use pools of blood to phase out of existence."
 	charge_max = 0
 	clothes_req = 0
+	phase_allowed = 1
 	selection_type = "range"
 	range = 1
 	cooldown_min = 0

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -92,6 +92,7 @@
 	panel = "Shadowling Abilities"
 	charge_max = 300 //Used to be twice this, buffed
 	clothes_req = 0
+	phase_allowed = 1
 	range = -1
 	include_user = 1
 	action_icon_state = "shadow_walk"

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -292,7 +292,7 @@
 	build_path = /obj/machinery/computer/syndie_supplycomp
 	origin_tech = "programming=3;syndicate=3"
 
-obj/item/circuitboard/syndicatesupplycomp/public
+/obj/item/circuitboard/syndicatesupplycomp/public
 	name = "Circuit board (Syndicate Public Supply Pad Console)"
 	build_path = /obj/machinery/computer/syndie_supplycomp/public
 	origin_tech = "programming=3;syndicate=3"

--- a/code/game/machinery/computer/syndie_cargo.dm
+++ b/code/game/machinery/computer/syndie_cargo.dm
@@ -304,10 +304,9 @@ GLOBAL_LIST_INIT(data_storages, list()) //list of all cargo console data storage
 
 		var/turf/T = pick_n_take(spawnTurfs)		//turf we will place it in
 		for(var/i in 1 to length(recievingPads))
-			var/obj/machinery/syndiepad/P = recievingPads[i]
-			P.use_power(10000 / P.power_efficiency)
-			flick("sqpad-beam", P)
-			playsound(get_turf(P), 'sound/weapons/emitter2.ogg', 25, 1, extrarange = 3, falloff = 5)
+			recievingPads[i].use_power(10000 / recievingPads[i].power_efficiency)
+			flick("sqpad-beam", recievingPads[i])
+			playsound(get_turf(recievingPads[i]), 'sound/weapons/emitter2.ogg', 25, 1, extrarange = 3, falloff = 5)
 
 		if(!T)
 			data_storage.shoppinglist.Cut(1, data_storage.shoppinglist.Find(SO))
@@ -611,8 +610,7 @@ GLOBAL_LIST_INIT(data_storages, list()) //list of all cargo console data storage
 				investigate_log("[key_name(usr)] has sold '[data_storage.sold_atoms]' using syndicate cargo. Remaining credits: [data_storage.cash]", "syndicate cargo")
 				data_storage.sold_atoms = null
 				for(var/i in 1 to length(DSLP))
-					var/obj/machinery/syndiepad/P = DSLP[i]
-					P.checks(usr)
+					DSLP[i].checks(usr)
 				data_storage.last_teleport = world.time
 				data_storage.is_cooldown = TRUE
 				buy()

--- a/code/game/machinery/computer/syndie_cargo.dm
+++ b/code/game/machinery/computer/syndie_cargo.dm
@@ -304,9 +304,10 @@ GLOBAL_LIST_INIT(data_storages, list()) //list of all cargo console data storage
 
 		var/turf/T = pick_n_take(spawnTurfs)		//turf we will place it in
 		for(var/i in 1 to length(recievingPads))
-			recievingPads[i].use_power(10000 / recievingPads[i].power_efficiency)
-			flick("sqpad-beam", recievingPads[i])
-			playsound(get_turf(recievingPads[i]), 'sound/weapons/emitter2.ogg', 25, 1, extrarange = 3, falloff = 5)
+			var/obj/machinery/syndiepad/P = recievingPads[i]
+			P.use_power(10000 / P.power_efficiency)
+			flick("sqpad-beam", P)
+			playsound(get_turf(P), 'sound/weapons/emitter2.ogg', 25, 1, extrarange = 3, falloff = 5)
 
 		if(!T)
 			data_storage.shoppinglist.Cut(1, data_storage.shoppinglist.Find(SO))
@@ -610,7 +611,8 @@ GLOBAL_LIST_INIT(data_storages, list()) //list of all cargo console data storage
 				investigate_log("[key_name(usr)] has sold '[data_storage.sold_atoms]' using syndicate cargo. Remaining credits: [data_storage.cash]", "syndicate cargo")
 				data_storage.sold_atoms = null
 				for(var/i in 1 to length(DSLP))
-					DSLP[i].checks(usr)
+					var/obj/machinery/syndiepad/P = DSLP[i]
+					P.checks(usr)
 				data_storage.last_teleport = world.time
 				data_storage.is_cooldown = TRUE
 				buy()

--- a/code/modules/ruins/syndicate_space_base.dm
+++ b/code/modules/ruins/syndicate_space_base.dm
@@ -107,7 +107,7 @@ var/global/all_taipan_jobs = list(TAIPAN_SCIENTIST,TAIPAN_MEDIC,TAIPAN_BOTANIST,
 		var/race = H.dna.species.name
 
 		switch(race)
-			if("Vox" || "Vox Armalis")
+			if("Vox", "Vox Armalis")
 				box = /obj/item/storage/box/survival_vox
 			if("Plasmaman")
 				box = /obj/item/storage/box/survival_plasmaman
@@ -125,7 +125,7 @@ var/global/all_taipan_jobs = list(TAIPAN_SCIENTIST,TAIPAN_MEDIC,TAIPAN_BOTANIST,
 		var/race = H.dna.species.name
 
 		switch(race)
-			if("Vox" || "Vox Armalis")
+			if("Vox", "Vox Armalis")
 				H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/syndicate(H), slot_wear_mask)
 				H.equip_to_slot_or_del(new /obj/item/tank/emergency_oxygen/vox(H), slot_l_hand)
 				H.internal = H.l_hand


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Устраняет баг когда маг мог стать богом внутри rod и на своё пожелание выйти. Теперь нельзя использовать заклинания когда в ethernal jaunt или rod. 
И ещё мелкие коды-фиксы в синди-карго.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Меньше багоюзов. И багов.

## Changelog
:cl:
Fix: Spell now checks phasing or user in rod. Also minor code-fix in syndie base.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
