### PR TITLE
Altclick revert fix

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -319,7 +319,6 @@ Pipelines + Other Objects -> Pipe network
 	if(is_type_in_list(src, GLOB.ventcrawl_machinery))
 		L.handle_ventcrawl(src)
 		return
-	..()
 
 /obj/machinery/atmospherics/proc/can_crawl_through()
 	return 1

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -332,7 +332,7 @@
 		..()
 
 /atom/proc/AltClick(var/mob/user)
-	return
+	turf_examine(user)
 
 /atom/proc/turf_examine(var/mob/user)
 	var/turf/T = get_turf(src)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -656,7 +656,3 @@ Class Procs:
 	. = . % 9
 	AM.pixel_x = -8 + ((.%3)*8)
 	AM.pixel_y = -8 + (round( . / 3)*8)
-
-/obj/machinery/AltClick(mob/user)
-	turf_examine(user)
-	. = ..()

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -563,8 +563,6 @@ REAGENT SCANNER
 	add_fingerprint(user)
 
 /obj/item/analyzer/AltClick(mob/user) //Barometer output for measuring when the next storm happens
-	..()
-
 	if(!user.incapacitated() && Adjacent(user))
 
 		if(cooldown)

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -86,7 +86,6 @@
 /obj/item/storage/secure/AltClick(mob/user)
 	if(!try_to_open())
 		return FALSE
-	return ..()
 
 /obj/item/storage/secure/MouseDrop(over_object, src_location, over_location)
 	if(!try_to_open())

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -93,7 +93,6 @@
 		add_fingerprint(user)
 	else if(isobserver(user))
 		show_to(user)
-	return ..()
 
 /obj/item/storage/proc/return_inv()
 	var/list/L = list()

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -70,7 +70,6 @@
 	togglelock(user)
 
 /obj/structure/closet/secure_closet/AltClick(mob/user)
-	..()
 	if(Adjacent(user))
 		togglelock(user)
 

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -265,10 +265,6 @@
 					C.add_delayedload(C.newavail() * 0.0375) // you can gain up to 3.5 via the 4x upgrades power is halved by the pole so thats 2x then 1X then .5X for 3.5x the 3 bounces shock.
 	return ..()
 
-/obj/structure/grille/AltClick(mob/user)
-	turf_examine(user)
-	. = ..()
-
 /obj/structure/grille/broken // Pre-broken grilles for map placement
 	icon_state = "brokengrille"
 	density = 0

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -94,10 +94,6 @@
 		new /obj/item/stack/sheet/plastic/five(loc)
 	qdel(src)
 
-/obj/structure/plasticflaps/AltClick(mob/user)
-	turf_examine(user)
-	. = ..()
-
 /obj/structure/plasticflaps/mining //A specific type for mining that doesn't allow airflow because of them damn crates
 	name = "airtight plastic flaps"
 	desc = "Heavy duty, airtight, plastic flaps."

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -118,7 +118,6 @@
 
 
 /obj/structure/reflector/AltClick(mob/user)
-	..()
 	if(user.incapacitated())
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -287,10 +287,6 @@
 			return 0
 	return T.straight_table_check(direction)
 
-/obj/structure/table/AltClick(mob/user)
-	turf_examine(user)
-	. = ..()
-
 /obj/structure/table/verb/do_flip()
 	set name = "Flip table"
 	set desc = "Flips a non-reinforced table"

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -323,7 +323,6 @@
 	return TRUE
 
 /obj/structure/windoor_assembly/AltClick(mob/user)
-	..()
 	if(user.incapacitated())
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -523,7 +523,3 @@
 
 /turf/proc/water_act(volume, temperature, source)
  	return FALSE
-
-/turf/AltClick(mob/user)
-	turf_examine(user)
-	. = ..()

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -25,7 +25,6 @@
 	adjustmask(user)
 
 /obj/item/clothing/mask/breath/AltClick(mob/user)
-	..()
 	if( (!in_range(src, user)) || user.stat || user.restrained() )
 		return
 	adjustmask(user)

--- a/code/modules/food_and_drinks/drinks/drinks/cans.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/cans.dm
@@ -70,7 +70,6 @@
 				handle_bursting(user)
 	else
 		to_chat(H, "<span class='warning'>You need to hold [src] in order to shake it.</span>")
