### PR TITLE
Hotfix: black carpet and chairs craft

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -91252,8 +91252,8 @@
 	},
 /area/security/permahallway)
 "onr" = (
-/obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/decal/warning_stripes/southeast,
+/obj/machinery/suit_storage_unit/rd/secure,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "onT" = (
@@ -95512,9 +95512,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/gambling_den)
 "pnT" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
@@ -113706,8 +113703,14 @@
 	},
 /area/library)
 "tCB" = (
-/turf/simulated/floor/plating,
-/area/medical/surgery/south)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/central/sw)
 "tCM" = (
 /obj/machinery/camera{
 	c_tag = "Virology Maintance Access";
@@ -167679,14 +167682,14 @@ eJR
 gtP
 umX
 dvf
-eJR
+igj
 eJR
 eRU
 dRB
 dWK
 gfQ
 pnT
-gfQ
+tCB
 ctL
 gfQ
 cwL
@@ -177226,7 +177229,7 @@ vNi
 tyJ
 vNi
 qsc
-tCB
+qwC
 qwC
 gJf
 mtL

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -17,8 +17,7 @@
 GLOBAL_LIST_INIT(metal_recipes, list(
 	new /datum/stack_recipe("stool", /obj/structure/chair/stool, one_per_turf = 1, on_floor = 1),
 	new /datum/stack_recipe("barstool", /obj/structure/chair/stool/bar, one_per_turf = 1, on_floor = 1),
-	new /datum/stack_recipe("chair (dark)", /obj/structure/chair, one_per_turf = 1, on_floor = 1),
-	new /datum/stack_recipe("chair (light)", /obj/structure/chair/light, one_per_turf = 1, on_floor = 1),
+	new /datum/stack_recipe("chair", /obj/structure/chair, one_per_turf = 1, on_floor = 1),
 	new /datum/stack_recipe("shuttle seat", /obj/structure/chair/comfy/shuttle, 2, one_per_turf = 1, on_floor = 1),
 	new /datum/stack_recipe_list("sofas", list(
 		new /datum/stack_recipe("sofa (middle)", /obj/structure/chair/sofa, 1, one_per_turf = TRUE, on_floor = TRUE),

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -141,11 +141,6 @@
 	rotate()
 
 // CHAIR TYPES
-/obj/structure/chair/light
-	name = "chair"
-	icon_state = "chair_greyscale"
-	resistance_flags = FLAMMABLE
-	item_chair = /obj/item/chair/light
 
 /obj/structure/chair/wood
 	name = "wooden chair"
@@ -372,9 +367,6 @@
 	var/break_chance = 5 //Likely hood of smashing the chair.
 	var/obj/structure/chair/origin_type = /obj/structure/chair
 
-/obj/item/chair/light
-	icon_state = "chair_greyscale_toppled"
-	origin_type = /obj/structure/chair/light
 
 /obj/item/chair/stool
 	name = "stool"

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -346,7 +346,7 @@
 	result = /obj/item/stack/tile/carpet/black
 	time = 10
 	reqs = list(/obj/item/stack/tile/carpet = 1)
-	pathtools = list(/obj/item/toy/crayon/black)
+	pathtools = list(/obj/item/toy/crayon)
 	category = CAT_MISC
 
 /datum/crafting_recipe/bluecarpet


### PR DESCRIPTION
Fix на ПР #1093
Исправил крафт черного ковра на изначальный
Удалил незапланированную версию стула без спрайта