### PR TITLE
fix: moves incorporeal check for shadowlings to prevent chat-spam

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -176,6 +176,12 @@
 #define INVISIBILITY_ABSTRACT 101
 #define UNHEALING_EAR_DAMAGE 100
 
+// Incorporeal movement
+#define INCORPOREAL_NONE 0
+#define INCORPOREAL_NORMAL 1
+#define INCORPOREAL_NINJA 2
+#define INCORPOREAL_REVENANT 3
+
 //Human sub-species
 #define isshadowling(A) (is_species(A, /datum/species/shadow/ling))
 #define isshadowlinglesser(A) (is_species(A, /datum/species/shadow/ling/lesser))

--- a/code/game/gamemodes/miniantags/guardian/types/ranged.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/ranged.dm
@@ -34,7 +34,7 @@
 			environment_smash = initial(environment_smash)
 			alpha = 255
 			range = 13
-			incorporeal_move = 0
+			incorporeal_move = INCORPOREAL_NONE
 			to_chat(src, "<span class='danger'>You switch to combat mode.</span>")
 			toggle = FALSE
 		else
@@ -45,7 +45,7 @@
 			environment_smash = ENVIRONMENT_SMASH_NONE
 			alpha = 60
 			range = 255
-			incorporeal_move = 1
+			incorporeal_move = INCORPOREAL_NORMAL
 			to_chat(src, "<span class='danger'>You switch to scout mode.</span>")
 			toggle = TRUE
 	else

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -15,7 +15,7 @@
 	var/icon_reveal = "revenant_revealed"
 	var/icon_stun = "revenant_stun"
 	var/icon_drain = "revenant_draining"
-	incorporeal_move = 3
+	incorporeal_move = INCORPOREAL_REVENANT
 	see_invisible = INVISIBILITY_REVENANT
 	invisibility = INVISIBILITY_REVENANT
 	health =  INFINITY //Revenants don't use health, they use essence instead
@@ -65,7 +65,7 @@
 	if(unreveal_time && world.time >= unreveal_time)
 		unreveal_time = 0
 		revealed = 0
-		incorporeal_move = 3
+		incorporeal_move = INCORPOREAL_REVENANT
 		invisibility = INVISIBILITY_REVENANT
 		to_chat(src, "<span class='revenboldnotice'>You are once more concealed.</span>")
 	if(unstun_time && world.time >= unstun_time)
@@ -267,7 +267,7 @@
 		return
 	revealed = 1
 	invisibility = 0
-	incorporeal_move = 0
+	incorporeal_move = INCORPOREAL_NONE
 	if(!unreveal_time)
 		to_chat(src, "<span class='revendanger'>You have been revealed!</span>")
 		unreveal_time = world.time + time

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -30,7 +30,7 @@
 	allowed_type = /mob/living/carbon/human
 
 /obj/effect/proc_holder/spell/targeted/click/glare/can_cast(mob/living/user = usr, charge_check = TRUE, show_message = FALSE)
-	if(user.incorporeal_move == 1)
+	if(user.incorporeal_move == INCORPOREAL_NORMAL)
 		return FALSE
 	. = ..()
 
@@ -71,7 +71,7 @@
 	action_icon_state = "veil"
 
 /obj/effect/proc_holder/spell/aoe_turf/veil/can_cast(mob/living/user = usr, charge_check = TRUE, show_message = FALSE)
-	if(user.incorporeal_move == 1)
+	if(user.incorporeal_move == INCORPOREAL_NORMAL)
 		return FALSE
 	. = ..()
 
@@ -108,7 +108,7 @@
 		target.visible_message("<span class='warning'>[target] vanishes in a puff of black mist!</span>", "<span class='shadowling'>You enter the space between worlds as a passageway.</span>")
 		target.SetStunned(0)
 		target.SetWeakened(0)
-		target.incorporeal_move = 1
+		target.incorporeal_move = INCORPOREAL_NORMAL
 		target.alpha = 0
 		target.ExtinguishMob()
 		var/turf/T = get_turf(target)
@@ -118,7 +118,7 @@
 		target.stop_pulling()
 		sleep(40) //4 seconds
 		target.visible_message("<span class='warning'>[target] suddenly manifests!</span>", "<span class='shadowling'>The pressure becomes too much and you vacate the interdimensional darkness.</span>")
-		target.incorporeal_move = 0
+		target.incorporeal_move = INCORPOREAL_NONE
 		target.alpha = 255
 		target.forceMove(user.loc)
 
@@ -178,7 +178,7 @@
 	action_icon_state = "icy_veins"
 
 /obj/effect/proc_holder/spell/aoe_turf/flashfreeze/can_cast(mob/living/user = usr, charge_check = TRUE, show_message = FALSE)
-	if(user.incorporeal_move == 1)
+	if(user.incorporeal_move == INCORPOREAL_NORMAL)
 		return FALSE
 	. = ..()
 
@@ -222,7 +222,7 @@
 	allowed_type = /mob/living/carbon/human
 
 /obj/effect/proc_holder/spell/targeted/click/enthrall/can_cast(mob/living/user = usr, charge_check = TRUE, show_message = FALSE)
-	if(enthralling || user.incorporeal_move == 1)
+	if(enthralling || user.incorporeal_move == INCORPOREAL_NORMAL)
 		return FALSE
 	. = ..()
 
@@ -318,7 +318,7 @@
 	action_icon_state = "collective_mind"
 
 /obj/effect/proc_holder/spell/targeted/collective_mind/can_cast(mob/living/user = usr, charge_check = TRUE, show_message = FALSE)
-	if(user.incorporeal_move == 1)
+	if(user.incorporeal_move == INCORPOREAL_NORMAL)
 		return FALSE
 	. = ..()
 
@@ -398,7 +398,7 @@
 	action_icon_state = "black_smoke"
 
 /obj/effect/proc_holder/spell/targeted/blindness_smoke/can_cast(mob/living/user = usr, charge_check = TRUE, show_message = FALSE)
-	if(user.incorporeal_move == 1)
+	if(user.incorporeal_move == INCORPOREAL_NORMAL)
 		return FALSE
 	. = ..()
 
@@ -452,7 +452,7 @@
 	action_icon_state = "screech"
 
 /obj/effect/proc_holder/spell/aoe_turf/unearthly_screech/can_cast(mob/living/user = usr, charge_check = TRUE, show_message = FALSE)
-	if(user.incorporeal_move == 1)
+	if(user.incorporeal_move == INCORPOREAL_NORMAL)
 		return FALSE
 	. = ..()
 
@@ -494,7 +494,7 @@
 	action_icon_state = "null_charge"
 
 /obj/effect/proc_holder/spell/aoe_turf/null_charge/can_cast(mob/living/user = usr, charge_check = TRUE, show_message = FALSE)
-	if(user.incorporeal_move == 1)
+	if(user.incorporeal_move == INCORPOREAL_NORMAL)
 		return FALSE
 	. = ..()
 
@@ -559,7 +559,7 @@
 	allowed_type = /mob/living/carbon/human
 
 /obj/effect/proc_holder/spell/targeted/click/reviveThrall/can_cast(mob/living/user = usr, charge_check = TRUE, show_message = FALSE)
-	if(user.incorporeal_move == 1)
+	if(user.incorporeal_move == INCORPOREAL_NORMAL)
 		return FALSE
 	. = ..()
 
@@ -649,7 +649,7 @@
 	var/global/extendlimit = 0
 
 /obj/effect/proc_holder/spell/targeted/click/shadowling_extend_shuttle/can_cast(mob/living/user = usr, charge_check = TRUE, show_message = FALSE)
-	if(user.incorporeal_move == 1)
+	if(user.incorporeal_move == INCORPOREAL_NORMAL)
 		return FALSE
 	. = ..()
 
@@ -789,12 +789,12 @@
 		if(SHA.phasing)
 			SHA.visible_message("<span class='danger'>[SHA] suddenly vanishes!</span>", \
 			"<span class='shadowling'>You begin phasing through planes of existence. Use the ability again to return.</span>")
-			SHA.incorporeal_move = 1
+			SHA.incorporeal_move = INCORPOREAL_NORMAL
 			SHA.alpha = 0
 		else
 			SHA.visible_message("<span class='danger'>[SHA] suddenly appears from nowhere!</span>", \
 			"<span class='shadowling'>You return from the space between worlds.</span>")
-			SHA.incorporeal_move = 0
+			SHA.incorporeal_move = INCORPOREAL_NONE
 			SHA.alpha = 255
 
 

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -3,9 +3,6 @@
 /obj/effect/proc_holder/spell/proc/shadowling_check(var/mob/living/carbon/human/H)
 	if(!H || !istype(H))
 		return
-	if(H.incorporeal_move == 1)
-		to_chat(H, "<span class='warning'>You can't use abilities affecting others while you are traversing between worlds!</span>")
-		return FALSE
 	if(isshadowling(H) && is_shadow(H))
 		return 1
 	if(isshadowlinglesser(H) && is_thrall(H))
@@ -32,10 +29,10 @@
 	selection_deactivated_message	= "<span class='notice'>Your eyes relax... for now.</span>"
 	allowed_type = /mob/living/carbon/human
 
