### PR TITLE
Fix: Parallax animation

### DIFF
--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -147,7 +147,8 @@
 
 		L.transform = newtransform
 
-		animate(L, transform = matrix(), time = T, loop = -1, flags = ANIMATION_END_NOW)
+		animate(L, transform = L.transform, time = 0, loop = -1, flags = ANIMATION_END_NOW)
+		animate(transform = matrix(), time = T)
 
 /datum/hud/proc/update_parallax()
 	var/client/C = mymob.client


### PR DESCRIPTION
Фиксит багованный Параллакс, теперь во время анимаций полёта не будет багулин с зависанием анимации.
Отсюда: https://github.com/yogstation13/Yogstation/pull/12252