### PR TITLE
Fix: Вещи оказываются под шкафом/ящиком

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -71,19 +71,17 @@
 	return TRUE
 
 /obj/structure/closet/proc/dump_contents()
-	var/turf/T = get_turf(src)
+	var/atom/L = drop_location()
 	for(var/atom/movable/AM in src)
-		AM.forceMove(T)
+		AM.layer = src.layer + 0.1
+		AM.forceMove(L)
 		if(throwing) // you keep some momentum when getting out of a thrown closet
 			step(AM, dir)
 	if(throwing)
 		throwing.finalize(FALSE)
 
 /obj/structure/closet/proc/open()
-	if(opened)
-		return FALSE
-
-	if(!can_open())
+	if(opened || !can_open())
 		return FALSE
 
 	dump_contents()
@@ -98,9 +96,7 @@
 	return TRUE
 
 /obj/structure/closet/proc/close()
-	if(!opened)
-		return FALSE
-	if(!can_close())
+	if(!opened || !can_close())
 		return FALSE
 
 	var/itemcount = 0

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -47,6 +47,7 @@
 
 	playsound(src.loc, 'sound/machines/click.ogg', 15, 1, -3)
 	for(var/obj/O in src) //Objects
+		O.layer = src.layer + 0.1
 		O.forceMove(loc)
 	for(var/mob/M in src) //Mobs
 		M.forceMove(loc)
@@ -59,9 +60,7 @@
 	return TRUE
 
 /obj/structure/closet/crate/close()
-	if(!src.opened)
-		return FALSE
-	if(!src.can_close())
+	if(!src.opened || !src.can_close())
 		return FALSE
 
 	playsound(src.loc, 'sound/machines/click.ogg', 15, 1, -3)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
При открытии ящика/шкафа все предметы поднимаются на 0.1 layer ( idk насколько это плохой подход в данном случае, но видел, что подобное юзали ранее )
[мой issue этой темы](https://github.com/ss220-space/Paradise/issues/849) // сам создал issue - сам исправил kekw

## Why It's Good For The Game
До этого при передвижении шкафов/ящиков предметы оказывались под шкафом/ящиком и взять можно было предмет только нажав ПКМ и выбрать предмет из списка

## Images of changes

До:
![image](https://user-images.githubusercontent.com/38399178/166874121-d06d9081-2a64-4b50-a01d-7547e5f9d66a.png)

После:
![image](https://user-images.githubusercontent.com/38399178/166942490-e827ebd9-8ff7-42ea-8daf-5fdada793785.png)


## Changelog
:cl:
fix: structure crate/closet now always under items in him
/:cl: