### PR TITLE
Fix: Добавляет ratge head в автомат с костюмами (я забыл это сделать)

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1484,6 +1484,7 @@
 					/obj/item/clothing/accessory/waistcoat = 1,
 					/obj/item/clothing/under/suit_jacket = 1,
 					/obj/item/clothing/head/that =1,
+					/obj/item/clothing/head/ratge = 1,
 					/obj/item/clothing/under/kilt = 1,
 					/obj/item/clothing/accessory/waistcoat = 1,
 					/obj/item/clothing/glasses/monocle =1,


### PR DESCRIPTION
[Предложка прошла](https://discord.com/channels/617003227182792704/755125334097133628/980594400432382062)

## What Does This PR Do
Добавляет «ratge head» как карнавальный шлем в автомат с карнавальными костюмами (я забыл это сделать в https://github.com/ss220-space/Paradise/pull/918).


## Changelog
:cl:
add: Added “ratge head” helmet to vending machine
/:cl:
