### PR TITLE
tweak: Небольшое обновление системы шаттлов

### DIFF
--- a/code/modules/shuttle/ert.dm
+++ b/code/modules/shuttle/ert.dm
@@ -25,6 +25,4 @@
 	y_offset = 0
 	resistance_flags = INDESTRUCTIBLE
 	flags = NODECONSTRUCT
-	access_tcomms = FALSE
-	access_construction = FALSE
 	access_mining = FALSE

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -10,11 +10,12 @@
 	var/shuttlePortId = ""
 	var/shuttlePortName = "custom location"
 	var/list/jumpto_ports = list() //list of ports to jump to
-	var/access_station = TRUE //can we park near X?
-	var/access_tcomms = TRUE
-	var/access_construction = TRUE
-	var/access_mining = TRUE
-	var/access_derelict = FALSE
+	var/access_station = TRUE 		//can we park near station?
+	var/access_admin_zone = FALSE	//can we park on Admin z_lvls?
+	var/access_mining = FALSE		//can we park on Lavaland z_lvl?
+	var/access_taipan = FALSE 		//can we park on Taipan z_lvl?
+	var/access_away = FALSE 		//can we park on Away_Mission z_lvl?
+	var/access_derelict = FALSE		//can we park in Unexplored Space?
 	var/obj/docking_port/stationary/my_port //the custom docking port placed by this console
 	var/obj/docking_port/mobile/shuttle_port //the mobile docking port of the connected shuttle
 	var/view_range = 7
@@ -28,14 +29,26 @@
 /obj/machinery/computer/camera_advanced/shuttle_docker/Initialize()
 	. = ..()
 	GLOB.navigation_computers += src
-	if(access_station)
-		jumpto_ports += list("nav_z1" = 1)
-	if(access_tcomms)
-		jumpto_ports += list("nav_z3" = 1)
-	if(access_mining)
-		jumpto_ports += list("nav_z5" = 1)
-	if(access_derelict)
-		jumpto_ports += list("nav_z6" = 1)
+	CalculateAvailable_z_lvls()
+
+/obj/machinery/computer/camera_advanced/shuttle_docker/proc/CalculateAvailable_z_lvls() //Вынесла в отдельный прок, для удобства работы с VV
+	jumpto_ports = list()
+	var/list/levels = GLOB.space_manager.z_list.Copy()
+	var/iterator = 1
+	for(var/level in levels)
+		if(access_station && is_station_level(level))
+			jumpto_ports += list("nav_z[num2text(iterator)]" = 1)
+		else if(access_admin_zone && is_admin_level(level))
+			jumpto_ports += list("nav_z[num2text(iterator)]" = 1)
+		else if(access_mining && is_mining_level(level))
+			jumpto_ports += list("nav_z[num2text(iterator)]" = 1)
+		else if(access_taipan && is_taipan(level))
+			jumpto_ports += list("nav_z[num2text(iterator)]" = 1)
+		else if(access_away && is_away_level(level))
+			jumpto_ports += list("nav_z[num2text(iterator)]" = 1)
+		else if(access_derelict && is_explorable_space(level))
+			jumpto_ports += list("nav_z[num2text(iterator)]" = 1)
+		iterator++
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/Destroy()
 	. = ..()
@@ -151,6 +164,10 @@
 		my_port.register()
 	my_port.setDir(the_eye.dir)
 	my_port.forceMove(locate(eyeobj.x - x_offset, eyeobj.y - y_offset, eyeobj.z))
+	if(is_mining_level(my_port.z))
+		my_port.turf_type = /turf/simulated/floor/plating/lava/smooth/lava_land_surface
+	else
+		my_port.turf_type  =/turf/space
 	if(current_user.client)
 		current_user.client.images -= the_eye.placed_images
 
@@ -234,7 +251,7 @@
 
 	if(space_turfs_only)
 		var/turf_type = hidden_turf_info ? hidden_turf_info[2] : T.type
-		if(!ispath(turf_type, /turf/space))
+		if(!ispath(turf_type, /turf/space) && !is_mining_level(T.z))
 			return SHUTTLE_DOCKER_BLOCKED
 
 	if(istype(T.loc.type, /area/syndicate_depot))
@@ -279,7 +296,7 @@
 	return ..()
 
 /mob/camera/aiEye/remote/shuttle_docker/setLoc(T)
-	if(istype(get_turf(T), /turf/space) || istype(get_area(T), /area/space) || istype(get_area(T), /area/shuttle))
+	if(/*istype(get_turf(T), /turf/space) ||*/ istype(get_area(T), /area/space) || istype(get_area(T), /area/shuttle) ||  istype(get_area(T), /area/lavaland) || istype(get_area(T), /area/ruin))
 		..()
 		var/obj/machinery/computer/camera_advanced/shuttle_docker/console = origin
 		console.checkLandingSpot()

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -928,9 +928,12 @@
 	x_offset = 0
 	y_offset = 0
 	resistance_flags = INDESTRUCTIBLE
