### PR TITLE
Tweak: Food preferences

### DIFF
--- a/code/modules/food_and_drinks/food.dm
+++ b/code/modules/food_and_drinks/food.dm
@@ -82,7 +82,7 @@
 				var/type_string = matched_food_type(foodtype & H.dna.species.liked_food)
 				to_chat(H, "<span class='notice'>[format_message(type_string, LOVE_MESSAGES, H.dna.species)]</span>")
 
-				H.AdjustDisgust(-11 + -8 * fraction)
+				H.AdjustDisgust(-12 + -8 * fraction)
 			last_check_time = world.time
 
 /obj/item/reagent_containers/food/proc/format_message(var/type, var/list/messages, var/datum/species/species)

--- a/code/modules/food_and_drinks/food.dm
+++ b/code/modules/food_and_drinks/food.dm
@@ -65,7 +65,7 @@
 	ant_timer = addtimer(CALLBACK(src, .proc/check_for_ants), 3000, TIMER_STOPPABLE)
 
 /obj/item/reagent_containers/food/proc/check_liked(var/fraction, mob/M)
-	if(last_check_time + 5 SECONDS < world.time)
+	if(last_check_time + 2 SECONDS < world.time)
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if(foodtype & H.dna.species.toxic_food)
@@ -73,16 +73,16 @@
 				to_chat(H, "<span class='warning'>[format_message(type_string, HATE_MESSAGES, H.dna.species)]</span>")
 
 				H.AdjustDisgust(25 + 30 * fraction)
-			else if(foodtype & H.dna.species.disliked_food)
+			if(foodtype & H.dna.species.disliked_food)
 				var/type_string = matched_food_type(foodtype & H.dna.species.disliked_food)
 				to_chat(H, "<span class='warning'>[format_message(type_string, DISLIKE_MESSAGES, H.dna.species)]</span>")
 
-				H.AdjustDisgust(11 + 15 * fraction)
-			else if(foodtype & H.dna.species.liked_food)
+				H.AdjustDisgust(15 + 16 * fraction)
+			if(foodtype & H.dna.species.liked_food)
 				var/type_string = matched_food_type(foodtype & H.dna.species.liked_food)
 				to_chat(H, "<span class='notice'>[format_message(type_string, LOVE_MESSAGES, H.dna.species)]</span>")
 
-				H.AdjustDisgust(-5 + -2.5 * fraction)
+				H.AdjustDisgust(-11 + -8 * fraction)
 			last_check_time = world.time
 
 /obj/item/reagent_containers/food/proc/format_message(var/type, var/list/messages, var/datum/species/species)
@@ -123,3 +123,18 @@
 		return pick("toxic garbage", "toxins", "literally poison")
 	if(matching_flags & JUNKFOOD)
 		return "junk food"
+
+/obj/item/reagent_containers/food/examine(mob/user)
+	. = ..()
+	if(foodtype & MEAT)	. += "<span class='notice'>It contains meat.</span>"
+	if(foodtype & VEGETABLES)	. += "<span class='notice'>It contains vegetables.</span>"
+	if(foodtype & RAW)	. += "<span class='notice'>It is not properly cooked.</span>"
+	if(foodtype & JUNKFOOD)	. += "<span class='notice'>It is junkfood.</span>"
+	if(foodtype & GRAIN)	. += "<span class='notice'>It is made of grain.</span>"
+	if(foodtype & FRUIT)	. += "<span class='notice'>It contains fruits.</span>"
+	if(foodtype & DAIRY)	. += "<span class='notice'>It contains dairy.</span>"
+	if(foodtype & FRIED)	. += "<span class='notice'>It is fried.</span>"
+	if(foodtype & SUGAR)	. += "<span class='notice'>It is sugary.</span>"
+	if(foodtype & EGG)	. += "<span class='notice'>It contains eggs.</span>"
+	if(foodtype & GROSS)	. += "<span class='notice'>This is pure garbage.</span>"
+	if(foodtype & TOXIC)	. += "<span class='notice'>This is straight up poisonous.</span>"

--- a/code/modules/food_and_drinks/food/foods/pasta.dm
+++ b/code/modules/food_and_drinks/food/foods/pasta.dm
@@ -60,7 +60,7 @@
 	filling_color = "#DE4545"
 	list_reagents = list("nutriment" = 8, "synaptizine" = 5, "vitamin" = 4)
 	tastes = list("pasta" = 1, "tomato" = 1, "meat" = 1)
-	foodtype = GRAIN | VEGETABLES | MEAT
+	foodtype = GRAIN | MEAT
 
 /obj/item/reagent_containers/food/snacks/spesslaw
 	name = "spesslaw"

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -292,6 +292,6 @@
 	icon = 'icons/obj/food/food.dmi'
 	icon_state = "deepfried_holder_icon"
 	list_reagents = list("nutriment" = 3)
-
+	foodtype = FRIED | JUNKFOOD | GROSS
 
 #undef MAX_WEIGHT_CLASS


### PR DESCRIPTION
Расовые диеты немного мусор в плане логики их работы. В данный момент проверка вкуса не учитывает вообще любимые тэги блюд если есть хоть один негативный. Кроме того даже если бы он учитывал, значения настолько низкие что эффекта не оказывают. 
Этот реворк предназначен для окостыливания самых проблемных мест в расовых диетах.

Общие изменения
 -Теперь любимый тип пищи учитывается при проверке вкуса даже если в блюде присутствуют нелюбимые
 -Эффект снижения тошноты от любимой пищи увеличен в несколько раз
 -Теперь тип пищи можно узнать через экзамайн
 -кулдаун между проверками на вкус снижен с 5 до 2 секунд

В целом это значит что можно съесть одно-два смешанных блюда без заметных последствий

Фритюр
 -Еда обжаренная во фритюре теперь является JUNKFOOD, FRIED и GROSS. Это значит что если раса не любит хоть что то из этого, то она будет получать огромные дебаффы, а те кому посчастливилось иметь в предпочтениях хоть что то из этого, смогут есть обжаренную в масле пищу с незначительными дебаффами. 
Также это значит что вульпы могут есть обжаренные во фритюре продукты абсолютно без последствий в отличие от людей и прочих рас(так как любят GROSS). Нет, меня не купило фурриное лобби, и если вы будете распространять подобные слухи акума придет и сломает вам колени

Какие проблемы этим ПРом НЕ решены
-Количество (не)любимых типов никак не будет влиять на тошноту. Проверяется только наличие хотя бы одного. Это значит что нет разницы между блюдом с соотношением не/любимого 1 к 1 и 4 к 1.
