### PR TITLE
Whitship MedShuttle Zombie Tweaks, cosmetic adds

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/whiteship.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/whiteship.dmm
@@ -62,13 +62,16 @@
 	desc = "The undead. Its good time to RUN!";
 	faction = list("zombie");
 	harm_intent_damage = 10;
-	health = 85;
+	health = 81;
 	icon = 'icons/mob/human.dmi';
 	icon_living = "zombie2_s";
 	icon_state = "zombie2_s";
 	loot = list(/obj/effect/decal/cleanable/blood/gibs);
 	maxHealth = 100;
+	melee_damage_lower = 13;
+	melee_damage_upper = 25;
 	name = "Zombie";
+	obj_damage = 80;
 	response_help = "gently probs";
 	speak = list("RAWR!","Rawr!","GRR!","Growl!");
 	speak_chance = 1;
@@ -156,6 +159,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
+/obj/item/paper,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "dark"
@@ -245,6 +249,7 @@
 	pixel_y = 26;
 	specialfunctions = 4
 	},
+/obj/item/paper,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "dark"
@@ -346,8 +351,7 @@
 /obj/machinery/atmospherics/unary/passive_vent{
 	dir = 1
 	},
-/obj/structure/closet/l3closet,
-/obj/item/clothing/mask/gas,
+/obj/structure/table,
 /turf/simulated/floor/plasteel{
 	icon_state = "barber"
 	},
@@ -456,6 +460,9 @@
 	desc = "Bluer than the standard model. Still look like a new one";
 	name = "old chief medical officer's labcoat"
 	},
+/obj/item/clothing/accessory/stethoscope{
+	desc = "An outdated medical apparatus for listening to the sounds of the human body. It also makes you look like you know what you're doing. It has small lable on it - James's Bane"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "darkblue"
@@ -502,6 +509,27 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs,
+/mob/living/simple_animal/hostile/creature{
+	del_on_death = 1;
+	desc = "The undead! Its good time to RUN!";
+	faction = list("zombie");
+	harm_intent_damage = 10;
+	health = 45;
+	icon = 'icons/mob/human.dmi';
+	icon_living = "zombie_s";
+	icon_state = "zombie_s";
+	loot = list(/obj/effect/decal/cleanable/blood/gibs);
+	maxHealth = 75;
+	melee_damage_lower = 10;
+	melee_damage_upper = 17;
+	name = "Fast zombie";
+	obj_damage = 60;
+	response_help = "gently probs";
+	speak = list("RAWR!","Rawr!","GRR!","Growl!");
+	speak_chance = 1;
+	speak_emote = list("growls","roars");
+	speed = -1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "dark"
@@ -527,6 +555,7 @@
 	pixel_y = -24;
 	specialfunctions = 4
 	},
+/obj/effect/decal/cleanable/blood/splatter,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
@@ -559,6 +588,13 @@
 	dir = 3;
 	icon_state = "swall1"
 	},
+/area/shuttle/abandoned)
+"kD" = (
+/obj/item/paper{
+	info = "whoever find this - the shuttle is under quarantine! We don't know what was that but it m..";
+	name = "note"
+	},
+/turf/simulated/floor/plating,
 /area/shuttle/abandoned)
 "kM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -730,8 +766,9 @@
 /turf/simulated/floor/plating,
 /area/shuttle/abandoned)
 "nP" = (
-/obj/machinery/iv_drip,
 /obj/machinery/light/built,
+/obj/structure/closet/l3closet,
+/obj/item/clothing/mask/gas,
 /turf/simulated/floor/plasteel{
 	icon_state = "barber"
 	},
@@ -869,6 +906,27 @@
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 8
 	},
