### PR TITLE
Malf nerf

### DIFF
--- a/code/ATMOSPHERICS/pipes/pipe.dm
+++ b/code/ATMOSPHERICS/pipes/pipe.dm
@@ -7,6 +7,7 @@
 	can_unwrench = 1
 	damage_deflection = 12
 	var/alert_pressure = 80*ONE_ATMOSPHERE //minimum pressure before check_pressure(...) should be called
+	resistance_flags = NO_MALF_EFFECT
 
 	//Buckling
 	can_buckle = TRUE

--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -142,6 +142,7 @@
 #define ACID_PROOF		(1<<5) //acid stuck on it doesn't melt it.
 #define INDESTRUCTIBLE	(1<<6) //doesn't take damage
 #define FREEZE_PROOF	(1<<7) //can't be frozen
+#define NO_MALF_EFFECT	(1<<8) //So malf cannot blow certain things
 
 #define MEAT 		1
 #define VEGETABLES 	2

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -503,6 +503,9 @@
 	if(!istype(target))
 		to_chat(ranged_ability_user, "<span class='warning'>You can only overload machines!</span>")
 		return
+	if(target.resistance_flags & NO_MALF_EFFECT)
+		to_chat(ranged_ability_user, "<span class='warning'>That machine can't be overloaded!</span>")
+		return
 
 	ranged_ability_user.playsound_local(ranged_ability_user, "sparks", 50, 0)
 	attached_action.adjust_uses(-1)
@@ -555,7 +558,7 @@
 	if(!istype(target))
 		to_chat(ranged_ability_user, "<span class='warning'>You can only animate machines!</span>")
 		return
-	if(!target.can_be_overridden())
+	if(target.resistance_flags & NO_MALF_EFFECT)
 		to_chat(ranged_ability_user, "<span class='warning'>That machine can't be overridden!</span>")
 		return
 

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -13,7 +13,7 @@ GLOBAL_VAR(bomb_set)
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "nuclearbomb0"
 	density = 1
-	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | NO_MALF_EFFECT
 	var/extended = FALSE
 	var/lighthack = FALSE
 	var/timeleft = 120

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -640,9 +640,6 @@ Class Procs:
 /obj/machinery/proc/on_deconstruction()
 	return
 
-/obj/machinery/proc/can_be_overridden()
-	. = 1
-
 /obj/machinery/tesla_act(power, explosive = FALSE)
 	..()
 	if(prob(85) && explosive)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -36,7 +36,7 @@
 	density = 1
 	anchored = FALSE
 	light_range = 4
-	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF | NO_MALF_EFFECT
 
 
 	var/gasefficency = 0.125


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
~~Частично переносит с оффов [этот фикс](https://github.com/ParadiseSS13/Paradise/pull/17708)~~
Добавляет флаг NO_MALF_EFFECT и даёт этот флаг трубам, СМу, ядерной боеголовке.
Теперь по этому флагу проверяется, может ли малф взломать машинери.
Убирает не нужную функцию у машинери.

## Why It's Good For The Game
Малф не сможет взорвать кристалл и трубы

## Changelog
:cl:
fix: malf's ability to blow up / animate things
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
