### PR TITLE
Feat: Toxin damage applies on organs on death

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -13,6 +13,8 @@
 #define DROPLIMB_BLUNT 1
 #define DROPLIMB_BURN 2
 
+#define TOXIN_TO_INTERNAL_DAMAGE_MULTIPLIER 2 // coefficient wich defines ratio of toxin into internal organs damage transfer
+
 #define AGE_MIN 17			//youngest a character can be
 #define AGE_MAX 85			//oldest a character can be
 

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -16,6 +16,9 @@ do {\
 * This feature increases amount of effort it takes to revive a victim of poisoning
 */
 /mob/living/carbon/proc/process_toxin_damage_on_death(mob/living/carbon/target)
+if (!target)
+	return
+	
 	var/internal_damage = target.getToxLoss()*TOXIN_TO_INTERNAL_DAMAGE_MULTIPLIER // getting toxin damage, converting into internal organ damage
 	if (internal_damage < 10) // don't wanna be bothering with random 1-2 toxin dmg
 		return

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -39,7 +39,6 @@ if (!target)
 		if (organ_picked.damage >= organ_picked.max_damage) // you can't check if the organ is dead because of immortality of the brain
 			to_be_picked_from.Remove(organ_picked)
 
-
 #undef APPLY_DAMAGE
 
 /mob/living/carbon/death(gibbed)

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -9,8 +9,10 @@ do {\
 	_res-=damage_to_be_applied;\
 } while(FALSE)
 
-// This function applies damage to internal organs in case the mob died having toxin damage
-// This feature increases amount of effort it takes to revive a victim of poisoning
+/**
+* This function applies damage to internal organs in case the mob died having toxin damage
+* This feature increases amount of effort it takes to revive a victim of poisoning
+*/
 /mob/living/carbon/proc/process_toxin_damage_on_death(mob/living/carbon/target)
 	var/internal_damage = target.getToxLoss()*TOXIN_TO_INTERNAL_DAMAGE_MULTIPLIER // getting toxin damage, converting into internal organ damage
 	if (internal_damage < 10) // don't wanna be bothering with random 1-2 toxin dmg

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -30,7 +30,7 @@ do {\
 
 	// now the rest of the damage is going to be distributed among other organs
 	var/list/to_be_picked_from = target.internal_organs.Copy()
-	while (internal_damage > 0 && to_be_picked_from.len > 0)
+	while (internal_damage > 0 && length(to_be_picked_from) > 0)
 		var/obj/item/organ/internal/organ_picked = pick(to_be_picked_from)
 		APPLY_DAMAGE(min(rand(5,19), internal_damage), organ_picked, internal_damage)
 		if (organ_picked.damage >= organ_picked.max_damage) // you can't check if the organ is dead because of immortality of the brain

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -1,4 +1,13 @@
-#define TOXIN_TO_INTERNAL_DAMAGE_MULTIPLIER 2
+// _DAMAGE = any rvalue, _PART = lvalue (DO NOT CALCULATE DYNAMICALLY), _RES = any lvalue
+// this macro tries to apply DAMAGE damage to the PART internal organ and
+// then subtracts RES by the damage actually taken
+#define APPLY_DAMAGE(_damage, _part, _res) \
+do {\
+	var/can_be_absorbed = _part.max_damage - _part.damage;\
+	var/damage_to_be_applied = min(can_be_absorbed, _damage);\
+	_part.receive_damage(damage_to_be_applied);\
+	_res-=damage_to_be_applied;\
+} while(FALSE)
 
 // This function applies damage to internal organs in case the mob died having toxin damage
 // This feature increases amount of effort it takes to revive a victim of poisoning
@@ -7,29 +16,24 @@
 	if (internal_damage < 10) // don't wanna be bothering with random 1-2 toxin dmg
 		return
 	// first the liver takes the hit
-	internal_damage -= __apply_damage(internal_damage, target.get_int_organ(/obj/item/organ/internal/liver))
+	APPLY_DAMAGE(internal_damage, target.get_int_organ(/obj/item/organ/internal/liver),internal_damage)
 
 	// now we either took all damage and wanna quit, or need another organ to be damaged. It's gonna be heart+1
 	if (internal_damage <= 0)
 		return
 	// heart takes at least 50% of the damage that is left after liver failure (unless it dies earlier)
-	internal_damage -= __apply_damage(internal_damage/2, target.get_int_organ(/obj/item/organ/internal/heart))
+	APPLY_DAMAGE(internal_damage/2, target.get_int_organ(/obj/item/organ/internal/heart),internal_damage)
 
 	// now the rest of the damage is going to be distributed among other organs
 	var/list/to_be_picked_from = target.internal_organs.Copy()
 	while (internal_damage > 0 && to_be_picked_from.len > 0)
 		var/obj/item/organ/internal/organ_picked = pick(to_be_picked_from)
-		internal_damage -= __apply_damage(min(rand(7,19), internal_damage), organ_picked)
+		APPLY_DAMAGE(min(rand(5,19), internal_damage), organ_picked, internal_damage)
 		if (organ_picked.damage >= organ_picked.max_damage) // you can't check if the organ is dead because of immortality of the brain
 			to_be_picked_from.Remove(organ_picked)
 
 
-/mob/living/carbon/proc/__apply_damage(var/dmg, var/obj/item/organ/targeted_organ) // only ment to be used in function above
-	var/can_be_absorbed = targeted_organ.max_damage - targeted_organ.damage
-	var/damage_to_be_applied = min(can_be_absorbed, dmg)
-	targeted_organ.receive_damage(damage_to_be_applied)
-	return damage_to_be_applied // returns damage wich was actually applied
-
+#undef APPLY_DAMAGE
 
 /mob/living/carbon/death(gibbed)
 	// Only execute the below if we successfully died

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -1,6 +1,8 @@
-// _DAMAGE = any rvalue, _PART = lvalue (DO NOT CALCULATE DYNAMICALLY), _RES = any lvalue
-// this macro tries to apply DAMAGE damage to the PART internal organ and
-// then subtracts RES by the damage actually taken
+/**
+* _DAMAGE = any rvalue, _PART = lvalue (DO NOT CALCULATE DYNAMICALLY), _RES = any lvalue
+* this macro tries to apply DAMAGE damage to the PART internal organ and
+* then subtracts RES by the damage actually taken
+*/
 #define APPLY_DAMAGE(_damage, _part, _res) \
 do {\
 	var/can_be_absorbed = _part.max_damage - _part.damage;\


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Dying with non-zero toxin damage results in harm to the liver, in case of liver failure, it also damages the heart and other inner organs. The more toxin damage the more organs suffer
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Increasing significance of the base damage type which didn't prevent from using a defibrillator and usually was negated on heart restart.
https://discord.com/channels/617003227182792704/755125334097133628/975109761089552484
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl: nopeucant
add: Added damage on internal organs in case you die with toxin damage on character. The more toxins the more organs suffer (heart necrosis on 120 dmg, total internal organs failure on 270 dmg)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
