### PR TITLE
Fix: Исправление расположения терминалов АПЦ и мелкие правки

### DIFF
--- a/_maps/map_files/Delta/Lavaland.dmm
+++ b/_maps/map_files/Delta/Lavaland.dmm
@@ -1502,10 +1502,6 @@
 /turf/simulated/mineral/random/volcanic,
 /area/lavaland/surface/outdoors/unexplored/danger)
 "eX" = (
-/obj/machinery/camera{
-	c_tag = "Mining Storage";
-	network = list("Mining Outpost")
-	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -3477,6 +3473,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
+	dir = 1;
 	name = "Mining EVA APC";
 	pixel_x = 1;
 	pixel_y = 24
@@ -3632,6 +3629,9 @@
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "qk" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/bluegrid,
 /area/mine/maintenance)
 "qt" = (
@@ -4296,9 +4296,6 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "wR" = (
-/obj/machinery/light_switch{
-	pixel_y = -25
-	},
 /turf/simulated/floor/bluegrid,
 /area/mine/maintenance)
 "wX" = (
@@ -4967,6 +4964,11 @@
 "EJ" = (
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Mining Storage";
+	dir = 8;
+	network = list("Mining Outpost")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -6751,6 +6753,12 @@
 /obj/machinery/status_display,
 /turf/simulated/wall,
 /area/mine/production)
+"ZU" = (
+/obj/machinery/light_switch{
+	pixel_y = -25
+	},
+/turf/simulated/floor/bluegrid,
+/area/mine/maintenance)
 
 (1,1,1) = {"
 aa
@@ -19057,7 +19065,7 @@ ab
 La
 qk
 bQ
-qk
+ZU
 La
 ee
 GZ

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -1881,15 +1881,16 @@
 /area/hallway/secondary/entry/westarrival)
 "ahR" = (
 /obj/item/twohanded/required/kirbyplants,
-/obj/machinery/power/apc{
-	name = "east bump";
-	pixel_x = 26
-	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/light,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "ahS" = (
@@ -3792,15 +3793,16 @@
 	},
 /area/shuttle/arrival/station)
 "asq" = (
-/obj/machinery/power/apc{
-	name = "west bump";
-	pixel_x = -26
-	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/effect/decal/warning_stripes/southwest,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "asE" = (
@@ -5192,10 +5194,6 @@
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
 "aBj" = (
-/obj/machinery/power/apc{
-	name = "east bump";
-	pixel_x = 26
-	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -5209,6 +5207,11 @@
 /obj/item/tank/jetpack/carbondioxide{
 	pixel_x = 4;
 	pixel_y = -3
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/mechanic_workshop/expedition)
@@ -5897,13 +5900,14 @@
 /turf/simulated/shuttle/floor,
 /area/shuttle/arrival/station)
 "aES" = (
-/obj/machinery/power/apc{
-	name = "north bump";
-	pixel_y = 26
-	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -6110,13 +6114,14 @@
 /area/shuttle/transport)
 "aGm" = (
 /obj/structure/closet/cardboard,
-/obj/machinery/power/apc{
-	name = "north bump";
-	pixel_y = 26
-	},
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fore{
@@ -6957,13 +6962,14 @@
 	dir = 1
 	},
 /obj/item/twohanded/required/kirbyplants,
-/obj/machinery/power/apc{
-	name = "east bump";
-	pixel_x = 26
-	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
@@ -7549,13 +7555,14 @@
 	},
 /obj/item/gps,
 /obj/structure/table/reinforced,
-/obj/machinery/power/apc{
-	name = "north bump";
-	pixel_y = 26
-	},
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -8229,13 +8236,14 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc{
-	name = "west bump";
-	pixel_x = -26
-	},
 /obj/machinery/camera{
 	c_tag = "Cargo Office SouthWest";
 	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -9848,10 +9856,6 @@
 	},
 /area/hallway/secondary/entry/eastarrival)
 "aZg" = (
-/obj/machinery/power/apc{
-	name = "north bump";
-	pixel_y = 26
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -9862,6 +9866,11 @@
 /obj/structure/closet/jcloset,
 /obj/item/reagent_containers/spray/pestspray,
 /obj/item/reagent_containers/spray/pestspray,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "purple"
@@ -12497,10 +12506,6 @@
 "bol" = (
 /obj/effect/turf_decal/box,
 /obj/structure/closet/crate/medical,
-/obj/machinery/power/apc{
-	name = "east bump";
-	pixel_x = 26
-	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -14805,8 +14810,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
+	dir = 4;
 	name = "east bump";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -15487,13 +15493,14 @@
 /area/crew_quarters/heads/hop)
 "bAV" = (
 /obj/item/twohanded/required/kirbyplants,
-/obj/machinery/power/apc{
-	name = "west bump";
-	pixel_x = -26
-	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -22377,16 +22384,17 @@
 /turf/space,
 /area/space/nearstation)
 "cew" = (
-/obj/machinery/power/apc{
-	name = "north bump";
-	pixel_y = 26
-	},
 /obj/machinery/camera{
 	c_tag = "Arrivals Hall Center"
 	},
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -32811,11 +32819,6 @@
 	pixel_x = 8;
 	pixel_y = 4
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -26
-	},
 /obj/structure/cable,
 /obj/item/storage/box/iv_bags{
 	pixel_x = -4;
@@ -33720,8 +33723,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
+	dir = 8;
 	name = "west bump";
-	pixel_x = -26
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -38585,11 +38589,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -40847,8 +40846,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
+	dir = 8;
 	name = "west bump";
-	pixel_x = -26
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -47526,10 +47526,6 @@
 	},
 /area/quartermaster/qm)
 "dWM" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -47570,12 +47566,13 @@
 	},
 /area/quartermaster/miningdock)
 "dWS" = (
-/obj/machinery/power/apc{
-	name = "north bump";
-	pixel_y = 26
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -50051,10 +50048,6 @@
 	icon_state = "0-2"
 	},
 /obj/structure/table,
-/obj/machinery/power/apc{
-	name = "north bump";
-	pixel_y = 26
-	},
 /obj/item/paper_bin,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -53371,11 +53364,6 @@
 /area/security/permabrig)
 "fjs" = (
 /obj/structure/curtain/open/shower,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = 12
@@ -56135,11 +56123,6 @@
 /area/medical/reception)
 "fTD" = (
 /obj/structure/table/reinforced,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
 /obj/structure/cable{
@@ -68374,11 +68357,6 @@
 	},
 /area/engine/hardsuitstorage)
 "iMk" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -69797,11 +69775,6 @@
 	},
 /area/medical/paramedic)
 "jig" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -26
-	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -79378,11 +79351,12 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	name = "east bump";
-	pixel_x = 26
-	},
 /obj/machinery/light,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "brown"
@@ -83208,11 +83182,6 @@
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -26
 	},
 /turf/simulated/floor/plating,
 /area/library/abandoned)
@@ -87959,10 +87928,6 @@
 /area/tcommsat/chamber)
 "nIm" = (
 /obj/machinery/light,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -91725,10 +91690,6 @@
 	icon_state = "dark"
 	},
 /area/crew_quarters/fitness)
-"oCX" = (
-/obj/item/radio/intercom,
-/turf/simulated/wall,
-/area/hallway/primary/central/ne)
 "oDk" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -93000,13 +92961,14 @@
 	},
 /area/chapel/main)
 "oSG" = (
-/obj/machinery/power/apc{
-	name = "west bump";
-	pixel_x = -26
-	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -126078,11 +126040,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -26
-	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -129961,11 +129918,6 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "xxi" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -26
-	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -133001,11 +132953,6 @@
 /area/hallway/primary/central/south)
 "yeA" = (
 /obj/structure/curtain/open/shower,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = 12
@@ -174741,7 +174688,7 @@ gAB
 hpc
 gkQ
 eKd
-oCX
+klj
 vPO
 vPO
 vPO

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -28242,11 +28242,6 @@
 	pixel_x = 24
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	desc = "Подаёт азот из атмосферки в систему охлаждения реактора, таким образом запитывая её хладагентом";
-	dir = 1;
-	name = "Труба подачи азота в реактор"
-	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "cDh" = (


### PR DESCRIPTION
АПЦ, установленные в последнем патче не имели параметра расположения из-за чего происходило вот это
![image](https://user-images.githubusercontent.com/91949115/166211326-b764570e-2650-4c06-904b-1cfad1028fdb.png)

# Фиксы
* Исправлены все положения терминалов АПЦ последнего патча дельты
* Исправлено расположение камеры в раздевалке на аванпосте
* Исправлены двойные объекты в основном коридоре (Телеком и fire alarm на одном тайле и две fire alarm буквально на соседних)
*  Удалена одинокая труба под баком с топливом у турбины

# Нововведения
* В комнату реле на аванпосте добавлено освещение