### PR TITLE
Fix: Больше фиксов богу фиксов для Delta Station (Kerberos)

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -8133,7 +8133,7 @@
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
-	req_access_txt = "32"
+	req_access_txt = "10"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -12604,6 +12604,10 @@
 /area/engine/supermatter)
 "boU" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_x = -32;
+	pixel_y = -32
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "yellow"
@@ -12993,7 +12997,11 @@
 /area/bridge/checkpoint/north)
 "bru" = (
 /obj/structure/closet,
-/obj/machinery/power/tracker,
+/obj/item/toy/crayon/spraycan,
+/obj/item/assembly/prox_sensor{
+	pixel_x = -5;
+	pixel_y = 5
+	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/bar)
 "brv" = (
@@ -13071,6 +13079,7 @@
 /area/engine/mechanic_workshop/hangar)
 "brO" = (
 /obj/structure/rack,
+/obj/item/stack/sheet/cardboard,
 /turf/simulated/floor/plasteel,
 /area/maintenance/bar)
 "brR" = (
@@ -13364,7 +13373,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
-	req_access_txt = "32"
+	req_access_txt = "24"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13705,7 +13714,7 @@
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
-	req_access_txt = "32"
+	req_access_txt = "10"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -14706,7 +14715,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
-	req_access_txt = "32"
+	req_access_txt = "24"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -14877,6 +14886,10 @@
 /area/shuttle/transport)
 "byP" = (
 /obj/item/twohanded/required/kirbyplants,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar/atrium)
 "byR" = (
@@ -17488,11 +17501,6 @@
 	},
 /area/maintenance/bar)
 "bKi" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -17508,7 +17516,15 @@
 	network = list("Engineering","SS13");
 	pixel_y = -22
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "yellow"
@@ -18821,11 +18837,6 @@
 /area/engine/engineering)
 "bQk" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -19371,10 +19382,6 @@
 	name = "\improper AI Satellite Service"
 	})
 "bSt" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/airlock/public/glass,
@@ -26519,7 +26526,6 @@
 /area/security/permabrig)
 "cxz" = (
 /obj/structure/rack,
-/obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -26811,10 +26817,6 @@
 	pixel_x = 6;
 	pixel_y = 4
 	},
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/radio,
 /turf/simulated/floor/plasteel,
 /area/gateway)
 "cyk" = (
@@ -27158,9 +27160,6 @@
 "czy" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical,
-/obj/structure/closet/walllocker/emerglocker{
-	pixel_x = -32
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/engrooms)
 "czz" = (
@@ -27208,10 +27207,18 @@
 /area/assembly/showroom)
 "czL" = (
 /obj/structure/table,
-/obj/machinery/recharger{
-	pixel_x = 1;
-	pixel_y = 3
+/obj/item/radio{
+	pixel_y = 6
 	},
+/obj/item/radio{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/radio{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/radio,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/gateway)
@@ -31432,6 +31439,15 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
+"cPc" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/central/north)
 "cPd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -33665,8 +33681,8 @@
 "cXD" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
-/obj/item/radio/intercom{
-	pixel_y = 22
+/obj/structure/sign/poster/official/high_class_martini{
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -36659,6 +36675,7 @@
 	network = list("Medical","SS13")
 	},
 /obj/machinery/button/windowtint{
+	anchored = 1;
 	id = "cloninglab";
 	pixel_x = 22;
 	pixel_y = 10
@@ -37869,7 +37886,7 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
-	req_access_txt = "63"
+	req_access_txt = "1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -38824,10 +38841,6 @@
 	},
 /area/construction/hallway)
 "dpR" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/door/airlock/public{
 	name = "Bar";
 	req_access_txt = "25"
@@ -41114,20 +41127,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/bookcase,
-/obj/item/book/manual/security_space_law,
-/obj/item/book/manual/sop_command,
-/obj/item/book/manual/sop_engineering,
-/obj/item/book/manual/sop_general,
-/obj/item/book/manual/sop_legal,
-/obj/item/book/manual/sop_medical,
-/obj/item/book/manual/sop_science,
-/obj/item/book/manual/sop_security,
-/obj/item/book/manual/sop_service,
-/obj/item/book/manual/sop_supply,
+/obj/structure/table/reinforced,
+/obj/item/radio/electropack,
+/obj/item/assembly/signaler,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -46624,16 +46626,16 @@
 	},
 /area/turret_protected/ai)
 "dUe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -51971,6 +51973,16 @@
 	icon_state = "darkred"
 	},
 /area/security/securearmoury)
+"eQb" = (
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/central/north)
 "eQd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light/small{
@@ -54581,17 +54593,17 @@
 	},
 /area/security/permabrig)
 "fzQ" = (
-/obj/structure/table/reinforced,
-/obj/item/implanter/mindshield{
-	pixel_x = 4;
-	pixel_y = 12
-	},
-/obj/item/storage/toolbox/surgery{
-	pixel_y = -6
-	},
-/obj/machinery/vending/wallmed{
-	pixel_y = 30
-	},
+/obj/structure/bookcase,
+/obj/item/book/manual/security_space_law,
+/obj/item/book/manual/sop_command,
+/obj/item/book/manual/sop_engineering,
+/obj/item/book/manual/sop_general,
+/obj/item/book/manual/sop_legal,
+/obj/item/book/manual/sop_medical,
+/obj/item/book/manual/sop_science,
+/obj/item/book/manual/sop_security,
+/obj/item/book/manual/sop_service,
+/obj/item/book/manual/sop_supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkred"
@@ -54804,7 +54816,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "fCJ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
@@ -54814,6 +54825,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1
@@ -55780,6 +55794,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
+"fPx" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/crew_quarters/locker)
 "fPA" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -55934,13 +55955,14 @@
 	},
 /area/assembly/robotics)
 "fRj" = (
-/obj/machinery/power/apc{
-	name = "east bump";
-	pixel_x = 26
-	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 26
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -58427,6 +58449,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
+"gwa" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/crew_quarters/locker)
 "gwx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -59298,6 +59330,13 @@
 	icon_state = "dark"
 	},
 /area/chapel/office)
+"gGH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/crew_quarters/locker)
 "gGI" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/scrubber,
@@ -62341,9 +62380,6 @@
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka{
 	pixel_x = 5;
 	pixel_y = -3
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -70071,10 +70107,6 @@
 	name = "Evidence Storage";
 	req_access_txt = "63"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -70277,11 +70309,6 @@
 	name = "Perma Maintenance"
 	})
 "jot" = (
-/obj/structure/rack,
-/obj/machinery/camera{
-	c_tag = "Gateway Access";
-	dir = 4
-	},
 /obj/item/stack/medical/bruise_pack,
 /obj/item/stack/medical/bruise_pack/advanced,
 /obj/item/stack/medical/ointment,
@@ -70293,6 +70320,14 @@
 /obj/item/reagent_containers/food/pill/patch/styptic,
 /obj/item/reagent_containers/food/pill/patch/silver_sulf,
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/closet/medical_wall{
+	pixel_x = -32
+	},
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_x = 1;
+	pixel_y = 3
+	},
 /turf/simulated/floor/plasteel,
 /area/gateway)
 "jox" = (
@@ -73165,9 +73200,6 @@
 /area/security/processing)
 "jXD" = (
 /obj/effect/decal/warning_stripes/yellow,
-/obj/structure/closet/medical_wall{
-	pixel_x = -32
-	},
 /obj/structure/closet/crate,
 /obj/item/storage/belt/utility,
 /obj/item/storage/belt/utility,
@@ -73181,6 +73213,10 @@
 /obj/item/multitool,
 /obj/item/multitool,
 /obj/item/multitool,
+/obj/machinery/camera{
+	c_tag = "Gateway Access";
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/gateway)
 "jXE" = (
@@ -77139,6 +77175,11 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "lfc" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26;
+	pixel_y = 28
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "redcorner"
@@ -77814,6 +77855,10 @@
 /obj/item/wirecutters{
 	pixel_y = 18
 	},
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 25
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkred"
@@ -78296,8 +78341,13 @@
 "luw" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/structure/table/reinforced,
-/obj/item/radio/electropack,
-/obj/item/assembly/signaler,
+/obj/item/storage/toolbox/surgery{
+	pixel_y = -6
+	},
+/obj/item/implanter/mindshield{
+	pixel_x = 4;
+	pixel_y = 12
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkred"
@@ -81912,7 +81962,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker/locker_toilet)
@@ -91013,9 +91062,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 0;
 	icon_state = "red"
@@ -92249,6 +92296,8 @@
 	dir = 4;
 	pixel_x = 28
 	},
+/obj/item/clothing/head/beret/med,
+/obj/item/clothing/head/beret/med,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whiteblue";
@@ -98912,7 +98961,6 @@
 /area/security/securearmoury)
 "qjN" = (
 /obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -98922,6 +98970,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -100915,8 +100966,11 @@
 	icon_state = "0-2"
 	},
 /obj/structure/table/glass,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/beakers,
+/obj/item/storage/fancy/vials{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/item/storage/fancy/vials,
 /turf/simulated/floor/plasteel,
 /area/medical/virology/lab)
 "qIk" = (
@@ -101498,6 +101552,21 @@
 	tag = "icon-whiteblue (NORTH)"
 	},
 /area/medical/surgery2)
+"qPP" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker/locker_toilet)
 "qQf" = (
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall/r_wall,
@@ -102925,7 +102994,7 @@
 	req_access_txt = "12"
 	},
 /turf/simulated/floor/plasteel,
-/area/storage/primary)
+/area/maintenance/fpmaint)
 "rfZ" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating/airless,
@@ -103377,6 +103446,12 @@
 	},
 /obj/effect/landmark/start{
 	name = "Station Engineer"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -106041,7 +106116,7 @@
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "rSH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "yellowcorner"
@@ -108922,7 +108997,9 @@
 	},
 /area/security/securehallway)
 "sDV" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -113316,12 +113393,8 @@
 /area/maintenance/bar)
 "tLr" = (
 /obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/machinery/light_switch{
-	pixel_x = 8;
-	pixel_y = -24
-	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/cell_charger,
 /turf/simulated/floor/plasteel,
 /area/gateway)
 "tLv" = (
@@ -123792,6 +123865,7 @@
 /obj/item/storage/secure/safe{
 	pixel_x = 32
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -126651,18 +126725,14 @@
 	},
 /area/hallway/primary/starboard/east)
 "wOc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 1
 	},
-/area/hallway/primary/starboard/east)
+/area/security/processing)
 "wOf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -131343,15 +131413,6 @@
 	},
 /area/hallway/primary/central/south)
 "xMs" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/disposal,
 /obj/effect/decal/warning_stripes/yellow,
 /obj/structure/disposalpipe/trunk{
@@ -131887,6 +131948,11 @@
 "xRU" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/item/storage/lockbox/vials{
+	layer = 4;
+	pixel_x = 1;
+	pixel_y = 12
+	},
 /turf/simulated/floor/plasteel,
 /area/medical/virology/lab)
 "xRX" = (
@@ -160896,7 +160962,7 @@ abj
 bCI
 aaa
 aaa
-aae
+aaa
 aaa
 aaa
 aaa
@@ -175434,7 +175500,7 @@ cex
 bea
 lIJ
 cqB
-ivV
+cPc
 glw
 ivL
 hKm
@@ -175691,7 +175757,7 @@ jJV
 dXb
 cqB
 cqB
-ivV
+eQb
 nwK
 ivV
 bNc
@@ -177510,7 +177576,7 @@ eqP
 vKJ
 qeJ
 rQz
-wOc
+aYe
 ydS
 pwU
 pwU
@@ -178301,7 +178367,7 @@ ctj
 cxn
 nbP
 wlx
-fFC
+qPP
 cxn
 cxn
 cxn
@@ -180863,8 +180929,8 @@ chH
 wti
 bYM
 gBu
-tbb
-fcN
+gGH
+gwa
 fHj
 cAk
 vSD
@@ -181120,8 +181186,8 @@ bYM
 bYM
 bYM
 jLp
-tbb
-vSD
+gGH
+fPx
 sDV
 qjN
 cyK
@@ -181377,7 +181443,7 @@ ctt
 cjh
 cnP
 yae
-tbb
+gGH
 dUe
 eZt
 cAj
@@ -184168,7 +184234,7 @@ hpZ
 hYQ
 iAf
 jlH
-mfo
+wOc
 fCJ
 ubg
 ubg

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -24038,19 +24038,19 @@
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
 "cmj" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/pump,
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
@@ -25146,7 +25146,6 @@
 	},
 /area/library)
 "cro" = (
-/obj/structure/cable,
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -38609,6 +38608,11 @@
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 27
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint{
@@ -56135,6 +56139,11 @@
 	dir = 8;
 	network = list("Minisat","SS13")
 	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 27
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkblue"
@@ -68358,6 +68367,11 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 27
+	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/aisat_interior)
 "iMx" = (
@@ -70659,6 +70673,18 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
+"jso" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/east,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/engine/controlroom)
 "jst" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
@@ -98197,6 +98223,7 @@
 	dir = 1;
 	network = list("Prison","SS13")
 	},