-	return ..()
 
 /obj/item/reagent_containers/food/drinks/cans/attack(mob/M, mob/user, proximity)
 	if(!canopened)

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -117,7 +117,6 @@
 	if(wrenchable && !usr.stat && !usr.lying && Adjacent(usr))
 		toggle_lid(usr)
 		return
-	return ..()
 
 /obj/machinery/hydroponics/proc/toggle_lid(mob/living/user)
 	if(!user || user.stat || user.restrained())
@@ -371,7 +370,7 @@
 	if(weedlevel >= 5)
 		. += "<span class='warning'>[src] is filled with weeds!</span>"
 	if(pestlevel >= 5)
-		. += "<span class='warning'>[src] is filled with tiny worms!</span>"  	
+		. += "<span class='warning'>[src] is filled with tiny worms!</span>"
 	. += "" // Empty line for readability.
 
 

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -95,10 +95,6 @@
 	else
 		icon_state = "book-5"
 
-/obj/structure/bookcase/AltClick(mob/user)
-	turf_examine(user)
-	. = ..()
-
 /obj/structure/bookcase/manuals/medical
 	name = "Medical Manuals bookcase"
 

--- a/code/modules/newscaster/obj/newspaper.dm
+++ b/code/modules/newscaster/obj/newspaper.dm
@@ -179,7 +179,6 @@
 		user.visible_message("<span class='notice'>[user] [verbtext]s [src].</span>",\
 								"<span class='notice'>You [verbtext] [src].</span>")
 		name = "[rolled ? "rolled" : ""] [initial(name)]"
-	return ..()
 
 #undef SCREEN_COVER
 #undef SCREEN_PAGE_INNER

--- a/code/modules/paperwork/paperplane.dm
+++ b/code/modules/paperwork/paperplane.dm
@@ -115,8 +115,6 @@
 		I = H.is_in_hands(/obj/item/paper)
 		if(I)
 			ProcFoldPlane(H, I)
-	else
-		..()
 
 /obj/item/paper/proc/ProcFoldPlane(mob/living/carbon/user, obj/item/I)
 	if(istype(user))

--- a/code/modules/pda/PDA.dm
+++ b/code/modules/pda/PDA.dm
@@ -158,7 +158,6 @@ GLOBAL_LIST_EMPTY(PDAs)
 		to_chat(usr, "<span class='notice'>You cannot do this while restrained.</span>")
 
 /obj/item/pda/AltClick(mob/user)
-	..()
 	if(issilicon(user))
 		return
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -414,7 +414,6 @@
 		azoom.Remove(user)
 
 /obj/item/gun/AltClick(mob/user)
-	..()
 	if(user.incapacitated())
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -345,6 +345,7 @@
 	playsound(user, 'sound/weapons/gun_interactions/selector.ogg', 100, 1)
 
 /obj/item/gun/projectile/shotgun/automatic/dual_tube/AltClick(mob/living/user)
+	. = ..()
 	if(user.incapacitated() || !Adjacent(user) || !istype(user))
 		return
 	pump()

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -333,7 +333,6 @@
 //Feeds a potion to slime
 /mob/living/simple_animal/slime/AltClick(mob/user)
 	SEND_SIGNAL(user, COMSIG_XENO_SLIME_CLICK_ALT, src)
-	..()
 
 //Picks up slime
 /mob/living/simple_animal/slime/ShiftClick(mob/user)

--- a/code/modules/vehicle/vehicle.dm
+++ b/code/modules/vehicle/vehicle.dm
@@ -79,7 +79,6 @@
 		inserted_key.forceMove(drop_location())
 		user.put_in_hands(inserted_key)
 		inserted_key = null
-	return ..()
 
 /obj/vehicle/proc/is_key(obj/item/I)
 	return I ? (key_type_exact ? (I.type == key_type) : istype(I, key_type)) : FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Возвращает действие на альтклик на действие по умолчанию (осмотр турфа)
Убирает осмотр турфа у специальных альт-клик действий, такие как открытие контейнера, запирание шкафа и другие.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Не все случаи были учтены при прошлом ПРе.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
del: AltClick examine_turf proc from AltClick with special actions
tweak: Reverted base AltClick examine_turf proc
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
