### PR TITLE
Fix: Disable mouse_opacity on dirt & dust sprites

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -29,6 +29,7 @@
 	icon_state = "dirt"
 	canSmoothWith = list(/obj/effect/decal/cleanable/dirt, /turf/simulated/wall, /obj/structure/falsewall)
 	smooth = SMOOTH_MORE
+	mouse_opacity = FALSE
 
 /obj/effect/decal/cleanable/dirt/Initialize(mapload)
 	. = ..()
@@ -43,6 +44,7 @@
 	layer = TURF_LAYER
 	icon = 'icons/effects/dirt.dmi'
 	icon_state = "dust"
+	mouse_opacity = FALSE
 
 /obj/effect/decal/cleanable/dirt/blackpowder
 	name = "black powder"


### PR DESCRIPTION
Исправляет допущенный мною недочет.
Мешало удобной работе инженеров.

![image](https://user-images.githubusercontent.com/20109643/167593907-7a2b33dd-015d-4fcc-93cf-3ce01be8f210.png)
![image](https://user-images.githubusercontent.com/20109643/167593957-125dc22a-2c02-4ede-955c-77f2d4ba683b.png)