+/obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -118931,9 +118958,6 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/structure/fans/tiny,
 /obj/machinery/door/window/brigdoor/southleft{
 	dir = 4;
@@ -124437,6 +124461,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
+"wmo" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/east,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/engine/controlroom)
 "wmD" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -131340,7 +131378,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/machinery/light,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
@@ -159573,8 +159610,8 @@ mmv
 caN
 cGs
 cgD
-cgD
-cSG
+jso
+wmo
 aFg
 aFf
 bzV

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -87674,7 +87674,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit)
+/area/maintenance/asmaint2)
 "nFA" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -19941,7 +19941,9 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/security/permabrig)
+/area/maintenance/storage{
+	name = "Perma Maintenance"
+	})
 "bUH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -34935,7 +34937,7 @@
 	req_access_txt = "5"
 	},
 /turf/simulated/floor/plating,
-/area/medical/ward)
+/area/maintenance/fsmaint)
 "dcE" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -37301,7 +37303,9 @@
 /turf/simulated/floor/plasteel{
 	dir = 1
 	},
-/area/security/range)
+/area/maintenance/port{
+	name = "Brig Maintenance"
+	})
 "dkM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -61962,7 +61966,7 @@
 	req_access_txt = "12"
 	},
 /turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/maintenance/fsmaint)
 "hkr" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -86993,7 +86997,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/crew_quarters/fitness)
+/area/maintenance/port{
+	name = "Brig Maintenance"
+	})
 "nvg" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/regular,
@@ -106056,7 +106062,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/crew_quarters/locker)
+/area/maintenance/port{
+	name = "Brig Maintenance"
+	})
 "rRV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -13093,6 +13093,13 @@
 	icon_state = "dark"
 	},
 /area/engine/mechanic_workshop/hangar)
+"brV" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/crew_quarters/locker)
 "brW" = (
 /turf/simulated/wall,
 /area/storage/tech)
@@ -31439,15 +31446,6 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
-"cPc" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/central/north)
 "cPd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -48409,6 +48407,21 @@
 /turf/space,
 /turf/space,
 /area/space/nearstation)
+"dZr" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker/locker_toilet)
 "dZt" = (
 /obj/structure/rack{
 	dir = 8;
@@ -51973,16 +51986,6 @@
 	icon_state = "darkred"
 	},
 /area/security/securearmoury)
-"eQb" = (
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/central/north)
 "eQd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light/small{
@@ -55794,13 +55797,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
-"fPx" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/crew_quarters/locker)
 "fPA" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -58449,16 +58445,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
-"gwa" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/crew_quarters/locker)
 "gwx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -59330,13 +59316,6 @@
 	icon_state = "dark"
 	},
 /area/chapel/office)
-"gGH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/locker)
 "gGI" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/scrubber,
@@ -69611,6 +69590,16 @@
 /area/maintenance/starboard{
 	name = "Engineering Maintenance"
 	})
