### PR TITLE
Fix: Правильно показывать антагонистов в Orbit

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -80,7 +80,7 @@
 
 				if(GLOB.ts_spiderlist.len && M.ckey)
 					other_antags += list(
-						"Terror Spiders" = GLOB.ts_spiderlist.Find(mind.current),
+						"Terror Spiders" = (mind.current in GLOB.ts_spiderlist)
 					)
 
 				if(user.antagHUD)

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -127,7 +127,7 @@
 			var/is_antag = other_antags[antag_name]
 			if(!is_antag)
 				continue
-			var/antag_serialized = serialized.Copy()
+			var/list/antag_serialized = serialized.Copy()
 			antag_serialized["antag"] = antag_name
 			antagonists += list(antag_serialized)
 

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -40,6 +40,7 @@
 
 	var/list/alive = list()
 	var/list/antagonists = list()
+	var/list/other_antags = list()
 	var/list/dead = list()
 	var/list/ghosts = list()
 	var/list/misc = list()
@@ -76,6 +77,12 @@
 				alive += list(serialized)
 
 				var/datum/mind/mind = M.mind
+
+				if(GLOB.ts_spiderlist.len && M.ckey)
+					other_antags += list(
+						"Terror Spiders" = GLOB.ts_spiderlist.Find(mind.current),
+					)
+
 				if(user.antagHUD)
 					// If a mind is many antags at once, we'll display all of them, each
 					// under their own antag sub-section.
@@ -90,7 +97,7 @@
 
 					// Not-very-datumized antags follow
 					// Associative list of antag name => whether this mind is this antag
-					var/other_antags = list(
+					other_antags += list(
 						"Changeling" = (mind.changeling != null),
 						"Vampire" = (mind.vampire != null),
 					)
@@ -112,13 +119,13 @@
 							"Xenomorphs" = (mind in SSticker.mode.xenos),
 						)
 
-					for(var/antag_name in other_antags)
-						var/is_antag = other_antags[antag_name]
-						if(!is_antag)
-							continue
-						var/antag_serialized = serialized.Copy()
-						antag_serialized["antag"] = antag_name
-						antagonists += list(antag_serialized)
+				for(var/antag_name in other_antags)
+					var/is_antag = other_antags[antag_name]
+					if(!is_antag)
+						continue
+					var/antag_serialized = serialized.Copy()
+					antag_serialized["antag"] = antag_name
+					antagonists += list(antag_serialized)
 
 		else
 			misc += list(serialized)

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -78,7 +78,7 @@
 
 				var/datum/mind/mind = M.mind
 
-				if(GLOB.ts_spiderlist.len && M.ckey)
+				if (length(GLOB.ts_spiderlist) && M.ckey)
 					other_antags += list(
 						"Terror Spiders" = (mind.current in GLOB.ts_spiderlist)
 					)

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -101,7 +101,7 @@
 							"Wizard's Apprentice" = (mind in SSticker.mode.apprentices),
 							"Nuclear Operative" = (mind in SSticker.mode.syndicates),
 							"Shadowling" = (mind in SSticker.mode.shadows),
-							"Shadowling Thrall" = (mind in SSticker.mode.shadowling_thralls),
+							"Shadowling Thralls" = (mind in SSticker.mode.shadowling_thralls),
 							"Abductor" = (mind in SSticker.mode.abductors),
 							"Revolutionary" = (mind in SSticker.mode.revolutionaries),
 							"Head Revolutionary" = (mind in SSticker.mode.head_revolutionaries),

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -78,11 +78,6 @@
 			else
 				alive += list(serialized)
 
-				if (length(GLOB.ts_spiderlist) && M.ckey)
-					other_antags += list(
-						"Terror Spiders" = (mind.current in GLOB.ts_spiderlist)
-					)
-
 				if(user.antagHUD)
 					// If a mind is many antags at once, we'll display all of them, each
 					// under their own antag sub-section.

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -104,6 +104,12 @@
 							"Shadowling Thrall" = (mind in SSticker.mode.shadowling_thralls),
 							"Abductor" = (mind in SSticker.mode.abductors),
 							"Revolutionary" = (mind in SSticker.mode.revolutionaries),
