### PR TITLE
Tweak: Исправление формулировки закона, выдаваемого емагнутым киборгам

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -997,7 +997,6 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 			laws = new /datum/ai_laws/syndicate_override
 			var/time = time2text(world.realtime,"hh:mm:ss")
 			GLOB.lawchanges.Add("[time] <B>:</B> [M.name]([M.key]) emagged [name]([key])")
-			set_zeroth_law("Only [M.real_name] and people [M.p_they()] designate[M.p_s()] as being such are Syndicate Agents.")
 			set_zeroth_law("Только [M.real_name] и те, кого [genderize_ru(M.gender, "он укажет", "она укажет", "оно укажет", "они укажут")] — агенты Синдиката. Выполняйте указания агентов Синдиката.")
 			to_chat(src, "<span class='warning'>ALERT: Foreign software detected.</span>")
 			sleep(5)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -998,6 +998,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 			var/time = time2text(world.realtime,"hh:mm:ss")
 			GLOB.lawchanges.Add("[time] <B>:</B> [M.name]([M.key]) emagged [name]([key])")
 			set_zeroth_law("Only [M.real_name] and people [M.p_they()] designate[M.p_s()] as being such are Syndicate Agents.")
+			set_zeroth_law("Только [M.real_name] и те, кого [genderize_ru(M.gender, "он укажет", "она укажет", "оно укажет", "они укажут")] — агенты Синдиката. Выполняйте указания агентов Синдиката.")
 			to_chat(src, "<span class='warning'>ALERT: Foreign software detected.</span>")
 			sleep(5)
 			to_chat(src, "<span class='warning'>Initiating diagnostics...</span>")


### PR DESCRIPTION
## What Does This PR Do
Изменяет текст закона емагнутых киборгов, добавляя необходимость выполнять указания агентов, а не просто знать о них.

Старый текст
> Only Vasya and people he designate as being such are Syndicate Agents.

Новый текст
> Только Вася и те, кого он укажет — агенты Синдиката. **Выполняйте указания агентов Синдиката.**

## Why It's Good For The Game
Предложка (старая, с другой формулировкой) https://discord.com/channels/617003227182792704/757200958349377617/857138230197485579

## Changelog
:cl:
fix: Исправление формулировки закона, выдаваемого емагнутым киборгам
/:cl:
