### PR TITLE
Feat: GPS would hide location names for other Z levels

### DIFF
--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -104,7 +104,7 @@ GLOBAL_LIST_EMPTY(GPS_list)
 
 		var/list/signal = list("tag" = G.gpstag, "area" = null, "position" = null)
 		if(!G.emped)
-			signal["area"] = get_area_name(G, TRUE)
+			signal["area"] = (GT.z == T.z) ? get_area_name(G, TRUE) : "???"
 			signal["position"] = ATOM_COORDS(GT)
 		signals += list(signal)
 	data["signals"] = signals


### PR DESCRIPTION
[Предложка прошла](https://discord.com/channels/617003227182792704/755125334097133628/984915309347614761)

## What Does This PR Do
GPS будет показывать «???» вместо названия локации на другом Z-уровне

## Why It's Good For The Game
Уменьшится метаёбство, как в космосе, так и в гейте.

## Changelog
:cl:
tweak: GPS не показывает название локации других Z-уровней
/:cl: