### PR TITLE
feat: Removes altclick/statpanel lag when not trying to look at turf contents

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -332,6 +332,9 @@
 		..()
 
 /atom/proc/AltClick(var/mob/user)
+	return
+
+/atom/proc/turf_examine(var/mob/user)
 	var/turf/T = get_turf(src)
 	if(T)
 		if(user.TurfAdjacent(T))

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -656,3 +656,7 @@ Class Procs:
 	. = . % 9
 	AM.pixel_x = -8 + ((.%3)*8)
 	AM.pixel_y = -8 + (round( . / 3)*8)
+
+/obj/machinery/AltClick(mob/user)
+	turf_examine(user)
+	. = ..()

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -265,6 +265,10 @@
 					C.add_delayedload(C.newavail() * 0.0375) // you can gain up to 3.5 via the 4x upgrades power is halved by the pole so thats 2x then 1X then .5X for 3.5x the 3 bounces shock.
 	return ..()
 
+/obj/structure/grille/AltClick(mob/user)
+	turf_examine(user)
+	. = ..()
+
 /obj/structure/grille/broken // Pre-broken grilles for map placement
 	icon_state = "brokengrille"
 	density = 0

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -94,6 +94,10 @@
 		new /obj/item/stack/sheet/plastic/five(loc)
 	qdel(src)
 
+/obj/structure/plasticflaps/AltClick(mob/user)
+	turf_examine(user)
+	. = ..()
+
 /obj/structure/plasticflaps/mining //A specific type for mining that doesn't allow airflow because of them damn crates
 	name = "airtight plastic flaps"
 	desc = "Heavy duty, airtight, plastic flaps."

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -287,6 +287,10 @@
 			return 0
 	return T.straight_table_check(direction)
 
+/obj/structure/table/AltClick(mob/user)
+	turf_examine(user)
+	. = ..()
+
 /obj/structure/table/verb/do_flip()
 	set name = "Flip table"
 	set desc = "Flips a non-reinforced table"

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -523,3 +523,7 @@
 
 /turf/proc/water_act(volume, temperature, source)
  	return FALSE
+
+/turf/AltClick(mob/user)
+	turf_examine(user)
+	. = ..()

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -95,6 +95,9 @@
 	else
 		icon_state = "book-5"
 
+/obj/structure/bookcase/AltClick(mob/user)
+	turf_examine(user)
+	. = ..()
 
 /obj/structure/bookcase/manuals/medical
 	name = "Medical Manuals bookcase"

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -75,6 +75,7 @@
 
 // flip and rotate verbs
 /obj/structure/disposalconstruct/verb/rotate()
+	set category = "Object"
 	set name = "Rotate Pipe"
 	set src in view(1)
 
@@ -97,6 +98,7 @@
 	rotate()
 
 /obj/structure/disposalconstruct/verb/flip()
+	set category = "Object"
 	set name = "Flip Pipe"
 	set src in view(1)
 	if(usr.stat)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Удаляет функционал по умолчанию на альт-клик для осмотра содержимого турфа.
Добавляет функционал на альт-клик для осмотра содержимого турфа для турфа и объектов, что скрывают его, такие как:
- Книжный шкаф
- Машины
- Пластиковые рамки
- Столы
- Решетки

Тем самым уменьшается количество лагов, например:
- При открытии контейнера
- Использовании второстепенного действия на объекте, например запирание шкафов

Также была добавлена категория для вербов мусорных труб, что вызывало лаг при проходе рядом с несобранными.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Меньше лагов, больше удовольствия

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
del: Altclick functional from /atom
add: Altclick functional to turf and some objects covering it
fix: Added category for disposal pipes which were lagging statpanel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
