### PR TITLE
Фикс притягивания тентакли (на прайм)

### DIFF
--- a/code/game/gamemodes/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/changeling/powers/mutations.dm
@@ -305,6 +305,7 @@
 					if(INTENT_HELP)
 						C.visible_message("<span class='danger'>[L] is pulled by [H]'s tentacle!</span>","<span class='userdanger'>A tentacle grabs you and pulls you towards [H]!</span>")
 						add_attack_logs(H, L, "[H] pulled [L] towards them with a tentacle")
+						C.client?.move_delay = world.time + 10
 						C.throw_at(get_step_towards(H,C), 8, 2)
 						return 1
 
@@ -327,11 +328,13 @@
 					if(INTENT_GRAB)
 						C.visible_message("<span class='danger'>[L] is grabbed by [H]'s tentacle!</span>","<span class='userdanger'>A tentacle grabs you and pulls you towards [H]!</span>")
 						add_attack_logs(H, C, "[H] grabbed [C] with a changeling tentacle")
+						C.client?.move_delay = world.time + 10
 						C.throw_at(get_step_towards(H,C), 8, 2, callback=CALLBACK(H, /mob/proc/tentacle_grab, C))
 						return 1
 
 					if(INTENT_HARM)
 						C.visible_message("<span class='danger'>[L] is thrown towards [H] by a tentacle!</span>","<span class='userdanger'>A tentacle grabs you and throws you towards [H]!</span>")
+						C.client?.move_delay = world.time + 10
 						C.throw_at(get_step_towards(H,C), 8, 2, callback=CALLBACK(H, /mob/proc/tentacle_stab, C))
 						return 1
 			else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Добавляет мувделей на одну (1) секунду, не позволяя жертве двигаться во время полета к генокраду. Так как тентакля генокрада использует throw_at, то можно движением сопротивляться броску. Данное изменение гарантирует, что цель не сможет сопротивляться броску своим движением во время полета.

Пример текущего взаимодействия (до этого ПРа): https://discord.com/channels/617003227182792704/981470952061804604/987619987105648650

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Фикс, который позволит тентакле генокрада взаимодействовать не в упор, не со стоячими целями, и не только в режиме дизарм. Так как во время боя много движения, полет к генокраду с помощью тентакли часто обрывался движением жертвы, что приводило к бесполезности трех из четырех режимов тентакли.

Tip of this PR: Все еще имеется возможность столкновения с целью после броска тентакли, так как тентакля кидает цель к генокраду, а не притягивает. Если вы попали в цель, лучше остановитесь или идите в бок!

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Хелп, Граб и Харм тентакля теперь не дает цели двигаться одну секунду во время полета к генокраду, гарантируя притягивание до генокрада.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
