### PR TITLE
Fix: Uniforms & Gear In Personal Lockers \ Access To Evidence Lockers

### DIFF
--- a/_maps/map_files/Delta/Lavaland.dmm
+++ b/_maps/map_files/Delta/Lavaland.dmm
@@ -965,7 +965,7 @@
 /area/mine/living_quarters)
 "cK" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/secure_closet/personal,
+/obj/structure/closet/secure_closet/personal/mining,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "brown"
@@ -1692,6 +1692,7 @@
 /turf/simulated/floor/plasteel,
 /area/mine/eva)
 "fz" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "brown"
@@ -3499,7 +3500,7 @@
 	},
 /area/mine/living_quarters)
 "og" = (
-/obj/structure/closet/secure_closet/personal,
+/obj/structure/closet/secure_closet/personal/mining,
 /obj/effect/turf_decal/bot,
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -3788,7 +3789,7 @@
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "rP" = (
-/obj/structure/closet/secure_closet/personal,
+/obj/structure/closet/secure_closet/personal/mining,
 /obj/effect/turf_decal/bot,
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
@@ -4052,7 +4053,7 @@
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "ur" = (
-/obj/structure/closet/secure_closet/personal,
+/obj/structure/closet/secure_closet/personal/mining,
 /obj/structure/sign/poster/random{
 	pixel_x = 32
 	},
@@ -4373,6 +4374,13 @@
 	icon_state = "brown"
 	},
 /area/mine/living_quarters)
+"xH" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "brown"
+	},
+/area/mine/living_quarters)
 "xL" = (
 /obj/machinery/atmospherics/unary/outlet_injector/on{
 	dir = 4;
@@ -4530,7 +4538,7 @@
 /turf/simulated/floor/plasteel,
 /area/mine/eva)
 "ze" = (
-/obj/structure/closet/secure_closet/personal,
+/obj/structure/closet/secure_closet/personal/mining,
 /obj/effect/turf_decal/bot,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -4820,6 +4828,13 @@
 	icon_state = "brown"
 	},
 /area/mine/production)
+"CX" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/mine/living_quarters)
 "Db" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4922,7 +4937,7 @@
 /area/mine/living_quarters)
 "DU" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/secure_closet/personal,
+/obj/structure/closet/secure_closet/personal/mining,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "brown"
@@ -5900,6 +5915,12 @@
 	icon_state = "brown"
 	},
 /area/mine/living_quarters)
+"PW" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "brown"
+	},
+/area/mine/living_quarters)
 "Qo" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/extinguisher_cabinet{
@@ -6385,6 +6406,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
+"UX" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "browncorner"
+	},
+/area/mine/living_quarters)
 "Vb" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -6629,7 +6657,7 @@
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "YQ" = (
-/obj/structure/closet/secure_closet/personal,
+/obj/structure/closet/secure_closet/personal/mining,
 /obj/effect/turf_decal/bot,
 /obj/structure/sign/poster/random{
 	pixel_x = -32
@@ -16753,8 +16781,8 @@ ad
 WO
 DU
 YQ
-IK
-IK
+xH
+xH
 gL
 mT
 Qo
@@ -17010,12 +17038,12 @@ ai
 Zf
 Jk
 ZL
-Lc
-Lc
+ZL
+ZL
 KV
 ML
 FK
-rZ
+PW
 fo
 Fe
 BD
@@ -17272,7 +17300,7 @@ Ad
 PQ
 vZ
 TO
-rZ
+PW
 fp
 Fe
 gh
@@ -17525,11 +17553,11 @@ WO
 Jk
 ZL
 ZL
-HH
+UX
 QM
 TS
 FK
-rZ
+PW
 fr
 Fe
 dX
@@ -17784,7 +17812,7 @@ ur
 ze
 eX
 FY
-td
+CX
 EJ
 fz
 fI

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -9093,7 +9093,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "aUE" = (
-/obj/structure/closet/secure_closet/personal,
+/obj/structure/closet/secure_closet/personal/mining,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -44875,7 +44875,7 @@
 	},
 /area/security/processing)
 "dNG" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig/evidence,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -45510,7 +45510,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "dQP" = (
-/obj/structure/closet/secure_closet/personal,
+/obj/structure/closet/secure_closet/personal/mining,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -68756,7 +68756,7 @@
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "siding8"
 	},
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig/evidence,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -78855,7 +78855,7 @@
 	},
 /area/atmos)
 "lAZ" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig/evidence,
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
@@ -79401,7 +79401,7 @@
 /area/hallway/secondary/exit)
 "lJF" = (
 /obj/machinery/light,
-/obj/structure/closet/secure_closet/personal,
+/obj/structure/closet/secure_closet/personal/mining,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -97627,7 +97627,7 @@
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "siding8"
 	},
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig/evidence,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -99311,7 +99311,7 @@
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "siding1"
 	},
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig/evidence,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -113229,7 +113229,7 @@
 	},
 /area/hallway/primary/central/sw)
 "tKh" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig/evidence,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -11,17 +11,20 @@
 		new /obj/item/storage/backpack(src)
 	else
 		new /obj/item/storage/backpack/satchel_norm(src)
