### PR TITLE
Feat: Make Atmospherics on Korobka normal

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -88331,6 +88331,11 @@
 	icon_state = "neutralfull"
 	},
 /area/shuttle/escape)
+"dwF" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/random_spawners/fungus_maybe,
+/turf/simulated/wall,
+/area/maintenance/asmaint)
 "dzR" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -91203,6 +91208,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
+"lsc" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall,
+/area/maintenance/asmaint)
 "lsY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -136638,7 +136647,7 @@ dhP
 chf
 csL
 ddH
-cYi
+lsc
 dkS
 dlA
 dfM
@@ -137152,7 +137161,7 @@ dhQ
 chf
 chf
 cUm
-cYi
+dwF
 cYi
 cYg
 dlO
@@ -137665,7 +137674,7 @@ chf
 cUB
 cYi
 dlA
-chf
+cDm
 chf
 csL
 csL

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -202,7 +202,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -621,8 +623,7 @@
 	},
 /area/shuttle/syndicate)
 "acO" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/machinery/atmospherics/unary/portables_connector,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -1486,11 +1487,18 @@
 /turf/simulated/floor/plating,
 /area/security/medbay)
 "aei" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/area/security/securearmoury)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/courtroom)
 "aej" = (
 /obj/effect/decal/warning_stripes/red/partial{
 	dir = 4
@@ -3012,19 +3020,17 @@
 	},
 /area/security/range)
 "agN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkredcorners"
+	dir = 4;
+	icon_state = "blue"
 	},
-/area/security/brig)
+/area/crew_quarters/courtroom)
 "agO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1;
 	on = 1
@@ -3035,9 +3041,6 @@
 	},
 /area/security/brig)
 "agP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
@@ -3047,9 +3050,6 @@
 	},
 /area/security/brig)
 "agQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -3097,9 +3097,6 @@
 /obj/machinery/camera{
 	c_tag = "Brig Main Hall Center"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkredcorners"
@@ -3110,13 +3107,12 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "bluered";
+	tag = "icon-siding1 (NORTH)"
 	},
-/area/security/brig)
+/area/crew_quarters/dorms)
 "agV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_y = 32
@@ -3127,9 +3123,6 @@
 	},
 /area/security/brig)
 "agW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -3220,19 +3213,18 @@
 	},
 /area/shuttle/syndicate)
 "ahj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plasteel{
+/obj/machinery/power/apc{
 	dir = 1;
-	icon_state = "darkredcorners"
+	name = "north bump";
+	pixel_y = 24
 	},
-/area/security/brig)
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint)
 "ahk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
@@ -3739,13 +3731,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -3885,10 +3878,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -4032,9 +4025,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -4330,9 +4323,6 @@
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "ajm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -4841,10 +4831,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredcorners"
 	},
@@ -4866,9 +4852,6 @@
 	},
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -4896,7 +4879,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/sortjunction{
+	dir = 2;
+	icon_state = "pipe-j2s";
+	name = "Brig HoS Office";
+	sortType = 7
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredcorners"
 	},
@@ -5326,13 +5314,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 1;
-	name = "Brig HoS Office";
-	sortType = 7
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -5827,10 +5814,6 @@
 /area/security/customs)
 "alO" = (
 /obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "open";
@@ -6839,11 +6822,6 @@
 /area/security/securearmoury)
 "anI" = (
 /obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/sortjunction{
-	dir = 1;
-	name = "Brig Equipment Storage";
-	sortType = 8
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -6861,6 +6839,7 @@
 	name = "Brig Foyer Right Entrance";
 	req_access_txt = "63"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkred"
@@ -9421,9 +9400,6 @@
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/security/permabrig)
 "ask" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -9431,7 +9407,12 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	icon_state = "pipe-j2s";
+	name = "Brig Equipment Storage";
+	sortType = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -10082,9 +10063,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkredcorners"
@@ -10276,6 +10254,10 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -11788,10 +11770,6 @@
 	},
 /area/security/prison/cell_block/A)
 "awb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -11799,6 +11777,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2";
+	tag = "icon-pipe-j2"
 	},
 /turf/simulated/floor/plasteel,
 /area/security/lobby)
@@ -12601,6 +12584,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/security/lobby)
 "axz" = (
@@ -12611,7 +12595,6 @@
 /turf/simulated/floor/plasteel,
 /area/security/lobby)
 "axA" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -12659,12 +12642,27 @@
 	},
 /area/security/evidence)
 "axD" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	tag = "icon-pipe-j1 (EAST)"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/security/lobby)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint)
 "axE" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -12687,6 +12685,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/security/lobby)
 "axG" = (
@@ -12976,12 +12975,22 @@
 /turf/space,
 /area/space/nearstation)
 "ayj" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/area/security/lobby)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ai_monitored/storage/eva)
 "ayk" = (
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -13970,6 +13979,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/security/lobby)
 "azK" = (
@@ -14028,7 +14038,6 @@
 /area/security/prison/cell_block/A)
 "azP" = (
 /obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "redcorner"
@@ -14342,13 +14351,6 @@
 	dir = 8
 	},
 /obj/structure/cable/yellow,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
 /obj/machinery/treadmill_monitor{
 	id = "Cell 5";
 	pixel_y = -32
@@ -14463,7 +14465,7 @@
 /area/lawoffice)
 "aAJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 100
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -14622,13 +14624,13 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -14679,6 +14681,13 @@
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_y = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plating,
 /area/security/prison/cell_block/A)
@@ -14867,7 +14876,7 @@
 "aBE" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 100
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
@@ -15047,12 +15056,12 @@
 /turf/simulated/floor/wood,
 /area/maintenance/bar)
 "aBY" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/area/hallway/primary/fore)
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2)
 "aBZ" = (
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plasteel/airless,
@@ -15206,6 +15215,7 @@
 	dir = 4
 	},
 /mob/living/simple_animal/bot/secbot/beepsky,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
 "aCp" = (
@@ -15276,7 +15286,6 @@
 	},
 /area/bridge)
 "aCv" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
 	name = "standard air scrubber";
@@ -15445,6 +15454,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
 "aCK" = (
@@ -15566,7 +15576,6 @@
 	},
 /area/shuttle/syndicate_sit)
 "aCZ" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -15698,10 +15707,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
 "aDm" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
@@ -15998,7 +16007,7 @@
 	pixel_x = 25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 100
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -16102,6 +16111,7 @@
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
 "aEi" = (
@@ -16775,11 +16785,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	tag = "icon-pipe-j1 (EAST)"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
 "aFy" = (
@@ -17183,12 +17194,12 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/courtroom)
 "aGw" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	tag = "icon-pipe-j1 (EAST)"
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/fore)
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2)
 "aGx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17612,6 +17623,11 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "aHp" = (
@@ -17628,6 +17644,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
 "aHr" = (
@@ -17823,9 +17840,14 @@
 /turf/simulated/wall,
 /area/maintenance/fsmaint2)
 "aHQ" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/fore)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
+/area/library)
 "aHR" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -18049,6 +18071,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
 "aIs" = (
@@ -18221,15 +18244,22 @@
 	},
 /area/magistrateoffice)
 "aIN" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/port)
 "aIO" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -18388,11 +18418,6 @@
 	},
 /area/hallway/primary/fore)
 "aJi" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -18592,16 +18617,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "aJF" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -18632,11 +18647,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "aJJ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
 	name = "standard air scrubber";
@@ -18792,6 +18802,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2";
+	tag = "icon-pipe-j2"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
 "aKh" = (
@@ -18826,16 +18841,35 @@
 /turf/simulated/floor/wood,
 /area/clownoffice)
 "aKo" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/port)
 "aKq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
@@ -18855,6 +18889,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "rampbottom";
@@ -18862,6 +18901,11 @@
 	},
 /area/crew_quarters/courtroom)
 "aKu" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "rampbottom";
 	tag = "icon-stage_stairs"
@@ -18873,8 +18917,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "rampbottom";
@@ -19380,7 +19424,7 @@
 "aLw" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 100
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -19565,11 +19609,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "blue"
@@ -19591,11 +19630,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "blue"
@@ -19607,11 +19641,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -19872,12 +19901,27 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "aMG" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "bluecorner"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/hallway/primary/fore)
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/port)
 "aMH" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -19925,7 +19969,11 @@
 	dir = 4
 	},
 /obj/structure/closet/walllocker/emerglocker/north,
-/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1;
+	frequency = 1379;
+	id_tag = "engineering_east_pump"
+	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "aMN" = (
@@ -20043,17 +20091,21 @@
 /area/hallway/primary/fore)
 "aNd" = (
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/courtroom)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/port)
 "aNf" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -20113,11 +20165,6 @@
 "aNl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
@@ -20274,13 +20321,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "aNG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/crew_quarters/courtroom)
+/area/hallway/primary/central/nw)
 "aNH" = (
 /obj/structure/grille,
 /obj/structure/window/basic,
@@ -20308,11 +20361,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "rampbottom";
@@ -20323,7 +20371,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -22
@@ -20416,6 +20463,11 @@
 	layer = 3.21;
 	name = "Courtroom Privacy Shutters";
 	opacity = 0
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/courtroom)
@@ -20611,9 +20663,6 @@
 /area/maintenance/fsmaint2)
 "aOl" = (
 /obj/effect/spawner/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "open";
@@ -20621,7 +20670,9 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/atmos)
 "aOm" = (
@@ -20739,13 +20790,20 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/courtroom)
 "aOA" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/crew_quarters/courtroom)
+/area/hallway/primary/central/nw)
 "aOB" = (
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/courtroom)
@@ -20825,11 +20883,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
 	icon_state = "open";
@@ -20854,12 +20907,19 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
 "aOS" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
+	dir = 1;
+	name = "Труба фильтрации"
 	},
-/obj/machinery/atmospherics/binary/volume_pump/on{
-	dir = 8;
-	name = "Space Loop Out"
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	desc = "Труба хранит в себе набор газов для смешивания";
+	dir = 4;
+	name = "Труба смешивания"
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics East";
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -21109,11 +21169,6 @@
 	},
 /area/crew_quarters/courtroom)
 "aPD" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "blue"
 	},
@@ -21415,9 +21470,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2";
+	tag = "icon-pipe-j2 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -21428,8 +21484,8 @@
 /obj/item/radio/intercom{
 	pixel_y = 28
 	},
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-y"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -21444,6 +21500,9 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -21451,6 +21510,9 @@
 /area/crew_quarters/dorms)
 "aQp" = (
 /obj/structure/chair,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -21459,6 +21521,9 @@
 "aQq" = (
 /obj/structure/sign/barber{
 	pixel_y = 30
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -21476,6 +21541,9 @@
 	},
 /obj/structure/table,
 /obj/item/stack/tape_roll,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -21500,7 +21568,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	tag = "icon-pipe-j1 (EAST)"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -21512,6 +21583,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
+	},
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-y"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -21541,6 +21615,9 @@
 	name = "Crew Quarters Requests Console";
 	pixel_y = 30
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -21561,6 +21638,9 @@
 "aQz" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "bluered";
@@ -21572,6 +21652,9 @@
 /obj/machinery/light{
 	dir = 1;
 	in_use = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -21587,7 +21670,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "bluered";
@@ -21614,6 +21700,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
@@ -21677,10 +21767,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "aQQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -21690,6 +21776,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -22072,6 +22161,7 @@
 	},
 /area/crew_quarters/dorms)
 "aRy" = (
+/obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "bluecorner"
@@ -22506,7 +22596,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "aSy" = (
@@ -22561,10 +22650,6 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
 	},
@@ -22594,10 +22679,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "aSH" = (
@@ -22612,11 +22694,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "aSI" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/starboard/east)
+/area/hallway/primary/central/ne)
 "aSJ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -22649,7 +22739,6 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "aSM" = (
@@ -22711,12 +22800,17 @@
 	},
 /area/hallway/primary/fore)
 "aSV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/starboard/east)
+/area/hallway/primary/central/nw)
 "aSW" = (
 /obj/structure/chair/comfy/beige,
 /turf/simulated/floor/plasteel{
@@ -23034,7 +23128,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "caution"
@@ -23049,12 +23142,11 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/dorms)
 "aTH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/starboard/east)
+/area/hallway/primary/central/ne)
 "aTI" = (
 /obj/structure/chair/sofa,
 /obj/structure/window/reinforced{
@@ -23564,7 +23656,6 @@
 /area/chapel/office)
 "aUM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
@@ -23666,16 +23757,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "aVb" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/starboard/east)
 "aVc" = (
 /turf/simulated/wall,
 /area/security/checkpoint2)
@@ -23697,9 +23791,6 @@
 	name = "\improper Garden"
 	})
 "aVf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 100
-	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	frequency = 1379;
@@ -23710,6 +23801,9 @@
 	pixel_y = -25
 	},
 /obj/effect/decal/warning_stripes/north,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "aVg" = (
@@ -24027,30 +24121,17 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "aVH" = (
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 4;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint)
+/area/crew_quarters/locker/locker_toilet)
 "aVI" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -24226,6 +24307,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "aWc" = (
@@ -24290,6 +24375,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -24474,15 +24562,14 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -24627,11 +24714,13 @@
 	},
 /area/crew_quarters/dorms)
 "aWQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/crew_quarters/locker)
 "aWR" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/chem_master,
@@ -25339,11 +25428,8 @@
 	},
 /area/medical/morgue)
 "aYn" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/plasteel,
 /area/storage/office)
@@ -25406,11 +25492,6 @@
 	},
 /area/crew_quarters/sleep)
 "aYt" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
 /obj/item/folder/yellow,
@@ -25425,6 +25506,11 @@
 /obj/item/paper_bin/nanotrasen,
 /obj/item/paper/tcommskey,
 /obj/item/lighter/zippo/ce,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -25591,11 +25677,16 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "aYL" = (
@@ -25620,16 +25711,12 @@
 	},
 /area/shuttle/arrival/station)
 "aYO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "aYP" = (
 /turf/simulated/wall,
 /area/chapel/main)
@@ -25680,13 +25767,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -25696,12 +25783,12 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "aYZ" = (
@@ -25967,7 +26054,6 @@
 /area/crew_quarters/dorms)
 "aZA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -26320,6 +26406,11 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/effect/decal/warning_stripes/northwestcorner,
 /obj/effect/decal/warning_stripes/southwestcorner,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -26329,6 +26420,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -26341,6 +26437,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -26352,6 +26458,16 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -26377,6 +26493,16 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -26439,6 +26565,11 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /obj/effect/decal/warning_stripes/northwestcorner,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -26566,15 +26697,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/escapepodbay)
-"baP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
 "baQ" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -26588,14 +26710,13 @@
 /turf/simulated/floor/engine,
 /area/escapepodbay)
 "baS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -26654,15 +26775,19 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -26672,15 +26797,14 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -26872,7 +26996,6 @@
 /area/maintenance/fsmaint2)
 "bbt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -27122,10 +27245,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "bbU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -27135,6 +27254,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -27158,20 +27280,23 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bbW" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	icon_state = "pipe-j2s";
-	name = "Chapel";
-	sortType = 17
-	},
-/turf/simulated/wall,
-/area/crew_quarters/kitchen)
+/obj/effect/decal/warning_stripes/west,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "bbX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	name = "Botany";
+	sortType = 21;
+	tag = "icon-pipe-j1s (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -27185,6 +27310,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -27270,14 +27398,13 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/dorms)
 "bcg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -27287,13 +27414,15 @@
 /obj/machinery/camera{
 	c_tag = "Library North"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/library)
 "bci" = (
 /obj/structure/chair/office/dark,
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -27386,15 +27515,17 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	icon_state = "pipe-j2s";
+	name = "Library";
+	sortType = 16
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -27747,7 +27878,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "bdd" = (
@@ -28104,11 +28234,6 @@
 	},
 /area/crew_quarters/dorms)
 "bdO" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -28150,11 +28275,6 @@
 /area/crew_quarters/dorms)
 "bdR" = (
 /obj/effect/decal/warning_stripes/southeastcorner,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -28218,14 +28338,9 @@
 "bdX" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -28250,14 +28365,9 @@
 "bdZ" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -28308,16 +28418,6 @@
 /area/crew_quarters/dorms)
 "bed" = (
 /obj/effect/decal/warning_stripes/south,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
 	name = "standard air scrubber";
@@ -28325,17 +28425,17 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/ai_monitored/storage/eva)
 "bee" = (
 /obj/effect/decal/warning_stripes/southeast,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/power/apc{
 	name = "south bump";
 	pixel_y = -24
@@ -28352,9 +28452,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"
@@ -28362,11 +28459,6 @@
 /area/crew_quarters/dorms)
 "beg" = (
 /obj/effect/decal/warning_stripes/south,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -28411,10 +28503,15 @@
 /turf/simulated/floor/wood,
 /area/library)
 "ben" = (
-/obj/structure/table/wood,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood,
-/area/library)
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/atmospherics/binary/pump{
+	dir = 1;
+	layer = 2.35;
+	on = 1;
+	target_pressure = 1000
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "beo" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -28572,12 +28669,13 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "beJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "beK" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -28684,10 +28782,6 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "beU" = (
@@ -28701,9 +28795,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -28754,10 +28845,9 @@
 "beZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2 (EAST)"
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -28912,17 +29002,17 @@
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior)
 "bfn" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bfo" = (
@@ -28941,10 +29031,8 @@
 "bfp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2 (EAST)"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -29144,12 +29232,6 @@
 	},
 /area/crew_quarters/kitchen)
 "bfG" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	name = "Botany";
-	sortType = 21;
-	tag = "icon-pipe-j1s (EAST)"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -29162,6 +29244,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bfH" = (
@@ -29247,16 +29330,12 @@
 	},
 /area/hydroponics)
 "bfO" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "bfP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -29268,17 +29347,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bfQ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/decal/warning_stripes/west,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "bfR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -29349,7 +29424,6 @@
 /area/library)
 "bfZ" = (
 /obj/structure/table/wood,
-/obj/structure/disposalpipe/segment,
 /obj/item/book/manual/sop_general,
 /turf/simulated/floor/wood,
 /area/library)
@@ -29794,7 +29868,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -30069,6 +30145,13 @@
 /obj/item/vending_refill/cola,
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -30582,6 +30665,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	icon_state = "pipe-j2s";
+	name = "Disposals Maint";
+	sortType = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
 "biH" = (
@@ -30919,10 +31008,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
-"bji" = (
-/obj/item/radio/beacon,
-/turf/simulated/floor/plasteel,
-/area/atmos)
 "bjj" = (
 /obj/structure/closet/gmcloset{
 	name = "formal wardrobe"
@@ -31084,9 +31169,16 @@
 	},
 /area/chapel/main)
 "bjE" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood,
-/area/library)
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "packageSort1"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/office)
 "bjF" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/wood,
@@ -31153,10 +31245,10 @@
 /turf/simulated/floor/carpet,
 /area/hallway/secondary/entry)
 "bjP" = (
+/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
 "bjQ" = (
@@ -31310,16 +31402,6 @@
 	icon_state = "hydrofloor"
 	},
 /area/hydroponics)
-"bkf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/port)
 "bkg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31327,13 +31409,19 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
 "bkh" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2 (EAST)"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/port)
+/area/hallway/primary/starboard/west)
 "bki" = (
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
@@ -31358,18 +31446,22 @@
 /area/hydroponics)
 "bkk" = (
 /obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Port Hallway";
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
 "bkm" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
@@ -31383,14 +31475,19 @@
 /turf/simulated/floor/wood,
 /area/library)
 "bko" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/port)
+/area/hallway/primary/starboard/west)
 "bkp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -31400,29 +31497,19 @@
 /area/library)
 "bkq" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
 "bkr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
 "bks" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
@@ -31434,35 +31521,21 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bku" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/central/nw)
-"bkv" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "bluecorner"
-	},
-/area/hallway/primary/central/nw)
+/area/hallway/primary/starboard/west)
 "bkw" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "bluecorner"
@@ -31474,11 +31547,6 @@
 /area/crew_quarters/locker)
 "bky" = (
 /obj/machinery/light,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
@@ -31490,23 +31558,7 @@
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/central/nw)
-"bkz" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "bluecorner"
-	},
-/area/hallway/primary/central/north)
 "bkA" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -31515,27 +31567,12 @@
 /area/hallway/primary/central/nw)
 "bkB" = (
 /obj/machinery/light,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/central/north)
 "bkC" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "bluecorner"
@@ -31557,47 +31594,28 @@
 	name = "HIGH VOLTAGE";
 	pixel_y = -32
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/central/north)
-"bkF" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "bluecorner"
-	},
-/area/hallway/primary/central/ne)
-"bkG" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "bluecorner"
-	},
-/area/hallway/primary/central/ne)
 "bkH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/central/ne)
+/area/hallway/primary/starboard/east)
 "bkI" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment{
@@ -31626,15 +31644,17 @@
 /turf/simulated/floor/wood,
 /area/library)
 "bkL" = (
-/obj/structure/chair/office/dark{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/library)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/starboard/east)
 "bkN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31842,9 +31862,13 @@
 /turf/simulated/floor/carpet,
 /area/library)
 "blk" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "packageSort1"
+	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/carpet,
-/area/library)
+/turf/simulated/floor/plating,
+/area/quartermaster/office)
 "bll" = (
 /obj/structure/bookcase{
 	name = "bookcase (Reference)"
@@ -32096,6 +32120,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
 "blP" = (
@@ -32109,6 +32137,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -32243,7 +32274,6 @@
 /turf/simulated/floor/plating,
 /area/bridge)
 "bme" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -32254,6 +32284,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2";
+	tag = "icon-pipe-j2 (EAST)"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
@@ -32268,6 +32303,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
@@ -32362,6 +32400,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
 "bmt" = (
@@ -32403,6 +32444,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
 "bmw" = (
@@ -32414,12 +32458,16 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /obj/effect/decal/warning_stripes/north,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/ai_monitored/storage/eva)
 "bmx" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -32427,6 +32475,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-y"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
 "bmy" = (
@@ -32440,6 +32492,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
@@ -32462,6 +32522,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
 "bmC" = (
@@ -32473,6 +32541,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
@@ -32572,13 +32648,22 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bmN" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
 "bmO" = (
@@ -32646,19 +32731,32 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
 "bmW" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
@@ -32683,6 +32781,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
 "bna" = (
@@ -32691,6 +32794,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/north)
@@ -32706,6 +32814,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "L4"
 	},
@@ -32717,6 +32830,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "L2"
 	},
@@ -32724,6 +32842,11 @@
 "bnf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "L8"
 	},
@@ -32747,21 +32870,31 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "L6"
 	},
 /area/hallway/primary/central/north)
 "bni" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "L12"
@@ -32778,6 +32911,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "L10"
 	},
@@ -32788,6 +32926,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	desc = "";
@@ -32814,6 +32957,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
 "bno" = (
@@ -32823,6 +32971,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
@@ -32858,6 +33011,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
 "bnt" = (
@@ -32866,6 +33024,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
@@ -32982,16 +33145,21 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
 "bnN" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
@@ -33317,6 +33485,11 @@
 /obj/effect/landmark/start{
 	name = "Cargo Technician"
 	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	icon_state = "pipe-j2s";
+	name = "Cargo Disposals"
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "boy" = (
@@ -33593,20 +33766,20 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	tag = "icon-pipe-j1 (EAST)"
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
 "bph" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
@@ -33616,29 +33789,23 @@
 /turf/simulated/floor/plating,
 /area/storage/emergency2)
 "bpj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
 "bpk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
 "bpl" = (
@@ -33665,18 +33832,9 @@
 	codes_txt = "patrol;next_patrol=QM";
 	location = "CHW"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
 "bpn" = (
@@ -33702,11 +33860,6 @@
 	},
 /area/bridge)
 "bpp" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -33766,11 +33919,6 @@
 	},
 /area/bridge)
 "bpv" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
 	name = "standard air scrubber";
@@ -33802,11 +33950,6 @@
 	},
 /area/bridge)
 "bpy" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -33816,11 +33959,6 @@
 	},
 /area/hallway/primary/central/north)
 "bpz" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -34122,6 +34260,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bqk" = (
@@ -34185,6 +34324,7 @@
 "bqq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "stairs-m"
 	},
@@ -34766,6 +34906,7 @@
 "brJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
 "brK" = (
@@ -34784,6 +34925,12 @@
 "brN" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "brO" = (
@@ -35025,8 +35172,10 @@
 	},
 /area/hallway/secondary/entry)
 "bst" = (
-/obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bsu" = (
@@ -35098,6 +35247,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/bridge)
@@ -35695,15 +35849,12 @@
 /turf/simulated/floor/carpet,
 /area/library)
 "btX" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/library)
+/obj/machinery/light,
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/starboard/west)
 "btY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -35723,9 +35874,11 @@
 /turf/simulated/floor/wood,
 /area/library)
 "bua" = (
-/obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/light,
 /obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bub" = (
@@ -35814,6 +35967,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
 "bun" = (
@@ -35897,7 +36051,6 @@
 /turf/simulated/floor/wood,
 /area/library)
 "bux" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/loading_area{
 	dir = 1
 	},
@@ -36144,17 +36297,9 @@
 /turf/simulated/floor/carpet,
 /area/library)
 "buW" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/carpet,
-/area/library)
+/obj/machinery/light,
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/starboard/west)
 "buX" = (
 /obj/structure/computerframe,
 /obj/machinery/light/small{
@@ -36209,17 +36354,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
 "bve" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -36254,25 +36396,11 @@
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/transport)
-"bvg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/starboard/east)
 "bvh" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
@@ -36446,16 +36574,10 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
 "bvE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/wall,
-/area/storage/tools)
+/obj/machinery/light,
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/starboard/east)
 "bvF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -36464,42 +36586,41 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bvG" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall,
-/area/maintenance/port)
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/crew_quarters/locker/locker_toilet)
 "bvH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/maintenance/port)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/quartermaster/office)
 "bvI" = (
 /obj/item/clothing/gloves/color/rainbow,
 /obj/item/clothing/shoes/rainbow,
 /obj/item/clothing/head/soft/rainbow,
 /obj/item/clothing/under/rainbow,
-/obj/structure/disposalpipe/segment{
+/turf/simulated/floor/plating,
+/area/maintenance/port)
+"bvJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
-"bvJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/storage/tools)
 "bvK" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j1 (WEST)"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/wall,
-/area/storage/tools)
+/turf/simulated/floor/plasteel,
+/area/quartermaster/office)
 "bvL" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
@@ -36562,6 +36683,9 @@
 	},
 /obj/structure/table/reinforced,
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bvR" = (
@@ -36720,19 +36844,16 @@
 	},
 /area/bridge)
 "bwd" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	name = "HoP Office";
+	sortType = 15
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "browncorner"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
+/area/hallway/primary/central/west)
 "bwe" = (
 /obj/machinery/door/window/eastright{
 	dir = 1;
@@ -36763,13 +36884,6 @@
 "bwi" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "blue"
-	},
-/area/hallway/primary/central/ne)
-"bwj" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "bluecorner"
 	},
 /area/hallway/primary/central/ne)
 "bwl" = (
@@ -36833,7 +36947,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bwr" = (
@@ -36914,6 +37033,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	tag = "icon-pipe-j1 (EAST)"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
 "bwC" = (
@@ -36989,7 +37112,6 @@
 	id_tag = "mechbay";
 	name = "Mech Bay"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
@@ -36999,6 +37121,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -37054,6 +37179,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "bwS" = (
@@ -37077,6 +37205,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "bwT" = (
@@ -37097,6 +37228,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "bwV" = (
@@ -37113,6 +37247,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -37153,6 +37290,9 @@
 	},
 /obj/structure/cable,
 /obj/structure/closet/secure_closet/personal,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bwZ" = (
@@ -37163,11 +37303,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bxa" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/maintenance/port)
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/central/west)
 "bxb" = (
 /turf/simulated/wall,
 /area/quartermaster/storage)
@@ -37211,20 +37354,25 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "bxg" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "bxh" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/wall,
 /area/quartermaster/office)
 "bxi" = (
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "browncorner"
@@ -37262,6 +37410,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel,
 /area/bridge)
@@ -37598,10 +37750,6 @@
 /turf/simulated/floor/wood,
 /area/library)
 "bxU" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/light,
 /obj/machinery/power/apc{
 	cell_type = 5000;
@@ -37614,6 +37762,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/simulated/floor/plasteel{
 	icon_state = "blue"
 	},
@@ -37651,11 +37800,6 @@
 	},
 /area/bridge)
 "bxZ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -37694,11 +37838,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -37813,10 +37952,6 @@
 "byl" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "packageSort2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -37952,6 +38087,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
 "byy" = (
@@ -37966,23 +38105,26 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "byA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/central/ne)
-"byB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/wall,
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/central/ne)
+"byB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	icon_state = "pipe-j2s";
+	name = "Sorting Office";
+	sortType = 2
+	},
+/turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "byC" = (
 /obj/structure/disposalpipe/segment{
@@ -38129,14 +38271,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 2;
-	icon_state = "pipe-j2s";
-	name = "Library";
-	sortType = 16
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
 "byR" = (
@@ -38149,9 +38286,6 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/library)
@@ -38174,9 +38308,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "byU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -38249,7 +38380,6 @@
 	},
 /area/chapel/main)
 "bza" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -38455,11 +38585,6 @@
 	name = "Escape Shuttle Cell";
 	req_access_txt = "1"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -38536,14 +38661,23 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bzF" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/quartermaster/office)
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "browncorner"
+	},
+/area/hallway/primary/central/west)
 "bzG" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "packageSort1"
 	},
 /obj/effect/decal/warning_stripes/west,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bzH" = (
@@ -38687,9 +38821,8 @@
 /area/crew_quarters/locker)
 "bzV" = (
 /obj/effect/decal/warning_stripes/south,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
@@ -38729,9 +38862,6 @@
 /area/crew_quarters/captain)
 "bAb" = (
 /obj/effect/decal/warning_stripes/south,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bAc" = (
@@ -38751,21 +38881,26 @@
 /area/crew_quarters/captain)
 "bAe" = (
 /obj/effect/decal/warning_stripes/southwestcorner,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bAf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/central/east)
+/area/hallway/primary/central/west)
 "bAg" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/central/east)
+/obj/effect/spawner/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/quartermaster/office)
 "bAh" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -38795,21 +38930,7 @@
 "bAk" = (
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/west)
-"bAl" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "bluecorner"
-	},
-/area/hallway/primary/central/east)
 "bAm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -38863,21 +38984,6 @@
 	icon_state = "green"
 	},
 /area/hallway/primary/starboard/west)
-"bAu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/port)
 "bAv" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -38886,9 +38992,6 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/bar)
 "bAw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -38901,9 +39004,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bAx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -38949,6 +39049,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "blue"
 	},
@@ -38987,6 +39088,11 @@
 	dir = 1
 	},
 /obj/effect/decal/warning_stripes/yellow,
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2";
+	tag = "icon-pipe-j1 (WEST)"
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bAG" = (
@@ -39092,9 +39198,6 @@
 /area/crew_quarters/bar)
 "bAW" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -39174,11 +39277,11 @@
 	c_tag = "Locker Room South";
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
@@ -39238,7 +39341,6 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "bBm" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
@@ -39247,6 +39349,10 @@
 /area/quartermaster/office)
 "bBo" = (
 /obj/machinery/hologram/holopad,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bBp" = (
@@ -39391,16 +39497,18 @@
 	c_tag = "Central Hallway East";
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_x = -32
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "bluecorner"
 	},
-/area/hallway/primary/central/east)
+/area/hallway/primary/central/se)
 "bBG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -39606,11 +39714,10 @@
 /turf/simulated/wall,
 /area/maintenance/port)
 "bCk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/port)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/quartermaster/office)
 "bCm" = (
 /obj/machinery/door/airlock{
 	name = "Unit 3"
@@ -39620,12 +39727,12 @@
 	},
 /area/crew_quarters/locker/locker_toilet)
 "bCn" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bCo" = (
