### PR TITLE
Tweak: stunbaton change

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -11,7 +11,7 @@
 	origin_tech = "combat=2"
 	attack_verb = list("beaten")
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 50, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 80)
-	var/staminaforce = 35
+	var/staminaforce = 30
 	var/stunforce = 1
 	var/status = 0
 	var/obj/item/stock_parts/cell/high/cell = null
@@ -232,8 +232,8 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	force = 3
 	throwforce = 5
-	staminaforce = 25
-	stunforce = 1
+	staminaforce = 35
+	stunforce = 0
 	hitcost = 500
 	throw_hit_chance = 50
 	slot_flags = SLOT_BACK

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -11,12 +11,12 @@
 	origin_tech = "combat=2"
 	attack_verb = list("beaten")
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 50, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 80)
-	var/staminaforce = 20
-	var/stunforce = 2
+	var/staminaforce = 35
+	var/stunforce = 1
 	var/status = 0
 	var/obj/item/stock_parts/cell/high/cell = null
 	var/hitcost = 500
-	var/throw_hit_chance = 50
+	var/throw_hit_chance = 75
 
 /obj/item/melee/baton/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is putting the live [name] in [user.p_their()] mouth! It looks like [user.p_theyre()] trying to commit suicide.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Понижает время оглушения станбатона сб до 1 секунды, повышает шанс стана при броске до 75%, повышает стамина урон до 30(4 удара до стаминакрита)
Убирает оглушение у станпрода, повышает стамина урон до 35(3 удара до стаминакрита)
До прохождения предложки не мерджить.

## Why It's Good For The Game
Предложка - > (Потом) 

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Changed stamina damage and stun time of stun batons
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
