### PR TITLE
Tweak: Remove Bracket Pair Colorizer 2 in recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,6 @@
 		"platymuus.dm-langclient",
 		"EditorConfig.EditorConfig",
 		"dbaeumer.vscode-eslint",
-		"coenraads.bracket-pair-colorizer-2",
 		"eamodio.gitlens"
     ]
 }


### PR DESCRIPTION
Его добавили в vscode по дефолту, больше не нужен.
Включается

в **settings.json** добавить

```
{
    "editor.bracketPairColorization.enabled": true,
    "editor.guides.bracketPairs":"active"
}
```