@@ -39647,9 +39754,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "bCr" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/maintenance/port)
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/lab)
 "bCs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -39659,6 +39771,11 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2";
+	tag = "icon-pipe-j2"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
 "bCu" = (
@@ -39695,6 +39812,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "bCx" = (
@@ -39946,21 +40064,15 @@
 	},
 /area/hallway/secondary/exit)
 "bCY" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "bluecorner"
 	},
-/area/hallway/primary/central/east)
+/area/hallway/primary/central/se)
 "bCZ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -39968,9 +40080,18 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/west)
 "bDa" = (
-/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/starboard/west)
+/area/quartermaster/office)
 "bDb" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "blue"
@@ -40171,7 +40292,9 @@
 	pixel_x = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -40306,20 +40429,14 @@
 "bDO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/west)
 "bDP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bDQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -40329,6 +40446,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -40352,12 +40472,12 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -40372,7 +40492,9 @@
 /obj/structure/disposaloutlet{
 	dir = 1
 	},
-/obj/structure/disposalpipe/trunk,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "bDV" = (
@@ -40480,6 +40602,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
 "bEh" = (
@@ -40498,10 +40621,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bEj" = (
@@ -40550,13 +40669,11 @@
 /turf/simulated/wall,
 /area/medical/reception)
 "bEr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
+	icon_state = "white"
 	},
-/area/crew_quarters/locker/locker_toilet)
+/area/toxins/lab)
 "bEs" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -40584,19 +40701,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
-"bEw" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "bluecorner"
-	},
-/area/hallway/primary/central/se)
 "bEx" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -40613,22 +40717,6 @@
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
-"bEz" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/crew_quarters/locker/locker_toilet)
 "bEA" = (
 /turf/simulated/wall/r_wall,
 /area/assembly/robotics)
@@ -40807,7 +40895,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -40827,9 +40914,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "bFd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -40878,8 +40962,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/central/east)
+/area/hallway/primary/central/se)
 "bFj" = (
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 1"
@@ -40892,18 +40977,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
 "bFl" = (
@@ -40916,41 +40992,37 @@
 	pixel_x = -24
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bFm" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/wall,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bFn" = (
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_y = 32
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
 "bFo" = (
 /obj/machinery/atm{
 	pixel_y = 32
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
@@ -40976,14 +41048,6 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
 "bFs" = (
@@ -40991,35 +41055,27 @@
 	pixel_x = -5;
 	pixel_y = 30
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
 "bFt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office)
+/area/hallway/secondary/exit)
 "bFu" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
@@ -41027,36 +41083,23 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
 "bFw" = (
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 6"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
 "bFx" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/bot,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bFy" = (
 /obj/structure/chair{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -41067,9 +41110,6 @@
 "bFz" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
@@ -41085,9 +41125,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -41115,24 +41152,32 @@
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "bFG" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "blue"
+	},
+/area/hallway/secondary/exit)
+"bFH" = (
+/obj/structure/chair{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "ramptop";
-	tag = "icon-stage_stairs"
+	icon_state = "blue"
 	},
-/area/hallway/primary/starboard/east)
-"bFH" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j1 (WEST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "bFI" = (
 /obj/machinery/alarm{
@@ -41265,12 +41310,6 @@
 	},
 /area/medical/morgue)
 "bFU" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "bluecorner"
@@ -41456,10 +41495,7 @@
 /turf/simulated/floor/plating,
 /area/medical/paramedic)
 "bGj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -41468,13 +41504,6 @@
 "bGk" = (
 /obj/machinery/light{
 	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -41492,16 +41521,11 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "bGn" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bGo" = (
@@ -41816,10 +41840,6 @@
 /area/maintenance/disposal)
 "bGR" = (
 /obj/item/cigbutt,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
@@ -41834,34 +41854,40 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bGU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/port)
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/exit)
 "bGV" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bGW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/wall,
-/area/crew_quarters/locker/locker_toilet)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/transparent/glass/reinforced,
+/area/hallway/secondary/exit)
 "bGX" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -41876,6 +41902,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/west)
 "bHa" = (
@@ -41888,10 +41915,6 @@
 /area/hallway/primary/central/west)
 "bHb" = (
 /obj/item/cigbutt,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bHc" = (
@@ -41905,7 +41928,9 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/disposalpipe/trunk,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "bHd" = (
@@ -42003,8 +42028,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/central/east)
+/area/hallway/primary/central/se)
 "bHp" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet,
@@ -42036,7 +42062,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/central/east)
+/area/hallway/primary/central/se)
 "bHs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -42045,7 +42071,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/central/east)
+/area/hallway/primary/central/se)
 "bHt" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -42071,9 +42097,6 @@
 "bHv" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bHw" = (
@@ -42125,22 +42148,20 @@
 "bHC" = (
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 2;
-	icon_state = "pipe-j2s";
-	name = "Sci R&D";
-	sortType = 12
-	},
-/obj/structure/cable{
-	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
 "bHD" = (
@@ -42155,18 +42176,6 @@
 	icon_state = "dark"
 	},
 /area/medical/morgue)
-"bHF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/starboard/east)
 "bHG" = (
 /obj/structure/filingcabinet/chestdrawer/autopsy,
 /turf/simulated/floor/plasteel{
@@ -42174,9 +42183,6 @@
 	},
 /area/medical/morgue)
 "bHH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -42188,14 +42194,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/starboard/east)
-"bHI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	name = "Sci Robotics";
+	sortType = 24;
+	tag = "icon-pipe-j1s (EAST)"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
@@ -42257,15 +42265,19 @@
 	},
 /area/medical/reception)
 "bHP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
@@ -42275,6 +42287,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-y"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
@@ -42287,6 +42302,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -42302,6 +42320,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "bHT" = (
@@ -42311,6 +42332,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "ramptop";
@@ -42318,12 +42342,16 @@
 	},
 /area/hallway/primary/starboard/east)
 "bHU" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2";
+	tag = "icon-pipe-j1 (WEST)"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -42332,6 +42360,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -42351,13 +42382,6 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "bHY" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
-	icon_state = "radiation";
-	name = "RADIOACTIVE AREA"
-	},
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "open";
@@ -42365,10 +42389,22 @@
 	name = "Engineering Security Doors";
 	opacity = 0
 	},
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/engine/equipmentstorage)
 "bHZ" = (
-/obj/machinery/vending/tool,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = 32
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering Equipment North"
+	},
+/obj/machinery/light{
+	dir = 1;
+	in_use = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "bIa" = (
@@ -42561,9 +42597,7 @@
 /obj/structure/mirror{
 	pixel_x = 28
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -42618,10 +42652,6 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bIx" = (
@@ -42709,6 +42739,8 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bIK" = (
@@ -42790,8 +42822,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/central/east)
+/area/hallway/primary/central/se)
 "bIS" = (
 /obj/structure/closet/secure_closet/cargotech,
 /turf/simulated/floor/plasteel,
@@ -42884,29 +42917,24 @@
 	},
 /area/hallway/primary/starboard/west)
 "bJd" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitecorner"
 	},
 /area/hallway/primary/starboard/west)
 "bJe" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
@@ -42920,30 +42948,35 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bJg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/starboard/west)
+/area/hallway/primary/central/sw)
 "bJh" = (
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 3";
 	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/west)
 "bJi" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 1;
-	name = "Sorting Office";
-	sortType = 2
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
@@ -42956,28 +42989,23 @@
 "bJk" = (
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 2;
-	icon_state = "pipe-j2s";
-	name = "Sci RD Office 1";
-	sortType = 13
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/starboard/east)
+/area/medical/research{
+	name = "Research Division"
+	})
 "bJl" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/starboard/west)
-"bJm" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -42986,7 +43014,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/starboard/east)
+/area/engine/gravitygenerator)
 "bJn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -43014,6 +43042,7 @@
 "bJq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
 "bJr" = (
@@ -43080,23 +43109,21 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 1;
-	icon_state = "pipe-j2s";
-	name = "Disposals Maint";
-	sortType = 1
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bJw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/blood/oil/streak,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -43106,18 +43133,34 @@
 	dir = 8
 	},
 /obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
 /area/crew_quarters/locker/locker_toilet)
 "bJy" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/maintenance/port)
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
 "bJz" = (
 /obj/structure/toilet{
 	dir = 8
@@ -43167,13 +43210,13 @@
 /area/medical/reception)
 "bJB" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "whitehall"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/maintenance/port)
+/area/medical/research{
+	name = "Research Division"
+	})
 "bJC" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -43242,7 +43285,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -43348,12 +43390,6 @@
 	tag = "icon-whitebluecorner"
 	},
 /area/medical/medbay2)
-"bJT" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/central/se)
 "bJU" = (
 /obj/machinery/door/airlock{
 	id_tag = "toilet_unit1";
@@ -43440,22 +43476,15 @@
 /area/medical/chemistry)
 "bKa" = (
 /obj/item/twohanded/required/kirbyplants,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
 "bKb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
 "bKc" = (
@@ -43529,15 +43558,6 @@
 	icon_state = "dark"
 	},
 /area/medical/morgue)
-"bKh" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/port)
 "bKi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43643,12 +43663,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bKu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/port)
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/central/se)
 "bKv" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -43678,6 +43702,9 @@
 /area/quartermaster/storage)
 "bKA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bKB" = (
@@ -43707,14 +43734,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "bKE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -43731,18 +43750,11 @@
 /turf/simulated/wall/r_wall,
 /area/maintenance/port)
 "bKG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bKH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -43754,9 +43766,6 @@
 "bKI" = (
 /obj/machinery/light{
 	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -43778,7 +43787,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -43808,6 +43816,7 @@
 "bKN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
 "bKO" = (
@@ -43832,13 +43841,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "bKQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
-/area/quartermaster/storage)
+/area/hallway/primary/central/south)
 "bKR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -43852,28 +43865,33 @@
 	name = "Mech Bay";
 	req_access_txt = "29"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "bKS" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	icon_state = "browncorner"
+	icon_state = "pipe-j2s";
+	name = "Janitor";
+	sortType = 22
 	},
-/area/hallway/primary/central/west)
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/central/south)
 "bKT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "purple"
 	},
@@ -43896,14 +43914,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bKW" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -43912,13 +43926,9 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bKY" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -43936,7 +43946,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Conference Room";
@@ -44017,15 +44026,6 @@
 	},
 /area/medical/morgue)
 "bLl" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/assembly/chargebay)
-"bLm" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -44067,12 +44067,15 @@
 	},
 /area/hydroponics)
 "bLo" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -44081,6 +44084,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -44096,6 +44102,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -44113,6 +44122,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -44330,10 +44342,6 @@
 /area/assembly/robotics)
 "bLN" = (
 /obj/machinery/mech_bay_recharge_port,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_x = -32
@@ -44355,10 +44363,6 @@
 /area/maintenance/port)
 "bLP" = (
 /obj/machinery/computer/mech_bay_power_console,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /turf/simulated/floor/bluegrid,
 /area/assembly/chargebay)
 "bLQ" = (
@@ -44431,6 +44435,7 @@
 /obj/item/multitool{
 	pixel_x = 3
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
 "bLU" = (
@@ -44516,10 +44521,6 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "bMd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -44529,6 +44530,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -44543,22 +44547,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "bMf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/port)
-"bMg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/turf/simulated/floor/plating,
+/area/maintenance/port)
+"bMg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	d1 = 4;
@@ -44571,13 +44571,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bMh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	d1 = 2;
@@ -44589,6 +44588,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -44620,17 +44623,24 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bMl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/wall,
-/area/quartermaster/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/central/south)
 "bMm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/west)
 "bMn" = (
@@ -44671,6 +44681,9 @@
 	pixel_y = 27
 	},
 /obj/machinery/hologram/holopad,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bMr" = (
@@ -44706,10 +44719,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
 "bMw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -44718,10 +44734,8 @@
 /turf/simulated/wall,
 /area/quartermaster/office)
 "bMy" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -44793,7 +44807,6 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -44955,12 +44968,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "bluecorner"
@@ -44995,15 +45002,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
@@ -45052,25 +45058,17 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "bNc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -45081,6 +45079,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -45105,13 +45107,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -45128,9 +45130,6 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "bNh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -45149,9 +45148,7 @@
 /obj/item/stack/cable_coil,
 /obj/item/flash,
 /obj/item/flash,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
 "bNj" = (
@@ -45176,9 +45173,6 @@
 	pixel_y = 5
 	},
 /obj/item/clothing/glasses/welding,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/item/radio/headset/headset_sci{
 	pixel_x = -3
 	},
@@ -45188,9 +45182,6 @@
 /area/assembly/robotics)
 "bNk" = (
 /obj/structure/closet/emcloset,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -45202,11 +45193,24 @@
 	name = "Research Division"
 	})
 "bNl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/wall/r_wall,
-/area/assembly/robotics)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	name = "Sci RD Office 2";
+	sortType = 13
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
 "bNm" = (
 /obj/machinery/camera{
 	c_tag = "Research Access";
@@ -45216,9 +45220,6 @@
 	dir = 4;
 	pixel_x = 11
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -45227,13 +45228,11 @@
 	name = "Research Division"
 	})
 "bNn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -45286,19 +45285,22 @@
 	name = "Science Requests Console";
 	pixel_x = -30
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/toxins/lab)
 "bNq" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/r_wall,
-/area/toxins/lab)
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "whitehall"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
 "bNr" = (
 /obj/machinery/light{
 	dir = 4
@@ -45314,26 +45316,33 @@
 	},
 /area/medical/reception)
 "bNs" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	icon_state = "pipe-j2s";
-	name = "Cargo Disposals"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/wall,
-/area/quartermaster/office)
-"bNt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit)
-"bNu" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/medical/ward)
+"bNt" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/engine/controlroom)
+"bNu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -45341,9 +45350,6 @@
 	},
 /area/hallway/secondary/exit)
 "bNv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -45355,9 +45361,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -45450,12 +45453,16 @@
 /turf/simulated/floor/plasteel,
 /area/medical/chemistry)
 "bNE" = (
-/obj/effect/spawner/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/assembly/robotics)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/engine/controlroom)
 "bNF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -45487,6 +45494,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bNI" = (
@@ -45494,13 +45502,25 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bNJ" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Maintenance";
+	req_access_txt = "5"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/area/assembly/robotics)
+/turf/simulated/floor/plating,
+/area/maintenance/genetics)
 "bNK" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -45525,11 +45545,6 @@
 	},
 /area/medical/biostorage)
 "bNM" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
@@ -45538,6 +45553,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
@@ -45616,11 +45635,6 @@
 	},
 /area/toxins/lab)
 "bNV" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -45630,11 +45644,6 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bNW" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	pixel_y = -32
@@ -45648,24 +45657,21 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bNX" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bNY" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/west)
 "bNZ" = (
@@ -45879,7 +45885,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
 	c_tag = "Accounts Uplink Terminal";
 	dir = 8;
@@ -45970,15 +45975,9 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/captain)
 "bOz" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
 	pixel_y = 1
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
@@ -46101,12 +46100,15 @@
 /turf/simulated/floor/plating,
 /area/engine/gravitygenerator)
 "bOI" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/turf/simulated/wall,
-/area/quartermaster/storage)
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
 "bOJ" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -46200,7 +46202,6 @@
 	},
 /area/medical/biostorage)
 "bOS" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -46248,10 +46249,6 @@
 /area/medical/morgue)
 "bOZ" = (
 /obj/machinery/mech_bay_recharge_port,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/item/radio/intercom{
 	dir = 8;
 	pixel_x = -28
@@ -46374,6 +46371,7 @@
 "bPi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -46442,7 +46440,7 @@
 "bPn" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
-	dir = 8
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
@@ -46835,6 +46833,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bQd" = (
@@ -46845,6 +46847,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bQe" = (
@@ -46864,17 +46867,14 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bQg" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bQh" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -46917,23 +46917,13 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
@@ -46956,15 +46946,6 @@
 	},
 /area/crew_quarters/heads)
 "bQm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
 	name = "standard air scrubber";
@@ -46972,12 +46953,21 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bQn" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
 "bQo" = (
@@ -46989,7 +46979,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel";
@@ -47209,8 +47198,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-y"
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -47227,9 +47217,6 @@
 	},
 /area/medical/morgue)
 "bQI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -47246,9 +47233,6 @@
 	},
 /area/medical/morgue)
 "bQJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Medbay Morgue South";
 	dir = 1
@@ -47259,9 +47243,6 @@
 	},
 /area/medical/morgue)
 "bQK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/bluegrid,
 /area/assembly/chargebay)
 "bQL" = (
@@ -47276,9 +47257,6 @@
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
 	req_access_txt = "6;29"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -47295,23 +47273,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/captain)
-"bQN" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plasteel,
-/area/assembly/chargebay)
 "bQO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
 "bQP" = (
@@ -47495,12 +47462,6 @@
 /turf/simulated/wall,
 /area/medical/genetics_cloning)
 "bRf" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -47536,10 +47497,6 @@
 /area/assembly/chargebay)
 "bRj" = (
 /obj/machinery/hologram/holopad,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -47642,16 +47599,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "bRs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -47706,9 +47659,6 @@
 /obj/effect/landmark/start{
 	name = "Roboticist"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -47718,9 +47668,6 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
 "bRz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -47777,9 +47724,6 @@
 	},
 /area/toxins/lab)
 "bRF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/decal/warning_stripes/east,
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -47855,10 +47799,6 @@
 /area/quartermaster/office)
 "bRO" = (
 /obj/machinery/hologram/holopad,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -47915,6 +47855,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -47953,12 +47894,12 @@
 /area/toxins/lab)
 "bRY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/toxins/lab)
 "bRZ" = (
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "redcorner"
@@ -48069,7 +48010,6 @@
 /obj/machinery/power/smes{
 	charge = 5e+006
 	},
-/obj/structure/cable,
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -48123,18 +48063,10 @@
 	},
 /area/medical/medbay2)
 "bSp" = (
-/obj/structure/disposalpipe/segment{
-	name = "Sorting Office"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -48270,6 +48202,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -48520,6 +48453,12 @@
 "bST" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
 "bSU" = (
@@ -48645,7 +48584,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -48838,9 +48776,14 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
 "bTz" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/central/sw)
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
 "bTA" = (
 /obj/structure/table,
 /obj/machinery/requests_console{
@@ -48920,12 +48863,6 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/captain)
 "bTG" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/sign/poster/random{
 	pixel_x = -32
 	},
@@ -49086,9 +49023,6 @@
 /turf/simulated/floor/plasteel,
 /area/teleporter)
 "bTW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
@@ -49142,6 +49076,12 @@
 	},
 /area/medical/genetics_cloning)
 "bUc" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -49153,7 +49093,6 @@
 	},
 /area/medical/genetics)
 "bUe" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -49208,6 +49147,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -49218,25 +49158,17 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 2;
-	icon_state = "pipe-j2s";
-	name = "Sci Robotics";
-	sortType = 14
-	},
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "bUm" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
@@ -49251,6 +49183,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
@@ -49276,7 +49212,6 @@
 	},
 /area/crew_quarters/heads)
 "bUs" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -49316,6 +49251,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
 "bUw" = (
@@ -49338,6 +49278,10 @@
 	pixel_x = 22
 	},
 /obj/machinery/power/terminal,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
 "bUz" = (
@@ -49348,6 +49292,11 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
@@ -49405,13 +49354,16 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain/bedroom)
 "bUE" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2 (EAST)"
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
-/turf/simulated/wall,
-/area/quartermaster/office)
+/turf/simulated/floor/plasteel{
+	icon_state = "floorgrime"
+	},
+/area/maintenance/incinerator)
 "bUF" = (
 /obj/machinery/computer/operating{
 	name = "Robotics Operating Computer"
@@ -49422,15 +49374,9 @@
 	},
 /area/assembly/robotics)
 "bUG" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
@@ -49535,6 +49481,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/medical/research{
 	name = "Research Division"
@@ -49555,33 +49502,29 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/toxins/lab)
 "bUS" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit)
-"bUT" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit)
+"bUT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -49625,6 +49568,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
@@ -49676,7 +49624,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -49728,13 +49675,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
 "bVk" = (
@@ -49743,15 +49690,13 @@
 	name = "Delivery Office";
 	req_access_txt = "50"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -49762,10 +49707,8 @@
 	name = "Cargo Bay";
 	req_access_txt = "31"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -49861,6 +49804,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bVt" = (
@@ -49877,15 +49821,9 @@
 	},
 /area/crew_quarters/heads)
 "bVw" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -22
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
@@ -49987,6 +49925,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
@@ -50006,6 +49945,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -50016,6 +49956,7 @@
 	name = "Delivery Office";
 	req_access_txt = "50"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bVI" = (
@@ -50036,7 +49977,6 @@
 	},
 /area/escapepodbay)
 "bVJ" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -50071,7 +50011,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -50140,15 +50079,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
 "bVT" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "blue"
@@ -50163,12 +50097,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	icon_state = "pipe-j2s";
+	name = "Genetics";
+	sortType = 23
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -50209,6 +50145,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurplecorner"
@@ -50230,6 +50169,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -50254,6 +50196,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -50263,6 +50208,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -50300,6 +50248,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -50351,6 +50302,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "whitehall"
@@ -50369,6 +50323,12 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 2;
+	icon_state = "pipe-j2s";
+	name = "Sci R&D";
+	sortType = 12
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -50398,6 +50358,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -50431,6 +50394,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -50447,6 +50413,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -50467,6 +50436,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -50531,25 +50504,19 @@
 /turf/simulated/floor/plating,
 /area/medical/cryo)
 "bWz" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
 	},
-/area/medical/medbay2)
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowcorner"
+	},
+/area/hallway/primary/aft)
 "bWA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/medbay2)
+/turf/simulated/wall,
+/area/engine/controlroom)
 "bWB" = (
 /obj/structure/table/reinforced,
 /obj/item/wrench,
@@ -50929,6 +50896,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-y"
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bXi" = (
@@ -50959,6 +50930,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
@@ -50997,7 +50972,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -51292,7 +51266,6 @@
 	},
 /area/medical/cryo)
 "bXP" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	pixel_x = -25
@@ -51434,25 +51407,25 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/central/se)
-"bYb" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/central/se)
+"bYb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -51502,17 +51475,18 @@
 	},
 /area/medical/medbay2)
 "bYg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
+	icon_state = "dark"
 	},
-/area/medical/genetics_cloning)
+/area/construction)
 "bYh" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -51554,7 +51528,6 @@
 /area/medical/genetics)
 "bYl" = (
 /obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/research/glass{
 	name = "Robotics Lab";
 	req_access_txt = "29"
@@ -51793,10 +51766,6 @@
 /area/quartermaster/office)
 "bYH" = (
 /obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/computer/guestpass{
 	pixel_y = -28
 	},
@@ -51842,10 +51811,6 @@
 /turf/simulated/wall,
 /area/quartermaster/qm)
 "bYN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -51858,6 +51823,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bYO" = (
@@ -51895,7 +51861,6 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint)
 "bYR" = (
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "blue"
@@ -51964,10 +51929,14 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
 "bYX" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
@@ -51981,7 +51950,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -52054,6 +52022,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
 "bZg" = (
@@ -52107,9 +52080,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/hologram/holopad,
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/junction{
 	dir = 1;
-	icon_state = "pipe-c"
+	tag = "icon-pipe-j1 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -52150,6 +52123,12 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -52173,12 +52152,17 @@
 	},
 /area/medical/cryo)
 "bZr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
 "bZs" = (
@@ -52187,22 +52171,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
 /area/medical/cryo)
 "bZt" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/sign/securearea{
 	pixel_x = -32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -52210,11 +52186,16 @@
 	},
 /area/hallway/primary/central/se)
 "bZu" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/area/medical/medbay2)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "floorgrime"
+	},
+/area/maintenance/incinerator)
 "bZv" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
@@ -52308,6 +52289,10 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/warning_stripes/east,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
 "bZD" = (
@@ -52531,13 +52516,10 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	icon_state = "pipe-j2s";
-	name = "Med. CMO";
-	sortType = 10
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -52575,11 +52557,14 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	icon_state = "pipe-j2s";
+	name = "Med. CMO";
+	sortType = 10
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -52720,7 +52705,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -52729,19 +52716,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 100
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-y"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
@@ -52756,19 +52743,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	icon_state = "pipe-j2s";
-	name = "Genetics";
-	sortType = 23
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -52898,7 +52880,6 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "cas" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
 	name = "Mining Dock";
@@ -52911,6 +52892,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "cat" = (
@@ -52938,7 +52920,6 @@
 	name = "Research Division"
 	})
 "caw" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_x = 32
@@ -52949,7 +52930,6 @@
 	},
 /area/hallway/primary/central/sw)
 "cax" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -52962,6 +52942,10 @@
 "cay" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -52997,6 +52981,12 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/sortjunction{
+	dir = 2;
+	icon_state = "pipe-j2s";
+	name = "Sci RD Office 2";
+	sortType = 13
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -53030,27 +53020,16 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/medical/sleeper)
 "caE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/sleeper)
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/aft)
 "caF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -53067,12 +53046,11 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -53085,12 +53063,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -53124,18 +53096,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/medical/sleeper)
 "caJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -53145,6 +53110,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -53170,23 +53138,20 @@
 	},
 /area/medical/cryo)
 "caL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
 /area/medical/cryo)
 "caM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -53208,51 +53173,47 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
 /area/medical/cryo)
 "caO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 100
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
 /area/medical/cryo)
 "caP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/structure/closet/emcloset,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "caution"
 	},
-/area/medical/medbay2)
+/area/hallway/primary/aft)
 "caQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "floorgrime"
 	},
-/area/medical/medbay2)
+/area/maintenance/incinerator)
 "caR" = (
 /obj/machinery/computer/crew,
 /turf/simulated/floor/plasteel{
@@ -53399,14 +53360,16 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads)
 "cbd" = (
-/turf/simulated/wall/r_wall,
-/area/toxins/server_coldroom)
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/aft)
 "cbe" = (
 /obj/structure/closet/secure_closet/hop2,
 /obj/machinery/camera{
@@ -53473,18 +53436,22 @@
 /turf/simulated/floor/plating,
 /area/teleporter)
 "cbm" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	name = "Captain's Office";
-	sortType = 18
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
 "cbn" = (
@@ -53496,20 +53463,6 @@
 	name = "Research Division"
 	})
 "cbo" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_x = -32
@@ -53553,15 +53506,17 @@
 	},
 /area/medical/biostorage)
 "cbs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/decal/warning_stripes/east,
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	name = "Captain's Office";
+	sortType = 18
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
 "cbt" = (
@@ -53629,6 +53584,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -53719,7 +53677,6 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "cbK" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -53732,6 +53689,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "cbL" = (
@@ -53806,13 +53764,11 @@
 	},
 /area/medical/medbay2)
 "cbU" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 5
 	},
-/area/medical/medbay2)
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/aft)
 "cbV" = (
 /obj/machinery/light,
 /obj/item/radio/intercom{
@@ -53831,6 +53787,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -53922,9 +53879,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -53933,6 +53887,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -53943,10 +53901,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -53969,6 +53923,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -53988,6 +53945,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -54005,6 +53965,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -54039,12 +54002,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -54057,13 +54019,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -54117,10 +54079,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/effect/landmark/start{
 	name = "Scientist"
 	},
@@ -54129,6 +54087,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-y"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -54506,7 +54468,7 @@
 	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/bluegrid/telecomms/server,
-/area/toxins/server_coldroom)
+/area/toxins/server)
 "ccU" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/sign/securearea{
@@ -54514,32 +54476,17 @@
 	name = "SERVER ROOM";
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
-	dir = 8;
-	tag = "icon-intact (WEST)"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/toxins/server)
 "ccV" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel/dark/telecomms,
-/area/toxins/server_coldroom)
+/area/toxins/server)
 "ccW" = (
 /obj/machinery/camera{
 	c_tag = "Research Server Room";
@@ -54565,7 +54512,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	id_tag = "hopofficedoor";
@@ -54581,11 +54527,6 @@
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/conveyor/east{
 	id = "packageExternal"
 	},
@@ -54594,11 +54535,6 @@
 /area/quartermaster/office)
 "ccZ" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/conveyor/east{
 	id = "packageExternal"
 	},
@@ -54613,6 +54549,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
 	tag = "icon-vault"
@@ -54629,12 +54570,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/toxins/server)
 "cdc" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
 	c_tag = "Central Hallway South East";
 	dir = 4
@@ -54917,6 +54852,9 @@
 	name = "Research Division"
 	})
 "cdG" = (
+/obj/item/storage/box,
+/obj/item/storage/box,
+/obj/item/storage/belt/utility,
 /obj/structure/table,
 /obj/machinery/status_display{
 	layer = 4;
@@ -55061,9 +54999,6 @@
 	},
 /area/hallway/primary/central/south)
 "cdY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "blue"
@@ -55074,10 +55009,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -55247,25 +55178,15 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	tag = "icon-pipe-j1 (EAST)"
-	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
 "cet" = (
 /obj/machinery/ai_status_display{
 	pixel_y = 32
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
 "ceu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
@@ -55275,15 +55196,16 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
 "cew" = (
 /obj/structure/sign/securearea{
 	pixel_y = 32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
 	},
 /obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plasteel,
@@ -55303,16 +55225,12 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
 "cez" = (
-/obj/machinery/alarm/server{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/simulated/floor/plasteel/dark/telecomms,
-/area/toxins/server_coldroom)
+/area/toxins/server)
 "ceA" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
@@ -55351,14 +55269,11 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
 "ceG" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/purple{
+	dir = 6
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/central/se)
+/area/hallway/primary/aft)
 "ceH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -55378,29 +55293,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
-"ceI" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/bluegrid/telecomms/server,
-/area/toxins/server_coldroom)
 "ceJ" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 100
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/toxins/server)
 "ceK" = (
@@ -55480,11 +55383,6 @@
 	},
 /area/crew_quarters/hor)
 "ceT" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -55610,14 +55508,15 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = "90Curve"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
 "cfi" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/item/radio/intercom{
 	dir = 1;
 	pixel_y = -28
@@ -55639,36 +55538,36 @@
 /area/hallway/primary/central/sw)
 "cfk" = (
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
 	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
 "cfl" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/central/sw)
+/area/hallway/primary/aft)
 "cfm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
@@ -55712,12 +55611,21 @@
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "cfq" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
@@ -55727,16 +55635,21 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cfs" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
@@ -55748,6 +55661,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
 "cfu" = (
@@ -55757,14 +55678,27 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
 "cfv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/central/south)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/engine,
+/area/engine/mechanic_workshop)
 "cfw" = (
 /obj/structure/table/glass,
 /obj/item/storage/toolbox/surgery,
@@ -55781,24 +55715,29 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/central/south)
-"cfy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
+"cfy" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/engine,
+/area/engine/mechanic_workshop)
 "cfz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/central/se)
+/area/hallway/primary/aft)
 "cfA" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/machinery/door_control{
@@ -55816,9 +55755,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
 	pixel_y = -32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
@@ -55904,7 +55840,6 @@
 /obj/item/reagent_containers/iv_bag/blood/BPlus,
 /obj/item/reagent_containers/iv_bag/blood/OPlus,
 /obj/item/reagent_containers/iv_bag/blood/OMinus,
-/obj/structure/disposalpipe/segment,
 /obj/item/reagent_containers/iv_bag/salglu,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -55956,9 +55891,12 @@
 	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
 	name = "Surgery Cleaner"
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
-	icon_state = "pipe-c"
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -55976,21 +55914,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
 /area/medical/surgery2)
 "cfP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -56033,10 +55965,6 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -56070,6 +55998,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
@@ -56176,7 +56112,7 @@
 	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/bluegrid/telecomms/server,