-	new /obj/item/radio/headset( src )
-
+	new /obj/item/radio/headset(src)
 
 /obj/structure/closet/secure_closet/personal/patient
 	name = "patient's closet"
 
 /obj/structure/closet/secure_closet/personal/patient/populate_contents()
-	new /obj/item/clothing/under/color/white( src )
-	new /obj/item/clothing/shoes/white( src )
+	new /obj/item/clothing/under/color/white(src)
+	new /obj/item/clothing/shoes/white(src)
 
+/obj/structure/closet/secure_closet/personal/mining
+	name = "personal miner's locker"
 
+/obj/structure/closet/secure_closet/personal/mining/populate_contents()
+	new /obj/item/stack/sheet/cardboard(src)
 
 /obj/structure/closet/secure_closet/personal/cabinet
 	icon_state = "cabinetdetective_locked"
@@ -46,8 +49,8 @@
 			icon_state = icon_opened
 
 /obj/structure/closet/secure_closet/personal/cabinet/populate_contents()
-	new /obj/item/storage/backpack/satchel/withwallet( src )
-	new /obj/item/radio/headset( src )
+	new /obj/item/storage/backpack/satchel/withwallet(src)
+	new /obj/item/radio/headset(src)
 
 /obj/structure/closet/secure_closet/personal/attackby(obj/item/W, mob/user, params)
 	if(opened || !istype(W, /obj/item/card/id))

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -382,7 +382,7 @@
 /obj/structure/closet/secure_closet/brig
 	name = "brig locker"
 	req_access = list(ACCESS_BRIG)
-	anchored = 1
+	anchored = TRUE
 	var/id = null
 
 /obj/structure/closet/secure_closet/brig/populate_contents()
@@ -393,6 +393,7 @@
 
 /obj/structure/closet/secure_closet/brig/evidence
 	name = "evidence locker"
+	req_access = list(ACCESS_SECURITY)
 
 /obj/structure/closet/secure_closet/brig/evidence/populate_contents()
 	new /obj/item/stack/sheet/cardboard(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -391,6 +391,11 @@
 	new /obj/item/card/id/prisoner/random(src)
 	new /obj/item/radio/headset(src)
 
+/obj/structure/closet/secure_closet/brig/evidence
+	name = "evidence locker"
+
+/obj/structure/closet/secure_closet/brig/evidence/populate_contents()
+	new /obj/item/stack/sheet/cardboard(src)
 
 /obj/structure/closet/secure_closet/courtroom
 	name = "courtroom locker"


### PR DESCRIPTION
## Список изменений
* Детектив теперь имеет доступ к шкафчикам для улик.
* Блокируемые шкафчики шахтёров для артефактов теперь без излишнего снаряжения на старте.
* Блокируемые шкафчики в комнате с уликами теперь прибиты к полу и не хранят в себе униформу.