### PR TITLE
Фикс очистки реагентов

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -10,7 +10,8 @@
 	var/datum/effect_system/reagents_explosion/e = new()
 	e.set_up(round (created_volume/10, 1), holder.my_atom, 0, 0)
 	e.start()
-	holder.clear_reagents()
+	if(!istype(holder.my_atom, /mob/living/carbon))
+		holder.clear_reagents()
 
 /datum/chemical_reaction/emp_pulse
 	name = "EMP Pulse"
@@ -24,7 +25,8 @@
 	// 100 created volume = 4 heavy range & 7 light range. A few tiles smaller than traitor EMP grandes.
 	// 200 created volume = 8 heavy range & 14 light range. 4 tiles larger than traitor EMP grenades.
 	empulse(location, round(created_volume / 24), round(created_volume / 14), 1)
-	holder.clear_reagents()
+	if(!istype(holder.my_atom, /mob/living/carbon))
+		holder.clear_reagents()
 
 /datum/chemical_reaction/beesplosion
 	name = "Bee Explosion"
@@ -63,7 +65,8 @@
 	var/datum/effect_system/reagents_explosion/e = new()
 	e.set_up(round(created_volume/2, 1), holder.my_atom, 0, 0)
 	e.start()
-	holder.clear_reagents()
+	if(!istype(holder.my_atom, /mob/living/carbon))
+		holder.clear_reagents()
 
 /datum/chemical_reaction/stabilizing_agent
 	name = "stabilizing_agent"


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Фиксит очистку реагентов для карбон мобов реакциями других реагентов.
## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Это необходимо по причине того, что сейчас с помощью небольшого количества воды и калия можно буквально лишить человека всех ядов, что находятся в нём. Так же повесила проверку на моба для ЕМП и Нитроглицерина. Ибо ими тоже можно, хоть это и менее безобидные для таких абузов реакции
