### PR TITLE
Fix: change sliding window in IA's office to prevent access to terminals

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -11177,7 +11177,7 @@
 	opacity = 0
 	},
 /obj/machinery/door/window/brigdoor{
-	dir = 1;
+	dir = 2;
 	name = "Internal Affairs Office";
 	req_access_txt = "38"
 	},


### PR DESCRIPTION
фикс офиса АВД.

Изменения:
Расположение стеклянной двери у приемной стойки офиса АВД
Цель:
Ограничение доступа к отчетам с охранного терминала при залезании на стойку у офиса АВД.