### PR TITLE
Фикс с ОФФов: Исправление многократной инициализации свармеров

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -98,9 +98,6 @@
 
 /obj/effect/mob_spawn/proc/create(ckey, flavour = TRUE, name)
 	var/mob/living/M = new mob_type(get_turf(src)) //living mobs only
-	var/mob/living/carbon/human/H = M
-	if(H && !H.dna)
-		H.Initialize(null)
 	if(!random)
 		M.real_name = mob_name ? mob_name : M.name
 		if(M.dna)


### PR DESCRIPTION
Оригинальный ПР: https://github.com/ParadiseSS13/Paradise/pull/16951

## What Does This PR Do
Исправления `Runtime in unsorted.dm,1992: Warning: Swarmer 204-gamma(/mob/living/simple_animal/hostile/swarmer) initialized multiple times!.`

Поскольку у роевиков и других простых мобов нет ДНК, они инициализируются несколько раз всякий раз, когда игрок использует спаунер.
Автор ПРа прошел через каждый /obj/effect/mob_spawnподтип с некоторыми точками останова, и единственные, которые когда-либо доходили до строки 116, — это простые мобы (вызывающие время выполнения).
![image](https://user-images.githubusercontent.com/41479614/173218751-395c5cd1-eba8-40d5-ad1e-e2a70765e674.png)


## Why It's Good For The Game
Этот код был необходим, когда https://github.com/ParadiseSS13/Paradise/pull/9806 был объединен, о чем свидетельствуют скриншоты в этом, но кажется, что с тех пор какая бы ни была основная проблема, она была исправлена.