### PR TITLE
Fix: correct handling custom jobs in telecoms

### DIFF
--- a/code/game/machinery/tcomms/_base.dm
+++ b/code/game/machinery/tcomms/_base.dm
@@ -179,6 +179,8 @@ GLOBAL_LIST_EMPTY(tcomms_machines)
 	var/sender_name = "Error"
 	/// What job are they
 	var/sender_job = "Error"
+	/// What rank are they
+	var/sender_rank = "Error"
 	/// Pieces of the message
 	var/list/message_pieces = list()
 	/// Source Z-level

--- a/code/game/machinery/tcomms/nttc.dm
+++ b/code/game/machinery/tcomms/nttc.dm
@@ -23,27 +23,18 @@
 		"Cyborg" = "airadio",
 		"Personal AI" = "airadio",
 		"Robot" = "airadio",
-		// Civilian + Varients
-		"Assistant" = "radio",
-		"Businessman" = "radio",
+		// Civilian
 		"Civilian" = "radio",
-		"Tourist" = "radio",
-		"Trader" = "radio",
 		// Command (Solo command, not department heads)
 		"Blueshield" = "comradio",
 		"Captain" = "comradio",
 		"Head of Personnel" = "comradio",
 		"Nanotrasen Representative" = "comradio",
 		// Engineeering
-		"Atmospheric Technician" = "engradio",
 		"Chief Engineer" = "engradio",
-		"Electrician" = "engradio",
-		"Engine Technician" = "engradio",
 		"Life Support Specialist" = "engradio",
-		"Maintenance Technician" = "engradio",
 		"Mechanic" = "engradio",
 		"Station Engineer" = "engradio",
-		"Trainee Engineer" = "engradio",
 		// Central Command
 		"Emergency Response Team Engineer" = "dsquadradio", // I know this says deathsquad but the class for responseteam is neon green. No.
 		"Emergency Response Team Leader" = "dsquadradio",
@@ -57,65 +48,35 @@
 		"Chief Medical Officer" = "medradio",
 		"Coroner" = "medradio",
 		"Medical Doctor" = "medradio",
-		"Student Medical Doctor" = "medradio",
-		"Microbiologist" = "medradio",
-		"Nurse" = "medradio",
 		"Paramedic" = "medradio",
-		"Pharmacologist" = "medradio",
-		"Pharmacist" = "medradio",
 		"Psychiatrist" = "medradio",
-		"Psychologist" = "medradio",
-		"Surgeon" = "medradio",
-		"Therapist" = "medradio",
 		"Virologist" = "medradio",
 		// Science
-		"Anomalist" = "sciradio",
-		"Biomechanical Engineer" = "sciradio",
-		"Chemical Researcher" = "sciradio",
 		"Geneticist" = "sciradio",
-		"Mechatronic Engineer" = "sciradio",
-		"Plasma Researcher" = "sciradio",
 		"Research Director" = "sciradio",
 		"Roboticist" = "sciradio",
-		"Student Roboticist" = "sciradio",
 		"Scientist" = "sciradio",
-		"Student Scientist" = "sciradio",
-		"Xenoarcheologist" = "sciradio",
-		"Xenobiologist" = "sciradio",
 		// Security
 		"Brig Physician" = "secradio",
 		"Detective" = "secradio",
-		"Forensic Technician" = "secradio",
 		"Head of Security" = "secradio",
-		"Human Resources Agent" = "secradio",
 		"Internal Affairs Agent" = "secradio",
 		"Magistrate" = "secradio",
 		"Security Officer" = "secradio",
-		"Security Cadet" = "secradio",
 		"Security Pod Pilot" = "secradio",
 		"Warden" = "secradio",
 		// Supply
 		"Quartermaster" = "supradio",
 		"Cargo Technician" = "supradio",
 		"Shaft Miner" = "supradio",
-		"Spelunker" = "supradio",
 		// Service
 		"Barber" = "srvradio",
 		"Bartender" = "srvradio",
-		"Beautician" = "srvradio",
-		"Botanical Researcher" = "srvradio",
 		"Botanist" = "srvradio",
