### PR TITLE
Fix: traitor implant infinite uses

### DIFF
--- a/code/game/objects/items/weapons/implants/implant_traitor.dm
+++ b/code/game/objects/items/weapons/implants/implant_traitor.dm
@@ -65,14 +65,16 @@
 			mindslave_target.mind.objectives += MS
 			mindslave_target.mind.add_antag_datum(/datum/antagonist/mindslave)
 
-			var/datum/mindslaves/slaved = user.mind.som
-			mindslave_target.mind.som = slaved
-			slaved.serv += mindslave_target
-			slaved.add_serv_hud(user.mind, "master") //handles master servent icons
-			slaved.add_serv_hud(mindslave_target.mind, "mindslave")
-
 			log_admin("[key_name(user)] has mind-slaved [key_name(mindslave_target)].")
 			activated = 1
+
+			if(user.mind.som) //if user have not "som" (for example, he's not antag) - skip this part
+				var/datum/mindslaves/slaved = user.mind.som
+				mindslave_target.mind.som = slaved
+				slaved.serv += mindslave_target
+				slaved.add_serv_hud(user.mind, "master") //handles master servent icons
+				slaved.add_serv_hud(mindslave_target.mind, "mindslave")
+
 			if(jobban_isbanned(M, ROLE_SYNDICATE))
 				SSticker.mode.replace_jobbanned_player(M, ROLE_SYNDICATE)
 			return 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Делает проверку на наличие "som" у человека при вкалывании импланта.
Со стороны игры поменялось: бесконечное использование импланта.
Чинит рантайм "null.som".

## Why It's Good For The Game
Меньше рантаймов - лучше.
Игрок не может бесконечно использовать один имплант.

## Changelog
:cl:
tweak: now traitor implant has finite uses
fix: fixed infinite implant
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
