### PR TITLE
Tajara hissing fix

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -107,15 +107,15 @@
 				return
 
 		if("hiss")
-			if(isunathi(src) || istajaran(src)) //Only Unathi can hiss.
+			if(isunathi(src)) //Only Unathi can hiss.
 				on_CD = handle_emote_CD()			//proc located in code\modules\mob\emote.dm'						//Everyone else fails, skip the emote attempt
 			else								//Everyone else fails, skip the emote attempt
 				return
 
-		if("hisses") //tajaran hissing(sounds like cat hissing)
-			if(isunathi(src) || istajaran(src)) 
-				on_CD = handle_emote_CD()							
-			else								
+		if("hisses")
+			if(istajaran(src)) //tajaran hissing(sounds like cat hissing)
+				on_CD = handle_emote_CD()
+			else
 				return
 
 		if("quill", "quills")
@@ -277,7 +277,7 @@
 
 			if(!muzzled)
 				message = "шипит[M ? " на [M]" : ""]."
-				playsound(loc, 'sound/voice/tajarahiss.mp3', 100, 1, frequency = get_age_pitch()) 
+				playsound(loc, 'sound/voice/tajarahiss.mp3', 100, 1, frequency = get_age_pitch())
 				m_type = 2
 			else
 				message = "тихо шипит."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Теперь таяры не могут шипеть как унатхи используя *hiss а унатхи не могут шипеть как таяры используя *hisses

## Why It's Good For The Game
Фикс бага

## Changelog
:cl:
fix: no more unathi hissing for tajarans and tajaran hissing for unathi
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
