### PR TITLE
tweak: soviet casual uniform in loadout

### DIFF
--- a/code/modules/client/preference/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference/loadout/loadout_uniform.dm
@@ -324,3 +324,7 @@
 	display_name = "tacticool turtleneck"
 	description = "A sleek black turtleneck paired with some khakis (WARNING DOES NOT HAVE SUIT SENSORS)"
 	path = /obj/item/clothing/under/syndicate/tacticool
+
+/datum/gear/uniform/suit/soviet_casual
+	display_name = "soviet casual uniform"
+	path = /obj/item/clothing/under/fluff/soviet_casual_uniform


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR adds soviet casual uniform (booba) into loadout menu.

## Why It's Good For The Game
Как пройдет предложку - так и будет хорошо.

## Images of changes
![image](https://user-images.githubusercontent.com/103588397/172659182-cdd147c5-8831-4e7a-9917-d03f1d49745f.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: soviet casual uniform and booba for all.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
