### PR TITLE
Fix: Щит культа только для культа

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -517,8 +517,9 @@
 			to_chat(holder, "<span class='warning'>[src] vibrates slightly, and starts glowing.")
 
 /obj/item/shield/mirror/IsReflect()
-	if(prob(reflect_chance))
-		return TRUE
+	if(isliving(loc))
+		var/mob/living/holder = loc
+		return prob(reflect_chance) && iscultist(holder) //so non-cultist can not reflect using this shield
 	return FALSE
 
 /obj/item/twohanded/cult_spear


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Добавляет проверку на культиста, чтобы обычный экипаж не мог отражать снаряды используя щит культа.

## Why It's Good For The Game
Вещи культистов не должны работать в руках не культей.

## Changelog
:cl:
fix: cult shield now reflects only in cultist's hands
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