+/mob/living/simple_animal/hostile/creature{
+	del_on_death = 1;
+	desc = "The undead! Its good time to RUN!";
+	faction = list("zombie");
+	harm_intent_damage = 10;
+	health = 60;
+	icon = 'icons/mob/human.dmi';
+	icon_living = "zombie_s";
+	icon_state = "zombie_s";
+	loot = list(/obj/effect/decal/cleanable/blood/gibs);
+	maxHealth = 75;
+	melee_damage_lower = 10;
+	melee_damage_upper = 17;
+	name = "Fast zombie";
+	obj_damage = 60;
+	response_help = "gently probs";
+	speak = list("RAWR!","Rawr!","GRR!","Growl!");
+	speak_chance = 1;
+	speak_emote = list("growls","roars");
+	speed = -1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -881,6 +939,27 @@
 /obj/effect/decal/cleanable/blood/drip,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
+	},
+/mob/living/simple_animal/hostile/creature{
+	del_on_death = 1;
+	desc = "The undead! Its good time to RUN!";
+	faction = list("zombie");
+	harm_intent_damage = 10;
+	health = 45;
+	icon = 'icons/mob/human.dmi';
+	icon_living = "zombie_s";
+	icon_state = "zombie_s";
+	loot = list(/obj/effect/decal/cleanable/blood/gibs);
+	maxHealth = 75;
+	melee_damage_lower = 10;
+	melee_damage_upper = 17;
+	name = "Fast zombie";
+	obj_damage = 60;
+	response_help = "gently probs";
+	speak = list("RAWR!","Rawr!","GRR!","Growl!");
+	speak_chance = 1;
+	speak_emote = list("growls","roars");
+	speed = -1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "barber"
@@ -932,6 +1011,7 @@
 /obj/structure/sign/vacuum{
 	pixel_y = -32
 	},
+/obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
@@ -969,6 +1049,27 @@
 "sO" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
+	},
+/mob/living/simple_animal/hostile/creature{
+	del_on_death = 1;
+	desc = "The undead! Its good time to RUN!";
+	faction = list("zombie");
+	harm_intent_damage = 10;
+	health = 60;
+	icon = 'icons/mob/human.dmi';
+	icon_living = "zombie_s";
+	icon_state = "zombie_s";
+	loot = list(/obj/effect/decal/cleanable/blood/gibs);
+	maxHealth = 75;
+	melee_damage_lower = 10;
+	melee_damage_upper = 17;
+	name = "Fast zombie";
+	obj_damage = 60;
+	response_help = "gently probs";
+	speak = list("RAWR!","Rawr!","GRR!","Growl!");
+	speak_chance = 1;
+	speak_emote = list("growls","roars");
+	speed = -1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -1118,24 +1219,6 @@
 /obj/structure/closet/medical_wall{
 	pixel_x = 32
 	},
-/mob/living/simple_animal/hostile/creature{
-	del_on_death = 1;
-	desc = "The undead. Its good time to RUN!";
-	faction = list("zombie");
-	harm_intent_damage = 10;
-	health = 65;
-	icon = 'icons/mob/human.dmi';
-	icon_living = "zombie2_s";
-	icon_state = "zombie2_s";
-	loot = list(/obj/effect/decal/cleanable/blood/gibs);
-	maxHealth = 100;
-	name = "Zombie";
-	response_help = "gently probs";
-	speak = list("RAWR!","Rawr!","GRR!","Growl!");
-	speak_chance = 1;
-	speak_emote = list("growls","roars");
-	speed = 0
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "barber"
 	},
@@ -1165,15 +1248,16 @@
 	desc = "The undead! Its good time to RUN!";
 	faction = list("zombie");
 	harm_intent_damage = 10;
-	health = 60;
+	health = 45;
 	icon = 'icons/mob/human.dmi';
 	icon_living = "zombie_s";
 	icon_state = "zombie_s";
 	loot = list(/obj/effect/decal/cleanable/blood/gibs);
 	maxHealth = 75;
-	melee_damage_lower = 15;
-	melee_damage_upper = 30;
+	melee_damage_lower = 10;
+	melee_damage_upper = 17;
 	name = "Fast zombie";
+	obj_damage = 60;
 	response_help = "gently probs";
 	speak = list("RAWR!","Rawr!","GRR!","Growl!");
 	speak_chance = 1;
@@ -1199,6 +1283,7 @@
 	},
 /area/shuttle/abandoned)
 "wG" = (
+/obj/machinery/iv_drip,
 /turf/simulated/floor/plasteel{
 	icon_state = "barber"
 	},
@@ -1224,15 +1309,16 @@
 	desc = "The undead! Its good time to RUN!";
 	faction = list("zombie");
 	harm_intent_damage = 10;
-	health = 45;
+	health = 60;
 	icon = 'icons/mob/human.dmi';
 	icon_living = "zombie_s";
 	icon_state = "zombie_s";
 	loot = list(/obj/effect/decal/cleanable/blood/gibs);
 	maxHealth = 75;
-	melee_damage_lower = 15;
-	melee_damage_upper = 30;
+	melee_damage_lower = 10;
+	melee_damage_upper = 17;
 	name = "Fast zombie";
+	obj_damage = 60;
 	response_help = "gently probs";
 	speak = list("RAWR!","Rawr!","GRR!","Growl!");
 	speak_chance = 1;
@@ -1359,26 +1445,6 @@
 "yE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hologram/holopad,
-/mob/living/simple_animal/hostile/creature{
-	del_on_death = 1;
-	desc = "The undead! Its good time to RUN!";
-	faction = list("zombie");
-	harm_intent_damage = 10;
-	health = 20;
-	icon = 'icons/mob/human.dmi';
-	icon_living = "zombie_s";
-	icon_state = "zombie_s";
-	loot = list(/obj/effect/decal/cleanable/blood/gibs);
-	maxHealth = 75;
-	melee_damage_lower = 15;
-	melee_damage_upper = 30;
-	name = "Fast zombie";
-	response_help = "gently probs";
-	speak = list("RAWR!","Rawr!","GRR!","Growl!");
-	speak_chance = 1;
-	speak_emote = list("growls","roars");
-	speed = -1
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "dark"
@@ -1399,6 +1465,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
 	},
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_x = -3;
+	pixel_y = 13
+	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "darkblue"
@@ -1407,26 +1477,6 @@
 "yU" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
-	},
-/mob/living/simple_animal/hostile/creature{
-	del_on_death = 1;
-	desc = "The undead! Its good time to RUN!";
-	faction = list("zombie");
-	harm_intent_damage = 10;
-	health = 60;
-	icon = 'icons/mob/human.dmi';
-	icon_living = "zombie_s";
-	icon_state = "zombie_s";
-	loot = list(/obj/effect/decal/cleanable/blood/gibs);
-	maxHealth = 75;
-	melee_damage_lower = 15;
-	melee_damage_upper = 30;
-	name = "Fast zombie";
-	response_help = "gently probs";
-	speak = list("RAWR!","Rawr!","GRR!","Growl!");
-	speak_chance = 1;
-	speak_emote = list("growls","roars");
-	speed = -1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -1565,6 +1615,27 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/item/storage/belt/medical,
+/mob/living/simple_animal/hostile/creature{
+	del_on_death = 1;
+	desc = "The undead! Its good time to RUN!";
+	faction = list("zombie");
+	harm_intent_damage = 10;
+	health = 45;
+	icon = 'icons/mob/human.dmi';
+	icon_living = "zombie_s";
+	icon_state = "zombie_s";
+	loot = list(/obj/effect/decal/cleanable/blood/gibs);
+	maxHealth = 75;
+	melee_damage_lower = 10;
+	melee_damage_upper = 17;
+	name = "Fast zombie";
+	obj_damage = 60;
+	response_help = "gently probs";
+	speak = list("RAWR!","Rawr!","GRR!","Growl!");
+	speak_chance = 1;
+	speak_emote = list("growls","roars");
+	speed = -1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "dark"
@@ -1727,6 +1798,7 @@
 	},
 /obj/structure/fans/tiny,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/plating,
 /area/shuttle/abandoned)
 "EF" = (
@@ -1842,6 +1914,27 @@
 /area/shuttle/abandoned)
 "Hf" = (
 /obj/effect/decal/cleanable/blood/drip,
+/mob/living/simple_animal/hostile/creature{
+	del_on_death = 1;
+	desc = "The undead. Its good time to RUN!";
+	faction = list("zombie");
+	harm_intent_damage = 10;
+	health = 81;
+	icon = 'icons/mob/human.dmi';
+	icon_living = "zombie2_s";
+	icon_state = "zombie2_s";
+	loot = list(/obj/effect/decal/cleanable/blood/gibs);
+	maxHealth = 100;
+	melee_damage_lower = 13;
+	melee_damage_upper = 25;
+	name = "Zombie";
+	obj_damage = 80;
+	response_help = "gently probs";
+	speak = list("RAWR!","Rawr!","GRR!","Growl!");
+	speak_chance = 1;
+	speak_emote = list("growls","roars");
+	speed = 0
+	},
 /turf/simulated/floor/plasteel,
 /area/shuttle/abandoned)
 "Hu" = (
@@ -1895,6 +1988,7 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/paper,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "dark"
@@ -1979,13 +2073,16 @@
 	desc = "The undead. Its good time to RUN!";
 	faction = list("zombie");
 	harm_intent_damage = 10;
-	health = 65;
+	health = 81;
 	icon = 'icons/mob/human.dmi';
 	icon_living = "zombie2_s";
 	icon_state = "zombie2_s";
 	loot = list(/obj/effect/decal/cleanable/blood/gibs);
 	maxHealth = 100;
+	melee_damage_lower = 13;
+	melee_damage_upper = 25;
 	name = "Zombie";
+	obj_damage = 80;
 	response_help = "gently probs";
 	speak = list("RAWR!","Rawr!","GRR!","Growl!");
 	speak_chance = 1;
@@ -2020,6 +2117,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
+/obj/item/paper{
+	info = "James, if you put your coffee mug into the cryocells I'll personally do a medical treatment for you with my stethoscope around your neck! - CMO";
+	name = "note from cmo"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -2033,26 +2134,6 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/creature{
-	del_on_death = 1;
-	desc = "The undead! Its good time to RUN!";
-	faction = list("zombie");
-	harm_intent_damage = 10;
-	health = 20;
-	icon = 'icons/mob/human.dmi';
-	icon_living = "zombie_s";
-	icon_state = "zombie_s";
-	loot = list(/obj/effect/decal/cleanable/blood/gibs);
-	maxHealth = 75;
-	melee_damage_lower = 15;
-	melee_damage_upper = 30;
-	name = "Fast zombie";
-	response_help = "gently probs";
-	speak = list("RAWR!","Rawr!","GRR!","Growl!");
-	speak_chance = 1;
-	speak_emote = list("growls","roars");
-	speed = -1
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "dark"
@@ -2069,6 +2150,27 @@
 	pixel_x = -4;
 	pixel_y = 32
 	},
+/mob/living/simple_animal/hostile/creature{
+	del_on_death = 1;
+	desc = "The undead. Its good time to RUN!";
+	faction = list("zombie");
+	harm_intent_damage = 10;
+	health = 65;
+	icon = 'icons/mob/human.dmi';
+	icon_living = "zombie2_s";
+	icon_state = "zombie2_s";
+	loot = list(/obj/effect/decal/cleanable/blood/gibs);
+	maxHealth = 100;
+	melee_damage_lower = 13;
+	melee_damage_upper = 25;
+	name = "Zombie";
+	obj_damage = 80;
+	response_help = "gently probs";
+	speak = list("RAWR!","Rawr!","GRR!","Growl!");
+	speak_chance = 1;
+	speak_emote = list("growls","roars");
+	speed = 0
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "barber"
 	},
@@ -2084,7 +2186,11 @@
 	},
 /area/shuttle/abandoned)
 "MM" = (
-/obj/item/wrench/medical,
+/obj/item/crowbar/red{
+	desc = "...";
+	force = 20;
+	name = "Легендарная монтировка"
+	},
 /turf/simulated/floor/plasteel,
 /area/shuttle/abandoned)
 "MY" = (
@@ -2161,13 +2267,16 @@
 	desc = "The undead. Its good time to RUN!";
 	faction = list("zombie");
 	harm_intent_damage = 10;
-	health = 85;
+	health = 65;
 	icon = 'icons/mob/human.dmi';
 	icon_living = "zombie2_s";
 	icon_state = "zombie2_s";
 	loot = list(/obj/effect/decal/cleanable/blood/gibs);
 	maxHealth = 100;
+	melee_damage_lower = 13;
+	melee_damage_upper = 25;
 	name = "Zombie";
+	obj_damage = 80;
 	response_help = "gently probs";
 	speak = list("RAWR!","Rawr!","GRR!","Growl!");
 	speak_chance = 1;
@@ -2197,6 +2306,7 @@
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 8
 	},
