### PR TITLE
Tweak: Instruments changes for cyborgs Generalist module

### DIFF
--- a/code/modules/mining/equipment/mineral_scanner.dm
+++ b/code/modules/mining/equipment/mineral_scanner.dm
@@ -56,7 +56,6 @@
 	cooldown = 50
 	flags = CONDUCT | NODROP
 
-
 /obj/item/t_scanner/adv_mining_scanner/scan()
 	if(current_cooldown <= world.time)
 		current_cooldown = world.time + cooldown

--- a/code/modules/mining/equipment/mineral_scanner.dm
+++ b/code/modules/mining/equipment/mineral_scanner.dm
@@ -52,6 +52,11 @@
 	range = 4
 	cooldown = 50
 
+/obj/item/mining_scanner/cyborg
+	cooldown = 50
+	flags = CONDUCT | NODROP
+
+
 /obj/item/t_scanner/adv_mining_scanner/scan()
 	if(current_cooldown <= world.time)
 		current_cooldown = world.time + cooldown

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -160,29 +160,38 @@
 
 /obj/item/robot_module/standard/New()
 	..()
-	modules += new /obj/item/stack/sheet/metal/cyborg(src)
-	modules += new /obj/item/stack/cable_coil/cyborg(src)
-	modules += new /obj/item/stack/rods/cyborg(src)
-	modules += new /obj/item/stack/tile/plasteel/cyborg(src)
+	modules += new /obj/item/extinguisher/mini(src) // for firefighting, and propulsion in space
+	modules += new /obj/item/crowbar/cyborg(src)
 	modules += new /obj/item/gps/cyborg(src)
 	// sec
 	modules += new /obj/item/restraints/handcuffs/cable/zipties/cyborg(src)
+	modules += new /obj/item/melee/classic_baton/telescopic(src) // for minimal possablity to execute sec part of the module and also for tests
 	// janitorial
 	modules += new /obj/item/soap/nanotrasen(src)
 	modules += new /obj/item/lightreplacer/cyborg(src)
+	modules += new /obj/item/reagent_containers/spray/cleaner/drone(src) // test if will be in active usage and become op to be cutted out later
+	// service
+	modules += new /obj/item/instrument/piano_synth(src) // added for minimal service part
 	// eng
-	modules += new /obj/item/crowbar/cyborg(src)
+	modules += new /obj/item/stack/sheet/metal/cyborg(src)
+	modules += new /obj/item/stack/sheet/glass/cyborg(src) // regular glass for simplest works on broken window replacement
+	modules += new /obj/item/stack/cable_coil/cyborg(src)
+	modules += new /obj/item/stack/rods/cyborg(src)
+	modules += new /obj/item/stack/tile/plasteel/cyborg(src)
 	modules += new /obj/item/wrench/cyborg(src)
-	modules += new /obj/item/extinguisher(src) // for firefighting, and propulsion in space
-	modules += new /obj/item/weldingtool/largetank/cyborg(src)
+	modules += new /obj/item/screwdriver/cyborg(src) //added for minor works
+	modules += new /obj/item/weldingtool(src) //added instead of upgraded version
+	modules += new /obj/item/wirecutters/cyborg(src) //addded to be able cut at least its own placed wires and rods
 	// mining
-	modules += new /obj/item/pickaxe(src)
-	modules += new /obj/item/t_scanner/adv_mining_scanner(src)
+	modules += new /obj/item/pickaxe/drill/cyborg(src) // instead of the pickaxe the worst tool for mining anywhere but killing someone with it
+	modules += new /obj/item/mining_scanner/cyborg(src) // instead of advanced scanner, we have mining module already
 	modules += new /obj/item/storage/bag/ore/cyborg(src)
 	// med
 	modules += new /obj/item/healthanalyzer(src)
 	modules += new /obj/item/reagent_containers/borghypo/basic(src)
 	modules += new /obj/item/roller_holder(src) // for taking the injured to medbay without worsening their injuries or leaving a blood trail the whole way
+	modules += new /obj/item/handheld_defibrillator(src) // test if will be in active usage and become op to be cutted out later, instead of salbutomol
+
 	emag = new /obj/item/melee/energy/sword/cyborg(src)
 
 	fix_modules()


### PR DESCRIPTION
## What Does This PR Do
Adding and changing some insturments of cyborgs Generalist module.

Added: 
screwdriver, wirecutters, regular glass, 
telescopic batton, 
drone cleaner, 
handled deffib, 
piano-synth. 

Changed: 
pickaxe to drill, 
adv scanner to regular-manual one, 
upgraded weilding tool to regular one, 
regular extingusher to mini version. 

Some comments added. 

## Why It's Good For The Game
Made in purpose to rebalance and revive gameplay for generalist cyborg, to make it not so clumsy as it was.
