### PR TITLE
Tweak: examine style tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -25,7 +25,7 @@
 		skipface |= wear_mask.flags_inv & HIDEFACE
 		skipeyes |= wear_mask.flags_inv & HIDEEYES
 
-	var/msg = "<span class='info'>*---------*\nThis is "
+	var/msg = "<span class='info'>This is "
 
 	if(!(skipjumpsuit && skipface) && icon) //big suits/masks/helmets make it hard to tell their gender
 		msg += "[bicon(icon(icon, dir=SOUTH))] " //fucking BYOND: this should stop dreamseeker crashing if we -somehow- examine somebody before their icon is generated
@@ -411,7 +411,6 @@
 			if(!H.disfigured)
 				msg += "[print_flavor_text()]\n"
 
-	msg += "*---------*</span>"
 	if(pose)
 		if( findtext(pose,".",length(pose)) == 0 && findtext(pose,"!",length(pose)) == 0 && findtext(pose,"?",length(pose)) == 0 )
 			pose = addtext(pose,".") //Makes sure all emotes end with a period.

--- a/goon/browserassets/css/browserOutput-dark.css
+++ b/goon/browserassets/css/browserOutput-dark.css
@@ -52,20 +52,20 @@ h1.alert, h2.alert			{color: #FFF;}
 
 
 .robot					{font-family: 'PxPlus IBM MDA';}
-.newscaster				{color: #CC0000;}
+.newscaster				{color: #C00000;}
 .adminmod				{color: #F0AA14;}
 .solcom					{color: #8282FB;}
 .kidan					{color: #C64C05;}
 .drask					{color: #a3d4eb;}
 .shadowling				{color: #Cb2799;}
-.cultspeech				{color: #AF0000;}
-.cultitalic				{color: #A60000;}
-.cultlarge				{color: #A60000;}
-.narsie					{color: #A60000;}
-.narsiesmall			{color: #A60000;}
-.interface				{color: #9031C4;}
-.purple					{color: #9031C4;}
-.skeleton				{color: #C8C8C8;}
+.cultspeech				{color: #C00000;}
+.cultitalic				{color: #C00000;}
+.cultlarge				{color: #C00000;}
+.narsie					{color: #C00000;}
+.narsiesmall			{color: #C00000;}
+.interface				{color: #8c00ff;}
+.purple					{color: #8c00ff;}
+.skeleton				{color: #C0C0C0C0;}
 
 .revennotice				{color: #6685F5;}
 .revenboldnotice			{color: #6685F5;}
@@ -89,11 +89,11 @@ span.body .codephrases {color: #5555FF;}
 span.body .coderesponses {color: #FF3333;}
 
 /* Examine styles */
-.examine {border: 1px solid #1c1c1c; padding: 10px; margin: 2px 10px; background: #252525; color: #e9e9e9}
-.examine a 						{color: #e9e9e9;}
-.examine .info					{color: #e9e9e9;}
-.examine .notice				{color: #e9e9e9;}
-.examine .boldnotice			{color: #e9e9e9;}
-.examine .deptradio				{color: #cf7dcf;}
+.examine {border: 1px solid #1c1c1c; padding: 10px; margin: 2px 10px; background: #252525; color: #FFFFFF}
+.examine a 						{color: #FFFFFF;}
+.examine .info					{color: #FFFFFF;}
+.examine .notice				{color: #FFFFFF;}
+.examine .boldnotice			{color: #FFFFFF;}
+.examine .deptradio				{color: #AD43AB;}
 
 /* .examineinfo			{color: #b6c5ff;} */

--- a/goon/browserassets/css/browserOutput-dark.css
+++ b/goon/browserassets/css/browserOutput-dark.css
@@ -7,7 +7,7 @@ html, body {
 	color: #fff;
 }
 body {
-	background: #171c20;
+	background: #151515;
 }
 h1, h2, h3, h4, h5, h6 {color: #06f;}
 
@@ -89,7 +89,7 @@ span.body .codephrases {color: #5555FF;}
 span.body .coderesponses {color: #FF3333;}
 
 /* Examine styles */
-.examine {border: 1px solid #1c1c1c; padding: 10px; margin: 2px 10px; background: #22272b; color: #e9e9e9}
+.examine {border: 1px solid #1c1c1c; padding: 10px; margin: 2px 10px; background: #252525; color: #e9e9e9}
 .examine a 						{color: #e9e9e9;}
 .examine .info					{color: #e9e9e9;}
 .examine .notice				{color: #e9e9e9;}


### PR DESCRIPTION
Подобрал цвета по предложенному ранее варианту, возвращая цвет чата в изначальное положение.
Это сравняет цвета со всей цветовой схемой интерфейса.
Также были убраны разделители " *---------* " при осмотре персонажа.

### Было (момент со стрима, literally тяжелочитаемо и очевидные различия по цветам)
![image](https://user-images.githubusercontent.com/20109643/176523822-d979a707-d55b-4643-9109-7192b29bbbf2.png)

### Стало
![image](https://user-images.githubusercontent.com/20109643/176524387-b4e328f1-ea1f-49ef-9707-08f4b5c26439.png)