-/area/toxins/server_coldroom)
+/area/toxins/server)
 "cgd" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/sign/securearea{
@@ -56187,13 +56123,21 @@
 /turf/simulated/floor/plating,
 /area/toxins/server)
 "cge" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
 "cgf" = (
@@ -56214,21 +56158,42 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
 "cgi" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	tag = "icon-pipe-j1 (EAST)"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
 "cgj" = (
@@ -56238,12 +56203,28 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
 "cgk" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-y"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
 "cgl" = (
@@ -56251,12 +56232,19 @@
 	codes_txt = "patrol;next_patrol=AftH";
 	location = "AIW"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
@@ -56271,11 +56259,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
 "cgn" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -56288,6 +56282,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
 "cgp" = (
@@ -56298,6 +56295,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -56323,6 +56323,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
@@ -56400,15 +56405,19 @@
 	},
 /area/quartermaster/miningdock)
 "cgI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
@@ -56423,23 +56432,31 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/central/se)
-"cgK" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/central/se)
+"cgK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
@@ -56452,16 +56469,14 @@
 	},
 /area/medical/sleeper)
 "cgM" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j1 (WEST)"
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	name = "standard air scrubber";
 	on = 1;
 	scrub_N2O = 1;
 	scrub_Toxins = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -56493,12 +56508,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -56529,7 +56538,6 @@
 /obj/effect/landmark/start{
 	name = "Medical Doctor"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -56541,14 +56549,8 @@
 /obj/effect/landmark{
 	name = "blobstart"
 	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /turf/simulated/floor/plasteel/dark/telecomms,
-/area/toxins/server_coldroom)
+/area/toxins/server)
 "cgU" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/ai_status_display{
@@ -56630,26 +56632,21 @@
 	name = "Server Interior Door";
 	req_access = null
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 4;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/toxins/server)
 "chb" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/binary/pump/on{
+	target_pressure = 4500
 	},
 /turf/simulated/floor/plasteel/dark/telecomms,
-/area/toxins/server_coldroom)
+/area/toxins/server)
 "chc" = (
 /turf/simulated/wall,
 /area/janitor)
@@ -56840,10 +56837,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel/dark,
 /area/toxins/server)
 "chw" = (
@@ -56877,7 +56872,6 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -57045,14 +57039,15 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-y"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -57072,17 +57067,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 1;
-	name = "Sci RD Office 2";
-	sortType = 13
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -57317,7 +57308,6 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "cis" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -57327,6 +57317,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "cit" = (
@@ -57361,14 +57352,13 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "ciy" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
 "ciz" = (
@@ -57406,19 +57396,11 @@
 	c_tag = "Central Primary Hallway South-West";
 	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
@@ -57518,36 +57500,40 @@
 /turf/simulated/floor/wood,
 /area/ntrep)
 "ciL" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
 "ciM" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/item/extinguisher,
+/obj/item/extinguisher,
+/obj/item/extinguisher,
+/obj/item/extinguisher,
+/obj/item/extinguisher,
+/obj/item/extinguisher,
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/central/south)
+/area/atmos/control)
 "ciN" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -57557,19 +57543,12 @@
 	},
 /area/hallway/primary/aft)
 "ciO" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/central/sw)
+/area/hallway/primary/aft)
 "ciP" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -57584,24 +57563,15 @@
 /area/medical/surgery2)
 "ciR" = (
 /obj/machinery/iv_drip,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
 /area/medical/surgery2)
 "ciS" = (
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
 	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
@@ -57630,7 +57600,6 @@
 	name = "Emergency NanoMed";
 	pixel_x = -25
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -57731,21 +57700,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/genetics)
 "cjb" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/central/south)
+/area/hallway/primary/aft)
 "cjc" = (
 /obj/structure/sign/poster/random{
 	pixel_x = 32
@@ -57800,10 +57760,13 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
 "cji" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -57811,86 +57774,58 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
 "cjj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
 "cjk" = (
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2"
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/central/south)
-"cjl" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	icon_state = "pipe-j2s";
-	name = "Janitor";
-	sortType = 22
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/central/south)
-"cjm" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/turf/simulated/floor/plating,
+/area/maintenance/genetics)
+"cjl" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/central/south)
+"cjm" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
 "cjn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
 "cjo" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
 "cjp" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
+/obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/central/se)
+/area/engine/break_room)
 "cjq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -57901,13 +57836,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cjr" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 6
 	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/central/se)
+/turf/space,
+/area/space/nearstation)
 "cjs" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -57920,28 +57854,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cjt" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/sleeper)
+/turf/simulated/wall/r_wall,
+/area/engine/equipmentstorage)
 "cju" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/sleeper)
+/turf/simulated/floor/plasteel,
+/area/atmos)
 "cjv" = (
 /obj/structure/closet/wardrobe/medic_white,
 /obj/item/clothing/head/surgery/blue,
@@ -58048,7 +57969,10 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	tag = "icon-pipe-j1 (EAST)"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -58074,7 +57998,6 @@
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -58091,6 +58014,9 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -58136,11 +58062,12 @@
 /turf/simulated/floor/engine,
 /area/toxins/explab_chamber)
 "cjH" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	dir = 8;
+	tag = "icon-intact (WEST)"
 	},
 /turf/simulated/floor/bluegrid/telecomms/server,
-/area/toxins/server_coldroom)
+/area/toxins/server)
 "cjI" = (
 /obj/machinery/camera{
 	c_tag = "Research E.X.P.E.R.I-MENTOR Chamber";
@@ -58156,22 +58083,15 @@
 /turf/simulated/floor/engine,
 /area/toxins/explab_chamber)
 "cjJ" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 9
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9
 	},
 /turf/simulated/floor/plasteel/dark/telecomms,
-/area/toxins/server_coldroom)
+/area/toxins/server)
 "cjK" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -58264,24 +58184,6 @@
 	icon_state = "dark"
 	},
 /area/crew_quarters/hor)
-"cjU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/quartermaster/miningdock)
 "cjV" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/machinery/meter,
@@ -58430,7 +58332,6 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "ckp" = (
@@ -58438,7 +58339,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "ckq" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -58455,6 +58355,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	name = "QM Office";
+	sortType = 3
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "ckr" = (
@@ -58469,6 +58374,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whiteblue";
@@ -58477,7 +58385,7 @@
 /area/medical/surgery2)
 "cks" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
+	dir = 2;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
@@ -58520,10 +58428,6 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "cky" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -58533,9 +58437,6 @@
 /obj/machinery/door/airlock/medical{
 	name = "Operating Theatre Storage";
 	req_access_txt = "45"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -58563,7 +58464,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/closet/walllocker/emerglocker/west,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitebluecorner";
@@ -58701,7 +58601,6 @@
 /turf/simulated/floor/wood,
 /area/ntrep)
 "ckO" = (
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "cautioncorner"
@@ -58719,13 +58618,18 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
 "ckR" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/central/south)
+/obj/effect/spawner/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	desc = "Труба ведёт газ на фильтрацию";
+	dir = 9;
+	name = "Труба на фильтрацию"
+	},
+/turf/simulated/floor/plating,
+/area/atmos/distribution)
 "ckS" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -58913,7 +58817,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -30
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitebluecorner";
@@ -59006,7 +58909,6 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
 "clr" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -59014,7 +58916,6 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "cls" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -59022,6 +58923,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "clt" = (
@@ -59190,10 +59092,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "clO" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
@@ -59405,6 +59307,11 @@
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "cmk" = (
@@ -59487,8 +59394,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-y"
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -59510,10 +59418,6 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -59666,17 +59570,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "cmG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	desc = "Труба хранит в себе набор газов для смешивания";
+	dir = 9;
+	name = "Труба смешивания"
 	},
-/turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/turf/space,
+/area/space/nearstation)
 "cmH" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	dir = 4;
-	location = "Engineering"
-	},
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/toy/figure/janitor,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cmJ" = (
@@ -59723,6 +59628,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cmP" = (
@@ -59732,7 +59638,6 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
 "cmQ" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -60007,10 +59912,6 @@
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "cns" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
@@ -60277,11 +60178,6 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "cnT" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	name = "QM Office";
-	sortType = 3
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -60293,13 +60189,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "cnU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -60311,6 +60206,10 @@
 	},
 /obj/effect/landmark/start{
 	name = "Shaft Miner"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -60584,6 +60483,7 @@
 "coq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cor" = (
@@ -60604,13 +60504,8 @@
 	},
 /area/shuttle/specops)
 "cot" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -60736,10 +60631,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "coF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -61065,6 +60956,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cph" = (
@@ -61096,7 +60988,6 @@
 	},
 /area/medical/medbay2)
 "cpi" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -61185,9 +61076,6 @@
 /obj/machinery/light/small{
 	dir = 4;
 	tag = "icon-bulb1 (EAST)"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -61914,12 +61802,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	name = "HoP Office";
-	sortType = 15
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -61958,6 +61844,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cqw" = (
@@ -61979,6 +61866,9 @@
 	},
 /obj/machinery/holosign/surgery{
 	id = "surgery2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -62126,11 +62016,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -62229,25 +62114,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cqX" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
+/obj/machinery/vending/tool,
+/turf/simulated/floor/plasteel,
+/area/engine/equipmentstorage)
 "cqY" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -62258,44 +62128,37 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cqZ" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/light_switch{
+	pixel_x = 27
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/plasteel,
+/area/engine/equipmentstorage)
+"cra" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/atmos)
+"crb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 10
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
-"cra" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
-"crb" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -62308,13 +62171,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "crd" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4
 	},
-/turf/simulated/wall,
-/area/engine/controlroom)
+/obj/machinery/portable_atmospherics/pump,
+/turf/simulated/floor/plasteel,
+/area/atmos)
 "cre" = (
 /obj/effect/landmark/start{
 	name = "Medical Doctor"
@@ -62329,6 +62191,9 @@
 "crf" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
@@ -62759,6 +62624,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "crV" = (
@@ -62790,14 +62656,14 @@
 	},
 /area/toxins/mixing)
 "crX" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/spawner/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	dir = 10;
+	name = "Труба дыхательной смеси"
 	},
-/obj/structure/grille/broken,
 /turf/simulated/floor/plating,
-/area/maintenance/asmaint)
+/area/atmos/distribution)
 "crY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -63164,6 +63030,11 @@
 	})
 "csG" = (
 /obj/structure/closet/firecloset,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "csH" = (
@@ -63179,7 +63050,6 @@
 	name = "Research Division"
 	})
 "csI" = (
-/obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom{
 	dir = 8;
 	pixel_x = -28
@@ -63246,6 +63116,9 @@
 	pixel_y = 30
 	},
 /obj/structure/closet/firecloset,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "csP" = (
@@ -63264,9 +63137,11 @@
 	},
 /area/toxins/mixing)
 "csQ" = (
-/obj/structure/cable,
 /obj/machinery/computer/monitor{
 	name = "Grid Power Monitoring Computer"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -63475,11 +63350,6 @@
 	},
 /area/medical/virology)
 "ctf" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
 	autoclose = 0;
@@ -63566,6 +63436,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "ctk" = (
@@ -63653,16 +63524,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/genetics)
 "ctt" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
+/turf/simulated/floor/plasteel,
+/area/engine/equipmentstorage)
 "ctu" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -63925,11 +63791,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2";
+	tag = "icon-pipe-j2"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "ctT" = (
@@ -63970,9 +63838,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/westright{
-	name = "Engineering Monitoring Station";
-	req_access = null;
-	req_one_access_txt = "11;24;34"
+	name = "Engineering Monitoring Station"
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -63988,11 +63854,6 @@
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_x = -32
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -64211,15 +64072,15 @@
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "cuu" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
+/obj/item/radio/intercom{
+	pixel_x = 28
+	},
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plasteel,
+/area/engine/equipmentstorage)
 "cuv" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluecorner";
@@ -64914,6 +64775,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cvK" = (
@@ -64952,13 +64814,13 @@
 	},
 /area/engine/controlroom)
 "cvN" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/spawner/window/reinforced,
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	name = "Труба дыхательной смеси"
 	},
-/turf/simulated/wall,
-/area/construction)
+/turf/simulated/floor/plating,
+/area/atmos/distribution)
 "cvO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -65376,6 +65238,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cwx" = (
@@ -65443,7 +65306,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/consarea)
 "cwJ" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
 	pixel_y = 1
@@ -65519,20 +65381,17 @@
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "cwS" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	desc = "Труба ведёт газ на фильтрацию";
+	name = "Труба на фильтрацию"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	dir = 4;
+	name = "Труба дыхательной смеси"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/construction)
+/turf/simulated/floor/plasteel,
+/area/atmos/distribution)
 "cwT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -65658,12 +65517,16 @@
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "cxe" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/briefcase/inflatable{
-	pixel_x = -2;
+/obj/structure/table,
+/obj/item/radio{
+	pixel_x = -6;
 	pixel_y = 4
 	},
-/obj/item/storage/briefcase/inflatable,
+/obj/item/radio{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/radio,
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "cxf" = (
@@ -65672,6 +65535,9 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
@@ -65719,14 +65585,13 @@
 	},
 /area/medical/medbay2)
 "cxk" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
 	pixel_x = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -65740,15 +65605,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cxm" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/binary/volume_pump/on{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/construction)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/atmos/distribution)
 "cxn" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 8
@@ -65866,18 +65728,14 @@
 /turf/simulated/floor/plating,
 /area/construction)
 "cxA" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "white"
 	},
-/area/construction)
+/area/toxins/xenobiology)
 "cxB" = (
 /obj/structure/chair/comfy/lime{
 	dir = 8
@@ -65888,11 +65746,6 @@
 /turf/simulated/floor/carpet,
 /area/medical/psych)
 "cxC" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/computer/general_air_control{
 	frequency = 1443;
 	level = 3;
@@ -66242,14 +66095,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "cym" = (
+/obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/cobweb2,
-/obj/structure/rack{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "cyn" = (
@@ -66267,11 +66114,10 @@
 /area/maintenance/incinerator)
 "cyo" = (
 /obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -66481,8 +66327,10 @@
 	},
 /area/engine/controlroom)
 "cyH" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -66554,6 +66402,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/computer/atmos_alert,
+/obj/machinery/requests_console{
+	department = "Atmospherics";
+	departmentType = 3;
+	name = "Atmospherics Requests Console";
+	pixel_x = 30
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "cyS" = (
@@ -66676,14 +66530,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "czd" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/suit_storage_unit/engine,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/grille/broken,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "cze" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -66884,16 +66736,14 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "czA" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -66932,30 +66782,35 @@
 	c_tag = "Engineering Construction Area";
 	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/construction)
 "czE" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/structure/disposaloutlet{
 	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "czF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table,
+/obj/item/radio{
+	pixel_y = 6
 	},
-/turf/simulated/wall/r_wall/coated,
-/area/maintenance/incinerator)
+/obj/item/radio{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/radio{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/radio,
+/turf/simulated/floor/plasteel,
+/area/engine/equipmentstorage)
 "czG" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	name = "standard air scrubber";
@@ -67034,12 +66889,14 @@
 	},
 /area/medical/virology)
 "czP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/structure/table,
+/obj/item/airlock_painter,
+/obj/item/airlock_painter{
+	pixel_x = -4;
+	pixel_y = 4
 	},
-/turf/simulated/wall/r_wall/coated,
-/area/maintenance/incinerator)
+/turf/simulated/floor/plasteel,
+/area/engine/equipmentstorage)
 "czQ" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -67267,6 +67124,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -67303,10 +67161,8 @@
 	},
 /area/construction)
 "cAo" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -67478,6 +67334,8 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/warning_stripes/south,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "cAG" = (
@@ -67514,11 +67372,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "cAI" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cAJ" = (
@@ -67558,6 +67416,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cAN" = (
@@ -67565,7 +67424,6 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
@@ -67582,9 +67440,6 @@
 	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
@@ -67670,6 +67525,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -67881,6 +67737,11 @@
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "cBv" = (
+/obj/machinery/atmospherics/binary/pump{
+	layer = 2.35;
+	on = 1;
+	target_pressure = 1000
+	},
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -67985,7 +67846,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "cBE" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -22
@@ -67996,12 +67856,24 @@
 	},
 /area/hallway/primary/aft)
 "cBF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 6;
-	level = 2
+/obj/structure/table,
+/obj/machinery/requests_console{
+	department = "Engineering";
+	departmentType = 3;
+	name = "Engineering Requests Console";
+	pixel_x = 30
 	},
-/turf/simulated/wall,
-/area/engine/controlroom)
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/turf/simulated/floor/plasteel,
+/area/engine/equipmentstorage)
 "cBG" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -68027,8 +67899,13 @@
 /area/maintenance/genetics)
 "cBJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
@@ -68037,8 +67914,15 @@
 /turf/simulated/wall/r_wall,
 /area/maintenance/asmaint)
 "cBL" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -68087,6 +67971,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "cBV" = (
@@ -68120,6 +68009,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "cBZ" = (
@@ -68140,6 +68034,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -68317,13 +68217,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "cCp" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = -28
 	},
-/turf/simulated/wall/r_wall,
-/area/maintenance/asmaint2)
+/obj/structure/dispenser,
+/turf/simulated/floor/plasteel,
+/area/atmos)
 "cCq" = (
 /turf/simulated/floor/engine/insulated,
 /area/maintenance/incinerator)
@@ -68333,7 +68233,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/closet/emcloset,
+/obj/structure/rack{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "cCs" = (
@@ -68419,6 +68325,9 @@
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
 	name = "Human remains"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -68436,6 +68345,9 @@
 	},
 /obj/machinery/hologram/holopad,
 /mob/living/simple_animal/mouse,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -68451,6 +68363,12 @@
 	name = "Incinerator Access";
 	req_access_txt = "24"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/incinerator)
 "cCD" = (
@@ -68458,6 +68376,12 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -68473,6 +68397,12 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
@@ -68522,6 +68452,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/construction)
@@ -68578,11 +68513,6 @@
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "cCP" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 22
@@ -68630,6 +68560,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -68653,8 +68586,7 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 1;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2"
+	icon_state = "pipe-y"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -68670,6 +68602,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -68697,6 +68632,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -68709,6 +68647,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -68725,6 +68666,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -68758,6 +68702,11 @@
 /obj/machinery/light_switch{
 	pixel_x = -23
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -68768,7 +68717,6 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -68779,6 +68727,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -68823,42 +68775,48 @@
 	},
 /area/atmos)
 "cDj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "yellow"
 	},
 /area/atmos)
 "cDk" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics North-East"
+/obj/machinery/atmospherics/binary/volume_pump{
+	desc = "Позволяет опустошить трубу дыхательной смеси, отправив её в отходы на повторную фильтрацию";
+	dir = 8;
+	name = "Дыхательную смесь в отходы"
 	},
 /obj/item/radio/intercom{
 	dir = 1;
 	pixel_y = 25
 	},
-/obj/machinery/atmospherics/binary/volume_pump/on{
-	dir = 8;
-	name = "Distro to Waste";
-	on = 0
+/obj/machinery/camera{
+	c_tag = "Atmospherics North-East"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
 "cDl" = (
-/obj/machinery/atmospherics/binary/volume_pump/on{
-	dir = 8;
-	name = "Air To Distro"
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	dir = 4;
+	name = "Труба дыхательной смеси"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump Engineering";
 	pixel_y = 24;
 	shock_proof = 1
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
@@ -68944,7 +68902,6 @@
 	},
 /area/toxins/misc_lab)
 "cDx" = (
-/obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom{
 	dir = 8;
 	pixel_x = -28
@@ -68977,19 +68934,17 @@
 /obj/item/radio/intercom{
 	pixel_x = -28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 6;
-	tag = "icon-intact (SOUTHEAST)"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "cDA" = (
 /obj/machinery/drone_fabricator,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "cDB" = (
@@ -69027,9 +68982,6 @@
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
@@ -69114,9 +69066,6 @@
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "cDO" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
-	},
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = 32
 	},
@@ -69196,9 +69145,6 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -69210,10 +69156,6 @@
 "cDZ" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
-	},
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -69242,11 +69184,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/consarea)
 "cEc" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -69311,12 +69248,12 @@
 /turf/simulated/floor/wood,
 /area/medical/psych)
 "cEi" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 4
-	},
 /obj/machinery/portable_atmospherics/pump,
 /obj/structure/window/reinforced{
 	dir = 1
+	},
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -69329,6 +69266,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
@@ -69346,9 +69286,6 @@
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/machinery/light,
 /obj/effect/decal/warning_stripes/southwestcorner,
@@ -69369,10 +69306,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -69385,21 +69318,17 @@
 	},
 /area/toxins/xenobiology)
 "cEn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurplecorner"
 	},
 /area/toxins/misc_lab)
 "cEo" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/toxins/misc_lab)
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
+/turf/simulated/floor/plasteel,
+/area/engine/equipmentstorage)
 "cEp" = (
 /obj/structure/closet,
 /obj/item/toy/russian_revolver,
@@ -69418,19 +69347,23 @@
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
-"cEr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/atmos)
 "cEs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table,
+/obj/item/stack/sheet/metal{
+	amount = 50
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+/obj/item/stack/sheet/metal{
+	amount = 50
 	},
-/area/toxins/misc_lab)
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 22
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/turf/simulated/floor/plasteel,
+/area/engine/equipmentstorage)
 "cEt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -69508,6 +69441,9 @@
 /area/maintenance/genetics)
 "cEG" = (
 /obj/structure/barricade/wooden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "cEH" = (
@@ -69607,29 +69543,11 @@
 	icon_state = "vault"
 	},
 /area/engine/mechanic_workshop)
-"cEQ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "yellowcorner"
-	},
-/area/hallway/primary/aft)
 "cER" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -69656,9 +69574,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellowcorner"
@@ -69677,9 +69592,6 @@
 	layer = 4;
 	pixel_y = 32
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellowcorner"
@@ -69693,9 +69605,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
@@ -69739,67 +69648,43 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
-"cFf" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j1 (WEST)"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "yellowcorner"
-	},
-/area/hallway/primary/aft)
 "cFg" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-y"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
 "cFh" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 4
-	},
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "arrival"
 	},
 /area/hallway/primary/aft)
-"cFi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "yellowcorner"
-	},
-/area/hallway/primary/aft)
 "cFj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 9;
-	level = 2
+/obj/effect/spawner/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
+	dir = 10;
+	name = "Труба фильтрации"
 	},
-/turf/simulated/wall,
-/area/engine/controlroom)
+/turf/simulated/floor/plating,
+/area/atmos/distribution)
 "cFk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -69809,9 +69694,6 @@
 	},
 /area/hallway/primary/aft)
 "cFl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway 3"
 	},
@@ -69835,9 +69717,6 @@
 	},
 /area/construction)
 "cFo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_y = 32
@@ -69875,10 +69754,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cFt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellowcorner"
@@ -69890,12 +69765,13 @@
 	name = "Engineering";
 	req_one_access_txt = "11;24"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 9;
-	tag = "icon-intact (NORTHWEST)"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "cFv" = (
@@ -69906,13 +69782,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/genetics)
 "cFw" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/wall/r_wall,
-/area/atmos/control)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology)
 "cFx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -70032,36 +69909,30 @@
 	name = "Distribution Loop";
 	req_access_txt = "24"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
 "cFG" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -70119,18 +69990,15 @@
 	},
 /area/toxins/misc_lab)
 "cFK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/engine,
 /area/engine/mechanic_workshop)
 "cFL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -70217,10 +70085,6 @@
 	},
 /area/engine/mechanic_workshop)
 "cFS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -70330,17 +70194,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/aft)
-"cGc" = (
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -70367,6 +70221,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -70399,6 +70256,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cGj" = (
@@ -70406,6 +70266,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -70417,26 +70280,40 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cGl" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2";
+	tag = "icon-pipe-j1 (WEST)"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cGm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-y"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cGn" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -70447,23 +70324,16 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cGp" = (
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -70473,18 +70343,19 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cGq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/purple{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cGr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cGs" = (
@@ -70503,6 +70374,7 @@
 	dir = 4
 	},
 /obj/structure/table,
+/obj/machinery/cell_charger,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cGv" = (
@@ -70615,9 +70487,13 @@
 	},
 /area/toxins/xenobiology)
 "cGC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/engine,
-/area/engine/mechanic_workshop)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/engine/equipmentstorage)
 "cGD" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
@@ -70665,12 +70541,12 @@
 	},
 /area/engine/mechanic_workshop)
 "cGJ" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 4
-	},
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/window/reinforced{
 	dir = 1
+	},
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -70685,11 +70561,6 @@
 /obj/machinery/door/airlock/medical{
 	name = "Psych Office";
 	req_access_txt = "64"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -70709,13 +70580,18 @@
 	},
 /area/hallway/primary/aft)
 "cGN" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
-	dir = 1;
-	tag = "icon-map (NORTH)"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/wall,
-/area/engine/controlroom)
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = -32
+	},
+/turf/simulated/floor/plasteel,
+/area/engine/equipmentstorage)
 "cGO" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -70948,14 +70824,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/genetics)
 "cHg" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 2;
-	icon_state = "pipe-j2s";
-	name = "Eng Atmospherics";
-	sortType = 6
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/closet/secure_closet/engineering_personal,
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/aft)
+/area/engine/equipmentstorage)
 "cHh" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -70971,7 +70853,12 @@
 	},
 /area/toxins/misc_lab)
 "cHj" = (
-/obj/structure/table,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowcorner"
 	},
@@ -70983,18 +70870,22 @@
 /area/engine/chiefs_office)
 "cHl" = (
 /obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cHm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cHn" = (
@@ -71058,13 +70949,15 @@
 	},
 /area/toxins/misc_lab)
 "cHt" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
 /obj/machinery/camera{
 	c_tag = "Engineering Foyer"
 	},
 /obj/structure/noticeboard{
 	pixel_y = 28
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -71072,9 +70965,8 @@
 	},
 /area/engine/break_room)
 "cHu" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -71172,6 +71064,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "cHF" = (
@@ -71202,26 +71096,29 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cHI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	icon_state = "pipe-j2s";
+	name = "Engineering Main";
+	sortType = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cHJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/structure/reagent_dispensers/watertank,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/aft)
+/area/engine/equipmentstorage)
 "cHK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -71234,15 +71131,21 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/aft)
-"cHL" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = "90Curve"
+	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
 	icon_state = "pipe-j2s";
-	name = "Eng Chief Engineer's Office";
-	sortType = 5
+	name = "Eng Atmospherics";
+	sortType = 6
 	},
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/aft)
+"cHL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -71258,23 +71161,25 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellow"
 	},
 /area/hallway/primary/aft)
 "cHN" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 4
-	},
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway 2";
 	dir = 8;
 	pixel_y = -22
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -71282,16 +71187,18 @@
 	},
 /area/hallway/primary/aft)
 "cHO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cHP" = (
@@ -71300,6 +71207,22 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cHQ" = (
@@ -71325,21 +71248,21 @@
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cHT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel,
-/area/engine/break_room)
-"cHU" = (
-/obj/structure/sign/securearea,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 9;
-	tag = "icon-intact (NORTHWEST)"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/turf/simulated/floor/plasteel,
+/area/atmos)
+"cHU" = (
+/obj/structure/sign/securearea,
 /turf/simulated/wall,
 /area/engine/break_room)
 "cHV" = (
@@ -71351,6 +71274,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
@@ -71372,6 +71300,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
@@ -71398,18 +71331,29 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cIb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table,
+/obj/item/t_scanner,
+/obj/item/multitool{
+	pixel_x = 5
 	},
-/turf/simulated/wall/r_wall,
-/area/maintenance/genetics)
+/obj/item/radio/headset/headset_eng,
+/obj/item/cartridge/atmos,
+/obj/item/cartridge/atmos,
+/obj/item/t_scanner,
+/obj/item/wrench,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/atmos)
 "cIc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/genetics)
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/simulated/floor/plasteel,
+/area/atmos)
 "cId" = (
 /obj/structure/chair{
 	dir = 1
@@ -71459,34 +71403,31 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cIh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
-"cIi" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "atmos";
-	name = "Atmos Blast Door";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/atmos/control)
 "cIj" = (
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken7";
@@ -71532,9 +71473,19 @@
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "cIq" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/maintenance/genetics)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/smes/engineering,
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "cIr" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plating,
@@ -71553,20 +71504,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/genetics)
 "cIv" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cIw" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
@@ -71578,6 +71525,7 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/engine/chiefs_office)
 "cIx" = (
@@ -71616,14 +71564,11 @@
 	},
 /area/medical/cmo)
 "cIy" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/engine/chiefs_office)
 "cIz" = (
@@ -71780,7 +71725,7 @@
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+	dir = 4
 	},
 /turf/simulated/floor/engine,
 /area/engine/mechanic_workshop)
@@ -71833,34 +71778,41 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/assembly_line)
 "cIR" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	icon_state = "pipe-j2s";
-	name = "Engineering Main";
-	sortType = 4
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
+/obj/machinery/power/smes/engineering,
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/aft)
+/area/engine/engineering)
 "cIS" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/sortjunction{
+	dir = 2;
+	icon_state = "pipe-j2s";
+	name = "Eng Chief Engineer's Office";
+	sortType = 5
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cIT" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/storage/box,
-/obj/item/storage/box,
-/obj/item/storage/belt/utility,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cIU" = (
@@ -71897,21 +71849,18 @@
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cIY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "cIZ" = (
@@ -71920,7 +71869,6 @@
 	},
 /area/hallway/primary/central/ne)
 "cJa" = (
-/obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "open";
@@ -71928,22 +71876,11 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/atmos/control)
 "cJb" = (
-/obj/machinery/atmospherics/unary/portables_connector,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "cJd" = (
@@ -72037,9 +71974,12 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/assembly_line)
 "cJk" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
@@ -72058,9 +71998,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
@@ -72074,6 +72017,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cJo" = (
@@ -72102,6 +72047,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cJp" = (
@@ -72111,6 +72062,16 @@
 "cJq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
@@ -72173,6 +72134,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "cJz" = (
@@ -72180,11 +72152,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/genetics)
 "cJA" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/structure/table/reinforced,
 /obj/item/paper/pamphlet,
 /obj/machinery/alarm{
@@ -72196,15 +72163,16 @@
 	c_tag = "EVA Motion Sensor";
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/ai_monitored/storage/eva)
 "cJB" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
 /obj/machinery/computer/monitor{
 	name = "Engine Power Monitoring Computer"
 	},
@@ -72234,25 +72202,28 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 9;
-	level = 2
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "cJE" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	level = 2
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
@@ -72291,23 +72262,18 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "cJI" = (
-/obj/machinery/light_switch{
-	pixel_x = -27
-	},
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/obj/item/holosign_creator/atmos,
+/obj/item/toy/figure/atmos,
+/turf/simulated/floor/plating,
+/area/maintenance/storage)
 "cJJ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door_control{
@@ -72346,6 +72312,7 @@
 	pixel_x = -25
 	},
 /obj/effect/decal/warning_stripes/northwest,
+/obj/item/storage/briefcase/inflatable,
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "cJN" = (
@@ -72447,6 +72414,12 @@
 	icon_state = "1-4"
 	},
 /obj/effect/decal/warning_stripes/north,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cJV" = (
@@ -72460,6 +72433,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -72593,7 +72572,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cKk" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -72641,7 +72619,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/maintenance/asmaint)
+/area/maintenance/genetics)
 "cKp" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light{
@@ -72674,9 +72652,7 @@
 /area/toxins/xenobiology)
 "cKr" = (
 /obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
+/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "cKs" = (
@@ -72786,12 +72762,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/computer/security/engineering,
-/obj/machinery/requests_console{
-	department = "Atmospherics";
-	departmentType = 3;
-	name = "Atmospherics Requests Console";
-	pixel_x = 30
-	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "cKA" = (
@@ -72899,7 +72869,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -72991,6 +72960,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cKV" = (
@@ -73151,6 +73121,8 @@
 	req_access = null;
 	req_access_txt = "70"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cLp" = (
@@ -73239,6 +73211,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/item/storage/briefcase/inflatable,
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "cLx" = (
@@ -73330,6 +73303,7 @@
 /obj/machinery/light,
 /obj/structure/closet/secure_closet/atmos_personal,
 /obj/effect/decal/warning_stripes/north,
+/obj/item/storage/briefcase/inflatable,
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "cLK" = (
@@ -73339,20 +73313,24 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "cLL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/unary/heat_reservoir/heater{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "yellowcorner"
-	},
-/area/hallway/primary/aft)
+/turf/simulated/floor/plasteel,
+/area/atmos)
 "cLM" = (
 /obj/effect/spawner/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/engine/break_room)
 "cLN" = (
@@ -73417,12 +73395,20 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "cLS" = (
-/obj/machinery/computer/security/engineering,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engine Room";
+	req_access_txt = "10";
+	req_one_access_txt = null
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/atmos)
+/area/engine/engineering)
 "cLT" = (
 /obj/machinery/vending/cola,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "arrival"
@@ -73481,18 +73467,17 @@
 /turf/simulated/floor/wood,
 /area/maintenance/asmaint)
 "cMa" = (
-/obj/machinery/atmospherics/unary/portables_connector,
-/obj/machinery/door_control{
-	id = "atmos";
-	name = "Atmospherics Lockdown";
-	pixel_x = 24;
-	pixel_y = 8;
-	req_access_txt = "24"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/door_control{
+	id = "atmos";
+	name = "Atmospherics Lockdown";
+	pixel_x = 24;
+	pixel_y = 24;
+	req_access_txt = "24"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
@@ -73561,9 +73546,6 @@
 /obj/item/radio/intercom{
 	pixel_x = -28
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
@@ -73618,6 +73600,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/engine,
 /area/engine/mechanic_workshop)
 "cMr" = (
@@ -73651,6 +73635,12 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -73795,8 +73785,20 @@
 	},
 /area/storage/secure)
 "cMN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
@@ -73813,7 +73815,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/asmaint)
+/area/maintenance/genetics)
 "cMP" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -73892,21 +73894,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
-"cMW" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/engine/break_room)
 "cMX" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
@@ -73919,6 +73906,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "cMZ" = (
@@ -73970,14 +73962,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cNe" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 5;
-	max_integrity = 1e+007
+/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "cNf" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -74002,7 +73996,7 @@
 	},
 /obj/effect/spawner/random_spawners/oil_maybe,
 /turf/simulated/floor/plating,
-/area/maintenance/asmaint)
+/area/maintenance/genetics)
 "cNj" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -74055,7 +74049,7 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
-/area/maintenance/asmaint)
+/area/maintenance/genetics)
 "cNp" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -74352,10 +74346,6 @@
 /area/hallway/primary/aft)
 "cNT" = (
 /obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -74366,20 +74356,9 @@
 	},
 /area/hallway/primary/aft)
 "cNU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/engine/break_room)
-"cNV" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/smes/engineering,
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/obj/effect/decal/cleanable/fungus,
+/turf/simulated/wall/r_wall,
+/area/maintenance/storage)
 "cNW" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/structure/cable/yellow{
@@ -74395,20 +74374,31 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cNX" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
 /obj/effect/decal/warning_stripes/east,
+/obj/structure/closet/radiation,
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = 32
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cNY" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/atmos)
 "cNZ" = (
 /obj/machinery/constructable_frame/machine_frame,
 /obj/effect/decal/cleanable/dirt,
@@ -74429,20 +74419,22 @@
 /area/engine/engineering)
 "cOb" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /obj/machinery/power/smes/engineering,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cOc" = (
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -74464,9 +74456,6 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cOe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -74474,13 +74463,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cOf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light,
 /obj/structure/table,
 /obj/machinery/firealarm{
 	dir = 8;
@@ -74504,6 +74490,7 @@
 	pixel_x = 1;
 	pixel_y = 9
 	},
+/obj/machinery/light,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cOi" = (
@@ -74511,6 +74498,11 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -74523,25 +74515,38 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cOk" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics East";
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/atmospherics/binary/valve/digital{
 	color = "";
 	dir = 4;
 	name = "Plasma Outlet Valve"
 	},
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
+	dir = 1;
+	name = "Труба фильтрации"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "purple"
+	},
 /area/atmos)
 "cOl" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/vending/cigarette,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 27
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engine/engineering)
 "cOm" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -74630,6 +74635,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cOu" = (
@@ -74660,7 +74666,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cOy" = (
-/obj/structure/sign/securearea,
+/obj/structure/sign/securearea{
+	pixel_x = -32
+	},
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -74677,7 +74685,12 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/assembly_line)
 "cOA" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
 "cOB" = (
@@ -74712,16 +74725,8 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/assembly_line)
 "cOF" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/extinguisher,
-/obj/item/extinguisher,
-/obj/item/extinguisher,
-/obj/item/extinguisher,
-/obj/item/extinguisher,
-/obj/item/extinguisher,
+/obj/machinery/computer/security/engineering,
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cOG" = (
@@ -74732,28 +74737,25 @@
 /area/assembly/assembly_line)
 "cOH" = (
 /obj/machinery/atmospherics/binary/volume_pump/on{
-	name = "Waste In"
+	desc = "Выкачивает углекислый газ и токсины со станции и отправляет на фильтрацию";
+	name = "Из скрабберов в фильтрацию"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
 "cOI" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 1;
-	name = "Mix to Distro"
-	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
 "cOJ" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	desc = "Труба хранит в себе набор газов для смешивания";
+	dir = 6;
+	name = "Труба смешивания"
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
@@ -74767,22 +74769,13 @@
 	codes_txt = "patrol;next_patrol=AIE";
 	location = "AftH"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cOL" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall,
-/area/engine/break_room)
+/obj/effect/decal/warning_stripes/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "cOM" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -74850,10 +74843,6 @@
 "cOT" = (
 /turf/simulated/wall/r_wall,
 /area/atmos/distribution)
-"cOU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/purple,
-/turf/simulated/wall/r_wall,
-/area/atmos/distribution)
 "cOV" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -74864,7 +74853,7 @@
 	},
 /area/assembly/assembly_line)
 "cOW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/wall/r_wall,
 /area/atmos/distribution)
 "cOX" = (
@@ -74873,11 +74862,6 @@
 	},
 /area/shuttle/administration)
 "cOY" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -22
@@ -74949,19 +74933,24 @@
 /turf/simulated/floor/plating,
 /area/maintenance/genetics)
 "cPf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/genetics)
+/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "cPg" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/machinery/power/smes/engineering,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cPh" = (
@@ -74987,7 +74976,15 @@
 	sensors = list("tox_sensor" = "Tank")
 	},
 /obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
+	dir = 1;
+	name = "Труба фильтрации"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purple"
+	},
 /area/atmos)
 "cPj" = (
 /obj/structure/cable{
@@ -75048,24 +75045,21 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cPo" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Equipment West";
-	dir = 4
-	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/structure/closet/secure_closet/engineering_personal,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump Engineering";
 	pixel_x = -24;
 	shock_proof = 1
 	},
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cPp" = (
@@ -75079,28 +75073,25 @@
 	},
 /area/toxins/xenobiology)
 "cPq" = (
-/obj/machinery/light_switch{
-	pixel_x = 27
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engine/engineering)
 "cPr" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/decal/warning_stripes/red/hollow,
-/obj/machinery/camera{
-	c_tag = "Atmospherics North-West";
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/atmos)
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "cPs" = (
-/obj/machinery/atmospherics/binary/volume_pump/on{
+/obj/machinery/atmospherics/binary/volume_pump{
+	desc = "Позволяет опустошить трубы для смеси, отправив весь газ в отходы на фильтрацию";
 	dir = 8;
-	name = "Mix to Filter"
+	name = "Смесь в отходы"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
 "cPt" = (
@@ -75179,7 +75170,9 @@
 /area/toxins/test_chamber)
 "cPB" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
-	dir = 8
+	desc = "Труба ведёт газ на фильтрацию";
+	dir = 8;
+	name = "Труба на фильтрацию"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
@@ -75193,21 +75186,25 @@
 /turf/space,
 /area/solar/port)
 "cPD" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow,
-/turf/simulated/floor/plasteel,
-/area/atmos/distribution)
-"cPE" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/binary/valve/digital{
 	color = "";
 	dir = 4;
 	name = "Gas Mix Outlet Valve"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/atmos/distribution)
+"cPE" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible/yellow{
+	desc = "Труба хранит в себе набор газов для смешивания";
+	name = "Труба смешивания"
+	},
+/obj/machinery/meter,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
 "cPF" = (
@@ -75288,110 +75285,111 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
-"cPN" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
-"cPO" = (
+"cPN" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
+"cPO" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cPP" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Equipment East";
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/engineeringcart,
-/obj/item/radio/intercom{
-	pixel_x = 28
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
+	dir = 4;
+	name = "Труба обработки"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/atmos)
 "cPQ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	dir = 4;
+	name = "Труба дыхательной смеси"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	desc = "Труба хранит в себе набор газов для смешивания";
+	dir = 1;
+	name = "Труба смешивания"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cPS" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/item/radio/beacon,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cPT" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	dir = 10;
+	name = "Труба дыхательной смеси"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"cPU" = (
-/obj/machinery/portable_atmospherics/canister/sleeping_agent,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/atmos)
 "cPV" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/green{
-	dir = 1;
-	tag = "icon-manifold-g (NORTH)"
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	dir = 4;
+	name = "Труба дыхательной смеси"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
 "cPW" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/green{
+/obj/machinery/atmospherics/binary/pump{
+	desc = "Позволяет пропустить смесь не загружая её в хранилище";
 	dir = 1;
-	tag = "icon-manifold-g (NORTH)"
+	name = "Смесь в обход хранилища";
+	target_pressure = 101
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	dir = 4;
+	name = "Труба дыхательной смеси"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
 "cPX" = (
-/obj/machinery/camera{
-	c_tag = "Engineering SMES";
-	dir = 8
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"cPY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/computer/camera_advanced/xenobio,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology)
 "cPZ" = (
 /obj/effect/spawner/window/reinforced,
+/obj/machinery/atmospherics/pipe/manifold/visible/purple{
+	desc = "Труба ведёт газ на фильтрацию";
+	dir = 1;
+	name = "Труба на фильтрацию"
+	},
 /turf/simulated/floor/plating,
 /area/atmos/distribution)
 "cQa" = (
@@ -75418,60 +75416,65 @@
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "cQc" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/structure/closet/firecloset,
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
-"cQe" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/southeast,
-/turf/simulated/floor/plasteel,
-/area/atmos)
-"cQf" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/meter{
-	id = "wloop_atm_meter";
-	name = "Waste Loop"
-	},
-/obj/machinery/light_switch{
-	pixel_y = 27
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/purple{
+/obj/effect/decal/warning_stripes/east,
+/obj/machinery/camera{
+	c_tag = "Engineering SMES";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
+/area/engine/engineering)
+"cQe" = (
+/obj/effect/decal/warning_stripes/southeast,
+/obj/machinery/atmospherics/trinary/filter/flipped{
+	name = "Gas filter (Toxins tank)";
+	on = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "purple"
+	},
+/area/atmos)
+"cQf" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible/purple,
+/obj/machinery/meter,
+/turf/simulated/floor/plasteel,
 /area/atmos/distribution)
 "cQg" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/machinery/atmospherics/binary/pump/on{
+	desc = "Отправляет дыхательную смесь из трубы распространяться по станции через вентиляции";
+	dir = 8;
+	name = "Дыхательную смесь на станцию";
+	target_pressure = 303.325
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 1
+/obj/machinery/light{
+	dir = 1;
+	in_use = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
 "cQh" = (
-/obj/machinery/meter{
-	id = "dloop_atm_meter";
-	name = "Distribution Loop"
+/obj/machinery/atmospherics/pipe/manifold4w/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	name = "Труба дыхательной смеси"
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan,
-/turf/simulated/floor/plasteel,
-/area/atmos/distribution)
-"cQi" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 10
-	},
+/obj/machinery/meter,
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
+/turf/simulated/floor/plasteel,
+/area/atmos/distribution)
+"cQi" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	dir = 1;
+	name = "Труба дыхательной смеси"
+	},
+/obj/machinery/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
 "cQj" = (
@@ -75482,35 +75485,18 @@
 /turf/simulated/wall/r_wall,
 /area/medical/virology)
 "cQl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/computer/camera_advanced/xenobio,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/toxins/xenobiology)
-"cQm" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "atmos";
-	name = "Atmos Blast Door";
-	opacity = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/atmos/distribution)
 "cQn" = (
 /turf/simulated/wall,
 /area/medical/virology)
 "cQo" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 6
+/obj/machinery/atmospherics/unary/heat_reservoir/heater{
+	dir = 8;
+	on = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
@@ -75538,15 +75524,12 @@
 	},
 /area/toxins/xenobiology)
 "cQs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/binary/valve/digital/open{
+	desc = "Позволяет отключить подачу дыхательной смеси на станцию, не отключая саму закачку газа. (Например, если требуется подать только смесь из оранжевых труб)";
+	name = "Подача дыхательной смеси на станцию"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology)
+/turf/simulated/floor/plasteel,
+/area/atmos)
 "cQt" = (
 /obj/structure/table/reinforced,
 /obj/item/scalpel,
@@ -75668,6 +75651,10 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -75734,6 +75721,9 @@
 	pixel_y = 37;
 	req_access_txt = "56"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -75745,6 +75735,8 @@
 /turf/simulated/floor/plating,
 /area/storage/secure)
 "cQK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/landmark{
 	name = "lightsout"
 	},
@@ -75753,27 +75745,19 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cQL" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/decal/warning_stripes/blue/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/atmos)
-"cQM" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/decal/warning_stripes/blue/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/atmos)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "cQN" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor{
@@ -75786,33 +75770,14 @@
 /turf/simulated/floor/plating,
 /area/engine/equipmentstorage)
 "cQO" = (
-/obj/structure/table,
-/obj/machinery/requests_console{
-	department = "Engineering";
-	departmentType = 3;
-	name = "Engineering Requests Console";
-	pixel_x = 30
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "cQP" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/storage)
 "cQR" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -75839,34 +75804,44 @@
 	},
 /area/medical/cmostore)
 "cQS" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cQT" = (
-/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/binary/pump{
+	desc = "Позволяет подать смесь в вентиляции станции";
+	dir = 1;
+	name = "Подача смеси в систему вентиляции";
+	target_pressure = 101
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
 "cQU" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -75885,39 +75860,43 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/door_control{
+	id = "Singularity";
+	name = "Singularity Blast Doors";
+	pixel_y = -32;
+	req_access_txt = "10"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cQW" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
 "cQX" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 9
+	desc = "Труба ведёт газ на фильтрацию";
+	name = "Труба на фильтрацию"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
@@ -75942,13 +75921,6 @@
 /obj/structure/grille,
 /turf/simulated/wall/r_wall,
 /area/atmos)
-"cRa" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 8
-	},
-/obj/machinery/meter,
-/turf/simulated/floor/plasteel,
-/area/atmos/distribution)
 "cRb" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -75973,18 +75945,15 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/atmos/distribution)
 "cRd" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
-	},
 /obj/machinery/atmospherics/binary/pump{
-	dir = 1;
-	name = "Mix to Gas Turbine"
+	dir = 4;
+	name = "Gas to Turbine"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
@@ -76056,46 +76025,40 @@
 /turf/simulated/floor/engine/co2,
 /area/atmos)
 "cRj" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 1;
-	name = "Pure to Mix"
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
+/obj/machinery/hologram/holopad,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
 "cRk" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 9;
-	tag = "icon-intact-y (NORTHWEST)"
+/obj/machinery/atmospherics/binary/pump,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
 "cRl" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	desc = "Труба хранит в себе набор газов для смешивания";
+	dir = 8;
+	name = "Труба смешивания"
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
@@ -76108,14 +76071,14 @@
 	},
 /area/toxins/xenobiology)
 "cRn" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/chair/comfy/blue{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	dir = 4;
+	name = "Труба дыхательной смеси"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology)
+/obj/machinery/meter,
+/turf/simulated/floor/plasteel,
+/area/atmos)
 "cRo" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -76368,6 +76331,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -76399,32 +76363,37 @@
 	},
 /area/ai_monitored/storage/eva)
 "cRO" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cRP" = (
-/obj/structure/table,
-/obj/item/airlock_electronics,
-/obj/item/airlock_electronics,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stack/tape_roll,
-/obj/item/stack/tape_roll,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/table,
+/obj/item/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 5
+	},
+/obj/item/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/storage/belt/utility,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cRQ" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -76437,50 +76406,39 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 5
+	},
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/storage/belt/utility,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cRT" = (
 /obj/structure/table,
-/obj/item/radio{
-	pixel_y = 6
-	},
-/obj/item/radio{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/radio{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/radio,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/crowbar/large,
+/obj/item/storage/box/lights/mixed,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cRU" = (
-/obj/structure/table,
-/obj/item/stack/sheet/plasteel{
-	amount = 10
-	},
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 22
-	},
-/obj/item/stack/rods{
-	amount = 50
+/obj/machinery/atmospherics/binary/volume_pump/on{
+	dir = 1;
+	name = "Space Loop Out"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/atmos)
 "cRV" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
@@ -76544,32 +76502,24 @@
 	},
 /area/toxins/xenobiology)
 "cSa" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Equipment North"
-	},
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
-	},
 /obj/machinery/vending/engivend,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cSb" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/decal/warning_stripes/red/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/suit_storage_unit/atmos,
+/obj/machinery/light{
+	dir = 8
 	},
+/turf/simulated/floor/plasteel,
 /area/atmos)
 "cSc" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5;
+	tag = "icon-intact (NORTHEAST)"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology)
+/turf/space,
+/area/space/nearstation)
 "cSd" = (
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -76641,8 +76591,9 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cSm" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold4w/visible/yellow{
+	desc = "Труба хранит в себе набор газов для смешивания";
+	name = "Труба смешивания"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
@@ -76654,15 +76605,6 @@
 /obj/machinery/meter,
 /turf/simulated/wall/r_wall,
 /area/atmos)
-"cSo" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/binary/pump{
-	name = "Air to Mix"
-	},
-/turf/simulated/floor/plasteel,
-/area/atmos/distribution)
 "cSp" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	name = "standard air scrubber";
@@ -76682,16 +76624,19 @@
 	opacity = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
+	desc = "Труба хранит в себе набор газов для смешивания";
+	dir = 4;
+	name = "Труба смешивания"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plating,
 /area/atmos/distribution)
 "cSr" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/binary/pump{
+	desc = "Переводит смесь из хранилища в трубы";
+	dir = 8;
+	name = "Из хранилища в трубы";
+	target_pressure = 101
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "green"
@@ -76710,6 +76655,7 @@
 "cSt" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -76745,12 +76691,6 @@
 	},
 /area/atmos)
 "cSx" = (
-/obj/machinery/door_control{
-	id = "Singularity";
-	name = "Singularity Blast Doors";
-	pixel_x = 25;
-	req_access_txt = "10"
-	},
 /obj/effect/decal/warning_stripes/northeastcorner,
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -76800,12 +76740,12 @@
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "cSA" = (
-/obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "cSB" = (
@@ -76901,13 +76841,13 @@
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "cSJ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cSK" = (
@@ -76939,48 +76879,16 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cSO" = (
-/obj/structure/table,
-/obj/item/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 5
-	},
-/obj/item/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/item/storage/belt/utility,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cSP" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/turf/space,
+/area/space/nearstation)
 "cSQ" = (
 /obj/structure/table,
 /obj/machinery/light,
@@ -77049,29 +76957,22 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/mrchangs)
 "cSY" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cSZ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
 	},
-/obj/machinery/computer/atmos_alert,
-/obj/effect/decal/warning_stripes/east,
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
+/turf/space,
+/area/space/nearstation)
 "cTa" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -77121,12 +77022,19 @@
 	},
 /area/assembly/assembly_line)
 "cTe" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/storage)
 "cTf" = (
 /obj/machinery/newscaster{
 	pixel_y = 30
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -77140,21 +77048,24 @@
 	name = "Chief Engineer";
 	req_access_txt = "56"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/engine/chiefs_office)
 "cTh" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/decal/warning_stripes/white/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/obj/machinery/suit_storage_unit/atmos,
+/turf/simulated/floor/plasteel,
 /area/atmos)
 "cTi" = (
 /obj/machinery/alarm{
 	pixel_y = 22
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -77162,37 +77073,36 @@
 	},
 /area/engine/chiefs_office)
 "cTj" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table,
+/obj/item/stack/sheet/plasteel{
+	amount = 15
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/atmos)
+/turf/simulated/floor/plasteel,
+/area/engine/equipmentstorage)
 "cTk" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 4
+/obj/machinery/computer/atmos_alert,
+/obj/effect/decal/warning_stripes/southeast,
+/obj/machinery/requests_console{
+	department = "Atmospherics";
+	departmentType = 3;
+	name = "Atmospherics Requests Console";
+	pixel_x = -30
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cTl" = (
-/obj/item/radio/intercom{
-	dir = 8;
-	pixel_x = -28
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
+	dir = 4;
+	name = "Труба фильтрации"
 	},
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/decal/warning_stripes/white/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	desc = "Подаёт азот из атмосферки в систему охлаждения реактора, таким образом запитывая её хладагентом";
+	dir = 1;
+	name = "Труба подачи азота в реактор"
 	},
+/obj/machinery/light,
+/turf/simulated/floor/plasteel,
 /area/atmos)
 "cTm" = (
 /obj/structure/cable/yellow{
@@ -77204,9 +77114,15 @@
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
 "cTn" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	dir = 4;
+	name = "Труба дыхательной смеси"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	desc = "Труба хранит в себе набор газов для смешивания";
+	dir = 1;
+	name = "Труба смешивания"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
@@ -77225,31 +77141,13 @@
 /turf/simulated/floor/plating,
 /area/atmos)
 "cTp" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/green{
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 4;
-	tag = "icon-manifold-g (NORTH)"
+	name = "Труба дыхательной смеси"
 	},
+/obj/machinery/meter,
 /turf/simulated/floor/plasteel,
-/area/atmos/distribution)
-"cTq" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/atmos)
-"cTr" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "atmos";
-	name = "Atmos Blast Door";
-	opacity = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/turf/simulated/floor/plating,
 /area/atmos/distribution)
 "cTs" = (
 /obj/item/wrench,
@@ -77429,6 +77327,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cTH" = (
@@ -77441,6 +77344,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -77498,44 +77405,36 @@
 /area/engine/chiefs_office)
 "cTN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cTO" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/item/airlock_painter,
-/obj/item/airlock_painter{
-	pixel_x = -4;
-	pixel_y = 4
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cTP" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6;
+	tag = "icon-intact (SOUTHEAST)"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/turf/space,
+/area/space/nearstation)
 "cTQ" = (
 /obj/effect/spawner/random_spawners/blood_maybe,
 /obj/effect/decal/cleanable/dirt,
@@ -77559,22 +77458,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "cTT" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
 	},
-/obj/structure/table,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/crowbar/large,
-/obj/item/storage/box/lights/mixed,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/turf/space,
+/area/space/nearstation)
 "cTU" = (
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
@@ -77689,9 +77578,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
 	icon_state = "door_locked";
@@ -77700,6 +77586,9 @@
 	name = "Engineering External Access";
 	req_access = null;
 	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
@@ -77779,9 +77668,6 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cUk" = (
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
 /obj/structure/table,
 /obj/item/book/manual/engineering_hacking{
 	pixel_x = 3;
@@ -77802,17 +77688,12 @@
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "cUm" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "cUn" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -77865,18 +77746,15 @@
 	},
 /area/crew_quarters/toilet)
 "cUs" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "cUt" = (
-/obj/structure/closet/secure_closet/engineering_personal,
+/obj/structure/engineeringcart,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cUu" = (
@@ -77905,21 +77783,31 @@
 	},
 /area/engine/chiefs_office)
 "cUv" = (
-/obj/machinery/hologram/holopad,
+/obj/structure/table,
+/obj/item/airlock_electronics,
+/obj/item/airlock_electronics,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/tape_roll,
+/obj/item/stack/tape_roll,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cUw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/engine/chiefs_office)
 "cUx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/wall/r_wall,
-/area/atmos)
+/turf/simulated/floor/plasteel,
+/area/engine/equipmentstorage)
 "cUy" = (
 /obj/machinery/computer/atmos_alert,
 /turf/simulated/floor/plasteel{
@@ -77928,11 +77816,16 @@
 	},
 /area/engine/chiefs_office)
 "cUz" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cUA" = (
@@ -77945,20 +77838,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cUB" = (
-/obj/machinery/door_control{
-	id = "Singularity";
-	name = "Singularity Blast Doors";
-	pixel_x = -25;
-	req_access_txt = "10"
+/obj/effect/landmark/damageturf,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "cUC" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -77977,21 +77863,21 @@
 /area/maintenance/asmaint)
 "cUD" = (
 /obj/structure/grille,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
 "cUE" = (
 /obj/structure/grille,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -78062,6 +77948,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering Singularity West";
+	dir = 4;
+	network = list("Singularity","SS13")
+	},
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
 "cUM" = (
@@ -78073,12 +77964,15 @@
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "cUN" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/binary/pump{
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 1;
-	name = "Unfiltered to Mix"
+	name = "Труба дыхательной смеси"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	desc = "Труба хранит в себе набор газов для смешивания";
+	dir = 4;
+	name = "Труба смешивания"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
@@ -78117,10 +78011,11 @@
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
 "cUS" = (
-/obj/machinery/atmospherics/binary/valve/digital{
-	color = "";
+/obj/machinery/atmospherics/binary/pump{
+	desc = "Отправляет смесь из трубы в хранилище для неё";
 	dir = 4;
-	name = "Gas Mix Inlet Valve"
+	name = "Смесь в хранилище";
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -78141,9 +78036,10 @@
 /area/engine/engineering)
 "cUV" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/hidden/green{
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 4;
-	level = 2
+	name = "Труба смешивания"
 	},
 /turf/space,
 /area/space/nearstation)
@@ -78164,10 +78060,6 @@
 /area/atmos)
 "cUX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -78183,6 +78075,7 @@
 /area/maintenance/aft)
 "cUZ" = (
 /obj/machinery/hologram/holopad,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -78219,15 +78112,16 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/aft)
 "cVc" = (
-/obj/machinery/door_control{
-	id = "Singularity";
-	name = "Singularity Blast Doors";
-	pixel_x = 25;
-	req_access_txt = "10"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "cVd" = (
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
@@ -78357,12 +78251,6 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cVp" = (
-/obj/machinery/door_control{
-	id = "Singularity";
-	name = "Singularity Blast Doors";
-	pixel_x = -25;
-	req_access_txt = "10"
-	},
 /obj/effect/decal/warning_stripes/northwestcorner,
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -78436,6 +78324,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cVv" = (
@@ -78571,18 +78460,12 @@
 /obj/structure/sign/deathsposal{
 	pixel_y = 32
 	},
-/obj/structure/disposalpipe/trunk,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/turbine)
-"cVI" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
 "cVJ" = (
 /obj/machinery/door_control{
 	id = "atmos";
@@ -78591,32 +78474,34 @@
 	pixel_y = 4;
 	req_access_txt = "24"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/purple,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cVK" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	desc = "Труба ведёт газ на фильтрацию";
+	dir = 4;
+	name = "Труба на фильтрацию"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/meter,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/atmos/distribution)
 "cVL" = (
 /obj/effect/spawner/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/visible/purple{
+	desc = "Труба ведёт газ на фильтрацию";
+	dir = 8;
+	name = "Труба на фильтрацию"
 	},
-/obj/structure/sign/nosmoking_2,
 /turf/simulated/floor/plating,
 /area/atmos/distribution)
 "cVM" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	desc = "Труба ведёт газ на фильтрацию";
+	dir = 4;
+	name = "Труба на фильтрацию"
 	},
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/turf/simulated/floor/plating,
+/turf/simulated/wall,
 /area/atmos/distribution)
 "cVN" = (
 /obj/item/wirecutters,
@@ -78628,27 +78513,32 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"cVO" = (
+"cVP" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	dir = 1;
+	name = "Труба дыхательной смеси"
 	},
-/turf/simulated/floor/plating,
-/area/atmos/distribution)
-"cVP" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	desc = "Труба ведёт газ на фильтрацию";
 	dir = 4;
-	level = 2
+	name = "Труба на фильтрацию"
 	},
-/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/atmos/distribution)
 "cVQ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
-	},
 /obj/effect/spawner/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	desc = "Труба ведёт газ на фильтрацию";
+	dir = 4;
+	name = "Труба на фильтрацию"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	desc = "Труба хранит в себе набор газов для смешивания";
+	dir = 1;
+	name = "Труба смешивания"
+	},
 /turf/simulated/floor/plating,
 /area/atmos/distribution)
 "cVR" = (
@@ -78659,9 +78549,6 @@
 	id_tag = "atmos";
 	name = "Atmos Blast Door";
 	opacity = 0
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/atmos/distribution)
@@ -78679,14 +78566,11 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cVU" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/engine/chiefs_office)
 "cVV" = (
@@ -78750,13 +78634,15 @@
 /turf/simulated/floor/plating,
 /area/storage/secure)
 "cWe" = (
-/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cWf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -78814,11 +78700,13 @@
 	req_access_txt = "10";
 	req_one_access_txt = null
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cWk" = (
@@ -78850,34 +78738,16 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "cWp" = (
-/obj/structure/table,
-/obj/machinery/requests_console{
-	department = "Atmospherics";
-	departmentType = 3;
-	name = "Atmospherics Requests Console";
-	pixel_y = -30
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/item/stack/sheet/glass{
-	amount = 50
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/clothing/head/welding,
-/obj/item/clothing/head/welding{
-	layer = 8
-	},
-/obj/item/clothing/glasses/welding,
-/obj/item/clothing/glasses/welding,
-/obj/item/stack/sheet/metal{
-	amount = 50;
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/stack/sheet/metal{
-	amount = 50;
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "cWq" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -78985,8 +78855,8 @@
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cWC" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -79028,55 +78898,40 @@
 "cWI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "yellow"
 	},
 /area/engine/engineering)
 "cWJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "cWK" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/obj/effect/decal/warning_stripes/east,
+/obj/structure/closet/radiation,
+/turf/simulated/floor/plating,
+/area/storage/secure)
 "cWL" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 5
+/obj/effect/spawner/window/reinforced,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "atmos";
+	name = "Atmos Blast Door";
+	opacity = 0
 	},
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/storage/belt/utility,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
+/turf/simulated/floor/plating,
+/area/atmos)
 "cWM" = (
 /obj/structure/sign/nosmoking_2{
 	pixel_y = 32
@@ -79107,10 +78962,20 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cWO" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/purple{
-	dir = 4
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "atmos";
+	name = "Atmos Blast Door";
+	opacity = 0
 	},
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	dir = 5;
+	name = "Труба дыхательной смеси"
+	},
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
 /area/atmos)
 "cWP" = (
 /obj/machinery/power/terminal{
@@ -79132,8 +78997,10 @@
 /turf/simulated/floor/beach/sand,
 /area/hallway/secondary/exit)
 "cWR" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4;
+	name = "Waste to Port"
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cWS" = (
@@ -79146,47 +79013,37 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cWT" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/binary/volume_pump/on{
-	dir = 4;
-	name = "External to Filter"
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cWU" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 4
-	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cWV" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 6
+/obj/item/pipe_painter,
+/obj/item/pipe_painter,
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/glasses/welding,
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
+/obj/item/grenade/chem_grenade/metalfoam,
+/obj/item/grenade/chem_grenade/metalfoam,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cWW" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/visible/purple{
+	desc = "Труба ведёт газ на фильтрацию";
+	dir = 8;
+	name = "Труба на фильтрацию"
 	},
-/obj/machinery/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cWX" = (
@@ -79194,30 +79051,38 @@
 	layer = 4;
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow,
-/turf/simulated/floor/plasteel,
-/area/atmos)
-"cWY" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 6
+/obj/machinery/atmospherics/binary/valve/digital{
+	desc = "Открывает газу путь к нагревателям, холодильникам и фильтрам";
+	dir = 4;
+	name = "Газ на обработку"
 	},
-/obj/machinery/meter,
+/obj/machinery/light{
+	dir = 1;
+	in_use = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cWZ" = (
 /turf/simulated/floor/engine/n20,
 /area/atmos)
 "cXa" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/atmospherics/binary/pump{
+	desc = "Подаёт оксид азота для смешивания с другими газами";
 	dir = 8;
-	name = "N2O to Pure"
+	name = "Оксид азота (NO2) в смеситель";
+	target_pressure = 101
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	dir = 1;
+	name = "Труба дыхательной смеси"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cXb" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold4w/visible/yellow{
+	desc = "Труба хранит в себе набор газов для смешивания";
+	name = "Труба смешивания"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -79231,9 +79096,10 @@
 	opacity = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
+	desc = "Труба хранит в себе набор газов для смешивания";
+	dir = 4;
+	name = "Труба смешивания"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plating,
 /area/atmos)
 "cXd" = (
@@ -79241,6 +79107,11 @@
 	color = "";
 	dir = 4;
 	name = "N2O Outlet Valve"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
+	dir = 1;
+	name = "Труба фильтрации"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -79262,7 +79133,6 @@
 /turf/simulated/floor/engine/n20,
 /area/atmos)
 "cXf" = (
-/obj/machinery/light,
 /obj/machinery/newscaster{
 	pixel_y = -30
 	},
@@ -79323,7 +79193,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "cXm" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+/obj/machinery/atmospherics/unary/tank/toxins{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -79373,13 +79243,6 @@
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/central/west)
-"cXr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "cXs" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -79406,26 +79269,26 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/toxins/xenobiology)
 "cXv" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "atmos";
+	name = "Atmos Blast Door";
+	opacity = 0
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	dir = 10;
+	name = "Труба дыхательной смеси"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology)
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/atmos)
 "cXw" = (
 /obj/machinery/computer/station_alert,
 /turf/simulated/floor/plasteel,
@@ -79454,14 +79317,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology)
+/mob/living/simple_animal/mouse/brown,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "cXA" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -79496,10 +79355,6 @@
 	},
 /area/toxins/xenobiology)
 "cXC" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engine Room";
@@ -79547,10 +79402,12 @@
 	pixel_x = -28
 	},
 /obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -79566,12 +79423,18 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cXI" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_y = -32
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cXJ" = (
@@ -79603,44 +79466,39 @@
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cXM" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/computer/monitor{
+	name = "Grid Power Monitoring Computer"
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
+/obj/structure/cable{
 	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cXN" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engine Room";
-	req_access_txt = "10";
-	req_one_access_txt = null
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
 /area/engine/engineering)
 "cXO" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/portable_atmospherics/canister/sleeping_agent,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plasteel,
 /area/atmos)
 "cXP" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
@@ -79650,20 +79508,15 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
 /area/storage/secure)
-"cXQ" = (
-/obj/machinery/atmospherics/binary/volume_pump/on{
-	dir = 8;
-	name = "Filter to External"
-	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
 "cXR" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/unary/outlet_injector/on{
+	dir = 1;
+	frequency = 1441;
+	id = "tox_in"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/purple,
-/turf/simulated/floor/plasteel,
-/area/atmos)
+/turf/space,
+/area/space/nearstation)
 "cXS" = (
 /obj/machinery/camera{
 	c_tag = "Engineering West";
@@ -79684,40 +79537,43 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"cXT" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/turf/simulated/floor/plasteel,
-/area/atmos)
-"cXU" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/turf/simulated/floor/plasteel,
-/area/atmos)
 "cXV" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cXW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 9
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	dir = 4;
+	name = "Труба дыхательной смеси"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
+	name = "Труба обработки"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cXX" = (
-/obj/machinery/atmospherics/binary/pump{
-	name = "Mix to Port"
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	dir = 1;
+	name = "Труба дыхательной смеси"
+	},
+/turf/space,
+/area/space/nearstation)
 "cXY" = (
-/obj/machinery/atmospherics/binary/pump{
-	name = "Air to Port"
+/obj/machinery/atmospherics/binary/volume_pump/on{
+	dir = 1;
+	name = "Port to Filter";
+	on = 0
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -79728,9 +79584,12 @@
 /turf/simulated/floor/engine/n20,
 /area/atmos)
 "cYa" = (
-/obj/machinery/atmospherics/binary/pump{
-	name = "Pure to Port"
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	desc = "Труба хранит в себе набор газов для смешивания";
+	dir = 1;
+	name = "Труба смешивания"
 	},
+/obj/machinery/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cYb" = (
@@ -79742,7 +79601,11 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	dir = 1;
+	name = "Труба дыхательной смеси"
+	},
 /turf/simulated/floor/plating,
 /area/atmos)
 "cYc" = (
@@ -79752,6 +79615,11 @@
 	name = "Nitrous Oxide Supply Control";
 	output_tag = "n2o_out";
 	sensors = list("n2o_sensor" = "Tank")
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
+	dir = 1;
+	name = "Труба фильтрации"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -79783,13 +79651,12 @@
 /turf/simulated/floor/engine/n20,
 /area/atmos)
 "cYg" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8;
-	name = "Mix to MiniSat"
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/maintenance/turbine)
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "cYh" = (
 /obj/structure/chair{
 	dir = 4
@@ -79812,6 +79679,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -79851,18 +79722,11 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "cYo" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light_switch{
+	pixel_x = -26;
+	pixel_y = 8
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cYp" = (
@@ -79942,18 +79806,14 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cYw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "cYx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/turf/space,
+/area/space/nearstation)
 "cYy" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /obj/machinery/meter,
@@ -80032,6 +79892,9 @@
 "cYG" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/warning_stripes/northwest,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cYH" = (
@@ -80044,15 +79907,13 @@
 	},
 /area/storage/office)
 "cYI" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
-/turf/simulated/wall/r_wall,
-/area/engine/chiefs_office)
+/turf/simulated/floor/plasteel,
+/area/maintenance/turbine)
 "cYJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/wall,
 /area/engine/engineering)
 "cYK" = (
@@ -80067,22 +79928,29 @@
 /obj/item/toner{
 	pixel_y = -4
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
 /area/storage/office)
 "cYL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 6
 	},
-/turf/simulated/wall/r_wall,
-/area/engine/chiefs_office)
+/obj/structure/lattice,
+/turf/space,
+/area/space/nearstation)
 "cYM" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable,
-/turf/simulated/floor/plating,
-/area/engine/engineering)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/closet/wardrobe/engineering_yellow,
+/turf/simulated/floor/plasteel,
+/area/engine/equipmentstorage)
 "cYN" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/machinery/alarm{
@@ -80133,11 +80001,11 @@
 /area/engine/engineering)
 "cYR" = (
 /obj/structure/disposalpipe/segment{
-	dir = 8;
+	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "cYS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -80151,26 +80019,21 @@
 	},
 /area/gateway)
 "cYT" = (
-/obj/machinery/atmospherics/trinary/tvalve/digital/flipped,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cYU" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
 	},
-/turf/simulated/wall/r_wall,
-/area/engine/engineering)
-"cYV" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible,
+/obj/structure/closet/secure_closet/engineering_personal,
 /turf/simulated/floor/plasteel,
-/area/atmos)
-"cYW" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold4w/visible,
-/turf/simulated/floor/plasteel,
-/area/atmos)
+/area/engine/equipmentstorage)
 "cYX" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -80180,9 +80043,6 @@
 /turf/simulated/wall/r_wall,
 /area/engine/engineering)
 "cYY" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
@@ -80196,6 +80056,9 @@
 /area/engine/engineering)
 "cYZ" = (
 /obj/effect/decal/warning_stripes/northeast,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cZa" = (
@@ -80215,25 +80078,17 @@
 	},
 /area/gateway)
 "cZb" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	name = "Waste to Port"
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cZc" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
-"cZd" = (
-/obj/machinery/atmospherics/trinary/filter{
-	dir = 1;
-	filter_type = 4;
-	name = "Gas filter (N2O tank)";
-	on = 1
-	},
+/obj/machinery/atmospherics/trinary/tvalve/digital,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cZe" = (
@@ -80246,9 +80101,10 @@
 	opacity = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
+	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
+	dir = 4;
+	name = "Труба фильтрации"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plating,
 /area/atmos)
 "cZf" = (
@@ -80256,9 +80112,6 @@
 	c_tag = "Engineering Particle Accelerator";
 	network = list("Singularity","SS13");
 	pixel_x = 23
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -80276,8 +80129,10 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cZg" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
+/obj/machinery/atmospherics/trinary/filter/flipped{
+	filter_type = 4;
+	name = "Gas filter (N2O tank)";
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -80287,7 +80142,9 @@
 "cZh" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
+	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
+	dir = 4;
+	name = "Труба фильтрации"
 	},
 /turf/space,
 /area/space/nearstation)
@@ -80316,18 +80173,17 @@
 	},
 /area/hallway/primary/central/west)
 "cZl" = (
-/obj/structure/closet/radiation,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/effect/decal/warning_stripes/southwestcorner,
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "yellow"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cZm" = (
 /obj/structure/chair{
@@ -80447,18 +80303,22 @@
 	},
 /area/hallway/secondary/exit)
 "cZE" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "cZF" = (
-/obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall/r_wall,
+/obj/structure/closet/cardboard{
+	icon_closed = "cardboard_engineering";
+	icon_opened = "cardboard_open_engineering";
+	icon_state = "cardboard_engineering"
+	},
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/turf/simulated/floor/plating,
 /area/maintenance/storage)
 "cZG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -80513,7 +80373,23 @@
 /turf/simulated/floor/plating,
 /area/storage/secure)
 "cZM" = (
-/turf/simulated/wall,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cZN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -80557,26 +80433,16 @@
 /area/engine/engineering)
 "cZQ" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cZR" = (
@@ -80602,61 +80468,39 @@
 	icon_state = "purple"
 	},
 /area/hallway/secondary/exit)
-"cZU" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/purple{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
 "cZV" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/power/apc{
 	name = "south bump";
 	pixel_y = -24
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/cable,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "green"
 	},
 /area/hallway/secondary/exit)
 "cZW" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/binary/valve,
-/turf/simulated/floor/plasteel,
-/area/atmos)
-"cZX" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9
-	},
+/obj/machinery/atmospherics/trinary/filter/flipped,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cZY" = (
-/obj/machinery/atmospherics/binary/valve,
+/obj/machinery/atmospherics/trinary/tvalve/digital/flipped,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cZZ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	desc = "Труба хранит в себе набор газов для смешивания";
+	dir = 1;
+	name = "Труба смешивания"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	desc = "Труба хранит в себе набор газов для смешивания";
+	dir = 4;
+	name = "Труба смешивания"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "daa" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/item/radio/intercom{
 	pixel_y = -28
 	},
@@ -80665,33 +80509,16 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/secondary/exit)
-"dab" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/wall/r_wall,
-/area/engine/engineering)
 "dac" = (
+/obj/structure/cable,
 /obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "dad" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible{
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
 	},
+/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "dae" = (
@@ -80717,16 +80544,24 @@
 	},
 /area/ai_monitored/storage/eva)
 "dag" = (
-/obj/machinery/atmospherics/binary/volume_pump/on{
-	dir = 8;
-	name = "Port to Filter"
+/obj/machinery/atmospherics/pipe/simple/visible{
+	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
+	dir = 4;
+	name = "Труба обработки"
 	},
+/obj/machinery/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dah" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	dir = 1;
+	name = "Труба дыхательной смеси"
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
+	desc = "Труба хранит в себе набор газов для смешивания";
+	dir = 4;
+	name = "Труба смешивания"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -80736,23 +80571,16 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "daj" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 1;
-	frequency = 1379;
-	id_tag = "engineering_east_pump"
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/maintenance/asmaint2)
 "dak" = (
 /obj/machinery/camera{
 	c_tag = "Departure Lounge South";
@@ -80770,9 +80598,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "dam" = (
@@ -80830,26 +80656,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/storage)
-"dav" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
 "daw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
+/obj/structure/lattice,
+/turf/simulated/wall/r_wall,
+/area/engine/engineering)
 "day" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "daz" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -80880,12 +80697,12 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-y"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -80971,10 +80788,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/genetics)
 "daK" = (
@@ -80993,44 +80806,51 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/storage)
 "daM" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple,
-/turf/simulated/floor/plasteel,
-/area/atmos)
-"daN" = (
-/obj/machinery/atmospherics/unary/portables_connector{
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"daO" = (
-/obj/machinery/hologram/holopad,
+"daN" = (
+/obj/machinery/atmospherics/binary/volume_pump/on{
+	dir = 8;
+	name = "Mix to Filter"
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"daP" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
+"daO" = (
+/obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "daQ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "daR" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering Singularity East";
+	dir = 8;
+	network = list("Singularity","SS13")
+	},
+/turf/simulated/floor/plating/airless,
+/area/engine/engineering)
 "daS" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -81072,10 +80892,16 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "daW" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/atmospherics/binary/pump{
+	desc = "Подаёт токсины для смешивания с другими газами";
 	dir = 8;
-	name = "Plasma to Pure"
+	name = "Токсины (Плазма) в смеситель";
+	target_pressure = 101
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	dir = 1;
+	name = "Труба дыхательной смеси"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -81084,12 +80910,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
-"daY" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
 "daZ" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -81103,14 +80923,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/escapepodbay)
-"dba" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
-/turf/space,
-/area/space/nearstation)
 "dbb" = (
 /turf/simulated/floor/engine/plasma,
 /area/atmos)
@@ -81171,10 +80983,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "dbk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -81196,9 +81004,6 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/genetics)
@@ -81222,17 +81027,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "dbq" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/genetics)
+/area/maintenance/storage)
 "dbr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -81253,22 +81051,9 @@
 /turf/simulated/floor/plating,
 /area/storage/secure)
 "dbu" = (
-/obj/machinery/power/emitter{
-	anchored = 1;
-	dir = 4;
-	state = 2
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering Singularity West";
-	dir = 4;
-	network = list("Singularity","SS13")
-	},
-/turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/space,
+/area/space)
 "dbv" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light_switch{
@@ -81284,12 +81069,6 @@
 	icon_state = "dark"
 	},
 /area/ai_monitored/storage/eva)
-"dbw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/genetics)
 "dbx" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -81307,6 +81086,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/storage)
 "dbz" = (
@@ -81333,17 +81113,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
-"dbB" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
-	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_x = 32
-	},
-/turf/simulated/wall/r_wall,
-/area/engine/engineering)
 "dbC" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -81363,6 +81138,10 @@
 	icon_state = "1-2"
 	},
 /obj/effect/spawner/random_spawners/grille_often,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "dbE" = (
@@ -81390,23 +81169,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/engine/engineering)
-"dbG" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Singularity";
-	name = "Singularity Shutters";
-	opacity = 0
-	},
-/obj/effect/spawner/window/reinforced,
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
-	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_x = 32
-	},
-/turf/simulated/floor/plating,
-/area/engine/engineering)
 "dbH" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -81417,44 +81179,51 @@
 /turf/simulated/floor/plasteel,
 /area/escapepodbay)
 "dbI" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "dbJ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 28
 	},
-/turf/simulated/wall/r_wall,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/northeast,
+/turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "dbK" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics West";
-	dir = 4
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/decal/warning_stripes/blue/hollow,
+/obj/structure/sign/nosmoking_2{
+	pixel_x = -28
 	},
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/plasteel,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/atmos)
 "dbL" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/decal/warning_stripes/blue/hollow,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/structure/reagent_dispensers/watertank/high,
-/turf/simulated/floor/plasteel,
 /area/atmos)
 "dbM" = (
 /obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "dbN" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible,
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dbO" = (
@@ -81485,23 +81254,6 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
-"dbQ" = (
-/obj/machinery/power/emitter{
-	anchored = 1;
-	dir = 8;
-	state = 2
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering Singularity East";
-	dir = 8;
-	network = list("Singularity","SS13")
-	},
-/turf/simulated/floor/plating/airless,
-/area/engine/engineering)
 "dbR" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -81563,16 +81315,13 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/airless,
-/area/space/nearstation)
+/area/toxins/mixing)
 "dcb" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "blue"
 	},
 /area/hallway/primary/central/north)
-"dcc" = (
-/turf/space,
-/area/toxins/mixing)
 "dcd" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -81583,13 +81332,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
-"dce" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
+"dce" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -81598,27 +81347,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "dcf" = (
 /obj/machinery/power/tesla_coil{
 	anchored = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
-"dcg" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "dch" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -81637,6 +81380,10 @@
 /area/engine/break_room)
 "dck" = (
 /obj/machinery/hologram/holopad,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -81672,6 +81419,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/storage)
 "dco" = (
@@ -81694,6 +81442,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "dcq" = (
@@ -81718,8 +81467,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "dct" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/simulated/floor/plasteel,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/decal/warning_stripes/red/hollow,
+/obj/machinery/camera{
+	c_tag = "Atmospherics North-West";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/atmos)
 "dcu" = (
 /obj/structure/cable{
@@ -81727,14 +81483,14 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "dcv" = (
-/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 8
+	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
+	dir = 8;
+	name = "Труба обработки"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -81750,6 +81506,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/turbine)
 "dcx" = (
@@ -81768,8 +81525,12 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "dcy" = (
-/obj/machinery/atmospherics/unary/tank/toxins{
+/obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/sign/nosmoking_2{
+	pixel_x = -32
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -81818,12 +81579,13 @@
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "dcF" = (
-/obj/structure/closet/firecloset,
-/obj/machinery/requests_console{
-	department = "Atmospherics";
-	departmentType = 3;
-	name = "Atmospherics Requests Console";
-	pixel_x = -30
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -81841,6 +81603,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/turbine)
 "dcH" = (
@@ -81873,13 +81639,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "dcL" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/decal/warning_stripes/red/hollow,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/simulated/floor/plasteel,
 /area/atmos)
 "dcM" = (
 /obj/structure/rack{
@@ -81911,14 +81675,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/storage/secure)
-"dcO" = (
-/obj/machinery/atmospherics/trinary/filter{
-	dir = 1;
-	name = "Gas filter (Toxins tank)";
-	on = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
 "dcP" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -81943,11 +81699,13 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "dcS" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
+	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
+	dir = 4;
+	name = "Труба фильтрации"
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
 "dcT" = (
@@ -81962,27 +81720,14 @@
 /turf/simulated/floor/engine/plasma,
 /area/atmos)
 "dcV" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/structure/sign/nosmoking_2{
-	pixel_x = -32
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
-"dcW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
 "dcX" = (
 /obj/structure/chair,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "dcY" = (
@@ -82005,8 +81750,8 @@
 	},
 /area/shuttle/syndicate)
 "dda" = (
-/obj/machinery/atmospherics/binary/valve,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/trinary/tvalve/digital,
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "ddb" = (
@@ -82016,42 +81761,21 @@
 "ddc" = (
 /obj/structure/chair,
 /obj/item/storage/fancy/cigarettes,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
-"ddd" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/maintenance/turbine)
 "dde" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "ddf" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/item/pen,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 9;
+	tag = "icon-intact-y (NORTHWEST)"
+	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "ddg" = (
@@ -82104,10 +81828,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
-"ddm" = (
-/obj/machinery/portable_atmospherics/pump,
-/turf/simulated/floor/plasteel,
-/area/atmos)
 "ddn" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/item/storage/toolbox/emergency,
@@ -82144,17 +81864,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/storage)
 "dds" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/decal/warning_stripes/white/hollow,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plasteel,
 /area/atmos)
 "ddt" = (
-/obj/machinery/atmospherics/binary/pump{
-	name = "Port to Filter"
+/obj/machinery/atmospherics/trinary/filter{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -82201,6 +81919,11 @@
 /obj/machinery/camera{
 	c_tag = "Atmospherics Central";
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
+	dir = 1;
+	name = "Труба фильтрации"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -82251,13 +81974,6 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/solar/starboard)
-"ddB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
 "ddC" = (
 /obj/structure/transit_tube{
 	icon_state = "E-W-Pass"
@@ -82291,7 +82007,7 @@
 /area/storage/secure)
 "ddH" = (
 /obj/structure/disposalpipe/segment{
-	dir = 8;
+	dir = 2;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
@@ -82455,7 +82171,10 @@
 /turf/space,
 /area/solar/starboard)
 "dec" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
+	name = "Труба обработки"
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "ded" = (
@@ -82500,27 +82219,25 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/solar/starboard)
-"deh" = (
-/obj/machinery/space_heater,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
 "dei" = (
-/obj/machinery/atmospherics/unary/heat_reservoir/heater{
-	dir = 8;
-	icon_state = "freezer_0"
+/obj/machinery/atmospherics/pipe/simple/visible{
+	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
+	dir = 10;
+	name = "Труба обработки"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dej" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/atmospherics/binary/pump{
+	desc = "Подаёт углекислый для смешивания с другими газами";
 	dir = 8;
-	name = "CO2 to Pure"
+	name = "Углекислый газ (CO2) в смеситель";
+	target_pressure = 101
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	dir = 1;
+	name = "Труба дыхательной смеси"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -82530,17 +82247,24 @@
 	dir = 4;
 	name = "CO2 Outlet Valve"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
+	dir = 1;
+	name = "Труба фильтрации"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "caution"
 	},
 /area/atmos)
 "del" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
+	desc = "Труба хранит в себе набор газов для смешивания";
+	dir = 4;
+	name = "Труба смешивания"
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
 "dem" = (
@@ -82562,9 +82286,6 @@
 /area/atmos)
 "deo" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -82633,7 +82354,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -82657,6 +82377,7 @@
 	req_access_txt = "10";
 	req_one_access_txt = null
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/storage)
 "dey" = (
@@ -82691,18 +82412,8 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "deD" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -82725,7 +82436,9 @@
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "deG" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -82734,26 +82447,19 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "deH" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
-"deI" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/purple,
-/turf/simulated/floor/plasteel,
-/area/atmos)
-"deJ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "deK" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 9
-	},
+/obj/machinery/atmospherics/binary/volume_pump,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "deL" = (
@@ -82764,10 +82470,6 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = -32
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -82777,18 +82479,20 @@
 	name = "Atmospherics Maintenance";
 	req_access_txt = "24"
 	},
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = -32
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/storage)
 "deM" = (
-/obj/structure/table,
-/obj/item/wrench,
-/obj/item/t_scanner,
-/obj/item/storage/belt/utility,
-/obj/item/storage/belt/utility,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -82806,18 +82510,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "deO" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 6
-	},
-/obj/machinery/power/apc{
+/obj/machinery/firealarm{
 	dir = 8;
-	name = "west bump Engineering";
-	pixel_x = -24;
-	shock_proof = 1
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -82828,15 +82523,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/storage)
 "deQ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 6
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "deR" = (
 /obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	name = "N2 to Pure"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -82860,8 +82554,9 @@
 /area/maintenance/asmaint)
 "deU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 9;
-	tag = "icon-intact-y (NORTHWEST)"
+	desc = "Труба хранит в себе набор газов для смешивания";
+	dir = 1;
+	name = "Труба смешивания"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -82872,6 +82567,11 @@
 	name = "Carbon Dioxide Supply Control";
 	output_tag = "co2_out";
 	sensors = list("co2_sensor" = "Tank")
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
+	dir = 1;
+	name = "Труба фильтрации"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -82889,6 +82589,7 @@
 	name = "EXTERNAL AIRLOCK";
 	pixel_x = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/storage)
 "deX" = (
@@ -82943,6 +82644,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
@@ -83038,7 +82742,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "dfo" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "dfp" = (
@@ -83133,7 +82837,10 @@
 /turf/simulated/wall/r_wall,
 /area/maintenance/storage)
 "dfy" = (
-/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dfz" = (
@@ -83158,7 +82865,11 @@
 	},
 /area/maintenance/storage)
 "dfB" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	desc = "Труба хранит в себе набор газов для смешивания";
+	dir = 4;
+	name = "Труба смешивания"
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dfC" = (
@@ -83190,57 +82901,60 @@
 	},
 /area/maintenance/storage)
 "dfF" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
+/obj/structure/closet/wardrobe/atmospherics_yellow,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump Engineering";
+	pixel_x = -24;
+	shock_proof = 1
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dfG" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	desc = "Труба хранит в себе набор газов для смешивания";
+	dir = 8;
+	name = "Труба смешивания"
 	},
-/obj/machinery/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dfH" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	desc = "Труба хранит в себе набор газов для смешивания";
+	dir = 4;
+	name = "Труба смешивания"
 	},
-/obj/machinery/atmospherics/binary/pump{
-	dir = 1;
-	name = "O2 to Pure"
+/obj/machinery/atmospherics/pipe/simple/visible{
+	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
+	name = "Труба обработки"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dfI" = (
-/obj/machinery/atmospherics/trinary/mixer{
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 4;
-	name = "Gas mixer (N2/O2)";
-	node1_concentration = 0.8;
-	node2_concentration = 0.2;
-	on = 1;
-	target_pressure = 4500
+	name = "Труба смешивания"
 	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
-"dfJ" = (
-/obj/machinery/atmospherics/trinary/filter{
-	dir = 1;
-	filter_type = 3;
-	name = "Gas filter (CO2 tank)";
-	on = 1
-	},
+/obj/machinery/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dfK" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	desc = "Труба хранит в себе набор газов для смешивания";
+	dir = 9;
+	name = "Труба смешивания"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dfL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /mob/living/simple_animal/mouse,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "dfM" = (
@@ -83250,7 +82964,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "dfN" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
+/obj/machinery/atmospherics/trinary/filter/flipped{
+	filter_type = 3;
+	name = "Gas filter (CO2 tank)";
+	on = 1
+	},
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -83364,11 +83083,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "dgg" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	dir = 6;
+	name = "Труба дыхательной смеси"
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dgh" = (
-/obj/machinery/atmospherics/unary/portables_connector,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	dir = 4;
+	name = "Труба дыхательной смеси"
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dgi" = (
@@ -83379,8 +83106,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/storage)
 "dgj" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
+	dir = 1;
+	name = "Труба фильтрации"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -83422,10 +83151,6 @@
 /obj/structure/sign/biohazard,
 /turf/simulated/wall,
 /area/maintenance/asmaint)
-"dgo" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/wall,
-/area/maintenance/asmaint)
 "dgp" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod"
@@ -83437,34 +83162,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/storage)
 "dgr" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics South-West";
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/purple,
-/turf/simulated/floor/plasteel,
-/area/atmos)
-"dgs" = (
-/obj/structure/table,
-/obj/item/radio{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/radio{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/radio,
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dgt" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 8
+/obj/machinery/atmospherics/trinary/mixer{
+	desc = "Смешивает кислород и азот, создавая смесь для дыхания на станции";
+	dir = 4;
+	name = "Дыхательный смеситель";
+	node1_concentration = 0.8;
+	node2_concentration = 0.2;
+	on = 1;
+	target_pressure = 4500
 	},
-/obj/machinery/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dgy" = (
@@ -83488,11 +83198,11 @@
 /obj/structure/shuttle/engine/propulsion/burst{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
 /turf/simulated/shuttle/wall{
 	icon_state = "swall_f6";
 	tag = "icon-swall_f6"
 	},
+/turf/simulated/floor/plating,
 /area/shuttle/pod_4)
 "dgE" = (
 /obj/machinery/power/grounding_rod{
@@ -83554,50 +83264,48 @@
 /turf/simulated/floor/carpet/black,
 /area/shuttle/trade/sol)
 "dgM" = (
-/obj/item/radio/intercom{
-	dir = 8;
-	pixel_x = -28
+/obj/machinery/atmospherics/binary/volume_pump{
+	desc = "Отправляет неотфильтрованные газы в отходы на повторную фильтрацию";
+	dir = 1;
+	name = "Остатки газа в отходы"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
-"dgN" = (
-/obj/machinery/atmospherics/trinary/filter{
-	dir = 4;
-	filter_type = 2;
-	name = "Gas filter (N2 tank)";
-	on = 1
+/obj/machinery/camera{
+	c_tag = "Atmospherics South-West";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dgO" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
+/obj/machinery/atmospherics/binary/pump{
+	desc = "Подаёт азот для смешивания с другими газами";
+	dir = 4;
+	name = "Азот (N2) в смеситель";
+	target_pressure = 101
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dgP" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	dir = 8;
+	name = "Труба дыхательной смеси"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dgQ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
+/obj/machinery/atmospherics/binary/pump{
+	desc = "Подаёт кислород для смешивания с другими газами";
+	dir = 8;
+	name = "Кислород (O2) в смеситель";
+	target_pressure = 101
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dgR" = (
-/obj/machinery/atmospherics/trinary/filter{
-	dir = 4;
-	filter_type = 1;
-	name = "Gas filter (O2 tank)";
-	on = 1
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	desc = "Труба хранит в себе набор газов для смешивания";
+	name = "Труба смешивания"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -83619,24 +83327,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "dgV" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	dir = 1;
+	name = "Труба дыхательной смеси"
 	},
 /turf/simulated/floor/plasteel,
-/area/atmos)
-"dgW" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "atmos";
-	name = "Atmos Blast Door";
-	opacity = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
 /area/atmos)
 "dgX" = (
 /obj/structure/closet,
@@ -83653,6 +83349,7 @@
 "dgZ" = (
 /obj/item/c_tube,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "dha" = (
@@ -83877,9 +83574,10 @@
 	},
 /area/crew_quarters/toilet)
 "dhx" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/binary/volume_pump/on{
-	name = "Space Loop In"
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
+	dir = 4;
+	name = "Труба фильтрации"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -83913,12 +83611,22 @@
 	output_tag = "n2_out";
 	sensors = list("n2_sensor" = "Tank")
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
+	dir = 4;
+	name = "Труба фильтрации"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
 /area/atmos)
 "dhB" = (
+/obj/machinery/atmospherics/trinary/filter/flipped{
+	dir = 8;
+	filter_type = 2;
+	name = "Gas filter (N2 tank)";
+	on = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "red"
@@ -83928,6 +83636,12 @@
 /obj/machinery/atmospherics/binary/valve/digital/open{
 	name = "Nitrogen Outlet Valve"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
+	dir = 4;
+	name = "Труба фильтрации"
+	},
+/obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "red"
@@ -83941,12 +83655,22 @@
 	output_tag = "o2_out";
 	sensors = list("o2_sensor" = "Tank")
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
+	dir = 4;
+	name = "Труба фильтрации"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "blue"
 	},
 /area/atmos)
 "dhE" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/atmospherics/trinary/filter/flipped{
+	dir = 8;
+	filter_type = 1;
+	name = "Gas filter (O2 tank)";
+	on = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "blue"
@@ -83955,6 +83679,11 @@
 "dhF" = (
 /obj/machinery/atmospherics/binary/valve/digital/open{
 	name = "Oxygen Outlet Valve"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
+	dir = 4;
+	name = "Труба фильтрации"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -83970,12 +83699,31 @@
 	pressure_setting = 2000;
 	sensors = list("air_sensor" = "Tank")
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
+	dir = 4;
+	name = "Труба фильтрации"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	dir = 1;
+	name = "Труба дыхательной смеси"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
 	},
 /area/atmos)
 "dhH" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	dir = 1;
+	name = "Труба дыхательной смеси"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
+	dir = 4;
+	name = "Труба фильтрации"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "arrival"
@@ -83997,8 +83745,10 @@
 	c_tag = "Atmospherics South-East";
 	dir = 1
 	},
-/obj/machinery/atmospherics/binary/valve/digital/open{
-	name = "Mixed Air Outlet Valve"
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
+	dir = 9;
+	name = "Труба фильтрации"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -84050,19 +83800,15 @@
 /area/crew_quarters/toilet)
 "dhP" = (
 /obj/structure/grille/broken,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "dhQ" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
-"dhR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/maintenance/asmaint2)
 "dhS" = (
 /obj/machinery/door/airlock{
 	id_tag = "toilet_unitb";
@@ -84076,11 +83822,11 @@
 /obj/structure/shuttle/engine/propulsion/burst{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
 /turf/simulated/shuttle/wall{
 	icon_state = "swall_f5";
 	tag = "icon-swall_f5"
 	},
+/turf/simulated/floor/plating,
 /area/shuttle/pod_4)
 "dhV" = (
 /obj/structure/sink/kitchen{
@@ -84154,34 +83900,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior)
-"dij" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "atmos";
-	name = "Atmos Blast Door";
-	opacity = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/atmos)
-"dik" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "atmos";
-	name = "Atmos Blast Door";
-	opacity = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 6
-	},
-/turf/simulated/floor/plating,
-/area/atmos)
 "dil" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
@@ -84210,18 +83928,6 @@
 	icon_state = "dark"
 	},
 /area/gateway)
-"dio" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "atmos";
-	name = "Atmos Blast Door";
-	opacity = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/plating,
-/area/atmos)
 "dip" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor{
@@ -84231,17 +83937,15 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	desc = "Труба хранит в себе набор газов для смешивания";
+	dir = 1;
+	name = "Труба смешивания"
+	},
 /turf/simulated/floor/plating,
 /area/atmos)
 "diq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/wall,
-/area/maintenance/asmaint)
-"dir" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/wall,
 /area/maintenance/asmaint)
 "dis" = (
@@ -84259,16 +83963,13 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
+	dir = 1;
+	name = "Труба фильтрации"
+	},
 /turf/simulated/floor/plating,
 /area/atmos)
-"diu" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 6
-	},
-/obj/structure/lattice,
-/turf/space,
-/area/space/nearstation)
 "div" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -84530,11 +84231,6 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
-"diU" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/turf/space,
-/area/space/nearstation)
 "diV" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -84544,49 +84240,49 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/administration)
-"diW" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5
-	},
-/turf/space,
-/area/space/nearstation)
 "diX" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
+	dir = 1;
+	name = "Труба фильтрации"
 	},
 /turf/space,
 /area/space/nearstation)
 "diY" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
+	dir = 5;
+	tag = "icon-intact (NORTHEAST)"
 	},
+/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "diZ" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	desc = "Труба хранит в себе набор газов для смешивания";
+	dir = 1;
+	name = "Труба смешивания"
 	},
 /turf/space,
 /area/space/nearstation)
 "dja" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	desc = "Труба содержит дыхательную смесь для подачи на станцию";
+	dir = 1;
+	name = "Труба дыхательной смеси"
+	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
+/obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
 "djb" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
-/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "djc" = (
@@ -84704,10 +84400,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
-"djo" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
 "djp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
@@ -84940,12 +84632,6 @@
 	tag = "icon-vault (NORTHEAST)"
 	},
 /area/turret_protected/aisat_interior)
-"djK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/maintenance/turbine)
 "djL" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
@@ -84955,11 +84641,18 @@
 /area/hallway/primary/central/nw)
 "djM" = (
 /obj/item/shard,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "djN" = (
-/obj/structure/disposalpipe/segment,
 /obj/item/cigbutt/roach,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "djO" = (
@@ -85046,18 +84739,6 @@
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/central/nw)
-"djX" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/closet,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
-"djY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/wall,
-/area/maintenance/asmaint)
 "djZ" = (
 /obj/machinery/light{
 	dir = 1
@@ -85196,6 +84877,9 @@
 /area/atmos)
 "dkj" = (
 /obj/effect/spawner/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/turbine)
 "dkk" = (
@@ -85205,7 +84889,7 @@
 	frequency = 1441;
 	icon_state = "in";
 	id_tag = "n2_out";
-	internal_pressure_bound = 4000;
+	internal_pressure_bound = 1600;
 	on = 1;
 	pressure_checks = 2;
 	pump_direction = 0
@@ -85275,18 +84959,13 @@
 	frequency = 1441;
 	icon_state = "in";
 	id_tag = "o2_out";
-	internal_pressure_bound = 4000;
+	internal_pressure_bound = 400;
 	on = 1;
 	pressure_checks = 2;
 	pump_direction = 0
 	},
 /turf/simulated/floor/engine/o2,
 /area/atmos)
-"dkt" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall,
-/area/maintenance/asmaint)
 "dku" = (
 /obj/machinery/air_sensor{
 	frequency = 1443;
@@ -85316,7 +84995,7 @@
 	frequency = 1443;
 	icon_state = "in";
 	id_tag = "air_out";
-	internal_pressure_bound = 2000;
+	internal_pressure_bound = 606;
 	on = 1;
 	pressure_checks = 2;
 	pump_direction = 0
@@ -85362,10 +85041,6 @@
 	icon_state = "grimy"
 	},
 /area/crew_quarters/bar)
-"dkF" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/wall,
-/area/maintenance/asmaint2)
 "dkH" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -85488,7 +85163,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "dkQ" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
 	},
@@ -85509,10 +85183,10 @@
 	},
 /area/crew_quarters/kitchen)
 "dkS" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "dkT" = (
@@ -85595,6 +85269,7 @@
 	name = "\improper AI Satellite Atmospherics"
 	})
 "dkY" = (
+/mob/living/simple_animal/bot/secbot/pingsky,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -85615,7 +85290,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/mob/living/simple_animal/bot/secbot/pingsky,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "dark";
@@ -85730,15 +85404,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
-"dli" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
 "dlj" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -85802,7 +85467,6 @@
 	name = "\improper AI Satellite Service"
 	})
 "dlp" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
 	},
