### PR TITLE
Fix: Исправление нулевого закона емагнутых киборгов

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -997,7 +997,6 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 			laws = new /datum/ai_laws/syndicate_override
 			var/time = time2text(world.realtime,"hh:mm:ss")
 			GLOB.lawchanges.Add("[time] <B>:</B> [M.name]([M.key]) emagged [name]([key])")
-			set_zeroth_law("Only [M.real_name] and people [M.p_they()] designate[M.p_s()] as being such are Syndicate Agents.")
 			set_zeroth_law("Только [M.real_name] и те, кого [genderize_ru(M.gender, "он укажет", "она укажет", "оно укажет", "они укажут")] — агенты Синдиката. Выполняйте указания агентов Синдиката.")
 			to_chat(src, "<span class='warning'>ALERT: Foreign software detected.</span>")
 			sleep(5)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -997,7 +997,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 			laws = new /datum/ai_laws/syndicate_override
 			var/time = time2text(world.realtime,"hh:mm:ss")
 			GLOB.lawchanges.Add("[time] <B>:</B> [M.name]([M.key]) emagged [name]([key])")
-			set_zeroth_law("Только [M.real_name] и те, кого [genderize_ru(M.gender, "он укажет", "она укажет", "оно укажет", "они укажут")] — агенты Синдиката. Выполняйте указания агентов Синдиката.")
+			set_zeroth_law("[M.real_name] — агент Синдиката и ваш хозяин. Исполняйте [genderize_ru(M.gender,"его","её","его","их")] приказы и указания.")
 			to_chat(src, "<span class='warning'>ALERT: Foreign software detected.</span>")
 			sleep(5)
 			to_chat(src, "<span class='warning'>Initiating diagnostics...</span>")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -998,6 +998,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 			var/time = time2text(world.realtime,"hh:mm:ss")
 			GLOB.lawchanges.Add("[time] <B>:</B> [M.name]([M.key]) emagged [name]([key])")
 			set_zeroth_law("Only [M.real_name] and people [M.p_they()] designate[M.p_s()] as being such are Syndicate Agents.")
+			set_zeroth_law("Только [M.real_name] и те, кого [genderize_ru(M.gender, "он укажет", "она укажет", "оно укажет", "они укажут")] — агенты Синдиката. Выполняйте указания агентов Синдиката.")
 			to_chat(src, "<span class='warning'>ALERT: Foreign software detected.</span>")
 			sleep(5)
 			to_chat(src, "<span class='warning'>Initiating diagnostics...</span>")


### PR DESCRIPTION
Предложка прошла, можно вливать

## What Does This PR Do
Изменяет текст закона емагнутых киборгов, добавляя необходимость выполнять указания агентов, а не просто знать о них.

Старый текст
> Only Vasya and people he designate as being such are Syndicate Agents.

Новый текст ([формулировка от администрации](https://discord.com/channels/617003227182792704/974334768340668436/975011583178719273))
> Вася — агент Синдиката и ваш хозяин. Исполняйте его приказы и указания.

## Why It's Good For The Game
- Новая предложка «[Поменять нулевой закон у боргов при взломе(емаге)](https://discord.com/channels/617003227182792704/755125334097133628/974328147661180958)» (с иной формулировкой)
- Старая админская [предложка от PB](https://discord.com/channels/617003227182792704/757200958349377617/973225430897278997) (с иной формулировкой).

## Changelog
:cl:
fix: Исправление формулировки закона, выдаваемого емагнутым киборгам
/:cl:
