### PR TITLE
fix: medical and science berets for all med and sci stuff.

### DIFF
--- a/code/modules/client/preference/loadout/loadout_hat.dm
+++ b/code/modules/client/preference/loadout/loadout_hat.dm
@@ -148,12 +148,12 @@
 /datum/gear/hat/beret_job/sci
 	display_name = "science beret"
 	path = /obj/item/clothing/head/beret/sci
-	allowed_roles = list("Research Director", "Scientist")
+	allowed_roles = list("Research Director", "Scientist", "Roboticist", "Geneticist")
 
 /datum/gear/hat/beret_job/med
 	display_name = "medical beret"
 	path = /obj/item/clothing/head/beret/med
-	allowed_roles = list("Chief Medical Officer", "Medical Doctor" , "Virologist", "Brig Physician" , "Coroner")
+	allowed_roles = list("Chief Medical Officer", "Medical Doctor" , "Virologist", "Brig Physician" , "Coroner", "Paramedic", "Chemist", "Geneticist", "Psychiatrist")
 
 /datum/gear/hat/beret_job/eng
 	display_name = "engineering beret"


### PR DESCRIPTION
Данный фикс слегка исправляет лодаут, давая доступ всему мед персоналу станции к медицинским беретам и всему начному составу к научным.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Позволяет парамедику, химику и психиатру носить медицинский берет. Роботехи теперь могут бегать в научном берете. Генетики могут бегать в обоих.

## Why It's Good For The Game
Недоразумение, в котором часть мед отдела не может носить мед берет исправлено. Тоже самое с наукой.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
fix: now sci stuff can wear sci beret, just like all medical stuff can wear medical beret.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