-	access_tcomms = TRUE
-	access_construction = TRUE
-	access_mining = TRUE
+	space_turfs_only = FALSE
+	access_admin_zone = TRUE	//can we park on Admin z_lvls?
+	access_mining = TRUE		//can we park on Lavaland z_lvl?
+	access_taipan = TRUE 		//can we park on Taipan z_lvl?
+	access_away = TRUE 		//can we park on Away_Mission z_lvl?
+	access_derelict = TRUE		//can we park in Unexplored Space?
 
 /obj/machinery/computer/shuttle/trade
 	name = "Freighter Console"

--- a/code/modules/shuttle/syndicate.dm
+++ b/code/modules/shuttle/syndicate.dm
@@ -76,6 +76,12 @@
 	y_offset = -1
 	see_hidden = TRUE
 	resistance_flags = INDESTRUCTIBLE
+	access_station = TRUE 		//can we park near station?
+	access_admin_zone = FALSE	//can we park on Admin z_lvls?
+	access_mining = FALSE		//can we park on Lavaland z_lvl?
+	access_taipan = FALSE 		//can we park on Taipan z_lvl?
+	access_away = FALSE 		//can we park on Away_Mission z_lvl?
+	access_derelict = FALSE		//can we park in Unexplored Space?
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/sst
 	name = "SST shuttle navigation computer"
@@ -86,6 +92,7 @@
 	view_range = 13
 	x_offset = 0
 	y_offset = 0
+	access_taipan = TRUE
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/sit
 	name = "SIT shuttle navigation computer"
@@ -96,5 +103,6 @@
 	view_range = 13
 	x_offset = 0
 	y_offset = 0
+	access_taipan = TRUE
 
 #undef SYNDICATE_CHALLENGE_TIMER

--- a/code/modules/shuttle/vox.dm
+++ b/code/modules/shuttle/vox.dm
@@ -18,4 +18,9 @@
 	y_offset = -10
 	resistance_flags = INDESTRUCTIBLE
 	flags = NODECONSTRUCT
-	access_derelict = TRUE
+	access_station = TRUE 		//can we park near station?
+	access_admin_zone = FALSE	//can we park on Admin z_lvls?
+	access_mining = FALSE		//can we park on Lavaland z_lvl?
+	access_taipan = FALSE 		//can we park on Taipan z_lvl?
+	access_away = FALSE 		//can we park on Away_Mission z_lvl?
+	access_derelict = FALSE		//can we park in Unexplored Space?

--- a/code/modules/space_management/level_traits.dm
+++ b/code/modules/space_management/level_traits.dm
@@ -28,6 +28,9 @@
 /proc/level_boosts_signal(z)
 	return check_level_trait(z, BOOSTS_SIGNAL)
 
+/proc/is_explorable_space(z)
+	return check_level_trait(z, SPAWN_RUINS)
+
 /proc/is_taipan(z)
 	return check_level_trait(z, TAIPAN)
 


### PR DESCRIPTION
## What Does This PR Do
* Добавляет более современные проверки с учётом существующих z лвлов, а не несуществующего более астероида
* Админский шатл получает право летать на любой з лвл и приземляться пробивая станцию. (На то он и админский)
* Потенциально добавляет возможность позволить любому шаттлу исследовать космос или прилетать туда, куда раньше попасть нельзя было, если консолям поставить соответствующие разрешения на TRUE и обновить доступные для полёта зоны вызовом прока CalculateAvailable_z_lvls()
* Так же из важного -  закомментила ограничение istype(get_turf(T), /turf/space) не позволявшее глазу шаттла ходить по клеткам НЕ космоса. Потому что иначе шаттл не приземлить на том же лаваленде при наличии права туда летать. Это всё ещё не даст тем же нюкерам приземлить шаттл где попало. Но добавит чуть больше мобильности при выборе позиции для точки прилёта шаттла
## Скриншот появившихся зон после изменений(Админский шаттл)
![2022-07-27_01-17-06](https://user-images.githubusercontent.com/67807868/181121852-1043b555-ebc4-4b24-bd39-c75df7070ee6.png)
## Скриншот зон полёта шаттла нюки
Для демонстрации того, что были убраны ненужные кнопки в списке. Как например кнопка полёта на лаваленд(Которая не работала раньше)
![2022-07-27_01-18-57](https://user-images.githubusercontent.com/67807868/181122182-651bf2f2-44cb-4c10-8766-aab889b709a6.png)

