### PR TITLE
Tweak/morph debuff

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -95,6 +95,7 @@
 		else
 			button.icon = button_icon
 			button.icon_state = background_icon_state
+		button.name = name
 		button.desc = desc
 
 		ApplyIcon(button)

--- a/code/game/gamemodes/miniantags/morph/morph.dm
+++ b/code/game/gamemodes/miniantags/morph/morph.dm
@@ -43,6 +43,7 @@
 							You can restore yourself to your original form while morphed by shift-clicking yourself.<br> \
 							Finally, you can attack any item or dead creature to consume it - creatures will restore 1/3 of your max health.</b>"
 
+	var/can_reproduce = FALSE
 	/// If the morph is disguised or not
 	var/morphed = FALSE
 	/// If the morph is ready to perform an ambush
@@ -322,6 +323,7 @@
 
 
 /mob/living/simple_animal/hostile/morph/proc/make_morph_antag(give_default_objectives = TRUE)
+	can_reproduce = TRUE
 	mind.assigned_role = SPECIAL_ROLE_MORPH
 	mind.special_role = SPECIAL_ROLE_MORPH
 	SSticker.mode.traitors |= mind

--- a/code/game/gamemodes/miniantags/morph/spells/ambush.dm
+++ b/code/game/gamemodes/miniantags/morph/spells/ambush.dm
@@ -3,7 +3,7 @@
 /obj/effect/proc_holder/spell/targeted/morph_spell/ambush
 	name = "Prepare Ambush"
 	desc = "Prepare an ambush. Dealing significantly more damage on the first hit and you will weaken the target. Only works while morphed. If the target tries to use you with their hands then you will do even more damage. \
-	 		Keeping still for another 15 seconds will perfect your disguise."
+	 		Keeping still for another 10 seconds will perfect your disguise."
 	action_icon_state = "morph_ambush"
 	charge_max = 8 SECONDS
 	self_only = TRUE

--- a/code/game/gamemodes/miniantags/morph/spells/morph_spell.dm
+++ b/code/game/gamemodes/miniantags/morph/spells/morph_spell.dm
@@ -4,10 +4,15 @@
 	/// How much food it costs the morph to use this
 	var/hunger_cost = 0
 
+/obj/effect/proc_holder/spell/targeted/morph_spell/proc/update_name()
+	if(hunger_cost)
+		name = "[initial(name)] ([hunger_cost])"
+		if (action)
+			action.name = name
+
 /obj/effect/proc_holder/spell/targeted/morph_spell/Initialize(mapload)
 	. = ..()
-	if(hunger_cost)
-		name = "[name] ([hunger_cost])"
+	update_name()
 
 /obj/effect/proc_holder/spell/targeted/morph_spell/can_cast(mob/living/simple_animal/hostile/morph/user, charge_check, show_message)
 	. = ..()

--- a/code/game/gamemodes/miniantags/morph/spells/reproduce.dm
+++ b/code/game/gamemodes/miniantags/morph/spells/reproduce.dm
@@ -10,6 +10,10 @@
 	. = ..()
 	if(!.)
 		return
+	if(!user.can_reproduce)
+		if(show_message)
+			to_chat(user, "<span class='warning'>You dont know how to do reproduce!</span>")
+		return FALSE
 	if(!isturf(user.loc))
 		if(show_message)
 			to_chat(user, "<span class='warning'>You can only split while on flooring!</span>")
@@ -17,6 +21,9 @@
 
 /obj/effect/proc_holder/spell/targeted/morph_spell/reproduce/cast(list/targets, mob/living/simple_animal/hostile/morph/user)
 	to_chat(user, "<span class='sinister'>You prepare to split in two, making you unable to vent crawl!</span>")
+	hunger_cost += 30
+	update_name()
+	user.update_action_buttons_icon()
 	user.ventcrawler = FALSE // Temporarily disable it
 	var/list/candidates = SSghost_spawns.poll_candidates("Do you want to play as a morph?", ROLE_MORPH, TRUE, poll_time = 10 SECONDS, source = /mob/living/simple_animal/hostile/morph)
 	if(!length(candidates))

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -196,7 +196,7 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Блоб",			/datum/event/blob, 				30,						list(ASSIGNMENT_ENGINEER =  5), TRUE),	// 6.9% on high pop, 5.5% on low pop
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Метеорный вал",	/datum/event/meteor_wave,		30,						list(ASSIGNMENT_ENGINEER =  5),	TRUE),	// 6.9% on high pop, 5.5% on low pop
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Визит абдукторов",/datum/event/abductor, 		    20, 					list(ASSIGNMENT_SECURITY =  3), TRUE),	// 5.8% on high pop, 4.5% on low pop
-		//new /datum/event_meta/alien(EVENT_LEVEL_MAJOR, "Alien Infestation",	/datum/event/alien_infestation, 		0,		list(ASSIGNMENT_SECURITY = 15), TRUE),
+		new /datum/event_meta/alien(EVENT_LEVEL_MAJOR, "Alien Infestation",	/datum/event/alien_infestation, 		0,		list(ASSIGNMENT_SECURITY = 15), TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Торговцы",		/datum/event/traders,			85, is_one_shot = TRUE),										// 8.4% on high pop, 9.4% on low pop
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Пауки Ужаса",		/datum/event/spider_terror, 	20,						list(ASSIGNMENT_SECURITY = 4), TRUE),	// 7.1% on high pop, 5.3% on low pop
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Демон Резни",		/datum/event/spawn_slaughter,	10,  is_one_shot = TRUE)	// 3% on high pop, 2.1% on low pop

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -196,7 +196,7 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Блоб",			/datum/event/blob, 				30,						list(ASSIGNMENT_ENGINEER =  5), TRUE),	// 6.9% on high pop, 5.5% on low pop
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Метеорный вал",	/datum/event/meteor_wave,		30,						list(ASSIGNMENT_ENGINEER =  5),	TRUE),	// 6.9% on high pop, 5.5% on low pop
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Визит абдукторов",/datum/event/abductor, 		    20, 					list(ASSIGNMENT_SECURITY =  3), TRUE),	// 5.8% on high pop, 4.5% on low pop
-		new /datum/event_meta/alien(EVENT_LEVEL_MAJOR, "Alien Infestation",	/datum/event/alien_infestation, 		0,		list(ASSIGNMENT_SECURITY = 15), TRUE),
+		//new /datum/event_meta/alien(EVENT_LEVEL_MAJOR, "Alien Infestation",	/datum/event/alien_infestation, 		0,		list(ASSIGNMENT_SECURITY = 15), TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Торговцы",		/datum/event/traders,			85, is_one_shot = TRUE),										// 8.4% on high pop, 9.4% on low pop
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Пауки Ужаса",		/datum/event/spider_terror, 	20,						list(ASSIGNMENT_SECURITY = 4), TRUE),	// 7.1% on high pop, 5.3% on low pop
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Демон Резни",		/datum/event/spawn_slaughter,	10,  is_one_shot = TRUE)	// 3% on high pop, 2.1% on low pop


### PR DESCRIPTION
## Changelog
:cl:
tweak: Only event morphs will be able to reproduce. Morphs from lavalend wont
tweak: Every time morph reproduces he increases cost of his reproducing by 30
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
