### PR TITLE
ERT mindshield implants for ERT

### DIFF
--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -117,7 +117,7 @@
 		/obj/item/organ/internal/cyberimp/arm/flash
 	)
 
-	implants = list(/obj/item/implant/mindshield,
+	implants = list(/obj/item/implant/mindshield/ert,
 		/obj/item/implant/death_alarm
 	)
 
@@ -176,7 +176,7 @@
 		/obj/item/ammo_box/magazine/laser = 2
 	)
 
-	implants = list(/obj/item/implant/mindshield,
+	implants = list(/obj/item/implant/mindshield/ert,
 		/obj/item/implant/death_alarm
 	)
 
@@ -209,7 +209,7 @@
 		/obj/item/organ/internal/cyberimp/chest/reviver/hardened
 	)
 
-	implants = list(/obj/item/implant/mindshield,
+	implants = list(/obj/item/implant/mindshield/ert,
 		/obj/item/implant/death_alarm
 	)
 
@@ -267,7 +267,7 @@
 		/obj/item/gun/energy/gun = 1
 	)
 
-	implants = list(/obj/item/implant/mindshield,
+	implants = list(/obj/item/implant/mindshield/ert,
 		/obj/item/implant/death_alarm
 	)
 
@@ -297,7 +297,7 @@
 		/obj/item/organ/internal/cyberimp/arm/toolset
 	)
 
-	implants = list(/obj/item/implant/mindshield,
+	implants = list(/obj/item/implant/mindshield/ert,
 		/obj/item/implant/death_alarm
 	)
 
@@ -371,7 +371,7 @@
 		/obj/item/handheld_defibrillator = 1
 	)
 
-	implants = list(/obj/item/implant/mindshield,
+	implants = list(/obj/item/implant/mindshield/ert,
 		/obj/item/implant/death_alarm
 	)
 
@@ -406,7 +406,7 @@
 		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened
 	)
 
-	implants = list(/obj/item/implant/mindshield,
+	implants = list(/obj/item/implant/mindshield/ert,
 		/obj/item/implant/death_alarm
 	)
 
@@ -455,7 +455,7 @@
 		/obj/item/organ/internal/cyberimp/chest/nutriment
 	)
 
-	implants = list(/obj/item/implant/mindshield,
+	implants = list(/obj/item/implant/mindshield/ert,
 		/obj/item/implant/death_alarm
 	)
 
@@ -474,7 +474,7 @@
 		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened
 	)
 
-	implants = list(/obj/item/implant/mindshield,
+	implants = list(/obj/item/implant/mindshield/ert,
 		/obj/item/implant/death_alarm
 	)
 
@@ -547,6 +547,6 @@
 		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened
 	)
 
-	implants = list(/obj/item/implant/mindshield,
+	implants = list(/obj/item/implant/mindshield/ert,
 		/obj/item/implant/death_alarm
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Меняет МШ ОБР с обычного, на ЕРТ вариант.
У капитана и ГСБ и так есть этот имплант. Почему бы и ЕРТ не дать?

## Why It's Good For The Game
Прикольно выглядит.
Смогут стрелять из PDW.

## Images of motivation to this PR
![image](https://user-images.githubusercontent.com/87372121/182595029-b9c31a39-4992-48b9-abf8-b4254bd23551.png)

## Changelog
:cl:
tweak: change mindshield for ert
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
