### PR TITLE
Фикс с ОФФов: Воздушная сигнализация теперь правильно высчитывает токсинные проценты

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -606,7 +606,8 @@
 		return
 
 	var/datum/gas_mixture/environment = location.return_air()
-	var/total = environment.oxygen + environment.nitrogen + environment.carbon_dioxide + environment.toxins
+	var/known_total = environment.oxygen + environment.nitrogen + environment.carbon_dioxide + environment.toxins
+	var/total = environment.total_moles()
 	if(total == 0)
 		return null
 
@@ -634,8 +635,9 @@
 	var/plasma_percent = round(environment.toxins / total * 100, 2)
 
 	cur_tlv = TLV["other"]
-	var/other_moles = environment.total_trace_moles()
-	var/other_dangerlevel = cur_tlv.get_danger_level(other_moles * GET_PP)
+	var/other_moles = total - known_total
+	var/other_dangerlevel = cur_tlv.get_danger_level(other_moles*GET_PP)
+	var/other_percent = round(other_moles / total * 100, 2)
 
 	cur_tlv = TLV["temperature"]
 	var/temperature_dangerlevel = cur_tlv.get_danger_level(environment.temperature)
@@ -651,7 +653,7 @@
 	percentages["nitrogen"] = nitrogen_percent
 	percentages["co2"] = co2_percent
 	percentages["plasma"] = plasma_percent
-	percentages["other"] = other_moles
+	percentages["other"] = other_percent
 	data["contents"] = percentages
 
 	var/list/danger = list()


### PR DESCRIPTION
## What Does This PR Do
Фикс: Воздушная сигнализация теперь правильно высчитывает токсинные проценты
ПР: https://github.com/ParadiseSS13/Paradise/pull/17540

## Why It's Good For The Game
Теперь нету 406% токсинов вместо суммы 100%

## Images of changes
### Было:
![image](https://user-images.githubusercontent.com/41479614/172817526-f7983b28-9db0-4d18-9975-3fbf7d814fea.png)

### Стало:
![image](https://user-images.githubusercontent.com/41479614/172817562-8f1c4a1e-a50e-40a4-8b88-de5fa2e15ac3.png)
