### PR TITLE
Feat: Added the ability to attach and detach the frame with wires

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -121,6 +121,15 @@
 				var/obj/item/stack/cable_coil/A = new /obj/item/stack/cable_coil(src.loc,5)
 				A.amount = 5
 				return
+			if(istype(P, /obj/item/wrench))
+				playsound(src.loc, P.usesound, 75, 1)
+				if(anchored == 1)
+					to_chat(user, "<span class='notice'>You have detached the frame</span>")
+					anchored = 0
+				else
+					to_chat(user, "<span class='notice'>You have secured the frame</span>")
+					anchored = 1
+				return
 		if(3)
 			if(istype(P, /obj/item/crowbar))
 				playsound(src.loc, P.usesound, 50, 1)


### PR DESCRIPTION
 ## What Does This PR Do
Добавил возможность откручивать и перемещать фрейм с проводами

![contruct](https://user-images.githubusercontent.com/50821472/180650428-6713b05f-90db-4701-995e-7852b276c4cc.gif)

## Why It's Good For The Game
Это просто удобно. Не придется полностью разбирать фрейм, чтобы его перенести. Достаточно воспользоваться гаечным ключом


## Changelog
🆑
Feat: Added the ability to attach and detach the frame with wires
/🆑