+"jen" = (
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/central/north)
 "jeA" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -101552,21 +101541,6 @@
 	tag = "icon-whiteblue (NORTH)"
 	},
 /area/medical/surgery2)
-"qPP" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker/locker_toilet)
 "qQf" = (
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall/r_wall,
@@ -103328,6 +103302,13 @@
 	icon_state = "red"
 	},
 /area/security/securehallway)
+"rle" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/crew_quarters/locker)
 "rlh" = (
 /obj/machinery/door/airlock/shuttle{
 	id_tag = "s_docking_airlock";
@@ -104849,6 +104830,15 @@
 	icon_state = "yellow"
 	},
 /area/engine/engineering)
+"rDJ" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/central/north)
 "rDK" = (
 /obj/machinery/autolathe/security,
 /obj/item/stack/sheet/metal{
@@ -106328,6 +106318,29 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/syndicate_sit)
+"rVt" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	initialize_directions = 11
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/primary/starboard/east)
 "rVw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -111547,6 +111560,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/ntrep)
+"tlJ" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/crew_quarters/locker)
 "tlZ" = (
 /obj/machinery/light{
 	dir = 1
@@ -175500,7 +175523,7 @@ cex
 bea
 lIJ
 cqB
-cPc
+rDJ
 glw
 ivL
 hKm
@@ -175757,7 +175780,7 @@ jJV
 dXb
 cqB
 cqB
-eQb
+jen
 nwK
 ivV
 bNc
@@ -178367,7 +178390,7 @@ ctj
 cxn
 nbP
 wlx
-qPP
+dZr
 cxn
 cxn
 cxn
@@ -179888,7 +179911,7 @@ daU
 fXv
 xnx
 vUF
-qze
+rVt
 kYC
 xBx
 wsP
@@ -180929,8 +180952,8 @@ chH
 wti
 bYM
 gBu
-gGH
-gwa
+rle
+tlJ
 fHj
 cAk
 vSD
@@ -181186,8 +181209,8 @@ bYM
 bYM
 bYM
 jLp
-gGH
-fPx
+rle
+brV
 sDV
 qjN
 cyK
@@ -181443,7 +181466,7 @@ ctt
 cjh
 cnP
 yae
-gGH
+rle
 dUe
 eZt
 cAj


### PR DESCRIPTION
## What Does This PR Do
Оставляет надежду на то, что больше мелких фиксов до следующего патча не предвидится.
Исправляет все, найденные за последнее время, ошибки, опять...

# Нововведения:

# Вирусология
* Пару коробок с бикерами по 50 юнитов были заменены на контейнеры с пробирками по 25 (vial storage box)
* Добавлена вариация данной коробки, но в формате контейнера с замком на доступ вирусолога (secure vial storage box)

# Фиксы:

* Исправлено положения лампы в туалете
* Исправлен двойной телеком в баре
* Исправлена атмосферная тревога в двери бара
* Исправлена настенная аптечка в гейтвее
* В дормах портативные скрабберы и помпы теперь работают
* Исправленная вторая air alarm в зоне ожидания перед ГП
* Исправлена вторая air alarm на коридор выше суда
* Скраббер в коридоре выше суда подключен
* Исправил экстренный доступ в технические тоннели пермабрига, брига и мед.блока
* Добавлены АПЦ на спутник ИИ, теперь он не питается святым космосом
* Восстановлен доступ во внутренний круг обшивки спутника с запада

# Бриг
* Исправлены куски трубы в комнате улик
* Исправлено АПЦ в комнате улик
* Переставлен шкаф в пыточной
* Убран двойной огнетушитель
* Добавлена кнопка пожарной тревоги в процедурную

# Инженерный
* Я запрещаю АВД ходить к кристаллу суперматерии через атмос
* Исправлено расположение АПЦ в диспетчерской, теперь не над мусоркой

# Технические тоннели
* Исправлен тулбокс в настенном локере старого инженерного отдела
* Исправлен двойной rack на старом складе карго
* Исправлен доступ в КПП прибытия со стороны технических тоннелей