+/obj/item/paper,
 /turf/simulated/floor/plasteel{
 	icon_state = "barber"
 	},
@@ -2276,7 +2386,6 @@
 	},
 /obj/structure/table,
 /obj/item/paper_bin,
-/obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "darkblue"
@@ -2305,26 +2414,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/under/retro/medical{
 	name = "old medical officer's uniform"
-	},
-/mob/living/simple_animal/hostile/creature{
-	del_on_death = 1;
-	desc = "The undead! Its good time to RUN!";
-	faction = list("zombie");
-	harm_intent_damage = 10;
-	health = 45;
-	icon = 'icons/mob/human.dmi';
-	icon_living = "zombie_s";
-	icon_state = "zombie_s";
-	loot = list(/obj/effect/decal/cleanable/blood/gibs);
-	maxHealth = 75;
-	melee_damage_lower = 15;
-	melee_damage_upper = 30;
-	name = "Fast zombie";
-	response_help = "gently probs";
-	speak = list("RAWR!","Rawr!","GRR!","Growl!");
-	speak_chance = 1;
-	speak_emote = list("growls","roars");
-	speed = -1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -2357,6 +2446,7 @@
 /area/shuttle/abandoned)
 "QN" = (
 /obj/effect/decal/cleanable/blood,
+/obj/item/paper,
 /turf/simulated/floor/plasteel{
 	icon_state = "barber"
 	},
@@ -2385,11 +2475,7 @@
 /area/shuttle/abandoned)
 "Sh" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/crowbar/red{
-	desc = "...";
-	force = 20;
-	name = "Легендарная монтировка"
-	},
+/obj/item/wrench/medical,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull";
 	tag = "icon-whitebluefull"
