### PR TITLE
Immortality nerf

### DIFF
--- a/code/modules/awaymissions/mission_code/wildwest.dm
+++ b/code/modules/awaymissions/mission_code/wildwest.dm
@@ -166,7 +166,7 @@
 		to_chat(C, "<span class='notice'>You're not dead yet!</span>")
 		return
 	to_chat(C, "<span class='notice'>Death is not your end!</span>")
-	addtimer(CALLBACK(src, C.resurrect(), usr), rand(80 SECONDS,120 SECONDS))
+	addtimer(CALLBACK(C, .proc/resurrect, C), rand(80 SECONDS, 120 SECONDS))
 
 /mob/living/carbon/proc/resurrect(var/mob/living/carbon/C)
 	C.revive()

--- a/code/modules/awaymissions/mission_code/wildwest.dm
+++ b/code/modules/awaymissions/mission_code/wildwest.dm
@@ -162,17 +162,17 @@
 	set name = "Resurrection"
 
 	var/mob/living/carbon/C = usr
-	if(C.stat == DEAD)
-		to_chat(C, "<span class='notice'>Death is not your end!</span>")
+	if(C.stat != DEAD)
+		to_chat(C, "<span class='notice'>You're not dead yet!</span>")
+		return
+	to_chat(C, "<span class='notice'>Death is not your end!</span>")
+	addtimer(CALLBACK(src, C.resurrect(), usr), rand(80 SECONDS,120 SECONDS))
 
-		spawn(rand(800,1200))
-			C.revive()
-			to_chat(C, "<span class='notice'>You have regenerated.</span>")
-			C.visible_message("<span class='warning'>[usr] appears to wake from the dead, having healed all wounds.</span>")
-		return 1
-
-	to_chat(C, "<span class='notice'>You're not dead yet!</span>")
-	return
+/mob/living/carbon/proc/resurrect(var/mob/living/carbon/C)
+	C.revive()
+	to_chat(C, "<span class='notice'>You have regenerated.</span>")
+	C.visible_message("<span class='warning'>[usr] appears to wake from the dead, having healed all wounds.</span>")
+	return 1
 
 /obj/item/wildwest_communicator
 	name = "Syndicate Comms Device"

--- a/code/modules/awaymissions/mission_code/wildwest.dm
+++ b/code/modules/awaymissions/mission_code/wildwest.dm
@@ -168,10 +168,10 @@
 	to_chat(C, "<span class='notice'>Death is not your end!</span>")
 	addtimer(CALLBACK(C, .proc/resurrect, C), rand(80 SECONDS, 120 SECONDS))
 
-/mob/living/carbon/proc/resurrect(var/mob/living/carbon/C)
-	C.revive()
-	to_chat(C, "<span class='notice'>You have regenerated.</span>")
-	C.visible_message("<span class='warning'>[usr] appears to wake from the dead, having healed all wounds.</span>")
+/mob/living/carbon/proc/resurrect(var/mob/living/carbon/user)
+	user.revive()
+	to_chat(user, "<span class='notice'>You have regenerated.</span>")
+	user.visible_message("<span class='warning'>[user] appears to wake from the dead, having healed all wounds.</span>")
 	return 1
 
 /obj/item/wildwest_communicator

--- a/code/modules/awaymissions/mission_code/wildwest.dm
+++ b/code/modules/awaymissions/mission_code/wildwest.dm
@@ -162,16 +162,17 @@
 	set name = "Resurrection"
 
 	var/mob/living/carbon/C = usr
-	if(!C.stat)
-		to_chat(C, "<span class='notice'>You're not dead yet!</span>")
-		return
-	to_chat(C, "<span class='notice'>Death is not your end!</span>")
+	if(C.stat == DEAD)
+		to_chat(C, "<span class='notice'>Death is not your end!</span>")
 
-	spawn(rand(800,1200))
-		C.revive()
-		to_chat(C, "<span class='notice'>You have regenerated.</span>")
-		C.visible_message("<span class='warning'>[usr] appears to wake from the dead, having healed all wounds.</span>")
-	return 1
+		spawn(rand(800,1200))
+			C.revive()
+			to_chat(C, "<span class='notice'>You have regenerated.</span>")
+			C.visible_message("<span class='warning'>[usr] appears to wake from the dead, having healed all wounds.</span>")
+		return 1
+
+	to_chat(C, "<span class='notice'>You're not dead yet!</span>")
+	return
 
 /obj/item/wildwest_communicator
 	name = "Syndicate Comms Device"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Меняет проверку у прока immortality, который достаётся с гейта.
Теперь только после смерти работает этот прок.

## Why It's Good For The Game
Больше нельзя уснуть, чтобы полностью восстановится

## Changelog
:cl:
fix: if in proc/immortality
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