-/obj/effect/proc_holder/spell/targeted/click/glare/cast_check(charge_check = TRUE, start_recharge = TRUE, mob/living/user = usr)
-	if(!shadowling_check(user))
+/obj/effect/proc_holder/spell/targeted/click/glare/can_cast(mob/living/user = usr, charge_check = TRUE, show_message = FALSE)
+	if(user.incorporeal_move == 1)
 		return FALSE
-	return ..()
+	. = ..()
 
 /obj/effect/proc_holder/spell/targeted/click/glare/valid_target(mob/living/carbon/human/target, user)
 	if(!..())
@@ -72,6 +69,11 @@
 	range = 5
 	var/blacklisted_lights = list(/obj/item/flashlight/flare, /obj/item/flashlight/slime)
 	action_icon_state = "veil"
+
+/obj/effect/proc_holder/spell/aoe_turf/veil/can_cast(mob/living/user = usr, charge_check = TRUE, show_message = FALSE)
+	if(user.incorporeal_move == 1)
+		return FALSE
+	. = ..()
 
 /obj/effect/proc_holder/spell/aoe_turf/veil/cast(list/targets, mob/user = usr)
 	if(!shadowling_check(user))
@@ -175,6 +177,11 @@
 	clothes_req = 0
 	action_icon_state = "icy_veins"
 
+/obj/effect/proc_holder/spell/aoe_turf/flashfreeze/can_cast(mob/living/user = usr, charge_check = TRUE, show_message = FALSE)
+	if(user.incorporeal_move == 1)
+		return FALSE
+	. = ..()
+
 /obj/effect/proc_holder/spell/aoe_turf/flashfreeze/cast(list/targets, mob/user = usr)
 	if(!shadowling_check(user))
 		charge_counter = charge_max
@@ -214,10 +221,10 @@
 	selection_deactivated_message	= "<span class='notice'>Your mind relaxes.</span>"
 	allowed_type = /mob/living/carbon/human
 
-/obj/effect/proc_holder/spell/targeted/click/enthrall/can_cast(mob/user = usr, charge_check = TRUE, show_message = FALSE)
-	if(enthralling || !shadowling_check(user))
+/obj/effect/proc_holder/spell/targeted/click/enthrall/can_cast(mob/living/user = usr, charge_check = TRUE, show_message = FALSE)
+	if(enthralling || user.incorporeal_move == 1)
 		return FALSE
-	return ..()
+	. = ..()
 
 /obj/effect/proc_holder/spell/targeted/click/enthrall/valid_target(mob/living/carbon/human/target, user)
 	if(!..())
@@ -310,6 +317,11 @@
 	var/reviveThrallAcquired
 	action_icon_state = "collective_mind"
 
+/obj/effect/proc_holder/spell/targeted/collective_mind/can_cast(mob/living/user = usr, charge_check = TRUE, show_message = FALSE)
+	if(user.incorporeal_move == 1)
+		return FALSE
+	. = ..()
+
 /obj/effect/proc_holder/spell/targeted/collective_mind/cast(list/targets, mob/user = usr)
 	if(!shadowling_check(user))
 		charge_counter = charge_max
@@ -385,6 +397,11 @@
 	include_user = 1
 	action_icon_state = "black_smoke"
 
+/obj/effect/proc_holder/spell/targeted/blindness_smoke/can_cast(mob/living/user = usr, charge_check = TRUE, show_message = FALSE)
+	if(user.incorporeal_move == 1)
+		return FALSE
+	. = ..()
+
 /obj/effect/proc_holder/spell/targeted/blindness_smoke/cast(list/targets, mob/user = usr) //Extremely hacky
 	if(!shadowling_check(user))
 		charge_counter = charge_max
@@ -434,6 +451,11 @@
 	clothes_req = 0
 	action_icon_state = "screech"
 
+/obj/effect/proc_holder/spell/aoe_turf/unearthly_screech/can_cast(mob/living/user = usr, charge_check = TRUE, show_message = FALSE)
+	if(user.incorporeal_move == 1)
+		return FALSE
+	. = ..()
+
 /obj/effect/proc_holder/spell/aoe_turf/unearthly_screech/cast(list/targets, mob/user = usr)
 	if(!shadowling_check(user))
 		charge_counter = charge_max
@@ -470,6 +492,11 @@
 	charge_max = 600
 	clothes_req = FALSE
 	action_icon_state = "null_charge"
+
+/obj/effect/proc_holder/spell/aoe_turf/null_charge/can_cast(mob/living/user = usr, charge_check = TRUE, show_message = FALSE)
+	if(user.incorporeal_move == 1)
+		return FALSE
+	. = ..()
 
 /obj/effect/proc_holder/spell/aoe_turf/null_charge/cast(mob/user = usr)
 	if(!shadowling_check(user))
@@ -531,10 +558,10 @@
 	selection_deactivated_message	= "<span class='notice'>Your mind relaxes.</span>"
 	allowed_type = /mob/living/carbon/human
 
-/obj/effect/proc_holder/spell/targeted/click/reviveThrall/can_cast(mob/user = usr)
-	if(!shadowling_check(user))
+/obj/effect/proc_holder/spell/targeted/click/reviveThrall/can_cast(mob/living/user = usr, charge_check = TRUE, show_message = FALSE)
+	if(user.incorporeal_move == 1)
 		return FALSE
-	return ..()
+	. = ..()
 
 /obj/effect/proc_holder/spell/targeted/click/reviveThrall/valid_target(mob/living/carbon/human/target, user)
 	if(!..())
@@ -621,18 +648,21 @@
 	action_icon_state = "extend_shuttle"
 	var/global/extendlimit = 0
 
-/obj/effect/proc_holder/spell/targeted/click/shadowling_extend_shuttle/can_cast(mob/user = usr, charge_check = TRUE, show_message = FALSE)
+/obj/effect/proc_holder/spell/targeted/click/shadowling_extend_shuttle/can_cast(mob/living/user = usr, charge_check = TRUE, show_message = FALSE)
+	if(user.incorporeal_move == 1)
+		return FALSE
+	. = ..()
+
+/obj/effect/proc_holder/spell/targeted/click/shadowling_extend_shuttle/cast_check(charge_check = TRUE, start_recharge = TRUE, mob/living/user)
 	if(!shadowling_check(user))
 		return FALSE
 	if(extendlimit == 1)
-		if(show_message)
-			to_chat(user, "<span class='warning'>Shuttle was already delayed.</span>")
+		to_chat(user, "<span class='warning'>Shuttle was already delayed.</span>")
 		return FALSE
 	if(SSshuttle.emergency.mode != SHUTTLE_CALL)
-		if(show_message)
-			to_chat(user, "<span class='warning'>The shuttle must be inbound only to the station.</span>")
+		to_chat(user, "<span class='warning'>The shuttle must be inbound only to the station.</span>")
 		return FALSE
-	return ..()
+	. = ..()
 
 /obj/effect/proc_holder/spell/targeted/click/shadowling_extend_shuttle/valid_target(mob/living/carbon/human/target, user)
 	if(!..())

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -24,7 +24,7 @@
 	var/last_special = 0 //Used by the resist verb, likely used to prevent players from bypassing next_move by logging in/out.
 
 	//Allows mobs to move through dense areas without restriction. For instance, in space or out of holder objects.
-	var/incorporeal_move = 0 //0 is off, 1 is normal, 2 is for ninjas.
+	var/incorporeal_move = INCORPOREAL_NONE
 
 	var/now_pushing = null
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -210,10 +210,10 @@
 		return
 	var/mob/living/L = mob
 	switch(L.incorporeal_move)
-		if(1)
+		if(INCORPOREAL_NORMAL)
 			L.forceMove(get_step(L, direct))
 			L.dir = direct
-		if(2)
+		if(INCORPOREAL_NINJA)
 			if(prob(50))
 				var/locx
 				var/locy
@@ -253,7 +253,7 @@
 				new /obj/effect/temp_visual/dir_setting/ninja/shadow(mobloc, L.dir)
 				L.forceMove(get_step(L, direct))
 			L.dir = direct
-		if(3) //Incorporeal move, but blocked by holy-watered tiles
+		if(INCORPOREAL_REVENANT) //Incorporeal move, but blocked by holy-watered tiles
 			var/turf/simulated/floor/stepTurf = get_step(L, direct)
 			if(stepTurf.flags & NOJAUNT)
 				to_chat(L, "<span class='warning'>Святые силы блокируют ваш путь.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Добавлены проверки can_cast к способностям.
Передвигает проверку на джаунт с прока shadowling_check на проки can_cast.
Добавляет проверки на джаунт у can_cast к способностям, что не могут быть использованы во время него.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Удаление спам-атаки, что ломала клиенты во время джаунта, что гарантировало бесславную смерть тенелинга. Также более понятно, какие способности нельзя использовать во время джаунта

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Затемнены способности во время джаунта тенелинга, которые не могут быть использованы во время него
fix: Исправлена спам-атака чата во время джаунта тенелинга
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