@@ -2614,26 +2700,6 @@
 	},
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/creature{
-	del_on_death = 1;
-	desc = "The undead! Its good time to RUN!";
-	faction = list("zombie");
-	harm_intent_damage = 10;
-	health = 45;
-	icon = 'icons/mob/human.dmi';
-	icon_living = "zombie_s";
-	icon_state = "zombie_s";
-	loot = list(/obj/effect/decal/cleanable/blood/gibs);
-	maxHealth = 75;
-	melee_damage_lower = 15;
-	melee_damage_upper = 30;
-	name = "Fast zombie";
-	response_help = "gently probs";
-	speak = list("RAWR!","Rawr!","GRR!","Growl!");
-	speak_chance = 1;
-	speak_emote = list("growls","roars");
-	speed = -1
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull";
 	tag = "icon-whitebluefull"
@@ -2653,13 +2719,16 @@
 	desc = "The undead. Its good time to RUN!";
 	faction = list("zombie");
 	harm_intent_damage = 10;
-	health = 65;
+	health = 81;
 	icon = 'icons/mob/human.dmi';
 	icon_living = "zombie2_s";
 	icon_state = "zombie2_s";
 	loot = list(/obj/effect/decal/cleanable/blood/gibs);
 	maxHealth = 100;
+	melee_damage_lower = 13;
+	melee_damage_upper = 25;
 	name = "Zombie";
+	obj_damage = 80;
 	response_help = "gently probs";
 	speak = list("RAWR!","Rawr!","GRR!","Growl!");
 	speak_chance = 1;
@@ -2699,24 +2768,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
-	},
-/mob/living/simple_animal/hostile/creature{
-	del_on_death = 1;
-	desc = "The undead. Its good time to RUN!";
-	faction = list("zombie");
-	harm_intent_damage = 10;
-	health = 35;
-	icon = 'icons/mob/human.dmi';
-	icon_living = "zombie2_s";
-	icon_state = "zombie2_s";
-	loot = list(/obj/effect/decal/cleanable/blood/gibs);
-	maxHealth = 100;
-	name = "Zombie";
-	response_help = "gently probs";
-	speak = list("RAWR!","Rawr!","GRR!","Growl!");
-	speak_chance = 1;
-	speak_emote = list("growls","roars");
-	speed = 0
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "barber"
@@ -2758,6 +2809,7 @@
 /area/shuttle/abandoned)
 "Zr" = (
 /obj/item/gun/energy/gun/mini,
+/obj/item/paper,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "dark"
@@ -2790,6 +2842,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/reagent_containers/food/drinks/mug/med,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -2952,7 +3005,7 @@ XL
 kc
 GK
 kc
-Td
+kD
 kc
 JI
 GK


### PR DESCRIPTION
Balancing mobs on ruin map whiteship.dmm aka Whiteship or NT Medical Shuttle
Few cosmetic adds

## What Does This PR Do
* Tweak health and damage of both zombie types to lower values. 
* Added 3 mugs, stethoscope and 2 notes.

## Why It's Good For The Game
Most times zombie not just beat players but breaks their limbs and make internal bleeding. From now, it could be a bit easy to beat them but will see. Its not Gate map so it should be easier than it was before.


