### PR TITLE
Feat: move from assassinate to prevent

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -628,8 +628,12 @@
 				else
 					to_chat(usr, "No active AIs with minds")
 
-			if("prevent")
+			if("kill all human")
 				new_objective = new /datum/objective/block
+				new_objective.owner = src
+
+			if("prevent from escaping alive")
+				new_objective = new /datum/objective/maroon
 				new_objective.owner = src
 
 			if("hijack")

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -104,17 +104,17 @@ GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","E
 		destroy_objective.find_target()
 		changeling.objectives += destroy_objective
 	else
-		var/datum/objective/assassinate/kill_objective = new
-		kill_objective.owner = changeling
-		kill_objective.find_target()
-		changeling.objectives += kill_objective
+		var/datum/objective/maroon/maroon_objective = new
+		maroon_objective.owner = changeling
+		maroon_objective.find_target()
+		changeling.objectives += maroon_objective
 
 		if(!(locate(/datum/objective/escape) in changeling.objectives))
 			var/datum/objective/escape/escape_with_identity/identity_theft = new
 			identity_theft.owner = changeling
-			identity_theft.target = kill_objective.target
+			identity_theft.target = maroon_objective.target
 			if(identity_theft.target && identity_theft.target.current)
-				identity_theft.target_real_name = kill_objective.target.current.real_name //Whoops, forgot this.
+				identity_theft.target_real_name = maroon_objective.target.current.real_name //Whoops, forgot this.
 				var/mob/living/carbon/human/H = identity_theft.target.current
 				if(can_absorb_species(H.dna.species)) // For species that can't be absorbed - should default to an escape objective
 					identity_theft.explanation_text = "Escape on the shuttle or an escape pod with the identity of [identity_theft.target_real_name], the [identity_theft.target.assigned_role] while wearing [identity_theft.target.p_their()] identification card."

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -130,7 +130,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 /datum/objective/maroon/find_target()
 	..()
 	if(target && target.current)
-		explanation_text = "Prevent [target.current.real_name], the [target.assigned_role] from escaping alive."
+		explanation_text = "Prevent from escaping alive or assassinate [target.current.real_name], the [target.assigned_role]."
 	else
 		explanation_text = "Free Objective"
 	return target

--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -148,10 +148,10 @@
 	blood_objective.gen_amount_goal(150, 400)
 	vampire.objectives += blood_objective
 
-	var/datum/objective/assassinate/kill_objective = new
-	kill_objective.owner = vampire
-	kill_objective.find_target()
-	vampire.objectives += kill_objective
+	var/datum/objective/maroon/maroon_objective = new
+	maroon_objective.owner = vampire
+	maroon_objective.find_target()
+	vampire.objectives += maroon_objective
 
 	var/datum/objective/steal/steal_objective = new
 	steal_objective.owner = vampire

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -202,7 +202,7 @@
 				assigned_targets.Add("[debrain_objective.target]")
 			add_objective(debrain_objective)
 
-		else if(prob(30))
+		else
 			var/datum/objective/maroon/maroon_objective = new
 			maroon_objective.owner = owner
 			maroon_objective.find_target()
@@ -211,16 +211,6 @@
 			else if(maroon_objective.target)
 				assigned_targets.Add("[maroon_objective.target]")
 			add_objective(maroon_objective)
-
-		else
-			var/datum/objective/assassinate/kill_objective = new
-			kill_objective.owner = owner
-			kill_objective.find_target()
-			if("[kill_objective.target]" in assigned_targets)
-				return 0
-			else if(kill_objective.target)
-				assigned_targets.Add("[kill_objective.target]")
-			add_objective(kill_objective)
 
 	else
 		var/datum/objective/steal/steal_objective = new


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Теперь генокраду, вампиру и предателю не выпадает цель "assassinate", вместо нее дает "prevent from escaping alive or assassinate". Добавил админам кнопку для добавления цели на превент, и сделал нормальное название цели для малфа.
## Why It's Good For The Game
Предложка + здравый смысл. https://discord.com/channels/617003227182792704/755125334097133628/999021404404060170

## Changelog
:cl:
tweak: now antags gets prevent target instead of assasinate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
