### PR TITLE
fix: Emergency locker в старом ксено теперь открывается на свободный тайл

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -30633,9 +30633,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/closet/walllocker/emerglocker{
-	pixel_x = -32
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/xenozoo)
 "cLA" = (
@@ -73865,7 +73862,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/area/maintenance/xenozoo,
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_x = -32;
+	pixel_y = -32;
+	})
 "khe" = (
 /obj/machinery/computer/operating,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{


### PR DESCRIPTION
## What Does This PR Do
Аварийны шкаф в старом ксено теперь открывается на свободный тайл.

## Changelog
:cl:
fix: Аварийны шкаф в старом ксено теперь открывается на свободный тайл.
/:cl:
