### PR TITLE
Фикс с ОФФов: Процесс безопасного телепортирования, стражей и свармеров в зоны с безопасным уровнем токсинов/других газов (таких как: усыпляющих)

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -185,8 +185,8 @@
 				to_chat(MM, "<span class='warning'>The bluespace interface on your bag of holding interferes with the teleport!</span>")
 	return 1
 
-// Safe location finder
-/proc/find_safe_turf(zlevel, list/zlevels, extended_safety_checks = FALSE)
+// Random safe location finder
+/proc/find_safe_turf(zlevel, list/zlevels)
 	if(!zlevels)
 		if(zlevel)
 			zlevels = list(zlevel)
@@ -198,38 +198,7 @@
 		var/x = rand(1, world.maxx)
 		var/y = rand(1, world.maxy)
 		var/z = pick(zlevels)
-		var/random_location = locate(x,y,z)
+		var/turf/random_location = locate(x, y, z)
 
-		if(!isfloorturf(random_location))
-			continue
-		var/turf/simulated/floor/F = random_location
-		if(!F.air)
-			continue
-
-		var/datum/gas_mixture/A = F.air
-
-		// Can most things breathe?
-		if(A.sleeping_agent)
-			continue
-		if(A.oxygen < 16)
-			continue
-		if(A.toxins)
-			continue
-		if(A.carbon_dioxide >= 10)
-			continue
-
-		// Aim for goldilocks temperatures and pressure
-		if((A.temperature <= 270) || (A.temperature >= 360))
-			continue
-		var/pressure = A.return_pressure()
-		if((pressure <= 20) || (pressure >= 550))
-			continue
-
-		if(extended_safety_checks)
-			if(islava(F)) //chasms aren't /floor, and so are pre-filtered
-				var/turf/simulated/floor/plating/lava/L = F
-				if(!L.is_safe())
-					continue
-
-		// DING! You have passed the gauntlet, and are "probably" safe.
-		return F
+		if(random_location.is_safe())
+			return random_location

--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -510,7 +510,7 @@
 		return
 
 	var/turf/simulated/floor/F
-	F = find_safe_turf(zlevels = z, extended_safety_checks = TRUE)
+	F = find_safe_turf(zlevels = z)
 
 	if(!F)
 		return

--- a/code/game/gamemodes/miniantags/guardian/types/healer.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/healer.dm
@@ -122,21 +122,16 @@
 	to_chat(src, "<span class='danger'>You begin to warp [A]</span>")
 	if(do_mob(src, A, 50))
 		if(!A.anchored)
-			if(beacon) //Check that the beacon still exists and is in a safe place. No instant kills.
-				if(beacon.air)
-					var/datum/gas_mixture/Z = beacon.air
-					if(Z.oxygen >= 16 && !Z.toxins && Z.carbon_dioxide < 10 && !Z.sleeping_agent)
-						if((Z.temperature > 270) && (Z.temperature < 360))
-							var/pressure = Z.return_pressure()
-							if((pressure > 20) && (pressure < 550))
-								new /obj/effect/temp_visual/guardian/phase/out(get_turf(A))
-								do_teleport(A, beacon, 0)
-								new /obj/effect/temp_visual/guardian/phase(get_turf(A))
-						else
-							to_chat(src, "<span class='danger'>The beacon isn't in a safe location!</span>")
-					else
-						to_chat(src, "<span class='danger'>The beacon isn't in a safe location!</span>")
-			else
+			if(!beacon) //Check that the beacon still exists and is in a safe place. No instant kills.
 				to_chat(src, "<span class='danger'>You need a beacon to warp things!</span>")
+				return
+			var/turf/T = beacon
+			if(T.is_safe())
+				new /obj/effect/temp_visual/guardian/phase/out(get_turf(A))
+				do_teleport(A, beacon, 0)
+				new /obj/effect/temp_visual/guardian/phase(get_turf(A))
+				return
+			to_chat(src, "<span class='danger'>The beacon isn't in a safe location!</span>")
+			return
 	else
 		to_chat(src, "<span class='danger'>You need to hold still!</span>")

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -84,6 +84,26 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 		if(A.level == 3)
 			return 1
 
+// Checks if the turf is safe to be on
+/turf/simulated/floor/is_safe()
+	if(!air)
+		return FALSE
+	var/datum/gas_mixture/Z = air
+	var/pressure = Z.return_pressure()
+	// Can most things breathe and tolerate the temperature and pressure?
+	if(Z.oxygen < 16 || Z.toxins >= 0.05 || Z.carbon_dioxide >= 10 || Z.sleeping_agent >= 1 || (Z.temperature <= 270) || (Z.temperature >= 360) || (pressure <= 20) || (pressure >= 550))
+		return FALSE
+	return TRUE
+
+// Checks if there is foothold over the turf
+/turf/simulated/floor/proc/find_safeties()
+	var/static/list/safeties_typecache = typecacheof(list(/obj/structure/lattice/catwalk, /obj/structure/stone_tile))
+	var/list/found_safeties = typecache_filter_list(contents, safeties_typecache)
+	for(var/obj/structure/stone_tile/S in found_safeties)
+		if(S.fallen)
+			LAZYREMOVE(found_safeties, S)
+	return LAZYLEN(found_safeties)
+
 /turf/simulated/floor/blob_act(obj/structure/blob/B)
 	return
 

--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -67,14 +67,10 @@
 		else
 			to_chat(user, "<span class='warning'>The plating is going to need some support! Place metal rods first.</span>")
 
-/turf/simulated/floor/chasm/proc/is_safe()
-	//if anything matching this typecache is found in the chasm, we don't drop things
-	var/static/list/chasm_safeties_typecache = typecacheof(list(/obj/structure/lattice/catwalk, /obj/structure/stone_tile))
-	var/list/found_safeties = typecache_filter_list(contents, chasm_safeties_typecache)
-	for(var/obj/structure/stone_tile/S in found_safeties)
-		if(S.fallen)
-			LAZYREMOVE(found_safeties, S)
-	return LAZYLEN(found_safeties)
+/turf/simulated/floor/chasm/is_safe()
+	if(find_safeties() && ..())
+		return TRUE
+	return FALSE
 
 /turf/simulated/floor/chasm/proc/drop_stuff(AM)
 	. = 0

--- a/code/game/turfs/simulated/floor/lava.dm
+++ b/code/game/turfs/simulated/floor/lava.dm
@@ -46,13 +46,10 @@
 	underlay_appearance.icon_state = "basalt"
 	return TRUE
 
-/turf/simulated/floor/plating/lava/proc/is_safe()
-	var/static/list/lava_safeties_typecache = typecacheof(list(/obj/structure/lattice/catwalk, /obj/structure/stone_tile))
-	var/list/found_safeties = typecache_filter_list(contents, lava_safeties_typecache)
-	for(var/obj/structure/stone_tile/S in found_safeties)
-		if(S.fallen)
-			LAZYREMOVE(found_safeties, S)
-	return LAZYLEN(found_safeties)
+/turf/simulated/floor/plating/lava/is_safe()
+	if(find_safeties() && ..())
+		return TRUE
+	return FALSE
 
 /turf/simulated/floor/plating/lava/proc/burn_stuff(AM)
 	. = 0

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -250,6 +250,9 @@
 /turf/proc/BeforeChange()
 	return
 
+/turf/proc/is_safe()
+	return FALSE
+
 // I'm including `ignore_air` because BYOND lacks positional-only arguments
 /turf/proc/AfterChange(ignore_air = FALSE, keep_cabling = FALSE) //called after a turf has been replaced in ChangeTurf()
 	levelupdate()


### PR DESCRIPTION
## What Does This PR Do
Этот ПР разбивает проверки безопасности `find_safe_turf` на отдельный `turf` процесс `is_safe` и вместо этого вызывает его.

Это позволяет проверять турфы без необходимости искать случайный турф, которые вызывают проверки свармеров.

Это также добавляет пороги безопасности для токсинов и снотворных из лёгких к проверке безопасности. Порог для усыпляющего агента ниже 1, что технически «безопасно», но вызывает временный паралич вместо полного сна.

## Оригинальный ПР
https://github.com/ParadiseSS13/Paradise/pull/16747

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![image](https://user-images.githubusercontent.com/41479614/173217723-487c16ae-6baa-4ddc-b46b-ddcb8a9c03f7.png)
