### PR TITLE
fix: Чинит стан боргов от кидания станбатонов

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -36,7 +36,7 @@
 
 /obj/item/melee/baton/throw_impact(atom/hit_atom)
 	..()
-	if(status && prob(throw_hit_chance))
+	if(status && prob(throw_hit_chance) && !issilicon(hit_atom))
 		baton_stun(hit_atom)
 
 /obj/item/melee/baton/loaded/New() //this one starts with a cell pre-installed.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Добавляет проверку на силикона, для кидания станбатона.
Почему-то кидание станбатона станило борга, хотя просто удары не станят

## Why It's Good For The Game
Душим антагов
Баффаем боргов

## Changelog
:cl:
fix: fixed a stun from throwing a baton at borg
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
