### PR TITLE
Feat: Месть Библии

### DIFF
--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -10,6 +10,8 @@
 	var/deity_name = "Christ"
 	/// Is the sprite of this bible customisable
 	var/customisable = FALSE
+	var/god_punishment = 0 //used for diffrent abuse with bible (healing self is one of them)
+	var/last_used = 0
 
 	/// Associative list of accociative lists of bible variants, used for the radial menu
 	var/static/list/bible_variants = list(
@@ -67,8 +69,14 @@
 				H.UpdateDamageIcon()
 	return
 
+/obj/item/storage/bible/proc/god_forgive()
+	god_punishment -= round((world.time - last_used) / 300) //forgive 1 sin every 30 seconds
+	last_used = world.time
+	god_punishment = max(0, god_punishment)
+
 /obj/item/storage/bible/attack(mob/living/M, mob/living/user)
 	add_attack_logs(user, M, "Hit with [src]")
+	god_forgive() //god forgives everyone
 	if(!iscarbon(user))
 		M.LAssailant = null
 	else
@@ -90,6 +98,7 @@
 
 	if(M.stat != DEAD && ishuman(M))
 		var/mob/living/carbon/human/H = M
+		var/mob/living/carbon/human/chaplain = user
 		if(prob(60))
 			bless(H)
 			H.visible_message("<span class='danger>[user] heals [H == user ? "[user.p_them()]self" : "[H]"] with the power of [deity_name]!</span>",
@@ -101,6 +110,17 @@
 				to_chat(M, "<span class='warning'>You feel dumber.</span>")
 			H.visible_message("<span class='danger'>[user] beats [H == user ? "[user.p_them()]self" : "[H]"] over the head with [src]!</span>")
 			playsound(src.loc, "punch", 25, 1, -1)
+		if(god_punishment > 5) //lets apply punishment AFTER heal
+			chaplain.electrocute_act(5, "Lightning Bolt", safety = TRUE, override = TRUE)
+			playsound(get_turf(chaplain), 'sound/magic/lightningshock.ogg', 50, 1, -1)
+			chaplain.adjustFireLoss(65)
+			chaplain.Weaken(5)
+			to_chat(chaplain, "<span class='userdanger'>Вы злоупотребили волей своего бога и за что были наказаны!</span>")
+		if(H == chaplain)
+			god_punishment++
+			if(god_punishment == 5)
+				to_chat(chaplain, "<span class='danger'>Вы злоупотребляете покровительством бога [deity_name], остановитесь и подумайте.</span>")
+
 	else
 		M.visible_message("<span class='danger'>[user] smacks [M]'s lifeless corpse with [src].</span>")
 		playsound(src.loc, "punch", 25, 1, -1)

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -70,9 +70,8 @@
 	return
 
 /obj/item/storage/bible/proc/god_forgive()
-	god_punishment -= round((world.time - last_used) / 300) //forgive 1 sin every 30 seconds
+	god_punishment = max(0, god_punishment - round((world.time - last_used) / (30 SECONDS))) //forgive 1 sin every 30 seconds
 	last_used = world.time
-	god_punishment = max(0, god_punishment)
 
 /obj/item/storage/bible/attack(mob/living/M, mob/living/user)
 	add_attack_logs(user, M, "Hit with [src]")
@@ -110,16 +109,17 @@
 				to_chat(M, "<span class='warning'>You feel dumber.</span>")
 			H.visible_message("<span class='danger'>[user] beats [H == user ? "[user.p_them()]self" : "[H]"] over the head with [src]!</span>")
 			playsound(src.loc, "punch", 25, 1, -1)
-		if(god_punishment > 5) //lets apply punishment AFTER heal
+		if(H == chaplain)
+			god_punishment++
+
+		if(god_punishment == 5)
+			to_chat(chaplain, "<h1><span class='danger'>Вы злоупотребляете покровительством бога [deity_name], остановитесь и подумайте.</span></h1>")
+		else if(god_punishment > 5) //lets apply punishment AFTER heal
 			chaplain.electrocute_act(5, "Lightning Bolt", safety = TRUE, override = TRUE)
 			playsound(get_turf(chaplain), 'sound/magic/lightningshock.ogg', 50, 1, -1)
 			chaplain.adjustFireLoss(65)
 			chaplain.Weaken(5)
 			to_chat(chaplain, "<span class='userdanger'>Вы злоупотребили волей бога и за что были наказаны!</span>")
-		if(H == chaplain)
-			god_punishment++
-			if(god_punishment == 5)
-				to_chat(chaplain, "<h1><span class='danger'>Вы злоупотребляете покровительством бога [deity_name], остановитесь и подумайте.</span></h1>")
 
 	else
 		M.visible_message("<span class='danger'>[user] smacks [M]'s lifeless corpse with [src].</span>")

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -110,16 +110,17 @@
 				to_chat(M, "<span class='warning'>You feel dumber.</span>")
 			H.visible_message("<span class='danger'>[user] beats [H == user ? "[user.p_them()]self" : "[H]"] over the head with [src]!</span>")
 			playsound(src.loc, "punch", 25, 1, -1)
-		if(god_punishment > 5) //lets apply punishment AFTER heal
+		if(H == chaplain)
+			god_punishment++
+		
+		if(god_punishment == 5)
+			to_chat(chaplain, "<h1><span class='danger'>Вы злоупотребляете покровительством бога [deity_name], остановитесь и подумайте.</span></h1>")
+		else if(god_punishment > 5) //lets apply punishment AFTER heal
 			chaplain.electrocute_act(5, "Lightning Bolt", safety = TRUE, override = TRUE)
 			playsound(get_turf(chaplain), 'sound/magic/lightningshock.ogg', 50, 1, -1)
 			chaplain.adjustFireLoss(65)
 			chaplain.Weaken(5)
 			to_chat(chaplain, "<span class='userdanger'>Вы злоупотребили волей бога и за что были наказаны!</span>")
-		if(H == chaplain)
-			god_punishment++
-			if(god_punishment == 5)
-				to_chat(chaplain, "<h1><span class='danger'>Вы злоупотребляете покровительством бога [deity_name], остановитесь и подумайте.</span></h1>")
 
 	else
 		M.visible_message("<span class='danger'>[user] smacks [M]'s lifeless corpse with [src].</span>")

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -115,11 +115,11 @@
 			playsound(get_turf(chaplain), 'sound/magic/lightningshock.ogg', 50, 1, -1)
 			chaplain.adjustFireLoss(65)
 			chaplain.Weaken(5)
-			to_chat(chaplain, "<span class='userdanger'>Вы злоупотребили волей своего бога и за что были наказаны!</span>")
+			to_chat(chaplain, "<span class='userdanger'>Вы злоупотребили волей бога и за что были наказаны!</span>")
 		if(H == chaplain)
 			god_punishment++
 			if(god_punishment == 5)
-				to_chat(chaplain, "<span class='danger'>Вы злоупотребляете покровительством бога [deity_name], остановитесь и подумайте.</span>")
+				to_chat(chaplain, "<h1><span class='danger'>Вы злоупотребляете покровительством бога [deity_name], остановитесь и подумайте.</span></h1>")
 
 	else
 		M.visible_message("<span class='danger'>[user] smacks [M]'s lifeless corpse with [src].</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Добавляет ограничение на Библию в виде смайта (70 урона и сообщение) после 5 ударов по голове самому себе.
Имеется откат в виде 30 секунд за удар.
[Окончание голосования.](https://discord.com/channels/617003227182792704/755125334097133628/977413194433847326)

## Why It's Good For The Game
Священник получит дебафф к своей самой сильной стороне.

## Images of changes
![image](https://user-images.githubusercontent.com/87372121/169639187-b663d2d7-37b7-48fa-8e43-f7370554b828.png)


## Changelog
:cl:
add: smite for bible abusers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
