### PR TITLE
fix: Add call of UnlinkSelf proc to hide clockwork borg from robot control console

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -472,6 +472,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 			status_flags &= ~CANPUSH
 			QDEL_NULL(mmi)
 			mmi = new /obj/item/mmi/robotic_brain/clockwork(src)
+			UnlinkSelf()
 
 	//languages
 	module.add_languages(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes Ratvarian borgs from robot control console. By addition removes any AI linking.

## Why It's Good For The Game
Hacked by Midas Touch borgs are already removed from console, so it's weird that totally ratvarian borgs can be locked or detonated by crew. Now this won't be possible and brass borgs won't be useless.

## Changelog
:cl:
add: Add call of UnlinkSelf() proc when ratvarian borg has chosen its module.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
