### PR TITLE
Fix: reinforced plasma glass now doesn't burn as usual glass

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -606,6 +606,7 @@ GLOBAL_LIST_INIT(wcCommon, pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e",
 	shardtype = /obj/item/shard/plasma
 	glass_type = /obj/item/stack/sheet/plasmarglass
 	reinf = TRUE
+    heat_resistance = 32000
 	max_integrity = 500
 	explosion_block = 2
 	armor = list("melee" = 85, "bullet" = 20, "laser" = 0, "energy" = 0, "bomb" = 60, "bio" = 100, "rad" = 100, "fire" = 99, "acid" = 100)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Reinforced plasma glass windows and usual plama glass windows now have the same heat resistance.

## Why It's Good For The Game
Reinforced plasma glass window was taking heat damage from temperatures over 800C when for usual plasma glass the number was 32000C. 

## Changelog
:cl:
fix: fixed wrong plasmarglass window heat resistance 
/:cl: