### PR TITLE
Feat:Spacebattle gateway rework

### DIFF
--- a/_maps/map_files/RandomZLevels/spacebattle.dmm
+++ b/_maps/map_files/RandomZLevels/spacebattle.dmm
@@ -584,7 +584,7 @@
 /area/awaymission/spacebattle/storage)
 "bF" = (
 /mob/living/simple_animal/hostile/syndicate/ranged/space{
-	health = 300
+	maxHealth = 300
 	},
 /turf/space,
 /area/space)
@@ -725,7 +725,8 @@
 /area/awaymission/spacebattle/cruiser)
 "cc" = (
 /mob/living/simple_animal/hostile/syndicate/ranged{
-	health = 300
+	health = 300;
+	maxHealth = 300
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -762,7 +763,10 @@
 	},
 /area/awaymission/spacebattle/medbay)
 "ch" = (
-/mob/living/simple_animal/hostile/syndicate/melee/space,
+/mob/living/simple_animal/hostile/syndicate/melee/space{
+	health = 400;
+	maxHealth = 400
+	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
 "ci" = (
@@ -815,7 +819,8 @@
 /area/awaymission/spacebattle/cruiser)
 "cr" = (
 /mob/living/simple_animal/hostile/syndicate/melee{
-	health = 400
+	health = 400;
+	maxHealth = 400
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/sec_storage)
@@ -922,7 +927,8 @@
 /area/awaymission/spacebattle/cruiser)
 "cL" = (
 /mob/living/simple_animal/hostile/syndicate/ranged{
-	health = 300
+	health = 300;
+	maxHealth = 300
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -997,7 +1003,10 @@
 	},
 /area/awaymission/spacebattle/engine)
 "cU" = (
-/mob/living/simple_animal/hostile/syndicate/melee,
+/mob/living/simple_animal/hostile/syndicate/melee{
+	health = 400;
+	maxHealth = 400
+	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway12)
 "cV" = (
@@ -1016,7 +1025,7 @@
 /area/awaymission/spacebattle/kitchen)
 "cY" = (
 /mob/living/simple_animal/hostile/syndicate/ranged/space{
-	health = 300
+	maxHealth = 300
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
@@ -1314,7 +1323,8 @@
 /area/awaymission/spacebattle/sec_storage)
 "ed" = (
 /mob/living/simple_animal/hostile/syndicate/ranged{
-	health = 300
+	health = 300;
+	maxHealth = 300
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -1429,7 +1439,9 @@
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/sec_storage)
 "eu" = (
-/mob/living/simple_animal/hostile/syndicate/ranged/space,
+/mob/living/simple_animal/hostile/syndicate/ranged/space{
+	maxHealth = 300
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -1496,7 +1508,10 @@
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "eE" = (
-/mob/living/simple_animal/hostile/syndicate/melee/space,
+/mob/living/simple_animal/hostile/syndicate/melee/space{
+	health = 400;
+	maxHealth = 400
+	},
 /turf/simulated/floor/plating/airless,
 /area/space)
 "eF" = (
@@ -1680,7 +1695,8 @@
 /mob/living/simple_animal/hostile/syndicate/ranged{
 	name = "Syndicate Commander Bodyguard";
 	health = 400;
-	damage_coeff = list("brute"=0.5,"fire"=1.5,"tox"=0,"clone"=0,"stamina"=0,"oxy"=0)
+	damage_coeff = list("brute"=0.5,"fire"=1.5,"tox"=0,"clone"=0,"stamina"=0,"oxy"=0);
+	maxHealth = 400
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -1779,7 +1795,8 @@
 /mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/armory{
 	name = "Syndicate Commander";
 	loot = list(/obj/effect/decal/cleanable/ash,/obj/item/documents/syndicate/blue);
-	health = 1000
+	health = 1000;
+	maxHealth = 1000
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/bridge)
@@ -1851,6 +1868,32 @@
 	dir = 5
 	},
 /area/awaymission/spacebattle/prhallway4)
+"fD" = (
+/mob/living/simple_animal/hostile/syndicate/ranged/space{
+	maxHealth = 300
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway4)
+"fF" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/awaymission/spacebattle/medbay)
 "fG" = (
 /obj/structure/bed,
 /obj/item/stack/sheet/cloth,
@@ -2171,7 +2214,9 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /mob/living/simple_animal/hostile/syndicate/ranged/space{
-	health = 300
+	health = 300;
+	aggro_vision_range = 12;
+	maxHealth = 300
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -2459,7 +2504,8 @@
 /area/awaymission/spacebattle/medbay)
 "hv" = (
 /mob/living/simple_animal/hostile/syndicate/melee{
-	health = 400
+	health = 400;
+	maxHealth = 400
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -2621,7 +2667,8 @@
 /area/awaymission/spacebattle/hallway12)
 "hW" = (
 /mob/living/simple_animal/hostile/syndicate/ranged{
-	health = 300
+	health = 300;
+	maxHealth = 300
 	},
 /obj/item/ammo_casing/c45,
 /obj/item/ammo_casing/c45,
@@ -3130,7 +3177,8 @@
 /area/awaymission/spacebattle/prhallway6)
 "kg" = (
 /mob/living/simple_animal/hostile/syndicate/melee{
-	health = 400
+	health = 400;
+	maxHealth = 400
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway8)
@@ -3231,7 +3279,8 @@
 /area/awaymission/spacebattle/hallway1)
 "kT" = (
 /mob/living/simple_animal/hostile/syndicate/melee{
-	health = 400
+	health = 400;
+	maxHealth = 400
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -3985,7 +4034,8 @@
 /area/awaymission/spacebattle/engineering)
 "qd" = (
 /mob/living/simple_animal/hostile/syndicate/ranged{
-	health = 300
+	health = 300;
+	maxHealth = 300
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -4014,7 +4064,7 @@
 /area/awaymission/spacebattle/hallway7)
 "qn" = (
 /mob/living/simple_animal/hostile/syndicate/ranged/space{
-	health = 300
+	maxHealth = 300
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/engineering)
@@ -4127,6 +4177,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/turret4)
+"qS" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/awaymission/spacebattle/medbay)
 "qT" = (
 /obj/structure/closet/crate/secure/bin,
 /turf/simulated/floor/plasteel{
@@ -4208,7 +4269,8 @@
 /area/space)
 "rK" = (
 /mob/living/simple_animal/hostile/syndicate/ranged{
-	health = 300
+	health = 300;
+	maxHealth = 300
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/sec_storage)
@@ -4660,7 +4722,8 @@
 /area/awaymission/spacebattle/hallway8)
 "ub" = (
 /mob/living/simple_animal/hostile/syndicate/ranged{
-	health = 300
+	health = 300;
+	maxHealth = 300
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -4724,7 +4787,8 @@
 /area/space/nearstation)
 "uz" = (
 /mob/living/simple_animal/hostile/syndicate/melee{
-	health = 400
+	health = 400;
+	maxHealth = 400
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral";
@@ -5551,7 +5615,9 @@
 /area/awaymission/spacebattle/sec_storage)
 "AI" = (
 /mob/living/simple_animal/hostile/syndicate/ranged/space{
-	health = 300
+	health = 300;
+	aggro_vision_range = 12;
+	maxHealth = 300
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral";
@@ -5561,7 +5627,8 @@
 "AK" = (
 /obj/effect/landmark/damageturf,
 /mob/living/simple_animal/hostile/syndicate/ranged{
-	health = 300
+	health = 300;
+	maxHealth = 300
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -5686,7 +5753,8 @@
 /area/awaymission/spacebattle/hallway11)
 "Bv" = (
 /mob/living/simple_animal/hostile/syndicate/melee{
-	health = 400
+	health = 400;
+	maxHealth = 400
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral";
@@ -5825,7 +5893,7 @@
 /area/awaymission/spacebattle/hallway10)
 "Cg" = (
 /mob/living/simple_animal/hostile/syndicate/ranged/space{
-	health = 300
+	maxHealth = 300
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/living)
@@ -5938,7 +6006,8 @@
 /area/awaymission/spacebattle/hallway7)
 "Dl" = (
 /mob/living/simple_animal/hostile/syndicate/ranged{
-	health = 300
+	health = 300;
+	maxHealth = 300
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -6028,7 +6097,7 @@
 /area/space/nearstation)
 "DH" = (
 /mob/living/simple_animal/hostile/syndicate/ranged/space{
-	health = 300
+	maxHealth = 300
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -6145,7 +6214,10 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway6)
 "EU" = (
-/mob/living/simple_animal/hostile/syndicate/ranged,
+/mob/living/simple_animal/hostile/syndicate/ranged{
+	health = 300;
+	maxHealth = 300
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -6283,7 +6355,9 @@
 /area/awaymission/spacebattle/hallway5)
 "FL" = (
 /mob/living/simple_animal/hostile/syndicate/ranged/space{
-	health = 300
+	health = 300;
+	aggro_vision_range = 12;
+	maxHealth = 300
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -6383,7 +6457,8 @@
 /area/awaymission/spacebattle/hallway5)
 "Gp" = (
 /mob/living/simple_animal/hostile/syndicate/melee{
-	health = 400
+	health = 400;
+	maxHealth = 400
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral";
@@ -6433,7 +6508,8 @@
 /area/awaymission/spacebattle/living)
 "GB" = (
 /mob/living/simple_animal/hostile/syndicate/melee{
-	health = 400
+	health = 400;
+	maxHealth = 400
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -6447,7 +6523,8 @@
 /area/awaymission/spacebattle/hallway12)
 "GK" = (
 /mob/living/simple_animal/hostile/syndicate/ranged{
-	health = 300
+	health = 300;
+	maxHealth = 300
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -6546,7 +6623,8 @@
 /area/awaymission/spacebattle/hallway1)
 "Hj" = (
 /mob/living/simple_animal/hostile/syndicate/melee{
-	health = 400
+	health = 400;
+	maxHealth = 300
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -6596,7 +6674,8 @@
 /area/awaymission/spacebattle/freezing)
 "Hz" = (
 /mob/living/simple_animal/hostile/syndicate/ranged{
-	health = 300
+	health = 300;
+	maxHealth = 300
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -6727,7 +6806,8 @@
 /area/awaymission/spacebattle/hallway11)
 "IF" = (
 /mob/living/simple_animal/hostile/syndicate/melee{
-	health = 400
+	health = 400;
+	maxHealth = 300
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -6792,7 +6872,10 @@
 	},
 /area/awaymission/spacebattle/engine)
 "Ji" = (
-/mob/living/simple_animal/hostile/syndicate/melee,
+/mob/living/simple_animal/hostile/syndicate/melee{
+	health = 400;
+	maxHealth = 400
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -6907,13 +6990,13 @@
 /area/awaymission/spacebattle/hallway9)
 "JR" = (
 /mob/living/simple_animal/hostile/syndicate/ranged/space{
-	health = 300
+	maxHealth = 300
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/engine)
 "JS" = (
 /mob/living/simple_animal/hostile/syndicate/ranged/space{
-	health = 300
+	maxHealth = 300
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -7054,7 +7137,8 @@
 /area/awaymission/spacebattle/hallway11)
 "Lo" = (
 /mob/living/simple_animal/hostile/syndicate/melee{
-	health = 400
+	health = 400;
+	maxHealth = 400
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral";
@@ -7169,18 +7253,6 @@
 	dir = 4
 	},
 /area/awaymission/spacebattle/prhallway2)
-"Mj" = (
-/obj/effect/decal/cleanable/blood,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/awaymission/spacebattle/medbay)
 "Mk" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -7330,7 +7402,7 @@
 /area/awaymission/spacebattle/hallway3)
 "Nm" = (
 /mob/living/simple_animal/hostile/syndicate/ranged/space{
-	health = 300
+	maxHealth = 300
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -7751,6 +7823,18 @@
 	dir = 1
 	},
 /area/awaymission/spacebattle/hallway10)
+"Qi" = (
+/obj/machinery/door/airlock/medical,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/awaymission/spacebattle/medbay)
 "Qm" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel{
@@ -7999,7 +8083,7 @@
 /area/awaymission/spacebattle/hallway9)
 "RI" = (
 /mob/living/simple_animal/hostile/syndicate/ranged/space{
-	health = 300
+	maxHealth = 300
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -8009,16 +8093,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/engine)
-"RK" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/awaymission/spacebattle/medbay)
 "RL" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel{
@@ -8052,17 +8126,6 @@
 	icon_state = "neutral"
 	},
 /area/awaymission/spacebattle/hallway4)
-"RU" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/awaymission/spacebattle/medbay)
 "Sd" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -8153,18 +8216,6 @@
 	dir = 9
 	},
 /area/space/nearstation)
-"SK" = (
-/obj/machinery/door/airlock/medical,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/awaymission/spacebattle/medbay)
 "SN" = (
 /obj/effect/mob_spawn/human/securty,
 /obj/effect/decal/cleanable/blood,
@@ -8298,7 +8349,8 @@
 /area/awaymission/spacebattle/sec_storage)
 "TH" = (
 /mob/living/simple_animal/hostile/syndicate/melee{
-	health = 400
+	health = 400;
+	maxHealth = 400
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -8327,6 +8379,16 @@
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/awaymission/spacebattle/storage)
+"TS" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/awaymission/spacebattle/medbay)
 "TV" = (
 /obj/machinery/vending/cigarette/free,
 /turf/simulated/floor/plasteel{
@@ -8380,7 +8442,8 @@
 "Ul" = (
 /mob/living/simple_animal/hostile/syndicate/melee{
 	name = "Syndicate Commander Bodyguard";
-	health = 400
+	health = 400;
+	maxHealth = 400
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/bridge)
@@ -8526,7 +8589,8 @@
 /area/awaymission/spacebattle/hallway1)
 "Vs" = (
 /mob/living/simple_animal/hostile/syndicate/melee{
-	health = 400
+	health = 400;
+	maxHealth = 400
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -8859,7 +8923,7 @@
 /area/awaymission/spacebattle/turret8)
 "WX" = (
 /mob/living/simple_animal/hostile/syndicate/ranged/space{
-	health = 300
+	maxHealth = 300
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -8919,7 +8983,7 @@
 "Xv" = (
 /obj/effect/landmark/damageturf,
 /mob/living/simple_animal/hostile/syndicate/ranged/space{
-	health = 300
+	maxHealth = 300
 	},
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
@@ -35927,7 +35991,7 @@ DH
 IO
 bS
 mD
-VE
+fD
 bS
 ls
 ls
@@ -37204,7 +37268,7 @@ cb
 cb
 cb
 hu
-SK
+Qi
 cb
 cb
 oD
@@ -37461,7 +37525,7 @@ gP
 Nq
 Gy
 gF
-RU
+qS
 hS
 hX
 bS
@@ -37717,8 +37781,8 @@ gR
 cg
 gF
 cc
-Mj
-RK
+fF
+TS
 gF
 Fu
 bS

--- a/_maps/map_files/RandomZLevels/spacebattle.dmm
+++ b/_maps/map_files/RandomZLevels/spacebattle.dmm
@@ -727,6 +727,12 @@
 /mob/living/simple_animal/hostile/syndicate/ranged{
 	health = 300
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -1674,7 +1680,7 @@
 /mob/living/simple_animal/hostile/syndicate/ranged{
 	name = "Syndicate Commander Bodyguard";
 	health = 400;
-	damage_coeff = list("brute" = 0.5, "fire" = 1.5, "tox" = 0, "clone" = 0, "stamina" = 0, "oxy" = 0)
+	damage_coeff = list("brute"=0.5,"fire"=1.5,"tox"=0,"clone"=0,"stamina"=0,"oxy"=0)
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -2164,7 +2170,9 @@
 	name = "Adam Smith"
 	},
 /obj/effect/decal/cleanable/blood,
-/mob/living/simple_animal/hostile/syndicate/ranged/space,
+/mob/living/simple_animal/hostile/syndicate/ranged/space{
+	health = 300
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -2384,8 +2392,10 @@
 /area/awaymission/spacebattle/sec_storage)
 "hj" = (
 /obj/structure/closet/crate/secure/plasma,
-/obj/item/tank/plasma/full,
-/obj/item/tank/plasma/full,
+/obj/item/tank/internals/plasma,
+/obj/item/tank/internals/plasma,
+/obj/item/tank/internals/plasma,
+/obj/item/tank/internals/plasma,
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/sec_storage)
 "hk" = (
@@ -3080,6 +3090,11 @@
 	d2 = 2;
 	icon_state = "1-2";
 	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral";
@@ -5535,7 +5550,9 @@
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/sec_storage)
 "AI" = (
-/mob/living/simple_animal/hostile/syndicate/ranged/space,
+/mob/living/simple_animal/hostile/syndicate/ranged/space{
+	health = 300
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral";
 	dir = 4
@@ -6265,7 +6282,9 @@
 	},
 /area/awaymission/spacebattle/hallway5)
 "FL" = (
-/mob/living/simple_animal/hostile/syndicate/ranged/space,
+/mob/living/simple_animal/hostile/syndicate/ranged/space{
+	health = 300
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -6394,9 +6413,18 @@
 	},
 /area/awaymission/spacebattle/kitchen)
 "Gy" = (
-/obj/structure/cable,
-/turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/obj/item/twohanded/required/kirbyplants,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	pixel_x = -24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/awaymission/spacebattle/medbay)
 "GA" = (
 /obj/machinery/vending/cigarette/free,
 /turf/simulated/floor/plasteel{
@@ -7104,6 +7132,12 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway1)
 "LT" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral";
 	dir = 6
@@ -7135,6 +7169,18 @@
 	dir = 4
 	},
 /area/awaymission/spacebattle/prhallway2)
+"Mj" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/awaymission/spacebattle/medbay)
 "Mk" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -7963,6 +8009,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/engine)
+"RK" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/awaymission/spacebattle/medbay)
 "RL" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel{
@@ -7996,6 +8052,17 @@
 	icon_state = "neutral"
 	},
 /area/awaymission/spacebattle/hallway4)
+"RU" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/awaymission/spacebattle/medbay)
 "Sd" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -8086,6 +8153,18 @@
 	dir = 9
 	},
 /area/space/nearstation)
+"SK" = (
+/obj/machinery/door/airlock/medical,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/awaymission/spacebattle/medbay)
 "SN" = (
 /obj/effect/mob_spawn/human/securty,
 /obj/effect/decal/cleanable/blood,
@@ -8156,7 +8235,9 @@
 	},
 /area/awaymission/spacebattle/hallway9)
 "Tn" = (
-/mob/living/simple_animal/hostile/syndicate/melee,
+/mob/living/simple_animal/hostile/syndicate/melee{
+	health = 400
+	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -8432,7 +8513,9 @@
 /area/awaymission/spacebattle/hallway4)
 "Vp" = (
 /obj/effect/landmark/damageturf,
-/mob/living/simple_animal/hostile/syndicate/melee,
+/mob/living/simple_animal/hostile/syndicate/melee{
+	health = 400
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -36607,7 +36690,7 @@ zh
 Bo
 zh
 wx
-zh
+Bo
 zh
 tG
 Gf
@@ -36864,7 +36947,7 @@ Zy
 Mi
 Zy
 Ok
-Zy
+ol
 Zy
 zn
 xa
@@ -37121,7 +37204,7 @@ cb
 cb
 cb
 hu
-hu
+SK
 cb
 cb
 oD
@@ -37376,9 +37459,9 @@ gF
 gF
 gP
 Nq
-qC
+Gy
 gF
-gF
+RU
 hS
 hX
 bS
@@ -37634,8 +37717,8 @@ gR
 cg
 gF
 cc
-gR
-gF
+Mj
+RK
 gF
 Fu
 bS
@@ -42783,7 +42866,7 @@ bS
 bZ
 bZ
 YK
-Gy
+AC
 bS
 ab
 ab
@@ -49438,7 +49521,7 @@ dW
 cb
 cp
 dl
-dl
+CX
 oD
 YU
 Tp
@@ -49694,8 +49777,8 @@ ab
 ab
 ab
 bS
-bZ
-bZ
+AA
+mi
 bS
 YU
 Tp

--- a/_maps/map_files/RandomZLevels/spacebattle.dmm
+++ b/_maps/map_files/RandomZLevels/spacebattle.dmm
@@ -23,7 +23,6 @@
 "ae" = (
 /obj/structure/shuttle/engine/propulsion{
 	tag = "icon-propulsion (NORTH)";
-	icon_state = "propulsion";
 	dir = 1
 	},
 /turf/simulated/shuttle/plating,
@@ -51,7 +50,6 @@
 "ai" = (
 /obj/structure/shuttle/engine/heater{
 	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
 	dir = 1
 	},
 /obj/structure/window/reinforced,
@@ -64,6 +62,7 @@
 /area/awaymission/spacebattle/syndicate2)
 "ak" = (
 /obj/machinery/door/airlock/external,
+/obj/structure/fans/tiny,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
 	},
@@ -152,7 +151,6 @@
 "ax" = (
 /obj/structure/shuttle/engine/propulsion{
 	tag = "icon-propulsion (NORTH)";
-	icon_state = "propulsion";
 	dir = 1
 	},
 /turf/simulated/shuttle/plating,
@@ -187,7 +185,6 @@
 "aC" = (
 /obj/structure/shuttle/engine/heater{
 	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
 	dir = 1
 	},
 /obj/structure/window/reinforced,
@@ -200,6 +197,7 @@
 /area/awaymission/spacebattle/syndicate3)
 "aE" = (
 /obj/machinery/door/airlock/external,
+/obj/structure/fans/tiny,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
 	},
@@ -287,7 +285,6 @@
 "aQ" = (
 /obj/structure/shuttle/engine/propulsion{
 	tag = "icon-propulsion (NORTH)";
-	icon_state = "propulsion";
 	dir = 1
 	},
 /turf/simulated/shuttle/plating,
@@ -309,6 +306,7 @@
 /area/awaymission/spacebattle/syndicate1)
 "aT" = (
 /obj/machinery/door/airlock/external,
+/obj/structure/fans/tiny,
 /turf/simulated/shuttle/plating,
 /area/awaymission/spacebattle/syndicate2)
 "aU" = (
@@ -325,7 +323,6 @@
 "aW" = (
 /obj/structure/shuttle/engine/heater{
 	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
 	dir = 1
 	},
 /obj/structure/window/reinforced,
@@ -335,7 +332,6 @@
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
 	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
 	dir = 1
 	},
 /obj/structure/window/reinforced{
@@ -347,7 +343,6 @@
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
 	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
 	dir = 1
 	},
 /obj/structure/window/reinforced{
@@ -378,6 +373,7 @@
 /area/awaymission/spacebattle/syndicate2)
 "bc" = (
 /obj/machinery/door/airlock/external,
+/obj/structure/fans/tiny,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
 	},
@@ -410,6 +406,13 @@
 	icon_state = "floor4"
 	},
 /area/awaymission/spacebattle/syndicate1)
+"bh" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 6
+	},
+/area/awaymission/spacebattle/hallway8)
 "bi" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/combat,
@@ -443,9 +446,9 @@
 /obj/machinery/door/poddoor{
 	icon_state = "pdoor1";
 	id_tag = "spacebattlepod3";
-	name = "Front Hull Door";
-	opacity = 1
+	name = "Front Hull Door"
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/shuttle/plating,
 /area/awaymission/spacebattle/syndicate2)
 "bn" = (
@@ -573,104 +576,80 @@
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/syndicate1)
 "bE" = (
-/turf/space,
-/turf/simulated/shuttle/wall{
-	dir = 8;
-	icon_state = "diagonalWall3"
-	},
-/area/awaymission/spacebattle/cruiser)
+/obj/structure/rack,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/jetpack/oxygen,
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
 "bF" = (
-/obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_r (NORTH)";
-	icon_state = "propulsion_r";
-	dir = 1
+/mob/living/simple_animal/hostile/syndicate/ranged/space{
+	health = 300
 	},
 /turf/space,
-/area/awaymission/spacebattle/cruiser)
+/area/space)
 "bG" = (
-/obj/machinery/door/airlock/external,
-/turf/simulated/shuttle/plating,
+/turf/simulated/shuttle/wall{
+	icon_state = "swallc4"
+	},
 /area/awaymission/spacebattle/cruiser)
 "bH" = (
-/obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_l (NORTH)";
-	icon_state = "propulsion_l";
-	dir = 1
-	},
-/turf/space,
-/area/awaymission/spacebattle/cruiser)
+/turf/simulated/floor/plating,
+/area/space/nearstation)
 "bI" = (
-/turf/space,
-/turf/simulated/shuttle/wall{
-	dir = 1;
-	icon_state = "diagonalWall3"
+/obj/structure/window/plasmareinforced{
+	dir = 4
 	},
-/area/awaymission/spacebattle/cruiser)
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
 "bJ" = (
-/turf/simulated/shuttle/wall{
-	icon_state = "wall3"
-	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
 "bK" = (
-/obj/structure/window/reinforced,
-/obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
-	dir = 1
+/obj/structure/table/reinforced,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating/airless,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/hallway13)
 "bL" = (
-/turf/simulated/shuttle/floor{
-	icon_state = "floor4"
-	},
-/area/awaymission/spacebattle/cruiser)
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plating,
+/area/space/nearstation)
 "bM" = (
-/obj/structure/window/reinforced,
-/obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
-	dir = 1
+/turf/simulated/shuttle/wall{
+	tag = "icon-swallc2";
+	icon_state = "swallc2"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/cruiser)
 "bN" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/turf/simulated/shuttle/floor{
-	icon_state = "floor4"
-	},
-/area/awaymission/spacebattle/cruiser)
+/obj/machinery/door/airlock/external,
+/turf/simulated/floor/plating/airless,
+/area/space)
 "bO" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
+/mob/living/simple_animal/hostile/syndicate/ranged/space,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/syndicate6)
 "bP" = (
-/turf/space,
-/turf/simulated/shuttle/wall{
-	tag = "icon-swall_f6";
-	icon_state = "swall_f6";
-	dir = 2
+/obj/structure/table/reinforced,
+/obj/item/folder{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/area/awaymission/spacebattle/cruiser)
+/turf/simulated/floor/plasteel/dark/telecomms,
+/area/awaymission/spacebattle/server)
 "bQ" = (
-/turf/simulated/shuttle/wall{
-	tag = "icon-swall12";
-	icon_state = "swall12";
-	dir = 2
+/obj/item/twohanded/required/kirbyplants,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
 	},
-/area/awaymission/spacebattle/cruiser)
+/turf/simulated/floor/plasteel,
+/area/space/nearstation)
 "bR" = (
 /turf/simulated/shuttle/wall{
 	tag = "icon-swall14";
@@ -684,54 +663,58 @@
 	},
 /area/awaymission/spacebattle/cruiser)
 "bT" = (
-/turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 3;
-	icon_state = "swall_f10";
-	layer = 2;
-	tag = "icon-swall_f10"
+	icon_state = "swallc1"
 	},
 /area/awaymission/spacebattle/cruiser)
 "bU" = (
-/obj/structure/shuttle/engine/propulsion{
-	tag = "icon-burst_l (EAST)";
-	icon_state = "burst_l";
-	dir = 4
-	},
-/turf/space,
-/area/awaymission/spacebattle/cruiser)
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel/dark/telecomms,
+/area/awaymission/spacebattle/server)
 "bV" = (
-/obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (WEST)";
-	icon_state = "heater";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	tag = "icon-engine";
-	icon_state = "engine"
-	},
-/area/awaymission/spacebattle/cruiser)
+/obj/structure/closet/cardboard,
+/obj/item/reagent_containers/food/snacks/beans,
+/obj/item/reagent_containers/food/snacks/beans,
+/obj/item/reagent_containers/food/snacks/beans,
+/obj/item/reagent_containers/food/snacks/beans,
+/obj/item/reagent_containers/food/snacks/beans,
+/obj/item/reagent_containers/food/snacks/beans,
+/obj/item/reagent_containers/food/snacks/beans,
+/obj/item/reagent_containers/food/snacks/beans,
+/obj/item/reagent_containers/food/snacks/beans,
+/obj/item/reagent_containers/food/snacks/beans,
+/obj/item/reagent_containers/food/snacks/beans,
+/obj/item/reagent_containers/food/snacks/beans,
+/obj/item/reagent_containers/food/snacks/beans,
+/obj/item/reagent_containers/food/snacks/beans,
+/obj/item/reagent_containers/food/snacks/beans,
+/obj/item/reagent_containers/food/snacks/beans,
+/obj/item/reagent_containers/food/snacks/beans,
+/obj/item/reagent_containers/food/snacks/beans,
+/obj/item/reagent_containers/food/snacks/beans,
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
 "bX" = (
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
 "bY" = (
-/obj/machinery/computer/pod{
-	id_tags = list("spacebattlepod");
-	name = "Hull Door Control"
+/obj/effect/mob_spawn/human/engineer,
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/power/terminal{
+	dir = 4
 	},
-/turf/simulated/shuttle/floor{
-	icon_state = "floor4"
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/area/awaymission/spacebattle/cruiser)
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
 "bZ" = (
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
 "ca" = (
-/obj/machinery/door/unpowered/shuttle,
+/obj/machinery/door/airlock,
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
 "cb" = (
@@ -741,51 +724,53 @@
 	},
 /area/awaymission/spacebattle/cruiser)
 "cc" = (
-/obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion (EAST)";
-	icon_state = "propulsion";
-	dir = 4
+/mob/living/simple_animal/hostile/syndicate/ranged{
+	health = 300
 	},
-/turf/space,
-/area/awaymission/spacebattle/cruiser)
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/awaymission/spacebattle/medbay)
 "cd" = (
 /obj/structure/table/reinforced,
-/turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/obj/item/clothing/glasses/night,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/awaymission/spacebattle/syndicate2)
 "ce" = (
-/turf/simulated/floor/plasteel,
-/turf/simulated/shuttle/wall{
-	icon_state = "diagonalWall3"
-	},
-/area/awaymission/spacebattle/cruiser)
+/obj/structure/lattice,
+/turf/space,
+/area/space)
 "cf" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "spacebattlepod";
-	name = "Front Hull Door";
-	opacity = 1;
-	tag = "icon-pdoor0"
+/obj/effect/landmark/damageturf,
+/obj/structure/closet/crate/secure/bin,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/turf/simulated/shuttle/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/kitchen)
 "cg" = (
-/turf/simulated/floor/plasteel,
-/turf/simulated/shuttle/wall{
-	dir = 4;
-	icon_state = "diagonalWall3"
+/obj/machinery/optable,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/medbay)
 "ch" = (
 /mob/living/simple_animal/hostile/syndicate/melee/space,
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
 "ci" = (
-/obj/item/ammo_casing/c10mm,
-/obj/item/ammo_casing/c10mm,
-/obj/effect/landmark/damageturf,
-/turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/obj/machinery/porta_turret/centcom{
+	use_power = 0;
+	reqpower = 0;
+	active_power_usage = 0;
+	idle_power_usage = 0;
+	name = "Space Defence Turret";
+	enabled = 1;
+	lethal = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret9)
 "cj" = (
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
@@ -795,24 +780,17 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
 "cl" = (
-/obj/effect/mob_spawn/human/engineer{
-	name = "Clay Dawson"
-	},
-/obj/effect/landmark/damageturf,
+/obj/structure/closet/toolcloset,
 /turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/engineering)
 "cm" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
 "cn" = (
-/obj/effect/mob_spawn/human/engineer{
-	name = "Rosen Miller"
-	},
-/obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/area/space/nearstation)
 "co" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel,
@@ -830,336 +808,318 @@
 	},
 /area/awaymission/spacebattle/cruiser)
 "cr" = (
-/turf/simulated/shuttle/wall{
-	tag = "icon-swallc2";
-	icon_state = "swallc2"
+/mob/living/simple_animal/hostile/syndicate/melee{
+	health = 400
 	},
-/area/awaymission/spacebattle/cruiser)
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
 "cs" = (
-/obj/machinery/power/smes/magical{
-	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit.";
-	name = "power storage unit"
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
 	},
-/turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/hallway12)
 "ct" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
 "cu" = (
-/obj/item/stack/sheet/metal,
-/obj/item/ammo_casing/c10mm,
-/turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
 "cv" = (
-/obj/item/ammo_casing/c10mm,
-/obj/item/ammo_casing/c10mm,
-/obj/item/ammo_casing/c10mm,
-/obj/item/ammo_casing/c10mm,
-/turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
-"cw" = (
-/obj/structure/closet/cabinet,
-/turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
-"cx" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
-"cy" = (
-/obj/machinery/vending/cigarette,
-/turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
-"cz" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/snacks/sausage,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+/obj/machinery/tcomms/core{
+	name = "Very Hi-tech Machine";
+	desc = "You totally don't give a shit what is this."
 	},
-/area/awaymission/spacebattle/cruiser)
-"cA" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel/dark/telecomms,
+/area/awaymission/spacebattle/server)
+"cw" = (
+/obj/effect/mob_spawn/human/bridgeofficer,
+/obj/effect/decal/cleanable/blood,
+/turf/space,
+/area/space)
+"cx" = (
+/obj/effect/mob_spawn/human/scientist,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel/dark/telecomms,
+/area/awaymission/spacebattle/server)
+"cy" = (
+/obj/effect/landmark/damageturf,
+/obj/effect/mob_spawn/human/corpse/assistant,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
+"cz" = (
+/obj/machinery/vending/cigarette/free,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway13)
+"cA" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swallc3"
 	},
 /area/awaymission/spacebattle/cruiser)
 "cB" = (
-/obj/structure/table/reinforced,
-/obj/item/kitchen/knife,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
-	},
-/area/awaymission/spacebattle/cruiser)
+/obj/structure/window/plasmareinforced,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
 "cC" = (
-/obj/structure/table/reinforced,
-/obj/item/kitchen/rollingpin,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+/obj/structure/window/plasmareinforced,
+/obj/structure/window/plasmareinforced{
+	dir = 4
 	},
+/turf/space,
 /area/awaymission/spacebattle/cruiser)
 "cD" = (
-/obj/structure/closet/secure_closet/freezer/kitchen,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
-	},
+/obj/effect/spawner/window/reinforced,
+/turf/space,
 /area/awaymission/spacebattle/cruiser)
 "cE" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+/obj/structure/shuttle/engine/heater{
+	dir = 8
 	},
-/area/awaymission/spacebattle/cruiser)
+/obj/structure/window/plasmareinforced{
+	dir = 4
+	},
+/turf/space,
+/area/space)
 "cF" = (
-/obj/structure/table/reinforced,
-/obj/machinery/kitchen_machine/microwave,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
-	},
-/area/awaymission/spacebattle/cruiser)
+/obj/structure/rack,
+/obj/item/stack/sheet/wood,
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
 "cG" = (
-/obj/machinery/door/unpowered/shuttle,
-/turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/mob/living/simple_animal/hostile/syndicate/ranged,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/awaymission/spacebattle/syndicate4)
 "cH" = (
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/sec_storage)
 "cI" = (
 /obj/item/ammo_casing/c10mm,
 /obj/item/ammo_casing/c10mm,
 /turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "cJ" = (
 /obj/item/ammo_casing/c10mm,
 /turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "cK" = (
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
 "cL" = (
-/obj/effect/landmark{
-	name = "awaystart"
+/mob/living/simple_animal/hostile/syndicate/ranged{
+	health = 300
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
 	},
 /turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/hallway10)
 "cM" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+/obj/machinery/optable,
+/obj/effect/mob_spawn/human/doctor{
+	name = "Allan Yoshimaru"
 	},
-/area/awaymission/spacebattle/cruiser)
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/awaymission/spacebattle/medbay)
 "cN" = (
-/obj/item/stack/sheet/metal,
+/obj/item/twohanded/required/kirbyplants,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/living)
 "cO" = (
 /turf/simulated/shuttle/wall{
 	tag = "icon-swallc3";
 	icon_state = "swallc3"
 	},
 /area/awaymission/spacebattle/cruiser)
-"cP" = (
-/obj/effect/mob_spawn/human/engineer{
-	name = "Bill Sanchez"
-	},
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
 "cQ" = (
-/obj/machinery/door/unpowered/shuttle,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+/obj/item/clothing/gloves/color/yellow{
+	pixel_y = -5
 	},
-/area/awaymission/spacebattle/cruiser)
+/turf/space,
+/area/space)
 "cR" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/snacks/fries,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
-	},
-/area/awaymission/spacebattle/cruiser)
+/obj/structure/rack,
+/obj/item/stack/sheet/metal,
+/obj/item/stack/sheet/metal,
+/obj/item/stack/sheet/metal,
+/obj/item/stack/sheet/metal,
+/obj/item/stack/sheet/metal,
+/obj/item/stack/sheet/metal,
+/obj/item/clothing/glasses/night,
+/obj/item/ammo_box/magazine/m45,
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
 "cS" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/snacks/soup/stew,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+/obj/structure{
+	desc = "It appears to be some sort of generator.";
+	icon = 'icons/obj/power.dmi';
+	icon_state = "teg";
+	name = "WaffeCo PGU"
 	},
-/area/awaymission/spacebattle/cruiser)
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
 "cT" = (
-/obj/structure/table/reinforced,
+/obj/structure/closet/toolcloset,
+/obj/item/clothing/glasses/material,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "yellow";
+	dir = 1
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/engine)
 "cU" = (
 /mob/living/simple_animal/hostile/syndicate/melee,
 /turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/hallway12)
 "cV" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
+/mob/living/simple_animal/hostile/syndicate/ranged,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/syndicate5)
 "cW" = (
 /turf/simulated/floor/plating/airless,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/turret9)
 "cX" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/kitchen)
 "cY" = (
-/mob/living/simple_animal/hostile/syndicate/ranged/space,
+/mob/living/simple_animal/hostile/syndicate/ranged/space{
+	health = 300
+	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
 "cZ" = (
-/obj/machinery/computer/pod{
-	id_tags = list("spacebattlepod2");
-	name = "Hull Door Control"
-	},
-/turf/simulated/shuttle/floor{
-	icon_state = "floor4"
-	},
-/area/awaymission/spacebattle/cruiser)
-"da" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
-"db" = (
-/obj/machinery/shieldgen{
-	anchored = 1
-	},
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/cruiser)
-"dc" = (
-/obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_r (EAST)";
-	icon_state = "propulsion_r";
+"da" = (
+/obj/structure/window/plasmareinforced{
 	dir = 4
 	},
+/obj/structure{
+	desc = "It appears to be broken SMES.";
+	icon = 'icons/obj/power.dmi';
+	icon_state = "smes";
+	name = "Nanotrasen PSU"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"db" = (
+/obj/machinery/optable,
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/awaymission/spacebattle/medbay)
+"dc" = (
+/obj/structure/window/plasmareinforced{
+	dir = 4
+	},
+/obj/structure/window/plasmareinforced,
 /turf/space,
 /area/awaymission/spacebattle/cruiser)
 "dd" = (
-/obj/effect/mob_spawn/human/engineer{
-	name = "John Locke"
-	},
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/turf/space,
+/area/space)
 "de" = (
 /obj/structure/rack,
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
 "df" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
-/turf/simulated/floor/plasteel,
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8
+	},
+/turf/space,
 /area/awaymission/spacebattle/cruiser)
 "dg" = (
-/obj/structure/closet/secure_closet/engineering_welding,
+/obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/area/space/nearstation)
 "dh" = (
-/obj/structure/closet/wardrobe/engineering_yellow,
+/obj/machinery/door/airlock/engineering,
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
 "di" = (
-/obj/structure/closet/toolcloset,
-/turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
-"dj" = (
-/obj/effect/mob_spawn/human/doctor{
-	name = "Daniel Kalla"
+/obj/item/clothing/gloves/color/yellow{
+	pixel_y = -5
 	},
-/obj/effect/decal/cleanable/blood,
+/turf/space,
+/area/space/nearstation)
+"dj" = (
+/obj/structure{
+	desc = "It appears to be some sort of generator.";
+	icon = 'icons/obj/power.dmi';
+	icon_state = "teg";
+	name = "WaffeCo PGU"
+	},
 /turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/engine)
 "dk" = (
-/obj/effect/decal/cleanable/blood,
+/obj/machinery/vending/snack/free,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/kitchen)
 "dl" = (
-/turf/simulated/shuttle/wall{
-	tag = "icon-swall7";
-	icon_state = "swall7";
-	dir = 2
-	},
-/area/awaymission/spacebattle/cruiser)
-"dm" = (
-/turf/simulated/shuttle/wall{
-	tag = "icon-swall11";
-	icon_state = "swall11";
-	dir = 2
-	},
-/area/awaymission/spacebattle/cruiser)
-"dn" = (
-/obj/effect/mob_spawn/human/corpse/syndicatesoldier,
-/obj/item/gun/projectile/automatic/c20r,
-/obj/effect/landmark/damageturf,
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
-"do" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "spacebattlepod2";
-	name = "Front Hull Door";
-	opacity = 1;
-	tag = "icon-pdoor0"
-	},
-/turf/simulated/shuttle/plating,
-/area/awaymission/spacebattle/cruiser)
-"dq" = (
-/turf/space,
-/turf/simulated/shuttle/wall{
-	tag = "icon-swall_f5";
-	icon_state = "swall_f5";
-	dir = 2
-	},
-/area/awaymission/spacebattle/cruiser)
-"dr" = (
+"dm" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel,
+/area/space/nearstation)
+"dn" = (
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/shuttle/wall{
-	tag = "icon-swall12";
-	icon_state = "swall12"
-	},
-/area/awaymission/spacebattle/cruiser)
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/simulated/floor/plasteel/freezer,
+/area/awaymission/spacebattle/freezing)
+"do" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/mineral/plasma/fifty,
+/obj/item/stack/sheet/mineral/plasma/fifty,
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
+"dq" = (
+/mob/living/simple_animal/hostile/syndicate/melee/space,
+/turf/simulated/floor/plasteel/dark/telecomms,
+/area/awaymission/spacebattle/server)
+"dr" = (
+/obj/item/wirecutters,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engineering)
 "ds" = (
-/turf/simulated/shuttle/wall{
-	tag = "icon-swall15";
-	icon_state = "swall15"
+/obj/item/clothing/glasses/night,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/syndicate1)
 "dt" = (
 /turf/simulated/shuttle/wall{
 	tag = "icon-swall11";
@@ -1175,117 +1135,93 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/kitchen)
 "dv" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/kitchen)
 "dw" = (
-/obj/structure/rack,
-/turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 9
-	},
-/area/awaymission/spacebattle/cruiser)
-"dx" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
-	},
-/area/awaymission/spacebattle/cruiser)
-"dy" = (
-/obj/effect/landmark{
-	name = "awaystart"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
-	},
-/area/awaymission/spacebattle/cruiser)
-"dz" = (
-/obj/structure/closet/secure_closet/security,
-/turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 5
-	},
-/area/awaymission/spacebattle/cruiser)
-"dB" = (
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/plating/airless,
-/area/awaymission/spacebattle/cruiser)
-"dC" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/engine,
-/area/awaymission/spacebattle/cruiser)
-"dD" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/engine,
-/area/awaymission/spacebattle/cruiser)
-"dE" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/engine,
-/area/awaymission/spacebattle/cruiser)
-"dF" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/engine,
-/area/awaymission/spacebattle/cruiser)
-"dH" = (
-/obj/item/stack/rods,
+/obj/structure/closet/secure_closet/engineering_personal,
 /turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engineering)
+"dx" = (
+/obj/structure/fans/tiny,
+/turf/simulated/floor/plasteel/freezer,
+/area/awaymission/spacebattle/freezing)
+"dy" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/grille/broken,
+/turf/simulated/floor/plating,
+/area/space/nearstation)
+"dz" = (
+/obj/structure/closet/secure_closet/freezer/meat/open,
+/turf/simulated/floor/plasteel/freezer,
+/area/awaymission/spacebattle/freezing)
+"dB" = (
+/turf/space,
+/area/space/nearstation)
+"dC" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
+"dD" = (
+/obj/structure/rack,
+/obj/item/wirecutters,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 1
+	},
+/area/awaymission/spacebattle/engineering)
+"dE" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"dF" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/awaymission/spacebattle/medbay)
+"dH" = (
+/turf/simulated/shuttle/wall{
+	tag = "icon-swall7";
+	icon_state = "swall14"
+	},
 /area/awaymission/spacebattle/cruiser)
 "dI" = (
-/obj/mecha/medical/odysseus,
-/turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
-"dJ" = (
-/obj/mecha/working/ripley/firefighter{
-	ruin_mecha = 1
-	},
-/turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
-"dK" = (
-/obj/structure/closet/crate{
-	name = "Gold Crate"
-	},
+/obj/item/pickaxe,
+/obj/item/gun/energy/plasmacutter,
+/obj/structure/closet/crate,
+/obj/item/mecha_parts/mecha_equipment/repair_droid,
 /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp,
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
-"dL" = (
-/obj/structure/closet/crate{
-	name = "Gold Crate"
+/area/awaymission/spacebattle/sec_storage)
+"dJ" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
 	},
-/obj/item/mecha_parts/mecha_equipment/drill,
+/area/awaymission/spacebattle/hallway13)
+"dK" = (
+/obj/mecha/working/ripley/firefighter,
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/sec_storage)
+"dL" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 6
+	},
+/area/awaymission/spacebattle/hallway12)
 "dM" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/sec_storage)
 "dN" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/sec_storage)
 "dO" = (
 /obj/structure/chair{
 	dir = 4
@@ -1293,20 +1229,20 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/kitchen)
 "dP" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/condiment/peppermill,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/kitchen)
 "dQ" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/kitchen)
 "dR" = (
 /obj/structure/chair{
 	dir = 8
@@ -1314,133 +1250,134 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/kitchen)
 "dS" = (
-/obj/structure/rack,
-/turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 8
-	},
-/area/awaymission/spacebattle/cruiser)
+/obj/structure/table/reinforced,
+/turf/simulated/floor/plasteel/freezer,
+/area/awaymission/spacebattle/freezing)
 "dT" = (
-/obj/structure/closet/secure_closet/security,
-/turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+/obj/structure/window/plasmareinforced{
+	dir = 1
 	},
-/area/awaymission/spacebattle/cruiser)
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
 "dV" = (
 /obj/effect/mob_spawn/human/engineer/hardsuit{
 	name = "Andrew Thorn"
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating/airless,
-/area/awaymission/spacebattle/cruiser)
+/area/space)
 "dW" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
+/turf/simulated/shuttle/wall{
+	tag = "icon-swall12";
+	icon_state = "swall_f10"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/engine,
 /area/awaymission/spacebattle/cruiser)
 "dX" = (
-/obj/machinery/porta_turret{
-	dir = 8;
-	emagged = 1;
-	installation = /obj/item/gun/energy/lasercannon
-	},
-/turf/simulated/floor/engine,
-/area/awaymission/spacebattle/cruiser)
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
 "dZ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/obj/structure/rack,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
 "ea" = (
 /obj/machinery/gateway{
 	dir = 9
 	},
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/sec_storage)
 "eb" = (
 /obj/machinery/gateway{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/sec_storage)
 "ec" = (
 /obj/machinery/gateway{
 	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/sec_storage)
 "ed" = (
-/obj/structure/closet/crate{
-	name = "Gold Crate"
+/mob/living/simple_animal/hostile/syndicate/ranged{
+	health = 300
 	},
-/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun,
-/turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/prhallway1)
 "ee" = (
-/obj/structure/closet/crate{
-	name = "Gold Crate"
-	},
-/obj/item/mecha_parts/mecha_equipment/repair_droid,
-/turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
 "ef" = (
-/mob/living/simple_animal/hostile/syndicate/melee,
+/mob/living/simple_animal/hostile/syndicate/melee{
+	health = 400
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/kitchen)
 "eg" = (
-/obj/structure/closet/l3closet/security,
-/turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
-	},
-/area/awaymission/spacebattle/cruiser)
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat/corgi,
+/obj/item/reagent_containers/food/snacks/meat/corgi,
+/turf/simulated/floor/plasteel/freezer,
+/area/awaymission/spacebattle/freezing)
+"eh" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret3)
 "ei" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/door/airlock/security{
+	name = "Turret Room"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/engine,
+/turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
 "ej" = (
-/turf/simulated/floor/engine,
-/area/awaymission/spacebattle/cruiser)
+/obj/structure/table/reinforced,
+/obj/item/clothing/glasses/night,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/awaymission/spacebattle/syndicate3)
 "ek" = (
 /obj/machinery/gateway{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/sec_storage)
 "el" = (
 /obj/machinery/gateway/centeraway{
 	calibrated = 0
 	},
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/sec_storage)
 "em" = (
 /obj/machinery/gateway{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/sec_storage)
 "en" = (
 /obj/structure/chair{
 	dir = 1
@@ -1448,7 +1385,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/kitchen)
 "eo" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
@@ -1472,106 +1409,103 @@
 /obj/machinery/gateway{
 	dir = 10
 	},
+/obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/sec_storage)
 "es" = (
 /obj/machinery/gateway,
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/sec_storage)
 "et" = (
 /obj/machinery/gateway{
 	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/sec_storage)
 "eu" = (
 /mob/living/simple_animal/hostile/syndicate/ranged/space,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/kitchen)
 "ev" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 8
-	},
-/area/awaymission/spacebattle/cruiser)
+/obj/structure/kitchenspike,
+/turf/simulated/floor/plasteel/freezer,
+/area/awaymission/spacebattle/freezing)
 "ew" = (
-/obj/effect/mob_spawn/human/bridgeofficer{
-	name = "Davis Hume"
-	},
-/obj/item/gun/projectile/shotgun/automatic/combat,
-/turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/turf/simulated/floor/plasteel/freezer,
+/area/awaymission/spacebattle/freezing)
 "ex" = (
 /obj/item/ammo_casing/shotgun,
 /turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "ey" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
-	},
-/area/awaymission/spacebattle/cruiser)
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/food/snacks/meat/slab,
+/obj/item/reagent_containers/food/snacks/meat/slab,
+/turf/simulated/floor/plasteel/freezer,
+/area/awaymission/spacebattle/freezing)
 "ez" = (
-/turf/simulated/shuttle/wall{
-	tag = "icon-swall3";
-	icon_state = "swall3";
-	dir = 2
-	},
-/area/awaymission/spacebattle/cruiser)
-"eA" = (
 /obj/structure/table/reinforced,
+/obj/item/clothing/glasses/night,
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
+"eA" = (
+/obj/structure/closet/crate/secure/bin,
+/obj/item/gun/projectile/automatic/pistol/APS,
+/obj/item/ammo_box/magazine/pistolm9mm,
+/obj/item/ammo_box/magazine/pistolm9mm,
+/obj/item/ammo_box/magazine/pistolm9mm,
+/obj/item/ammo_box/magazine/pistolm9mm,
+/obj/item/ammo_box/magazine/pistolm9mm,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "blue"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "eB" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "eC" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
 	tag = "icon-bluefull";
 	icon_state = "bluefull"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "eD" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/porta_turret/centcom{
+	use_power = 0;
+	reqpower = 0;
+	active_power_usage = 0;
+	idle_power_usage = 0;
+	name = "Space Defence Turret";
+	enabled = 1;
+	lethal = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
 "eE" = (
 /mob/living/simple_animal/hostile/syndicate/melee/space,
 /turf/simulated/floor/plating/airless,
-/area/awaymission/spacebattle/cruiser)
+/area/space)
 "eF" = (
 /obj/effect/mob_spawn/human/engineer/hardsuit{
 	name = "Peter West"
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating/airless,
-/area/awaymission/spacebattle/cruiser)
+/area/space)
 "eG" = (
-/turf/simulated/shuttle/wall{
-	tag = "icon-swall13";
-	icon_state = "swall13";
-	dir = 2
+/mob/living/simple_animal/hostile/syndicate/ranged,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/syndicate6)
 "eH" = (
 /turf/simulated/shuttle/wall{
 	tag = "icon-swallc4";
@@ -1594,32 +1528,27 @@
 	icon_state = "blue";
 	dir = 8
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "eL" = (
 /obj/item/shield/energy,
+/obj/effect/landmark/damageturf,
 /turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "eM" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "eN" = (
 /obj/machinery/computer/med_data,
 /turf/simulated/floor/plasteel{
 	tag = "icon-bluefull";
 	icon_state = "bluefull"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "eO" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/cruiser)
 "eP" = (
@@ -1638,28 +1567,29 @@
 	},
 /area/awaymission/spacebattle/syndicate4)
 "eR" = (
-/obj/structure/closet/crate,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/armory_contraband,
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/sec_storage)
 "eS" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/condiment/saltshaker,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/kitchen)
 "eT" = (
 /obj/structure/table/reinforced,
 /obj/item/kitchen/utensil/fork,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/kitchen)
 "eU" = (
 /obj/effect/mob_spawn/human/corpse/syndicatesoldier,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "eV" = (
 /obj/effect/mob_spawn/human/bridgeofficer{
 	name = "Kurt Kliest"
@@ -1667,105 +1597,130 @@
 /obj/item/gun/projectile/shotgun/automatic/combat,
 /obj/item/ammo_casing/shotgun,
 /turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "eW" = (
 /obj/item/ammo_casing/shotgun,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "eX" = (
-/obj/machinery/computer/crew,
+/obj/structure{
+	desc = "It appearce to be broken.";
+	icon = 'icons/obj/machines/particle_accelerator3.dmi';
+	icon_state = "control_boxp";
+	name = "Bluespace Artillery Control"
+	},
 /turf/simulated/floor/plasteel{
 	tag = "icon-bluefull";
 	icon_state = "bluefull"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "eY" = (
 /obj/effect/mob_spawn/human/engineer/hardsuit{
 	name = "Eric Abnett"
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating/airless,
-/area/awaymission/spacebattle/cruiser)
+/area/space)
 "eZ" = (
-/obj/structure/closet/crate,
-/obj/item/clothing/glasses/night,
-/turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/space/nearstation)
 "fa" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 10
+/obj/machinery/atmospherics/unary/cold_sink/freezer{
+	dir = 8
 	},
-/area/awaymission/spacebattle/cruiser)
+/turf/simulated/floor/plasteel/freezer,
+/area/awaymission/spacebattle/freezing)
 "fb" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "red"
+/obj/machinery/vending/cigarette/free,
+/obj/machinery/light{
+	dir = 8
 	},
-/area/awaymission/spacebattle/cruiser)
+/turf/simulated/floor/plasteel{
+	icon_state = "blue";
+	dir = 8
+	},
+/area/awaymission/spacebattle/bridge)
 "fc" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 6
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/area/awaymission/spacebattle/cruiser)
+/obj/machinery/power/apc{
+	pixel_x = 24
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/awaymission/spacebattle/freezing)
 "fd" = (
-/obj/structure/closet/crate,
-/obj/item/clothing/gloves/color/blue,
+/obj/structure/rack,
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/sec_storage)
 "fe" = (
 /obj/item/hand_labeler,
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/sec_storage)
 "ff" = (
 /obj/machinery/door/poddoor{
 	id_tag = "spacebattlestorage";
 	name = "Secure Storage"
 	},
 /turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/sec_storage)
 "fg" = (
-/mob/living/simple_animal/hostile/syndicate/ranged,
+/mob/living/simple_animal/hostile/syndicate/ranged{
+	name = "Syndicate Commander Bodyguard";
+	health = 400;
+	damage_coeff = list("brute" = 0.5, "fire" = 1.5, "tox" = 0, "clone" = 0, "stamina" = 0, "oxy" = 0)
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	pixel_x = -24
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "blue";
 	dir = 8
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "fh" = (
 /obj/machinery/computer/security/telescreen,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/shuttle/wall,
-/area/awaymission/spacebattle/cruiser)
-"fi" = (
-/turf/space,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "fj" = (
 /obj/machinery/door/airlock/external,
+/obj/structure/fans/tiny,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
 	},
 /area/awaymission/spacebattle/syndicate4)
 "fk" = (
-/obj/structure/closet/crate,
-/obj/item/clothing/glasses/material,
-/turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway13)
 "fl" = (
-/obj/structure/closet/crate,
-/obj/item/light/tube,
-/obj/item/light/tube,
-/obj/item/light/tube,
-/turf/simulated/floor/plating,
+/obj/structure/window/plasmareinforced{
+	dir = 4
+	},
+/turf/space,
 /area/awaymission/spacebattle/cruiser)
 "fm" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "fn" = (
 /obj/effect/mob_spawn/human/corpse/syndicatesoldier,
-/obj/item/gun/projectile/automatic/c20r,
 /obj/item/ammo_casing/c10mm,
 /obj/item/ammo_casing/c10mm,
 /obj/effect/decal/cleanable/blood,
@@ -1773,15 +1728,21 @@
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "fo" = (
 /obj/item/ammo_casing/c10mm,
 /obj/item/ammo_casing/c10mm,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "fp" = (
 /obj/effect/mob_spawn/human/bridgeofficer{
 	name = "Walter Strider"
@@ -1794,122 +1755,229 @@
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "fq" = (
 /obj/item/ammo_casing/shotgun,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "bluecorner"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "fr" = (
 /obj/item/ammo_casing/a357,
 /obj/item/ammo_casing/a357,
-/obj/item/gun/projectile/revolver/mateba,
 /obj/effect/mob_spawn/human/corpse/syndicatecommando{
 	name = "Aaron Bowden"
 	},
 /obj/effect/decal/cleanable/blood,
+/mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/armory{
+	name = "Syndicate Commander";
+	loot = list(/obj/effect/decal/cleanable/ash,/obj/item/documents/syndicate/blue);
+	health = 1000
+	},
 /turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "fs" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "ft" = (
 /obj/machinery/computer/shuttle,
 /turf/simulated/floor/plasteel{
 	tag = "icon-bluefull";
 	icon_state = "bluefull"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "fu" = (
-/obj/machinery/bsa/full/east,
-/turf/simulated/floor/plating/airless,
-/area/awaymission/spacebattle/cruiser)
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 10
+	},
+/area/awaymission/spacebattle/engine)
 "fv" = (
-/obj/machinery/computer/bsa_control,
+/obj/structure{
+	desc = "Long range bluespace artillery. It appearce to be broken or unactive";
+	icon = 'icons/obj/lavaland/cannon.dmi';
+	icon_state = "cannon_east";
+	name = "Bluespace Artillery"
+	},
 /turf/simulated/floor/plating/airless,
-/area/awaymission/spacebattle/cruiser)
+/area/space)
 "fw" = (
-/obj/structure/closet/crate,
-/obj/item/stack/spacecash/c10,
-/obj/item/stack/spacecash/c10,
-/turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 4
+	},
+/area/awaymission/spacebattle/engineering)
 "fx" = (
-/obj/item/instrument/violin,
-/turf/simulated/floor/wood,
-/area/awaymission/spacebattle/cruiser)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel/dark/telecomms,
+/area/awaymission/spacebattle/server)
+"fy" = (
+/obj/machinery/porta_turret/centcom{
+	use_power = 0;
+	reqpower = 0;
+	active_power_usage = 0;
+	idle_power_usage = 0;
+	name = "Space Defence Turret";
+	enabled = 1;
+	lethal = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret2)
+"fz" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 6
+	},
+/area/awaymission/spacebattle/prhallway3)
+"fB" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 5
+	},
+/area/awaymission/spacebattle/prhallway4)
 "fG" = (
-/obj/structure/closet/crate/internals,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/storage/firstaid/o2,
-/turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/obj/structure/bed,
+/obj/item/stack/sheet/cloth,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/living)
 "fH" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	dir = 0;
 	icon_state = "blue"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "fI" = (
 /obj/item/ammo_casing/c10mm,
 /obj/item/ammo_casing/c10mm,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	dir = 0;
 	icon_state = "blue"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "fJ" = (
 /obj/item/ammo_casing/shotgun,
 /obj/item/ammo_casing/c10mm,
 /obj/item/ammo_casing/c10mm,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	dir = 0;
 	icon_state = "blue"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "fK" = (
 /obj/item/ammo_casing/shotgun,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	dir = 0;
 	icon_state = "blue"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "fL" = (
 /obj/effect/mob_spawn/human/corpse/syndicatesoldier,
-/obj/item/gun/projectile/automatic/c20r,
 /obj/item/ammo_casing/c10mm,
 /obj/item/ammo_casing/c10mm,
 /obj/effect/decal/cleanable/blood,
+/obj/machinery/door/airlock/command,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	dir = 0;
 	icon_state = "blue"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "fM" = (
 /obj/item/ammo_casing/c10mm,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "bluecorner"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "fN" = (
 /obj/machinery/computer/communications,
 /turf/simulated/floor/plasteel{
 	tag = "icon-bluefull";
 	icon_state = "bluefull"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
+"fT" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"fV" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway12)
+"fW" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/hallway9)
 "ga" = (
-/obj/structure/closet/crate,
-/obj/item/poster/random_contraband,
-/turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
 "gb" = (
 /obj/effect/mob_spawn/human/bridgeofficer{
 	name = "Robert Faver"
@@ -1917,95 +1985,154 @@
 /obj/item/ammo_casing/shotgun,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
-"gm" = (
-/obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (WEST)";
-	icon_state = "heater";
+/area/awaymission/spacebattle/bridge)
+"gc" = (
+/obj/structure/window/plasmareinforced{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/window/plasmareinforced,
+/obj/structure{
+	desc = "It looks like a unactive supermatter shard.. Can I touch it?";
+	icon = 'icons/obj/supermatter.dmi';
+	icon_state = "darkmatter_shard";
+	name = "supermatter shard"
 	},
-/turf/simulated/shuttle/plating,
-/area/awaymission/spacebattle/cruiser)
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"gd" = (
+/obj/machinery/door/airlock/external,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway6)
+"gg" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 9
+	},
+/area/awaymission/spacebattle/prhallway4)
+"gh" = (
+/obj/machinery/door/airlock,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/prhallway4)
+"gj" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/prhallway4)
+"gm" = (
+/obj/structure/rack,
+/obj/item/crowbar/large,
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
 "gn" = (
-/obj/structure/closet/crate/secure/weapon,
 /obj/item/ammo_casing/a357,
+/obj/structure/rack,
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/sec_storage)
 "go" = (
-/obj/structure/closet/crate,
-/obj/item/lipstick/black,
-/obj/item/lipstick/jade,
-/turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/turf/simulated/floor/mineral/titanium{
+	icon_state = "titanium_dam1"
+	},
+/area/awaymission/spacebattle/storage)
 "gp" = (
-/obj/structure/closet/crate,
-/obj/item/clothing/gloves/color/rainbow,
+/obj/effect/landmark/damageturf,
+/obj/structure/rack,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/sec_storage)
 "gq" = (
 /obj/machinery/door_control{
-	dir = 2;
 	id = "spacebattlestorage";
 	name = "Secure Storage";
 	pixel_x = 24;
-	pixel_y = 0
+	use_power = 0
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/sec_storage)
 "gr" = (
 /obj/machinery/computer/operating,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "whitehall"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/medbay)
 "gs" = (
-/obj/structure/table/reinforced,
-/obj/item/scalpel,
-/obj/item/circular_saw,
+/obj/machinery/optable,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "whitehall"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/medbay)
 "gt" = (
 /obj/structure/table/reinforced,
-/obj/item/retractor,
-/turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 2
+/obj/item/retractor{
+	pixel_y = 2;
+	pixel_x = 3
 	},
-/area/awaymission/spacebattle/cruiser)
+/obj/item/circular_saw{
+	pixel_y = 11;
+	pixel_x = -1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitehall"
+	},
+/area/awaymission/spacebattle/medbay)
 "gu" = (
 /obj/structure/table/reinforced,
-/obj/item/hemostat,
-/turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 2
-	},
-/area/awaymission/spacebattle/cruiser)
-"gv" = (
-/obj/structure/table/reinforced,
 /obj/item/scalpel,
+/obj/item/storage/firstaid/regular,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "whitehall"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/medbay)
+"gv" = (
+/obj/structure/table/tray,
+/obj/item/retractor,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitehall"
+	},
+/area/awaymission/spacebattle/medbay)
 "gw" = (
-/obj/machinery/vending/cigarette,
-/turf/simulated/floor/wood,
-/area/awaymission/spacebattle/cruiser)
+/obj/structure/table/reinforced,
+/obj/item/flashlight/lamp{
+	pixel_y = 9;
+	pixel_x = -4
+	},
+/obj/item/paper_bin,
+/turf/simulated/floor/plasteel/dark/telecomms,
+/area/awaymission/spacebattle/server)
 "gx" = (
-/turf/simulated/floor/wood,
-/area/awaymission/spacebattle/cruiser)
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/simulated/floor/plasteel/dark/telecomms,
+/area/awaymission/spacebattle/server)
 "gy" = (
 /obj/item/gun/projectile/shotgun/automatic/combat,
 /turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "gz" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
@@ -2021,9 +2148,10 @@
 /area/awaymission/spacebattle/syndicate4)
 "gB" = (
 /obj/structure/closet/crate/secure/weapon,
-/obj/item/gun/energy/laser,
+/obj/item/gun/energy/laser/retro/old,
+/obj/item/gun/energy/laser/retro/old,
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/sec_storage)
 "gD" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/shuttle/wall{
@@ -2036,42 +2164,62 @@
 	name = "Adam Smith"
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/mob/living/simple_animal/hostile/syndicate/ranged/space,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/prhallway2)
 "gF" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/medbay)
 "gG" = (
-/obj/machinery/vending/coffee,
-/turf/simulated/floor/wood,
-/area/awaymission/spacebattle/cruiser)
+/obj/structure/table/reinforced,
+/obj/item/pen{
+	pixel_y = 15;
+	pixel_x = -4
+	},
+/obj/item/folder/yellow{
+	pixel_y = -7;
+	pixel_x = 6
+	},
+/turf/simulated/floor/plasteel/dark/telecomms,
+/area/awaymission/spacebattle/server)
 "gH" = (
-/mob/living/simple_animal/hostile/syndicate/melee/space,
-/turf/simulated/floor/wood,
-/area/awaymission/spacebattle/cruiser)
+/obj/structure/rack,
+/obj/item/storage/firstaid/brute,
+/obj/item/storage/firstaid/brute,
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
 "gI" = (
 /obj/machinery/computer/security,
 /turf/simulated/floor/plasteel{
 	tag = "icon-bluefull";
 	icon_state = "bluefull"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "gJ" = (
 /obj/machinery/computer/secure_data,
 /turf/simulated/floor/plasteel{
 	tag = "icon-bluefull";
 	icon_state = "bluefull"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "gK" = (
 /obj/effect/mob_spawn/human/engineer/hardsuit{
 	name = "Jeremy Tailor"
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating/airless,
-/area/awaymission/spacebattle/cruiser)
+/area/space)
 "gL" = (
 /obj/machinery/porta_turret{
 	dir = 8;
@@ -2097,59 +2245,55 @@
 "gO" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/sec_storage)
 "gP" = (
 /obj/machinery/computer/operating,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/medbay)
 "gQ" = (
-/obj/effect/mob_spawn/human/doctor{
-	name = "Allan Yoshimaru"
-	},
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/awaymission/spacebattle/cruiser)
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/simulated/floor/plasteel/freezer,
+/area/awaymission/spacebattle/freezing)
 "gR" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/medbay)
 "gS" = (
-/obj/structure/chair{
-	dir = 8
+/obj/machinery/tcomms/core{
+	name = "Very Hi-tech Machine";
+	desc = "You totally don't give a shit what is this."
 	},
-/turf/simulated/floor/wood,
-/area/awaymission/spacebattle/cruiser)
+/turf/simulated/floor/plasteel/dark/telecomms,
+/area/awaymission/spacebattle/server)
 "gT" = (
-/obj/structure/table/reinforced,
+/obj/structure/closet/crate/secure/bin,
 /turf/simulated/floor/plasteel{
 	icon_state = "blue";
 	dir = 10
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "gU" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
 	dir = 0;
 	icon_state = "blue"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/bridge)
 "gV" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
+/obj/structure/shuttle/engine/heater{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
+/obj/structure/window/plasmareinforced{
 	dir = 4
 	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/obj/structure/window/plasmareinforced,
+/turf/space,
+/area/space)
 "gW" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
@@ -2167,21 +2311,23 @@
 /turf/simulated/shuttle/plating,
 /area/awaymission/spacebattle/syndicate4)
 "gZ" = (
-/obj/item/pickaxe,
-/obj/item/gun/energy/plasmacutter,
-/obj/structure/closet/crate,
-/turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
-"ha" = (
-/obj/item/circular_saw,
+/obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "neutral";
+	dir = 1
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/hallway2)
+"ha" = (
+/obj/effect/mob_spawn/human/corpse/assistant,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
 "hb" = (
-/obj/item/paper_bin,
-/turf/simulated/floor/wood,
-/area/awaymission/spacebattle/cruiser)
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark/telecomms,
+/area/awaymission/spacebattle/server)
 "hc" = (
 /obj/effect/mob_spawn/human/engineer/hardsuit{
 	name = "Dan Hedricks"
@@ -2189,7 +2335,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating/airless,
-/area/awaymission/spacebattle/cruiser)
+/area/space)
 "hd" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -2217,7 +2363,6 @@
 "hg" = (
 /obj/structure/shuttle/engine/heater{
 	tag = "icon-heater (EAST)";
-	icon_state = "heater";
 	dir = 4
 	},
 /obj/structure/window/reinforced{
@@ -2236,48 +2381,34 @@
 "hi" = (
 /obj/structure/largecrate,
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/sec_storage)
 "hj" = (
 /obj/structure/closet/crate/secure/plasma,
-/obj/item/tank/internals/plasma,
+/obj/item/tank/plasma/full,
+/obj/item/tank/plasma/full,
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/sec_storage)
 "hk" = (
-/obj/structure/closet/crate/medical,
-/obj/item/storage/firstaid/fire,
-/turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway10)
 "hl" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/space/hardsuit,
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
 "hn" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
+/mob/living/simple_animal/hostile/syndicate/ranged/space,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/engine,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/syndicate5)
 "ho" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/engine,
-/area/awaymission/spacebattle/cruiser)
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret9)
 "hp" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -2289,48 +2420,52 @@
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/syndicate7)
 "hr" = (
-/obj/structure/largecrate,
-/mob/living/simple_animal/pet/dog/corgi/puppy,
+/obj/effect/mob_spawn/human/bridgeofficer,
+/obj/item/ammo_casing/c45,
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/sec_storage)
 "hs" = (
-/obj/structure/closet/crate/medical,
-/obj/item/storage/firstaid/regular,
+/obj/effect/landmark/damageturf,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/sec_storage)
 "ht" = (
-/obj/structure/closet/crate/medical,
-/obj/item/tank/internals/anesthetic,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/sec_storage)
 "hu" = (
-/obj/machinery/door/unpowered/shuttle,
+/obj/machinery/door/airlock/medical,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/medbay)
 "hv" = (
-/mob/living/simple_animal/hostile/syndicate/melee,
+/mob/living/simple_animal/hostile/syndicate/melee{
+	health = 400
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/medbay)
 "hw" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/regular,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/medbay)
 "hy" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/engine,
+/obj/machinery/door/airlock/external,
+/obj/structure/fans/tiny,
+/turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
 "hz" = (
 /turf/space,
@@ -2340,68 +2475,78 @@
 	},
 /area/awaymission/spacebattle/syndicate7)
 "hA" = (
-/turf/simulated/shuttle/wall{
-	tag = "icon-swall14";
-	icon_state = "swall14";
-	dir = 2
-	},
-/area/awaymission/spacebattle/cruiser)
+/obj/item/weldingtool/hugetank,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engineering)
 "hB" = (
-/obj/structure/table/reinforced,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
+/turf/space,
 /area/awaymission/spacebattle/cruiser)
 "hC" = (
-/obj/structure/bed,
-/obj/item/bedsheet/captain,
-/turf/simulated/floor/wood,
-/area/awaymission/spacebattle/cruiser)
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel/dark/telecomms,
+/area/awaymission/spacebattle/server)
 "hD" = (
-/obj/structure/closet/secure_closet/captains,
-/turf/simulated/floor/wood,
-/area/awaymission/spacebattle/cruiser)
+/obj/machinery/computer{
+	desc = "A computer long since rendered non-functional due to lack of maintenance. Spitting out error messages.";
+	dir = 1;
+	name = "Broken Computer";
+	obj_integrity = 150
+	},
+/turf/simulated/floor/plasteel/dark/telecomms,
+/area/awaymission/spacebattle/server)
 "hE" = (
 /obj/effect/mob_spawn/human/engineer{
 	name = "William Gannon"
 	},
+/obj/effect/decal/cleanable/blood/gibs/down,
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
 "hG" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/effect/decal/cleanable/blood,
+/obj/structure/table/tray,
+/obj/item/circular_saw,
+/obj/item/hemostat,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/turf/simulated/floor/engine,
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/medbay)
 "hH" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/engine,
-/area/awaymission/spacebattle/cruiser)
-"hI" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/engine,
-/area/awaymission/spacebattle/cruiser)
-"hJ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
+/obj/structure/closet/toolcloset,
+/obj/item/clothing/glasses/material,
+/obj/item/clothing/glasses/material,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
 	dir = 4
 	},
-/turf/simulated/floor/engine,
-/area/awaymission/spacebattle/cruiser)
-"hK" = (
-/obj/effect/mob_spawn/human/engineer{
-	name = "Javier Wismer"
+/area/awaymission/spacebattle/engine)
+"hI" = (
+/obj/effect/mob_spawn/human/securty,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway12)
+"hJ" = (
+/obj/machinery/door/airlock,
+/obj/effect/landmark/damageturf,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
+"hK" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 8
+	},
+/obj/structure/window/plasmareinforced{
+	dir = 4
+	},
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/turf/space,
+/area/space)
 "hL" = (
 /obj/machinery/computer/shuttle,
 /turf/simulated/shuttle/floor{
@@ -2419,142 +2564,116 @@
 /area/awaymission/spacebattle/syndicate7)
 "hN" = (
 /obj/machinery/door/airlock/external,
+/obj/structure/fans/tiny,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
 	},
 /area/awaymission/spacebattle/syndicate7)
 "hO" = (
-/obj/machinery/shower{
-	tag = "icon-shower (EAST)";
-	icon_state = "shower";
-	dir = 4
-	},
-/obj/item/bikehorn/rubberducky,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/awaymission/spacebattle/cruiser)
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/space,
+/area/space)
 "hP" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/awaymission/spacebattle/cruiser)
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plating/airless,
+/area/space)
 "hQ" = (
-/obj/machinery/shower{
-	tag = "icon-shower (WEST)";
-	icon_state = "shower";
+/obj/structure/shuttle/engine/propulsion{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/awaymission/spacebattle/cruiser)
+/turf/space,
+/area/space)
 "hR" = (
-/obj/structure/toilet,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/awaymission/spacebattle/cruiser)
+/turf/simulated/floor/plating/airless,
+/area/space)
 "hS" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/tactical/empty,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/medbay)
 "hT" = (
-/turf/space,
 /turf/simulated/shuttle/wall{
-	tag = "icon-swall_f9";
-	icon_state = "swall_f9";
-	dir = 2
+	tag = "icon-swall12";
+	icon_state = "swall_f9"
 	},
 /area/awaymission/spacebattle/cruiser)
 "hU" = (
-/obj/machinery/door/unpowered/shuttle,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/awaymission/spacebattle/cruiser)
+/obj/structure/grille/broken,
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
 "hV" = (
-/turf/simulated/shuttle/wall{
-	tag = "icon-swall1";
-	icon_state = "swall1"
-	},
-/area/awaymission/spacebattle/cruiser)
-"hW" = (
-/obj/item/storage/firstaid/regular,
+/obj/machinery/vending/cola/free,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "neutral"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/hallway12)
+"hW" = (
+/mob/living/simple_animal/hostile/syndicate/ranged{
+	health = 300
+	},
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
 "hX" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/firstaid/o2,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/medbay)
 "hY" = (
-/obj/machinery/shower{
-	tag = "icon-shower (EAST)";
-	icon_state = "shower";
+/obj/structure/table/reinforced,
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
+"hZ" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/space,
+/area/space)
+"ia" = (
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/obj/structure/window/plasmareinforced{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/awaymission/spacebattle/cruiser)
-"hZ" = (
-/obj/machinery/shower{
-	tag = "icon-shower (WEST)";
-	icon_state = "shower";
-	dir = 8
-	},
-/obj/item/soap,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/awaymission/spacebattle/cruiser)
-"ia" = (
-/mob/living/simple_animal/hostile/syndicate/ranged/space,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
+/turf/space,
 /area/awaymission/spacebattle/cruiser)
 "ib" = (
-/obj/effect/mob_spawn/human/doctor{
-	name = "Herbert West"
+/obj/structure/window/plasmareinforced{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
 	},
-/area/awaymission/spacebattle/cruiser)
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
 "ic" = (
-/obj/effect/mob_spawn/human/engineer{
-	name = "Carth Robinson"
-	},
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
+/turf/simulated/shuttle/wall{
+	tag = "icon-swall13";
+	icon_state = "swall13"
 	},
 /area/awaymission/spacebattle/cruiser)
 "id" = (
-/obj/item/ammo_casing/c10mm,
-/obj/item/ammo_casing/c10mm,
-/obj/item/ammo_casing/c10mm,
-/obj/item/ammo_casing/c10mm,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/awaymission/spacebattle/cruiser)
+/obj/structure/lattice,
+/obj/item/twohanded/required/kirbyplants,
+/turf/space,
+/area/space/nearstation)
 "ie" = (
-/obj/machinery/sleeper,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+/obj/machinery/computer{
+	desc = "A computer long since rendered non-functional due to lack of maintenance. Spitting out error messages.";
+	dir = 1;
+	name = "Broken Computer";
+	obj_integrity = 150
 	},
-/area/awaymission/spacebattle/cruiser)
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel/dark/telecomms,
+/area/awaymission/spacebattle/server)
 "ig" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
@@ -2562,47 +2681,73 @@
 	},
 /area/awaymission/spacebattle/syndicate7)
 "ih" = (
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
-	},
+/obj/effect/landmark/damageturf,
 /turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
+	icon_state = "neutral"
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/space/nearstation)
 "ii" = (
-/obj/machinery/sleeper,
-/turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 1
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/yellow{
+	pixel_y = 3
 	},
-/area/awaymission/spacebattle/cruiser)
+/obj/item/clothing/gloves/color/yellow{
+	pixel_y = 1
+	},
+/obj/item/clothing/gloves/color/yellow{
+	pixel_y = -2
+	},
+/obj/item/clothing/gloves/color/yellow{
+	pixel_y = -5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 4
+	},
+/area/awaymission/spacebattle/engine)
 "ik" = (
+/obj/effect/mob_spawn/human/bridgeofficer,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 1
+	icon_state = "neutral";
+	dir = 8
 	},
-/area/awaymission/spacebattle/cruiser)
+/area/awaymission/spacebattle/prhallway3)
 "il" = (
-/obj/effect/mob_spawn/human/engineer{
-	name = "Cyrion"
-	},
-/obj/item/flamethrower/full,
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
+/obj/structure/rack,
+/obj/item/stack/sheet/mineral/plasma/fifty,
+/obj/item/stack/sheet/mineral/plasma/fifty,
+/obj/item/stack/sheet/mineral/plasma/fifty,
+/obj/item/ammo_box/magazine/m45,
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
 "im" = (
-/mob/living/simple_animal/hostile/syndicate/ranged,
-/turf/simulated/floor/plasteel,
+/obj/structure/shuttle/engine/heater{
+	dir = 8
+	},
+/obj/structure/window/plasmareinforced{
+	dir = 4
+	},
+/turf/space,
 /area/awaymission/spacebattle/cruiser)
 "ip" = (
-/obj/effect/mob_spawn/human/engineer{
-	name = "Mercutio"
+/turf/simulated/shuttle/wall{
+	tag = "icon-swall12";
+	icon_state = "swall_f6"
 	},
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
 "iq" = (
 /obj/structure/lattice,
@@ -2610,6 +2755,7 @@
 /area/space/nearstation)
 "ir" = (
 /obj/effect/mob_spawn/human/corpse/syndicatesoldier,
+/obj/item/clothing/glasses/night,
 /turf/space,
 /area/space/nearstation)
 "is" = (
@@ -2845,42 +2991,2411 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/space/nearstation)
 "jd" = (
-/turf/simulated/wall/mineral/plasma,
-/area/awaymission/spacebattle/secret)
-"je" = (
-/turf/simulated/floor/plasteel{
-	tag = "icon-alienvault";
-	icon_state = "alienvault"
+/obj/item/twohanded/required/kirbyplants,
+/obj/machinery/light{
+	dir = 8
 	},
-/area/awaymission/spacebattle/secret)
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/hallway1)
+"je" = (
+/turf/simulated/mineral/random/high_chance,
+/area/space/nearstation)
 "jf" = (
 /obj/machinery/door/airlock/plasma,
-/turf/simulated/wall/mineral/plasma,
-/area/awaymission/spacebattle/secret)
-"nG" = (
-/obj/structure/window/reinforced,
-/obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
+/turf/simulated/mineral/random,
+/area/space/nearstation)
+"jk" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	pixel_x = -24
+	},
+/turf/simulated/floor/plasteel/dark/telecomms,
+/area/awaymission/spacebattle/server)
+"jr" = (
+/obj/structure/window/plasmareinforced{
 	dir = 1
 	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"ju" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 1
+	},
+/area/awaymission/spacebattle/engineering)
+"jA" = (
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway10)
+"jB" = (
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"jC" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/closet/crate/secure/bin,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/awaymission/spacebattle/medbay)
+"jI" = (
+/obj/structure/window/plasmareinforced,
+/obj/machinery/computer/sm_monitor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"jN" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/awaymission/spacebattle/freezing)
+"jS" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 10
+	},
+/area/awaymission/spacebattle/hallway10)
+"jT" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/prhallway1)
+"jY" = (
+/obj/item/ammo_casing/c10mm,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/bridge)
+"kf" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 10
+	},
+/area/awaymission/spacebattle/prhallway6)
+"kg" = (
+/mob/living/simple_animal/hostile/syndicate/melee{
+	health = 400
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway8)
+"kw" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow"
+	},
+/area/space/nearstation)
+"kx" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret10)
+"ky" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/space/nearstation)
+"kE" = (
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret5)
+"kF" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway12)
+"kI" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"kO" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/prhallway1)
+"kP" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/prhallway3)
+"kQ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/prhallway5)
+"kR" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret10)
+"kS" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 9
+	},
+/area/awaymission/spacebattle/hallway1)
+"kT" = (
+/mob/living/simple_animal/hostile/syndicate/melee{
+	health = 400
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway6)
+"kU" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
+"kY" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway5)
+"ld" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 9
+	},
+/area/awaymission/spacebattle/prhallway6)
+"le" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/awaymission/spacebattle/kitchen)
+"lk" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret9)
+"lm" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/secure_data/laptop{
+	pixel_y = 3;
+	pixel_x = 3
+	},
+/turf/simulated/floor/plasteel/dark/telecomms,
+/area/awaymission/spacebattle/server)
+"lq" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 10
+	},
+/area/awaymission/spacebattle/hallway5)
+"lr" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/bridge)
+"ls" = (
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret10)
+"lt" = (
+/obj/machinery/door/airlock,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/prhallway6)
+"lw" = (
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret1)
+"lB" = (
+/obj/machinery/door/airlock,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/kitchen)
+"lG" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"lJ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel/dark/telecomms,
+/area/awaymission/spacebattle/server)
+"lM" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/hallway13)
+"lP" = (
+/obj/machinery/vending/engivend,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 1
+	},
+/area/awaymission/spacebattle/engineering)
+"lU" = (
+/obj/item/twohanded/required/kirbyplants,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway4)
+"lW" = (
+/obj/machinery/vending/tool,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow"
+	},
+/area/awaymission/spacebattle/engine)
+"lY" = (
+/obj/item/screwdriver,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engineering)
+"lZ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway5)
+"mc" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway8)
+"md" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/obj/effect/landmark{
+	name = "awaystart"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway13)
+"mi" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/cruiser)
+"mk" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 4
+	},
+/area/awaymission/spacebattle/engine)
+"mp" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/hallway1)
+"mq" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway11)
+"mr" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"ms" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow"
+	},
+/area/awaymission/spacebattle/engine)
+"mu" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/secure_data/laptop{
+	pixel_y = 2;
+	pixel_x = -5
+	},
+/turf/simulated/floor/plasteel{
+	tag = "icon-bluefull";
+	icon_state = "bluefull"
+	},
+/area/awaymission/spacebattle/bridge)
+"mw" = (
+/obj/effect/mob_spawn/human/securty,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway7)
+"my" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 10
+	},
+/area/awaymission/spacebattle/prhallway5)
+"mD" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway4)
+"mF" = (
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret4)
+"mQ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 9
+	},
+/area/awaymission/spacebattle/hallway9)
+"mW" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "blue";
+	dir = 8
+	},
+/area/awaymission/spacebattle/bridge)
+"mY" = (
+/obj/structure/window/plasmareinforced{
+	dir = 8
+	},
+/obj/structure{
+	desc = "It appears to be broken SMES.";
+	icon = 'icons/obj/power.dmi';
+	icon_state = "smes";
+	name = "Nanotrasen PSU"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"nd" = (
+/obj/structure/closet/toolcloset,
+/obj/item/clothing/glasses/material,
+/obj/item/clothing/glasses/material,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 4
+	},
+/area/awaymission/spacebattle/engine)
+"ne" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret1{
+	requires_power = 0
+	})
+"np" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 10
+	},
+/area/awaymission/spacebattle/hallway4)
+"nr" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/prhallway6)
+"ns" = (
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret7)
+"nt" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 5
+	},
+/area/awaymission/spacebattle/prhallway3)
+"nu" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway11)
+"ny" = (
+/obj/effect/mob_spawn/human/securty,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway8)
+"nC" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway7)
+"nE" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "blue"
+	},
+/area/awaymission/spacebattle/bridge)
+"nF" = (
+/obj/machinery/door/airlock,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway10)
+"nG" = (
+/obj/structure/closet/fireaxecabinet,
+/turf/simulated/shuttle/wall{
+	tag = "icon-swall12";
+	icon_state = "swall12"
+	},
+/area/awaymission/spacebattle/cruiser)
+"nJ" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/prhallway1)
+"nN" = (
+/obj/structure/rack,
+/obj/item/ammo_box/magazine/m45,
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
+"nO" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	pixel_y = 24
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
+"nW" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"nY" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/hallway10)
+"oa" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 6
+	},
+/area/awaymission/spacebattle/engineering)
+"od" = (
+/obj/structure/rack,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"oh" = (
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway11)
+"oi" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway10)
+"oj" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway12)
+"ol" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/prhallway2)
+"ot" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway12)
+"ou" = (
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/simulated/floor/plasteel/freezer,
+/area/awaymission/spacebattle/freezing)
+"ov" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel/dark/telecomms,
+/area/awaymission/spacebattle/server)
+"ox" = (
+/obj/item/ammo_casing/c45,
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"oB" = (
+/obj/structure/closet/crate/secure/bin,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway12)
+"oD" = (
+/turf/simulated/shuttle/wall{
+	tag = "icon-swall14";
+	icon_state = "swall13"
+	},
+/area/awaymission/spacebattle/cruiser)
+"oH" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"oJ" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway9)
+"oM" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/hallway12)
+"oN" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway2)
+"oP" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway6)
+"oT" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 6
+	},
+/area/awaymission/spacebattle/prhallway6)
+"oW" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/awaymission/spacebattle/kitchen)
+"oY" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/turret1)
+"pe" = (
+/obj/effect/mob_spawn/human/bridgeofficer,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/prhallway2)
+"pf" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/living)
+"pk" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 9
+	},
+/area/awaymission/spacebattle/hallway4)
+"pm" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret4{
+	requires_power = 0
+	})
+"pn" = (
+/mob/living/simple_animal/hostile/syndicate/melee{
+	health = 400
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/prhallway3)
+"pp" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway5)
+"pq" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 10
+	},
+/area/awaymission/spacebattle/prhallway1)
+"pu" = (
+/obj/machinery/tcomms/core{
+	name = "Very Hi-tech Machine";
+	desc = "You totally don't give a shit what is this."
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark/telecomms,
+/area/awaymission/spacebattle/server)
+"py" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/window/plasmareinforced{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"pH" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"pK" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/hallway9)
+"pL" = (
+/obj/structure/rack,
+/obj/machinery/light,
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
+"pM" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
+"pP" = (
+/obj/structure/rack,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 4
+	},
+/area/awaymission/spacebattle/engineering)
+"pQ" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway10)
+"pR" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engineering)
+"qd" = (
+/mob/living/simple_animal/hostile/syndicate/ranged{
+	health = 300
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/prhallway3)
+"qg" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 6
+	},
+/area/awaymission/spacebattle/hallway6)
+"qi" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 6
+	},
+/area/awaymission/spacebattle/hallway7)
+"qn" = (
+/mob/living/simple_animal/hostile/syndicate/ranged/space{
+	health = 300
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engineering)
+"qo" = (
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/obj/structure/window/plasmareinforced{
+	dir = 8
+	},
+/obj/structure{
+	desc = "It appears to be broken SMES.";
+	icon = 'icons/obj/power.dmi';
+	icon_state = "smes";
+	name = "Nanotrasen PSU"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"qA" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway6)
+"qB" = (
+/obj/effect/mob_spawn/human/securty,
+/obj/effect/decal/cleanable/blood,
+/obj/item/gun/projectile/automatic/pistol/m1911,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway9)
+"qC" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/awaymission/spacebattle/medbay)
+"qD" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 10
+	},
+/area/awaymission/spacebattle/hallway7)
+"qH" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway11)
+"qI" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"qJ" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway4)
+"qM" = (
+/obj/structure/closet/crate/secure/bin,
+/obj/item/gun/projectile/shotgun/automatic/combat,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway13)
+"qO" = (
+/obj/machinery/vending/dinnerware,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/awaymission/spacebattle/kitchen)
+"qP" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway12)
+"qQ" = (
+/obj/machinery/door/airlock/security{
+	name = "Turret Room"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/turret4)
+"qT" = (
+/obj/structure/closet/crate/secure/bin,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 10
+	},
+/area/awaymission/spacebattle/hallway11)
+"qW" = (
+/obj/machinery/door/airlock/command,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/bridge)
+"rc" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway1)
+"rg" = (
+/obj/effect/landmark/damageturf,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret4{
+	requires_power = 0
+	})
+"rp" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/hallway13)
+"rv" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 6
+	},
+/area/awaymission/spacebattle/hallway4)
+"rw" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/prhallway1)
+"rx" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 9
+	},
+/area/awaymission/spacebattle/hallway6)
+"rB" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 5
+	},
+/area/awaymission/spacebattle/prhallway1)
+"rC" = (
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/awaymission/spacebattle/kitchen)
+"rE" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/space,
+/area/space)
+"rK" = (
+/mob/living/simple_animal/hostile/syndicate/ranged{
+	health = 300
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"rL" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/hallway10)
+"rM" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway4)
+"rN" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway5)
+"rP" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway9)
+"rR" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway13)
+"rS" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 9
+	},
+/area/awaymission/spacebattle/prhallway3)
+"rU" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/living)
+"rW" = (
+/obj/structure/window/plasmareinforced{
+	dir = 4
+	},
+/obj/structure{
+	desc = "It looks like a unactive supermatter shard.. Can I touch it?";
+	icon = 'icons/obj/supermatter.dmi';
+	icon_state = "darkmatter_shard";
+	name = "supermatter shard"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"rY" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/space/nearstation)
+"sb" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 6
+	},
+/area/awaymission/spacebattle/prhallway1)
+"sc" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 5
+	},
+/area/awaymission/spacebattle/hallway6)
+"sf" = (
+/obj/machinery/porta_turret/centcom{
+	use_power = 0;
+	reqpower = 0;
+	active_power_usage = 0;
+	idle_power_usage = 0;
+	name = "Space Defence Turret";
+	enabled = 1;
+	lethal = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret1)
+"sh" = (
+/obj/structure/closet/crate/secure/bin,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 9
+	},
+/area/awaymission/spacebattle/hallway4)
+"sj" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway5)
+"sl" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway12)
+"sn" = (
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/awaymission/spacebattle/medbay)
+"so" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 6
+	},
+/area/awaymission/spacebattle/hallway9)
+"sp" = (
+/obj/structure/table/tray,
+/obj/item/reagent_containers/hypospray/safety{
+	pixel_x = 10;
+	pixel_y = 9
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/awaymission/spacebattle/medbay)
+"ss" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway13)
+"sv" = (
+/obj/machinery/door/airlock,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway1)
+"sw" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway6)
+"sz" = (
+/obj/effect/mob_spawn/human/bridgeofficer,
+/obj/effect/mob_spawn/human/securty,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway1)
+"sA" = (
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway1)
+"sC" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 8
+	},
+/area/awaymission/spacebattle/engine)
+"sE" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/hallway13)
+"sH" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway2)
+"sJ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/space/nearstation)
+"sL" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/mob_spawn/human/scientist,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel/dark/telecomms,
+/area/awaymission/spacebattle/server)
+"sM" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret2{
+	requires_power = 0
+	})
+"sO" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/prhallway3)
+"sS" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"sW" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway12)
+"tf" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 4
+	},
+/area/awaymission/spacebattle/engineering)
+"ti" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway1)
+"tk" = (
+/obj/item/ammo_casing/c10mm,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/bridge)
+"tl" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 9
+	},
+/area/awaymission/spacebattle/hallway3)
+"tm" = (
+/obj/effect/landmark/damageturf,
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway13)
+"tp" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 1
+	},
+/area/awaymission/spacebattle/engine)
+"tq" = (
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/prhallway6)
+"tu" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/mineral/titanium{
+	icon_state = "titanium_dam1"
+	},
+/area/awaymission/spacebattle/storage)
+"tB" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 5
+	},
+/area/awaymission/spacebattle/hallway9)
+"tG" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 10
+	},
+/area/awaymission/spacebattle/prhallway2)
+"tH" = (
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/obj/structure/window/plasmareinforced{
+	dir = 4
+	},
+/obj/structure{
+	desc = "It appears to be broken SMES.";
+	icon = 'icons/obj/power.dmi';
+	icon_state = "smes";
+	name = "Nanotrasen PSU"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"tI" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"tM" = (
+/obj/structure/window/plasmareinforced{
+	dir = 4
+	},
+/obj/structure/window/plasmareinforced,
+/obj/structure{
+	desc = "It looks like a unactive supermatter shard.. Can I touch it?";
+	icon = 'icons/obj/supermatter.dmi';
+	icon_state = "darkmatter_shard";
+	name = "supermatter shard"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"tO" = (
+/obj/structure/closet/secure_closet/freezer/meat/open,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/awaymission/spacebattle/freezing)
+"tS" = (
+/obj/item/gun/projectile/automatic/pistol,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/awaymission/spacebattle/syndicate2)
+"tT" = (
+/obj/machinery/door/airlock/command,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "blue"
+	},
+/area/awaymission/spacebattle/bridge)
+"tU" = (
+/obj/structure/bed,
+/obj/item/stack/sheet/cloth,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/living)
+"tV" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 5
+	},
+/area/awaymission/spacebattle/hallway4)
+"tW" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/hallway8)
+"ua" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway8)
+"ub" = (
+/mob/living/simple_animal/hostile/syndicate/ranged{
+	health = 300
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/prhallway6)
+"ue" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway13)
+"um" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/hallway6)
+"us" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret1)
+"uu" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway13)
+"uv" = (
+/obj/machinery/door/airlock,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway5)
+"ux" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/shuttle/plating,
-/area/awaymission/spacebattle/cruiser)
-"qC" = (
-/obj/structure/window/reinforced,
-/obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
+/turf/space,
+/area/space/nearstation)
+"uz" = (
+/mob/living/simple_animal/hostile/syndicate/melee{
+	health = 400
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 5
+	},
+/area/awaymission/spacebattle/prhallway5)
+"uK" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	dir = 0;
+	icon_state = "blue"
+	},
+/area/awaymission/spacebattle/bridge)
+"uU" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/food/snacks/meat/human,
+/obj/item/reagent_containers/food/snacks/meat/human,
+/obj/item/reagent_containers/food/snacks/meat/human,
+/obj/item/reagent_containers/food/snacks/meat/slab,
+/obj/item/organ/internal/brain/vulpkanin,
+/turf/simulated/floor/plasteel/freezer,
+/area/awaymission/spacebattle/freezing)
+"uW" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret3)
+"uZ" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/living)
+"ve" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 10
+	},
+/area/awaymission/spacebattle/hallway8)
+"vf" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway10)
+"vh" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
 	dir = 8
 	},
-/turf/simulated/shuttle/plating,
+/area/awaymission/spacebattle/living)
+"vi" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/living)
+"vj" = (
+/obj/structure/closet/crate/secure/bin,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 10
+	},
+/area/awaymission/spacebattle/hallway1)
+"vm" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway7)
+"vn" = (
+/obj/machinery/door/airlock/security{
+	name = "Turret Room"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/turret8)
+"vo" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway9)
+"vs" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/prhallway1)
+"vu" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 6
+	},
+/area/awaymission/spacebattle/prhallway5)
+"vw" = (
+/obj/machinery/door/airlock,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway12)
+"vH" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/hallway13)
+"vJ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"vL" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel/freezer,
+/area/awaymission/spacebattle/freezing)
+"vM" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway10)
+"vN" = (
+/obj/machinery/vending/cola/free,
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/living)
+"vO" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	dir = 0;
+	icon_state = "blue"
+	},
+/area/awaymission/spacebattle/bridge)
+"vQ" = (
+/obj/machinery/door/airlock,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
+"vS" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/hallway6)
+"vY" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/hallway1)
+"vZ" = (
+/obj/structure/closet/crate/secure/bin,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway9)
+"wg" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/cruiser)
+"wm" = (
+/obj/machinery/door/airlock/engineering,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/cruiser)
+"wo" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"wp" = (
+/obj/machinery/door/airlock/external,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway6)
+"wq" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway11)
+"ww" = (
+/obj/machinery/door/airlock,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/prhallway5)
+"wx" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/prhallway2)
+"wz" = (
+/obj/structure/rack,
+/obj/item/ammo_casing/c45,
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"wC" = (
+/obj/machinery/vending/engivend,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 1
+	},
+/area/awaymission/spacebattle/engine)
+"wD" = (
+/obj/item/ammo_casing/c10mm,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/bridge)
+"wH" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret1{
+	requires_power = 0
+	})
+"wJ" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/space/nearstation)
+"wK" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/prhallway2)
+"wR" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret6)
+"wV" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/prhallway1)
+"wY" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/prhallway1)
+"wZ" = (
+/obj/machinery/porta_turret/centcom{
+	use_power = 0;
+	reqpower = 0;
+	active_power_usage = 0;
+	idle_power_usage = 0;
+	name = "Space Defence Turret";
+	enabled = 1;
+	lethal = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret3)
+"xa" = (
+/obj/machinery/door/airlock,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/prhallway2)
+"xb" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/damageturf,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"xe" = (
+/obj/effect/mob_spawn/human/securty,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway1)
+"xo" = (
+/turf/simulated/floor/mineral/titanium{
+	icon_state = "titanium_dam2"
+	},
+/area/awaymission/spacebattle/storage)
+"xp" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
+"xq" = (
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway11)
+"xw" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway1)
+"xz" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret9{
+	requires_power = 0
+	})
+"xB" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/prhallway4)
+"xE" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/food/snacks/meat/slab,
+/obj/item/reagent_containers/food/snacks/meat/slab,
+/obj/item/reagent_containers/food/snacks/meat/slab,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/awaymission/spacebattle/freezing)
+"xL" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 10
+	},
+/area/awaymission/spacebattle/hallway13)
+"xM" = (
+/obj/structure/window/plasmareinforced{
+	dir = 8
+	},
+/obj/structure{
+	desc = "It looks like a unactive supermatter shard.. Can I touch it?";
+	icon = 'icons/obj/supermatter.dmi';
+	icon_state = "darkmatter_shard";
+	name = "supermatter shard"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"xN" = (
+/obj/structure/table/reinforced,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 9
+	},
+/area/awaymission/spacebattle/hallway12)
+"xT" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner";
+	dir = 4
+	},
+/area/awaymission/spacebattle/hallway12)
+"xU" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway1)
+"xX" = (
+/obj/structure/shuttle/engine/large{
+	dir = 8
+	},
+/turf/space,
+/area/awaymission/spacebattle/cruiser)
+"xZ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"yb" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/hallway6)
+"yh" = (
+/obj/machinery/door/airlock/external,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway9)
+"yo" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway8)
+"yr" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
+"yt" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway13)
+"yu" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/titanium{
+	icon_state = "titanium_dam1"
+	},
+/area/awaymission/spacebattle/storage)
+"yA" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 9
+	},
+/area/awaymission/spacebattle/prhallway2)
+"yB" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engineering)
+"yG" = (
+/obj/machinery/door/airlock/command,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/bridge)
+"yM" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway8)
+"yO" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway4)
+"yQ" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/bed,
+/obj/item/bedsheet,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/living)
+"yS" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway5)
+"yX" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 5
+	},
+/area/awaymission/spacebattle/hallway12)
+"yZ" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow"
+	},
+/area/space/nearstation)
+"zb" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret6)
+"zd" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway6)
+"ze" = (
+/obj/structure/table/reinforced,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway12)
+"zg" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway9)
+"zh" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/prhallway2)
+"zl" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway7)
+"zn" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 6
+	},
+/area/awaymission/spacebattle/prhallway2)
+"zC" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow"
+	},
+/area/awaymission/spacebattle/engine)
+"zK" = (
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway12)
+"zQ" = (
+/obj/effect/landmark{
+	name = "awaystart"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway13)
 "zS" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4;
@@ -2889,6 +5404,1381 @@
 	},
 /turf/simulated/shuttle/plating,
 /area/space/nearstation)
+"zU" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/turret2)
+"zX" = (
+/obj/machinery/vending/tool,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 1
+	},
+/area/awaymission/spacebattle/engineering)
+"Ab" = (
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/prhallway4)
+"Ac" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/space/nearstation)
+"Ag" = (
+/obj/machinery/door/airlock/engineering,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/storage)
+"Ah" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway4)
+"Ai" = (
+/obj/machinery/power/apc{
+	pixel_y = -24
+	},
+/obj/structure/cable,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow"
+	},
+/area/awaymission/spacebattle/engine)
+"Ap" = (
+/obj/machinery/door/airlock,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway3)
+"Au" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/effect/landmark{
+	name = "awaystart"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway9)
+"Av" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 8
+	},
+/area/awaymission/spacebattle/engine)
+"Ax" = (
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"AA" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/cruiser)
+"AB" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
+"AC" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/cruiser)
+"AF" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	pixel_x = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/prhallway3)
+"AH" = (
+/obj/effect/landmark/damageturf,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"AI" = (
+/mob/living/simple_animal/hostile/syndicate/ranged/space,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/prhallway2)
+"AK" = (
+/obj/effect/landmark/damageturf,
+/mob/living/simple_animal/hostile/syndicate/ranged{
+	health = 300
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway1)
+"AL" = (
+/obj/machinery/door/airlock/security{
+	name = "Turret Room"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/turret2)
+"AN" = (
+/obj/machinery/light,
+/turf/simulated/floor/plasteel/dark/telecomms,
+/area/awaymission/spacebattle/server)
+"AO" = (
+/obj/machinery/porta_turret/centcom{
+	use_power = 0;
+	reqpower = 0;
+	active_power_usage = 0;
+	idle_power_usage = 0;
+	name = "Space Defence Turret";
+	enabled = 1;
+	lethal = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret5)
+"AQ" = (
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 8
+	},
+/area/awaymission/spacebattle/engine)
+"AR" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway5)
+"AS" = (
+/obj/machinery/door/airlock/security{
+	name = "Turret Room"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/turret1)
+"AT" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/cruiser)
+"AV" = (
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"AZ" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway7)
+"Bd" = (
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/bridge)
+"Bg" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway1)
+"Bo" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/prhallway2)
+"Bp" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway11)
+"Bv" = (
+/mob/living/simple_animal/hostile/syndicate/melee{
+	health = 400
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway6)
+"Bx" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret3{
+	requires_power = 0
+	})
+"By" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 9
+	},
+/area/awaymission/spacebattle/engine)
+"BA" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 9
+	},
+/area/awaymission/spacebattle/prhallway5)
+"BI" = (
+/obj/effect/mob_spawn/human/securty,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner";
+	dir = 4
+	},
+/area/awaymission/spacebattle/hallway10)
+"BK" = (
+/obj/structure/window/plasmareinforced{
+	dir = 4
+	},
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/turf/space,
+/area/awaymission/spacebattle/cruiser)
+"BL" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 8
+	},
+/area/awaymission/spacebattle/engine)
+"BO" = (
+/obj/structure/largecrate,
+/obj/machinery/light,
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"BQ" = (
+/obj/structure/rack,
+/obj/item/wrench,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 4
+	},
+/area/awaymission/spacebattle/engineering)
+"BS" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/awaymission/spacebattle/kitchen)
+"BT" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway5)
+"BU" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/hallway5)
+"BV" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/obj/machinery/light,
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"Cc" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway11)
+"Ce" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway10)
+"Cg" = (
+/mob/living/simple_animal/hostile/syndicate/ranged/space{
+	health = 300
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/living)
+"Ck" = (
+/obj/machinery/light,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/cruiser)
+"Cl" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/hallway10)
+"Cr" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/landmark{
+	name = "awaystart"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway13)
+"Cu" = (
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/living)
+"Cz" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 10
+	},
+/area/awaymission/spacebattle/prhallway3)
+"CE" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/prhallway5)
+"CF" = (
+/obj/structure/closet/toolcloset,
+/obj/item/clothing/glasses/material,
+/obj/item/clothing/glasses/material,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 6
+	},
+/area/awaymission/spacebattle/engine)
+"CI" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 6
+	},
+/area/awaymission/spacebattle/hallway1)
+"CN" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/simulated/floor/plasteel,
+/area/space/nearstation)
+"CR" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"CS" = (
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret3)
+"CW" = (
+/obj/machinery/door/airlock,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/prhallway4)
+"CX" = (
+/obj/machinery/door/airlock/external,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/cruiser)
+"CY" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
+"Dd" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/hallway7)
+"Dl" = (
+/mob/living/simple_animal/hostile/syndicate/ranged{
+	health = 300
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway1)
+"Dr" = (
+/obj/machinery/porta_turret/centcom{
+	use_power = 0;
+	reqpower = 0;
+	active_power_usage = 0;
+	idle_power_usage = 0;
+	name = "Space Defence Turret";
+	enabled = 1;
+	lethal = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret8)
+"Dt" = (
+/obj/structure/closet/crate/secure/bin,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 1
+	},
+/area/awaymission/spacebattle/engine)
+"Du" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	pixel_x = 24
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"Dv" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 9
+	},
+/area/awaymission/spacebattle/hallway10)
+"Dw" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/prhallway3)
+"Dx" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"DC" = (
+/obj/machinery/door/airlock,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway13)
+"DF" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/space/nearstation)
+"DH" = (
+/mob/living/simple_animal/hostile/syndicate/ranged/space{
+	health = 300
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/living)
+"DL" = (
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"DN" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret7{
+	requires_power = 0
+	})
+"DP" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/prhallway3)
+"DT" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/prhallway6)
+"DZ" = (
+/obj/structure/closet/toolcloset,
+/obj/item/clothing/glasses/material,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 5
+	},
+/area/awaymission/spacebattle/engine)
+"Ea" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret10{
+	requires_power = 0
+	})
+"Ee" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"Eg" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway7)
+"Eo" = (
+/turf/simulated/floor/mineral/titanium{
+	icon_state = "titanium_dam5"
+	},
+/area/awaymission/spacebattle/storage)
+"Ey" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow"
+	},
+/area/awaymission/spacebattle/engine)
+"EB" = (
+/obj/structure/rack,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 1
+	},
+/area/awaymission/spacebattle/engineering)
+"ED" = (
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway9)
+"EJ" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/hallway1)
+"EQ" = (
+/obj/structure/table/reinforced,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway1)
+"ES" = (
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway6)
+"EU" = (
+/mob/living/simple_animal/hostile/syndicate/ranged,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway12)
+"EX" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway11)
+"Fk" = (
+/obj/structure/closet/crate/secure/bin,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 1
+	},
+/area/awaymission/spacebattle/engineering)
+"Fq" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"Fr" = (
+/obj/structure/window/plasmareinforced,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"Fs" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 5
+	},
+/area/awaymission/spacebattle/hallway13)
+"Ft" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret7)
+"Fu" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/syndie_kit/bonerepair,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/awaymission/spacebattle/medbay)
+"Fv" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engineering)
+"Fy" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/hallway7)
+"Fz" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway10)
+"FA" = (
+/obj/effect/landmark/damageturf,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engineering)
+"FH" = (
+/obj/machinery/door/airlock,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway5)
+"FI" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway10)
+"FJ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/hallway5)
+"FL" = (
+/mob/living/simple_animal/hostile/syndicate/ranged/space,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/prhallway2)
+"FM" = (
+/obj/machinery/door/airlock/external,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway9)
+"FN" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/prhallway1)
+"FT" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway10)
+"FX" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 9
+	},
+/area/awaymission/spacebattle/hallway5)
+"FZ" = (
+/obj/structure/closet/crate/secure/bin,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway5)
+"Gc" = (
+/obj/machinery/vending/cola/free,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 5
+	},
+/area/awaymission/spacebattle/hallway11)
+"Gf" = (
+/obj/machinery/door/airlock,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/prhallway2)
+"Gi" = (
+/obj/item/storage/box/syndie_kit/hardsuit,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/awaymission/spacebattle/syndicate3)
+"Gl" = (
+/obj/machinery/door/airlock,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/prhallway3)
+"Gm" = (
+/obj/structure/rack,
+/obj/item/wrench,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/cruiser)
+"Gn" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway5)
+"Gp" = (
+/mob/living/simple_animal/hostile/syndicate/melee{
+	health = 400
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/prhallway1)
+"Gs" = (
+/obj/effect/mob_spawn/human/engineer,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"Gx" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/awaymission/spacebattle/kitchen)
+"Gy" = (
+/obj/structure/cable,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/cruiser)
+"GA" = (
+/obj/machinery/vending/cigarette/free,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/living)
+"GB" = (
+/mob/living/simple_animal/hostile/syndicate/melee{
+	health = 400
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway10)
+"GI" = (
+/obj/structure/table/reinforced,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway12)
+"GK" = (
+/mob/living/simple_animal/hostile/syndicate/ranged{
+	health = 300
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway5)
+"GP" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/awaymission/spacebattle/kitchen)
+"GQ" = (
+/obj/effect/landmark/damageturf,
+/obj/item/ammo_casing/c45,
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"GR" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway12)
+"GU" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 10
+	},
+/area/awaymission/spacebattle/hallway3)
+"GW" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret2{
+	requires_power = 0
+	})
+"GZ" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway5)
+"Hd" = (
+/obj/machinery/power/port_gen/pacman/upgraded,
+/obj/structure/cable,
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/engine)
+"He" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 5
+	},
+/area/awaymission/spacebattle/prhallway6)
+"Hh" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/hallway1)
+"Hj" = (
+/mob/living/simple_animal/hostile/syndicate/melee{
+	health = 400
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/prhallway2)
+"Hm" = (
+/obj/machinery/vending/cigarette/free,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway12)
+"Hn" = (
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/power/smes/upgraded,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 4
+	},
+/area/awaymission/spacebattle/engine)
+"Hv" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 9
+	},
+/area/awaymission/spacebattle/hallway11)
+"Hx" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/awaymission/spacebattle/freezing)
+"Hz" = (
+/mob/living/simple_animal/hostile/syndicate/ranged{
+	health = 300
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway10)
+"HC" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret4)
+"HD" = (
+/obj/machinery/door/airlock/security{
+	name = "Turret Room"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/turret7)
+"HG" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway1)
+"HK" = (
+/obj/effect/mob_spawn/human/securty,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway4)
+"HM" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"HN" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/living)
+"HO" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/prhallway2)
+"Ic" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway6)
+"Id" = (
+/obj/machinery/door/airlock,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/prhallway3)
+"Ie" = (
+/obj/machinery/door/airlock,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway10)
+"If" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/hallway5)
+"Ig" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/hallway12)
+"Io" = (
+/obj/machinery/porta_turret/centcom{
+	use_power = 0;
+	reqpower = 0;
+	active_power_usage = 0;
+	idle_power_usage = 0;
+	name = "Space Defence Turret";
+	enabled = 1;
+	lethal = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret4)
+"Ip" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway1)
+"Iu" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway11)
+"Ix" = (
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/hallway11)
+"IF" = (
+/mob/living/simple_animal/hostile/syndicate/melee{
+	health = 400
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/prhallway2)
+"IN" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/living)
+"IO" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/living)
+"IT" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/hallway1)
+"IU" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway11)
+"IY" = (
+/obj/structure/closet/crate/secure/bin,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway4)
+"Je" = (
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway7)
+"Jg" = (
+/obj/structure/closet/toolcloset,
+/obj/structure/closet/wardrobe/engineering_yellow,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 4
+	},
+/area/awaymission/spacebattle/engine)
+"Ji" = (
+/mob/living/simple_animal/hostile/syndicate/melee,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway12)
 "Jj" = (
 /obj/structure/shuttle/engine/propulsion{
 	tag = "icon-propulsion_l (NORTH)";
@@ -2897,6 +6787,39 @@
 	},
 /turf/simulated/shuttle/plating,
 /area/awaymission/spacebattle/syndicate2)
+"Jm" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway12)
+"Js" = (
+/obj/item/screwdriver,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow"
+	},
+/area/awaymission/spacebattle/engineering)
+"Jt" = (
+/obj/machinery/door/airlock,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/prhallway1)
+"Jv" = (
+/obj/machinery/door/airlock/command,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/server)
 "Jw" = (
 /obj/structure/shuttle/engine/propulsion{
 	tag = "icon-propulsion_r (NORTH)";
@@ -2905,49 +6828,2434 @@
 	},
 /turf/simulated/shuttle/plating,
 /area/awaymission/spacebattle/syndicate2)
+"Jy" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 1
+	},
+/area/awaymission/spacebattle/engine)
+"JB" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
+"JD" = (
+/obj/effect/landmark/damageturf,
+/obj/effect/landmark{
+	name = "awaystart"
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
+"JH" = (
+/obj/machinery/door_control{
+	id = "spacebattlestorage";
+	name = "Secure Storage";
+	pixel_x = 8;
+	use_power = 0
+	},
+/turf/simulated/shuttle/wall{
+	tag = "icon-swall3";
+	icon_state = "swall3"
+	},
+/area/awaymission/spacebattle/cruiser)
+"JJ" = (
+/obj/structure/rack,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"JN" = (
+/obj/effect/mob_spawn/human/securty,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway9)
+"JR" = (
+/mob/living/simple_animal/hostile/syndicate/ranged/space{
+	health = 300
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
 "JS" = (
-/obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_l (NORTH)";
-	icon_state = "propulsion_l";
-	dir = 1
+/mob/living/simple_animal/hostile/syndicate/ranged/space{
+	health = 300
 	},
-/turf/simulated/shuttle/plating,
-/area/awaymission/spacebattle/cruiser)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/space/nearstation)
 "JW" = (
-/obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_r (NORTH)";
-	icon_state = "propulsion_r";
+/obj/structure/rack,
+/obj/item/tank/jetpack/void,
+/obj/item/tank/jetpack/void,
+/obj/item/tank/jetpack/void,
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
+"JZ" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 5
+	},
+/area/awaymission/spacebattle/hallway1)
+"Kb" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 6
+	},
+/area/awaymission/spacebattle/hallway11)
+"Ke" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/living)
+"Kl" = (
+/mob/living/simple_animal/hostile/syndicate/melee/space,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel/dark/telecomms,
+/area/awaymission/spacebattle/server)
+"Kp" = (
+/obj/effect/mob_spawn/human/securty,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway12)
+"Ks" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/prhallway6)
+"Kv" = (
+/obj/structure/rack,
+/obj/item/clothing/glasses/night,
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
+"Kw" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
 	dir = 1
 	},
-/turf/simulated/shuttle/plating,
-/area/awaymission/spacebattle/cruiser)
-"YV" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "burst_r";
-	tag = "icon-burst_r (EAST)"
+/area/awaymission/spacebattle/hallway11)
+"KA" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret5)
+"KC" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 9
 	},
-/turf/simulated/shuttle/plating,
+/area/awaymission/spacebattle/hallway8)
+"KM" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/bridge)
+"KO" = (
+/obj/structure/rack,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"KP" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/hallway7)
+"KT" = (
+/obj/effect/mob_spawn/human/securty,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway6)
+"Lc" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"Ld" = (
+/obj/machinery/power/apc{
+	pixel_y = -24
+	},
+/obj/structure/cable,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/living)
+"Le" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway11)
+"Lo" = (
+/mob/living/simple_animal/hostile/syndicate/melee{
+	health = 400
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway5)
+"Lp" = (
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway2)
+"Lq" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret9{
+	requires_power = 0
+	})
+"Lu" = (
+/obj/structure/table/reinforced,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway1)
+"Lv" = (
+/obj/structure/table/tray,
+/obj/item/scalpel,
+/obj/item/reagent_containers/hypospray/autoinjector/survival{
+	pixel_y = 5;
+	pixel_x = 2
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/awaymission/spacebattle/medbay)
+"Ly" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/living)
+"LA" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway6)
+"LE" = (
+/obj/machinery/door/airlock/security{
+	name = "Turret Room"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/turret5)
+"LI" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway4)
+"LQ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway1)
+"LT" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 6
+	},
+/area/awaymission/spacebattle/hallway10)
+"Mh" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway10)
+"Mi" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	pixel_x = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/prhallway2)
+"Mk" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/living)
+"Mn" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 9
+	},
+/area/awaymission/spacebattle/prhallway1)
+"Mr" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/prhallway3)
+"Mt" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/prhallway3)
+"My" = (
+/turf/simulated/floor/plasteel/dark/telecomms,
+/area/awaymission/spacebattle/server)
+"MA" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 9
+	},
+/area/awaymission/spacebattle/hallway13)
+"MD" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/prhallway3)
+"MI" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 10
+	},
+/area/space/nearstation)
+"ML" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway9)
+"MS" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/hallway7)
+"MW" = (
+/obj/effect/landmark/damageturf,
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 5
+	},
+/area/awaymission/spacebattle/hallway12)
+"MX" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway1)
+"Nb" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/prhallway4)
+"Ne" = (
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"Nf" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway12)
+"Nh" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway6)
+"Nl" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 6
+	},
+/area/awaymission/spacebattle/hallway3)
+"Nm" = (
+/mob/living/simple_animal/hostile/syndicate/ranged/space{
+	health = 300
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/hallway5)
+"Nq" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/awaymission/spacebattle/medbay)
+"Nr" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 5
+	},
+/area/awaymission/spacebattle/hallway7)
+"Nv" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 8
+	},
+/area/awaymission/spacebattle/engine)
+"Nw" = (
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway12)
+"NA" = (
+/obj/structure/closet/crate/secure/bin,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 10
+	},
+/area/awaymission/spacebattle/engineering)
+"NC" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 1
+	},
+/area/awaymission/spacebattle/engineering)
+"NH" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/prhallway6)
+"NT" = (
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway13)
+"NV" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway3)
+"NY" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 5
+	},
+/area/awaymission/spacebattle/hallway10)
+"Od" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/surgery,
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/awaymission/spacebattle/medbay)
+"Of" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 10
+	},
+/area/awaymission/spacebattle/hallway12)
+"Oh" = (
+/obj/machinery/door/airlock,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/prhallway5)
+"Oi" = (
+/obj/structure/closet/crate/secure/bin,
+/turf/simulated/floor/plasteel/dark/telecomms,
+/area/awaymission/spacebattle/server)
+"Ok" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/prhallway2)
+"Ol" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 6
+	},
+/area/awaymission/spacebattle/living)
+"Om" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/awaymission/spacebattle/kitchen)
+"Op" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway4)
+"Os" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret5{
+	requires_power = 0
+	})
+"Ov" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/hallway8)
+"OA" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway1)
+"OB" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"OG" = (
+/obj/machinery/porta_turret/centcom{
+	use_power = 0;
+	reqpower = 0;
+	active_power_usage = 0;
+	idle_power_usage = 0;
+	name = "Space Defence Turret";
+	enabled = 1;
+	lethal = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret10)
+"OL" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway4)
+"OO" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/prhallway4)
+"OS" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/prhallway5)
+"OU" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/bridge)
+"OX" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway11)
+"OY" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/prhallway6)
+"Pe" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway3)
+"Pf" = (
+/turf/simulated/floor/mineral/titanium{
+	icon_state = "titanium_dam4"
+	},
+/area/awaymission/spacebattle/storage)
+"Pm" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/prhallway2)
+"Pn" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret6{
+	requires_power = 0
+	})
+"Po" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/space/nearstation)
+"Pq" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/hallway1)
+"Pr" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/space,
+/area/space/nearstation)
+"Ps" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway8)
+"Pw" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/living)
+"Px" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 6
+	},
+/area/awaymission/spacebattle/hallway2)
+"Py" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 6
+	},
+/area/awaymission/spacebattle/hallway5)
+"PB" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 6
+	},
+/area/awaymission/spacebattle/hallway13)
+"PC" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/hallway11)
+"PN" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/effect/landmark{
+	name = "awaystart"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway9)
+"PO" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret8)
+"PT" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/hallway4)
+"Qd" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway10)
+"Qm" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway11)
+"Qo" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway8)
+"Qp" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/hallway12)
+"Qq" = (
+/obj/effect/landmark/damageturf,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret3{
+	requires_power = 0
+	})
+"Qs" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/space/nearstation)
+"Qt" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/prhallway1)
+"Qx" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
+/area/awaymission/spacebattle/hallway11)
+"QA" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 8
+	},
+/area/awaymission/spacebattle/engineering)
+"QB" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/space/nearstation)
+"QE" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway10)
+"QI" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/awaymission/spacebattle/kitchen)
+"QL" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway10)
+"QM" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway12)
+"QO" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/prhallway3)
+"QP" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway7)
+"QR" = (
+/obj/machinery/door/airlock/engineering,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"QS" = (
+/obj/structure/rack,
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
+"QW" = (
+/obj/machinery/porta_turret/centcom{
+	use_power = 0;
+	reqpower = 0;
+	active_power_usage = 0;
+	idle_power_usage = 0;
+	name = "Space Defence Turret";
+	enabled = 1;
+	lethal = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret7)
+"Ra" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/living)
+"Rd" = (
+/obj/effect/decal/cleanable/blood,
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel/dark/telecomms,
+/area/awaymission/spacebattle/server)
+"Re" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 9
+	},
+/area/awaymission/spacebattle/hallway7)
+"Rj" = (
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret2)
+"Rk" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret1)
+"Rm" = (
+/obj/effect/landmark/damageturf,
+/obj/effect/mob_spawn/human/corpse/assistant,
+/obj/effect/decal/cleanable/blood,
+/obj/item/gun/projectile/automatic/pistol/m1911,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium{
+	icon_state = "titanium_dam1"
+	},
+/area/awaymission/spacebattle/storage)
+"Ro" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway4)
+"Rq" = (
+/obj/structure/closet/crate/secure/bin,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 9
+	},
+/area/awaymission/spacebattle/living)
+"Rr" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/living)
+"Ry" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway9)
+"RC" = (
+/obj/machinery/computer/operating,
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/awaymission/spacebattle/medbay)
+"RD" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway9)
+"RI" = (
+/mob/living/simple_animal/hostile/syndicate/ranged/space{
+	health = 300
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"RL" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway7)
+"RM" = (
+/obj/structure/rack,
+/obj/item/storage/firstaid,
+/obj/item/ammo_box/c45,
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
+"RO" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engineering)
+"RQ" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway5)
+"RS" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway4)
+"Sd" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/effect/landmark{
+	name = "awaystart"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway13)
+"Se" = (
+/obj/effect/mob_spawn/human/securty,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway10)
+"Sh" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway8)
+"Sk" = (
+/obj/structure/rack,
+/obj/item/storage/firstaid/machine,
+/obj/item/storage/firstaid/machine,
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
+"Sl" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway1)
+"So" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway5)
+"Ss" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner";
+	dir = 4
+	},
+/area/awaymission/spacebattle/hallway2)
+"St" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engineering)
+"Su" = (
+/obj/structure/rack,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"SA" = (
+/obj/effect/landmark/damageturf,
+/obj/effect/mob_spawn/human/securty,
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
+"SI" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 9
+	},
+/area/space/nearstation)
+"SN" = (
+/obj/effect/mob_spawn/human/securty,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway13)
+"SU" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/prhallway1)
+"SW" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret8{
+	requires_power = 0
+	})
+"Ta" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway9)
+"Tb" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway1)
+"Td" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 10
+	},
+/area/awaymission/spacebattle/prhallway4)
+"Tf" = (
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway9)
+"Tn" = (
+/mob/living/simple_animal/hostile/syndicate/melee,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway1)
+"Tp" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway9)
+"Tr" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/hallway9)
+"Ts" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 5
+	},
+/area/awaymission/spacebattle/hallway2)
+"Ty" = (
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway9)
+"Tz" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/hallway1)
+"TC" = (
+/obj/machinery/door/airlock/security{
+	name = "Turret Room"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/turret6)
+"TG" = (
+/obj/effect/mob_spawn/human/bridgeofficer,
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"TH" = (
+/mob/living/simple_animal/hostile/syndicate/melee{
+	health = 400
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway7)
+"TL" = (
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engineering)
+"TN" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 6
+	},
+/area/awaymission/spacebattle/prhallway4)
+"TP" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway13)
+"TQ" = (
+/obj/effect/landmark{
+	name = "awaystart"
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
+"TV" = (
+/obj/machinery/vending/cigarette/free,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway1)
+"TW" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/prhallway2)
+"TX" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway1)
+"Uh" = (
+/obj/machinery/porta_turret/centcom{
+	use_power = 0;
+	reqpower = 0;
+	active_power_usage = 0;
+	idle_power_usage = 0;
+	name = "Space Defence Turret";
+	enabled = 1;
+	lethal = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret6)
+"Ui" = (
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway12)
+"Ul" = (
+/mob/living/simple_animal/hostile/syndicate/melee{
+	name = "Syndicate Commander Bodyguard";
+	health = 400
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/bridge)
+"Um" = (
+/obj/structure/table/reinforced,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow"
+	},
+/area/awaymission/spacebattle/engine)
+"Uv" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/prhallway1)
+"UD" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/prhallway1)
+"UE" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/hallway2)
+"UF" = (
+/obj/machinery/vending/chinese/free,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/living)
+"UH" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/living)
+"UJ" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swallc2"
+	},
 /area/awaymission/spacebattle/cruiser)
+"UK" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway7)
+"UL" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/living)
+"UN" = (
+/obj/structure/closet/crate/secure/bin,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 10
+	},
+/area/awaymission/spacebattle/living)
+"UO" = (
+/obj/machinery/vending/cola/free,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/awaymission/spacebattle/kitchen)
+"UR" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 1
+	},
+/area/awaymission/spacebattle/engineering)
+"US" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/living)
+"Va" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway6)
+"Vd" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway4)
+"Vp" = (
+/obj/effect/landmark/damageturf,
+/mob/living/simple_animal/hostile/syndicate/melee,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway1)
+"Vs" = (
+/mob/living/simple_animal/hostile/syndicate/melee{
+	health = 400
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/prhallway1)
+"Vt" = (
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/yellow{
+	pixel_y = 3
+	},
+/obj/item/clothing/gloves/color/yellow{
+	pixel_y = 1
+	},
+/obj/item/clothing/gloves/color/yellow{
+	pixel_y = -2
+	},
+/obj/item/clothing/gloves/color/yellow{
+	pixel_y = -5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 4
+	},
+/area/awaymission/spacebattle/engine)
+"Vv" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/turret3)
+"Vx" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret8{
+	requires_power = 0
+	})
+"Vz" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	pixel_x = -24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/awaymission/spacebattle/kitchen)
+"VB" = (
+/obj/structure/closet/crate/secure/bin,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway6)
+"VC" = (
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/c45,
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
+"VE" = (
+/mob/living/simple_animal/hostile/syndicate/ranged/space{
+	health = 300
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway4)
+"VF" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/living)
+"VI" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/hallway11)
+"VK" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/prhallway4)
+"VL" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/hallway4)
+"VM" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/rglass,
+/obj/item/stack/sheet/rglass,
+/obj/item/stack/sheet/rglass,
+/obj/item/stack/sheet/rglass,
+/obj/item/stack/sheet/rglass,
+/obj/item/stack/sheet/rglass,
+/obj/item/stack/sheet/rglass,
+/obj/item/stack/sheet/rglass,
+/obj/item/stack/sheet/rglass,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
+"VQ" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
+"VR" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engineering)
+"VT" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/prhallway5)
+"VV" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway12)
+"VX" = (
+/obj/item/twohanded/required/kirbyplants,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/prhallway1)
+"VZ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner";
+	dir = 8
+	},
+/area/awaymission/spacebattle/hallway10)
+"Wc" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/turret4)
+"We" = (
+/obj/machinery/door/airlock,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/prhallway1)
+"Wi" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/hallway8)
+"Wj" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
+"Wl" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 10
+	},
+/area/awaymission/spacebattle/hallway6)
+"Wp" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway11)
+"Ws" = (
+/obj/machinery/door/airlock/engineering,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/cruiser)
+"Wu" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 10
+	},
+/area/awaymission/spacebattle/hallway10)
+"Wv" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway11)
+"Wz" = (
+/obj/machinery/door/airlock,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/living)
+"WB" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 5
+	},
+/area/awaymission/spacebattle/prhallway2)
+"WE" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 8
+	},
+/area/awaymission/spacebattle/engineering)
+"WH" = (
+/obj/machinery/door/airlock,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/prhallway6)
+"WI" = (
+/obj/structure/closet/crate/secure/bin,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway1)
+"WK" = (
+/obj/structure/rack,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 9
+	},
+/area/awaymission/spacebattle/engineering)
+"WL" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plating/airless,
+/area/space)
+"WR" = (
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret8)
+"WX" = (
+/mob/living/simple_animal/hostile/syndicate/ranged/space{
+	health = 300
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway2)
+"Xb" = (
+/obj/effect/mob_spawn/human/corpse/assistant,
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
+"Xf" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway11)
+"Xl" = (
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/prhallway1)
+"Xn" = (
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/living)
+"Xq" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/hallway12)
+"Xs" = (
+/obj/machinery/door/poddoor{
+	id_tag = "spacebattlestorage";
+	name = "Secure Storage"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/sec_storage)
+"Xt" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 8
+	},
+/area/awaymission/spacebattle/engine)
+"Xv" = (
+/obj/effect/landmark/damageturf,
+/mob/living/simple_animal/hostile/syndicate/ranged/space{
+	health = 300
+	},
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
+"Xz" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret4)
+"XA" = (
+/obj/machinery/door/airlock/security{
+	name = "Turret Room"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/turret3)
+"XC" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 5
+	},
+/area/awaymission/spacebattle/hallway3)
+"XE" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway12)
+"XG" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway4)
+"XJ" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/engine)
+"XN" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/hallway12)
+"XP" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/hallway9)
+"XQ" = (
+/obj/structure/rack,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow";
+	dir = 5
+	},
+/area/awaymission/spacebattle/engineering)
+"XW" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/prhallway4)
+"XZ" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret7)
+"Yc" = (
+/obj/effect/landmark/damageturf,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
+"Ye" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway4)
+"Yf" = (
+/obj/item/storage/box/syndie_kit/hardsuit,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/awaymission/spacebattle/syndicate1)
+"Yg" = (
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"Yh" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 9
+	},
+/area/awaymission/spacebattle/hallway5)
+"Yj" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/living)
+"Ym" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway6)
+"Yo" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/living)
+"Yq" = (
+/turf/simulated/floor/mineral/titanium{
+	icon_state = "titanium_dam3"
+	},
+/area/awaymission/spacebattle/storage)
+"Yr" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/hallway6)
+"Yt" = (
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway4)
+"Yu" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 5
+	},
+/area/awaymission/spacebattle/living)
+"Yv" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/living)
+"Yx" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret7{
+	requires_power = 0
+	})
+"Yz" = (
+/obj/effect/mob_spawn/human/engineer/hardsuit,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/engine)
+"YH" = (
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"YI" = (
+/obj/machinery/door/airlock/engineering,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/storage)
+"YJ" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "yellow"
+	},
+/area/awaymission/spacebattle/engineering)
+"YK" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/cruiser)
+"YU" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/awaymission/spacebattle/hallway9)
+"YV" = (
+/turf/simulated/shuttle/wall{
+	tag = "icon-swall12";
+	icon_state = "swall_f5"
+	},
+/area/awaymission/spacebattle/cruiser)
+"YX" = (
+/turf/simulated/mineral/random{
+	name = "SUS?";
+	desc = "SUS?"
+	},
+/area/space/nearstation)
+"Za" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 5
+	},
+/area/awaymission/spacebattle/hallway8)
+"Zb" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/mineral/plasma/fifty,
+/turf/simulated/floor/mineral/titanium,
+/area/awaymission/spacebattle/storage)
+"Zc" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 5
+	},
+/area/awaymission/spacebattle/hallway5)
+"Zg" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/awaymission/spacebattle/hallway6)
+"Zh" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/hallway1)
+"Zl" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"Zm" = (
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/obj/item/ammo_casing/c45,
+/turf/simulated/floor/plating,
+/area/awaymission/spacebattle/sec_storage)
+"Zp" = (
+/obj/structure/table/tray,
+/obj/item/hemostat{
+	pixel_y = 2;
+	pixel_x = -6
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitehall"
+	},
+/area/awaymission/spacebattle/medbay)
+"Zr" = (
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway8)
+"Zs" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/space,
+/area/space/nearstation)
+"Zt" = (
+/turf/simulated/mineral/random/high_chance,
+/area/space)
+"Zy" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 4
+	},
+/area/awaymission/spacebattle/prhallway2)
+"ZD" = (
+/obj/machinery/vending/cola/free,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 8
+	},
+/area/awaymission/spacebattle/hallway4)
+"ZF" = (
+/obj/machinery/door/airlock,
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/kitchen)
+"ZH" = (
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway10)
+"ZI" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 6
+	},
+/area/awaymission/spacebattle/hallway11)
+"ZJ" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating/airless,
+/area/awaymission/spacebattle/turret2)
+"ZM" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/awaymission/spacebattle/medbay)
+"ZN" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plating/airless,
+/area/space)
+"ZQ" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral";
+	dir = 10
+	},
+/area/awaymission/spacebattle/hallway9)
+"ZW" = (
+/obj/machinery/door/airlock/freezer,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/freezing)
+"ZX" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/spacebattle/hallway2)
 
 (1,1,1) = {"
 aa
+je
+je
+je
 aa
 aa
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
+je
 aa
+je
 aa
 aa
 aa
@@ -2955,25 +9263,16 @@ aa
 aa
 aa
 aa
+je
+je
 aa
 aa
+je
+je
+je
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
 ab
 ab
 ab
@@ -3019,23 +9318,17 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
+je
 aa
+je
 aa
+je
 aa
 aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
+aa
 ab
 ab
 ab
@@ -3152,25 +9445,28 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
-aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
+je
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
+je
 aa
+je
 aa
 aa
 aa
@@ -3178,6 +9474,7 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -3188,50 +9485,50 @@ aa
 aa
 "}
 (2,1,1) = {"
+je
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
+je
+je
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
+je
+je
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
+je
+je
+je
+je
+je
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
+je
 ab
 ab
 ab
@@ -3278,18 +9575,17 @@ ab
 ab
 ab
 ab
-ab
-aa
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
-aa
-ab
 ab
 ab
 ab
@@ -3406,14 +9702,6 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -3421,12 +9709,18 @@ aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
+je
+je
 aa
 aa
 aa
@@ -3437,18 +9731,28 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
+je
 aa
 "}
 (3,1,1) = {"
 aa
 aa
+je
+je
+je
 aa
+je
+je
+je
 aa
+je
 aa
 aa
 aa
@@ -3457,36 +9761,31 @@ aa
 aa
 aa
 aa
+je
+je
 aa
 aa
+je
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
+je
+je
 aa
+je
 aa
 aa
+je
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
 ab
 ab
 ab
@@ -3533,10 +9832,10 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
+je
 aa
+je
+je
 aa
 aa
 aa
@@ -3544,10 +9843,6 @@ aa
 aa
 aa
 aa
-aa
-aa
-ab
-ab
 ab
 ab
 ab
@@ -3665,18 +9960,18 @@ ab
 ab
 ab
 ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
+je
+je
+je
+je
+je
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -3690,7 +9985,9 @@ aa
 aa
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
@@ -3709,42 +10006,43 @@ aa
 aa
 aa
 aa
+je
 aa
+je
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
+je
+je
+je
 aa
 aa
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
 ab
 ab
 ab
@@ -3791,20 +10089,18 @@ ab
 ab
 ab
 ab
-ab
-ab
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
-aa
-ab
-ab
 ab
 ab
 ab
@@ -3922,19 +10218,18 @@ ab
 ab
 ab
 ab
-ab
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
+je
+je
 aa
+je
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
@@ -3944,6 +10239,7 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -3956,6 +10252,7 @@ aa
 aa
 aa
 aa
+je
 aa
 "}
 (5,1,1) = {"
@@ -3965,6 +10262,9 @@ aa
 aa
 aa
 aa
+je
+je
+je
 aa
 aa
 aa
@@ -3972,12 +10272,18 @@ aa
 aa
 aa
 aa
+je
+je
 aa
+je
+je
 aa
 aa
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
@@ -3990,20 +10296,10 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -4050,18 +10346,18 @@ ab
 ab
 ab
 ab
+je
 aa
+je
 aa
 aa
 aa
 aa
+je
 aa
+je
+je
 aa
-aa
-aa
-aa
-ab
-ab
 ab
 ab
 ab
@@ -4179,20 +10475,20 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-aa
-aa
 aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
+je
+je
 aa
+je
+je
 aa
 aa
 aa
@@ -4211,52 +10507,55 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 "}
 (6,1,1) = {"
 aa
+je
+je
 aa
 aa
 aa
+je
 aa
+je
+je
 aa
 aa
+je
+je
+je
+je
+je
+je
 aa
+je
 aa
+je
 aa
+je
+je
 aa
 aa
+je
 aa
 aa
+je
+je
 aa
+je
+je
 aa
 aa
 aa
 aa
+je
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -4304,24 +10603,18 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-aa
-aa
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
+je
 aa
+je
 aa
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -4410,11 +10703,11 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -4447,14 +10740,18 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
+je
 aa
+je
 aa
 aa
 aa
@@ -4476,12 +10773,16 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
+je
+je
 aa
 aa
 aa
@@ -4500,23 +10801,18 @@ aa
 aa
 aa
 aa
+je
 aa
+je
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
 ab
 ab
 ab
@@ -4564,22 +10860,18 @@ ab
 ab
 ab
 ab
+je
 aa
+je
 aa
 aa
+je
 aa
 aa
 aa
+je
+je
 aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -4665,17 +10957,16 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
+aa
+aa
+aa
+je
+je
+je
+aa
+aa
 ab
 ab
 ab
@@ -4699,14 +10990,19 @@ ab
 ab
 ab
 ab
+aa
 aa
 aa
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
@@ -4715,6 +11011,7 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -4738,6 +11035,7 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -4746,33 +11044,32 @@ aa
 aa
 aa
 aa
+je
+je
+je
 aa
+je
+je
+je
 aa
 aa
+je
+je
 aa
 aa
+je
+je
+je
+je
+je
+je
+je
 aa
+je
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
 ab
 ab
 ab
@@ -4823,14 +11120,15 @@ ab
 ab
 aa
 aa
+je
 aa
+je
+je
 aa
+je
 aa
+je
 aa
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -4914,20 +11212,18 @@ ab
 ab
 ab
 ab
-ab
-ab
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
-aa
-aa
-ab
 ab
 ab
 ab
@@ -4952,19 +11248,16 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
+je
 aa
+je
+je
+je
+je
+je
 aa
 aa
 aa
@@ -4974,14 +11267,18 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
@@ -4991,7 +11288,10 @@ aa
 aa
 aa
 aa
+je
 aa
+je
+je
 aa
 aa
 aa
@@ -4999,35 +11299,34 @@ aa
 aa
 aa
 aa
+je
+je
 aa
+je
 aa
+je
 aa
+je
 aa
+je
 aa
 aa
+je
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
 aa
+je
+je
+je
+je
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -5076,20 +11375,18 @@ ab
 ab
 ab
 ab
-ab
-ab
-aa
 aa
+je
+je
 aa
+je
+je
 aa
+je
 aa
 aa
 aa
 aa
-aa
-aa
-ab
-ab
 ab
 ab
 ab
@@ -5171,19 +11468,20 @@ ab
 ab
 ab
 ab
-ab
-ab
-aa
-aa
-aa
+je
+je
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
+je
+je
 ab
 ab
 ab
@@ -5207,12 +11505,9 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
+aa
 aa
 aa
 aa
@@ -5227,6 +11522,7 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -5234,6 +11530,7 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -5246,47 +11543,47 @@ aa
 (10,1,1) = {"
 aa
 aa
+je
+je
+je
 aa
 aa
+je
 aa
 aa
+je
 aa
 aa
+je
+je
 aa
 aa
 aa
+je
 aa
 aa
+je
+je
+je
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
 ab
 ab
 ab
@@ -5336,18 +11633,17 @@ ab
 ab
 ab
 aa
+je
+je
 aa
+je
+je
 aa
+je
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
 ab
 ab
 ab
@@ -5428,25 +11724,22 @@ ab
 ab
 ab
 ab
-ab
-ab
+Zt
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -5480,6 +11773,7 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -5495,55 +11789,58 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
+je
+je
 aa
 aa
 "}
 (11,1,1) = {"
+je
 aa
 aa
 aa
 aa
+je
 aa
+je
 aa
+je
+je
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
+je
+je
+je
 aa
 aa
+je
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
 ab
 ab
 ab
@@ -5594,15 +11891,16 @@ ab
 ab
 aa
 aa
+je
 aa
+je
 aa
+je
+je
 aa
+je
 aa
 aa
-aa
-aa
-aa
-ab
 ab
 ab
 ab
@@ -5684,27 +11982,22 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
 ab
 ab
 ab
@@ -5727,12 +12020,14 @@ ab
 ab
 ab
 ab
+aa
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -5753,13 +12048,17 @@ aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
 "}
 (12,1,1) = {"
 aa
+je
 aa
+je
 aa
 aa
 aa
@@ -5768,37 +12067,37 @@ aa
 aa
 aa
 aa
+je
+je
 aa
+je
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -5847,16 +12146,16 @@ ab
 ab
 ab
 ab
-ab
-ab
-aa
-aa
-aa
 aa
+je
+je
 aa
+je
 aa
+je
 aa
 aa
+je
 aa
 aa
 ab
@@ -5939,34 +12238,29 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
 aa
+je
 aa
 aa
 aa
+je
 aa
+je
+je
 aa
 aa
 aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
+je
+je
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -5984,11 +12278,6 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -5996,12 +12285,16 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
+je
+je
 aa
 aa
+je
 aa
 aa
 aa
@@ -6012,53 +12305,56 @@ aa
 aa
 aa
 aa
+je
+je
+je
+je
 aa
 "}
 (13,1,1) = {"
 aa
+je
 aa
 aa
 aa
 aa
+je
+je
 aa
+je
 aa
+je
 aa
+je
+je
+je
 aa
 aa
+je
 aa
+je
 aa
+je
 aa
+je
 aa
+je
 aa
 aa
+je
+je
 aa
 aa
+je
 aa
 aa
+je
 aa
+je
+je
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
 ab
 ab
 ab
@@ -6079,10 +12375,10 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
+je
+je
+aa
+aa
 ab
 ab
 ab
@@ -6106,17 +12402,18 @@ ab
 ab
 ab
 ab
-aa
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
+je
+je
 aa
-aa
-aa
-ab
 ab
 ab
 ab
@@ -6198,32 +12495,30 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
 aa
 aa
 aa
 aa
 aa
+je
+je
+je
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
+aa
+je
+je
+je
+aa
+aa
 ab
 ab
 ab
@@ -6241,48 +12536,62 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
+je
 aa
+je
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 "}
 (14,1,1) = {"
 aa
 aa
+je
 aa
+je
 aa
+je
+je
+je
+je
+je
 aa
+je
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
+je
+je
 aa
 aa
 aa
@@ -6291,34 +12600,18 @@ aa
 aa
 aa
 aa
+je
+je
 aa
+je
+je
 aa
 aa
+je
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -6336,13 +12629,16 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+je
+aa
+aa
+aa
+aa
+je
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -6364,19 +12660,17 @@ ab
 ab
 ab
 aa
+je
+je
+je
 aa
 aa
 aa
+je
+je
 aa
+je
 aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -6460,27 +12754,29 @@ ab
 ab
 aa
 aa
+je
 aa
 aa
+je
+je
+je
+je
 aa
 aa
 aa
 aa
+je
 aa
+je
 aa
 aa
+je
 aa
 aa
+je
+je
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
 ab
 ab
 ab
@@ -6497,22 +12793,22 @@ ab
 ab
 ab
 ab
-ab
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
+je
 aa
+je
+je
 aa
+je
 aa
 aa
 aa
@@ -6522,6 +12818,7 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -6531,48 +12828,47 @@ aa
 (15,1,1) = {"
 aa
 aa
+je
+je
+je
 aa
+je
+je
 aa
 aa
 aa
+je
 aa
 aa
+je
+je
+je
 aa
+je
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
+je
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
+je
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
 ab
 ab
 ab
@@ -6589,19 +12885,19 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
 aa
+je
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
-ab
+aa
+aa
+aa
 ab
 ab
 ab
@@ -6620,16 +12916,18 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
-aa
+je
+je
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
+je
+je
 ab
 ab
 ab
@@ -6711,34 +13009,31 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
+je
 aa
+je
 aa
+je
 aa
+je
+je
+je
+je
+je
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-ab
-ab
+je
 ab
 ab
 ab
@@ -6755,13 +13050,7 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -6769,64 +13058,74 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
+je
+je
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
+je
 aa
+je
 aa
 aa
+je
 aa
 "}
 (16,1,1) = {"
 aa
 aa
 aa
+je
 aa
 aa
+je
+je
+je
 aa
 aa
+je
 aa
 aa
+je
 aa
+je
 aa
+je
 aa
+je
 aa
+je
+je
 aa
 aa
+je
 aa
+je
+je
 aa
 aa
+je
+je
+je
+je
 aa
+je
+je
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -6840,24 +13139,22 @@ ab
 ab
 ab
 ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
 aa
+je
+je
+je
 aa
 aa
+je
+je
+je
 aa
 aa
 aa
 aa
-aa
 ab
 ab
 ab
@@ -6876,19 +13173,18 @@ ab
 ab
 ab
 ab
-ab
-aa
-aa
-aa
-aa
+je
+je
+je
 aa
 aa
+je
 aa
 aa
+je
 aa
-aa
-ab
-ab
+je
+je
 ab
 ab
 ab
@@ -6971,12 +13267,12 @@ ab
 ab
 ab
 ab
-ab
-aa
-aa
+je
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -6985,15 +13281,16 @@ aa
 aa
 aa
 aa
+je
+je
+je
 aa
+je
+je
+je
+je
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -7011,20 +13308,18 @@ ab
 ab
 ab
 ab
-ab
-aa
-aa
-aa
-aa
-aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
+je
 aa
+je
 aa
 aa
 aa
@@ -7039,51 +13334,55 @@ aa
 aa
 aa
 aa
+je
 aa
+je
 aa
 "}
 (17,1,1) = {"
 aa
+je
 aa
 aa
+je
+je
+je
+je
+je
 aa
 aa
+je
+je
 aa
+je
 aa
+je
 aa
 aa
 aa
+je
+je
 aa
+je
 aa
+je
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -7097,24 +13396,22 @@ ab
 ab
 ab
 ab
-ab
-ab
-aa
-aa
-aa
-aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
+je
 aa
+je
+je
+je
 aa
-aa
-aa
-aa
+je
+je
 ab
 ab
 ab
@@ -7133,20 +13430,18 @@ ab
 ab
 ab
 ab
-ab
-aa
 aa
+je
+je
 aa
 aa
 aa
 aa
+je
+je
 aa
-aa
-aa
-aa
-ab
-ab
-ab
+je
+je
 ab
 ab
 ab
@@ -7230,9 +13525,11 @@ ab
 ab
 ab
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -7243,14 +13540,14 @@ aa
 aa
 aa
 aa
+je
 aa
+je
 aa
+je
+je
+je
 aa
-aa
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -7268,20 +13565,20 @@ ab
 ab
 ab
 ab
-ab
-aa
-aa
-aa
-aa
-aa
 aa
+je
 aa
 aa
+je
 aa
+je
 aa
+je
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
@@ -7301,8 +13598,13 @@ aa
 "}
 (18,1,1) = {"
 aa
+je
+je
+je
 aa
+je
 aa
+je
 aa
 aa
 aa
@@ -7313,35 +13615,31 @@ aa
 aa
 aa
 aa
+je
+je
 aa
 aa
+je
 aa
+je
 aa
+je
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
 ab
 ab
 ab
@@ -7355,23 +13653,23 @@ ab
 ab
 ab
 ab
-ab
-aa
 aa
 aa
 aa
+je
 aa
+je
 aa
+je
+je
+je
+je
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
 ab
 ab
 ab
@@ -7388,22 +13686,19 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
 aa
+je
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
+je
 aa
 aa
-aa
-ab
-ab
-ab
 ab
 ab
 ab
@@ -7488,27 +13783,28 @@ ab
 ab
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+je
+je
+je
+aa
+aa
+aa
+aa
+je
+je
+aa
 ab
 ab
 ab
@@ -7526,80 +13822,81 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
+je
+je
 aa
 aa
+je
+je
 aa
+je
+je
 aa
+je
 aa
 aa
 aa
 aa
+je
+je
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
+je
 "}
 (19,1,1) = {"
 aa
+je
+je
 aa
 aa
+je
 aa
+je
+je
 aa
+je
 aa
 aa
 aa
+je
 aa
+je
+je
 aa
 aa
 aa
 aa
+je
 aa
+je
+je
 aa
+je
 aa
 aa
+je
+je
 aa
 aa
+je
 aa
 aa
+je
 aa
+je
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
 ab
 ab
 ab
@@ -7612,25 +13909,24 @@ ab
 ab
 ab
 ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
 aa
+je
 aa
 aa
 aa
+je
+je
+je
+je
+je
 aa
+je
+je
 aa
 aa
 aa
 aa
-aa
-ab
-ab
+je
 ab
 ab
 ab
@@ -7647,18 +13943,19 @@ ab
 ab
 ab
 ab
-ab
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
 aa
+je
 aa
+je
 aa
-aa
-ab
 ab
 ab
 ab
@@ -7741,31 +14038,30 @@ ab
 ab
 ab
 ab
-ab
-ab
 aa
 aa
+je
+je
+je
+je
+je
 aa
 aa
 aa
 aa
 aa
+je
+je
 aa
+je
+je
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+je
+je
+aa
+aa
 ab
 ab
 ab
@@ -7783,19 +14079,19 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
-aa
 aa
 aa
+je
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -7806,6 +14102,7 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -7814,24 +14111,41 @@ aa
 aa
 "}
 (20,1,1) = {"
+je
+je
+je
+je
 aa
 aa
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
+je
+je
+je
 aa
+je
 aa
 aa
+je
 aa
+je
 aa
+je
+je
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
@@ -7840,24 +14154,6 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
 ab
 ab
 ab
@@ -7870,26 +14166,25 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
+je
 aa
+je
+je
+je
 aa
+je
+je
 aa
 aa
 aa
+je
+je
+je
+je
+je
+je
 aa
-aa
-aa
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -7905,7 +14200,9 @@ ab
 ab
 ab
 ab
+je
 aa
+je
 aa
 aa
 aa
@@ -7915,9 +14212,7 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
+aa
 ab
 ab
 ab
@@ -8002,26 +14297,27 @@ ab
 ab
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
+je
 aa
 aa
+je
+je
+je
+je
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+je
+je
+aa
+aa
 ab
 ab
 ab
@@ -8040,19 +14336,19 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
 aa
 aa
+je
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -8069,52 +14365,52 @@ aa
 aa
 aa
 aa
+je
 "}
 (21,1,1) = {"
+je
+je
+je
 aa
+je
+je
+je
+je
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
+je
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
+je
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
 ab
 ab
 ab
@@ -8127,21 +14423,24 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
+je
+je
+je
 aa
 aa
+je
+je
+je
 aa
 aa
+je
+je
+je
 aa
 aa
 aa
+je
 aa
 ab
 ab
@@ -8158,21 +14457,19 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-aa
-aa
+je
 aa
 aa
+je
+je
 aa
+je
 aa
 aa
+je
+je
+je
 aa
-aa
-aa
-ab
 ab
 ab
 ab
@@ -8255,30 +14552,29 @@ ab
 ab
 ab
 ab
-ab
-ab
 aa
 aa
+je
+je
 aa
 aa
+je
 aa
+je
+je
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+je
+je
+aa
+aa
 ab
 ab
 ab
@@ -8297,9 +14593,9 @@ ab
 ab
 ab
 ab
-aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -8312,6 +14608,7 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -8329,46 +14626,48 @@ aa
 "}
 (22,1,1) = {"
 aa
+je
+je
 aa
+je
+je
 aa
+je
+je
 aa
 aa
+je
 aa
+je
+je
+je
 aa
 aa
+je
 aa
 aa
+je
+je
+je
+je
 aa
+je
+je
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
+je
+je
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -8381,33 +14680,25 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
+je
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
+je
+je
 aa
 aa
 aa
+je
 aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -8419,17 +14710,23 @@ ab
 ab
 ab
 ab
-aa
+ab
+ab
+ab
+ab
 aa
+je
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
+je
 aa
 aa
-ab
 ab
 ab
 ab
@@ -8513,28 +14810,27 @@ ab
 ab
 ab
 ab
-ab
 aa
 aa
+je
+je
 aa
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+je
+je
+je
+aa
+aa
+aa
 ab
 ab
 ab
@@ -8554,16 +14850,11 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
+je
+je
+je
 aa
 aa
 aa
@@ -8573,63 +14864,67 @@ aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
 aa
+je
 aa
+je
 aa
 "}
 (23,1,1) = {"
 aa
 aa
+je
 aa
+je
+je
 aa
+je
 aa
+je
+je
+je
 aa
 aa
 aa
+je
 aa
 aa
+je
 aa
 aa
+je
 aa
 aa
+je
 aa
 aa
+je
+je
+je
+je
+je
 aa
+je
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -8641,30 +14936,26 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
+je
+je
 aa
 aa
 aa
+je
 aa
+je
+je
 aa
+je
+je
+je
 aa
 aa
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -8676,13 +14967,20 @@ ab
 ab
 ab
 ab
-aa
+ab
+ab
+ab
+je
 aa
+je
+je
 aa
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -8769,29 +15067,27 @@ ab
 ab
 ab
 ab
-ab
-ab
 aa
 aa
+je
+je
 aa
+je
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
+je
+je
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
+aa
 ab
 ab
 ab
@@ -8811,11 +15107,9 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
-aa
 aa
+je
+je
 aa
 aa
 aa
@@ -8827,6 +15121,7 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -8839,18 +15134,28 @@ aa
 aa
 aa
 aa
+je
 aa
+je
 "}
 (24,1,1) = {"
 aa
 aa
 aa
+je
+je
 aa
+je
 aa
+je
+je
 aa
+je
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -8859,30 +15164,25 @@ aa
 aa
 aa
 aa
+je
 aa
+je
+je
+je
 aa
+je
 aa
 aa
+je
 aa
+je
+je
 aa
+je
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -8893,31 +15193,26 @@ ab
 ab
 ab
 ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
+je
+je
+je
 aa
+je
+je
+je
 aa
 aa
+je
 aa
+je
 aa
 aa
+je
+je
 aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -8932,16 +15227,19 @@ ab
 ab
 ab
 ab
-ab
-aa
-aa
+je
 aa
 aa
+je
+je
+je
 aa
 aa
 aa
 aa
 aa
+je
+je
 aa
 ab
 ab
@@ -9026,29 +15324,27 @@ ab
 ab
 ab
 ab
-ab
-ab
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+je
+je
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -9068,25 +15364,26 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
+je
+je
+je
+je
+je
 aa
+je
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
@@ -9102,17 +15399,31 @@ aa
 aa
 aa
 aa
+je
+je
 aa
+je
 aa
 aa
+je
+je
+je
 aa
+je
 aa
+je
 aa
+je
+je
 aa
 aa
 aa
 aa
 aa
+je
+je
+je
+je
 aa
 aa
 aa
@@ -9120,26 +15431,15 @@ aa
 aa
 aa
 aa
+je
+je
+je
 aa
+je
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -9150,28 +15450,26 @@ ab
 ab
 ab
 ab
-ab
-aa
-aa
 aa
 aa
+je
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
+je
 aa
 aa
-aa
-aa
-aa
-aa
-ab
 ab
 ab
 ab
@@ -9185,24 +15483,21 @@ ab
 ab
 ab
 ab
-ab
-aa
 aa
 aa
+je
 aa
+je
+je
 aa
 aa
 aa
 aa
+je
 aa
+je
 aa
 aa
-aa
-aa
-aa
-ab
-ab
-ab
 ab
 ab
 ab
@@ -9287,24 +15582,25 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
 aa
 aa
+je
+je
+je
+je
 aa
 aa
 aa
+je
+je
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
+je
+aa
+je
+aa
+aa
 ab
 ab
 ab
@@ -9325,13 +15621,11 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
-aa
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
@@ -9342,9 +15636,12 @@ aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -9357,47 +15654,49 @@ aa
 "}
 (26,1,1) = {"
 aa
+je
+je
+je
+je
+je
 aa
 aa
+je
 aa
+je
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
+je
+je
+je
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
+je
+je
+je
+je
+je
 ab
 ab
 ab
@@ -9410,26 +15709,24 @@ ab
 ab
 aa
 aa
+je
+je
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
 ab
 ab
 ab
@@ -9443,19 +15740,20 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
-aa
-aa
-aa
 aa
+je
+je
+je
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
+je
 aa
 ab
 ab
@@ -9541,27 +15839,25 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
 aa
 aa
+je
 aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+je
+je
+je
+je
+aa
+aa
+je
+je
+je
+aa
+aa
+aa
 ab
 ab
 ab
@@ -9582,9 +15878,9 @@ ab
 ab
 ab
 ab
-aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -9607,53 +15903,58 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 "}
 (27,1,1) = {"
+je
+je
+je
 aa
 aa
 aa
+je
+je
+je
 aa
+je
+je
 aa
 aa
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
 aa
+je
+je
+je
+je
+je
+je
+je
+je
+je
 aa
+je
 aa
+je
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -9663,26 +15964,25 @@ ab
 ab
 ab
 ab
-ab
-ab
-aa
-aa
 aa
 aa
+je
+je
+je
+je
 aa
 aa
+je
+je
+je
+je
+je
+je
 aa
 aa
 aa
+je
 aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -9696,22 +15996,22 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
 aa
 aa
+je
+je
+je
 aa
+je
 aa
 aa
+je
+je
 aa
-ab
-ab
 aa
+je
+je
 aa
-ab
-ab
 ab
 ab
 ab
@@ -9797,27 +16097,23 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 aa
 aa
+je
+je
 aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+je
+aa
+je
+je
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -9839,20 +16135,19 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -9860,6 +16155,7 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -9868,18 +16164,26 @@ aa
 aa
 aa
 aa
+je
 "}
 (28,1,1) = {"
 aa
+je
+je
+je
+je
 aa
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -9887,32 +16191,27 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
+je
 aa
+je
+je
+je
 aa
+je
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
 ab
 ab
 ab
@@ -9922,28 +16221,25 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
 aa
 aa
+je
 aa
+je
+je
+je
+je
+je
+je
 aa
 aa
+je
+je
+je
 aa
+je
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -9960,17 +16256,18 @@ ab
 aa
 aa
 aa
+je
+je
+je
+je
 aa
 aa
 aa
-ab
-ab
 aa
 aa
-ab
-ab
-ab
-ab
+je
+je
+je
 ab
 ab
 ab
@@ -10057,24 +16354,23 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
 aa
 aa
 aa
 aa
+je
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
+je
+je
+je
+aa
+aa
+je
+aa
+aa
 ab
 ab
 ab
@@ -10096,12 +16392,12 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
 aa
 aa
+je
 aa
+je
+je
 aa
 aa
 aa
@@ -10111,6 +16407,7 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -10128,51 +16425,50 @@ aa
 "}
 (29,1,1) = {"
 aa
+je
+je
+je
+je
+je
+je
+je
 aa
+je
 aa
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
+je
+je
 aa
 aa
+je
+je
+je
+je
+je
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
 ab
 ab
 ab
@@ -10182,25 +16478,25 @@ ab
 ab
 ab
 ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
 aa
 aa
+je
+je
+je
+je
 aa
+je
+je
 aa
 aa
 aa
+je
+je
 aa
+je
+je
 aa
 aa
-aa
-ab
-ab
 ab
 ab
 ab
@@ -10217,14 +16513,18 @@ ab
 aa
 aa
 aa
+je
+je
 aa
 aa
+je
 aa
-ab
-ab
+je
+je
+je
+je
+je
 aa
-aa
-ab
 ab
 ab
 ab
@@ -10312,25 +16612,21 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
 aa
 aa
 aa
+je
 aa
 aa
+je
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+je
+je
+aa
+je
+aa
+aa
 ab
 ab
 ab
@@ -10353,13 +16649,9 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
-aa
-aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -10369,10 +16661,15 @@ aa
 aa
 aa
 aa
+je
+je
 aa
+je
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -10385,48 +16682,50 @@ aa
 "}
 (30,1,1) = {"
 aa
+je
+je
+je
+je
 aa
+je
 aa
 aa
+je
+je
 aa
+je
+je
 aa
+je
 aa
 aa
 aa
+je
+je
 aa
 aa
+je
+je
 aa
 aa
+je
 aa
+je
+je
+je
+je
+je
 aa
 aa
 aa
+je
 aa
 aa
+je
 aa
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -10436,24 +16735,23 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
+je
+je
 aa
 aa
+je
+je
 aa
+je
 aa
+je
 aa
 aa
 ab
@@ -10470,23 +16768,19 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
 aa
 aa
-ab
-ab
-ab
+je
+je
+je
+je
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
+je
+je
+aa
+je
+aa
 ab
 ab
 ab
@@ -10577,16 +16871,18 @@ ab
 ab
 aa
 aa
+je
 aa
+je
+je
+je
+je
+je
+je
+je
+je
 aa
 aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -10610,17 +16906,11 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
@@ -10628,66 +16918,71 @@ aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
 aa
+je
+je
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
+je
 aa
 "}
 (31,1,1) = {"
+je
 aa
+je
+je
+je
 aa
+je
+je
+je
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
+je
+je
+je
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
+je
 aa
 aa
+je
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -10697,24 +16992,25 @@ ab
 ab
 ab
 ab
-ab
-aa
-aa
 aa
 aa
+je
 aa
+je
+je
 aa
+je
+je
 aa
 aa
 aa
+je
 aa
 aa
+je
+je
 aa
 aa
-aa
-aa
-ab
-ab
 ab
 ab
 ab
@@ -10729,21 +17025,19 @@ ab
 ab
 ab
 ab
-ab
-ab
 aa
 aa
-ab
-ab
-ab
 aa
+je
 aa
-ab
-ab
-ab
-ab
-ab
-ab
+je
+aa
+je
+je
+je
+aa
+je
+aa
 ab
 ab
 ab
@@ -10834,16 +17128,18 @@ ab
 ab
 aa
 aa
+je
 aa
+je
 aa
+je
+je
+je
 aa
+je
 aa
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
 ab
 ab
 ab
@@ -10867,18 +17163,16 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
+jc
+jc
+jc
 aa
 aa
 aa
@@ -10892,57 +17186,60 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
+je
 "}
 (32,1,1) = {"
 aa
+je
+je
+je
+je
+je
 aa
+je
+je
 aa
+je
 aa
 aa
+je
 aa
+je
+je
+je
+je
 aa
+je
+je
 aa
 aa
+je
+je
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
+je
 aa
+je
 aa
+je
+je
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
 ab
 ab
 ab
@@ -10952,24 +17249,24 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
 aa
 aa
+je
 aa
+je
+je
 aa
+je
+je
+je
 aa
+je
+je
+je
+je
+je
+je
 aa
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -10986,20 +17283,18 @@ ab
 ab
 ab
 ab
-ab
-ab
 aa
 aa
-ab
-ab
-ab
 aa
+je
+je
+je
 aa
-ab
-ab
-ab
-ab
-ab
+aa
+aa
+aa
+je
+je
 ab
 ab
 ab
@@ -11095,11 +17390,12 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
+je
+je
+je
+aa
+aa
+aa
 ab
 ab
 ab
@@ -11124,24 +17420,24 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
 aa
+je
 aa
+jc
+jc
+jc
+jc
 aa
 aa
 aa
 aa
+je
 aa
 aa
+je
 aa
 aa
 aa
@@ -11152,14 +17448,25 @@ aa
 aa
 aa
 aa
+je
 aa
 "}
 (33,1,1) = {"
 aa
+je
+je
 aa
+je
+je
+je
+je
+je
 aa
+je
 aa
+je
 aa
+je
 aa
 aa
 aa
@@ -11168,37 +17475,28 @@ aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
+je
+je
+je
 aa
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
 ab
 ab
 ab
@@ -11208,27 +17506,24 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-aa
-aa
 aa
 aa
+je
 aa
+je
+je
 aa
+je
+je
+je
 aa
 aa
+je
+je
 aa
 aa
+je
 aa
-aa
-aa
-aa
-aa
-ab
-ab
 ab
 ab
 ab
@@ -11247,15 +17542,16 @@ ab
 ab
 aa
 aa
-ab
-ab
-ab
 aa
+je
+je
+je
 aa
-ab
-ab
-ab
-ab
+je
+aa
+je
+aa
+aa
 ab
 ab
 ab
@@ -11347,13 +17643,16 @@ ab
 ab
 ab
 aa
+je
+je
+je
+je
+je
 aa
 aa
 aa
 aa
 aa
-ab
-ab
 ab
 ab
 ab
@@ -11378,13 +17677,14 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
+je
 aa
 aa
+jc
+jc
+jc
 jc
 jc
 jc
@@ -11406,24 +17706,24 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+je
 "}
 (34,1,1) = {"
 aa
 aa
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -11435,26 +17735,25 @@ aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
+je
+je
 aa
 aa
 aa
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -11464,27 +17763,24 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
 aa
 aa
+je
 aa
+je
 aa
 aa
+je
+je
 aa
 aa
+je
 aa
 aa
 aa
 aa
+je
 aa
-aa
-aa
-ab
 ab
 ab
 ab
@@ -11503,13 +17799,16 @@ ab
 ab
 ab
 aa
+je
+je
+je
+je
+je
+je
 aa
-ab
-ab
-ab
 aa
 aa
-ab
+je
 ab
 ab
 ab
@@ -11600,21 +17899,16 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
 ab
 ab
 ab
@@ -11640,8 +17934,14 @@ ab
 ab
 ab
 ab
+aa
+aa
+je
 aa
 aa
+jc
+jc
+jc
 jc
 jc
 jc
@@ -11651,16 +17951,13 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -11669,18 +17966,29 @@ aa
 aa
 "}
 (35,1,1) = {"
+je
+je
+je
 aa
+je
 aa
+je
 aa
+je
+je
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
+je
 aa
 aa
+je
 aa
 aa
 aa
@@ -11689,31 +17997,20 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
+je
 aa
+je
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
 ab
 ab
 ab
@@ -11724,23 +18021,23 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-aa
-aa
 aa
+je
+je
+je
+je
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
-aa
-aa
 ab
 ab
 ab
@@ -11758,20 +18055,17 @@ ab
 ab
 ab
 ab
-ab
 aa
+je
+je
 aa
-ab
-ab
-ab
+je
 aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
+je
+je
 ab
 ab
 ab
@@ -11846,8 +18140,10 @@ ab
 ab
 ab
 ab
-ab
-ab
+je
+aa
+aa
+aa
 ab
 ab
 ab
@@ -11863,6 +18159,8 @@ ab
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
@@ -11893,39 +18191,45 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
+aa
+aa
 aa
 aa
 jc
 jc
 jc
+jc
+jc
+jc
+jc
 aa
 aa
 aa
 aa
 aa
+je
+je
+aa
+je
+aa
+je
+aa
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 "}
 (36,1,1) = {"
+je
+je
+je
+aa
+aa
+je
+je
 aa
 aa
 aa
@@ -11935,6 +18239,7 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -11943,57 +18248,23 @@ aa
 aa
 aa
 aa
+je
+aa
+je
+aa
+je
+je
+aa
+aa
+je
+je
+aa
+je
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -12007,22 +18278,22 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+je
+je
+je
+je
+aa
+je
+je
+je
+je
+je
+je
 aa
 aa
+je
+je
 aa
 aa
 ab
@@ -12041,45 +18312,16 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+je
+je
+je
+aa
+je
+je
+je
+je
+aa
 ab
 ab
 ab
@@ -12155,9 +18397,75 @@ ab
 ab
 ab
 aa
+aa
+je
+je
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+je
 aa
 jc
 jc
+jc
+jc
+jc
+jc
+jc
+aa
+aa
+aa
+aa
+aa
+aa
+je
 aa
 aa
 aa
@@ -12167,22 +18475,12 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 "}
 (37,1,1) = {"
+je
 aa
 aa
 aa
@@ -12190,45 +18488,44 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
+je
+je
 aa
 aa
+je
 aa
+je
 aa
+je
+je
+je
+je
+je
+je
+je
+je
+je
 aa
 aa
+je
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
+je
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
 ab
 ab
 ab
@@ -12239,28 +18536,23 @@ ab
 ab
 ab
 ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
+je
+je
 aa
+je
+je
+je
+je
 aa
 aa
+je
+je
 aa
+je
 aa
 aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -12277,13 +18569,16 @@ ab
 ab
 ab
 ab
-ab
 aa
 aa
+je
+je
 aa
+je
+je
 aa
-ab
-ab
+aa
+aa
 ab
 ab
 ab
@@ -12358,19 +18653,16 @@ ab
 ab
 ab
 ab
-aa
-aa
 aa
 aa
+je
+je
+je
 aa
+je
+je
+je
 aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -12381,8 +18673,10 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -12411,18 +18705,21 @@ ab
 ab
 ab
 ab
+aa
+aa
 aa
 aa
 jc
 jc
+jc
+jc
+jc
+jc
+jc
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
 aa
 aa
 aa
@@ -12440,6 +18737,45 @@ aa
 aa
 "}
 (38,1,1) = {"
+je
+je
+aa
+aa
+je
+je
+aa
+je
+aa
+je
+je
+je
+je
+je
+je
+je
+je
+je
+aa
+aa
+aa
+aa
+je
+aa
+aa
+je
+je
+je
+je
+aa
+aa
+aa
+aa
+je
+aa
+je
+aa
+aa
+je
 aa
 aa
 aa
@@ -12457,68 +18793,23 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
 aa
 aa
+je
 aa
 aa
+je
+aa
+je
+aa
+je
+aa
+je
+je
 aa
 aa
-ab
-ab
-ab
-ab
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -12538,89 +18829,11 @@ ab
 aa
 aa
 aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+je
 aa
 aa
-aa
-aa
-aa
-aa
+je
+je
 aa
 aa
 ab
@@ -12668,21 +18881,105 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
+aa
+je
+je
+je
+je
+je
+je
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+je
 aa
 jc
 jc
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
 aa
 aa
 aa
@@ -12698,67 +18995,40 @@ aa
 "}
 (39,1,1) = {"
 aa
+je
+aa
+aa
+je
+aa
+aa
+aa
+je
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+je
+aa
+je
 aa
 aa
 aa
 aa
 aa
+je
+je
 aa
-ab
-ab
-ab
-ab
-aa
-aa
+je
+je
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -12780,81 +19050,23 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
+aa
+je
+je
+je
 aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+je
+je
+je
+aa
+aa
+je
+aa
 ab
 ab
 ab
@@ -12874,10 +19086,11 @@ ab
 ab
 aa
 aa
+je
 aa
 aa
-aa
-aa
+je
+je
 aa
 aa
 ab
@@ -12925,10 +19138,100 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
 aa
+je
+je
+aa
+je
+aa
+je
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+je
+je
 jc
 jc
+jc
+jc
+jc
+jc
+jc
+je
+je
 aa
 aa
 aa
@@ -12937,17 +19240,11 @@ aa
 aa
 aa
 aa
+je
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -12960,71 +19257,44 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 aa
 aa
 aa
 aa
 aa
-aa
-ab
-ab
-ab
-ab
+je
 aa
 aa
 aa
 aa
+je
+je
+je
+aa
+je
 aa
 aa
 aa
 aa
+je
+aa
+je
+je
+je
+je
+aa
+je
+je
+je
+je
+aa
+je
+je
 aa
 aa
 aa
 aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 ab
 ab
@@ -13038,78 +19308,22 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+je
+je
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+je
+aa
+aa
+aa
+aa
+aa
+je
+aa
+aa
+je
+aa
 ab
 ab
 ab
@@ -13133,9 +19347,7 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+je
 aa
 ab
 ab
@@ -13182,28 +19394,113 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
+je
+je
 aa
+je
+je
+je
+je
+je
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+je
 jc
 jc
+jc
+jc
+jc
+jc
+jc
+je
+aa
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -13213,6 +19510,45 @@ aa
 (41,1,1) = {"
 aa
 aa
+je
+je
+je
+aa
+je
+aa
+aa
+je
+aa
+je
+je
+aa
+je
+je
+aa
+aa
+je
+je
+aa
+je
+aa
+aa
+aa
+je
+je
+aa
+aa
+aa
+aa
+je
+aa
+aa
+aa
+aa
+je
+je
+je
+aa
+je
 aa
 aa
 aa
@@ -13229,84 +19565,21 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
+aa
+je
+aa
+je
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
-aa
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
+je
+je
+je
 aa
 ab
 ab
@@ -13328,6 +19601,29 @@ ab
 ab
 ab
 ab
+je
+aa
+aa
+je
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -13387,15 +19683,15 @@ ab
 ab
 ab
 aa
+je
+je
 aa
 aa
 aa
+je
+je
+je
 aa
-aa
-aa
-aa
-ab
-ab
 ab
 ab
 ab
@@ -13443,6 +19739,21 @@ aa
 aa
 jc
 jc
+jc
+jc
+jc
+jc
+aa
+aa
+je
+aa
+aa
+aa
+je
+aa
+aa
+aa
+je
 aa
 aa
 aa
@@ -13450,52 +19761,26 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 "}
 (42,1,1) = {"
 aa
 aa
 aa
+je
 aa
+je
 aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+je
 aa
 aa
 aa
 aa
+je
 aa
-aa
-ab
+je
+je
 ab
 ab
 ab
@@ -13513,32 +19798,17 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 aa
 aa
+je
 aa
+je
+je
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
+je
 aa
 ab
 ab
@@ -13552,17 +19822,20 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+je
+aa
+je
+je
+aa
+je
+aa
+aa
+aa
+aa
+je
+je
+je
 aa
 aa
 ab
@@ -13585,71 +19858,10 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
+je
 aa
 ab
 ab
@@ -13696,20 +19908,105 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+je
+je
 aa
 aa
+je
+je
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+je
+jc
+jc
+jc
+jc
 jc
 jc
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
+je
+je
+je
 aa
 aa
 aa
@@ -13731,50 +20028,13 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+je
+je
+je
+aa
+aa
 ab
 ab
 ab
@@ -13792,98 +20052,18 @@ aa
 aa
 aa
 aa
+ab
+ab
+ab
+ab
+ab
+je
+je
+je
+je
+je
+je
 aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -13903,11 +20083,75 @@ ab
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+je
+je
+je
+je
+je
+je
+je
+je
+je
+je
+je
+je
+je
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -13955,24 +20199,77 @@ ab
 ab
 aa
 aa
+je
+aa
+aa
+aa
+je
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+je
+aa
+je
 jc
 jc
+jc
+jc
+jc
+aa
+aa
+je
+je
+aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -13984,51 +20281,15 @@ aa
 (44,1,1) = {"
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+je
+je
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -14042,16 +20303,7 @@ ab
 ab
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 ab
@@ -14085,29 +20337,22 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+je
+aa
+aa
+aa
+aa
+aa
+je
+je
+je
+je
+je
+je
+je
+aa
+aa
 ab
 ab
 ab
@@ -14212,33 +20457,91 @@ ab
 ab
 aa
 aa
+je
+je
+je
+je
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+je
+aa
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 aa
 aa
 aa
 aa
+je
+aa
+aa
+aa
+je
+je
+je
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 "}
 (45,1,1) = {"
+je
+je
+je
+je
+aa
+aa
 aa
 aa
 ab
@@ -14257,12 +20560,6 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
 aa
 ab
 ab
@@ -14298,72 +20595,20 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+je
+je
+je
+je
+aa
+aa
+je
+je
+je
+je
+je
+je
+je
 ab
 ab
 ab
@@ -14469,6 +20714,55 @@ ab
 ab
 aa
 aa
+je
+je
+je
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
 aa
 aa
@@ -14476,12 +20770,15 @@ aa
 aa
 aa
 aa
+je
+aa
+je
 aa
 aa
 aa
 aa
 aa
-aa
+je
 aa
 aa
 aa
@@ -14498,180 +20795,11 @@ aa
 (46,1,1) = {"
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+je
+je
+aa
+aa
+aa
 ab
 ab
 ab
@@ -14728,6 +20856,180 @@ aa
 aa
 aa
 aa
+je
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+je
+aa
+aa
+aa
+aa
+aa
+je
+aa
+aa
+je
 aa
 aa
 aa
@@ -14743,17 +21045,71 @@ aa
 aa
 aa
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 "}
 (47,1,1) = {"
 aa
+je
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
 ab
 ab
@@ -14921,66 +21277,13 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+je
+aa
+aa
+aa
+je
+je
 aa
 aa
 aa
@@ -14991,16 +21294,10 @@ aa
 aa
 aa
 aa
+je
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -15012,10 +21309,8 @@ aa
 (48,1,1) = {"
 aa
 aa
-ab
-ab
-ab
-ab
+je
+aa
 ab
 ab
 ab
@@ -15242,36 +21537,36 @@ aa
 aa
 aa
 aa
+je
+je
+aa
+aa
+je
+je
+aa
+aa
+aa
+je
+aa
+je
+je
+je
+je
 aa
 aa
 aa
 aa
+je
+je
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
 "}
 (49,1,1) = {"
-ab
-ab
-ab
-ab
-ab
+je
+je
+je
 ab
 ab
 ab
@@ -15497,6 +21792,11 @@ ab
 ab
 aa
 aa
+je
+aa
+je
+aa
+je
 aa
 aa
 aa
@@ -15507,6 +21807,7 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -15514,18 +21815,14 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
 aa
 aa
 "}
 (50,1,1) = {"
-ab
-ab
+je
+aa
 ab
 ab
 ab
@@ -15751,37 +22048,37 @@ ab
 ab
 ab
 ab
-ab
+aa
+je
+je
+je
+aa
+aa
+aa
+je
+je
+aa
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
 aa
 "}
 (51,1,1) = {"
-ab
+aa
 ab
 ab
 ab
@@ -16008,7 +22305,16 @@ ab
 ab
 ab
 ab
-ab
+aa
+je
+je
+je
+je
+je
+je
+je
+aa
+je
 aa
 aa
 aa
@@ -16026,16 +22332,7 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 "}
 (52,1,1) = {"
 ab
@@ -16265,7 +22562,14 @@ ab
 ab
 ab
 ab
-ab
+je
+je
+je
+aa
+aa
+aa
+aa
+je
 aa
 aa
 aa
@@ -16277,20 +22581,13 @@ aa
 aa
 aa
 aa
+jc
+jc
+jc
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 "}
@@ -16522,30 +22819,30 @@ ab
 ab
 ab
 ab
-ab
+je
+aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
+aa
+aa
+je
+aa
+aa
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 aa
@@ -16778,8 +23075,10 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+je
+aa
+je
 aa
 aa
 aa
@@ -16788,23 +23087,21 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+je
 aa
 aa
 "}
@@ -16936,7 +23233,7 @@ eI
 eI
 eI
 eI
-eI
+cG
 eI
 eI
 eI
@@ -17035,8 +23332,8 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+je
 aa
 aa
 aa
@@ -17046,21 +23343,21 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+jc
+jc
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 aa
@@ -17292,8 +23589,15 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+je
+aa
+je
+aa
+aa
+aa
+aa
+je
 aa
 aa
 aa
@@ -17303,21 +23607,14 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 aa
@@ -17549,8 +23846,8 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+je
 aa
 aa
 aa
@@ -17564,17 +23861,17 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 aa
@@ -17766,13 +24063,11 @@ ab
 ab
 ab
 ab
-ab
 aa
 aa
 aa
-aa
-ab
-ab
+je
+je
 ab
 ab
 ab
@@ -17809,30 +24104,32 @@ ab
 ab
 ab
 aa
+je
+aa
+je
+aa
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 "}
@@ -17967,7 +24264,7 @@ eI
 eI
 eI
 eI
-eI
+cG
 eP
 ep
 gA
@@ -18022,15 +24319,13 @@ ab
 ab
 ab
 ab
-ab
 aa
 aa
+je
+je
 aa
 aa
-aa
-ab
-ab
-ab
+je
 ab
 ab
 ab
@@ -18066,31 +24361,33 @@ ab
 ab
 ab
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
+je
+aa
+aa
+je
 aa
 aa
 aa
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
 aa
 "}
 (60,1,1) = {"
@@ -18278,16 +24575,14 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+je
+je
 aa
 aa
+je
 aa
-aa
-aa
-ab
-ab
-ab
+je
 ab
 ab
 ab
@@ -18323,6 +24618,13 @@ ab
 ab
 ab
 aa
+je
+aa
+aa
+aa
+aa
+aa
+je
 aa
 aa
 aa
@@ -18332,22 +24634,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
 aa
 "}
 (61,1,1) = {"
@@ -18535,6 +24832,46 @@ ab
 ab
 ab
 ab
+aa
+je
+aa
+je
+je
+je
+je
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 aa
@@ -18542,43 +24879,11 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+je
+aa
+aa
+je
 aa
 aa
 aa
@@ -18586,25 +24891,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
 aa
 "}
 (62,1,1) = {"
@@ -18793,55 +25090,50 @@ ab
 ab
 ab
 ab
+je
+je
+je
+je
+je
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 aa
 aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -18854,14 +25146,19 @@ aa
 aa
 aa
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
 aa
 "}
 (63,1,1) = {"
@@ -19052,11 +25349,9 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
+aa
 ab
 ab
 ab
@@ -19095,6 +25390,14 @@ ab
 ab
 aa
 aa
+je
+je
+aa
+aa
+je
+aa
+aa
+je
 aa
 aa
 aa
@@ -19102,23 +25405,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
 aa
 "}
 (64,1,1) = {"
@@ -19348,8 +25645,6 @@ ab
 ab
 ab
 ab
-ab
-ab
 aa
 aa
 aa
@@ -19359,23 +25654,25 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
 aa
 "}
 (65,1,1) = {"
@@ -19605,8 +25902,6 @@ ab
 ab
 ab
 ab
-ab
-ab
 aa
 aa
 aa
@@ -19615,24 +25910,26 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
 aa
 "}
 (66,1,1) = {"
@@ -19863,33 +26160,33 @@ ab
 ab
 ab
 ab
-ab
+aa
+aa
+je
+aa
+aa
+aa
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
 aa
 "}
 (67,1,1) = {"
@@ -20009,30 +26306,29 @@ ab
 ab
 ab
 ab
+hB
+xX
+hB
+xX
+df
+hB
+xX
+hB
+xX
 ab
 ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+hB
+xX
+hB
+xX
+df
+hB
+xX
+hB
+xX
 ab
 ab
 ab
@@ -20124,17 +26420,7 @@ ab
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
+je
 aa
 aa
 aa
@@ -20142,11 +26428,22 @@ aa
 aa
 aa
 aa
+je
+aa
+je
 aa
 aa
-aa
-aa
-aa
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
 aa
 "}
 (68,1,1) = {"
@@ -20265,35 +26562,31 @@ ab
 ab
 ab
 ab
+ip
+BK
+fl
+fl
+fl
+im
+fl
+fl
+fl
+dc
+YV
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+ip
+ia
+fl
+fl
+fl
+im
+fl
+fl
+fl
+cC
+YV
 ab
 ab
 ab
@@ -20384,25 +26677,29 @@ ab
 aa
 aa
 aa
+je
 aa
 aa
-aa
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
+je
+je
+je
+je
+je
 aa
 aa
 aa
 aa
 aa
-aa
-aa
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 "}
@@ -20522,35 +26819,31 @@ ab
 ab
 ab
 ab
+dH
+cb
+cb
+cb
+cb
+cb
+cb
+cb
+cb
+cb
+oD
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+dH
+cb
+cb
+cb
+cb
+cb
+cb
+cb
+cb
+cb
+oD
 ab
 ab
 ab
@@ -20642,24 +26935,28 @@ aa
 aa
 aa
 aa
+je
+je
+je
+je
+aa
+je
+aa
+je
+aa
+je
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 "}
@@ -20779,35 +27076,31 @@ ab
 ab
 ab
 ab
+bS
+WK
+QA
+QA
+WE
+QA
+QA
+QA
+QA
+NA
+bS
 ab
+rE
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+bS
+hY
+yu
+gH
+JW
+RM
+bV
+bV
+CY
+pM
+bS
 ab
 ab
 ab
@@ -20898,25 +27191,29 @@ ab
 aa
 aa
 aa
+je
+aa
+je
+je
 aa
 aa
+je
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+je
+je
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 "}
@@ -21036,34 +27333,31 @@ ab
 ab
 ab
 ab
+bS
+dD
+qn
+TL
+TL
+hA
+TL
+RO
+Fv
+YJ
+bS
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+bS
+VC
+ga
+ga
+ga
+ga
+Wj
+Wj
+ga
+QS
+bS
 ab
 ab
 ab
@@ -21155,25 +27449,28 @@ ab
 aa
 aa
 aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+je
 aa
 aa
 aa
 aa
+je
+je
+je
+aa
+je
 aa
 aa
-aa
-aa
-aa
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 "}
@@ -21293,31 +27590,31 @@ ab
 ab
 ab
 ab
+bS
+Fk
+TL
+cl
+TL
+TL
+FA
+TL
+dw
+kw
+dB
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+bS
+dZ
+ga
+tu
+cy
+Wj
+Wj
+Eo
+Yq
+QS
+bS
 ab
 ab
 ab
@@ -21406,31 +27703,31 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
 aa
 aa
 aa
+je
+je
+je
+je
+je
+je
+je
+je
+je
+je
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 "}
@@ -21543,46 +27840,46 @@ ab
 ab
 ab
 ab
-bP
-bU
-cc
-cc
-cc
-cc
-cc
-cc
-cc
-dc
-dq
 ab
 ab
 ab
 ab
+ip
+cb
+cb
+oD
+UR
+TL
+TL
+Fv
+TL
+dg
+cn
+cn
+yZ
+dB
+cQ
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-bP
+bS
+nN
+ga
+cF
+Yc
+ga
+Sk
+ga
+ga
+gm
+dH
+cb
+cb
 YV
-YV
-YV
-YV
-YV
-YV
-YV
-YV
-YV
-dq
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -21663,33 +27960,33 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
+aa
+aa
+je
+aa
+je
+je
+je
 aa
 aa
 aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+je
 aa
 aa
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 "}
 (74,1,1) = {"
 ab
@@ -21800,46 +28097,46 @@ ab
 ab
 ab
 ab
-bQ
-bV
-bV
-bV
-bV
-bV
-bV
-bV
-bV
-bV
+ab
+ab
+ab
+us
+us
+ne
+lw
 bS
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+zX
+cl
+TL
+lY
+cn
+cn
+bL
+bH
+iq
+Zs
 ab
 ab
 ab
 bS
+VM
+Wj
+do
+ga
+ga
+Kv
+ga
+ga
 gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-bQ
+bS
+ho
+Lq
+lk
+lk
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -21921,21 +28218,14 @@ ab
 ab
 ab
 ab
-ab
-ab
 aa
 aa
 aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+je
+je
+je
+je
+je
 aa
 aa
 aa
@@ -21944,6 +28234,13 @@ aa
 aa
 aa
 aa
+jc
+jc
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 aa
@@ -22057,46 +28354,46 @@ ab
 ab
 ab
 ab
-bQ
-bZ
-cd
-cd
-cs
-cs
-cs
-cd
-cd
-cd
+ab
+ab
+ab
+oY
+sf
+lw
+lw
 bS
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+NC
+St
+St
+St
+QB
+iq
+dg
+bL
+di
+dB
 ab
 ab
 ab
 bS
-cd
-cd
-cd
-cs
-cs
-cs
-cd
-cd
-bZ
-bQ
+il
+Wj
+cR
+ga
+Wj
+QS
+ga
+ee
+pL
+bS
+cW
+cW
+ci
+lk
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -22115,7 +28412,7 @@ iD
 iD
 iD
 iD
-iD
+cV
 iD
 iD
 iD
@@ -22178,32 +28475,32 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+je
+aa
+je
+je
+aa
+je
+je
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 "}
 (76,1,1) = {"
 ab
@@ -22314,46 +28611,46 @@ ab
 ab
 ab
 ab
-bQ
-bX
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-cN
-bZ
+ab
+ab
+ab
+dy
+us
+lw
+Rk
 bS
+ju
+hA
+TL
+cl
+sJ
+cn
+CN
+bH
+bH
+iq
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+hO
 ab
 bS
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-ip
-bQ
+ez
+ga
+ga
+go
+TQ
+TQ
+ha
+ga
+ga
+bS
+cW
+ho
+lk
+lk
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -22374,7 +28671,7 @@ iD
 iD
 iD
 iD
-iD
+cV
 iD
 iD
 iD
@@ -22435,27 +28732,27 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 aa
 aa
 aa
+je
+je
+aa
+je
 aa
 aa
-aa
+jc
+jc
+jc
+jc
 aa
 aa
 aa
@@ -22515,7 +28812,7 @@ aZ
 bg
 aV
 bj
-aZ
+Yf
 bj
 aZ
 aZ
@@ -22564,24 +28861,6 @@ ab
 ab
 ab
 ab
-bE
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-ce
-bZ
-bX
-bZ
-bZ
-bZ
-bZ
-dd
-dr
 ab
 ab
 ab
@@ -22592,25 +28871,43 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
+dB
+iq
+lw
+lw
+AS
+ju
+TL
+TL
+TL
+yB
+TL
+dg
+cn
+kw
+bS
 ab
 ab
 ab
 bS
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bQ
+Pf
+ga
+Wj
+ga
+TQ
+JD
+ga
+ga
+Pf
+ei
+cW
+cW
+ci
+lk
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -22692,32 +28989,32 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+aa
+je
+je
+aa
+aa
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+je
 aa
 aa
+jc
+jc
 aa
 aa
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+je
 "}
 (78,1,1) = {"
 ab
@@ -22821,53 +29118,53 @@ ab
 ab
 ab
 ab
-bF
-bK
-bN
-bN
-bN
-bN
-bN
-bL
-bY
-bJ
-ce
-bZ
-cI
-bZ
-bZ
-co
-co
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+iq
+hU
+Rk
+lw
+bS
+lP
+TL
+cl
+RO
+yB
+qn
+cn
+iq
+YJ
 bS
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 bS
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bQ
+ga
+do
+Zb
+Kv
+bE
+QS
+QS
+Wj
+ga
+bS
+cW
+cW
+lk
+lk
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -22949,32 +29246,32 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+aa
+aa
+je
+aa
+aa
+aa
+aa
+je
+je
+aa
+aa
+aa
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 "}
 (79,1,1) = {"
 ab
@@ -23078,53 +29375,53 @@ ab
 ab
 ab
 ab
-bG
-bL
-bL
-bL
-bL
-bL
-bL
-bL
-bL
-cf
-bX
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+oY
+eD
+lw
+lw
+bS
+EB
+dr
+pR
+St
+VR
+St
+St
+QB
+Js
+bS
+hQ
+hQ
+hQ
+bS
+nO
+yr
+yr
+JB
+JB
+xp
+ga
+Wj
+ee
+bS
+cW
+cW
 ci
-bX
-bZ
-cN
-bZ
-de
-bS
+lk
 ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-bS
-de
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bQ
 ab
 ab
 ab
@@ -23206,32 +29503,32 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+je
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
+je
+aa
+je
 aa
 aa
 aa
-aa
-aa
+je
+je
+je
 "}
 (80,1,1) = {"
 ab
@@ -23335,53 +29632,53 @@ ab
 ab
 ab
 ab
-bG
-bL
-bL
-bL
-bL
-bL
-bL
-bL
-bL
-cf
-bX
-bX
-cJ
-bZ
-bZ
-bZ
-de
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+oY
+us
+wH
+lw
 bS
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+XQ
+fw
+tf
+fw
+BQ
+pP
+pP
+tf
+oa
 bS
-de
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bQ
+hK
+cE
+gV
+bS
+xo
+ga
+Rm
+ga
+Wj
+kU
+hY
+AB
+ee
+bS
+cW
+xz
+lk
+lk
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -23400,7 +29697,7 @@ iD
 iD
 iD
 iD
-iD
+hn
 iD
 iD
 iD
@@ -23463,21 +29760,14 @@ ab
 ab
 ab
 ab
-ab
-ab
 aa
 aa
 aa
+je
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+je
 aa
 aa
 aa
@@ -23487,7 +29777,14 @@ aa
 aa
 aa
 aa
+je
+je
 aa
+aa
+aa
+aa
+aa
+je
 aa
 "}
 (81,1,1) = {"
@@ -23592,24 +29889,6 @@ ab
 ab
 ab
 ab
-bH
-bM
-bO
-bO
-bO
-bO
-bO
-bL
-bL
-bJ
-cg
-cu
-bX
-cJ
-bZ
-bZ
-de
-bS
 ab
 ab
 ab
@@ -23621,24 +29900,42 @@ ab
 ab
 ab
 ab
+dH
+cb
+cb
+dt
+cb
+cb
+wm
+cb
+cb
+cp
+cb
+QR
+cb
+dt
+cb
+cb
+cb
+dt
+cb
+Ag
+cb
+cp
+cb
+YI
+cb
+cb
+cb
+dt
+cb
+cp
+hT
 ab
 ab
 ab
 ab
 ab
-ab
-ab
-bS
-de
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bQ
 ab
 ab
 ab
@@ -23720,25 +30017,25 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+aa
+je
+je
+aa
+je
+je
+je
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
+je
+je
 aa
 aa
 aa
@@ -23800,7 +30097,7 @@ aZ
 bi
 aV
 bj
-aZ
+ds
 bj
 aZ
 aZ
@@ -23849,31 +30146,6 @@ ab
 ab
 ab
 ab
-bI
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-cg
-bX
-bZ
-bX
-bZ
-bZ
-co
-df
-bS
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -23886,16 +30158,41 @@ ab
 ab
 ab
 bS
-df
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bQ
+xN
+cs
+cs
+Xq
+cs
+oM
+cs
+Of
+bS
+By
+Nv
+sC
+Xt
+BL
+Av
+BL
+Av
+AQ
+BL
+fu
+bS
+kS
+Hh
+Pq
+jd
+Tz
+Tz
+vj
+bS
+bF
+ab
+ab
+hZ
+ab
+ab
 ab
 ab
 ab
@@ -23977,31 +30274,31 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+aa
+aa
+je
+je
+je
+je
+aa
+je
+aa
+je
+je
+aa
+je
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
+je
+je
+je
 aa
 "}
 (83,1,1) = {"
@@ -24113,16 +30410,39 @@ ab
 ab
 ab
 ab
-bQ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-cP
-bZ
-df
+ab
+ab
+ab
+ab
+bS
+kF
+Ui
+sl
+Ui
+cU
+XE
+Ui
+Jm
+bS
+wC
+nW
+Gs
+Fq
+Yg
+Yg
+Yg
+fT
+JR
+XJ
+Hd
+bS
+Sl
+xU
+sA
+sA
+sA
+sA
+EQ
 bS
 ab
 ab
@@ -24130,29 +30450,6 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-bS
-df
-bZ
-bZ
-bZ
-bZ
-co
-bZ
-bZ
-im
-bQ
 ab
 ab
 ab
@@ -24235,30 +30532,30 @@ ab
 ab
 ab
 ab
-ab
+aa
+je
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+je
+je
+je
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
-aa
+je
+je
 aa
 "}
 (84,1,1) = {"
@@ -24370,16 +30667,39 @@ ab
 ab
 ab
 ab
-bQ
-bZ
-bZ
-bZ
-bZ
-cI
-cN
-bZ
-bZ
-dg
+ab
+ab
+ab
+ab
+bS
+ze
+Ui
+Ui
+Ui
+Ui
+XE
+Ui
+GI
+bS
+Jy
+Yg
+fT
+Lc
+bI
+bI
+bI
+bI
+Yg
+Dx
+Um
+bS
+HG
+Vp
+sA
+rc
+rc
+sA
+OA
 bS
 ab
 ab
@@ -24399,30 +30719,6 @@ ab
 ab
 ab
 ab
-bS
-dg
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bQ
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -24499,16 +30795,6 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 aa
 aa
 aa
@@ -24516,7 +30802,18 @@ aa
 aa
 aa
 aa
+je
 aa
+aa
+aa
+aa
+aa
+je
+aa
+je
+aa
+aa
+je
 "}
 (85,1,1) = {"
 ab
@@ -24627,16 +30924,44 @@ ab
 ab
 ab
 ab
-bQ
-bZ
-bZ
-bZ
-cv
-cJ
-bZ
-bZ
-bZ
-dg
+ab
+ab
+ab
+ab
+bS
+ze
+Ui
+Ui
+Ui
+Ui
+XE
+Ui
+GI
+bS
+Jy
+Yg
+Yg
+Fr
+qo
+xM
+mY
+gc
+jr
+Lc
+zC
+bS
+WI
+MX
+ti
+xe
+ti
+Dl
+EQ
+dH
+cb
+Pr
+ab
+ab
 bS
 ab
 ab
@@ -24656,50 +30981,6 @@ ab
 ab
 ab
 ab
-bS
-dg
-bZ
-bZ
-bZ
-bZ
-bZ
-il
-bZ
-bZ
-bQ
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -24768,11 +31049,27 @@ ab
 ab
 aa
 aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+je
+je
+aa
+je
 aa
 aa
 aa
 aa
-aa
+je
+je
+je
 aa
 "}
 (86,1,1) = {"
@@ -24884,16 +31181,44 @@ ab
 ab
 ab
 ab
-bQ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-dh
+ab
+ab
+ab
+ab
+bS
+Hm
+Ui
+Ui
+hI
+Ui
+XE
+Ui
+hV
+bS
+tp
+Yg
+Yg
+jI
+cS
+Yg
+dj
+cB
+dT
+Lc
+Ey
+bS
+Lu
+sA
+sA
+sA
+sA
+xU
+TV
+bS
+SI
+cn
+ab
+MI
 bS
 ab
 ab
@@ -24913,40 +31238,6 @@ ab
 ab
 ab
 ab
-bS
-dh
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bQ
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -25026,11 +31317,17 @@ ab
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
 aa
 aa
+je
+aa
+aa
+je
 "}
 (87,1,1) = {"
 ab
@@ -25141,52 +31438,45 @@ ab
 ab
 ab
 ab
-bQ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-dh
-bS
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
 ab
 bS
-dh
-bZ
-bZ
-bZ
-bZ
-bZ
-im
-bZ
-cI
-bQ
-ab
-ab
-ab
-ab
-ab
-ab
+MW
+Ig
+xT
+Ui
+Ui
+qP
+Ui
+oB
+bS
+Jy
+Yg
+HM
+Fr
+cS
+Yg
+dj
+cB
+dT
+Lc
+ms
+bS
+Lu
+sA
+sA
+sA
+sA
+Tb
+xw
+bS
+eZ
+dm
+cn
+Po
+cD
 ab
 ab
 ab
@@ -25284,6 +31574,13 @@ ab
 ab
 aa
 aa
+aa
+je
+aa
+je
+aa
+aa
+je
 aa
 aa
 aa
@@ -25398,51 +31695,45 @@ ab
 ab
 ab
 ab
-bQ
-bZ
-bZ
-bZ
-bZ
-bZ
-cL
-cL
-cL
-dh
+ab
+ip
+cb
+cb
+dt
+cb
+cO
+VV
+Ui
+Ui
+EU
+sW
+oj
+nG
+Dt
+Yg
+Yg
+Fr
+tH
+rW
+da
+tM
+dT
+Lc
+zC
 bS
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Lu
+sA
+sA
+sA
+sA
+xU
+xw
 bS
-dh
-bZ
-bZ
-bZ
-bZ
-bZ
-bX
-bZ
-cI
-bQ
-ab
-ab
-ab
-ab
-ab
+eZ
+id
+dg
+ih
+ux
 ab
 ab
 ab
@@ -25542,8 +31833,14 @@ ab
 aa
 aa
 aa
+je
+je
 aa
+je
+je
 aa
+je
+je
 aa
 "}
 (89,1,1) = {"
@@ -25655,51 +31952,45 @@ ab
 ab
 ab
 ab
-bQ
-bZ
-bZ
-bZ
-co
-bZ
-cL
-cL
-cL
-di
-bS
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 bS
-di
-bZ
-bZ
-bZ
-bZ
-bZ
-cJ
-bX
-bX
-bQ
-ab
-ab
-ab
-ab
-ab
+Hv
+PC
+PC
+qT
+bS
+Nw
+Ui
+Ui
+GR
+Kp
+fV
+bS
+cT
+sS
+RI
+tI
+py
+py
+ib
+ib
+vJ
+CR
+lW
+bS
+Ip
+ti
+ti
+AK
+sz
+LQ
+xw
+bS
+gZ
+cn
+Lp
+iq
+cD
 ab
 ab
 ab
@@ -25797,10 +32088,16 @@ ab
 ab
 ab
 aa
+je
 aa
 aa
 aa
 aa
+aa
+aa
+aa
+je
+je
 aa
 "}
 (90,1,1) = {"
@@ -25912,50 +32209,45 @@ ab
 ab
 ab
 ab
-bQ
-bZ
-bZ
-cn
-bZ
-bZ
-bZ
-bZ
-bZ
-di
-bS
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 bS
-di
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-dn
-bX
-bQ
-ab
-ab
-ab
-ab
+Kw
+Bp
+OX
+mq
+vw
+Nf
+Ji
+ot
+QM
+Ui
+zK
+bS
+cT
+bY
+Yg
+qI
+Yz
+oH
+xb
+oH
+vJ
+vJ
+Ai
+bS
+Tn
+sA
+sA
+sA
+sA
+TX
+Bg
+sv
+oN
+ZX
+WX
+rY
+cZ
 ab
 ab
 ab
@@ -26055,9 +32347,14 @@ ab
 ab
 aa
 aa
+je
 aa
 aa
 aa
+aa
+aa
+aa
+je
 aa
 "}
 (91,1,1) = {"
@@ -26169,16 +32466,44 @@ ab
 ab
 ab
 ab
-bQ
-bZ
-bZ
-co
-bZ
-bZ
-bZ
-bZ
-bZ
-di
+ab
+cZ
+Wp
+qH
+Qx
+Kb
+bS
+yX
+Qp
+Ig
+Ig
+XN
+dL
+bS
+DZ
+Hn
+Vt
+ii
+mk
+mk
+mk
+hH
+Jg
+nd
+CF
+bS
+JZ
+mp
+Zh
+EJ
+IT
+vY
+CI
+bS
+Ts
+UE
+Ss
+sH
 bS
 ab
 ab
@@ -26198,39 +32523,6 @@ ab
 ab
 ab
 ab
-bS
-di
-bZ
-bZ
-bZ
-bZ
-bZ
-bX
-bX
-bX
-bQ
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -26314,8 +32606,13 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
+aa
+aa
+je
+je
 "}
 (92,1,1) = {"
 ab
@@ -26426,18 +32723,20 @@ ab
 ab
 ab
 ab
-bR
-ca
-ca
+ab
+cZ
+Kw
+qH
+Le
+bM
+dt
+cb
+DC
+cb
 cp
 cb
 cb
-cb
-cb
-cb
-cb
-ds
-cb
+dt
 cb
 cb
 cb
@@ -26449,26 +32748,20 @@ cb
 cb
 cb
 cb
-cb
-cb
-cb
-cb
-cb
-cb
-ds
-cb
-cb
-cb
+dt
 cb
 cb
 cb
 cp
-ca
-ca
-eG
-ab
-ab
-ab
+cb
+Wz
+cb
+dt
+cb
+cA
+Ts
+Px
+bS
 ab
 ab
 ab
@@ -26569,9 +32862,13 @@ ab
 ab
 aa
 aa
+je
 aa
 aa
 aa
+aa
+aa
+je
 aa
 "}
 (93,1,1) = {"
@@ -26683,17 +32980,17 @@ ab
 ab
 ab
 ab
-bQ
-bZ
-bZ
-bQ
-cw
-cw
-cw
-cw
-cw
-cw
-bQ
+ab
+cZ
+Cc
+nu
+Le
+bS
+MA
+lM
+vH
+xL
+bS
 cH
 cH
 cH
@@ -26701,31 +32998,27 @@ cH
 cH
 eR
 eR
-fd
-fk
-fG
-fG
-gn
+JJ
+ht
+eR
 gB
+gn
+JJ
 gB
 gO
 gO
 hi
-hr
-bQ
-hO
-hP
-hY
-hP
-hY
-hP
-bQ
-bZ
-bZ
-bQ
-ab
-ab
-ab
+hi
+bS
+Rq
+vh
+Yv
+HN
+UN
+dH
+cb
+Ap
+oD
 ab
 ab
 ab
@@ -26829,6 +33122,10 @@ aa
 aa
 aa
 aa
+je
+aa
+aa
+je
 aa
 "}
 (94,1,1) = {"
@@ -26940,17 +33237,17 @@ ab
 ab
 ab
 ab
-bQ
-bZ
-bZ
-bQ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bQ
+ab
+cZ
+Kw
+qH
+Le
+bS
+dJ
+NT
+uu
+fk
+bS
 cH
 ea
 ek
@@ -26962,26 +33259,23 @@ cH
 cH
 cH
 cH
+dE
 cH
-cH
-cH
+dE
 gO
 gO
 hi
 hi
-bQ
-hP
-hP
-hP
-hP
-hP
-hP
-bQ
-bZ
-bZ
-bQ
-ab
-ab
+bS
+pf
+Xn
+IN
+Xn
+GA
+bS
+tl
+GU
+bS
 ab
 ab
 ab
@@ -27087,6 +33381,9 @@ aa
 aa
 aa
 aa
+je
+je
+je
 "}
 (95,1,1) = {"
 ab
@@ -27197,48 +33494,45 @@ ab
 ab
 ab
 ab
-bQ
-bZ
-bZ
-bQ
-cx
-bZ
-cx
-bZ
-cx
-bZ
-bQ
+ab
+cZ
+dX
+sJ
+oh
+bS
+ue
+NT
+uu
+tm
+bS
 cH
 eb
 el
 es
+jB
+AV
+AH
+dE
+cr
 cH
 cH
 cH
 cH
+Ne
 cH
 cH
-cH
-cH
-cH
-cH
-eR
-gZ
 hi
-hi
-bQ
-hQ
-hP
-hZ
-hP
-hQ
-hP
-bQ
-bZ
-bZ
-bQ
-ab
-ab
+BO
+bS
+Ly
+Cg
+uZ
+Xn
+UF
+bS
+NV
+Pe
+cZ
 ab
 ab
 ab
@@ -27340,7 +33634,10 @@ ab
 ab
 aa
 aa
-aa
+je
+je
+je
+je
 aa
 aa
 aa
@@ -27454,46 +33751,46 @@ ab
 ab
 ab
 ab
-bQ
-bZ
-bZ
-bQ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bQ
+ab
+bS
+eZ
+Ac
+Po
+bS
+dJ
+NT
+uu
+fk
+bS
 cH
 ec
 em
 et
+YH
+fd
+hs
+fd
+ht
+ht
+fd
+ht
 cH
-eR
-eZ
-eR
-eR
-eR
-ga
-go
-fw
-cH
+Ne
 cH
 cH
 hi
 hi
-hA
-cb
-cb
-cb
-gD
-hV
-hU
-bQ
-bZ
-bZ
-bQ
+bS
+tU
+Ra
+UH
+dX
+vN
+bS
+XC
+Nl
+bS
+ab
 ab
 ab
 ab
@@ -27592,15 +33889,15 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
+je
 "}
 (97,1,1) = {"
 ab
@@ -27711,17 +34008,23 @@ ab
 ab
 ab
 ab
-bQ
-bZ
-bZ
-bQ
-cx
-bZ
-cx
-bZ
-cx
-bZ
-bQ
+ab
+bS
+eZ
+iq
+Ix
+bS
+dJ
+NT
+SN
+fk
+bS
+OB
+cH
+cH
+cH
+hW
+Ax
 cH
 cH
 cH
@@ -27729,28 +34032,22 @@ cH
 cH
 cH
 cH
-cH
-cH
-cH
-cH
-cH
-cH
-cH
-cH
-cH
+TG
+DL
+ox
 hi
 hi
-bQ
-hR
-hU
-hP
-ic
-hP
-hP
-bQ
-im
-bZ
-bQ
+bS
+Ly
+dX
+dC
+Xn
+IO
+dH
+cb
+Ap
+oD
+ab
 ab
 ab
 ab
@@ -27850,14 +34147,14 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+aa
+je
 aa
 aa
 aa
-aa
-aa
-aa
+je
+je
 "}
 (98,1,1) = {"
 ab
@@ -27968,46 +34265,46 @@ ab
 ab
 ab
 ab
+ab
+bS
+eZ
 bQ
-bZ
-bZ
-bQ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bQ
+Po
+bS
+dJ
+NT
+uu
+cz
+bS
 dI
 cH
 cH
+hs
+ht
+ht
+fd
 cH
 cH
+dE
+DL
+fd
 cH
 cH
-cH
-cH
-cH
-cH
-cH
-cH
-cH
-cH
-cH
+hs
+DL
 hj
 hj
-hA
-cb
-hV
-hP
-hP
-hP
-hP
-bQ
-bZ
-bZ
-bQ
+bS
+Pw
+Rr
+iq
+Xn
+IO
+bS
+sh
+np
+bS
+ab
 ab
 ab
 ab
@@ -28107,14 +34404,14 @@ ab
 ab
 ab
 ab
-ab
-ab
 aa
 aa
 aa
 aa
+je
+je
 aa
-aa
+je
 "}
 (99,1,1) = {"
 ab
@@ -28223,50 +34520,50 @@ ab
 ab
 ab
 ab
-ab
-ab
-bQ
-bZ
-bZ
-bQ
-cx
-cL
-cx
-bZ
-cx
-bZ
-bQ
-dJ
-dJ
+ip
+cb
+cb
+oD
+eZ
+Xv
+Po
+bS
+ss
+md
+Cr
+bK
+bS
+dI
 cH
 cH
+dE
 cH
-eR
-eR
-eR
-fl
-eR
-eR
+cH
+dE
+cH
+fd
+cH
+cH
 gp
-gp
 cH
 cH
-cH
+ht
+DL
 hj
 hj
-bQ
-hR
-hU
-hP
-hP
-hP
-hP
-bQ
-bZ
-bZ
-bQ
-ab
-ab
+bS
+Pw
+Xb
+iq
+dX
+IO
+bS
+mD
+RS
+dH
+cb
+cb
+YV
 ab
 ab
 ab
@@ -28308,9 +34605,9 @@ iT
 iT
 iT
 iT
+bO
 iT
-iT
-iT
+eG
 iT
 iT
 iV
@@ -28364,14 +34661,14 @@ ab
 ab
 ab
 ab
-ab
-ab
 aa
 aa
 aa
+je
+je
 aa
 aa
-aa
+je
 "}
 (100,1,1) = {"
 ab
@@ -28479,22 +34776,21 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-bQ
-bZ
-bZ
-bQ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bQ
+ZJ
+ZJ
+GW
+Rj
+bS
+eZ
+sJ
+Le
+bS
+yt
+Sd
+zQ
+bK
+bS
 dK
-ed
 cH
 cH
 cH
@@ -28502,29 +34798,30 @@ cH
 cH
 cH
 cH
+ht
 cH
 cH
+wz
 cH
+dE
+fd
+ox
 cH
-cH
-cH
-cH
-eR
-eR
-hA
-cb
-hV
-hP
-hP
-hP
-hP
-bQ
-bZ
-bZ
-bQ
-ab
-ab
-ab
+dN
+bS
+fG
+Xn
+VF
+Mk
+Ld
+bS
+mD
+RS
+bS
+ls
+Ea
+kR
+kR
 ab
 ab
 ab
@@ -28622,15 +34919,16 @@ ab
 ab
 ab
 ab
-ab
+aa
+aa
+je
 aa
 aa
 aa
-aa
-aa
-aa
+je
 "}
 (101,1,1) = {"
+aa
 ab
 ab
 ab
@@ -28735,53 +35033,52 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-bQ
-bZ
-bZ
-bQ
-cx
-bZ
-cx
-bZ
-cx
-bZ
-bQ
-dL
-ee
+zU
+fy
+Rj
+Rj
+bS
+Kw
+qH
+Po
+bS
+yt
+Sd
+zQ
+bK
+bS
+dK
 cH
 cH
+ht
 cH
-cH
-cH
+Zm
+Zm
 fe
+fd
 cH
 cH
+pH
 cH
+dE
+cr
+ox
 cH
-cH
-cH
-cH
-cH
-eR
-eR
-bQ
-hR
-hU
-hP
-hP
-hP
-hP
-bQ
-bZ
-bZ
-bQ
-ab
-ab
-ab
+kI
+bS
+VQ
+Xn
+cN
+iq
+IO
+bS
+mD
+RS
+bS
+ls
+ls
+OG
+kR
 ab
 ab
 ab
@@ -28879,15 +35176,17 @@ ab
 ab
 ab
 ab
-ab
 aa
 aa
 aa
 aa
+je
 aa
 aa
 "}
 (102,1,1) = {"
+aa
+aa
 ab
 ab
 ab
@@ -28991,54 +35290,52 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-bQ
-bZ
-bZ
-bQ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bQ
+zU
+ZJ
+Rj
+Rj
+bS
+Cc
+nu
+Le
+bS
+dJ
+uu
+TP
+rR
+bS
+Zl
 dM
-dM
 cH
+hs
+cr
+hr
 cH
+dE
+fd
 cH
+rK
+KO
+ox
+DL
+ox
+GQ
 cH
-cH
-cH
-cH
-cH
-cH
-cH
-cH
-cH
-cH
-cH
-eR
-eR
-hA
-cb
-hV
-hP
-hP
-hP
-hP
-bQ
-bZ
-bZ
-bQ
-ab
-ab
-ab
+kI
+bS
+yQ
+Xn
+IN
+Xn
+IO
+bS
+rM
+RS
+bS
+ls
+ls
+kR
+kR
 ab
 ab
 ab
@@ -29081,7 +35378,7 @@ iT
 iT
 iT
 iT
-iT
+eG
 iT
 iT
 iT
@@ -29136,15 +35433,18 @@ ab
 ab
 ab
 ab
-ab
 aa
+je
 aa
-aa
+je
 aa
 aa
 aa
 "}
 (103,1,1) = {"
+je
+je
+je
 ab
 ab
 ab
@@ -29247,55 +35547,52 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-bQ
-bZ
-bZ
-bQ
-cx
-bZ
-cx
-bZ
-cx
-co
-bQ
+zU
+fy
+Rj
+Rj
+AL
+Xf
+qH
+Le
+bS
+ue
+uu
+TP
+qM
+bS
 dM
 dM
 cH
+ht
+cH
+fd
+Su
 cH
 cH
 cH
 cH
+wz
+cH
+TG
 cH
 cH
 cH
-cH
-cH
-cH
-cH
-cH
-cH
-eR
-hs
-bQ
-hR
-hU
-ia
-id
-ia
-hP
-bQ
-bZ
-bZ
-bQ
-ab
-ab
-ab
+BV
+bS
+Yo
+Xn
+vi
+US
+Cu
+bS
+rM
+RS
+ei
+ls
+ls
+OG
+kR
 ab
 ab
 ab
@@ -29393,16 +35690,19 @@ ab
 ab
 ab
 ab
-ab
 aa
 aa
 aa
+je
 aa
-aa
+je
 aa
 "}
 (104,1,1) = {"
+je
+je
 aa
+je
 aa
 ab
 ab
@@ -29504,55 +35804,52 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-bQ
-bZ
-bZ
-bQ
-bZ
-bZ
-bZ
-bZ
-bZ
-dj
-bQ
+zU
+ZJ
+Rj
+Rj
+bS
+Kw
+qH
+Le
+bS
+dJ
+uu
+NT
+fk
+bS
 dN
 dN
 cH
+fd
 cH
 cH
 cH
 cH
 cH
+lG
+Ee
+Ee
+mr
+wz
+od
+gp
 cH
-cH
-cH
-cH
-cH
-cH
-cH
-cH
-hk
-hs
-hA
-cb
-hV
-hP
-hP
-hP
-hP
-bQ
-bZ
-bZ
-bQ
-ab
-ab
-ab
+ht
+bS
+pf
+Xn
+Yj
+DH
+IO
+bS
+mD
+VE
+bS
+ls
+ls
+kR
+kR
 ab
 ab
 ab
@@ -29570,8 +35867,8 @@ ab
 aa
 aa
 aa
-aa
-ab
+je
+je
 ab
 ab
 ab
@@ -29592,7 +35889,7 @@ iR
 iT
 iT
 iT
-iT
+bO
 iT
 iT
 iT
@@ -29650,7 +35947,7 @@ ab
 ab
 ab
 ab
-ab
+aa
 aa
 aa
 aa
@@ -29659,6 +35956,10 @@ aa
 aa
 "}
 (105,1,1) = {"
+je
+je
+aa
+je
 aa
 aa
 ab
@@ -29760,58 +36061,52 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-bQ
-bZ
-bZ
-bQ
-cy
-bZ
-bZ
-bZ
-bZ
-co
-bQ
+zU
+fy
+Rj
+Rj
+bS
+Kw
+qH
+Le
+bS
+Fs
+sE
+rp
+PB
+bS
 dN
 dN
 cH
+xZ
 cH
 cH
 cH
 cH
 cH
-cH
-cH
-cH
+wo
+dE
 gq
+Du
 cH
 cH
+dE
 cH
-cH
-hk
 ht
-bQ
-hR
-hU
-hP
-hP
-ih
-ih
-bQ
-bZ
-bZ
-bQ
-ab
-ab
-ab
-ab
-ab
+bS
+Yu
+rU
+UL
+Ke
+Ol
+bS
+Ro
+Vd
+bS
+ls
+ls
+OG
+kR
 ab
 ab
 ab
@@ -29826,10 +36121,12 @@ ab
 ab
 ab
 aa
-ab
 aa
-ab
-ab
+je
+aa
+je
+aa
+Zt
 ab
 ab
 ab
@@ -29907,21 +36204,21 @@ ab
 ab
 ab
 ab
-ab
+aa
+je
 aa
 aa
-aa
-aa
+je
 aa
 aa
 "}
 (106,1,1) = {"
+je
+je
+je
+je
+je
 aa
-aa
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -30021,18 +36318,18 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
+zU
+ZJ
+sM
+Rj
 bS
-bZ
-bZ
-cq
-cb
-cb
-ca
-ca
-cb
+Iu
+Wv
+EX
+dH
+We
+Jt
+cp
 cb
 dt
 cb
@@ -30044,9 +36341,9 @@ cb
 cb
 ff
 ff
+Xs
 ff
-ff
-cb
+JH
 gD
 cb
 cb
@@ -30056,20 +36353,17 @@ cb
 dt
 cb
 cb
-ca
-ca
-cb
-cb
-eH
-bZ
-bZ
-bQ
-ab
-ab
-ab
-ab
-ab
-ab
+cp
+WH
+lt
+oD
+mD
+RS
+bS
+ls
+kx
+kR
+kR
 ab
 ab
 ab
@@ -30083,10 +36377,13 @@ ab
 ab
 aa
 aa
-ab
+je
+je
+je
+je
+je
 aa
-ab
-ab
+je
 ab
 ab
 ab
@@ -30164,20 +36461,21 @@ ab
 ab
 ab
 ab
-ab
+aa
+je
 aa
 aa
+je
 aa
-aa
-aa
-aa
+je
 "}
 (107,1,1) = {"
+je
+je
+je
 aa
-aa
-aa
-aa
-aa
+je
+je
 aa
 ab
 ab
@@ -30278,54 +36576,49 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-bQ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-cU
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
+dW
+cb
+cb
+oD
+Kw
+qH
+Qm
+bS
+Mn
+pq
+Gf
+yA
+zh
+Bo
+wx
+zh
+HO
+FL
+IF
+wx
+zh
+zh
+Pm
+zh
+wx
 gE
-co
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bQ
-ab
-ab
-ab
-ab
-ab
+TW
+zh
+Bo
+zh
+wx
+zh
+zh
+tG
+Gf
+ld
+kf
+bS
+mD
+RS
+dH
+cb
+iq
 ab
 ab
 ab
@@ -30340,11 +36633,15 @@ ab
 ab
 aa
 aa
+je
+je
+je
+je
 aa
-aa
-ab
-ab
-ab
+je
+je
+je
+je
 ab
 ab
 ab
@@ -30420,187 +36717,22 @@ ab
 ab
 ab
 ab
-ab
-ab
 aa
 aa
 aa
 aa
+aa
+je
 aa
 aa
 "}
 (108,1,1) = {"
 aa
+je
+je
 aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-bQ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-cU
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-ch
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bQ
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
 aa
 ab
 ab
@@ -30679,6 +36811,171 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+bS
+Kw
+qH
+Qm
+bS
+SU
+jT
+xa
+WB
+Zy
+ol
+Zy
+wK
+pe
+Zy
+Zy
+Zy
+Zy
+Zy
+Hj
+AI
+Zy
+Zy
+Zy
+Zy
+Mi
+Zy
+Ok
+Zy
+Zy
+zn
+xa
+OY
+Ks
+bS
+mD
+RS
+bS
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+je
+je
+aa
+je
+je
+aa
+je
+aa
+aa
+je
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+je
 aa
 aa
 aa
@@ -30688,10 +36985,11 @@ aa
 "}
 (109,1,1) = {"
 aa
+je
 aa
 aa
-aa
-aa
+je
+je
 aa
 ab
 ab
@@ -30796,27 +37094,26 @@ ab
 ab
 ab
 bS
-bZ
-ch
-cr
+wq
+qH
+Qm
+bS
+SU
+wY
+dH
+cb
+ZF
+lB
+cb
+cb
+cb
 cb
 cb
 cb
 cp
-cb
-cb
-ca
-ca
-cb
-cb
-cb
-cb
-cb
-cb
-cO
-bZ
-bZ
-cr
+CW
+gh
+cp
 cb
 cb
 cb
@@ -30827,14 +37124,13 @@ hu
 hu
 cb
 cb
-cb
-cb
-cb
-cb
-cO
-bZ
-ch
-bQ
+oD
+OY
+tq
+bS
+mD
+lU
+bS
 ab
 ab
 ab
@@ -30845,26 +37141,22 @@ ab
 ab
 ab
 ab
+ab
+aa
+je
+je
+je
+je
 aa
+je
+je
+je
 aa
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
+je
+je
+je
+je
+je
 ab
 ab
 ab
@@ -30941,15 +37233,22 @@ aa
 aa
 aa
 aa
+aa
+aa
+aa
+je
+je
 aa
 "}
 (110,1,1) = {"
 aa
 aa
+je
 aa
 aa
+je
+je
 aa
-aa
 ab
 ab
 ab
@@ -31051,51 +37350,48 @@ ab
 ab
 ab
 ab
-ab
+cZ
+Kw
+qH
+Le
 bS
-bZ
-bZ
+SU
+Qt
 bS
-cz
-cM
-cM
-bQ
+qO
 cX
-cX
-cX
-cX
-cX
-cX
-cX
+Gx
+Vz
+BS
+QI
 dO
 dO
 cX
 bS
-bZ
-bZ
+gg
+Td
 bS
 gr
 gF
 gF
 gP
+Nq
+qC
 gF
 gF
-gF
-gF
-gF
-gF
-gF
-ie
-gF
-ii
+hS
+hX
 bS
-bZ
-bZ
+ub
+Ks
+bS
+mD
+RS
 bS
 ab
 ab
 ab
-ab
+cw
 ab
 ab
 ab
@@ -31103,26 +37399,21 @@ ab
 ab
 ab
 aa
+je
+je
+je
 aa
 aa
 aa
+je
 aa
+je
 aa
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
+je
+je
+je
+je
+je
 ab
 ab
 ab
@@ -31197,16 +37488,24 @@ aa
 aa
 aa
 aa
+je
 aa
+aa
+aa
+aa
+aa
+je
 aa
 "}
 (111,1,1) = {"
 aa
+je
+je
 aa
 aa
 aa
+je
 aa
-aa
 ab
 ab
 ab
@@ -31308,46 +37607,43 @@ ab
 ab
 ab
 ab
-ab
+cZ
+Kw
+qH
+oh
 bS
-bZ
-bZ
+SU
+jT
 bS
-cA
-cM
-cM
-cQ
 cX
 cX
-cX
-cX
-cX
+Om
+oW
 cX
 dv
 dQ
 eS
 en
 bS
-bZ
-bZ
+Nb
+XW
 bS
 gs
 gF
+gR
+cg
+gF
+cc
+gR
 gF
 gF
-gF
-gF
-hv
-gF
-gF
-hv
-gF
-gF
-gF
-ik
+Fu
 bS
-bZ
-bZ
+OY
+NH
+bS
+mD
+DF
 bS
 ab
 ab
@@ -31359,99 +37655,100 @@ ab
 ab
 ab
 ab
+aa
+je
+je
+aa
+aa
+aa
+je
+aa
+aa
+je
+je
+je
+je
+je
+je
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 aa
 aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-aa
-aa
-ab
-ab
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
+je
+je
 aa
 aa
 aa
@@ -31459,11 +37756,14 @@ aa
 "}
 (112,1,1) = {"
 aa
+je
+je
 aa
 aa
+je
+je
+je
 aa
-aa
-aa
 ab
 ab
 ab
@@ -31564,17 +37864,14 @@ ab
 ab
 ab
 ab
-ab
-ab
+cZ
+Kw
+qH
+Le
 bS
-bZ
-bZ
+Gp
+jT
 bS
-cB
-cM
-cM
-bQ
-cX
 dk
 cX
 cX
@@ -31585,141 +37882,144 @@ dQ
 dQ
 en
 bS
-bZ
-bZ
+Nb
+OO
 bS
-gs
+Zp
+dF
+gF
+Lv
 gF
 gF
+dF
 gF
-gF
-gF
-gF
-gF
-gF
-gF
-gF
-gF
-gF
-ik
+gR
+Od
 bS
-bZ
-bZ
+nr
+DT
 bS
+mD
+ky
+iq
+dd
 ab
 ab
 ab
-ab
-ab
+dd
 ab
 ab
 ab
 ab
 ab
 aa
+je
+je
+je
+je
+je
+je
+je
+je
+aa
+je
+je
+je
+je
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+je
+je
+aa
+aa
+je
+je
 aa
 aa
 aa
-aa
-aa
-ab
-ab
-ab
-ab
-aa
-aa
-ab
-ab
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
+je
 aa
 "}
 (113,1,1) = {"
 aa
+je
 aa
 aa
 aa
+je
 aa
+je
 aa
 ab
 ab
@@ -31821,18 +38121,15 @@ ab
 ab
 ab
 ab
-ab
-ab
+cZ
+Kw
+nu
+Le
 bS
-bZ
-bZ
+rw
+Uv
 bS
-cC
-cM
-cM
-cR
-cX
-dk
+GP
 du
 cX
 cX
@@ -31842,26 +38139,25 @@ dR
 dR
 cX
 bS
-bZ
-bZ
+Nb
+OO
 bS
 gt
 gF
 gF
 gF
+hv
+gF
+dF
 gF
 gF
-gF
-gF
-gF
-gF
-gF
-ie
-gF
-ii
+sp
 bS
-bZ
-bZ
+OY
+Ks
+bS
+mD
+RS
 bS
 ab
 ab
@@ -31874,110 +38170,114 @@ ab
 ab
 ab
 aa
+je
+je
+je
+je
+aa
+aa
+je
+je
+je
+je
+aa
+je
+je
 aa
 aa
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+je
+je
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 "}
 (114,1,1) = {"
 aa
+je
 aa
+je
 aa
+je
 aa
-aa
-aa
+je
+je
 ab
 ab
 ab
@@ -32076,49 +38376,45 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
+bF
+ab
+cZ
+Kw
+qH
+Le
 bS
-bZ
-bZ
+SU
+VX
 bS
-cD
-cM
-cM
-cR
-cX
-cX
+dQ
 cX
 dO
 dO
 cX
-cX
+BS
 dO
 dO
-cX
+rC
 bS
-bZ
-bZ
+gj
+VK
 bS
 gu
+gR
 gF
-gF
-gQ
-ha
-gF
-gF
+gR
 gF
 gF
 gF
 gF
 gF
-gF
-ik
+cM
 bS
-bZ
-bZ
+OY
+Ks
+bS
+eZ
+VE
 bS
 ab
 ab
@@ -32131,23 +38427,20 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
+je
+je
+je
+je
+je
+je
+je
+je
+je
+je
+je
+aa
 ab
 ab
 ab
@@ -32217,7 +38510,11 @@ ab
 ab
 ab
 aa
+je
 aa
+aa
+aa
+je
 aa
 aa
 aa
@@ -32230,14 +38527,15 @@ aa
 "}
 (115,1,1) = {"
 aa
+je
+aa
+je
 aa
 aa
 aa
+je
+je
 aa
-aa
-ab
-ab
-ab
 ab
 ab
 ab
@@ -32338,15 +38636,14 @@ ab
 ab
 ab
 bS
-bZ
-bZ
+Kw
+qH
+Le
 bS
-cE
-cM
-cM
-cS
-cX
-cX
+SU
+jT
+bS
+dQ
 dv
 dP
 dQ
@@ -32356,26 +38653,25 @@ dP
 dQ
 en
 bS
-bZ
-bZ
+Nb
+xB
 bS
 gv
-gF
-gF
-gR
 gR
 gF
+hG
+gR
 gF
+gR
 gF
-gF
-gF
-ib
-gF
-gF
-ik
+sn
+RC
 bS
-bZ
-bZ
+OY
+tq
+bS
+mD
+RS
 bS
 ab
 ab
@@ -32393,18 +38689,14 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+je
+aa
+je
+je
+je
+aa
+aa
+aa
 ab
 ab
 ab
@@ -32474,27 +38766,33 @@ ab
 ab
 ab
 aa
+je
+aa
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
+je
 aa
-aa
-aa
-aa
+je
 "}
 (116,1,1) = {"
 aa
+je
 aa
+je
 aa
+je
+je
+je
+je
 aa
-aa
-aa
-ab
-ab
-ab
 ab
 ab
 ab
@@ -32595,15 +38893,14 @@ ab
 ab
 ab
 bS
-bZ
-bZ
+Kw
+qH
+Le
 bS
-cF
-cM
-cM
-cT
-cX
-cX
+SU
+jT
+bS
+UO
 dv
 dQ
 dQ
@@ -32613,27 +38910,26 @@ dQ
 eT
 en
 bS
-bZ
-bZ
+Nb
+Ab
 bS
 gs
 gF
 gF
+db
 gF
 gF
 gF
 gF
 gF
-gF
-hW
-gR
-ie
-gF
-ii
+jC
 bS
-bZ
-bZ
+OY
+Ks
 bS
+mD
+RS
+cZ
 ab
 ab
 ab
@@ -32727,31 +39023,33 @@ ab
 ab
 ab
 aa
+je
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 "}
 (117,1,1) = {"
 aa
+je
 aa
+je
 aa
+je
+je
 aa
+je
 aa
-aa
-ab
-ab
-ab
 ab
 ab
 ab
@@ -32852,46 +39150,43 @@ ab
 ab
 ab
 bS
-bZ
-bZ
+Cc
+JS
+Le
 bS
-cF
-cM
-cM
-cT
+SU
+ed
+bS
+cf
 cX
-cX
-cX
-dR
+le
 dR
 cX
 cX
-dR
+le
 dR
 cX
 bS
-bZ
-bZ
+fB
+TN
 bS
 gr
 gF
 gF
 gP
-gF
-gF
+ZM
+qC
 hw
-hB
+hX
 hS
 hX
-gF
-gF
-gF
-ik
 bS
-bZ
-bZ
+He
+oT
 bS
-ab
+mD
+RS
+cZ
 ab
 ab
 ab
@@ -32984,6 +39279,10 @@ ab
 ab
 ab
 aa
+je
+aa
+aa
+je
 aa
 aa
 aa
@@ -32991,20 +39290,22 @@ aa
 aa
 aa
 aa
+je
 aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 "}
 (118,1,1) = {"
 aa
+je
 aa
 aa
 aa
 aa
+je
+aa
+je
 aa
 ab
 ab
@@ -33105,13 +39406,27 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
+dB
+eZ
+sJ
+dX
 bS
-bZ
-bZ
-cq
+FN
+jT
+dH
+cb
+cb
+cb
+cb
+cb
+cb
+cb
+cb
+cb
+dt
+CW
+CW
+dt
 cb
 cb
 cb
@@ -33122,33 +39437,13 @@ cb
 cb
 cb
 cb
-cb
-cb
-cb
-cb
-eH
-bZ
-bZ
-cq
-cb
-cb
-cb
-cb
-cb
-cb
-cb
-cb
-cb
-cb
-cb
-cb
-cb
-cb
-eH
-bZ
-bZ
-bS
-ab
+dt
+ww
+Oh
+oD
+mD
+RS
+cZ
 ab
 ab
 ab
@@ -33241,28 +39536,34 @@ ab
 ab
 ab
 aa
+je
 aa
 aa
+je
 aa
 aa
+je
 aa
 aa
+je
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
+je
 "}
 (119,1,1) = {"
 aa
+je
 aa
 aa
+je
+je
+je
 aa
+je
 aa
-aa
 ab
 ab
 ab
@@ -33330,6 +39631,20 @@ ab
 ab
 ab
 ab
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
 ab
 ab
 ab
@@ -33348,65 +39663,44 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+dB
+dX
+Ac
+Po
 bS
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
+SU
+vs
+Gl
+rS
+DP
+DP
+MD
+DP
+pn
+DP
+Mt
+DP
+MD
+DP
+kP
+MD
+DP
+ik
+kP
+qd
+DP
+MD
+DP
+Cz
+Gl
+BA
+OS
+kQ
+my
 bS
-ab
-ab
+mD
+RS
+cZ
 ab
 ab
 ab
@@ -33501,11 +39795,14 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
+aa
+je
 aa
 aa
 aa
@@ -33515,11 +39812,15 @@ aa
 "}
 (120,1,1) = {"
 aa
+je
 aa
 aa
+je
+je
 aa
+je
 aa
-aa
+je
 ab
 ab
 ab
@@ -33585,6 +39886,23 @@ ab
 ab
 ab
 ab
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
 ab
 ab
 ab
@@ -33601,69 +39919,45 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+hZ
+dB
+dB
+iq
+ih
 bS
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-cY
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-cY
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
+SU
+jT
+Id
+nt
+sO
+Dw
+sO
+sO
+Mr
+sO
+sO
+sO
+sO
+sO
+QO
+sO
+sO
+sO
+AF
+Mr
+sO
+sO
+sO
+fz
+Id
+uz
+VT
+CE
+vu
 bS
-ab
-ab
+mD
+yO
+cZ
 ab
 ab
 ab
@@ -33755,33 +40049,36 @@ ab
 ab
 ab
 aa
+je
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+je
+je
 aa
 "}
 (121,1,1) = {"
 aa
+je
+je
+aa
+je
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
 ab
 ab
 ab
@@ -33845,6 +40142,24 @@ ab
 ab
 ab
 ab
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
 ab
 ab
 ab
@@ -33862,63 +40177,45 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-bT
+dB
+dB
+cu
+Po
+bS
+SU
+jT
+dH
+cb
+cb
+cb
+cb
+cb
+cb
+cb
 cb
 cb
 cp
-cG
-cG
-cO
-bZ
-bZ
-cr
-cb
-cb
-cb
-cb
-cb
-cb
-cb
-cb
-dl
-ca
-ca
-dl
-cb
-cb
-cb
-cb
-cb
-cb
-cb
-cb
-cO
-bZ
-bZ
-cr
-cG
-cG
+qW
+yG
 cp
 cb
 cb
-hT
+cb
+cb
+cb
+cb
+cb
+cb
+cp
+ca
+vQ
+cp
+cb
+eH
+mD
+RS
+cZ
+ab
 ab
 ab
 ab
@@ -34009,6 +40306,10 @@ ab
 ab
 ab
 aa
+je
+aa
+aa
+je
 aa
 aa
 aa
@@ -34018,22 +40319,104 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
 "}
 (122,1,1) = {"
 aa
+je
+aa
+aa
+je
+je
+aa
+aa
+aa
+je
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+jc
+jc
+jc
+jc
 aa
 aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
+aa
+jc
+jc
+jc
+jc
 ab
 ab
 ab
@@ -34051,108 +40434,22 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-bQ
-cH
-cH
+dB
+iq
+SA
+dX
 bS
-bZ
-bZ
+SU
+Vs
 bS
-dw
 dS
 dS
+gQ
 dS
 ev
 ev
-ev
+ew
+fa
 fa
 bS
 fm
@@ -34160,21 +40457,21 @@ fH
 bS
 gw
 gG
-gx
-gx
-gx
-gx
-fx
+bP
+lm
+hC
+jk
+My
 hC
 bS
-bZ
-bZ
+FX
+lq
 bS
-cH
-cH
-bQ
-ab
-ab
+pk
+ZD
+Op
+RS
+cZ
 ab
 ab
 ab
@@ -34268,14 +40565,14 @@ ab
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -34289,6 +40586,96 @@ aa
 aa
 aa
 aa
+je
+je
+aa
+je
+aa
+je
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+jc
+jc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 ab
@@ -34304,134 +40691,44 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-bQ
-cH
-cH
+cZ
+dC
+wJ
+Po
 bS
-bZ
-bZ
+wV
+UD
 bS
-dx
-bZ
-bZ
-bZ
+dn
 ew
-bZ
-bZ
-fb
+ew
+ew
+ew
+ew
+vL
+dn
+ew
 bS
 fn
 fI
 bS
+bU
+sL
+My
 gx
-gx
-gx
-gx
-gx
-gx
-gH
-gx
+My
+Kl
+My
+Oi
 bS
-bZ
-bZ
+RQ
+rN
 bS
-cH
-cH
-bQ
-ab
-ab
+mD
+Yt
+Yt
+RS
+bS
 ab
 ab
 ab
@@ -34523,31 +40820,124 @@ ab
 ab
 ab
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
+je
 aa
-aa
-aa
-aa
-aa
-aa
+je
 "}
 (124,1,1) = {"
 aa
+je
+aa
+aa
+je
+je
+aa
+je
+aa
+je
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
 aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -34558,138 +40948,44 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+cZ
+Qs
 bQ
-cH
-cH
+Le
 bS
-bZ
-bZ
+kO
+Xl
 bS
+dn
 dx
-bZ
-bZ
-bZ
-ex
-bZ
-bZ
-fb
-ca
+vL
+ew
+dx
+ew
+ew
+dx
+jN
+ZW
 fo
 fJ
-ca
-gx
-gH
-gx
-gx
-gx
-gx
-gx
-gx
+Jv
+fx
+fx
+fx
+ov
+fx
+lJ
+cx
+AN
 bS
-bZ
-bZ
+RQ
+rN
 bS
-cH
-cH
-bQ
-ab
-ab
-ab
+mD
+HK
+XG
+OL
+bS
 ab
 ab
 ab
@@ -34781,30 +41077,124 @@ ab
 ab
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+je
 "}
 (125,1,1) = {"
 aa
+je
+aa
+aa
+je
+je
+je
+je
+aa
+je
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
 aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -34815,138 +41205,44 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-bQ
-cH
-cH
 bS
-bZ
-bZ
+Kw
+qH
+Le
 bS
-dy
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-fb
+kO
+nJ
+bS
+vL
+ew
+ew
+vL
+ew
+ou
+ou
+ew
+Hx
 bS
 fp
-fH
+vO
 bS
-gx
-gx
-gx
-gx
+Rd
+dq
+My
+My
 hb
-gx
-gx
-gx
+hb
+hb
+hb
 bS
-bZ
-bZ
+RQ
+rN
 bS
-cH
-cH
-bQ
-ab
-ab
-ab
+mD
+Yt
+Ye
+LI
+bS
 ab
 ab
 ab
@@ -35039,6 +41335,7 @@ ab
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -35048,8 +41345,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+je
+je
 aa
 aa
 aa
@@ -35058,92 +41355,13 @@ aa
 (126,1,1) = {"
 aa
 aa
+je
 aa
+je
 aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
+je
 aa
 ab
 ab
@@ -35167,40 +41385,121 @@ ab
 ab
 ab
 ab
-bQ
-cH
-cH
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 bS
-bZ
-bZ
+Kw
+qH
+Le
+bS
+rB
+sb
 bS
 dz
-dT
+tO
+dz
+dz
 eg
-eg
-ey
-ey
+uU
+xE
 ey
 fc
 bS
 fm
 fK
 bS
-gx
-gx
-gx
+cv
 gS
-gx
-gx
-gx
+pu
+gS
+ie
+hD
+hD
 hD
 bS
-bZ
-bZ
+RQ
+rN
 bS
-cH
-cH
-bQ
+mD
+qJ
+Ah
+LI
+bS
 ab
 ab
 ab
@@ -35241,12 +41540,9 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
+aa
 ab
 ab
 ab
@@ -35296,18 +41592,19 @@ ab
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -35315,92 +41612,13 @@ aa
 (127,1,1) = {"
 aa
 aa
+je
 aa
+je
 aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
+je
 aa
 ab
 ab
@@ -35424,40 +41642,121 @@ ab
 ab
 ab
 ab
-bQ
-cH
-cH
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+bF
 bS
-bZ
-bZ
-bR
+Kw
+qH
+Le
+dH
+Jt
+cb
+dt
+cp
 cb
 cb
 cb
-dl
-ez
-ez
-ez
-ez
+cp
+cb
+cb
+cb
+cb
 eH
-fm
+tT
 fL
 cq
-ez
-ez
-ez
-ez
-dl
-ez
-ez
-ez
-eG
-bZ
-bZ
+cb
+cb
+cb
+cb
+cp
+cb
+cb
+cb
+oD
+RQ
+pp
 bS
-cH
-cH
-bQ
+mD
+Yt
+Ye
+IY
+bS
 ab
 ab
 ab
@@ -35495,18 +41794,15 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+YX
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -35552,6 +41848,10 @@ ab
 ab
 aa
 aa
+je
+aa
+aa
+je
 aa
 aa
 aa
@@ -35561,103 +41861,21 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
+je
 aa
 "}
 (128,1,1) = {"
 aa
+je
 aa
+je
+je
 aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
+je
 aa
 ab
 ab
@@ -35681,95 +41899,121 @@ ab
 ab
 ab
 ab
-bT
-cG
-cG
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+jc
+jc
+jc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 bS
-bZ
-bZ
+Cc
+qH
+Le
 bS
-de
+Dv
+Cl
+Wu
+bS
+Gm
 de
 de
 bS
 eA
 eK
 eK
+fb
 eK
-fg
 fq
 fM
 fg
-eK
+mW
 eK
 eK
 gT
 bS
 hl
 de
-de
-bS
-bZ
 bZ
 bS
-cG
-cG
-hT
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
+Lo
+rN
+bS
+tV
+PT
+VL
+rv
+bS
 ab
 ab
 ab
@@ -35818,103 +42062,77 @@ aa
 aa
 aa
 aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+aa
+je
+aa
+aa
+aa
+je
+je
 aa
 "}
 (129,1,1) = {"
 aa
 aa
+je
+je
+je
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 ab
 ab
@@ -35932,6 +42150,80 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+jc
+jc
+jc
+jc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -35942,8 +42234,13 @@ ab
 ab
 ab
 bS
-bZ
-bZ
+Kw
+nu
+Le
+bS
+QE
+ZH
+jA
 bS
 bZ
 bZ
@@ -35952,82 +42249,28 @@ bS
 eB
 eL
 eU
-bZ
+Bd
 cI
 cJ
-bZ
-cJ
-bZ
-co
-bZ
+KM
+wD
+Bd
+lr
+Bd
 gU
 bS
 bZ
 bZ
 bZ
 bS
-bZ
-bZ
-bS
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
+RQ
+rN
+dH
+cb
+dl
+CX
+cb
+oD
 ab
 ab
 ab
@@ -36076,96 +42319,145 @@ aa
 aa
 aa
 aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+je
 aa
 aa
 aa
 aa
+je
+aa
+je
+je
+je
+je
 aa
 aa
+aa
+aa
+je
 "}
 (130,1,1) = {"
 aa
+je
+je
+je
+aa
+aa
+je
+je
+je
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 aa
@@ -36173,22 +42465,22 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -36199,32 +42491,42 @@ ab
 ab
 ab
 bS
-bZ
-bZ
+Kw
+IU
+mq
+hJ
+FI
+oi
+FT
 bS
 bZ
 bZ
-bZ
+Ck
 bS
-eB
-bZ
-bZ
-co
+nE
+Bd
+Bd
+lr
 cJ
 cI
-cJ
-cJ
-bZ
-bZ
-bZ
-gU
+jY
+tk
+Bd
+Bd
+Bd
+uK
 bS
 ch
 bZ
-bZ
+Ck
+bS
+RQ
+rN
 bS
 bZ
 bZ
+wg
+cY
 bS
 ab
 ab
@@ -36262,15 +42564,6 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 aa
 aa
 aa
@@ -36279,13 +42572,14 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -36325,16 +42619,19 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
-aa
+je
 aa
 aa
 aa
@@ -36343,92 +42640,12 @@ aa
 (131,1,1) = {"
 aa
 aa
+je
+je
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 ab
 ab
@@ -36446,6 +42663,81 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+jc
+jc
+jc
+jc
+jc
+jc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -36456,32 +42748,42 @@ ab
 ab
 ab
 bS
-bZ
-bZ
+Kw
+xq
+Le
 bS
-bZ
-bZ
-bZ
+vf
+cL
+FT
 bS
-eB
-bZ
-bZ
-cU
 bZ
 co
-bZ
+bX
+bS
+eB
+Bd
+Bd
+Ul
+Bd
+lr
+OU
 gb
 gy
-bZ
-bZ
+Bd
+lr
 gU
 bS
 bZ
 bZ
 hE
 bS
+RQ
+rN
+bS
 bZ
 bZ
+YK
+Gy
 bS
 ab
 ab
@@ -36519,15 +42821,6 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 aa
 aa
 aa
@@ -36536,18 +42829,18 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -36582,31 +42875,35 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
+je
+je
 aa
+je
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
+je
+je
 "}
 (132,1,1) = {"
 aa
+je
+je
+je
+aa
+je
 aa
 aa
 aa
-aa
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -36665,9 +42962,17 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
+aa
+aa
+aa
+aa
+aa
+jc
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 aa
@@ -36679,30 +42984,17 @@ aa
 aa
 aa
 aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -36713,32 +43005,42 @@ ab
 ab
 ab
 bS
-bZ
-bZ
-ca
-bZ
-bZ
-bZ
+Gc
+VI
+ZI
+bS
+NY
+BI
+Fz
+Ws
+AT
+AT
+AC
 bS
 eB
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
+Bd
+Bd
+Bd
+Bd
+Bd
+Bd
 eW
-bZ
-bZ
-bZ
+Bd
+Bd
+OU
 gU
 bS
+AA
+AT
+AT
+Ws
+BT
+kY
+bS
+bJ
 bZ
 bZ
-bZ
-ca
-bZ
-bZ
+bX
 bS
 ab
 ab
@@ -36778,13 +43080,6 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 aa
 aa
 aa
@@ -36793,22 +43088,19 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -36850,19 +43142,24 @@ aa
 aa
 aa
 aa
+je
+aa
+aa
+je
+je
 aa
 aa
 aa
 "}
 (133,1,1) = {"
 aa
+je
+je
+je
+je
+je
 aa
 aa
-aa
-aa
-ab
-ab
-ab
 ab
 ab
 ab
@@ -36922,9 +43219,17 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
+aa
+aa
+aa
+aa
+aa
+jc
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 aa
@@ -36936,14 +43241,16 @@ aa
 aa
 aa
 aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -36954,56 +43261,44 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+dW
+cb
+cb
+cb
+dt
+cO
+Mh
+FT
 bS
 bZ
-bZ
-bS
-bZ
-bZ
+co
 bZ
 bS
 eB
-co
+lr
 eV
 ex
-bZ
-co
-bZ
-bZ
-cU
-bZ
-bZ
+Bd
+lr
+Bd
+Bd
+Bd
+Bd
+Bd
 gU
 bS
 bZ
-bZ
-bZ
+bX
+co
 bS
-bZ
-bZ
-bS
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+RQ
+rN
+dH
+cb
+hy
+hy
+cb
+hT
 ab
 ab
 ab
@@ -37064,12 +43359,8 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
 ab
 ab
 ab
@@ -37096,6 +43387,14 @@ aa
 aa
 aa
 aa
+je
+je
+aa
+je
+aa
+je
+aa
+je
 aa
 aa
 aa
@@ -37104,22 +43403,20 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
 "}
 (134,1,1) = {"
 aa
+je
+je
+je
 aa
 aa
 aa
 aa
-ab
-ab
-ab
 ab
 ab
 ab
@@ -37141,7 +43438,7 @@ ah
 aj
 aj
 aj
-aj
+tS
 aj
 aj
 ah
@@ -37179,17 +43476,17 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
+jc
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 aa
@@ -37227,32 +43524,32 @@ ab
 ab
 ab
 bS
-bZ
-bZ
+QE
+hk
 bS
 bZ
 bZ
-bZ
+Ck
 bS
-eB
-bZ
+nE
+Bd
 eW
-bZ
-bZ
+Bd
+Bd
 fr
-bZ
-bZ
-bZ
-bZ
-bZ
-gU
+Bd
+Bd
+Bd
+Bd
+Bd
+uK
 bS
 bZ
-ch
 bZ
+Ck
 bS
-cY
-bZ
+RQ
+rN
 bS
 ab
 ab
@@ -37314,13 +43611,13 @@ aa
 aa
 aa
 aa
+jc
+jc
+jc
 aa
 aa
 aa
 aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -37339,13 +43636,6 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
 ab
 ab
 ab
@@ -37353,6 +43643,11 @@ aa
 aa
 aa
 aa
+je
+aa
+aa
+je
+je
 aa
 aa
 aa
@@ -37363,6 +43658,8 @@ aa
 aa
 aa
 aa
+aa
+je
 aa
 aa
 aa
@@ -37370,12 +43667,12 @@ aa
 "}
 (135,1,1) = {"
 aa
+je
+je
 aa
 aa
 aa
 aa
-ab
-ab
 ab
 ab
 ab
@@ -37393,7 +43690,7 @@ ai
 aj
 aj
 aj
-an
+cd
 ah
 aj
 aj
@@ -37436,17 +43733,17 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
+jc
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 aa
@@ -37484,8 +43781,8 @@ ab
 ab
 ab
 bS
-bZ
-bZ
+QE
+FT
 bS
 bZ
 bZ
@@ -37494,12 +43791,12 @@ bS
 eB
 eM
 eM
-bZ
+Bd
 eM
 fs
 eM
 eM
-bZ
+Bd
 eM
 eM
 gU
@@ -37508,8 +43805,8 @@ bZ
 bZ
 bZ
 bS
-bZ
-bZ
+Gn
+kY
 bS
 ab
 ab
@@ -37570,14 +43867,15 @@ aa
 aa
 aa
 aa
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -37595,26 +43893,25 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
 ab
 ab
 ab
 aa
 aa
 aa
+je
+aa
+aa
+je
 aa
 aa
 aa
+je
 aa
 aa
-aa
+je
+je
+je
 aa
 aa
 aa
@@ -37627,11 +43924,11 @@ aa
 "}
 (136,1,1) = {"
 aa
+je
+je
+je
 aa
-ab
-ab
-ab
-ab
+aa
 ab
 ab
 ab
@@ -37694,8 +43991,15 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+aa
+aa
+aa
+aa
+jc
+jc
+jc
+jc
 aa
 aa
 aa
@@ -37715,13 +44019,6 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -37741,8 +44038,8 @@ ab
 ab
 ab
 bS
-bZ
-bZ
+QE
+FT
 bS
 cj
 ck
@@ -37751,7 +44048,7 @@ bS
 eC
 eN
 eX
-eC
+mu
 fh
 ft
 fN
@@ -37765,8 +44062,8 @@ ct
 ck
 cK
 bS
-bZ
-bZ
+RQ
+rN
 bS
 ab
 ab
@@ -37826,11 +44123,12 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+jc
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 aa
@@ -37855,17 +44153,13 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+je
+je
 aa
 aa
 aa
-ab
-ab
-ab
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -37873,22 +44167,25 @@ aa
 aa
 aa
 aa
+je
+aa
+je
 aa
 aa
 aa
 aa
 aa
-aa
+je
 aa
 aa
 "}
 (137,1,1) = {"
 aa
+je
+je
 aa
-ab
-ab
-ab
-ab
+aa
+aa
 ab
 ab
 ab
@@ -37951,8 +44248,14 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+aa
+aa
+aa
+aa
+aa
+jc
+jc
 aa
 aa
 aa
@@ -37972,15 +44275,9 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
+aa
 ab
 ab
 ab
@@ -37998,36 +44295,35 @@ ab
 ab
 ab
 bS
-bZ
-bZ
+QE
+FT
 bR
 cb
-ca
+dh
 cb
 dt
-eD
+eO
+eO
+eO
+eO
+eO
+cZ
 eO
 eO
 eO
 eO
 eO
 eO
-eO
-eO
-eO
-eO
-gV
 dt
 cb
-ca
+dh
 cb
-eG
-bZ
-bZ
+ic
+RQ
+rN
 bS
 ab
-ab
-ab
+bF
 ab
 ab
 ab
@@ -38084,9 +44380,12 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+jc
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 aa
@@ -38110,41 +44409,39 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
+aa
+aa
+je
+aa
+aa
+aa
+aa
+je
+aa
+aa
+aa
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 "}
 (138,1,1) = {"
 aa
+je
+je
+je
 aa
-ab
-ab
-ab
 ab
 ab
 ab
@@ -38229,6 +44526,16 @@ aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -38241,53 +44548,40 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+ip
+cb
+cb
+oD
+QE
+jA
 bS
-bZ
-bZ
+hR
+hR
+hR
+hR
+cZ
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+cZ
+hR
+hR
+hR
+hR
 bS
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-bS
-bZ
-bZ
-bS
-ab
-ab
-ab
-ab
-ab
-ab
+RQ
+rN
+dH
+cb
+cb
+YV
 ab
 ab
 ab
@@ -38343,6 +44637,11 @@ aa
 aa
 aa
 aa
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 aa
@@ -38367,21 +44666,19 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
 aa
 aa
 aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
 aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -38397,10 +44694,10 @@ aa
 aa
 "}
 (139,1,1) = {"
+je
+je
+je
 aa
-aa
-ab
-ab
 ab
 ab
 ab
@@ -38486,6 +44783,17 @@ aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -38496,56 +44804,42 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+uW
+uW
+Bx
+eh
 bS
-bZ
-cU
+QE
+GB
 bS
-cW
-cW
-cW
-cW
+hR
+hR
+hR
 eE
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
+cZ
+hR
+hR
+hR
+hR
+hR
+hR
+eE
+hR
+hR
+hR
+cZ
+hR
+hR
+hR
+hR
 bS
-bZ
-bZ
+RQ
+rN
 bS
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+WR
+Vx
+PO
+PO
 ab
 ab
 ab
@@ -38599,7 +44893,12 @@ aa
 aa
 aa
 aa
-aa
+jc
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 aa
@@ -38624,9 +44923,8 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
+aa
+je
 aa
 aa
 aa
@@ -38645,18 +44943,17 @@ aa
 aa
 aa
 aa
+je
 aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
 "}
 (140,1,1) = {"
+je
+je
 aa
-aa
-ab
 ab
 ab
 ab
@@ -38731,11 +45028,6 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
 aa
 aa
 aa
@@ -38746,6 +45038,19 @@ aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -38756,53 +45061,42 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Vv
+wZ
+CS
+eh
 bS
-bZ
-bZ
+Ce
+FT
 bS
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
+hR
+hR
+hR
+hR
+bN
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
 gK
-cW
-cW
-cW
-cW
-cW
+bN
+hR
+hR
+hR
+hR
 bS
-bZ
-bZ
+RQ
+rN
 bS
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+WR
+WR
+Dr
+PO
 ab
 ab
 ab
@@ -38856,7 +45150,11 @@ aa
 aa
 aa
 aa
-aa
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 aa
@@ -38882,24 +45180,23 @@ ab
 ab
 ab
 ab
-ab
-ab
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -38911,9 +45208,9 @@ aa
 aa
 "}
 (141,1,1) = {"
+je
 aa
 aa
-ab
 ab
 ab
 ab
@@ -38991,8 +45288,16 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -39013,59 +45318,42 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Vv
+uW
+CS
+CS
 bS
-cU
-bZ
+QE
+FT
 bS
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
+hR
+hR
+hR
+hR
+cZ
+hR
+hR
+hR
+hR
+hR
 fv
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
+hR
+hR
+hR
+hR
+cZ
+hR
+hR
+hP
+hR
 bS
-bZ
-bZ
+RQ
+rN
 bS
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+WR
+WR
+PO
+PO
 ab
 ab
 ab
@@ -39120,8 +45408,16 @@ aa
 aa
 aa
 aa
-ab
-ab
+jc
+jc
+jc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -39142,21 +45438,22 @@ ab
 ab
 ab
 aa
+je
+aa
+aa
+je
+je
+aa
+je
+je
+aa
+je
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -39168,8 +45465,8 @@ aa
 aa
 "}
 (142,1,1) = {"
-ab
-ab
+aa
+aa
 ab
 ab
 ab
@@ -39250,6 +45547,8 @@ ab
 ab
 ab
 ab
+ab
+ab
 aa
 aa
 aa
@@ -39260,6 +45559,12 @@ aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -39270,54 +45575,42 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Vv
+wZ
+eh
+CS
+XA
+QE
+FT
 bS
-bZ
-bZ
-bS
-dB
+ZN
 dV
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-eE
-cW
-cW
-cW
-cW
+hR
+hR
+cZ
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+cZ
+hR
+hR
+hR
+hR
 bS
-bZ
-bZ
-bS
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+GZ
+rN
+vn
+WR
+WR
+Dr
+PO
 ab
 ab
 ab
@@ -39377,7 +45670,10 @@ aa
 aa
 aa
 aa
-ab
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -39399,24 +45695,25 @@ ab
 ab
 ab
 aa
+je
+je
+je
 aa
 aa
 aa
 aa
+je
+je
+aa
+je
+aa
+aa
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
 aa
 aa
 aa
@@ -39425,7 +45722,7 @@ aa
 aa
 "}
 (143,1,1) = {"
-ab
+aa
 ab
 ab
 ab
@@ -39520,6 +45817,11 @@ ab
 ab
 ab
 ab
+aa
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -39530,43 +45832,42 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Vv
+uW
+CS
+CS
 bS
-bZ
-bZ
+QE
+Se
 bS
-cW
-cW
-cW
-cW
-cW
-cW
+hR
+hR
+hR
+hP
+cZ
+hR
 eY
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+cZ
+hR
+hR
+hR
+hR
 bS
-bZ
-bZ
+RQ
+GK
 bS
+WR
+WR
+PO
+PO
 ab
 ab
 ab
@@ -39611,28 +45912,23 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -39660,6 +45956,12 @@ aa
 aa
 aa
 aa
+je
+je
+aa
+aa
+aa
+je
 aa
 aa
 aa
@@ -39668,16 +45970,11 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 "}
@@ -39777,6 +46074,11 @@ ab
 ab
 ab
 ab
+aa
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -39787,43 +46089,42 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Vv
+wZ
+CS
+eh
 bS
-bZ
-bZ
+QE
+QL
 bS
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
+hR
+hR
+hP
+hR
+cZ
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hP
+hR
+hR
+cZ
+hP
+hP
+hR
+hR
 bS
-bZ
-bZ
+RQ
+rN
 bS
+WR
+WR
+Dr
+PO
 ab
 ab
 ab
@@ -39868,28 +46169,23 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jc
+jc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+jc
+jc
+jc
+jc
 ab
 ab
 ab
@@ -39913,14 +46209,15 @@ ab
 ab
 ab
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
-aa
-aa
-aa
+je
+je
 aa
 aa
 aa
@@ -40049,38 +46346,42 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
+Vv
+uW
+Qq
+CS
 bS
-bZ
-bZ
+QE
+FT
 bS
-cW
-cW
-cW
-cW
-cW
-eE
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
+hR
+hR
+hR
+hR
+cZ
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+cZ
 hc
-dB
-cW
+WL
+hR
 eE
 bS
-bZ
-bZ
+RQ
+rN
 bS
+WR
+SW
+PO
+PO
 ab
 ab
 ab
@@ -40125,27 +46426,22 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
 ab
 ab
 ab
@@ -40173,6 +46469,7 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -40187,11 +46484,11 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
-aa
-aa
+je
 aa
 aa
 "}
@@ -40233,7 +46530,7 @@ an
 an
 an
 an
-an
+cd
 aA
 ah
 ao
@@ -40307,37 +46604,40 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
+dW
+cb
+cb
+oD
+Qd
+pQ
 bS
-bZ
-bZ
+hR
+hR
+hR
+hR
+cZ
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+cZ
+hR
+WL
+hR
+hR
 bS
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-fu
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-dB
-cW
-cW
-bS
-bZ
-bZ
-bS
+RQ
+rN
+dH
+cb
+cb
+hT
 ab
 ab
 ab
@@ -40385,24 +46685,20 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
+jc
 ab
 ab
 ab
@@ -40427,6 +46723,15 @@ ab
 ab
 ab
 aa
+je
+aa
+aa
+aa
+je
+aa
+aa
+je
+je
 aa
 aa
 aa
@@ -40436,15 +46741,7 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -40568,32 +46865,32 @@ ab
 ab
 ab
 bS
-bZ
-bZ
+QE
+jA
 bS
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
+hR
+hR
+hR
+hR
+cZ
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+cZ
+hR
+hR
+hR
+hR
 bS
-bZ
-bZ
+RQ
+rN
 bS
 ab
 ab
@@ -40682,23 +46979,23 @@ ab
 ab
 ab
 ab
-ab
+aa
+je
+aa
+je
+aa
+aa
+aa
+aa
+je
+je
 aa
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -40825,32 +47122,32 @@ ab
 ab
 ab
 bS
-bZ
-bZ
+QE
+FT
 bS
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
+hR
+hR
+hR
+hR
+cZ
+cZ
+cZ
+cZ
+cZ
+hR
+cZ
+cZ
+cZ
+cZ
+cZ
+cZ
+hR
+hR
+hR
+hR
 bS
-bZ
-bZ
+RQ
+rN
 bS
 ab
 ab
@@ -40939,7 +47236,6 @@ ab
 ab
 ab
 ab
-ab
 aa
 aa
 aa
@@ -40948,16 +47244,17 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
+je
 aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -41082,32 +47379,32 @@ ab
 ab
 ab
 bS
-bZ
-bZ
+QE
+FT
 bS
-cW
-cW
-cW
-dB
+hR
+hR
+hR
+WL
 eF
-dB
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
+WL
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
 bS
-bZ
-bZ
+yS
+So
 bS
 ab
 ab
@@ -41195,31 +47492,31 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+aa
+aa
+je
+aa
+aa
+aa
+aa
+aa
+je
+aa
+je
+je
+je
+je
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 "}
@@ -41339,36 +47636,34 @@ ab
 ab
 ab
 bS
-bZ
-bZ
+QE
+FT
 bS
-cW
-cW
-cW
-cW
-dB
-dB
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
+hR
+hR
+hR
+hR
+WL
+WL
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
 eE
-cW
-cW
-cW
-cW
+hR
+hR
+hR
+hR
 bS
-bZ
-bZ
+AR
+sj
 bS
-ab
-ab
-ab
+bF
 ab
 ab
 ab
@@ -41463,16 +47758,18 @@ aa
 aa
 aa
 aa
+je
+je
+je
+aa
+aa
+aa
+je
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -41596,32 +47893,32 @@ ab
 ab
 ab
 bS
-bZ
-bZ
+QE
+Hz
 bS
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+ab
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
 bS
-bZ
-bZ
+AR
+sj
 bS
 ab
 ab
@@ -41709,30 +48006,30 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+aa
+je
+aa
+aa
+aa
+je
+aa
+je
+aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -41853,32 +48150,32 @@ ab
 ab
 ab
 bS
-bZ
-bZ
+QE
+hk
 bS
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
+hR
+hR
+eE
+hR
+hR
+hR
+hR
+hR
+hR
+ab
+hR
+hR
+hR
+hR
+hR
+hR
+hP
+hR
+hR
+hR
 bS
-bZ
-bZ
+AR
+sj
 bS
 ab
 ab
@@ -41966,30 +48263,30 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+aa
+aa
+je
 aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
+je
 aa
 aa
+je
+je
 aa
 aa
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -42110,32 +48407,32 @@ ab
 ab
 ab
 bS
-bZ
-bZ
+QE
+FT
 bS
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+ab
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
+hR
 bS
-bZ
-bZ
+AR
+sj
 bS
 ab
 ab
@@ -42223,8 +48520,15 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+je
 aa
 aa
 aa
@@ -42239,14 +48543,7 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -42367,32 +48664,32 @@ ab
 ab
 ab
 bS
-bZ
-bZ
-cq
+QE
+FT
+bT
+cb
+cp
 cb
 cb
 cb
 cb
-cb
-cb
-cb
-cb
-cO
+cA
+ce
+ce
 ab
-ab
-cr
+ce
+ce
+UJ
 cb
 cb
 cb
 cb
+cp
 cb
 cb
-cb
-cb
-eH
-bZ
-bZ
+bG
+AR
+sj
 bS
 ab
 ab
@@ -42480,8 +48777,6 @@ ab
 ab
 ab
 ab
-ab
-ab
 aa
 aa
 aa
@@ -42490,17 +48785,19 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -42624,37 +48921,35 @@ ab
 ab
 ab
 bS
-bZ
-bZ
-ca
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-ch
-bZ
+vM
+VZ
+rL
+jS
+Ie
+mQ
+XP
+pK
+ZQ
+bS
+ce
+ab
+ab
+ab
+ce
+bS
+rx
+vS
+Yr
+Wl
+FH
+Yh
+FJ
+Nm
+lZ
+FZ
 bS
 ab
 ab
-bS
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-ca
-bZ
-bZ
-bS
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -42745,6 +49040,9 @@ aa
 aa
 aa
 aa
+je
+je
+je
 aa
 aa
 aa
@@ -42752,8 +49050,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -42881,37 +49178,35 @@ ab
 ab
 ab
 bS
-bZ
-bZ
-ca
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
+NY
+nY
+nY
+LT
+nF
+YU
+qB
+oJ
+vZ
+bS
+ab
+ce
+ab
+ce
+ab
+bS
+VB
+ES
+LA
+Va
+uv
+Zc
+If
+BU
+BU
+Py
 bS
 ab
 ab
-bS
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-ca
-bZ
-bZ
-bS
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -43003,22 +49298,24 @@ aa
 aa
 aa
 aa
+je
+aa
+je
+aa
+aa
+aa
+aa
+je
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 "}
@@ -43137,30 +49434,30 @@ ab
 ab
 ab
 ab
-bT
+dW
 cb
-cb
+cp
 dl
 dl
-dl
-dl
-dl
-cO
-bZ
-ch
-bZ
+oD
+YU
+Tp
+ED
+ML
 bS
 ab
+ce
+ab
+ce
 ab
 bS
-bZ
-bZ
-bZ
-cr
-cp
-cp
-cp
-cp
+sw
+ES
+LA
+Va
+bR
+dl
+CX
 cp
 cb
 cb
@@ -43250,9 +49547,16 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+je
 aa
 aa
 aa
@@ -43265,17 +49569,10 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 "}
@@ -43396,32 +49693,29 @@ ab
 ab
 ab
 ab
-ab
-bT
-ds
-ds
-ds
-ds
-eG
-bZ
-bZ
-bZ
-bS
-ab
-ab
 bS
 bZ
 bZ
-bZ
-bR
-ds
-ds
-ds
-ds
-hT
+bS
+YU
+Tp
+ED
+Ty
+bS
 ab
+ce
 ab
+ce
 ab
+bS
+Bv
+ES
+LA
+Va
+bS
+AA
+mi
+bS
 ab
 ab
 ab
@@ -43512,6 +49806,22 @@ ab
 ab
 aa
 aa
+je
+je
+je
+aa
+aa
+aa
+aa
+je
+aa
+aa
+aa
+aa
+je
+aa
+je
+je
 aa
 aa
 aa
@@ -43519,20 +49829,7 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 "}
@@ -43653,34 +49950,31 @@ ab
 ab
 ab
 ab
-ab
-ab
-cq
-dm
-dm
-dm
-eG
+bS
 bZ
+bX
+bS
+YU
+RD
+ED
+ML
+bS
+ab
+ce
+ab
+ce
+ab
+bS
+sw
+Ym
+LA
+Va
+bS
 bZ
 bZ
 bS
 ab
 ab
-bS
-bZ
-bZ
-bZ
-bR
-dt
-dt
-dt
-eH
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -43769,27 +50063,30 @@ ab
 ab
 aa
 aa
+je
+aa
+aa
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
+je
+je
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
 aa
 aa
 "}
@@ -43910,32 +50207,29 @@ ab
 ab
 ab
 ab
-ab
-ab
-dC
 dW
-ei
-ej
-bS
-bZ
-bZ
-bZ
-bS
-ab
-ab
-bS
-bZ
-bZ
-bZ
-bS
-ej
-hn
 hy
-hG
+hy
+oD
+YU
+Tp
+ED
+ML
+bS
 ab
+ce
 ab
+ce
 ab
-ab
+bS
+sw
+ES
+LA
+Va
+bR
+hy
+hy
+hT
 ab
 ab
 ab
@@ -44026,22 +50320,25 @@ ab
 ab
 aa
 aa
+je
+aa
+je
+aa
+aa
+je
+aa
+je
+aa
+aa
+je
+je
+je
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -44169,27 +50466,24 @@ ab
 ab
 ab
 ab
-dD
-dX
-ej
-ej
-bS
-bZ
-bZ
-bZ
-bS
-ab
 ab
 bS
-bZ
-bZ
-bZ
+YU
+Ta
+Ry
+rP
 bS
-ej
-ej
-dX
-hH
 ab
+ce
+ab
+ce
+ab
+bS
+qA
+zd
+Nh
+Va
+bS
 ab
 ab
 ab
@@ -44290,17 +50584,20 @@ aa
 aa
 aa
 aa
+je
+aa
+aa
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -44426,27 +50723,24 @@ ab
 ab
 ab
 ab
-dE
-dW
-ei
-ej
-bS
-bZ
-bZ
-bZ
-bS
-ab
 ab
 bS
-bZ
-bZ
-bZ
+YU
+Tp
+ED
+ML
 bS
-ej
-hn
-hy
-hI
+ce
+ce
 ab
+ce
+ce
+bS
+sw
+ES
+kT
+Va
+bS
 ab
 ab
 ab
@@ -44540,6 +50834,16 @@ ab
 ab
 aa
 aa
+je
+aa
+aa
+aa
+aa
+aa
+je
+je
+je
+je
 aa
 aa
 aa
@@ -44549,19 +50853,12 @@ aa
 aa
 aa
 aa
+je
+je
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 "}
 (163,1,1) = {"
@@ -44683,26 +50980,26 @@ ab
 ab
 ab
 ab
-dD
-dX
-ej
-ej
+ab
 bS
-bZ
-bZ
-bZ
+YU
+Au
+ED
+ML
+bS
+ab
+ce
+ab
+ce
+ab
+bS
+sw
+ES
+LA
+Va
 bS
 ab
 ab
-bS
-bZ
-bZ
-bZ
-bS
-ej
-ej
-dX
-hH
 ab
 ab
 ab
@@ -44792,9 +51089,16 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
+aa
+aa
+aa
+aa
+aa
+je
+aa
+aa
+je
+je
 aa
 aa
 aa
@@ -44808,16 +51112,9 @@ aa
 aa
 aa
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 "}
@@ -44940,27 +51237,24 @@ ab
 ab
 ab
 ab
-dE
-dW
-ei
-ej
-bS
-bZ
-bZ
-bZ
-bS
-ab
 ab
 bS
-bZ
-bZ
-bZ
+YU
+PN
+vo
+ML
 bS
-ej
-hn
-hy
-hI
 ab
+ce
+ab
+ce
+ab
+bS
+sw
+ES
+LA
+Va
+bS
 ab
 ab
 ab
@@ -45054,6 +51348,12 @@ ab
 ab
 aa
 aa
+je
+aa
+aa
+je
+aa
+je
 aa
 aa
 aa
@@ -45067,15 +51367,12 @@ aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 "}
 (165,1,1) = {"
@@ -45197,27 +51494,24 @@ ab
 ab
 ab
 ab
-dD
-dX
-ej
-ej
-bS
-bZ
-bZ
-bZ
-bS
-ab
 ab
 bS
-bZ
-bZ
-bZ
+YU
+Tp
+vo
+ML
 bS
-ej
-ej
-dX
-hH
 ab
+ce
+ab
+ce
+ab
+bS
+sw
+ES
+LA
+Ic
+bS
 ab
 ab
 ab
@@ -45315,6 +51609,7 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -45322,16 +51617,18 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
-aa
+je
 aa
 aa
 "}
@@ -45454,27 +51751,24 @@ ab
 ab
 ab
 ab
-dE
-dW
-ei
-ej
-bS
-bZ
-bZ
-bZ
-bS
-ab
 ab
 bS
-bZ
-bZ
-bZ
+YU
+Tp
+ED
+JN
 bS
-ej
-ho
-hy
-hI
 ab
+ce
+ab
+ce
+ab
+bS
+Bv
+ES
+LA
+Va
+bS
 ab
 ab
 ab
@@ -45568,6 +51862,14 @@ ab
 ab
 aa
 aa
+je
+je
+aa
+je
+aa
+aa
+aa
+je
 aa
 aa
 aa
@@ -45579,15 +51881,10 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -45709,29 +52006,29 @@ ab
 ab
 ab
 ab
-ab
-ab
-dD
-dX
-ej
-ej
-bS
-bZ
-bZ
-bZ
+ip
+cb
+cb
+oD
+YU
+Tp
+oJ
+Tf
 bS
 ab
+ce
+ab
+ce
 ab
 bS
-bZ
-bZ
-bZ
-bS
-ej
-ej
-dX
-hH
-ab
+sw
+ES
+LA
+KT
+bR
+cb
+cb
+YV
 ab
 ab
 ab
@@ -45820,9 +52117,12 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
+aa
+aa
+aa
+aa
+aa
+je
 aa
 aa
 aa
@@ -45837,17 +52137,14 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
 "}
 (168,1,1) = {"
 ab
@@ -45965,31 +52262,31 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-dE
-dW
-ei
-ej
+HC
+HC
+rg
+Xz
 bS
-bZ
-bZ
-bZ
+YU
+Tp
+ED
+zg
 bS
 ab
+ce
+ab
+ce
 ab
 bS
-bZ
-bZ
-bZ
+sw
+oP
+LA
+Zg
 bS
-ej
-ho
-hy
-hI
-ab
-ab
+XZ
+DN
+Ft
+Ft
 ab
 ab
 ab
@@ -46077,27 +52374,27 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
+aa
+aa
+je
+aa
+aa
+aa
+je
+aa
+aa
+je
+aa
+aa
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -46222,31 +52519,31 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-dD
-dX
-ej
-ej
-bS
-bZ
-bZ
-bZ
+Wc
+Io
+mF
+mF
+qQ
+YU
+Tp
+ED
+ML
 bS
 ab
+ce
+ab
+ce
 ab
 bS
-bZ
-bZ
-bZ
-bS
-ej
-ej
-dX
-hH
-ab
-ab
+sw
+ES
+LA
+Va
+HD
+ns
+ns
+QW
+Ft
 ab
 ab
 ab
@@ -46334,9 +52631,9 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
+aa
+aa
+je
 aa
 aa
 aa
@@ -46354,14 +52651,14 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
-aa
-aa
+je
 "}
 (170,1,1) = {"
 ab
@@ -46479,31 +52776,31 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-dE
-dW
-ei
-ej
+Wc
+HC
+Xz
+mF
 bS
-bZ
-bZ
-bZ
+tB
+Tr
+fW
+so
 bS
 ab
+ce
+ab
+ce
 ab
 bS
-bZ
-bZ
-bZ
+sc
+yb
+um
+qg
 bS
-ej
-ho
-hy
-hI
-ab
-ab
+ns
+ns
+Ft
+Ft
 ab
 ab
 ab
@@ -46592,27 +52889,27 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+aa
+je
+aa
+je
+aa
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -46736,31 +53033,31 @@ ab
 ab
 ab
 ab
+Wc
+Io
+mF
+mF
+bR
+cb
+FM
+yh
+cb
+oD
+ce
+ce
 ab
-ab
-ab
-dD
-dX
-ej
-ej
-ca
-bZ
-bZ
-bZ
-bS
-ab
-ab
-bS
-bZ
-bZ
-bZ
-ca
-ej
-ej
-dX
-hH
-ab
-ab
+ce
+ce
+bR
+cb
+wp
+gd
+cb
+oD
+ns
+XZ
+QW
+Ft
 ab
 ab
 ab
@@ -46849,8 +53146,15 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+je
+aa
+aa
+je
+aa
+aa
+aa
+je
 aa
 aa
 aa
@@ -46862,20 +53166,13 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 "}
 (172,1,1) = {"
 ab
@@ -46993,31 +53290,31 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-dE
-dW
-ei
-ej
+Wc
+HC
+mF
+Xz
 bS
-bZ
-bZ
-bZ
+KC
+Ov
+Wi
+ve
 bS
 ab
+ce
+ab
+ce
 ab
 bS
-bZ
-bZ
-bZ
+Re
+KP
+Fy
+qD
 bS
-ej
-ho
-hy
-hI
-ab
-ab
+XZ
+ns
+Ft
+Ft
 ab
 ab
 ab
@@ -47106,15 +53403,15 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+je
 aa
 aa
 aa
 aa
 aa
-aa
-aa
+je
+je
 aa
 aa
 aa
@@ -47250,31 +53547,31 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-dD
-dX
-ej
-ej
+Wc
+Io
+mF
+mF
 bS
-bZ
-bZ
-bZ
+yM
+Sh
+Zr
+mc
 bS
 ab
+ce
+ab
+ce
 ab
 bS
-bZ
-bZ
-bZ
+AZ
+Je
+Eg
+RL
 bS
-ej
-ej
-dX
-hH
-ab
-ab
+ns
+ns
+QW
+Ft
 ab
 ab
 ab
@@ -47363,8 +53660,15 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+aa
+je
+aa
+je
+aa
+je
+aa
+je
 aa
 aa
 aa
@@ -47376,18 +53680,11 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 "}
@@ -47507,31 +53804,31 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-dE
-dW
-ei
-ej
+Wc
+HC
+pm
+mF
 bS
-bZ
-bZ
-bZ
+yo
+ny
+Zr
+mc
 bS
 ab
+ce
+ab
+ce
 ab
 bS
-bZ
-bZ
-bZ
+zl
+Je
+UK
+vm
 bS
-ej
-ho
-hy
-hI
-ab
-ab
+ns
+Yx
+Ft
+Ft
 ab
 ab
 ab
@@ -47620,8 +53917,12 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+aa
+aa
+je
+je
+je
 aa
 aa
 aa
@@ -47629,24 +53930,20 @@ aa
 aa
 aa
 aa
+je
+aa
+aa
+aa
+je
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 "}
 (175,1,1) = {"
 ab
@@ -47765,29 +54062,29 @@ ab
 ab
 ab
 ab
-ab
-ab
-dD
-dX
-ej
-ej
-bS
-bZ
-bZ
-bZ
+dW
+cb
+cb
+oD
+Qo
+Ps
+kg
+mc
 bS
 ab
+ce
+ab
+ce
 ab
 bS
-bZ
-bZ
-bZ
-bS
-ej
-ej
-dX
-hH
-ab
+mw
+Je
+QP
+TH
+bR
+cb
+cb
+hT
 ab
 ab
 ab
@@ -47877,8 +54174,15 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+aa
+je
+aa
+je
+je
+aa
+aa
+je
 aa
 aa
 aa
@@ -47891,19 +54195,12 @@ aa
 aa
 aa
 aa
+je
+je
+je
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 "}
 (176,1,1) = {"
 ab
@@ -48024,26 +54321,26 @@ ab
 ab
 ab
 ab
-dE
-dW
-ei
-ej
+ab
 bS
-bZ
-bZ
-bZ
+yM
+ua
+ua
+mc
+bS
+ab
+ce
+ab
+ce
+ab
+bS
+AZ
+nC
+Je
+vm
 bS
 ab
 ab
-bS
-bZ
-bZ
-bZ
-bS
-ej
-ho
-hy
-hI
 ab
 ab
 ab
@@ -48134,8 +54431,11 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+aa
+je
+je
+je
 aa
 aa
 aa
@@ -48143,20 +54443,17 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -48281,26 +54578,26 @@ ab
 ab
 ab
 ab
-dD
-dX
-ej
-ej
+ab
 bS
-bZ
-bZ
-bZ
+Za
+tW
+tW
+bh
+bS
+ab
+ce
+ab
+ce
+ab
+bS
+Nr
+Dd
+MS
+qi
 bS
 ab
 ab
-bS
-bZ
-bZ
-bZ
-bS
-ej
-ej
-dX
-hH
 ab
 ab
 ab
@@ -48391,8 +54688,22 @@ ab
 ab
 ab
 ab
-ab
-ab
+aa
+aa
+aa
+je
+je
+je
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+je
+je
 aa
 aa
 aa
@@ -48402,21 +54713,7 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 "}
 (178,1,1) = {"
@@ -48538,26 +54835,26 @@ ab
 ab
 ab
 ab
-dE
+ab
 dW
-ei
-ej
-bS
-bZ
-bZ
-bZ
-bS
+cb
+cp
+LE
+cb
+oD
+ab
+ce
+ab
+ce
+ab
+bR
+TC
+cb
+cp
+cb
+hT
 ab
 ab
-bS
-bZ
-bZ
-bZ
-bS
-ej
-ho
-hy
-hI
 ab
 ab
 ab
@@ -48649,27 +54946,27 @@ ab
 ab
 ab
 ab
-ab
+je
+aa
+je
+je
+je
+je
+aa
+je
+aa
+aa
+aa
+aa
+je
+aa
+je
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -48795,27 +55092,22 @@ ab
 ab
 ab
 ab
-dD
-dX
-ej
-ej
-bS
-bZ
-bZ
-bZ
-bS
+ab
 ab
 ab
 bS
-bZ
-bZ
-bZ
+kE
+Os
 bS
-ej
-ej
-dX
-hH
+ce
+ce
 ab
+ce
+ce
+bS
+wR
+Pn
+bS
 ab
 ab
 ab
@@ -48907,30 +55199,35 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+je
+aa
+je
 aa
 aa
 aa
 aa
 aa
+je
+aa
+je
+aa
+aa
+aa
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 "}
 (180,1,1) = {"
@@ -49052,26 +55349,26 @@ ab
 ab
 ab
 ab
-dE
-dW
-ei
-ej
-bS
-bZ
-bZ
-bZ
-bS
 ab
 ab
-bS
-bZ
-bZ
-bZ
-bS
-ej
-ho
-hy
-hI
+ab
+KA
+AO
+AO
+KA
+ab
+ab
+ab
+ab
+ab
+zb
+Uh
+Uh
+zb
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -49163,32 +55460,32 @@ ab
 ab
 ab
 ab
-ab
+aa
+aa
+je
+aa
+je
+aa
+aa
+aa
+je
+aa
+je
+aa
+aa
+aa
+je
+aa
+aa
+aa
+je
+aa
+je
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 "}
 (181,1,1) = {"
 ab
@@ -49309,26 +55606,25 @@ ab
 ab
 ab
 ab
-dD
-dX
-ej
-ej
-bS
-bZ
-bZ
-bZ
-bS
 ab
 ab
-bS
-bZ
-bZ
-bZ
-bS
-ej
-ej
-dX
-hH
+ab
+ab
+KA
+KA
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+zb
+zb
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -49424,28 +55720,29 @@ ab
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
 aa
+je
+je
+aa
+aa
+je
 aa
 aa
 aa
+je
+aa
+aa
+je
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 "}
 (182,1,1) = {"
 ab
@@ -49566,26 +55863,25 @@ ab
 ab
 ab
 ab
-dF
-dW
-ei
-ej
-bS
-bZ
-bZ
-bZ
-bS
 ab
 ab
-bS
-bZ
-bZ
-bZ
-bS
-ej
-ho
-hy
-hJ
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -49685,9 +55981,10 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
-aa
+je
 aa
 aa
 aa
@@ -49823,26 +56120,25 @@ ab
 ab
 ab
 ab
-cr
-dl
-dl
-dl
-eG
-bZ
-bZ
-bZ
-bS
 ab
 ab
-bS
-bZ
-bZ
-bZ
-bR
-cp
-cp
-cp
-cO
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -49942,6 +56238,8 @@ aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
@@ -49949,17 +56247,16 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
+je
 "}
 (184,1,1) = {"
 ab
@@ -50079,28 +56376,27 @@ ab
 ab
 ab
 ab
-bP
-ds
-ds
-ds
-ds
-eG
-bZ
-bZ
-bZ
-bS
 ab
 ab
-bS
-bZ
-bZ
-bZ
-bR
-ds
-ds
-ds
-ds
-dq
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -50196,6 +56492,18 @@ aa
 aa
 aa
 aa
+je
+aa
+aa
+aa
+aa
+aa
+aa
+je
+je
+aa
+aa
+je
 aa
 aa
 aa
@@ -50204,19 +56512,8 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
 "}
 (185,1,1) = {"
 ab
@@ -50333,34 +56630,33 @@ ab
 ab
 ab
 ab
-bP
-cb
-cb
-dm
-dm
-dm
-dm
-dm
-eH
-bZ
-bZ
-bZ
-bS
 ab
 ab
-bS
-bZ
-bZ
-bZ
-cq
-dt
-dt
-dt
-dt
-dt
-cb
-cb
-dq
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -50457,9 +56753,10 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
-aa
+je
 aa
 aa
 aa
@@ -50590,34 +56887,33 @@ ab
 ab
 ab
 ab
-bS
-bZ
-bZ
-bZ
-cN
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bS
 ab
 ab
-bS
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bS
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -50709,6 +57005,14 @@ ab
 aa
 aa
 aa
+je
+je
+aa
+je
+aa
+aa
+je
+je
 aa
 aa
 aa
@@ -50719,18 +57023,11 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 "}
 (187,1,1) = {"
 ab
@@ -50847,34 +57144,33 @@ ab
 ab
 ab
 ab
-bS
-bZ
-bX
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bS
 ab
 ab
-bS
-bZ
-bZ
-bZ
-ch
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bS
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -50964,6 +57260,16 @@ ab
 ab
 ab
 aa
+je
+je
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+je
 aa
 aa
 aa
@@ -50974,16 +57280,7 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -51035,7 +57332,7 @@ aD
 aJ
 aB
 aD
-aD
+Gi
 aD
 aD
 aD
@@ -51104,34 +57401,33 @@ ab
 ab
 ab
 ab
-bS
-bX
-bX
-bX
-bX
-bX
-bZ
-dH
-bZ
-cU
-bZ
-bZ
-bS
 ab
 ab
-bS
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bS
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -51221,6 +57517,13 @@ ab
 ab
 ab
 aa
+je
+aa
+aa
+je
+je
+aa
+je
 aa
 aa
 aa
@@ -51238,13 +57541,7 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 "}
 (189,1,1) = {"
 ab
@@ -51355,40 +57652,39 @@ ab
 ab
 ab
 ab
-bE
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-ce
-bX
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bS
 ab
 ab
-bS
-ch
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bS
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -51480,27 +57776,28 @@ ab
 aa
 aa
 aa
+je
+je
+je
+aa
+aa
+je
+aa
+aa
+aa
+je
+aa
+je
+je
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 "}
 (190,1,1) = {"
@@ -51612,46 +57909,6 @@ ab
 ab
 ab
 ab
-JW
-nG
-bN
-bN
-bN
-bN
-bN
-bL
-cZ
-bJ
-ce
-bX
-bZ
-bZ
-cN
-bZ
-bZ
-bZ
-bS
-ab
-ab
-bS
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bS
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -51738,6 +57995,41 @@ aa
 aa
 aa
 aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
 aa
 aa
@@ -51748,9 +58040,14 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+aa
+je
+aa
+je
 aa
 aa
 aa
@@ -51869,40 +58166,37 @@ ab
 ab
 ab
 ab
-bG
-bL
-bL
-bL
-bL
-bL
-bL
-bL
-bL
-do
-bX
-bX
-bX
-bZ
-bZ
-bZ
-bZ
-bZ
-bS
 ab
 ab
-bS
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-hK
-bZ
-bZ
-bZ
-bS
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -51957,9 +58251,11 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
+aa
+aa
+aa
+je
+aa
 ab
 ab
 ab
@@ -51992,27 +58288,28 @@ ab
 ab
 ab
 aa
+je
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
+je
+aa
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -52126,40 +58423,6 @@ ab
 ab
 ab
 ab
-bG
-bL
-bL
-bL
-bL
-bL
-bL
-bL
-bL
-do
-bX
-cl
-bZ
-bZ
-bZ
-bZ
-bZ
-cN
-bS
-ab
-ab
-bS
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bS
 ab
 ab
 ab
@@ -52204,16 +58467,6 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -52249,6 +58502,53 @@ ab
 ab
 ab
 aa
+je
+je
+aa
+aa
+je
+je
+je
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+je
+je
 aa
 aa
 aa
@@ -52263,13 +58563,10 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -52383,40 +58680,6 @@ ab
 ab
 ab
 ab
-JS
-qC
-bO
-bO
-bO
-bO
-bO
-bL
-bL
-bJ
-cg
-bZ
-bX
-bZ
-bZ
-dH
-bZ
-cU
-bS
-ab
-ab
-bS
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bS
 ab
 ab
 ab
@@ -52460,17 +58723,6 @@ ab
 ab
 ab
 ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -52509,21 +58761,66 @@ aa
 aa
 aa
 aa
+je
+aa
+aa
+aa
+aa
+je
+je
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+je
+aa
+aa
+aa
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
 aa
 aa
 aa
@@ -52640,40 +58937,6 @@ ab
 ab
 ab
 ab
-bI
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-cg
-bZ
-bX
-bX
-cN
-bZ
-bZ
-bZ
-bZ
-bS
-ab
-ab
-bS
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bS
 ab
 ab
 ab
@@ -52716,18 +58979,6 @@ ab
 ab
 ab
 ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -52764,6 +59015,52 @@ ab
 ab
 aa
 aa
+aa
+aa
+aa
+je
+aa
+aa
+aa
+aa
+je
+je
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+je
 aa
 aa
 aa
@@ -52903,34 +59200,6 @@ ab
 ab
 ab
 ab
-bS
-bZ
-bX
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bS
-ab
-ab
-bS
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bS
 ab
 ab
 ab
@@ -52960,25 +59229,6 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -53028,6 +59278,51 @@ aa
 aa
 aa
 aa
+je
+je
+je
+aa
+je
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+je
+aa
+aa
+aa
+aa
+je
 aa
 aa
 aa
@@ -53038,6 +59333,8 @@ aa
 aa
 aa
 aa
+aa
+je
 aa
 aa
 aa
@@ -53160,34 +59457,6 @@ ab
 ab
 ab
 ab
-bS
-bX
-bZ
-bZ
-dH
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bS
-ab
-ab
-bS
-bZ
-bZ
-bZ
-bZ
-cY
-bZ
-bZ
-bZ
-bZ
-cY
-bZ
-bS
 ab
 ab
 ab
@@ -53216,26 +59485,6 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -53279,6 +59528,53 @@ ab
 aa
 aa
 aa
+je
+aa
+aa
+aa
+aa
+je
+je
+aa
+je
+je
+je
+aa
+aa
+aa
+je
+je
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+je
 aa
 aa
 aa
@@ -53298,9 +59594,10 @@ aa
 aa
 aa
 aa
+je
+je
 aa
-aa
-aa
+je
 "}
 (197,1,1) = {"
 ab
@@ -53417,34 +59714,6 @@ ab
 ab
 ab
 ab
-bS
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bS
-ab
-ab
-bS
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bZ
-bS
 ab
 ab
 ab
@@ -53472,27 +59741,6 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -53541,23 +59789,72 @@ aa
 aa
 aa
 aa
+je
+aa
+je
+je
+je
+je
+aa
+je
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
+jc
+jc
+jc
 aa
 aa
 aa
+je
+je
 aa
+je
 aa
-aa
-aa
-aa
+je
 "}
 (198,1,1) = {"
 ab
@@ -53612,7 +59909,7 @@ aU
 aD
 aB
 bk
-aJ
+ej
 aJ
 aJ
 aJ
@@ -53674,34 +59971,6 @@ ab
 ab
 ab
 ab
-bS
-cV
-da
-cG
-cV
-dZ
-dZ
-dZ
-da
-cG
-cV
-da
-bS
-ab
-ab
-bS
-cV
-da
-cG
-cV
-dZ
-dZ
-dZ
-da
-cG
-cV
-da
-bS
 ab
 ab
 ab
@@ -53746,6 +60015,46 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+je
+je
+aa
+je
+je
+aa
+je
+aa
+je
+aa
+je
+aa
+je
+aa
+aa
+je
+je
 aa
 aa
 aa
@@ -53777,23 +60086,10 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 aa
+je
 aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -53807,10 +60103,11 @@ jc
 jc
 jc
 jc
+jc
 aa
 aa
 aa
-aa
+je
 aa
 aa
 aa
@@ -53931,34 +60228,6 @@ ab
 ab
 ab
 ab
-bS
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-bS
-ab
-ab
-bS
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-cW
-bS
 ab
 ab
 ab
@@ -53986,27 +60255,6 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -54049,11 +60297,59 @@ ab
 ab
 aa
 aa
+je
+aa
+je
+aa
+aa
+je
+aa
+aa
+aa
+je
+aa
+je
+aa
+je
 aa
 aa
 aa
 aa
 aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+je
+je
+aa
+je
+je
+aa
+je
 aa
 aa
 aa
@@ -54064,12 +60360,13 @@ jc
 jc
 jc
 jc
+jc
+jc
 aa
 aa
 aa
-aa
-aa
-aa
+je
+je
 aa
 aa
 "}
@@ -54188,34 +60485,28 @@ ab
 ab
 ab
 ab
-bT
-cW
-db
-cW
-db
-cW
-db
-cW
-db
-cW
-db
-cW
-fi
 ab
 ab
-bT
-cW
-db
-cW
-db
-cW
-db
-cW
-db
-cW
-db
-cW
-hT
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -54262,6 +60553,25 @@ ab
 ab
 aa
 aa
+je
+aa
+je
+je
+aa
+aa
+je
+je
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+je
+aa
+je
 aa
 aa
 ab
@@ -54289,29 +60599,15 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+je
+je
+je
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
+je
+je
 aa
 aa
 aa
@@ -54321,13 +60617,14 @@ jc
 jc
 jc
 jc
+jc
+jc
 aa
 aa
 aa
 aa
-aa
-aa
-aa
+je
+je
 aa
 "}
 (201,1,1) = {"
@@ -54511,64 +60808,62 @@ ab
 ab
 ab
 ab
-ab
+aa
+aa
+aa
+aa
+je
+je
+je
+aa
+aa
+aa
+aa
+je
+aa
+je
+aa
+je
+aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
+je
+je
 aa
 aa
 aa
@@ -54579,13 +60874,15 @@ jc
 jc
 jc
 jc
+jc
+jc
+jc
 aa
 aa
 aa
 aa
-aa
-aa
-aa
+je
+je
 "}
 (202,1,1) = {"
 ab
@@ -54768,64 +61065,62 @@ ab
 ab
 ab
 ab
+aa
+aa
+aa
+je
+aa
+aa
+je
+je
+je
+aa
+je
+aa
+je
+je
+je
+je
+aa
+je
+aa
+je
+aa
+aa
+je
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 aa
 aa
 aa
 aa
+je
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -54836,13 +61131,15 @@ jc
 jc
 jc
 jc
+jc
+jc
+jc
 aa
 aa
 aa
 aa
-aa
-aa
-aa
+je
+je
 "}
 (203,1,1) = {"
 ab
@@ -55025,33 +61322,30 @@ ab
 ab
 ab
 ab
-ab
 aa
 aa
 aa
 aa
+je
+aa
+je
+je
+je
 aa
 aa
+je
+je
 aa
 aa
+je
+je
 aa
 aa
+je
 aa
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -55076,12 +61370,14 @@ ab
 ab
 ab
 aa
+je
 aa
 aa
 aa
-aa
-aa
-aa
+je
+je
+je
+je
 aa
 aa
 aa
@@ -55093,13 +61389,14 @@ jc
 jc
 jc
 jc
+jc
+jc
 aa
 aa
 aa
 aa
 aa
-aa
-aa
+je
 "}
 (204,1,1) = {"
 ab
@@ -55282,7 +61579,10 @@ ab
 ab
 ab
 ab
-ab
+je
+je
+aa
+je
 aa
 aa
 aa
@@ -55296,49 +61596,45 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+je
 aa
 aa
 aa
 aa
 aa
 aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+je
 aa
+aa
+aa
+aa
+aa
+je
+aa
+je
 aa
 aa
 aa
@@ -55350,13 +61646,14 @@ jc
 jc
 jc
 jc
+jc
+jc
 aa
 aa
 aa
 aa
 aa
-aa
-aa
+je
 "}
 (205,1,1) = {"
 ab
@@ -55539,61 +61836,61 @@ ab
 ab
 ab
 ab
+aa
+aa
+aa
+je
+aa
+aa
+je
+je
+aa
+aa
+aa
+je
+aa
+aa
+je
+aa
+aa
+aa
+aa
+je
+aa
+aa
+aa
+je
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 aa
 aa
 aa
 aa
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -55607,11 +61904,11 @@ jc
 jc
 jc
 jc
+jc
 aa
 aa
 aa
-aa
-aa
+je
 aa
 aa
 "}
@@ -55796,6 +62093,52 @@ ab
 ab
 ab
 ab
+aa
+je
+je
+aa
+aa
+je
+je
+aa
+aa
+aa
+je
+je
+aa
+aa
+je
+je
+aa
+aa
+je
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 aa
 aa
@@ -55804,56 +62147,9 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
+je
 aa
 aa
 aa
@@ -55864,7 +62160,8 @@ jc
 jc
 jc
 jc
-aa
+jc
+jc
 aa
 aa
 aa
@@ -55873,8 +62170,7 @@ aa
 aa
 "}
 (207,1,1) = {"
-ab
-ab
+je
 ab
 ab
 ab
@@ -56055,6 +62351,13 @@ ab
 ab
 ab
 aa
+je
+aa
+aa
+aa
+aa
+je
+je
 aa
 aa
 aa
@@ -56064,54 +62367,47 @@ aa
 aa
 aa
 aa
+je
+je
+aa
+je
+je
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -56121,17 +62417,17 @@ jc
 jc
 jc
 jc
+jc
+jc
 aa
 aa
 aa
+je
 aa
-aa
-aa
-aa
+je
 "}
 (208,1,1) = {"
-ab
-ab
+aa
 ab
 ab
 ab
@@ -56314,30 +62610,28 @@ ab
 aa
 aa
 aa
+je
+aa
+aa
+aa
+je
+aa
+je
+aa
+aa
+aa
+aa
+je
+je
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -56362,10 +62656,12 @@ ab
 ab
 aa
 aa
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -56378,13 +62674,14 @@ jc
 jc
 jc
 jc
+jc
+jc
 aa
 aa
 aa
 aa
 aa
-aa
-aa
+je
 "}
 (209,1,1) = {"
 aa
@@ -56567,7 +62864,53 @@ ab
 ab
 ab
 ab
+aa
+aa
+aa
+aa
+je
+je
+aa
+aa
+aa
+aa
+aa
+aa
+je
+je
+aa
+aa
+aa
+aa
+je
+aa
+aa
+je
+aa
+aa
+aa
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+Zt
 aa
 aa
 aa
@@ -56575,58 +62918,11 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -56635,17 +62931,19 @@ jc
 jc
 jc
 jc
+jc
+jc
 aa
 aa
 aa
-aa
-aa
+je
 aa
 aa
 "}
 (210,1,1) = {"
+je
+je
 aa
-aa
 ab
 ab
 ab
@@ -56792,57 +63090,6 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -56876,6 +63123,15 @@ ab
 ab
 aa
 aa
+je
+aa
+aa
+aa
+aa
+aa
+je
+aa
+je
 aa
 aa
 aa
@@ -56883,10 +63139,51 @@ aa
 aa
 aa
 aa
+je
+je
+je
+je
+aa
+je
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+je
 aa
 aa
 aa
 aa
+aa
+aa
+aa
+je
+je
+aa
+aa
+aa
+aa
+aa
+aa
+jc
 jc
 jc
 jc
@@ -56901,202 +63198,8 @@ aa
 aa
 "}
 (211,1,1) = {"
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
 aa
 aa
 aa
@@ -57131,226 +63234,231 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+je
+aa
+je
+aa
+je
+je
+je
+aa
+aa
+aa
+je
+je
+aa
+aa
+je
+aa
+je
+je
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+je
+aa
+aa
+jc
+jc
+aa
+aa
+aa
+je
+je
 aa
 aa
 aa
 aa
 aa
 aa
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 "}
 (212,1,1) = {"
 aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
+je
 aa
 aa
 aa
@@ -57388,12 +63496,204 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+je
+aa
+aa
+aa
+je
+je
+aa
+je
+je
+aa
+aa
+je
+aa
+aa
+aa
+aa
+je
+aa
+aa
+je
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+je
+aa
+aa
+jc
+jc
+jc
 jc
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -57406,205 +63706,18 @@ aa
 aa
 aa
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
 "}
 (213,1,1) = {"
 aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
+je
+je
+je
 aa
 aa
 aa
@@ -57645,6 +63758,191 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+je
+aa
+je
+aa
+aa
+je
+aa
+je
+je
+aa
+aa
+je
+je
+aa
+je
+aa
+je
+je
+aa
+aa
+aa
+je
+je
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+je
+je
+aa
+aa
+jc
+jc
 jc
 jc
 aa
@@ -57653,19 +63951,18 @@ aa
 aa
 aa
 aa
+je
+je
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
 aa
 aa
 aa
@@ -57674,22 +63971,22 @@ aa
 (214,1,1) = {"
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+je
+je
+aa
+je
+je
+je
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -57858,55 +64155,58 @@ aa
 aa
 aa
 aa
+je
+aa
+aa
+je
+je
+je
+aa
+aa
+je
+aa
+aa
+je
+aa
+je
+je
+je
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jc
 jc
 aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
@@ -57915,41 +64215,38 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 "}
 (215,1,1) = {"
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+je
+aa
+je
+je
+je
+aa
+je
+aa
+je
+je
+aa
+je
+aa
+aa
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -58111,19 +64408,25 @@ ab
 ab
 ab
 aa
+je
+je
 aa
 aa
 aa
+je
+je
+je
+je
+je
 aa
+je
+je
+je
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
+je
 aa
 aa
 aa
@@ -58146,19 +64449,21 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
+je
+aa
+aa
+aa
+aa
+jc
+jc
+aa
+aa
+aa
+aa
+je
+je
 aa
 aa
 aa
@@ -58172,20 +64477,14 @@ aa
 aa
 aa
 aa
+je
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 "}
 (216,1,1) = {"
+je
+je
 aa
 aa
 aa
@@ -58196,192 +64495,14 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -58416,6 +64537,185 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+je
+je
+je
+aa
+aa
+aa
+aa
+je
+aa
+aa
+aa
+aa
+je
+aa
+aa
+aa
+je
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+je
+aa
+aa
+aa
+aa
+aa
+aa
+je
 aa
 aa
 aa
@@ -58423,49 +64723,47 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
+je
+je
 aa
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
 "}
 (217,1,1) = {"
 aa
+je
 aa
+je
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
+je
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-ab
 ab
 ab
 ab
@@ -58623,38 +64921,29 @@ ab
 ab
 ab
 ab
-ab
-aa
-aa
-aa
-aa
-aa
+je
 aa
+je
+je
+je
+je
 aa
 aa
+je
 aa
 aa
+je
+je
 aa
 aa
+je
+je
 aa
 aa
 aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -58676,11 +64965,16 @@ ab
 aa
 aa
 aa
+je
+je
+je
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -58688,9 +64982,11 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -58698,6 +64994,7 @@ aa
 aa
 aa
 aa
+je
 "}
 (218,1,1) = {"
 aa
@@ -58705,6 +65002,7 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -58717,188 +65015,140 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -58934,6 +65184,50 @@ aa
 aa
 aa
 aa
+je
+je
+je
+je
+aa
+je
+je
+je
+je
+je
+aa
+je
+aa
+je
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+je
+aa
+aa
+je
+je
+je
 aa
 aa
 aa
@@ -58944,6 +65238,7 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -58954,7 +65249,9 @@ aa
 aa
 aa
 aa
+je
 aa
+je
 "}
 (219,1,1) = {"
 aa
@@ -58964,198 +65261,153 @@ aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
+je
+je
+je
 aa
+je
+je
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 ab
 ab
-aa
-aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -59190,62 +65442,103 @@ aa
 aa
 aa
 aa
+je
+aa
+aa
+aa
+aa
+je
+aa
+je
+je
+je
+je
+je
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
+je
+je
+je
+je
+je
+je
+aa
+je
+aa
+aa
+je
+je
+aa
+aa
+je
+aa
+aa
+je
+je
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 "}
 (220,1,1) = {"
 aa
+je
+aa
+je
+aa
+aa
+aa
+je
+je
+aa
+aa
+je
+aa
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
+je
+aa
+aa
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -59404,8 +65697,19 @@ ab
 aa
 aa
 aa
+je
+je
+je
 aa
 aa
+aa
+aa
+aa
+aa
+aa
+aa
+je
+je
 aa
 aa
 aa
@@ -59427,14 +65731,18 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
+je
+je
+je
+aa
+aa
+aa
+aa
+aa
+aa
+je
 aa
 aa
 aa
@@ -59444,24 +65752,13 @@ aa
 aa
 aa
 aa
+je
+je
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -59474,6 +65771,13 @@ aa
 aa
 aa
 aa
+je
+aa
+aa
+aa
+aa
+aa
+je
 aa
 aa
 aa
@@ -59484,15 +65788,15 @@ aa
 aa
 aa
 aa
+je
+je
+aa
+je
+je
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -59615,51 +65919,6 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
 ab
 ab
 ab
@@ -59698,6 +65957,46 @@ aa
 aa
 aa
 aa
+je
+aa
+aa
+aa
+aa
+je
+je
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+je
+aa
+aa
+je
+aa
+je
+je
+je
 aa
 aa
 aa
@@ -59705,22 +66004,20 @@ aa
 aa
 aa
 aa
+je
+je
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
+je
+je
 aa
 aa
 aa
@@ -59732,6 +66029,14 @@ aa
 aa
 aa
 aa
+je
+aa
+aa
+aa
+aa
+je
+aa
+je
 aa
 aa
 aa
@@ -59741,59 +66046,14 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -59951,6 +66211,47 @@ ab
 ab
 aa
 aa
+je
+aa
+je
+je
+aa
+aa
+aa
+je
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+je
+aa
+aa
+aa
+aa
+je
+je
 aa
 aa
 aa
@@ -59959,28 +66260,24 @@ aa
 aa
 aa
 aa
+je
+aa
+aa
+je
+aa
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 "}
@@ -59995,62 +66292,26 @@ aa
 aa
 aa
 aa
+je
+aa
+je
 aa
 aa
 aa
+je
+aa
+aa
+je
 aa
 aa
 aa
+je
+aa
+je
+je
+je
 aa
 aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -60211,20 +66472,56 @@ aa
 aa
 aa
 aa
+je
+je
+je
+aa
+aa
+aa
+aa
+je
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+je
+aa
+aa
+aa
+je
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
+je
+je
 aa
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
 aa
 aa
 aa
@@ -60242,6 +66539,14 @@ aa
 aa
 "}
 (224,1,1) = {"
+je
+aa
+aa
+aa
+aa
+je
+aa
+je
 aa
 aa
 aa
@@ -60249,65 +66554,22 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
+je
+aa
+je
+aa
+je
+je
+je
+je
+je
+je
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -60472,6 +66734,34 @@ aa
 aa
 aa
 aa
+je
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+je
+je
 aa
 aa
 aa
@@ -60488,10 +66778,17 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
+aa
+je
 aa
 aa
 aa
@@ -60499,6 +66796,18 @@ aa
 aa
 "}
 (225,1,1) = {"
+je
+aa
+aa
+je
+aa
+je
+je
+je
+aa
+aa
+aa
+je
 aa
 aa
 aa
@@ -60509,16 +66818,13 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
+je
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 ab
@@ -60582,6 +66888,11 @@ ab
 ab
 ab
 ab
+je
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -60673,31 +66984,13 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+je
+aa
+aa
+aa
+je
+aa
+je
 ab
 ab
 ab
@@ -60721,48 +67014,57 @@ ab
 ab
 ab
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
+aa
+je
+aa
+aa
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
+aa
+je
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
+je
 aa
 aa
 "}
 (226,1,1) = {"
+je
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
+je
+je
 aa
 aa
 aa
@@ -60771,32 +67073,18 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -60855,9 +67143,14 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
+aa
+aa
+aa
+je
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -60977,18 +67270,14 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
+je
 aa
+je
+je
 aa
 aa
+je
 aa
 aa
 aa
@@ -60998,53 +67287,62 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
+je
+je
+je
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
+je
 aa
+je
 "}
 (227,1,1) = {"
+je
+je
 aa
 aa
 aa
+je
+je
+je
 aa
+je
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
+je
+je
 aa
 aa
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ab
 ab
 ab
@@ -61099,8 +67397,6 @@ ab
 ab
 ab
 ab
-ab
-aa
 aa
 aa
 aa
@@ -61108,10 +67404,10 @@ aa
 aa
 aa
 aa
+je
+je
+je
 aa
-aa
-aa
-ab
 ab
 ab
 ab
@@ -61230,31 +67526,30 @@ ab
 ab
 ab
 ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
+je
+je
 aa
 aa
+je
+je
 aa
 aa
 aa
+je
 aa
+je
+je
+je
 aa
 aa
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -61266,17 +67561,27 @@ aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 "}
 (228,1,1) = {"
+je
+je
+je
 aa
 aa
+je
 aa
 aa
 aa
+je
+je
 aa
+je
 aa
+je
 aa
 aa
 aa
@@ -61284,25 +67589,17 @@ aa
 aa
 aa
 aa
+je
+je
 aa
 aa
+je
+je
+je
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
 ab
 ab
 ab
@@ -61355,22 +67652,19 @@ ab
 ab
 ab
 ab
-ab
-ab
-aa
 aa
 aa
 aa
 aa
 aa
+je
+je
+je
 aa
 aa
 aa
+je
 aa
-aa
-ab
-ab
-ab
 ab
 ab
 ab
@@ -61488,29 +67782,28 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
+je
+je
+je
+je
+je
 aa
+je
 aa
 aa
+je
 aa
+je
 aa
+je
 aa
 aa
+je
+je
 aa
 aa
+je
 aa
 aa
 aa
@@ -61523,107 +67816,111 @@ aa
 aa
 aa
 aa
+je
+je
+je
+je
 aa
 aa
 "}
 (229,1,1) = {"
+je
 aa
 aa
 aa
 aa
 aa
+je
+aa
+aa
+aa
+aa
+je
+aa
+aa
+je
+aa
+aa
+aa
+je
+aa
+aa
+aa
+je
+je
+je
+aa
+aa
+je
+je
+je
+aa
+je
+je
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+je
 aa
 aa
 aa
 aa
 aa
+je
+aa
+aa
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 ab
 ab
@@ -61742,9 +68039,13 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
+aa
+aa
+je
+je
+aa
+aa
+je
 aa
 aa
 aa
@@ -61757,6 +68058,7 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -61766,17 +68068,12 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
 aa
 aa
 aa
@@ -61784,6 +68081,94 @@ aa
 aa
 "}
 (230,1,1) = {"
+je
+aa
+aa
+je
+je
+aa
+aa
+je
+aa
+aa
+aa
+aa
+aa
+aa
+je
+je
+aa
+aa
+aa
+aa
+je
+je
+aa
+aa
+je
+aa
+aa
+aa
+aa
+je
+je
+aa
+je
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+je
 aa
 aa
 aa
@@ -61792,95 +68177,7 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 ab
 ab
@@ -61999,9 +68296,17 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
+aa
+je
+aa
+aa
+aa
+je
+aa
+je
+je
+aa
+je
 aa
 aa
 aa
@@ -62019,20 +68324,12 @@ aa
 aa
 aa
 aa
+je
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
 aa
 aa
 aa
@@ -62041,6 +68338,15 @@ aa
 aa
 "}
 (231,1,1) = {"
+je
+je
+aa
+je
+aa
+je
+aa
+aa
+je
 aa
 aa
 aa
@@ -62049,94 +68355,85 @@ aa
 aa
 aa
 aa
+je
+aa
+aa
+je
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
+je
+je
+je
+aa
+je
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+je
+aa
+aa
+je
+je
+je
+je
+je
+je
+aa
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 ab
@@ -62255,10 +68552,14 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
+aa
+aa
+aa
+aa
+je
+je
+je
+je
 aa
 aa
 aa
@@ -62267,6 +68568,7 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -62275,29 +68577,37 @@ aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
+je
+aa
+aa
+je
+aa
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 "}
 (232,1,1) = {"
+je
+aa
+je
+aa
+je
+je
+aa
+aa
+aa
+aa
+aa
+aa
+je
 aa
 aa
 aa
@@ -62305,36 +68615,21 @@ aa
 aa
 aa
 aa
+je
+je
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
+je
+je
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -62384,16 +68679,18 @@ aa
 aa
 aa
 aa
+je
 aa
+je
 aa
+je
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
+je
+je
 aa
 aa
 ab
@@ -62512,10 +68809,17 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
+aa
+aa
+je
+je
+je
+je
+je
+aa
+aa
+aa
+je
 aa
 aa
 aa
@@ -62524,33 +68828,26 @@ aa
 aa
 aa
 aa
+je
+aa
+aa
+aa
+aa
+je
+je
+aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 "}
@@ -62559,37 +68856,37 @@ aa
 aa
 aa
 aa
+je
+je
+aa
+je
+je
+je
+aa
+aa
+aa
+aa
+je
+aa
+je
+aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
+je
 aa
 aa
+je
 aa
+je
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
 ab
 ab
 ab
@@ -62637,22 +68934,22 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
+je
+je
 aa
 aa
+je
+je
+je
 aa
 aa
+je
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
 ab
 ab
 ab
@@ -62768,11 +69065,22 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
+aa
+je
+je
+aa
+je
+aa
+je
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+je
 aa
 aa
 aa
@@ -62789,18 +69097,7 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -62812,38 +69109,45 @@ aa
 aa
 "}
 (234,1,1) = {"
+je
+je
+aa
+je
+aa
+je
+aa
+je
+aa
+aa
+je
 aa
 aa
 aa
 aa
+je
+aa
+je
+aa
+je
+aa
+je
 aa
 aa
+je
+aa
+je
 aa
 aa
+je
 aa
+je
+je
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ab
+ab
+ab
 ab
 ab
 ab
@@ -62882,34 +69186,27 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
+aa
+je
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
 ab
 ab
 ab
@@ -63026,7 +69323,18 @@ ab
 ab
 ab
 aa
-jc
+aa
+aa
+aa
+aa
+je
+aa
+aa
+aa
+aa
+aa
+je
+je
 aa
 aa
 aa
@@ -63051,56 +69359,52 @@ aa
 aa
 aa
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 "}
 (235,1,1) = {"
+je
+je
+aa
+aa
+aa
+je
+aa
+je
+aa
+aa
+je
+aa
+je
+aa
+je
+aa
+aa
+aa
+je
+aa
+je
+je
+aa
+je
+aa
+je
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ab
+ab
+ab
 ab
 ab
 ab
@@ -63139,34 +69443,27 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
+aa
+je
+je
+aa
+aa
+je
+je
+je
+je
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
 ab
 ab
 ab
@@ -63280,16 +69577,14 @@ ab
 ab
 ab
 ab
-ab
-ab
-aa
-jc
 aa
 aa
 aa
+je
 aa
 aa
-aa
+je
+je
 aa
 aa
 aa
@@ -63302,6 +69597,10 @@ aa
 aa
 aa
 aa
+je
+aa
+je
+je
 aa
 aa
 aa
@@ -63310,15 +69609,13 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -63326,38 +69623,45 @@ aa
 aa
 "}
 (236,1,1) = {"
+je
+je
+je
+aa
+je
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
+je
+aa
+aa
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ab
+ab
+ab
 ab
 ab
 ab
@@ -63396,34 +69700,27 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+je
+je
+aa
+je
+je
+je
+je
+je
+aa
+aa
+je
+je
+aa
+aa
+je
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
+je
 ab
 ab
 ab
@@ -63536,11 +69833,6 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-aa
-jc
 aa
 aa
 aa
@@ -63576,6 +69868,11 @@ aa
 aa
 aa
 aa
+aa
+aa
+aa
+je
+je
 aa
 aa
 aa
@@ -63593,6 +69890,79 @@ aa
 aa
 aa
 aa
+je
+aa
+aa
+je
+je
+aa
+je
+je
+aa
+je
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+je
+aa
+aa
+aa
+je
+aa
+je
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+je
+je
+je
 aa
 aa
 aa
@@ -63606,81 +69976,8 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
+je
+je
 ab
 ab
 ab
@@ -63792,14 +70089,12 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-aa
-jc
 aa
 aa
+aa
+je
+je
+je
 aa
 aa
 aa
@@ -63812,8 +70107,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+je
+je
 aa
 aa
 aa
@@ -63821,12 +70116,12 @@ aa
 aa
 jc
 jc
-jc
-jc
-jc
-jc
-jc
-jc
+aa
+aa
+aa
+aa
+aa
+je
 aa
 aa
 aa
@@ -63834,6 +70129,8 @@ aa
 aa
 aa
 aa
+aa
+je
 aa
 aa
 aa
@@ -63841,6 +70138,11 @@ aa
 "}
 (238,1,1) = {"
 aa
+je
+aa
+je
+aa
+je
 aa
 aa
 aa
@@ -63850,6 +70152,15 @@ aa
 aa
 aa
 aa
+je
+aa
+aa
+je
+je
+aa
+aa
+aa
+je
 aa
 aa
 aa
@@ -63859,26 +70170,10 @@ aa
 aa
 aa
 aa
+je
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -63919,6 +70214,11 @@ ab
 ab
 ab
 aa
+je
+je
+aa
+je
+je
 aa
 aa
 aa
@@ -63933,10 +70233,7 @@ aa
 aa
 aa
 aa
-aa
-aa
-ab
-ab
+je
 ab
 ab
 ab
@@ -64048,27 +70345,24 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-aa
-jc
 aa
 aa
 aa
 aa
 aa
+je
+aa
+je
+je
+aa
+aa
+je
 aa
 aa
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 aa
@@ -64077,18 +70371,21 @@ aa
 aa
 aa
 jc
-aa
-aa
-aa
-aa
-aa
-aa
 jc
 aa
 aa
 aa
 aa
+je
+je
 aa
+aa
+aa
+aa
+aa
+je
+aa
+je
 aa
 aa
 aa
@@ -64099,44 +70396,41 @@ aa
 (239,1,1) = {"
 aa
 aa
+je
+aa
+je
+aa
+aa
+je
+je
+aa
+aa
+je
+aa
+aa
+je
+je
 aa
 aa
 aa
 aa
+je
+je
+aa
+je
+aa
+je
+je
+aa
+je
 aa
 aa
+je
 aa
 aa
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -64177,6 +70471,16 @@ ab
 ab
 aa
 aa
+je
+je
+je
+aa
+aa
+aa
+je
+aa
+je
+je
 aa
 aa
 aa
@@ -64184,16 +70488,9 @@ aa
 aa
 aa
 aa
+je
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
 ab
 ab
 ab
@@ -64304,28 +70601,24 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-jc
-jc
-jc
-jc
 aa
 aa
 aa
+je
+aa
+aa
+je
 aa
 aa
 aa
+je
 aa
 aa
+je
+je
 aa
-aa
-aa
+je
+je
 aa
 aa
 aa
@@ -64334,18 +70627,22 @@ aa
 aa
 aa
 jc
+jc
 aa
-jd
-jd
-jd
-jd
-jd
+aa
+aa
+aa
+aa
+je
+aa
+aa
+aa
 jf
-jd
-jd
-jd
-jd
-jd
+aa
+aa
+je
+aa
+aa
 aa
 aa
 aa
@@ -64367,6 +70664,9 @@ aa
 aa
 aa
 aa
+je
+je
+je
 aa
 aa
 aa
@@ -64377,76 +70677,16 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
+je
+je
 aa
 aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 ab
@@ -64486,6 +70726,63 @@ ab
 ab
 ab
 ab
+aa
+aa
+je
+je
+aa
+aa
+aa
+aa
+je
+aa
+aa
+aa
+aa
+aa
+aa
+je
+aa
+aa
+je
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -64566,11 +70863,25 @@ aa
 aa
 aa
 aa
+je
+je
+je
+je
+je
+aa
+aa
+je
+aa
+je
+aa
+je
 aa
 aa
 aa
 aa
 aa
+aa
+jc
 jc
 aa
 aa
@@ -64584,33 +70895,25 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-jc
-aa
-jd
 je
-je
-je
-je
-je
-je
-je
-je
-je
-jd
 aa
 aa
 aa
 aa
 aa
+aa
+aa
+aa
+je
 aa
 "}
 (241,1,1) = {"
+je
+aa
+aa
+aa
+aa
+je
 aa
 aa
 aa
@@ -64627,83 +70930,20 @@ aa
 aa
 aa
 aa
+je
+je
+aa
+aa
+je
+je
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
+je
+je
 aa
 aa
 ab
@@ -64742,6 +70982,62 @@ ab
 ab
 ab
 ab
+aa
+aa
+je
+aa
+aa
+aa
+je
+je
+je
+je
+aa
+je
+aa
+aa
+je
+je
+je
+aa
+aa
+aa
+je
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -64823,17 +71119,31 @@ aa
 aa
 aa
 aa
+je
+je
+aa
+je
+je
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
+aa
+aa
+je
+aa
+je
 jc
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -64842,32 +71152,28 @@ aa
 aa
 aa
 aa
+je
+je
 aa
 aa
-aa
-aa
-aa
-jc
-aa
-jd
 je
 je
 je
 je
-je
-je
-je
-je
-je
-jd
 aa
-aa
-aa
-aa
-aa
+je
 aa
 "}
 (242,1,1) = {"
+je
+je
+aa
+je
+aa
+aa
+je
+aa
+je
 aa
 aa
 aa
@@ -64877,6 +71183,16 @@ aa
 aa
 aa
 aa
+je
+aa
+aa
+je
+je
+je
+je
+je
+aa
+je
 aa
 aa
 aa
@@ -64885,82 +71201,7 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
 aa
 aa
 ab
@@ -64998,6 +71239,28 @@ ab
 ab
 ab
 ab
+aa
+je
+je
+je
+je
+je
+aa
+je
+aa
+je
+je
+je
+aa
+je
+aa
+aa
+aa
+aa
+aa
+aa
+je
+aa
 ab
 ab
 ab
@@ -65075,6 +71338,49 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+je
+aa
+aa
+je
+aa
+je
+je
+je
 aa
 aa
 aa
@@ -65086,135 +71392,70 @@ aa
 aa
 aa
 jc
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 jc
-aa
-jd
 je
-je
-je
-je
-je
-je
-je
-je
-je
-jd
 aa
 aa
+aa
+aa
+je
+aa
+je
+aa
+aa
+aa
+aa
+je
+aa
+aa
+je
+aa
+je
+aa
+aa
+aa
+aa
+je
 aa
 aa
 aa
 aa
 "}
 (243,1,1) = {"
+je
+je
+aa
+aa
+aa
+je
+aa
+je
+aa
+aa
+aa
+aa
+je
+aa
+aa
+je
+aa
+je
+aa
+aa
+je
+aa
+aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
 aa
 aa
 aa
@@ -65255,6 +71496,60 @@ ab
 ab
 ab
 ab
+aa
+je
+je
+je
+je
+je
+je
+aa
+aa
+aa
+je
+aa
+aa
+aa
+je
+je
+je
+aa
+je
+aa
+je
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -65333,6 +71628,15 @@ ab
 ab
 ab
 aa
+aa
+aa
+aa
+aa
+aa
+je
+aa
+je
+je
 aa
 aa
 aa
@@ -65343,45 +71647,41 @@ aa
 aa
 aa
 jc
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 jc
-aa
-jd
+jc
 je
-je
-je
-je
-je
-je
-je
-je
-je
-jd
 aa
 aa
 aa
 aa
+aa
+aa
+je
+aa
+aa
+aa
+je
+je
+aa
+je
+aa
+aa
+aa
+aa
+je
+aa
+je
+aa
+aa
+aa
+je
 aa
 aa
 "}
 (244,1,1) = {"
+je
+aa
+je
 aa
 aa
 aa
@@ -65394,84 +71694,25 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
+je
+aa
+aa
+je
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+je
+je
 aa
 aa
 aa
@@ -65512,244 +71753,229 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-jc
-jc
-jc
-jc
-jc
-jc
-jc
-jc
-jc
-jc
-jc
-jc
-jc
-jc
-jc
-jc
-jc
-jc
-jc
-jc
-aa
-jd
 je
 je
 je
 je
+aa
+aa
+je
+aa
+je
+aa
+je
+aa
+je
+aa
 je
 je
 je
-je
-je
-jd
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
 aa
 aa
 aa
+aa
+aa
+je
+aa
+je
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+jc
+jc
+jc
+aa
+aa
+aa
+aa
+je
+aa
+aa
+aa
+je
+aa
+je
+aa
+je
+je
+aa
+aa
+aa
+aa
+aa
+aa
+je
+aa
+aa
+aa
+aa
+aa
+je
+je
 aa
 aa
 "}
 (245,1,1) = {"
 aa
+je
+je
+je
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
+je
+je
 aa
+je
+je
+je
 aa
+je
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -65784,100 +72010,12 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
 aa
+je
 aa
-jd
 je
 je
 je
@@ -65887,9 +72025,168 @@ je
 je
 je
 je
-jd
+je
+je
+je
+je
 aa
 aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+je
+je
+je
+aa
+aa
+je
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+jc
+jc
+jc
+aa
+aa
+aa
+aa
+je
+aa
+aa
+aa
+aa
+aa
+aa
+je
+aa
+aa
+je
+aa
+aa
+je
+aa
+aa
+aa
+aa
+aa
+aa
+je
+aa
+aa
+je
 aa
 aa
 aa
@@ -65897,11 +72194,17 @@ aa
 "}
 (246,1,1) = {"
 aa
+je
 aa
+je
 aa
 aa
+je
+je
+je
 aa
 aa
+je
 aa
 aa
 aa
@@ -65909,6 +72212,8 @@ aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
@@ -65919,94 +72224,15 @@ aa
 aa
 aa
 aa
+je
 aa
+je
+je
+je
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+je
 ab
 ab
 ab
@@ -66041,131 +72267,210 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
 aa
+je
 aa
+je
 aa
+je
+je
+je
 aa
+je
 aa
-jd
 je
 je
 je
 je
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
 je
 je
+aa
 je
+aa
+aa
 je
-je
-jd
 aa
 aa
 aa
 aa
 aa
+jc
+jc
+jc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+je
+aa
+aa
+aa
+je
+aa
+aa
+aa
+aa
+je
+aa
+aa
+aa
+aa
+je
+aa
+aa
+aa
+aa
+je
+je
+je
+aa
+aa
+je
 aa
 "}
 (247,1,1) = {"
+je
 aa
 aa
+je
 aa
+je
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
+je
+je
 aa
+je
 aa
 aa
 aa
@@ -66177,94 +72482,15 @@ aa
 aa
 aa
 aa
+je
 aa
+je
+je
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+je
 ab
 ab
 ab
@@ -66299,231 +72525,229 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
+je
+je
 aa
 aa
+je
 aa
+je
 aa
 aa
-jd
 je
 je
 je
 je
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+je
+aa
+aa
+je
+aa
+aa
+aa
+aa
+je
+aa
+aa
+aa
+aa
+jc
+jc
+aa
+aa
+aa
+je
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+je
+aa
+aa
 je
 je
+aa
+aa
+aa
+aa
 je
 je
+aa
+aa
 je
-jd
 aa
 aa
 aa
 aa
+je
 aa
+je
 aa
+je
 "}
 (248,1,1) = {"
 aa
+je
 aa
+je
+je
 aa
 aa
+je
 aa
 aa
+je
 aa
 aa
+je
 aa
+je
 aa
 aa
+je
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+je
 ab
 ab
 ab
@@ -66558,367 +72782,440 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
+je
+je
+je
+je
+je
 aa
-jd
 je
 je
 je
 je
 je
 je
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
 je
 je
+aa
+aa
 je
-jd
+je
 aa
 aa
 aa
 aa
+aa
+jc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+je
+aa
+aa
+aa
+aa
+je
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+je
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+je
+aa
+aa
+aa
+je
 aa
 aa
 "}
 (249,1,1) = {"
+je
+je
 aa
+je
 aa
+je
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-jd
 je
 je
 je
+aa
 je
 je
-je
-je
-je
-je
-jd
 aa
 aa
 aa
+aa
+je
+je
+aa
+aa
+aa
+aa
+aa
+je
+aa
+aa
+aa
+aa
+je
+je
+aa
+je
+je
+je
+aa
+je
+je
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+je
+je
+je
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+je
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+je
+aa
+aa
+je
+aa
+aa
+je
+aa
+aa
+aa
+aa
+je
+aa
+aa
+aa
+je
+aa
+aa
+je
+je
+aa
+aa
+aa
+je
+aa
+aa
+aa
+je
+je
+aa
+aa
+aa
+aa
+aa
+je
 aa
 aa
 aa
@@ -66927,265 +73224,273 @@ aa
 aa
 aa
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-jd
 je
 je
 je
+aa
+aa
+aa
+aa
+aa
+je
+aa
+aa
+je
+aa
+je
+aa
+je
+aa
+aa
+je
+aa
+aa
+aa
+je
+aa
+je
+aa
+aa
+je
+aa
+aa
 je
 je
+aa
+je
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+je
+aa
+je
+aa
 je
 je
+aa
+aa
 je
-je
-jd
 aa
 aa
 aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
+aa
+aa
+je
+aa
+aa
+aa
+aa
+je
+je
+je
+aa
+aa
+aa
+aa
+je
+aa
+je
+aa
+je
+je
+aa
+aa
+aa
+aa
+je
+aa
+aa
+je
+aa
+je
+je
 "}
 (251,1,1) = {"
+je
 aa
 aa
+je
 aa
+je
 aa
+je
 aa
+je
+je
+je
+je
 aa
 aa
 aa
@@ -67195,37 +73500,27 @@ aa
 aa
 aa
 aa
+je
+je
+je
+je
 aa
 aa
+je
 aa
 aa
 aa
+je
+je
 aa
+je
 aa
+je
+je
+je
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -67390,19 +73685,24 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
+je
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -67412,6 +73712,10 @@ aa
 aa
 aa
 aa
+je
+je
+je
+je
 aa
 aa
 aa
@@ -67419,26 +73723,22 @@ aa
 aa
 aa
 aa
-jd
-jd
-jd
-jd
-jd
-jd
-jd
-jd
-jd
-jd
-jd
+je
 aa
 aa
+je
+je
+je
 aa
 aa
 aa
 aa
 "}
 (252,1,1) = {"
+je
+je
 aa
+je
 aa
 aa
 aa
@@ -67453,34 +73753,31 @@ aa
 aa
 aa
 aa
+je
+je
 aa
 aa
+je
+je
 aa
+je
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
+je
 aa
+je
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
 ab
 ab
 ab
@@ -67641,47 +73938,45 @@ ab
 ab
 ab
 ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
+je
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
+je
 aa
 aa
+je
+je
 aa
 aa
 aa
@@ -67691,52 +73986,55 @@ aa
 aa
 aa
 aa
+je
 aa
+je
 aa
 "}
 (253,1,1) = {"
+je
+je
 aa
+je
+je
+je
+je
+je
+je
 aa
 aa
+je
+je
 aa
+je
 aa
+je
 aa
+je
+je
+je
 aa
 aa
 aa
 aa
 aa
+je
+je
 aa
+je
 aa
 aa
 aa
 aa
 aa
 aa
+je
 aa
+je
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
+je
 ab
 ab
 ab
@@ -67896,29 +74194,23 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
+je
+je
+je
+je
 aa
+je
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -67930,11 +74222,13 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -67944,56 +74238,60 @@ aa
 aa
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
 aa
+je
 aa
 "}
 (254,1,1) = {"
+je
+je
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
 aa
+je
+je
 aa
+je
+je
+je
+je
 aa
 aa
 aa
 aa
+je
+je
 aa
 aa
+je
 aa
 aa
+je
 aa
 aa
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
 ab
 ab
 ab
@@ -68153,46 +74451,40 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
+je
+je
 aa
+je
 aa
 aa
 aa
+je
 aa
 aa
+je
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
@@ -68201,14 +74493,20 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
+je
+je
+je
 aa
 aa
 aa
 "}
 (255,1,1) = {"
+je
 aa
 aa
 aa
@@ -68220,14 +74518,20 @@ aa
 aa
 aa
 aa
+je
 aa
+je
 aa
 aa
 aa
+je
+je
 aa
 aa
+je
 aa
 aa
+je
 aa
 aa
 aa
@@ -68239,22 +74543,13 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
+je
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
+je
 ab
 ab
 ab
@@ -68413,19 +74708,6 @@ ab
 ab
 ab
 ab
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -68433,16 +74715,24 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
+je
+je
 aa
 aa
 aa
 aa
+je
+je
 aa
 aa
+je
+je
 aa
+je
 aa
 aa
 aa
@@ -68450,6 +74740,7 @@ aa
 aa
 aa
 aa
+je
 aa
 aa
 aa
@@ -68457,10 +74748,16 @@ aa
 aa
 aa
 aa
+je
 aa
+je
+je
+je
+je
 aa
 aa
 aa
+je
 aa
 aa
 aa

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -448,6 +448,12 @@
 	id_job = "Scientist"
 	outfit = /datum/outfit/job/scientist
 
+/obj/effect/mob_spawn/human/securty
+	name = "Security Officer"
+	mob_name = "Security Officer"
+	id_job = "Security Officer"
+	outfit = /datum/outfit/job/officer
+
 /obj/effect/mob_spawn/human/miner
 	name = "Shaft Miner"
 	mob_name = "Shaft Miner"

--- a/code/modules/awaymissions/mission_code/spacebattle.dm
+++ b/code/modules/awaymissions/mission_code/spacebattle.dm
@@ -3,9 +3,8 @@
 /area/awaymission/spacebattle
 	name = "\improper Space Battle"
 	icon_state = "away"
-	requires_power = FALSE
+	requires_power = TRUE
 	report_alerts = FALSE
-	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
 
 /area/awaymission/spacebattle/cruiser
 	name = "\improper Nanotrasen Cruiser"
@@ -33,3 +32,147 @@
 
 /area/awaymission/spacebattle/secret
 	name = "\improper Hidden Chamber"
+
+/area/awaymission/spacebattle/prhallway1
+	name = "\improper Primary Hallway"
+
+/area/awaymission/spacebattle/prhallway2
+	name = "\improper Primary Hallway"
+
+/area/awaymission/spacebattle/prhallway3
+	name = "\improper Primary Hallway"
+
+/area/awaymission/spacebattle/prhallway4
+	name = "\improper Primary Hallway"
+
+/area/awaymission/spacebattle/prhallway5
+	name = "\improper Primary Hallway"
+
+/area/awaymission/spacebattle/prhallway6
+	name = "\improper Primary Hallway"
+
+/area/awaymission/spacebattle/prhallway7 
+	name = "\improper Primary Hallway"
+
+/area/awaymission/spacebattle/kitchen
+	name = "\improper Kitchen"
+
+/area/awaymission/spacebattle/medbay
+	name = "\improper MedBay"
+
+/area/awaymission/spacebattle/freezing
+	name = "\improper Freezing Room"
+
+/area/awaymission/spacebattle/server
+	name = "\improper Server Room"
+
+/area/awaymission/spacebattle/bridge
+	name = "\improper Bridge"
+
+/area/awaymission/spacebattle/space_exit1
+	name = "\improper Space Exit"
+
+/area/awaymission/spacebattle/space_exit2
+	name = "\improper Space Exit"
+
+/area/awaymission/spacebattle/space_exit3
+	name = "\improper Space Exit"
+
+/area/awaymission/spacebattle/space_exit4
+	name = "\improper Space Exit"
+
+/area/awaymission/spacebattle/space_exit5
+	name = "\improper Space Exit"
+
+/area/awaymission/spacebattle/hallway1
+	name = "\improper Hallway"
+
+/area/awaymission/spacebattle/hallway2
+	name = "\improper Hallway"
+
+/area/awaymission/spacebattle/hallway3
+	name = "\improper Hallway"
+
+/area/awaymission/spacebattle/hallway4
+	name = "\improper Hallway"
+
+/area/awaymission/spacebattle/hallway5
+	name = "\improper Hallway"
+
+/area/awaymission/spacebattle/hallway6
+	name = "\improper Hallway"
+
+/area/awaymission/spacebattle/hallway7
+	name = "\improper Hallway"
+
+/area/awaymission/spacebattle/hallway8
+	name = "\improper Hallway"
+
+/area/awaymission/spacebattle/hallway9
+	name = "\improper Hallway"
+
+/area/awaymission/spacebattle/hallway10
+	name = "\improper Hallway"
+
+/area/awaymission/spacebattle/hallway11
+	name = "\improper Hallway"
+
+/area/awaymission/spacebattle/hallway12
+	name = "\improper Hallway"
+
+/area/awaymission/spacebattle/hallway13
+	name = "\improper Hallway"
+
+/area/awaymission/spacebattle/hallway14
+	name = "\improper Hallway"
+
+/area/awaymission/spacebattle/engine
+	name = "\improper Engine Room"
+
+/area/awaymission/spacebattle/engineering
+	name = "\improper Engineering"
+
+/area/awaymission/spacebattle/storage
+	name = "\improper Storage"
+
+/area/awaymission/spacebattle/living
+	name = "\improper Living Room"
+
+/area/awaymission/spacebattle/turret1
+	name = "\improper Turret Room"
+
+/area/awaymission/spacebattle/turret2
+	name = "\improper Turret Room"
+
+/area/awaymission/spacebattle/turret3
+	name = "\improper Turret Room"
+
+/area/awaymission/spacebattle/turret4
+	name = "\improper Turret Room"
+
+/area/awaymission/spacebattle/turret5
+	name = "\improper Turret Room"
+
+/area/awaymission/spacebattle/turret6
+	name = "\improper Turret Room"
+
+/area/awaymission/spacebattle/turret7
+	name = "\improper Turret Room"
+
+/area/awaymission/spacebattle/turret8
+	name = "\improper Turret Room"
+
+/area/awaymission/spacebattle/turret10
+	name = "\improper Turret Room"
+
+/area/awaymission/spacebattle/turret9
+	name = "\improper Turret Room"
+
+/area/awaymission/spacebattle/bsa
+	name = "\improper BSA Chamber"
+
+/area/awaymission/spacebattle/sec_storage
+	name = "\improper Secure Storage"
+
+
+


### PR DESCRIPTION
## Что ПР делает
Перерабатывает старый гейт spacebattle.dmm или же Nanotrasen Cruiser.

Почему это хорошо для игры
Вообще по-сути я это уже перечислял в предложке, прошедшей авоут. Но могу всё-же объяснить причину почему я взялся за переработку гейта:Слишком мало по-настоящему сложных гейтов. Из сложных врат я могу вспомнить только шахты дикого запада, что достаточно плохо.
Если рассудить здраво, гейты - Подземелья, которые исследователю( или попавшему туда бедолаге ) нужно пройти что-бы налутаться вещей или попросту выжить.
Возьму как пример не сложного гейта:academy.dmm AKA Академия магов. В ней все вещи исследователю или проходимцу даются чуть-ли не на блюде, а чуть-ли не единственные абсолютно не опасные враги это плачущие статуи из доктора кто( мимиков можно даже не встретить ).

## Сам гейт
![2022 07 29-00 50 09](https://user-images.githubusercontent.com/109545437/182091469-c25f21f0-c03c-4540-aa47-5a127da66e23.png)


## Changelog
🆑
Увеличено ХП мобов.
Добавлено больше стартового оружия.
Проведена проводка для возможности запитать корабль.
Все отсеки корабля( не включая мед, кухню и мостик ) были изменены.
/🆑

## Post Scriptum
Во-первых, лут с мобов никак не изменён. ( С синдикатовцев падают мечи и щиты )
Во-вторых, вот предложка прошедшая авоут:https://discord.com/channels/617003227182792704/755125334097133628/1002235056984698931