@@ -85818,13 +85482,6 @@
 /area/aisat/entrance{
 	name = "\improper AI Satellite Atmospherics"
 	})
-"dlr" = (
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-y"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "dls" = (
 /mob/living/simple_animal/bot/floorbot{
 	on = 0
@@ -85903,7 +85560,7 @@
 /area/maintenance/asmaint2)
 "dlA" = (
 /obj/structure/disposalpipe/segment{
-	dir = 1;
+	dir = 8;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
@@ -85966,23 +85623,22 @@
 /area/aisat/maintenance{
 	name = "\improper AI Satellite Service"
 	})
-"dlM" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "dlN" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "dlO" = (
 /obj/structure/chair/stool,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "dlP" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
@@ -86110,10 +85766,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "dmc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/item/clipboard,
@@ -86186,13 +85838,6 @@
 	},
 /turf/simulated/floor/engine/insulated,
 /area/maintenance/turbine)
-"dmi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/wall/r_wall/coated,
-/area/maintenance/asmaint)
 "dmj" = (
 /obj/item/radio,
 /turf/simulated/floor/plating/airless,
@@ -86207,23 +85852,10 @@
 	name = "\improper AI Satellite Hallway"
 	})
 "dml" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2 (EAST)"
-	},
 /obj/machinery/atmospherics/binary/pump{
 	name = "Waste Out";
 	on = 1
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
-"dmm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "dmn" = (
@@ -86237,14 +85869,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "dmq" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "dmr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
@@ -86293,6 +85925,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
 "dmw" = (
@@ -86304,16 +85939,24 @@
 	name = "\improper AI Satellite Hallway"
 	})
 "dmx" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
@@ -86633,7 +86276,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/airless,
-/area/space/nearstation)
+/area/maintenance/turbine)
 "dne" = (
 /obj/structure/cable,
 /obj/machinery/power/turbine,
@@ -86913,16 +86556,6 @@
 	},
 /area/turret_protected/ai)
 "dnC" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "bluecorner"
@@ -87235,7 +86868,7 @@
 "dof" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 100
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -87347,6 +86980,7 @@
 	pixel_x = 22;
 	pixel_y = 10
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/storage)
 "dop" = (
@@ -87371,6 +87005,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/storage)
 "dos" = (
@@ -87379,13 +87014,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/storage)
-"dot" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	dir = 4;
-	level = 2
-	},
-/turf/simulated/wall,
-/area/engine/controlroom)
 "dou" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "swall12";
@@ -88451,9 +88079,6 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "dsI" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/closet/secure_closet/engineering_electrical,
 /obj/machinery/power/apc{
 	cell_type = 25000;
@@ -88473,9 +88098,6 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "dsL" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/item/radio/intercom{
 	dir = 1;
 	pixel_y = 25
@@ -88483,19 +88105,6 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"dsN" = (
-/obj/structure/table,
-/obj/item/t_scanner,
-/obj/item/multitool{
-	pixel_x = 5
-	},
-/obj/item/radio/headset/headset_eng,
-/obj/item/cartridge/atmos,
-/obj/item/cartridge/atmos,
-/obj/item/t_scanner,
-/obj/item/wrench,
-/turf/simulated/floor/plasteel,
-/area/atmos)
 "dsO" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -88533,10 +88142,6 @@
 /area/engine/chiefs_office)
 "dsU" = (
 /obj/effect/decal/cleanable/blood/oil,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -88547,10 +88152,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "dsW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "dsX" = (
@@ -88590,13 +88192,6 @@
 /obj/structure/table,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"dtc" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
-	dir = 4
-	},
-/obj/structure/closet/wardrobe/atmospherics_yellow,
-/turf/simulated/floor/plasteel,
-/area/atmos)
 "dtk" = (
 /obj/item/pipe_painter,
 /obj/item/clothing/ears/earmuffs{
@@ -88615,10 +88210,19 @@
 	pixel_y = 5
 	},
 /obj/structure/table,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "dtn" = (
-/obj/machinery/suit_storage_unit/atmos,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4
+	},
+/obj/structure/sign/nosmoking_2{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dtp" = (
@@ -88633,6 +88237,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/light,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "dtq" = (
@@ -88667,10 +88272,6 @@
 /turf/simulated/floor/plating,
 /area/storage/secure)
 "dtt" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
@@ -88680,11 +88281,10 @@
 /area/storage/secure)
 "dtv" = (
 /obj/machinery/space_heater,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plasteel,
 /area/atmos)
 "dtw" = (
 /obj/machinery/light/small{
@@ -88869,6 +88469,7 @@
 /obj/structure/barricade/wooden/crude{
 	layer = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/xenozoo)
 "dUY" = (
@@ -88956,6 +88557,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/xenozoo)
 "egE" = (
@@ -89522,15 +89124,6 @@
 	icon_state = "neutral"
 	},
 /area/shuttle/escape)
-"fzL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/secondary/exit)
 "fAw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/machinery/tcomms/core/station,
@@ -90197,10 +89790,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
-"hnb" = (
-/obj/item/toy/figure/atmos,
-/turf/simulated/floor/plating,
-/area/maintenance/storage)
 "hnQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -90599,6 +90188,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/holosign/barrier,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/maintenance/xenozoo)
 "irr" = (
@@ -90758,9 +90348,6 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/dorms)
 "iPr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "darkblue"
@@ -90906,10 +90493,6 @@
 /obj/machinery/light_switch{
 	pixel_y = -25
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkredcorners"
@@ -90984,7 +90567,6 @@
 	},
 /area/security/securearmoury)
 "jSI" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -91009,6 +90591,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -91039,6 +90624,16 @@
 	},
 /obj/structure/flora/ausbushes/genericbush,
 /obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/grass,
 /area/hallway/secondary/exit)
 "jXY" = (
@@ -91062,7 +90657,6 @@
 	req_access_txt = "1"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -91445,14 +91039,6 @@
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
 /area/security/range)
-"kYT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/hallway/secondary/exit)
 "kZd" = (
 /obj/structure/chair/wood/wings{
 	dir = 4;
@@ -91488,6 +91074,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/warning_stripes/south,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreen";
 	tag = "icon-whitehall (WEST)"
@@ -91688,10 +91275,7 @@
 	},
 /area/crew_quarters/locker)
 "lLC" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
-	},
+/obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "lLQ" = (
@@ -91822,6 +91406,11 @@
 /obj/item/seeds/corn,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel/white,
 /area/security/permabrig)
 "lVG" = (
@@ -91834,6 +91423,11 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2";
+	tag = "icon-pipe-j2 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
@@ -92550,6 +92144,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/maintenance/xenozoo)
 "nVM" = (
@@ -92604,6 +92199,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/xenozoo)
 "obn" = (
@@ -92638,7 +92234,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "oec" = (
-/mob/living/simple_animal/mouse/brown,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	d1 = 1;
@@ -92648,6 +92243,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/xenozoo)
 "oiL" = (
@@ -92665,17 +92261,6 @@
 	icon_state = "purple"
 	},
 /area/maintenance/xenozoo)
-"oiP" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/secondary/exit)
 "onN" = (
 /obj/machinery/kitchen_machine/microwave{
 	pixel_x = -3;
@@ -92959,6 +92544,7 @@
 /area/shuttle/administration)
 "pcR" = (
 /obj/machinery/recharge_station,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "pdr" = (
@@ -92979,6 +92565,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/xenozoo)
 "phk" = (
@@ -93067,14 +92654,15 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -93621,6 +93209,10 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -93715,12 +93307,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
-"qYx" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/toy/figure/janitor,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "rac" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool,
@@ -94065,7 +93651,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -94150,11 +93735,6 @@
 /turf/simulated/shuttle/plating,
 /area/shuttle/administration)
 "rSU" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutral"
@@ -94293,9 +93873,6 @@
 	},
 /area/shuttle/administration)
 "sAQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkbluecorners"
@@ -94309,6 +93886,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -94675,7 +94253,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/mob/living/simple_animal/hostile/hivebot,
+/mob/living/simple_animal/hostile/hivebot{
+	faction = list("slime")
+	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/xenozoo)
 "tvr" = (
@@ -94835,6 +94416,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -94862,6 +94446,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/xenozoo)
 "uom" = (
@@ -95166,6 +94751,7 @@
 	info = "<center><h1>ЗАПЕЧАТАНО</h1><h2>ВХОД СТРОГО ЗАПРЕЩЕН</h2>Модуль заблокирован в связи с ненадлежащим техническим состоянием. Попытки восстановить модуль не увенчались успехом, последующая разблокировка может привести к негативным последствиям.<br />Командование станции вправе оценить риски и взять на себя ответственность за разблокировку модуля.</center>";
 	name = "Постановление о блокировке модуля"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/maintenance/xenozoo)
 "vbu" = (
@@ -95504,14 +95090,6 @@
 	icon_state = "grimy"
 	},
 /area/library/abandoned)
-"vWu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "green"
-	},
-/area/hallway/secondary/exit)
 "vZA" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -95883,13 +95461,29 @@
 /area/library/abandoned)
 "wOS" = (
 /obj/structure/table,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/pipe_painter,
-/obj/item/pipe_painter,
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/clothing/head/welding,
+/obj/item/clothing/head/welding{
+	layer = 8
+	},
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/glasses/welding,
+/obj/item/stack/sheet/metal{
+	amount = 50;
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/stack/sheet/metal{
+	amount = 50;
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "wPc" = (
@@ -96387,6 +95981,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -112542,7 +112140,7 @@ bnq
 bnq
 bIr
 bJv
-bKh
+bKW
 bKW
 bMd
 bKF
@@ -112569,7 +112167,7 @@ aMr
 aaa
 afO
 aaa
-cxY
+bOI
 czE
 aaa
 aaa
@@ -112800,7 +112398,7 @@ bvs
 bvs
 bvs
 bvs
-bGW
+bvs
 bDQ
 bKw
 bMo
@@ -112826,8 +112424,8 @@ aMr
 aab
 aab
 aaa
-cxY
-czF
+bTz
+cEU
 cBi
 cBi
 cBi
@@ -113057,7 +112655,7 @@ bvs
 bwP
 bvs
 bwP
-bGW
+bvs
 bDQ
 bKw
 bMo
@@ -113083,8 +112681,8 @@ afO
 afO
 aab
 aaa
-cxY
-czF
+bTz
+cEU
 cBg
 cCw
 cDP
@@ -113314,7 +112912,7 @@ bvs
 bCm
 bvs
 bEW
-bGW
+bvs
 bDQ
 bKw
 bMo
@@ -113340,8 +112938,8 @@ cgQ
 afO
 afO
 aab
-cxY
-czF
+bTz
+cEU
 cAX
 cCx
 cAX
@@ -113565,13 +113163,13 @@ bvk
 bnD
 bvs
 bBN
+aVH
 byn
-bEr
 bGk
 bCx
+bvG
 byn
-byn
-bGW
+bvs
 bDQ
 bKF
 bMo
@@ -113597,8 +113195,8 @@ cgQ
 cng
 cng
 cgQ
-cxY
-czF
+bTz
+cEU
 cBj
 cCq
 cDU
@@ -113823,12 +113421,12 @@ bvT
 bzQ
 bBP
 bDv
-bEz
+bIs
 byo
 bIs
 bJx
 bKq
-bGW
+bvs
 bDQ
 bKw
 bMr
@@ -113855,7 +113453,7 @@ coL
 cvk
 cwx
 cyo
-czP
+cEU
 cAX
 cCy
 cAX
@@ -114085,7 +113683,7 @@ bvs
 bvs
 bym
 bym
-bGW
+bvs
 bDQ
 blQ
 aaa
@@ -114626,7 +114224,7 @@ coL
 coL
 cwx
 cyc
-czJ
+bUE
 cBb
 cCz
 cDX
@@ -115097,7 +114695,7 @@ aXQ
 bdh
 aVi
 bgz
-biJ
+aIN
 bkg
 blM
 bnF
@@ -115112,7 +114710,7 @@ blM
 blM
 blM
 blQ
-bKu
+bnK
 bHb
 bMg
 bxb
@@ -115142,8 +114740,8 @@ cwx
 cye
 czK
 cBd
-czJ
-cBb
+bZu
+caQ
 cEW
 cFX
 cFX
@@ -115354,8 +114952,8 @@ aXQ
 aNv
 beR
 bgz
-biJ
-bkf
+aIN
+bpj
 blM
 bnG
 bnD
@@ -115364,9 +114962,9 @@ bnD
 bwa
 bAb
 brN
-brN
-brN
-brN
+aWQ
+beJ
+beJ
 blM
 bDP
 bKE
@@ -115611,22 +115209,22 @@ aZg
 bgQ
 bhT
 biC
-blH
+aKo
 bkg
 blM
 bnH
 bnD
 bnD
 bnD
-bwd
+bwa
 bzV
 bst
-bst
-bst
+aYO
+bfO
 bua
 blM
-bCk
-bKy
+bnK
+bvJ
 bxb
 bxb
 bxb
@@ -115869,7 +115467,7 @@ bdk
 beU
 bgF
 bme
-bkh
+bkg
 blM
 bnI
 bnD
@@ -115878,16 +115476,16 @@ bvu
 bwq
 bAe
 bCn
-bCn
-bCn
+bbW
+bfQ
 bGn
 blM
-bCk
-bKy
+bnK
+bvJ
 bxb
 bIV
 bKz
-bKz
+bQg
 bOh
 bHh
 bRR
@@ -116135,16 +115733,16 @@ bsk
 btT
 bvx
 bwY
-bsk
+ben
 pcR
 bBf
 bOn
-bJy
+bCs
 bKG
 bxb
 bIU
 bKz
-bKz
+bQg
 bSj
 bHh
 bRR
@@ -116178,7 +115776,7 @@ cFW
 cFW
 cII
 cEY
-cTc
+cRG
 cLp
 cNB
 cPu
@@ -116382,7 +115980,7 @@ aaa
 aaa
 beL
 bgA
-biJ
+aIN
 bkg
 blM
 blM
@@ -116396,12 +115994,12 @@ blM
 blM
 blM
 blM
-bCk
+bnK
 bFd
 bxb
 bIY
 bKz
-bKz
+bQg
 bOh
 bPO
 bRR
@@ -116435,7 +116033,7 @@ cFX
 cFX
 cIJ
 cEY
-cTc
+cRG
 cLi
 dbh
 cND
@@ -116652,13 +116250,13 @@ bCs
 bCs
 bCs
 bGR
-bxa
-bJB
+bCs
+bCs
 bKH
 bxb
 bIX
 bKz
-bKz
+bQg
 bOh
 bKz
 bPQ
@@ -116692,7 +116290,7 @@ cFX
 cFX
 cIK
 cEY
-cTc
+cRG
 cLi
 cLi
 cLi
@@ -116896,7 +116494,7 @@ aUE
 aaa
 beK
 bgA
-biJ
+aIN
 bkg
 blQ
 bnL
@@ -116904,18 +116502,18 @@ bpf
 bnL
 bnL
 bwu
-bAu
-bCr
-bCr
-bCr
-bGU
+bAx
 bnK
-bCk
+bnK
+bnK
+bnK
+bnK
+bnK
 bnK
 bxb
 bIS
 bKz
-bKz
+bQg
 bOk
 ceE
 bJf
@@ -116946,7 +116544,7 @@ cvp
 cEW
 cEI
 cFL
-cGC
+cFX
 cIM
 cEY
 cJW
@@ -117153,7 +116751,7 @@ bbq
 bcY
 beN
 bgA
-biJ
+aIN
 bkg
 blR
 blR
@@ -117167,7 +116765,7 @@ bxb
 bxb
 bxb
 bxb
-bFm
+bxb
 bxb
 bxb
 bIZ
@@ -117203,8 +116801,8 @@ aaa
 cEW
 cFX
 cFK
-cFX
-cFX
+cfv
+cfy
 cLo
 cMv
 cNN
@@ -117430,7 +117028,7 @@ bIw
 bJf
 bJf
 bMw
-bOh
+bFm
 bKz
 bRL
 bQf
@@ -117667,7 +117265,7 @@ bbq
 bcY
 beN
 bgA
-blO
+aMG
 bph
 bPr
 brz
@@ -117683,7 +117281,7 @@ bGY
 bIz
 byw
 bFp
-bFm
+bxb
 bMi
 bKz
 bQg
@@ -117924,7 +117522,7 @@ aUE
 aaa
 beK
 bgA
-biJ
+aIN
 bkk
 blR
 bnz
@@ -117940,7 +117538,7 @@ byw
 bBj
 byw
 bFq
-bFm
+bxb
 bxb
 bKB
 bVl
@@ -118181,7 +117779,7 @@ aUE
 aab
 beK
 bgA
-biJ
+aIN
 bkg
 blT
 blT
@@ -118189,7 +117787,7 @@ blT
 blT
 blT
 blT
-bvG
+bCj
 bxb
 byw
 bEC
@@ -118197,7 +117795,7 @@ bBj
 bCz
 bJD
 byw
-bFm
+bxb
 bIW
 crC
 bMy
@@ -118446,17 +118044,17 @@ bsM
 bqD
 bsi
 blT
-bvH
+blQ
 bxb
 bzB
 bBj
 bCu
 bDR
 byw
-bKQ
-bOI
-bJi
-bzF
+byw
+bxb
+bBn
+bBn
 bQm
 bOp
 bPS
@@ -118710,17 +118308,17 @@ bxb
 bxb
 bxb
 bxb
-bFm
-bMl
-bUE
+bxb
+bxb
+bzJ
 bNM
 bQj
 bSp
 bUm
-bzF
+bBn
 bVJ
-bzF
-bzF
+bBn
+bBn
 bYH
 cam
 cbH
@@ -118960,14 +118558,14 @@ bsQ
 bqF
 bso
 blT
-bvH
+blQ
 bxe
 byy
 byy
-byy
-byy
+bjE
+blk
 bDU
-bNs
+bzJ
 bHc
 byC
 bVk
@@ -119217,30 +118815,30 @@ blT
 blT
 blT
 blT
-bvH
+blQ
 bxd
 byk
 byz
 bzG
 bzJ
 bzJ
-byB
+bzJ
 bAF
-bDX
-bOp
+bAg
+bDa
 bDX
 bSK
 bPV
 bRN
 bTv
-bUX
+bJi
 bBn
 bYJ
 cam
 cbJ
 cdz
 cfc
-cjU
+cnT
 clr
 cko
 cnT
@@ -119466,7 +119064,7 @@ cGR
 cYH
 dim
 bgz
-biG
+aNd
 bgz
 blW
 bnS
@@ -119474,15 +119072,15 @@ bpl
 bqG
 bsm
 buc
-bvJ
+bnS
 bxd
 bDN
 bBn
-bBn
+bPS
 bIG
 bJE
 bKI
-bKZ
+bMy
 bKZ
 bNW
 bzJ
@@ -119515,7 +119113,7 @@ cCA
 cwF
 cvo
 cER
-cGc
+cGi
 cnA
 cJZ
 cLy
@@ -119731,15 +119329,15 @@ bsR
 buj
 bvw
 bud
-bvJ
+bnS
 bxd
 byl
-bzF
-bzF
-bzF
-bzF
-bFt
 bBn
+bPS
+bBn
+bBn
+bBn
+bPS
 bMk
 bNV
 bzJ
@@ -119747,7 +119345,7 @@ bOt
 bHi
 bUU
 bUU
-bUX
+bJi
 bBn
 bYL
 cao
@@ -119771,7 +119369,7 @@ cwI
 cwI
 cwF
 cvo
-cEQ
+cER
 cGb
 cGM
 cOs
@@ -119988,22 +119586,22 @@ bsZ
 bul
 bqJ
 bwA
-bvJ
+bnS
 bxf
-byB
+bzJ
 bzI
-bBn
+bPS
 bIK
 bzE
-bzE
-bzE
-bzE
+bvK
+byB
+bCk
 bNX
 bVH
-bBn
-bBn
-bBn
-bBn
+bvH
+bvH
+bvH
+bvH
 bXk
 bYD
 bYL
@@ -120028,7 +119626,7 @@ cwI
 cwI
 cDS
 cvo
-cEQ
+cER
 cGi
 cMV
 cKb
@@ -120238,20 +119836,20 @@ aSA
 aSA
 bfc
 bmz
-bko
+bfc
 blK
 bnS
 bsW
 buk
 bvz
 bwz
-bvJ
+bnS
 bxd
-byB
+bzJ
 bzH
 bBo
 bIJ
-bBn
+bvH
 box
 bBn
 bKC
@@ -120502,9 +120100,9 @@ bpn
 bqK
 bsr
 bwz
-bvK
+bnS
 bxg
-byB
+bzJ
 bzK
 bBp
 bCE
@@ -120759,9 +120357,9 @@ bnT
 bnT
 bnT
 bnT
-bvE
+bnS
 bxh
-byC
+bzJ
 bzJ
 bzJ
 bzJ
@@ -121009,7 +120607,7 @@ aUF
 din
 bgP
 bmV
-bku
+bgS
 dnN
 bnO
 bnO
@@ -121023,10 +120621,10 @@ bzM
 bBq
 bCF
 bEj
-bEj
-bEj
+bwd
+bzF
 bMn
-bKS
+bEj
 bMJ
 bOw
 bOw
@@ -121056,7 +120654,7 @@ cvo
 cFT
 cvo
 cvo
-cEQ
+cER
 cGj
 cGU
 ctT
@@ -121280,20 +120878,20 @@ bDO
 bGZ
 bDO
 bDO
-bDO
-bDO
+bxa
+bAf
 bMm
 bNY
 bQn
 bST
-bST
+bJg
 bUY
-bST
-bST
+ciy
+ciy
 bYW
-bST
-bST
-bST
+ciy
+ciy
+ciy
 cfh
 bNx
 cgQ
@@ -121313,7 +120911,7 @@ cyg
 cCH
 coL
 cqF
-cEQ
+cER
 cGj
 cJZ
 cKb
@@ -121522,14 +121120,14 @@ aUF
 cZa
 aSA
 djW
-bmV
-bku
+aNG
+bgS
 brq
 bnP
 bnP
 bnP
 bnP
-bmV
+aSV
 bAz
 bxk
 byF
@@ -121545,18 +121143,18 @@ cdI
 bSU
 bQh
 bRZ
-bTz
-bTz
+bTy
+bTy
 bYX
 bYR
 caw
-bTz
+bTy
 cfq
 ciy
 cjD
-cly
-cly
-cly
+coF
+coF
+coF
 coF
 cqu
 cly
@@ -121585,7 +121183,7 @@ dsG
 dsG
 dsO
 dsW
-cNB
+dsW
 pzr
 cZw
 dar
@@ -121598,7 +121196,7 @@ cVz
 cQj
 cVW
 cVY
-cQj
+cWK
 cWb
 cWb
 cQj
@@ -121786,7 +121384,7 @@ bmb
 bmb
 bmb
 bgP
-bmV
+aSV
 bAy
 bxl
 bxl
@@ -121827,7 +121425,7 @@ cng
 cng
 cvp
 cFa
-cFf
+cFt
 cGl
 cGW
 cKe
@@ -121860,8 +121458,8 @@ dcP
 dcP
 dcP
 dar
-aab
-aab
+cSU
+aaa
 aaa
 aaa
 aaa
@@ -122017,9 +121615,9 @@ aFl
 aGt
 aGt
 aIZ
+aei
 aIZ
 aIZ
-aNd
 aOx
 aPz
 aRR
@@ -122036,14 +121634,14 @@ aPi
 aPi
 bCq
 bgS
-bmV
-bkv
+aNG
+bkw
 bmb
 aaa
 aaa
 bmb
 bgP
-bmV
+aSV
 bAB
 bxl
 byG
@@ -122066,7 +121664,7 @@ bQb
 bME
 cdT
 cfm
-cfl
+bTy
 cgS
 ciA
 oAh
@@ -122118,8 +121716,8 @@ dcP
 dcP
 dar
 alw
-aab
-aab
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -122293,8 +121891,8 @@ aRw
 aRw
 aRw
 djZ
-bmV
-bkv
+aNG
+bkw
 bmb
 aaa
 aaa
@@ -122341,7 +121939,7 @@ cyr
 cCM
 aaa
 cFa
-cFi
+cFt
 cGi
 cnA
 cKb
@@ -122376,11 +121974,11 @@ kCz
 dar
 alw
 alw
-aab
-aab
-aab
-aaa
-aaa
+daw
+alw
+alw
+alw
+daw
 aaa
 aaa
 aaa
@@ -122638,8 +122236,8 @@ cSU
 cSU
 cSU
 dns
-aab
-aab
+alw
+aaa
 aaa
 aaa
 aaa
@@ -122807,8 +122405,8 @@ bdO
 aSC
 beX
 bgP
-bmV
-bkv
+aNG
+bkw
 bmb
 aaa
 aaa
@@ -122855,7 +122453,7 @@ cBq
 cCN
 aaa
 cFa
-cFi
+cFt
 cGi
 cnA
 cKf
@@ -122896,7 +122494,7 @@ cUD
 cUF
 cSU
 cSU
-aaa
+alw
 aaa
 aaa
 aaa
@@ -123051,8 +122649,8 @@ aNJ
 aJc
 aPC
 aEl
-aPi
-aVD
+ahj
+axD
 aRw
 baj
 bbP
@@ -123064,8 +122662,8 @@ bdX
 das
 bfg
 bgP
-bmV
-bkv
+aNG
+bkw
 bmb
 aaa
 bmc
@@ -123094,7 +122692,7 @@ bYV
 bMG
 cdJ
 cfT
-ciO
+cdJ
 cgS
 ciH
 cku
@@ -123112,7 +122710,7 @@ cBk
 cwV
 cvq
 cvq
-cFi
+cFt
 cGi
 cnA
 cKf
@@ -123124,7 +122722,7 @@ cOQ
 cKb
 cPh
 cSU
-dsK
+czd
 cOg
 cSl
 dbr
@@ -123149,12 +122747,12 @@ cUp
 cTt
 cUo
 dib
-dbu
+cTz
 cUI
 cSU
 cYX
 cSU
-aaa
+alw
 aaa
 aaa
 aaa
@@ -123302,9 +122900,9 @@ aFm
 aIl
 aHB
 aJb
-aKr
+agN
 aLT
-aNG
+aOB
 aOz
 aPB
 aEl
@@ -123321,8 +122919,8 @@ bdR
 bdz
 beX
 bgP
-bmV
-bkv
+aNG
+bkw
 bmb
 aaa
 bmc
@@ -123351,7 +122949,7 @@ uoE
 bMG
 cdX
 cfx
-ciM
+ccl
 cgW
 cgW
 cgW
@@ -123369,7 +122967,7 @@ cBl
 cCO
 cEd
 cvx
-cFi
+cFt
 cGg
 cHc
 cKf
@@ -123412,7 +123010,7 @@ cUL
 cUR
 cSU
 cSU
-aaa
+cSU
 aaa
 aaa
 aaa
@@ -123566,7 +123164,7 @@ aOB
 aPE
 aEl
 aPi
-aVH
+aVD
 aRw
 aRw
 bbQ
@@ -123578,8 +123176,8 @@ bed
 dbv
 bfh
 bgP
-bmV
-bkv
+aNG
+bkw
 bmb
 aaa
 bmc
@@ -123608,7 +123206,7 @@ cbc
 ccX
 cdZ
 cge
-cjb
+cdN
 cgW
 ccL
 ckv
@@ -123669,7 +123267,7 @@ aaa
 cUH
 cUR
 cSU
-aaa
+alw
 aaa
 aaa
 aaa
@@ -123819,11 +123417,11 @@ aDL
 aKu
 aLV
 aJF
-aOA
+aOB
 aPD
-aVb
-aTw
-aVE
+bCq
+aPi
+aVD
 aYa
 aRw
 aRw
@@ -123835,7 +123433,7 @@ bdZ
 daT
 bfg
 bgP
-bmV
+aNG
 bky
 bmc
 bmc
@@ -123883,7 +123481,7 @@ cBs
 cwO
 cEe
 cvx
-cFi
+cFt
 cGi
 cnA
 cKb
@@ -123926,7 +123524,7 @@ cUM
 aab
 cVa
 cSU
-aaa
+alw
 aaa
 aaa
 aaa
@@ -124087,12 +123685,12 @@ bbS
 aKb
 aRw
 biM
-bat
+ayj
 beg
 dbO
 aRw
 bgV
-bmB
+aOA
 bkA
 blU
 bnU
@@ -124140,7 +123738,7 @@ cBu
 cwO
 cEe
 cvx
-cFi
+cFt
 cGi
 cnA
 cKb
@@ -124183,7 +123781,7 @@ cSF
 aab
 cVa
 cSU
-aaa
+alw
 aaa
 aaa
 aaa
@@ -124350,7 +123948,7 @@ aRw
 aRw
 bgU
 bna
-bkz
+bkC
 blU
 bnR
 bpo
@@ -124377,7 +123975,7 @@ bXr
 bYZ
 cbe
 bZd
-cfv
+cdN
 cgh
 cjh
 cgZ
@@ -124440,7 +124038,7 @@ cSF
 aab
 cVa
 cSU
-aaa
+cSU
 aaa
 aaa
 aaa
@@ -124655,10 +124253,10 @@ cAL
 cDY
 cvx
 cFt
-cGl
-cHG
+cGi
+cHD
 cKk
-cLL
+cMG
 cJl
 cMG
 cMG
@@ -124670,10 +124268,10 @@ cUu
 cRM
 cWD
 cXG
-cYL
+cRR
 cWF
 cXC
-dbB
+dns
 cSU
 cQV
 cSU
@@ -124697,7 +124295,7 @@ cUO
 aab
 cVa
 cSU
-aaa
+alw
 aaa
 aaa
 aaa
@@ -124864,7 +124462,7 @@ aRw
 diw
 bhb
 bnd
-bkz
+bkC
 blU
 bnV
 bpq
@@ -124912,12 +124510,12 @@ cvx
 cvx
 cvx
 cFr
-cGi
-cHD
-cHH
-cIR
-cJk
+cfl
 cHG
+cHH
+cHG
+cJk
+ciO
 cHG
 cNS
 dbp
@@ -124933,7 +124531,7 @@ cXx
 dbF
 cYG
 cQF
-cUB
+cVB
 cVw
 cVB
 cVG
@@ -124954,7 +124552,7 @@ cSF
 aaa
 cVa
 cSU
-aaa
+alw
 aaa
 aaa
 aaa
@@ -125090,24 +124688,24 @@ arp
 arp
 auL
 avd
-axD
+aAW
 axA
-ayj
-ayj
+avd
+avd
 azP
-aBY
+aFy
 aCv
 aCZ
 aDm
-aBY
-aGw
-aHQ
-aIN
-aKo
-aHQ
-aMG
+aFy
+aFF
+aFF
+aUq
+aGx
+aFF
+aSN
 aNK
-aMG
+aSN
 aQQ
 aRF
 atc
@@ -125121,7 +124719,7 @@ dcb
 bdv
 bhc
 bnh
-bkz
+bkC
 bma
 bnY
 bpu
@@ -125150,8 +124748,8 @@ cbh
 bFC
 cew
 cgl
-cjk
-ckR
+cdN
+ccl
 clO
 cmQ
 ckO
@@ -125168,13 +124766,13 @@ cpi
 cAN
 cBE
 cDx
-cHG
-cGp
-cHg
-cHL
-cHJ
-cHI
 cHD
+cGp
+cHD
+cHL
+cHD
+cHI
+cjb
 cHD
 cMV
 cJZ
@@ -125211,7 +124809,7 @@ cSF
 aaa
 cVa
 cSU
-aaa
+alw
 aaa
 aaa
 aaa
@@ -125338,7 +124936,7 @@ anB
 aov
 api
 eZh
-agN
+aqX
 akV
 alb
 anI
@@ -125403,7 +125001,7 @@ bVj
 bVO
 bXu
 bZf
-bUv
+bJl
 cda
 cev
 cgk
@@ -125468,7 +125066,7 @@ cUO
 aaa
 cVa
 cSU
-aaa
+cSU
 aaa
 aaa
 aaa
@@ -125635,7 +125233,7 @@ bhh
 bhV
 biK
 bnj
-bkz
+bkC
 bma
 boa
 bpw
@@ -125664,7 +125262,7 @@ cbi
 bFC
 cey
 cgm
-cfv
+cdN
 ccl
 ciN
 cfn
@@ -125677,19 +125275,19 @@ cue
 cvK
 cMV
 crV
-cnA
+bWz
 cHD
-cHD
-cHD
-cHD
-cHD
+caE
+cbd
+cbU
+ceG
 cGq
 cHl
 cHO
-cHD
+cfz
 cHD
 cnA
-cMV
+cnA
 cOc
 cJZ
 cRR
@@ -125701,7 +125299,7 @@ cIe
 cIy
 cSl
 cXH
-dbG
+dbF
 cZf
 cNk
 cVj
@@ -125725,7 +125323,7 @@ cSF
 aaa
 cVa
 cSU
-aaa
+alw
 aaa
 aaa
 aaa
@@ -125920,23 +125518,23 @@ gpA
 iVV
 iVV
 cex
-cgj
-cfv
+bKQ
+cdN
 che
 chc
 chc
 chc
 chc
 cpk
-cJZ
+csD
 csD
 ctX
 cvB
 ctJ
 cvB
-csD
+bWA
 cBv
-cBv
+caP
 cEi
 cFh
 cGJ
@@ -125946,8 +125544,8 @@ cHM
 cLT
 cML
 cHQ
-cOL
-cNU
+cHQ
+cHQ
 cFa
 cRR
 cTg
@@ -125955,13 +125553,13 @@ cFC
 cHa
 cHk
 cRR
-cYI
+cRR
 cZP
 cXx
 dbF
 cYZ
 cQG
-cVc
+cQH
 cVy
 cQH
 cVT
@@ -125982,7 +125580,7 @@ cSF
 aaa
 cVa
 cSU
-aaa
+alw
 aaa
 aaa
 aaa
@@ -126093,9 +125691,9 @@ aiv
 abO
 aiv
 acO
-aei
-alU
-alU
+alY
+alY
+alY
 acb
 ajr
 aci
@@ -126177,8 +125775,8 @@ rtB
 nvb
 iVV
 ceB
-cgj
-cfv
+bKQ
+cdN
 chc
 ccO
 cfp
@@ -126193,10 +125791,10 @@ cxd
 cyx
 csD
 csD
-cBF
-dot
-cFj
-cGN
+csD
+csD
+csD
+csD
 cHU
 cLM
 cTG
@@ -126207,15 +125805,15 @@ cOY
 cOf
 cOy
 cPo
-cRX
+ctt
 cUt
-cUt
+cEo
 cWB
 cXL
 cYJ
 cWM
 cXJ
-cSU
+dns
 cSU
 cQV
 cSU
@@ -126239,7 +125837,7 @@ cUO
 aab
 cVa
 cSU
-aaa
+alw
 aaa
 aaa
 aaa
@@ -126406,7 +126004,7 @@ aDN
 aDN
 bdD
 bna
-bkz
+bkC
 bmd
 aCu
 bpx
@@ -126435,7 +126033,7 @@ kVW
 iVV
 ceA
 cgn
-cfv
+cdN
 chc
 ccN
 cfo
@@ -126460,7 +126058,7 @@ cHP
 cIT
 cJo
 cKU
-cMW
+cOe
 cOe
 cOt
 cPn
@@ -126472,7 +126070,7 @@ cTN
 cWj
 cWI
 cXI
-cSU
+cLS
 cZl
 cOd
 cVp
@@ -126496,7 +126094,7 @@ cSF
 aab
 cVa
 cSU
-aaa
+cSU
 aaa
 aaa
 aaa
@@ -126623,7 +126221,7 @@ anJ
 aoB
 apC
 aqz
-agU
+wyy
 asn
 aki
 awK
@@ -126663,7 +126261,7 @@ dhp
 aDN
 dkl
 bna
-bkz
+bkC
 bma
 boh
 bpB
@@ -126691,8 +126289,8 @@ eQU
 fxo
 iVV
 ceD
-cgj
-cfv
+bKQ
+cdN
 chc
 ccR
 cmT
@@ -126701,13 +126299,13 @@ chc
 cNq
 csD
 csO
-ctY
-cvE
+bNt
+bNE
 cxf
 cxv
 czC
 csD
-cmG
+ctY
 cBL
 cDE
 csD
@@ -126718,21 +126316,21 @@ dcj
 dcj
 dcj
 dcj
-cHT
+dcj
 bHY
-cTe
+cRX
 cPO
-cTe
+cRX
 cRQ
-cWJ
-cPO
-cYR
-cZM
+cRX
+cGC
+dns
+cSU
 cXN
 cSU
-cVj
+cOl
 cZR
-cVq
+cPf
 cRb
 cRp
 dfo
@@ -126753,7 +126351,7 @@ cSF
 aab
 cVa
 cSU
-aaa
+alw
 aaa
 aaa
 aaa
@@ -126926,7 +126524,7 @@ bmc
 bmc
 bqZ
 bsE
-bwU
+bxj
 bvU
 bxv
 byS
@@ -126948,8 +126546,8 @@ bSi
 bSi
 bSi
 ceC
-cgj
-cfv
+bKQ
+cdN
 chc
 clP
 cmR
@@ -126978,16 +126576,16 @@ cNO
 cNO
 cQN
 cSa
-cPN
+cRX
 cUv
 cRP
 cSO
 cTO
 cYM
-cJI
+cSU
 cXM
 cYo
-cZE
+cXx
 cZQ
 cVq
 cRb
@@ -127010,7 +126608,7 @@ cUQ
 aab
 cVa
 cSU
-aaa
+alw
 aaa
 aaa
 aaa
@@ -127177,7 +126775,7 @@ dhq
 aDN
 dkn
 bno
-bkG
+bza
 bmi
 aaa
 bmc
@@ -127205,7 +126803,7 @@ bXl
 cbl
 bSi
 ceF
-cgj
+bKS
 cjl
 ckP
 clQ
@@ -127233,20 +126831,20 @@ cHS
 cNP
 cOZ
 cOh
-cQN
+cjt
 bHZ
 cRX
-cRX
+czF
 cRT
-cWL
-cTT
-cYM
+cRX
+cRX
+cGN
+cSU
 cNX
-cNX
-cNX
+cNe
 cWe
 dal
-cSv
+cPq
 deF
 dft
 cSU
@@ -127267,7 +126865,7 @@ aaa
 cUJ
 cUU
 cSU
-aaa
+alw
 aaa
 aaa
 aaa
@@ -127434,7 +127032,7 @@ aDN
 aDN
 dkm
 bnn
-bkF
+dnC
 bmi
 aaa
 bmc
@@ -127462,15 +127060,15 @@ bXl
 bZa
 bSi
 ccl
-cfx
-cfy
+bMl
+ccl
 chc
 cde
 cmU
 cgX
 chc
 cqP
-crd
+csD
 csQ
 cui
 cvM
@@ -127491,19 +127089,19 @@ cNQ
 cON
 cON
 cQN
+cqX
 cRX
-cRX
-cRX
+czP
 cRS
-cWK
-cTP
-cYM
-cNV
+cRX
+cRX
+cHg
+dac
 cOb
 cPg
 cPX
 dai
-cSv
+cPr
 cSU
 dfz
 cSU
@@ -127520,11 +127118,11 @@ dib
 dib
 diR
 cUJ
-cUL
+daR
 cUU
 cSU
 cSU
-aaa
+cSU
 aaa
 aaa
 aaa
@@ -127691,7 +127289,7 @@ dhs
 djg
 bhg
 bns
-bkF
+dnC
 bmi
 aaa
 bmc
@@ -127720,7 +127318,7 @@ bZb
 bSi
 ccm
 cgp
-cfz
+ccm
 chc
 bYF
 chc
@@ -127750,14 +127348,14 @@ dcj
 cyh
 cRX
 cRX
-cQP
+cRX
 cRV
 cSY
-cUs
-cYX
+cRX
+cHg
 dac
-dac
-dac
+cIq
+cPg
 cZM
 cOi
 cVu
@@ -127775,13 +127373,13 @@ cUq
 cTt
 cUn
 dib
-dbQ
+cTC
 cUI
 cSU
 cYX
 cSU
-aaa
-aaa
+alw
+dbu
 aaa
 aaa
 aaa
@@ -127908,7 +127506,7 @@ vMu
 lGT
 apH
 aqA
-ahj
+aqX
 aiP
 akj
 alP
@@ -127985,13 +127583,13 @@ chd
 cnC
 cqV
 chf
-qYx
+csL
 cmH
 cvI
 cxk
 cyH
-cyD
-cyD
+cyH
+bYg
 cDc
 cCa
 cDR
@@ -128003,24 +127601,24 @@ cIX
 cJq
 cKX
 cMX
-cOl
+dcj
 cQN
-cPq
-cPP
-cQO
-cRU
-cSP
-cUm
+cRX
+cRX
+cRX
+cRX
+cRX
+cRX
 cYU
-dab
-dab
+dac
+cIR
 dbJ
 cQc
-cQH
+cOL
 cVr
 aLz
 aMM
-daj
+daG
 cSU
 cTm
 cTt
@@ -128205,7 +127803,7 @@ dhu
 aUQ
 bhg
 bnn
-bkF
+dnC
 bmi
 aaa
 aaa
@@ -128245,7 +127843,7 @@ cmt
 csL
 csL
 cvI
-cxm
+cyD
 cyD
 cyD
 cAn
@@ -128255,22 +127853,22 @@ cEa
 cGK
 cGK
 cHx
-cIi
+cJa
 cJa
 cJy
 cGK
 cGK
+cjp
 cZS
-cZS
-cZS
-cZS
-cZS
-cZS
+cqZ
+cuu
+cBF
+cEs
 cTj
 cUx
-cZS
+cHJ
 dcq
-hnb
+dcq
 dcq
 dcq
 dex
@@ -128462,7 +128060,7 @@ dht
 aUQ
 dky
 bnn
-bkF
+dnC
 bmi
 aaa
 aaa
@@ -128497,12 +128095,12 @@ chf
 chf
 chf
 csL
-cqX
+cFp
 chf
 csU
 cub
 cvI
-cxm
+cyD
 cyD
 cyD
 cyD
@@ -128517,30 +128115,30 @@ cIY
 cMN
 cJM
 cGK
-cPU
-cQL
-cPr
-cTl
-dsN
-cLS
-cSZ
-dtc
-cWp
+cZS
+cZS
+cZS
+cZS
+cZS
+cZS
+cZS
+cZS
+cZS
 dcq
-ddr
-ddr
+cJI
+cNU
 cZF
 dau
 daL
 dby
 dcn
 ddr
+cQP
+cTe
 ddr
-deP
 ddr
 ddr
-ddr
-deP
+cTe
 ddr
 ddr
 ddr
@@ -128548,7 +128146,7 @@ deW
 dgI
 doo
 dop
-dop
+dbq
 dor
 dos
 dgp
@@ -128748,18 +128346,18 @@ bXo
 bSi
 cco
 cgr
-cjp
+bFO
 chf
 cea
 ceb
 chf
 csL
-cqX
+cFp
 cuc
 chf
 cuc
 cvI
-cxm
+cyD
 cyD
 cyD
 cAp
@@ -128774,16 +128372,16 @@ cJb
 cJE
 cLJ
 cGK
-cPU
-cQM
+cTh
+cTh
 cSb
 cTh
-cSd
+cCp
 cOF
 cTk
 dfF
 wOS
-dcq
+cIb
 dcq
 dcq
 dcq
@@ -128976,7 +128574,7 @@ dhw
 aUQ
 dkD
 bnn
-bkF
+dnC
 bmi
 bmi
 bmi
@@ -129011,19 +128609,19 @@ cdW
 ceb
 cmt
 csL
-cqZ
-crX
-ctt
-cuu
-cvN
-cwS
-cxA
+cFp
+cuE
+cEy
+daX
+cvI
+cyD
+cyD
 czD
 cAo
-cAo
+cyD
 cCP
 cEc
-cFw
+cGK
 cxC
 cyQ
 cKz
@@ -129033,26 +128631,26 @@ cLw
 cGK
 aPd
 cSd
-bji
-cPQ
+deD
+cSd
 cSd
 cSd
 cWT
-cXQ
+cXV
 cSd
 lLC
 cXO
 dbK
 dct
-ddm
+dds
 dtv
 deO
 deG
 dgr
 dgM
 dcF
-dhI
-aab
+dit
+cXR
 cQZ
 cQZ
 cQZ
@@ -129232,21 +128830,21 @@ cVv
 dhN
 aUQ
 aWN
-bnN
-bkH
+aSI
+bhq
 bWH
 bod
 bod
 bod
 bod
 byA
-bwj
-bwj
+dnC
+dnC
 bza
-bAl
+bFU
 bBF
 bCY
-bEw
+bFU
 bFU
 bFU
 bMT
@@ -129260,9 +128858,9 @@ bYb
 bZt
 cbo
 cdc
-ceG
+bFO
 cgK
-cjr
+bFO
 chf
 cec
 cfr
@@ -129284,39 +128882,39 @@ cGK
 cGK
 cGK
 cGK
-cGK
+ciM
 cJH
 cLK
 cMY
 cDj
-cEr
-cEr
+daQ
+cra
 cPS
 cQU
-cVI
+cSd
 cWU
 cXV
-cVI
-cVI
-cVI
+deD
+cIc
+cXO
 dbL
 dcL
 dds
-deh
+dtv
 deD
 deM
-dgs
-deH
+cSd
+cSd
 dhB
-dik
-diU
+dit
+diX
 djB
 dki
 dkO
 dkO
 cQZ
 dcq
-ddr
+cQP
 dcq
 dfC
 dgb
@@ -129497,13 +129095,13 @@ bpA
 bpA
 bvD
 byx
-bpA
-bpA
+aTH
+aTH
 bEg
 bFi
 bHo
 bIR
-bJT
+bKN
 bKN
 bKN
 bKN
@@ -129516,8 +129114,8 @@ bVS
 bYa
 bZr
 cbm
-bKN
-bKN
+bKu
+bKu
 cgJ
 bFO
 chf
@@ -129525,47 +129123,47 @@ ceb
 ceb
 chf
 cAB
-cra
-ckS
-ckS
-ckS
-ckS
-ckS
-ckS
-ctt
-ckS
-ckS
-ckS
-ckS
-ckS
-ckS
-ckS
-czd
+cFp
+csL
+csL
+csL
+csL
+csL
+csL
+cEy
+csL
+csL
+csL
+csL
+csL
+csL
+cuE
+cBP
 cGK
 cJF
 cGK
 cGK
 cDi
 cSd
+cZb
 cSd
-cPT
 cQS
-cEr
-cTq
+daQ
+daQ
 cUz
-cEr
-cEr
-cEr
-cEr
-cEr
-dav
+cHT
+daQ
+daQ
+cNY
+daQ
+daQ
 daQ
 deH
 dfy
-dfy
-dgN
+cSd
+cSd
 dhA
-dij
+dhI
 aab
 cTo
 dkh
@@ -129757,10 +129355,10 @@ buC
 bhq
 bhq
 bzb
-bAf
+bFO
 bHs
-bAf
-bEn
+bFO
+bFO
 bFW
 bLg
 bFO
@@ -129783,47 +129381,47 @@ chf
 chf
 chJ
 crb
-cmJ
-cmJ
-cmJ
-cmJ
-cmJ
-cmJ
-cmJ
-cmJ
-cmJ
-cmJ
-cmJ
-cmJ
-cmJ
-cmJ
+cIv
+cIv
+cIv
+cIv
+cIv
+cIv
+cIv
+cIv
+cIv
+cIv
+cIv
+cIv
+cIv
+cIv
 cIv
 cPd
 cJN
 csK
 cZS
 dtn
-dtn
-dtn
-dtn
+cju
+crd
+crd
 cFG
 cVJ
-cWO
-cXR
+cSd
+cSd
 cYT
-cZU
+cSd
+cSd
 daM
-daM
-daM
-day
-daM
-deI
-deQ
+cSd
+cSd
+cSd
+cSd
+cYT
 dgg
 dgP
 dhC
 dip
-djE
+diZ
 djB
 dkk
 dkO
@@ -129995,7 +129593,7 @@ aTJ
 aTJ
 aTJ
 aTJ
-beW
+bdN
 aTb
 aUQ
 bJz
@@ -130014,9 +129612,9 @@ aUS
 bsN
 aUS
 bzc
-bAg
+bEn
 bHr
-bAg
+bEn
 bEp
 bEp
 bEp
@@ -130060,27 +129658,27 @@ cAm
 csL
 cOT
 cPZ
-cPZ
-cPZ
-cPZ
+ckR
+crX
+cvN
 cFF
 cVE
 cWV
-cXW
+cSd
 cZb
-dag
+cSd
+cSd
 daN
-daN
-daN
-daw
-daR
-deJ
-dfF
+cSd
+cSd
+cSd
+cSd
+cZb
 dgh
 dgO
 dhx
-dio
-diW
+dhI
+aab
 cQZ
 cQZ
 cQZ
@@ -130314,26 +129912,26 @@ chf
 czf
 cnV
 cKc
-cNY
-cOU
+cps
+cOW
 cQf
 cOH
 cPB
-cPB
+cwS
 cQX
 cVL
 cWW
 cXY
-cYV
+dcv
 cZW
-cZc
+cZW
 dbN
-cZc
 ddt
-cZU
+ddt
+dcv
 deK
 dfG
-cSd
+cPQ
 dgR
 dhE
 dit
@@ -130576,25 +130174,25 @@ cOT
 cDk
 cOA
 cPs
-cPs
+cxm
 cQW
 cVK
 cWR
-cXX
-cYW
-cZX
+cSd
+dag
 daO
-cSd
-cSd
-cSd
+daO
+daO
+daO
+daO
 dag
 deQ
 dfB
-cSd
+dgh
 dgQ
 dhD
 dhI
-diY
+aab
 cTo
 dkp
 bbO
@@ -130835,20 +130433,20 @@ cQT
 cSm
 cTn
 cRk
-cVO
-cWY
+cVQ
+cXb
 cYa
 cZc
 cZY
-daP
-daP
 dcv
-daP
+dcv
+dcv
+dcv
 dec
 deR
 dfI
 dgt
-dgP
+cRn
 dhF
 dip
 diZ
@@ -131016,7 +130614,7 @@ aFI
 aMC
 aOb
 aPf
-aQv
+agU
 aSJ
 aUI
 aWJ
@@ -131044,7 +130642,7 @@ bJQ
 aUS
 bAk
 bHy
-bCZ
+btX
 bEp
 aTU
 bDf
@@ -131061,7 +130659,7 @@ cuo
 bWm
 bXD
 bYs
-cjt
+bZk
 bYC
 caA
 bUu
@@ -131095,19 +130693,19 @@ cRj
 cVM
 cWX
 cSd
-cSd
-cSd
-daV
-daV
+cWU
+dfI
+cLL
+cLL
 daV
 daV
 dei
-cXb
+cPP
 dfH
 cXW
-dgQ
-cSd
-dhI
+cRU
+cTl
+cWL
 diY
 cQZ
 cQZ
@@ -131318,7 +130916,7 @@ cbN
 bWs
 bXD
 bYs
-cju
+bZk
 bUM
 caA
 cck
@@ -131351,18 +130949,18 @@ cPW
 cRl
 cVQ
 cXb
-cXT
-cXT
+cYa
+deU
 cZZ
-daY
-cXT
-cXT
-cXT
-daY
+dfG
+deU
+cYa
+deU
+dfG
 deU
 dfK
-dgg
-dgP
+cPT
+dgV
 dhH
 cYb
 dja
@@ -131575,7 +131173,7 @@ cbv
 caA
 caA
 bXJ
-caE
+bZk
 cca
 caA
 cfA
@@ -131602,27 +131200,27 @@ cKh
 cLN
 cOT
 cQi
-cRa
-cSo
+cUN
+cUN
 cTp
 cUN
 cVP
 cXa
-cXU
-cZd
+dgV
+dgV
 dah
 daW
-cXU
-dcO
-cXU
+dgV
+dgV
+dgV
 dej
-cXU
-dfJ
-cXU
+dgV
+dgV
+cQs
 dgV
 dhG
-dhI
-diY
+cWO
+djb
 cTo
 dku
 bdG
@@ -131790,7 +131388,7 @@ aPg
 aQB
 aSL
 aUM
-aWQ
+aWY
 aZA
 bbt
 bdc
@@ -131798,7 +131396,7 @@ bfp
 bhf
 aOI
 baS
-beJ
+aGY
 aUS
 djj
 dkL
@@ -131832,7 +131430,7 @@ cbP
 bWu
 bXF
 bZh
-caE
+bZk
 ccs
 caA
 cfE
@@ -131863,7 +131461,7 @@ cRd
 cSr
 cTu
 cUS
-cVQ
+cFj
 cXd
 cYc
 cZg
@@ -131876,10 +131474,10 @@ dek
 deV
 dfN
 dgj
-deQ
+dgj
 dhJ
-cYb
-dja
+cXv
+cXX
 djU
 dkx
 dkV
@@ -132054,8 +131652,8 @@ aSD
 bfo
 bhe
 aOI
-baP
-bkN
+baS
+aGY
 aUS
 aRL
 beF
@@ -132115,25 +131713,25 @@ ctZ
 cjq
 cLO
 cOT
-cQm
+cVR
 cRc
 cSq
-cTr
+cVR
 cSq
 cVR
 cXc
-cYb
+dhI
 cZe
 aOl
 cXc
-cYb
+dhI
 cZe
-cYb
+dhI
 cXc
-cYb
+dhI
 cZe
-cYb
-dgW
+dhI
+dhI
 dhI
 dhI
 djb
@@ -132372,17 +131970,17 @@ csL
 cKi
 cLO
 cBK
-cQp
-aab
-cQp
+cjr
+cmG
+cUV
 aab
 cUV
 aab
-cQp
+cUV
 aab
 cZh
 dad
-dba
+del
 dbI
 dcS
 dbI
@@ -132390,12 +131988,12 @@ del
 dbI
 dcS
 dbI
-dbI
-dbI
-dbI
-djc
-aab
-aab
+cSc
+cTP
+cSc
+dad
+cYx
+cSc
 aab
 aab
 aab
@@ -132647,12 +132245,12 @@ cSn
 cTo
 cSn
 cQZ
-doE
-doE
-doE
-doE
-doE
-doE
+cSP
+cSP
+cSP
+cTP
+cSc
+cSP
 doE
 doE
 doE
@@ -132866,7 +132464,7 @@ ceg
 cfI
 cho
 cfI
-cjC
+bNs
 crZ
 cxh
 cnB
@@ -132904,16 +132502,16 @@ den
 deX
 dfO
 cQZ
-doE
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cSP
+cSP
+cSP
+cSP
+cSP
+cSP
 aab
+aab
+alv
+aaa
 aab
 dmB
 dna
@@ -133161,16 +132759,16 @@ dem
 cRi
 dem
 cQZ
-doE
+cSP
+cSP
+cSP
+cSP
+cSP
+cSP
 aab
-alw
-alw
-alw
-alw
-alw
-alw
-ayi
-aab
+aaa
+alv
+aaa
 aab
 dmB
 dnb
@@ -133418,15 +133016,15 @@ dem
 deY
 dem
 cQZ
-doE
+cSZ
+cTT
+cSZ
+cTT
+cSZ
+cTT
 aab
-alw
-aab
-aab
 aaa
-aaa
-aaa
-aaa
+alv
 aab
 aab
 dmB
@@ -133677,10 +133275,10 @@ cQZ
 cQZ
 doE
 aaa
-diu
-djd
-djE
-djE
+aaa
+aab
+aab
+cYL
 djd
 djd
 djd
@@ -133934,7 +133532,7 @@ cPw
 cPw
 cPw
 dhM
-dhL
+dgS
 dgS
 dgS
 dkj
@@ -134448,9 +134046,9 @@ csL
 cTB
 dgT
 cTV
-cYg
 dcz
 dcz
+cYI
 ddg
 ddo
 dgS
@@ -134631,7 +134229,7 @@ djt
 bjd
 boV
 bpG
-bbW
+bdT
 boj
 btJ
 bus
@@ -134899,7 +134497,7 @@ bxJ
 bzf
 bAk
 bHy
-bAk
+buW
 bEu
 bEu
 bEu
@@ -135156,7 +134754,7 @@ bxI
 bzf
 bAk
 bHy
-bDa
+bAk
 bEu
 aYk
 bEt
@@ -135169,11 +134767,11 @@ bRb
 cbr
 bJR
 bZN
-cbU
-bWz
+cbO
+bXA
 bXP
-bZu
-caP
+cuo
+cuo
 ccC
 cDf
 cfO
@@ -135216,7 +134814,7 @@ cTB
 chf
 dbA
 dcp
-cPd
+cQL
 dcw
 dcG
 dcQ
@@ -135427,10 +135025,10 @@ cby
 cuo
 bZP
 cbW
-bWA
-bWA
-bWA
-caQ
+bRt
+bRt
+bRt
+bRt
 ccE
 cei
 cfR
@@ -135470,7 +135068,7 @@ cWq
 cWq
 cWq
 daB
-ckS
+cPN
 dbD
 crc
 csL
@@ -135478,7 +135076,7 @@ dgT
 cVH
 dcu
 dew
-ddd
+ddy
 ddk
 ddy
 dly
@@ -135955,7 +135553,7 @@ ckC
 cxj
 ckC
 ciY
-czY
+bNJ
 cqM
 crE
 cvX
@@ -135992,7 +135590,7 @@ dgT
 dgT
 dgT
 dgT
-djK
+dgT
 dgT
 dgT
 dlm
@@ -136167,7 +135765,7 @@ aLA
 aGY
 aGY
 bbU
-beJ
+aGY
 beb
 bhY
 bjq
@@ -136249,7 +135847,7 @@ dhk
 dhY
 csL
 djl
-dir
+chf
 dkr
 dkP
 dkP
@@ -136424,7 +136022,7 @@ aLA
 aQI
 aGY
 bbY
-bfO
+aOE
 beb
 bib
 bjN
@@ -136452,7 +136050,7 @@ pXp
 pXp
 bWd
 bSC
-bYg
+bUa
 bZX
 ccb
 bWD
@@ -136496,22 +136094,22 @@ cJu
 cKw
 cJt
 cLZ
-cNe
+cNf
 daF
 dbe
 dbY
 cTB
 dgn
 dgX
-csL
-csL
-csL
-djY
-dgo
+cUm
+cYi
+cYg
+chf
+chf
 dkQ
 dlp
-dlM
-dmi
+cJG
+dma
 dma
 aab
 aab
@@ -136760,15 +136358,15 @@ dbE
 csL
 chf
 dgY
-csL
+dfM
 chf
-csL
+ddH
 djM
 chf
 dkZ
+cUm
+cYg
 csL
-csL
-dfM
 cBP
 aaa
 aaa
@@ -136938,7 +136536,7 @@ aGX
 aMz
 aGX
 bcg
-bfQ
+hQC
 beb
 bif
 bjW
@@ -137014,18 +136612,18 @@ cNf
 csL
 cyJ
 dce
-cYi
-dgo
-dgo
+csL
+chf
+chf
 dhP
-dgo
+chf
+csL
+ddH
 cYi
-cYi
-dgo
 dkS
 dlA
-csL
 dfM
+csL
 cBQ
 aaa
 aaa
@@ -137272,15 +136870,15 @@ csL
 cyJ
 dcd
 dfL
-cps
+cQO
 dgZ
-cps
+cUs
 diq
 djm
 cps
 dge
 dla
-dlr
+cps
 dlN
 dml
 dmt
@@ -137468,7 +137066,7 @@ xFN
 vbu
 bzk
 bAr
-bHA
+bkh
 bJe
 aTO
 buO
@@ -137534,10 +137132,10 @@ chf
 dhQ
 chf
 chf
-csL
-chf
-csL
-dfM
+cUm
+cYi
+cYi
+cYg
 dlO
 dmr
 cBQ
@@ -137725,7 +137323,7 @@ mlU
 oHF
 bjB
 bAr
-bHy
+bko
 bJd
 bEu
 wKr
@@ -137759,11 +137357,11 @@ bQX
 bUx
 ctq
 cuC
-csL
-csL
-ceb
-ceb
-csL
+bQX
+bQX
+cAa
+cAa
+bQX
 chf
 chf
 chf
@@ -137784,19 +137382,19 @@ cMd
 chf
 czf
 dbk
-dcg
-cYi
-cYi
-dgo
-cYi
-cYi
-cYi
+crc
+csL
+csL
+chf
+csL
+csL
+cUm
 djN
-dkt
-cYi
+cuc
+csL
 ddH
-cXr
-dmm
+dlA
+dgm
 cBP
 aaa
 aaa
@@ -137982,7 +137580,7 @@ bru
 bxL
 bzj
 bAr
-bHy
+bko
 bJh
 bEu
 wKr
@@ -138045,13 +137643,13 @@ chf
 cBN
 chf
 chf
-cTU
-cXr
+cUB
 cYi
-dgo
-dgo
-cYi
-cYi
+dlA
+chf
+chf
+csL
+csL
 dmc
 cBP
 cBP
@@ -138239,8 +137837,8 @@ bws
 bxN
 bjB
 bAt
-bHy
-bJg
+bko
+bAk
 bEu
 bzi
 bFV
@@ -138280,8 +137878,8 @@ bQX
 bQX
 bQX
 bQX
-csL
-csL
+bQX
+bQX
 cNi
 cDo
 ciY
@@ -138302,8 +137900,8 @@ ciY
 chf
 chf
 dha
-csL
 dfM
+csL
 djz
 chf
 cBN
@@ -138496,8 +138094,8 @@ beb
 beb
 kxm
 bAi
-bHt
-bJl
+bku
+bAi
 bte
 bGr
 bGr
@@ -138537,9 +138135,9 @@ cts
 cep
 cep
 cep
-cBP
-csL
-cNq
+cep
+bQX
+cjk
 bQX
 ciY
 cga
@@ -138554,13 +138152,13 @@ chf
 cyP
 chf
 cPe
-dbw
+bQX
 ciY
 cSg
 cuQ
 cuQ
 cEG
-dhR
+cuQ
 bGH
 cBP
 cBP
@@ -138737,7 +138335,7 @@ aGX
 aWb
 aYK
 bct
-bfR
+bfn
 bfR
 bfR
 bfR
@@ -138750,11 +138348,11 @@ bfR
 bPx
 byQ
 bAW
-bCN
+aVb
 bCN
 bFk
 bHC
-bJk
+bwv
 bKa
 bGr
 bIf
@@ -138768,11 +138366,11 @@ aZS
 bWi
 bWg
 bVY
-cbd
-cbd
-cbd
-cbd
-cbd
+cbf
+cbf
+cbf
+cbf
+cbf
 clT
 cnt
 cov
@@ -138811,13 +138409,13 @@ cOm
 cOm
 cOm
 daJ
-dbq
+cOm
 dep
 cac
 cac
 cac
-dcI
-dcW
+cVc
+bGG
 bGH
 aaa
 cBQ
@@ -138991,10 +138589,10 @@ aIE
 aGY
 aGY
 aMz
-aSg
-aYO
-aGY
-aGY
+bcg
+aYW
+aBY
+aGw
 aGY
 aGY
 aTg
@@ -139005,13 +138603,13 @@ aGY
 aTg
 aGY
 aGX
-bvg
-bwv
-bwv
-bwv
 bvh
+bwv
+bwv
+bwv
+bwv
 bHH
-bJm
+bKb
 bKb
 bKR
 bLl
@@ -139025,11 +138623,11 @@ bpD
 bWj
 bLR
 bWc
-cbd
+cbf
 ccT
 cez
 cgc
-cbd
+cbf
 clU
 cjG
 cox
@@ -139060,21 +138658,21 @@ bQX
 cFv
 bQX
 bQX
-cIc
-cIq
-cIq
-cIq
-cIq
-cIq
-cIq
-cPf
+bQX
+bQX
+bQX
+bQX
+bQX
+bQX
+bQX
+bQX
 cDo
 cep
 bGH
 bGH
 bGH
-dia
-dcW
+cWp
+bGG
 bZZ
 aaa
 cBQ
@@ -139248,8 +138846,8 @@ aGX
 aMz
 aMz
 aMz
-aSg
-aYO
+bcg
+aYW
 aGY
 bau
 bau
@@ -139266,9 +138864,9 @@ bve
 bwv
 bwv
 bwv
-bvh
-bHF
-aSI
+bwv
+bHP
+bwv
 bwv
 bGr
 bIg
@@ -139282,11 +138880,11 @@ bSI
 bWj
 cab
 bWc
-cbd
-ceI
+cbf
+cjH
 cgT
 cjH
-cbd
+cbf
 cjG
 cjG
 cow
@@ -139317,7 +138915,7 @@ ciY
 ciY
 dci
 ciY
-cIb
+cep
 ciY
 ciY
 dci
@@ -139330,8 +138928,8 @@ cep
 aaa
 aaa
 bZZ
-dia
-dcW
+cWp
+bGG
 bZZ
 aaa
 cBQ
@@ -139523,27 +139121,27 @@ bvh
 bwv
 bwv
 bwv
-bvh
+bwv
 bHP
-aTH
+bwv
 bux
 bwL
 bBm
 bNb
-bLm
+bUl
 bRr
 bUl
-bQN
+bUl
 bVC
 bRU
 bWj
 bLR
 bWc
-cbd
+cbf
 ccV
 chb
 cjJ
-cbd
+cbf
 cjI
 clm
 cow
@@ -139574,7 +139172,7 @@ cEF
 bQX
 bQX
 bUx
-cIb
+cep
 bQX
 bQX
 bQX
@@ -139587,8 +139185,8 @@ aaa
 aaa
 aaa
 bZZ
-dia
-dcW
+cWp
+bGG
 bZZ
 aaa
 doE
@@ -139762,7 +139360,7 @@ aQI
 aUc
 aAY
 aVQ
-aSg
+bcg
 aYW
 bau
 bco
@@ -139780,9 +139378,9 @@ bvh
 bwv
 bxP
 bxP
-bvh
-bHI
-aSV
+bwv
+bHP
+bwv
 bux
 bwL
 bBm
@@ -139831,7 +139429,7 @@ cEE
 cFv
 bQX
 cHf
-cIb
+cep
 cIr
 cpE
 cKE
@@ -139844,8 +139442,8 @@ aaa
 aaa
 aaa
 bZZ
-dia
-dcW
+cWp
+bGG
 bZZ
 aaa
 aaa
@@ -140022,7 +139620,7 @@ aGX
 aWA
 aYY
 bqj
-bfU
+aHQ
 bhx
 bij
 bkp
@@ -140038,15 +139636,15 @@ bAX
 bau
 bau
 bFn
-bHI
-bwv
+bHP
+bvE
 bEA
 bEA
 bIa
 bNf
 bLI
-bNE
-bNE
+bLI
+bLI
 bIa
 bIa
 bIa
@@ -140088,7 +139686,7 @@ cep
 cep
 cep
 cep
-cIb
+cep
 cIs
 bQX
 cKF
@@ -140101,8 +139699,8 @@ aab
 aab
 aab
 bGH
-dia
-dcW
+cWp
+bGG
 bGH
 aab
 aab
@@ -140294,8 +139892,8 @@ byR
 blj
 bxQ
 bau
-bvh
-bHI
+bwv
+bHP
 bwv
 bEA
 bGu
@@ -140345,7 +139943,7 @@ cxN
 cKP
 cJK
 cJK
-cIb
+cep
 ciY
 ciY
 ciY
@@ -140358,8 +139956,8 @@ aaa
 aaa
 aaa
 bZZ
-dia
-dcW
+cWp
+bGG
 bZZ
 aaa
 aaa
@@ -140537,22 +140135,22 @@ bbh
 bau
 bav
 bci
-ben
+btl
 bfZ
-bkL
-bjE
-blk
-blk
-blk
-btX
-blk
-blk
-buW
+bkn
+bcp
+blj
+blj
+blj
+btV
+blj
+blj
+buV
 blj
 bxR
 bau
 bFo
-bHI
+bHP
 bwv
 bEA
 bGA
@@ -140602,7 +140200,7 @@ cxN
 cKQ
 cMg
 cJK
-cIb
+cep
 cIu
 cJz
 cKG
@@ -140615,7 +140213,7 @@ aaa
 aaa
 aaa
 bZZ
-dia
+cWp
 ddc
 bZZ
 aaa
@@ -140808,13 +140406,13 @@ buV
 blj
 bxS
 bau
-bvh
-bHI
+bwv
+bHP
 cXf
 bEA
 bGw
 bId
-bNJ
+bId
 bLL
 bRs
 bTX
@@ -140859,7 +140457,7 @@ cxN
 cKR
 cJK
 cJK
-cIb
+cep
 cIt
 thk
 bQX
@@ -140872,7 +140470,7 @@ aaa
 aaa
 aaa
 bZZ
-dia
+cWp
 dcX
 bZZ
 aaa
@@ -141066,12 +140664,12 @@ blj
 bxT
 bau
 bFr
-bHI
+bHP
 bJp
 bEA
 bEA
 bIm
-bNJ
+bId
 bLM
 bRF
 bPp
@@ -141116,7 +140714,7 @@ cxN
 cTJ
 cVe
 cWi
-cIb
+cep
 cep
 cep
 cep
@@ -141129,8 +140727,8 @@ aaa
 aaa
 aaa
 bZZ
-dia
-dcW
+cWp
+bGG
 bZZ
 aaa
 aaa
@@ -141322,13 +140920,13 @@ bzp
 bAY
 bCO
 bau
-bvh
-bHI
+bwv
+bHP
 bwv
 bEJ
 bGB
 bIc
-bNJ
+bId
 bId
 bRz
 bId
@@ -141386,8 +140984,8 @@ aab
 aab
 aab
 bGH
-dia
-dcW
+cWp
+bGG
 bGH
 aaa
 aaa
@@ -141580,12 +141178,12 @@ blj
 bxV
 bau
 bFs
-bHI
+bHP
 bwv
 bDq
 bGE
 bIl
-bNJ
+bId
 bPb
 bRO
 bUe
@@ -141630,7 +141228,7 @@ cEH
 cPp
 cEH
 cPp
-cXv
+cPp
 cEH
 cZB
 wEX
@@ -141643,8 +141241,8 @@ aaa
 aaa
 aaa
 bZZ
-dia
-dcW
+cWp
+bGG
 bZZ
 aaa
 aaa
@@ -141836,8 +141434,8 @@ buV
 blj
 bxW
 bau
-bvh
-bHI
+bwv
+bHP
 bwv
 bDq
 bGB
@@ -141900,8 +141498,8 @@ aaa
 aaa
 aaa
 bZZ
-dia
-dcW
+cWp
+bGG
 bZZ
 aaa
 aaa
@@ -142094,12 +141692,12 @@ blj
 bCS
 bau
 bFv
-bHI
+bHP
 bwv
 bDr
 bEA
 bEA
-bNl
+bEA
 bEA
 bEA
 bPs
@@ -142108,7 +141706,7 @@ bTa
 bIa
 bIa
 bLR
-cch
+bJy
 cbk
 cbj
 cbj
@@ -142142,9 +141740,9 @@ cOo
 cOP
 cPJ
 cQl
-cRn
-cSc
-cXz
+cRm
+cRv
+cPp
 cEH
 mKB
 cxN
@@ -142157,8 +141755,8 @@ aaa
 aaa
 aaa
 bZZ
-dia
-dcW
+cWp
+bGG
 bZZ
 aaa
 aaa
@@ -142351,7 +141949,7 @@ blj
 bCR
 bau
 bFu
-bHI
+bkH
 bwv
 bDq
 bGF
@@ -142398,7 +141996,7 @@ cEH
 cOn
 cOO
 cPF
-cPY
+cQl
 cRm
 cRv
 cXA
@@ -142414,8 +142012,8 @@ aaa
 aaa
 aaa
 bZZ
-dia
-dcW
+cWp
+bGG
 bZZ
 aaa
 aaa
@@ -142620,13 +142218,13 @@ bSz
 bUP
 bVF
 bWl
-bYm
+bJk
 caB
 ccp
 cdL
 ceN
 chO
-ceN
+bNl
 cln
 cmi
 cny
@@ -142655,7 +142253,7 @@ cNs
 cOp
 cOR
 cPK
-cQs
+cRt
 cRt
 cSf
 noE
@@ -142672,7 +142270,7 @@ sLU
 wtL
 wtL
 dff
-dhR
+cuQ
 bGH
 bGH
 bGH
@@ -142865,7 +142463,7 @@ khg
 bjD
 aYP
 bFw
-bHI
+bkL
 bwv
 bDq
 bEM
@@ -142879,11 +142477,11 @@ bVE
 bWk
 cbn
 cay
-cbn
-cbn
-cbn
+bJB
+bJB
+bJB
 chN
-cbn
+bNq
 bTw
 cbn
 cbn
@@ -142912,9 +142510,9 @@ cNr
 cEH
 cEH
 cSH
-cQr
+cxA
 cUZ
-cSH
+cFw
 xZm
 cVf
 cZv
@@ -142928,14 +142526,14 @@ vAX
 eNb
 uDy
 wtL
-dia
-ddB
-djo
-djX
-dkF
-dli
+cWp
+bGG
+bGG
+wPi
+cuQ
+cQC
 dlP
-djo
+bGG
 dmq
 dmu
 dmN
@@ -143121,13 +142719,13 @@ khg
 khg
 byZ
 aYP
-aSI
-bHI
 bwv
-bDq
+bkL
+bwv
+bDr
 bED
 bED
-bNq
+bED
 bED
 bED
 bED
@@ -143157,7 +142755,7 @@ cAP
 cAP
 cDu
 cCX
-cEo
+cDu
 cBS
 cBR
 cxN
@@ -143185,7 +142783,7 @@ itr
 kuy
 veJ
 rIN
-dia
+cWp
 cTS
 bGG
 cLh
@@ -143193,7 +142791,7 @@ cuQ
 cJQ
 bGG
 bGG
-bGG
+cZE
 bGH
 aab
 aab
@@ -143378,8 +142976,8 @@ khg
 khg
 bya
 aYQ
-aSI
-bHI
+bwv
+bkL
 bwv
 bDq
 bGK
@@ -143442,7 +143040,7 @@ iHj
 irr
 jxx
 ioj
-dia
+cWp
 cuQ
 cuQ
 cuQ
@@ -143450,7 +143048,7 @@ cuQ
 cuQ
 cuQ
 cuQ
-bGG
+cZE
 bGH
 bGH
 aaa
@@ -143635,13 +143233,13 @@ khg
 khg
 khg
 bEl
-aSI
-bHI
+bwv
+bkL
 bwv
 bDq
 bGL
 bPD
-bKi
+bIp
 bPl
 bRX
 bUj
@@ -143671,7 +143269,7 @@ cAQ
 cCf
 cDw
 cCZ
-cEs
+cDw
 cHi
 cAP
 cJK
@@ -143707,7 +143305,7 @@ cQC
 dlj
 dlz
 cuQ
-bGG
+cZE
 dbg
 bGH
 aab
@@ -143892,13 +143490,13 @@ khg
 khg
 khg
 aYQ
-aSI
-bHI
+bwv
+bkL
 bwv
 bEM
 bGK
 bIv
-bKi
+bIp
 bKx
 bMt
 bUi
@@ -143928,7 +143526,7 @@ cAZ
 cCe
 cBB
 cCY
-cEs
+cDw
 cHi
 cAP
 cJL
@@ -143956,15 +143554,15 @@ rOj
 oiL
 kZk
 ioj
-bGG
-dia
-bGG
-bGG
-bGG
-bGG
-bGG
+cWJ
+cXz
+cYw
+cYw
+cYw
+cYw
+cYR
 cuQ
-bGG
+cZE
 bPA
 bZZ
 aaa
@@ -144149,14 +143747,14 @@ khg
 khg
 khg
 bEl
-aSI
-bHI
-bDr
+bwv
+bkL
+bDq
 bED
 bED
 bIo
-bKi
-bIp
+bCr
+bEr
 bRY
 bUk
 bUR
@@ -144219,9 +143817,9 @@ cuQ
 cuQ
 cuQ
 bGG
-bGG
+cZE
 cuQ
-bGG
+cZE
 cLh
 bZZ
 aaa
@@ -144406,7 +144004,7 @@ khg
 khg
 bya
 aYQ
-aSI
+bwv
 bHR
 bDq
 bED
@@ -144476,9 +144074,9 @@ cuQ
 aaa
 cuQ
 cuQ
-dgf
+daj
 cuQ
-bGG
+cZE
 bKl
 cMs
 aab
@@ -144663,7 +144261,7 @@ khg
 khg
 bzl
 aYP
-bFG
+cXh
 bHT
 cXh
 bED
@@ -144733,9 +144331,9 @@ bZZ
 aaa
 bZZ
 bGG
-bGG
-bGG
-bGG
+cWJ
+cYw
+day
 cMs
 bGH
 aaa
@@ -145177,7 +144775,7 @@ buG
 buG
 aYP
 aYP
-cYw
+bmm
 bHV
 cXj
 cXn
@@ -145434,16 +145032,16 @@ bmm
 bAZ
 bAI
 bAI
-bFH
+bAI
 bHU
 bJr
 bJr
 bJr
 bLo
-bNt
 bPq
 bPq
 bPq
+bFt
 bUS
 bXi
 bWv
@@ -145697,11 +145295,11 @@ aSs
 hMg
 dbf
 jUV
-kYT
+cUP
 cZm
 cZD
-cZm
-oiP
+bFG
+qzQ
 bEF
 cOC
 bGG
@@ -145954,7 +145552,7 @@ bGh
 bAJ
 qzQ
 jUV
-vWu
+bCX
 mwj
 bAK
 jXu
@@ -146211,10 +145809,10 @@ bjR
 bEF
 cXs
 jUV
-fzL
+dbf
 cZn
 cZn
-cZn
+bFH
 daa
 big
 big
@@ -146471,7 +146069,7 @@ bLp
 bNu
 bzs
 bSa
-aSs
+bGU
 rSU
 dat
 baN
@@ -146728,7 +146326,7 @@ bLr
 bNw
 bPu
 bPu
-bPu
+bGW
 bUT
 bVI
 bWR
@@ -147239,7 +146837,7 @@ bjR
 bAK
 cYe
 ueF
-kYT
+cUP
 cZm
 cZm
 cZm
@@ -147496,7 +147094,7 @@ bGo
 bAL
 hbU
 ueF
-vWu
+bCX
 gWM
 bAK
 kxS
@@ -147509,7 +147107,7 @@ baT
 aYS
 aaa
 dca
-dcc
+aaa
 xWg
 duq
 xAw
@@ -147753,7 +147351,7 @@ aSs
 iKh
 cUP
 ueF
-fzL
+dbf
 cZn
 cZI
 cZn
@@ -148010,7 +147608,7 @@ bmm
 bmm
 bmm
 cYk
-cYx
+buH
 buH
 cZH
 bmm
@@ -148034,10 +147632,10 @@ csi
 ctL
 cvb
 cgs
+bGH
 bZZ
 bZZ
-bZZ
-cCp
+ddK
 bGH
 aab
 aaa

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -55511,8 +55511,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
@@ -57516,8 +57515,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
@@ -57776,8 +57774,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
@@ -63117,6 +63114,8 @@
 	},
 /obj/structure/closet/firecloset,
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
@@ -63141,6 +63140,7 @@
 	name = "Grid Power Monitoring Computer"
 	},
 /obj/structure/cable{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plasteel{
@@ -65537,6 +65537,8 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel,
@@ -65591,6 +65593,7 @@
 	pixel_x = -24
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel{
@@ -68038,8 +68041,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -69268,6 +69270,8 @@
 	dir = 8
 	},
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
@@ -70825,17 +70829,16 @@
 /area/maintenance/genetics)
 "cHg" = (
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/closet/secure_closet/engineering_personal,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cHh" = (
@@ -71131,17 +71134,16 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
-	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
 	icon_state = "pipe-j2s";
 	name = "Eng Atmospherics";
 	sortType = 6
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
@@ -71208,12 +71210,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -71222,6 +71218,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
@@ -72066,12 +72067,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
@@ -75756,6 +75759,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cQN" = (
@@ -77422,8 +77426,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
@@ -77469,9 +77472,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cTV" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/firealarm{
 	dir = 8;
@@ -77481,6 +77481,10 @@
 	pixel_y = 27
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "cTW" = (
@@ -77492,15 +77496,18 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 10
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "cTY" = (
@@ -77824,6 +77831,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel,
@@ -78456,14 +78465,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/disposal,
 /obj/structure/sign/deathsposal{
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/turbine)
 "cVJ" = (
@@ -79193,7 +79198,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "cXm" = (
-/obj/machinery/atmospherics/unary/tank/toxins{
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -79432,8 +79437,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -79516,7 +79520,7 @@
 	id = "tox_in"
 	},
 /turf/space,
-/area/space/nearstation)
+/area/atmos)
 "cXS" = (
 /obj/machinery/camera{
 	c_tag = "Engineering West";
@@ -79907,12 +79911,13 @@
 	},
 /area/storage/office)
 "cYI" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
+	dir = 5;
+	tag = "icon-intact-y (NORTHWEST)"
 	},
-/turf/simulated/floor/plasteel,
-/area/maintenance/turbine)
+/turf/space,
+/area/space/nearstation)
 "cYJ" = (
 /turf/simulated/wall,
 /area/engine/engineering)
@@ -79936,12 +79941,12 @@
 	},
 /area/storage/office)
 "cYL" = (
+/obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 6
+	dir = 4
 	},
-/obj/structure/lattice,
-/turf/space,
-/area/space/nearstation)
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "cYM" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -80025,13 +80030,12 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cYU" = (
+/obj/structure/closet/secure_closet/engineering_personal,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
-/obj/structure/closet/secure_closet/engineering_personal,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cYX" = (
@@ -80675,6 +80679,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "daA" = (
@@ -80882,6 +80889,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "daV" = (
@@ -80946,6 +80956,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 5;
+	tag = "icon-intact-y (NORTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -81101,6 +81115,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 5;
+	tag = "icon-intact-y (NORTHWEST)"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "dbA" = (
@@ -81117,6 +81135,9 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "dbC" = (
@@ -81127,6 +81148,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -81443,6 +81467,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "dcq" = (
@@ -81507,6 +81532,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/turbine)
 "dcx" = (
@@ -81525,14 +81551,13 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "dcy" = (
-/obj/machinery/atmospherics/unary/portables_connector{
+/obj/machinery/atmospherics/unary/tank/toxins{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/nosmoking_2{
 	pixel_x = -32
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "dcz" = (
@@ -81603,8 +81628,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 9;
+	tag = "icon-intact-y (NORTHWEST)"
+	},
 /obj/structure/disposalpipe/segment{
-	dir = 1;
+	dir = 8;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
@@ -81619,6 +81648,12 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "dcI" = (
@@ -81720,10 +81755,11 @@
 /turf/simulated/floor/engine/plasma,
 /area/atmos)
 "dcV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 6
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4
 	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "dcX" = (
@@ -81751,7 +81787,9 @@
 /area/shuttle/syndicate)
 "dda" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/trinary/tvalve/digital,
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "ddb" = (
@@ -81771,61 +81809,45 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "ddf" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 9;
-	tag = "icon-intact-y (NORTHWEST)"
+	dir = 6
 	},
-/turf/simulated/floor/plasteel,
-/area/maintenance/turbine)
+/obj/structure/lattice,
+/turf/space,
+/area/space/nearstation)
 "ddg" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "ddh" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 8
-	},
-/obj/machinery/meter,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/binary/valve,
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "ddi" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 4
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8;
+	name = "Mix to MiniSat"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "ddj" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "ddk" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
 /area/maintenance/turbine)
 "ddl" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 4
-	},
 /obj/machinery/meter,
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "ddn" = (
@@ -81848,16 +81870,20 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "ddp" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple,
-/obj/machinery/computer/turbine_computer{
-	id = "incineratorturbine"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "ddq" = (
-/obj/machinery/hologram/holopad,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/turbine_computer{
+	id = "incineratorturbine"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "ddr" = (
@@ -81905,6 +81931,9 @@
 	req_access_txt = "32"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "ddw" = (
@@ -81937,7 +81966,6 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "ddz" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/embedded_controller/radio/airlock/access_controller{
 	frequency = 1449;
 	id_tag = "turbine_control";
@@ -81954,6 +81982,9 @@
 	pixel_y = -24
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "ddA" = (
@@ -82839,6 +82870,8 @@
 "dfy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel,
@@ -83310,7 +83343,11 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dgS" = (
-/turf/simulated/wall/r_wall,
+/obj/effect/spawner/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/maintenance/turbine)
 "dgT" = (
 /turf/simulated/wall,
@@ -83764,17 +83801,16 @@
 	},
 /area/crew_quarters/toilet)
 "dhL" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/binary/valve{
 	dir = 4
 	},
-/turf/simulated/wall/r_wall,
-/area/maintenance/turbine)
-"dhM" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 5;
-	tag = "icon-intact-y (NORTHWEST)"
-	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "dhN" = (
 /obj/machinery/alarm{
@@ -84875,13 +84911,6 @@
 	},
 /turf/simulated/floor/engine/n2,
 /area/atmos)
-"dkj" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/turbine)
 "dkk" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
@@ -85600,9 +85629,10 @@
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "dlI" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/binary/pump/on,
-/turf/space,
+/obj/machinery/atmospherics/unary/outlet_injector/on{
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless,
 /area/maintenance/turbine)
 "dlJ" = (
 /obj/effect/decal/cleanable/blood/gibs/robot,
@@ -85746,11 +85776,6 @@
 	},
 /turf/simulated/floor/engine/insulated,
 /area/maintenance/turbine)
-"dlY" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple,
-/obj/structure/lattice,
-/turf/space,
-/area/space/nearstation)
 "dlZ" = (
 /obj/structure/chair{
 	dir = 8
@@ -86271,12 +86296,6 @@
 /obj/structure/sign/securearea,
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai)
-"dnd" = (
-/obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 1
-	},
-/turf/simulated/floor/plating/airless,
-/area/maintenance/turbine)
 "dne" = (
 /obj/structure/cable,
 /obj/machinery/power/turbine,
@@ -133275,10 +133294,10 @@ cQZ
 cQZ
 doE
 aaa
-aaa
-aab
-aab
-cYL
+ddf
+djE
+djE
+djE
 djd
 djd
 djd
@@ -133525,19 +133544,19 @@ cPw
 cPw
 cPw
 cPw
-cPw
-cPw
-cPw
-cPw
-cPw
-cPw
-dhM
+cYI
+doE
+doE
+doE
+doE
+doE
+dgT
 dgS
-dgS
-dgS
-dkj
-dgS
-dgS
+dgT
+ddk
+dgT
+ddk
+dgT
 aaa
 aaa
 aab
@@ -133782,19 +133801,19 @@ cBQ
 cBP
 cBP
 cBQ
+cYL
 cBQ
-cBQ
 cBP
 cBP
 cBP
-dgS
-dhL
+dgT
+dgT
 cXm
 dcy
 dcV
-ddf
+ddg
 ddn
-dgS
+dgT
 aaa
 aaa
 aab
@@ -134046,12 +134065,12 @@ csL
 cTB
 dgT
 cTV
+ddi
 dcz
 dcz
-cYI
 ddg
 ddo
-dgS
+dgT
 aaa
 aaa
 aab
@@ -134310,10 +134329,10 @@ ddh
 ddp
 dll
 dlI
-dlY
-dlY
-dlY
-dnd
+aab
+aab
+aab
+aab
 aab
 aab
 aab
@@ -134563,7 +134582,7 @@ dcH
 dcz
 dev
 dez
-ddi
+ddg
 ddq
 dlm
 dlm
@@ -135077,8 +135096,8 @@ cVH
 dcu
 dew
 ddy
-ddk
 ddy
+dhL
 dly
 dlX
 dmh


### PR DESCRIPTION
# Голосование пройдено:
https://discord.com/channels/617003227182792704/930740675350233098/985573195774062662

# Реворк инженерного отдела:
* Изменены параметры контура воздушной смеси с начала раунда: урегулированы подачи воздушной смеси, кислорода и азота, добавлен нагреватель, уменьшено давление в сеть станции с 9000 кПа до 303 кПа 
* Изменено направление фильтрующего контура
* В шкафы атмосферных техников добавлены чемоданы с надувными стенами (inflatable barrier box)
* Поративные скрабберы и помпы теперь подключены к сети
* Добавлен шкаф с одеждой и шкаф с инженерным снаряжением
* Изменена комната СМЕСов, питающих станцию, теперь провода не уходят под армированные стены

![ENG](https://user-images.githubusercontent.com/91949115/174116460-e125afa9-2390-454c-b953-3da61c33ba3d.png)


# Изменения системы труб и проводки на станции
* Изменены развязки труб системы disposal
* В коридоре инженерного отдела и в дормах были подключены портативные скрабберы и воздушные помпы
* В коридорах станции произведена укладка проводов и труб в единую линию (технические тоннели не затронуты)

![Pipes](https://user-images.githubusercontent.com/91949115/174117717-bf5c6859-3ec5-46c7-860a-b994c0613765.png)

# Остальные фиксы/твики:
* Генератор гравитации подключен к сети станции
* Исправлена система охлаждения серверной
* Исправлены оставшиеся прямые участки труб на станции, что не были исправлены в предыдущем патче: подключены некоторые выходы в космос, восстановлена подача в бриг, криокапсулы мед. блока
* Добавлено освещение в основной восточный коридор станции (от мостика к отбытию)
* Удалена зона восточного коридора, занимавшая площадь 3x4 тайла и не имеющая смысла
* Исправлена доставка мулботом в инженерный отдел
* Исправлена агрессивность к слаймам от Hivebot'а
* Портативная воздушная помпа в бриге заменена канистрой с кислородом