### PR TITLE
Spy spider fixes

### DIFF
--- a/code/controllers/subsystem/radio.dm
+++ b/code/controllers/subsystem/radio.dm
@@ -25,6 +25,7 @@ SUBSYSTEM_DEF(radio)
 	var/list/CENT_FREQS = list(ERT_FREQ, DTH_FREQ)
 	var/list/ANTAG_FREQS = list(SYND_FREQ, SYNDTEAM_FREQ, SYND_TAIPAN_FREQ)
 	var/list/DEPT_FREQS = list(AI_FREQ, COMM_FREQ, ENG_FREQ, MED_FREQ, SEC_FREQ, SCI_FREQ, SRV_FREQ, SUP_FREQ, PROC_FREQ)
+	var/list/syndicate_blacklist = list(SPY_SPIDER_FREQ)	//list of frequencies syndicate headset can't hear
 	var/list/datum/radio_frequency/frequencies = list()
 
 // This is fucking disgusting and needs to die

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -528,7 +528,7 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 	if(!freq) //recieved on main frequency
 		if(!listening)
 			return -1
-	else if(syndiekey)
+	else if(syndiekey && !(freq in SSradio.syndicate_blacklist))
 		return canhear_range
 	else
 		var/accept = (freq==frequency && listening)

--- a/goon/browserassets/css/browserOutput.css
+++ b/goon/browserassets/css/browserOutput.css
@@ -266,7 +266,7 @@ em						{font-style: normal;	font-weight: bold;}
 .siliconsay				{font-family: 'Courier New', Courier, monospace;}
 .deadsay				{color: #5c00e6;}
 .radio					{color: #408010;}
-.spyradio				{color: #1b790e;}
+.spyradio				{color: #776f96;}
 .deptradio				{color: #993399;}
 .comradio				{color: #204090;}
 .syndradio				{color: #6D3F40;}


### PR DESCRIPTION
Синдинаушники теперь не будут прослушивать канал паучка
Цвет чата изменён на серо-фиолетовый
![image](https://user-images.githubusercontent.com/10997188/173040761-73a8d67d-be52-4573-a866-fa76e3ed8b50.png)
