### PR TITLE
Feat: Не емагнутные борги и не малфы не могут поменять законы

### DIFF
--- a/code/modules/tgui/modules/law_manager.dm
+++ b/code/modules/tgui/modules/law_manager.dm
@@ -201,7 +201,13 @@
 	return law_sets
 
 /datum/ui_module/law_manager/proc/is_malf(var/mob/user)
-	return (is_admin(user) && !owner.is_slaved()) || is_special_character(owner)
+	if(is_admin(user) && !owner.is_slaved())
+		return TRUE
+	if(isAI(owner))
+		return is_special_character(owner)
+	else
+		var/mob/living/silicon/robot/silic = owner
+		return silic.module.module_type == "Malf" || silic.emagged
 
 /mob/living/silicon/proc/is_slaved()
 	return FALSE

--- a/code/modules/tgui/modules/law_manager.dm
+++ b/code/modules/tgui/modules/law_manager.dm
@@ -204,7 +204,8 @@
 	if(is_admin(user) && !owner.is_slaved())
 		return TRUE
 	if(isAI(owner))
-		return is_special_character(owner)
+		var/mob/living/silicon/ai/malf = owner
+		return malf.malf_picker
 	else
 		var/mob/living/silicon/robot/silic = owner
 		return silic.module.module_type == "Malf" || silic.emagged


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Немного переписывает логику у Law Manager, чтобы трейторы которых боргировали (*UPD и трейторы, которых пересадили в ИИ) или ЕРТ борги не могли менять себе законы.
На ИИ-малф, на взломанных боргов или на боргов синди (саботёр, мед, ассаулт и т.д.) не должно повлиять.

## Why It's Good For The Game
Хорошо когда борги ЕРТ подчиняются ЕРТ, а не скаченному паку законов.
Боргированные трейторы не могут больше менять себе законы.
Больше логики(?)

## Images of Changes
![image](https://user-images.githubusercontent.com/87372121/166986410-3d46ad00-58c1-4b0a-b4e6-3826ec543726.png)

## Changelog
:cl:
tweak: tweaked a proc isMalf, so antags in cyborgs can not change their laws
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
