### PR TITLE
Fix: Проигрывать звук закрытия моргов при их закрытии по клику на выезжающий трей

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -190,6 +190,7 @@
 	anchored = 1.0
 	pass_flags = LETPASSTHROW
 	max_integrity = 350
+	var/close_sound = 'sound/items/deconstruct.ogg'
 
 
 /obj/structure/m_tray/attack_hand(mob/user as mob)
@@ -200,6 +201,7 @@
 		connected.connected = null
 		connected.update()
 		add_fingerprint(user)
+		playsound(loc, close_sound, 50, 1)
 		qdel(src)
 		return
 	return

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -190,7 +190,6 @@
 	anchored = 1.0
 	pass_flags = LETPASSTHROW
 	max_integrity = 350
-	var/close_sound = 'sound/items/deconstruct.ogg'
 
 
 /obj/structure/m_tray/attack_hand(mob/user as mob)
@@ -201,7 +200,7 @@
 		connected.connected = null
 		connected.update()
 		add_fingerprint(user)
-		playsound(loc, close_sound, 50, 1)
+		playsound(loc, connected.open_sound, 50, 1)
 		qdel(src)
 		return
 	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
При закрытии морга через его выезжающий трей теперь проигрывается звук, который проигрывается и при закрытии кликом на сам морг. Раньше этого звука не было.
## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Я уверена что отсутствие звука при закрытии морга через трей это баг, а этот PR его исправляет.

## Changelog
:cl:
fix: morgues now play closing sound when closed by clicking the morgue tray
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
