### PR TITLE
fix: Игрушечные мечи больше не убивают

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -302,7 +302,7 @@
 	..()
 	if((CLUMSY in user.mutations) && (wielded) && prob(40))
 		to_chat(user, "<span class='warning'>You twirl around a bit before losing your balance and impaling yourself on the [src].</span>")
-		if(force == 0)//so toy swords cannot kill clowns
+		if(!force)//so toy swords cannot kill clowns
 			return
 		user.take_organ_damage(20, 25)
 		return

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -302,6 +302,8 @@
 	..()
 	if((CLUMSY in user.mutations) && (wielded) && prob(40))
 		to_chat(user, "<span class='warning'>You twirl around a bit before losing your balance and impaling yourself on the [src].</span>")
+		if(force == 0)//so toy swords cannot kill clowns
+			return
 		user.take_organ_damage(20, 25)
 		return
 	if((wielded) && prob(50))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Добавляет проверку для dualsaber'а на урон, чтобы любой с геном CLUMSY не помирал от ударов по себе.

## Why It's Good For The Game
Клоуны смогут бегать с двойными игрушечными мечами и не помирать

## Changelog
:cl:
fix: now clown cannot die by toy swords
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
