### PR TITLE
Fix: Невлезайки в окне автолата

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -85,7 +85,7 @@
 /obj/machinery/autolathe/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = TRUE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
-		ui = new(user, src, ui_key, "Autolathe", name, 780, 700, master_ui, state)
+		ui = new(user, src, ui_key, "Autolathe", name, 800, 700, master_ui, state)
 		ui.open()
 
 


### PR DESCRIPTION
## What Does This PR Do
Чуть расширяет окно автолата под название платы

## Images of changes
![изображение](https://user-images.githubusercontent.com/3854741/171296985-f0124b5a-184e-4a86-a348-5aeae623256b.png)

## Changelog
:cl:
fix: Чуть расширяет окно автолата под название платы
/:cl: