### PR TITLE
Fix: frame cartridge at nuke uplink

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1248,6 +1248,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "FRAME"
 	item = /obj/item/cartridge/frame
 	cost = 4
+	excludefrom = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 
 /datum/uplink_item/stealthy_tools/agent_card
 	name = "Agent ID Card"
@@ -1736,7 +1737,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	The briefcase also feels a little heavier to hold; it has been manufactured to pack a little bit more of a punch if your client needs some convincing."
 	reference = "CASH"
 	item = /obj/item/storage/secure/briefcase/syndie
-	cost = 5 
+	cost = 5
 
 /datum/uplink_item/badass/plasticbag
 	name = "Plastic Bag"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Убирает картридж подставы из аплинка ядерных оперативников.

## Why It's Good For The Game
Фиксит недочет. Больше нельзя купить свиток карпа, арбалет, и голопаразита за нюкера. Изначально это не было возможным, но после изменения логики работы типов аплинков, это стало возможным. Больше нельзя.

## Changelog
:cl:
fix: Nukies can't buy frame cartridge now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