-		"Butcher" = "srvradio",
 		"Chaplain" = "srvradio",
 		"Chef" = "srvradio",
 		"Clown" = "srvradio",
-		"Cook" = "srvradio",
-		"Culinary Artist" = "srvradio",
-		"Custodial Technician" = "srvradio",
-		"Hair Stylist" = "srvradio",
-		"Hydroponicist" = "srvradio",
 		"Janitor" = "srvradio",
-		"Journalist" = "srvradio",
 		"Librarian" = "srvradio",
 		"Mime" = "srvradio",
 	)
@@ -238,8 +199,8 @@
 		tcm.pass = FALSE
 	// All job and coloring shit
 	if(toggle_job_color || toggle_name_color)
-		var/job = tcm.sender_job
-		job_class = all_jobs[job]
+		var/rank = tcm.sender_rank
+		job_class = all_jobs[rank]
 
 	if(toggle_name_color)
 		var/new_name = "<span class=\"[job_class]\">" + tcm.sender_name + "</span>"
@@ -282,8 +243,8 @@
 
 	// Makes heads of staff bold
 	if(toggle_command_bold)
-		var/job = tcm.sender_job
-		if((job in ert_jobs) || (job in heads) || (job in cc_jobs))
+		var/rank = tcm.sender_rank
+		if((rank in ert_jobs) || (rank in heads) || (rank in cc_jobs))
 			for(var/datum/multilingual_say_piece/S in message_pieces)
 				if(S.message)
 					S.message = "<b>[capitalize(S.message)]</b>" // This only capitalizes the first word

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -287,6 +287,7 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 	tcm.sender_name = from
 	tcm.message_pieces = message_pieces
 	tcm.sender_job = "Automated Announcement"
+	tcm.sender_rank = "Automated Announcement"
 	tcm.vname = "synthesized voice"
 	tcm.data = SIGNALTYPE_AINOTRACK
 	// Datum radios dont have a location (obviously)
@@ -384,6 +385,7 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 	var/displayname = M.name	// grab the display name (name you get when you hover over someone's icon)
 	var/voicemask = 0 // the speaker is wearing a voice mask
 	var/jobname // the mob's "job"
+	var/rank // the mob's "rank"
 
 	if(jammed)
 		Gibberish_all(message_pieces, 100)
@@ -392,27 +394,32 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		jobname = H.get_assignment()
+		rank = H.get_authentification_rank()
 
 	// --- Carbon Nonhuman ---
 	else if(iscarbon(M)) // Nonhuman carbon mob
 		jobname = "No id"
+		rank = "No id"
 
 	// --- AI ---
 	else if(isAI(M))
 		jobname = "AI"
+		rank = "AI"
 
 	// --- Cyborg ---
 	else if(isrobot(M))
 		jobname = "Cyborg"
+		rank = "Cyborg"
 
 	// --- Personal AI (pAI) ---
 	else if(istype(M, /mob/living/silicon/pai))
 		jobname = "Personal AI"
+		rank = "Personal AI"
 
 	// --- Unidentifiable mob ---
 	else
 		jobname = "Unknown"
-
+		rank = "Unknown"
 
 	// --- Modifications to the mob's identity ---
 
@@ -437,6 +444,7 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 	var/datum/tcomms_message/tcm = new
 	tcm.sender_name = displayname
 	tcm.sender_job = jobname
+	tcm.sender_rank = rank
 	tcm.message_pieces = message_pieces_copy
 	tcm.source_level = position.z
 	tcm.freq = connection.frequency


### PR DESCRIPTION
## What Does This PR Do
Исправляет обработку профессий с кастомным названием в телекомах, а именно "job coloring", "name coloring" и "command amplification"
## Why It's Good For The Game
1. Персонажи с кастомной профой будут иметь правильное форматирование речи по радио
2. Так как теперь для обработки телекомов берется не "job name" а "rank" можно добавлять новые раундстартовые альтернативные названия для проф и при этом не нужно будет перечислять их в файле телекомов

Также я убрал из перечисления альтернативные названия проф которые были вписаны туда ранее (они больше не используются, вместо них всегда берется название базовой профы)