### PR TITLE
ОФФы: Роботизированные легкие теперь можно настроить для воксов и плазмаменов

### DIFF
--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -342,6 +342,38 @@
 	icon_state = "lungs-c"
 	origin_tech = "biotech=4"
 	status = ORGAN_ROBOT
+	var/species_state = "human"
+
+/obj/item/organ/internal/lungs/cybernetic/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>[src] is configured for [species_state] standards of atmosphere.</span>"
+
+/obj/item/organ/internal/lungs/cybernetic/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	switch(species_state)
+		if("human") // from human to vox
+			safe_oxygen_min = 0
+			safe_oxygen_max = safe_toxins_max
+			safe_nitro_min = 16
+			oxy_damage_type = TOX
+			to_chat(user, "<span class='notice'>You configure [src] to replace vox lungs.</span>")
+			species_state = "vox"
+		if("vox") // from vox to plasmamen
+			safe_oxygen_max = initial(safe_oxygen_max)
+			safe_toxins_min = 16
+			safe_toxins_max = 0
+			safe_nitro_min = initial(safe_nitro_min)
+			oxy_damage_type = OXY
+			to_chat(user, "<span class='notice'>You configure [src] to replace plasmamen lungs.</span>")
+			species_state = "plasmamen"
+		if("plasmamen") // from plasmamen to human
+			safe_oxygen_min = initial(safe_oxygen_min)
+			safe_toxins_min = initial(safe_toxins_min)
+			safe_toxins_max = initial(safe_toxins_max)
+			to_chat(user, "<span class='notice'>You configure [src] back to default settings.</span>")
+			species_state = "human"
 
 /obj/item/organ/internal/lungs/cybernetic/upgraded
 	name = "upgraded cybernetic lungs"


### PR DESCRIPTION
## What Does This PR Do
Роботизированные легкие теперь можно настроить для воксов и плазмаменов
ПР: https://github.com/ParadiseSS13/Paradise/pull/17923

## Why It's Good For The Game
Позволяет настраивать кибернетические и модернизированные кибернетические легкие в соответствии с настройками вокс- и плазмомен-легких. Модернизированные легкие также будут давать кислород vox 20 в качестве максимального уровня кислорода, подобно тому, как улучшенные легкие уже дают бонус токсина и СО2, но их НЕ достаточно, чтобы безопасно дышать кислородом станции. Однако это снизит урон от токсинов до 1 за цикл.