### PR TITLE
Fix: При простуде люди теперь «шмыгают носом», а не «нюхают»

### DIFF
--- a/code/datums/diseases/advance/symptoms/sneeze.dm
+++ b/code/datums/diseases/advance/symptoms/sneeze.dm
@@ -32,7 +32,7 @@ Bonus
 		var/mob/living/M = A.affected_mob
 		switch(A.stage)
 			if(1, 2, 3)
-				M.emote("sniff")
+				M.emote("snuffle")
 			else
 				M.emote("sneeze")
 				A.spread(5)

--- a/code/modules/mob/emote_panel_ru.dm
+++ b/code/modules/mob/emote_panel_ru.dm
@@ -148,6 +148,11 @@
 	set category = "Эмоции"
 	usr.emote("sniff")
 
+/mob/living/carbon/human/verb/emote_snuffle()
+	set name = "~ Шмыгать носом "
+	set category = "Эмоции"
+	usr.emote("snuffle")
+
 /mob/living/carbon/human/verb/emote_snore()
 	set name = "> Храпеть "
 	set category = "Эмоции"

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -834,6 +834,13 @@
 			if(miming)
 				m_type = 1
 
+		if("snuffle")
+			message = pluralize_ru(gender,"шмыгает","шмыгают") + " носом."
+			m_type = 2
+			if(miming)
+				message = "беззвучно " + message
+				m_type = 1
+
 		if("snore", "snores")
 			if(miming)
 				message = "крепко спит."


### PR DESCRIPTION
## What Does This PR Do
Эмоция «нюхать» (sniff) теперь не воспроизводится вирусом простуды, вместо неё воспроизводится новая эмоция «Шмыгать носом» (snuffle)

[Просьба администратора Eshi](https://discord.com/channels/@me/929694066462036009/977491261302906930) 

## Why It's Good For The Game
> обычно никто не юзает этот эмоут сам по себе, но зато его спамит вирус. И получается, что больные вирусом не "шмыгают", а "нюхают". Такой сюр.

## Changelog
:cl:
add: Добавлена эмоция «Шмыгать носом»
fix: При простуде люди теперь «шмыгают носом», а не «нюхают».
/:cl:
