### PR TITLE
Deathsquad tweak

### DIFF
--- a/code/modules/admin/verbs/striketeam.dm
+++ b/code/modules/admin/verbs/striketeam.dm
@@ -168,36 +168,25 @@ GLOBAL_VAR_INIT(sent_strike_team, 0)
 	if(is_leader)
 		equip_to_slot_or_del(new /obj/item/clothing/under/rank/centcom_officer(src), slot_w_uniform)
 	else
-		equip_to_slot_or_del(new /obj/item/clothing/under/color/green(src), slot_w_uniform)
+		equip_to_slot_or_del(new /obj/item/clothing/under/syndicate/combat(src), slot_w_uniform)
 	equip_to_slot_or_del(new /obj/item/clothing/shoes/magboots/advance(src), slot_shoes)
 	equip_to_slot_or_del(new /obj/item/clothing/suit/space/hardsuit/deathsquad(src), slot_wear_suit)
 	equip_to_slot_or_del(new /obj/item/clothing/gloves/combat(src), slot_gloves)
 	equip_to_slot_or_del(new /obj/item/clothing/mask/gas/sechailer/swat(src), slot_wear_mask)
-	equip_to_slot_or_del(new /obj/item/clothing/glasses/thermal(src), slot_glasses)
-
+	equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/health/night(src), slot_glasses)
 	equip_to_slot_or_del(new /obj/item/storage/backpack/security(src), slot_back)
-	equip_to_slot_or_del(new /obj/item/storage/box(src), slot_in_backpack)
-
+	equip_to_slot_or_del(new /obj/item/ammo_box/a357(src), slot_in_backpack)
+	equip_to_slot_or_del(new /obj/item/ammo_box/a357(src), slot_in_backpack)
 	equip_to_slot_or_del(new /obj/item/ammo_box/a357(src), slot_in_backpack)
 	equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/combat/nanites(src), slot_in_backpack)
-	equip_to_slot_or_del(new /obj/item/storage/box/flashbangs(src), slot_in_backpack)
-	equip_to_slot_or_del(new /obj/item/flashlight(src), slot_in_backpack)
 	equip_to_slot_or_del(new /obj/item/pinpointer(src), slot_in_backpack)
-	if(is_leader)
-		equip_to_slot_or_del(new /obj/item/disk/nuclear/unrestricted(src), slot_in_backpack)
-	else
-		equip_to_slot_or_del(new /obj/item/grenade/plastic/x4(src), slot_in_backpack)
-
-
 	equip_to_slot_or_del(new /obj/item/melee/energy/sword/saber(src), slot_l_store)
 	equip_to_slot_or_del(new /obj/item/shield/energy(src), slot_r_store)
 	equip_to_slot_or_del(new /obj/item/tank/internals/emergency_oxygen/double(src), slot_s_store)
 	equip_to_slot_or_del(new /obj/item/gun/projectile/revolver/mateba(src), slot_belt)
 	equip_to_slot_or_del(new /obj/item/gun/energy/pulse(src), slot_r_hand)
-
 	var/obj/item/implant/mindshield/ert/L = new/obj/item/implant/mindshield/ert(src)
 	L.implant(src)
-
 	var/obj/item/card/id/W = new(src)
 	W.name = "[real_name]'s ID Card"
 	W.icon_state = "deathsquad"
@@ -205,5 +194,8 @@ GLOBAL_VAR_INIT(sent_strike_team, 0)
 	W.access = get_centcom_access(W.assignment)
 	W.registered_name = real_name
 	equip_to_slot_or_del(W, slot_wear_id)
+	if(is_leader)
+		equip_to_slot_or_del(new /obj/item/disk/nuclear/unrestricted(src), slot_in_backpack)
+	else
+		return
 
-	return 1

--- a/code/modules/clothing/spacesuits/ert.dm
+++ b/code/modules/clothing/spacesuits/ert.dm
@@ -289,5 +289,6 @@
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/deathsquad
 	taser_proof = TRUE
 	strip_delay = 130
+	jetpack = /obj/item/tank/jetpack/suit
 	dog_fashion = /datum/dog_fashion/back/deathsquad
 

--- a/code/modules/clothing/under/syndicate.dm
+++ b/code/modules/clothing/under/syndicate.dm
@@ -9,6 +9,8 @@
 
 /obj/item/clothing/under/syndicate/combat
 	name = "combat turtleneck"
+	desc = "A worn-out and slightly suspicious-looking special forces turtleneck with digital camouflage cargo pants. Born to kill."
+	armor = list("melee" = 10, "bullet" = 10, "laser" = 20,"energy" = 20, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 40)
 
 /obj/item/clothing/under/syndicate/tacticool
 	name = "tacticool turtleneck"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Небольшой ребаланс эквипа отряда смерти под современные реалии. Их экипировку делали очень давно, и сейчас она не очень адекватно смотрится. Убрал у них фонарик, термальные очки(термалы и так в шлеме), убрал х4(у них пульсачи которые ломают стены) Убрал коробку флешек и пустую коробку, добавил ПНВ медхуд, 2 дополнительных барабана на револьвер, поменял зеленый комбинезон на нормальный, добавил ригу джетпак.
## Why It's Good For The Game
Актуализируем устаревшее говно.

## Changelog
tweak: Changed deathsquad loadout
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