+							"Head Revolutionary" = (mind in SSticker.mode.head_revolutionaries),
+							"Abductees" = (mind in SSticker.mode.abductees),
+							"Devils" = (mind in SSticker.mode.devils),
+							"Event Roles" = (mind in SSticker.mode.eventmiscs),
+							"Vampire Thralls" = (mind in SSticker.mode.vampire_enthralled),
+							"Xenomorphs" = (mind in SSticker.mode.xenos),
 						)
 
 					for(var/antag_name in other_antags)

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -116,8 +116,8 @@
 
 		else if (istype(M, /obj/structure/blob/core))
 			var/obj/structure/blob/core/core = M
-			if(core.overmind?.mind && core.overmind?.key) // Почему-то срабатывает даже при core.overmind = null
-				other_antags += list("Blob Cores" = (core.overmind?.mind in SSticker.mode.blob_overminds))
+			if(core.overmind && core.overmind.mind && core.overmind.key)
+				other_antags += list("Blob Cores" = (core.overmind.mind in SSticker.mode.blob_overminds))
 			else
 				misc += list(serialized)
 		else

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -65,6 +65,8 @@
 		serialized["ref"] = "\ref[M]"
 
 		if(istype(M))
+			var/datum/mind/mind = M.mind
+
 			if(isnewplayer(M))  // People in the lobby screen; only have their ckey as a name.
 				continue
 			if(isobserver(M))
@@ -75,8 +77,6 @@
 				dead += list(serialized)
 			else
 				alive += list(serialized)
-
-				var/datum/mind/mind = M.mind
 
 				if(GLOB.ts_spiderlist.len && M.ckey)
 					other_antags += list(
@@ -119,16 +119,22 @@
 							"Xenomorphs" = (mind in SSticker.mode.xenos),
 						)
 
-				for(var/antag_name in other_antags)
-					var/is_antag = other_antags[antag_name]
-					if(!is_antag)
-						continue
-					var/antag_serialized = serialized.Copy()
-					antag_serialized["antag"] = antag_name
-					antagonists += list(antag_serialized)
-
+		else if (istype(M, /obj/structure/blob/core))
+			var/obj/structure/blob/core/core = M
+			if(core.overmind?.mind && core.overmind?.key) // Почему-то срабатывает даже при core.overmind = null
+				other_antags += list("Blob Cores" = (core.overmind?.mind in SSticker.mode.blob_overminds))
+			else
+				misc += list(serialized)
 		else
 			misc += list(serialized)
+
+		for(var/antag_name in other_antags)
+			var/is_antag = other_antags[antag_name]
+			if(!is_antag)
+				continue
+			var/antag_serialized = serialized.Copy()
+			antag_serialized["antag"] = antag_name
+			antagonists += list(antag_serialized)
 
 	data["alive"] = alive
 	data["antagonists"] = antagonists


### PR DESCRIPTION
[Предложка (принята)](https://discord.com/channels/617003227182792704/755125334097133628/977523223010889738).

**Пожалуйста, вливайте на Вегу + Клео для теста, я не уверен что на локалке протестил все кейсы, особенно если много игроков.**

## What Does This PR Do

Orbit теперь будет показывать антагонистов как антагонистов. 

### Всегда (видны как антаги для всех призраков)
* Блоб

### При включённом Antag HUD
* Главы революции (отдельно от революционеров)
* Жертвы абдукторов
* Дьяволы
* Рабы вампиров
* Ксеноморфы (только рождённых из яйца в гуманоиде или раундстартовых, но не щитспавн)
* Ивентовые роли


## Why It's Good For The Game
Всех антагов теперь легко находить через Orbit

## Images of changes
Не смотрите что на скринах есть перевод меню — он не входит в эту правку.
![Ксеноморфы](https://user-images.githubusercontent.com/3854741/168926147-39039db6-e280-4300-a8a2-0648b91a9eb2.png)
![Хэдревы](https://user-images.githubusercontent.com/3854741/168926150-2d13a0ac-1c66-4f1c-bc57-0895d330fecd.png)
![похищенные абдукторами](https://user-images.githubusercontent.com/3854741/168926151-04fd5354-18af-4a00-aa09-1bd1824352ea.png)
![ивентрольки](https://user-images.githubusercontent.com/3854741/168926155-9dfff402-7f7f-4a85-8fed-d616fa23d2f2.png)
![Дьяволы](https://user-images.githubusercontent.com/3854741/168926156-422d1e34-2a40-46a0-a1ed-f2ab5d3fb26e.png)

## Changelog

:cl:
fix: Правильно показываются антагонисты в Orbit
/:cl: