### PR TITLE
Feat: Agent ID card and telecomms/HUDs (Prime)

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -496,7 +496,7 @@
 			if("Show")
 				return ..()
 			if("Edit")
-				switch(input(user,"What would you like to edit on \the [src]?") in list("Name", "Photo", "Appearance", "Sex", "Age", "Occupation", "Money Account", "Blood Type", "DNA Hash", "Fingerprint Hash", "Reset Access", "Delete Card Information"))
+				switch(input(user,"What would you like to edit on \the [src]?") in list("Name", "Photo", "Appearance", "Sex", "Age", "Occupation", "Money Account", "Blood Type", "DNA Hash", "Fingerprint Hash", "Tracking", "Reset Access", "Delete Card Information"))
 					if("Name")
 						var/new_name = reject_bad_name(input(user,"What name would you like to put on this card?","Agent Card Name", ishuman(user) ? user.real_name : user.name), TRUE)
 						if(!Adjacent(user))
@@ -577,9 +577,26 @@
 
 						var/department = input(user, "What job would you like to put on this card?\nChoose a department or a custom job title.\nChanging occupation will not grant or remove any access levels.","Agent Card Occupation") in departments
 						var/new_job = "Civilian"
+						var/new_rank = "Civilian"
 
 						if(department == "Custom")
 							new_job = sanitize(stripped_input(user,"Choose a custom job title:","Agent Card Occupation", "Civilian", MAX_MESSAGE_LEN))
+							var/department_icon = input(user, "What job would you like to be shown on this card (for SecHUDs)?\nChanging occupation will not grant or remove any access levels.","Agent Card Occupation") in departments
+							switch(department_icon)
+								if("Engineering")
+									new_rank = input(user, "What job would you like to be shown on this card (for SecHUDs)?\nChanging occupation will not grant or remove any access levels.","Agent Card Occupation") in GLOB.engineering_positions
+								if("Medical")
+									new_rank = input(user, "What job would you like to be shown on this card (for SecHUDs)?\nChanging occupation will not grant or remove any access levels.","Agent Card Occupation") in GLOB.medical_positions
+								if("Science")
+									new_rank = input(user, "What job would you like to be shown on this card (for SecHUDs)?\nChanging occupation will not grant or remove any access levels.","Agent Card Occupation") in GLOB.science_positions
+								if("Security")
+									new_rank = input(user, "What job would you like to be shown on this card (for SecHUDs)?\nChanging occupation will not grant or remove any access levels.","Agent Card Occupation") in GLOB.security_positions
+								if("Support")
+									new_rank = input(user, "What job would you like to be shown on this card (for SecHUDs)?\nChanging occupation will not grant or remove any access levels.","Agent Card Occupation") in GLOB.support_positions
+								if("Command")
+									new_rank = input(user, "What job would you like to be shown on this card (for SecHUDs)?\nChanging occupation will not grant or remove any access levels.","Agent Card Occupation") in GLOB.command_positions
+								if("Custom")
+									new_rank = null
 						else if(department != "Civilian")
 							switch(department)
 								if("Engineering")
@@ -594,10 +611,12 @@
 									new_job = input(user, "What job would you like to put on this card?\nChanging occupation will not grant or remove any access levels.","Agent Card Occupation") in GLOB.support_positions
 								if("Command")
 									new_job = input(user, "What job would you like to put on this card?\nChanging occupation will not grant or remove any access levels.","Agent Card Occupation") in GLOB.command_positions
+							new_rank = new_job
 
 						if(!Adjacent(user))
 							return
 						assignment = new_job
+						rank = new_rank
 						to_chat(user, "<span class='notice'>Occupation changed to [new_job].</span>")
 						UpdateName()
 						RebuildHTML()
@@ -650,6 +669,14 @@
 						fingerprint_hash = new_fingerprint_hash
 						to_chat(user, "<span class='notice'>Fingerprint hash changed to [new_fingerprint_hash].</span>")
 						RebuildHTML()
+
+					if("Tracking")
+						var/response = alert(user, "Do you want this ID card to be trackable by AI's?", "Tracking", "No", "Yes")
+						if(response == "Yes")
+							untrackable = 0
+						else
+							untrackable = 1
+						to_chat(user, "<span class='notice'>This ID card is now [untrackable ? "untrackable" : "trackable"] by the AI's.</span>")
 
 					if("Reset Access")
 						var/response = alert(user, "Are you sure you want to reset access saved on the card?","Reset Access", "No", "Yes")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
(оригинал: https://github.com/ss220-space/Paradise/pull/1056 , смена ветки)
(Предложка пройдена: https://discord.com/channels/617003227182792704/755125334097133628/1007544949526507540)
Этот ПР позволяет уменьшить метагейминг, путем корректного поведения Сек/СкиллХУДов и телекоммов с настроенной картой агента, а именно:
- Настройка трекинга ИИ по карте
- Настройка изображения профессии на ХУДах, для случаев альтернативных названий профессий
- Корректный цвет отдела, при настройке телекоммов на отдел
- Использование жирного текста при профессии глав, при настройке телекоммов на глав

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Из-за данных ограничений, метагейминг вполне возможен и реален с помощью телекоммов, если они настроены. Данное изменение не только убирает метагейминг, но и добавляет новые возможности для альтернативных названий.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![Screenshot_24](https://user-images.githubusercontent.com/31931237/176839626-2921ed53-6d88-4492-904d-39d4251a24de.png)
![Screenshot_25](https://user-images.githubusercontent.com/31931237/176839633-f0d1bb5c-0a2e-4696-bafc-7560b8dd9f2f.png)
![Screenshot_26](https://user-images.githubusercontent.com/31931237/176839638-e6df7adf-018e-430c-b04d-2eba5b34128d.png)
![Screenshot_27](https://user-images.githubusercontent.com/31931237/176839643-2ac5abb5-e015-4c5d-ab0d-4dcf90822929.png)
![Screenshot_28](https://user-images.githubusercontent.com/31931237/176839644-70710aab-7d6d-4efe-9c4b-db4a9ecee935.png)

## Changelog
:cl:
add: Добавлена возможность отдельного изменения иконки на Сек/СкиллХУДов для карты агента при кастомных названиях профессий
add: Добавлена функция переключения трекинга карты агента от ИИ
fix: Агентская карта теперь корректно работает с телекоммами
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
