### PR TITLE
Fix vox skipjack airlocks

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -43,6 +43,7 @@
 	pixel_x = -29;
 	req_one_access_txt = "152"
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
 "aah" = (
@@ -137,6 +138,7 @@
 	pixel_x = 28;
 	req_access_txt = "152"
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
 "aat" = (
@@ -8324,7 +8326,7 @@
 	name = "Donksoft gear"
 	},
 /obj/effect/spawner/lootdrop/trade_sol/donksoft{
-	loot = list(/obj/item/gun/projectile/automatic/c20r/toy = 50, /obj/item/gun/projectile/automatic/c20r/toy = 50, /obj/item/gun/projectile/automatic/c20r/toy = 50, /obj/item/gun/projectile/automatic/l6_saw/toy = 50, /obj/item/gun/projectile/automatic/l6_saw/toy = 50, /obj/item/gun/projectile/automatic/toy/pistol = 100, /obj/item/gun/projectile/automatic/toy/pistol = 100, /obj/item/gun/projectile/automatic/toy/pistol/enforcer = 50, /obj/item/gun/projectile/automatic/toy/pistol/enforcer = 50, /obj/item/gun/projectile/shotgun/toy = 50, /obj/item/gun/projectile/shotgun/toy = 50, /obj/item/gun/projectile/shotgun/toy/crossbow = 50, /obj/item/gun/projectile/shotgun/toy/crossbow = 50, /obj/item/gun/projectile/shotgun/toy/tommygun = 50, /obj/item/gun/projectile/shotgun/toy/tommygun = 50, /obj/item/gun/projectile/automatic/sniper_rifle/toy = 50, /obj/item/gun/projectile/automatic/sniper_rifle/toy = 50, /obj/item/ammo_box/foambox/sniper = 50, /obj/item/ammo_box/foambox = 50, /obj/item/ammo_box/foambox = 50, /obj/item/ammo_box/foambox = 50, /obj/item/ammo_box/foambox/riot = 50, /obj/item/ammo_box/foambox/riot = 50, /obj/item/ammo_box/foambox/sniper/riot = 50, /obj/item/twohanded/toy/chainsaw = 50, /obj/item/twohanded/dualsaber/toy = 50);
+	loot = list(/obj/item/gun/projectile/automatic/c20r/toy=50,/obj/item/gun/projectile/automatic/c20r/toy=50,/obj/item/gun/projectile/automatic/c20r/toy=50,/obj/item/gun/projectile/automatic/l6_saw/toy=50,/obj/item/gun/projectile/automatic/l6_saw/toy=50,/obj/item/gun/projectile/automatic/toy/pistol=100,/obj/item/gun/projectile/automatic/toy/pistol=100,/obj/item/gun/projectile/automatic/toy/pistol/enforcer=50,/obj/item/gun/projectile/automatic/toy/pistol/enforcer=50,/obj/item/gun/projectile/shotgun/toy=50,/obj/item/gun/projectile/shotgun/toy=50,/obj/item/gun/projectile/shotgun/toy/crossbow=50,/obj/item/gun/projectile/shotgun/toy/crossbow=50,/obj/item/gun/projectile/shotgun/toy/tommygun=50,/obj/item/gun/projectile/shotgun/toy/tommygun=50,/obj/item/gun/projectile/automatic/sniper_rifle/toy=50,/obj/item/gun/projectile/automatic/sniper_rifle/toy=50,/obj/item/ammo_box/foambox/sniper=50,/obj/item/ammo_box/foambox=50,/obj/item/ammo_box/foambox=50,/obj/item/ammo_box/foambox=50,/obj/item/ammo_box/foambox/riot=50,/obj/item/ammo_box/foambox/riot=50,/obj/item/ammo_box/foambox/sniper/riot=50,/obj/item/twohanded/toy/chainsaw=50,/obj/item/twohanded/dualsaber/toy=50);
 	lootcount = 8;
 	name = "2. Donksoft gear"
 	},
@@ -8457,7 +8459,7 @@
 	name = "Science gear"
 	},
 /obj/effect/spawner/lootdrop/trade_sol/sci{
-	loot = list(/obj/item/mmi/robotic_brain = 50, /obj/item/assembly/signaler/anomaly = 50, /obj/item/mecha_parts/mecha_equipment/weapon/energy/xray = 50, /obj/item/mecha_parts/mecha_equipment/teleporter/precise = 50, /obj/item/autoimplanter = 50, /obj/item/paper/researchnotes = 50, /obj/item/paper/researchnotes = 50, /obj/item/slimepotion/fireproof = 50, /obj/item/slimepotion/speed = 50, /obj/item/slimepotion/enhancer = 50,/obj/item/slimepotion/slime/mutator = 50, /obj/item/slimepotion/transference = 50, /obj/item/slimepotion/slime/steroid = 50, /obj/item/slimepotion/slime/stabilizer = 50, /obj/item/slimepotion/slime/docility = 50, /obj/item/slime_extract/bluespace = 50, /obj/item/slime_extract/adamantine = 50, /obj/item/slime_extract/rainbow = 50, /obj/item/slime_extract/sepia = 50, /obj/item/assembly/signaler/anomaly/vortex = 50, /obj/item/assembly/signaler/anomaly/bluespace = 50, /obj/item/assembly/signaler/anomaly/flux = 50, /obj/item/assembly/signaler/anomaly/grav = 50, /obj/item/assembly/signaler/anomaly/pyro = 50);
+	loot = list(/obj/item/mmi/robotic_brain=50,/obj/item/assembly/signaler/anomaly=50,/obj/item/mecha_parts/mecha_equipment/weapon/energy/xray=50,/obj/item/mecha_parts/mecha_equipment/teleporter/precise=50,/obj/item/autoimplanter=50,/obj/item/paper/researchnotes=50,/obj/item/paper/researchnotes=50,/obj/item/slimepotion/fireproof=50,/obj/item/slimepotion/speed=50,/obj/item/slimepotion/enhancer=50,/obj/item/slimepotion/slime/mutator=50,/obj/item/slimepotion/transference=50,/obj/item/slimepotion/slime/steroid=50,/obj/item/slimepotion/slime/stabilizer=50,/obj/item/slimepotion/slime/docility=50,/obj/item/slime_extract/bluespace=50,/obj/item/slime_extract/adamantine=50,/obj/item/slime_extract/rainbow=50,/obj/item/slime_extract/sepia=50,/obj/item/assembly/signaler/anomaly/vortex=50,/obj/item/assembly/signaler/anomaly/bluespace=50,/obj/item/assembly/signaler/anomaly/flux=50,/obj/item/assembly/signaler/anomaly/grav=50,/obj/item/assembly/signaler/anomaly/pyro=50);
 	lootcount = 8;
 	name = "6. Science gear"
 	},
@@ -8558,7 +8560,7 @@
 	name = "Sec. gear"
 	},
 /obj/effect/spawner/lootdrop/trade_sol/sec{
-	loot = list(/obj/item/clothing/gloves/combat = 50, /obj/item/grenade/clusterbuster/smoke = 50, /obj/item/clothing/suit/armor/laserproof = 50, /obj/item/clothing/suit/armor/vest/combat = 50, /obj/item/clothing/suit/armor/vest/combat = 50, /obj/item/clothing/suit/armor/vest/combat = 50, /obj/item/kitchen/knife/combat = 50, /obj/item/kitchen/knife/combat = 50, /obj/item/kitchen/knife/combat = 50, /obj/item/fluff/desolate_baton_kit = 50, /obj/item/storage/belt/military/assault = 50, /obj/item/storage/belt/military/assault = 50, /obj/item/storage/belt/military/assault = 50, /obj/item/clothing/mask/gas/sechailer/swat = 50, /obj/item/clothing/mask/gas/sechailer/swat = 50, /obj/item/clothing/suit/space/swat = 50, /obj/item/clothing/suit/space/swat = 50, /obj/item/clothing/glasses/thermal = 50, /obj/item/storage/box/enforcer_rubber = 50, /obj/item/storage/box/enforcer_rubber = 50, /obj/item/storage/box/enforcer_lethal = 50, /obj/item/melee/classic_baton/telescopic = 50, /obj/item/melee/classic_baton/telescopic = 50, /obj/item/gun/projectile/shotgun/automatic/combat = 50, /obj/item/gun/projectile/shotgun/automatic/combat = 50, /obj/item/gun/projectile/shotgun/automatic/combat = 50, /obj/item/gun/projectile/shotgun/automatic/dual_tube = 50, /obj/item/gun/projectile/shotgun/automatic/dual_tube = 50, /obj/item/storage/box/buck = 50, /obj/item/storage/box/buck = 50, /obj/item/storage/box/buck = 50, /obj/item/ammo_box/shotgun/buck = 50, /obj/item/ammo_box/shotgun/buck = 50, /obj/item/grenade/clusterbuster = 50, /obj/item/grenade/clusterbuster = 50, /obj/item/grenade/clusterbuster/teargas = 50, /obj/item/grenade/clusterbuster/n2o = 50);
+	loot = list(/obj/item/clothing/gloves/combat=50,/obj/item/grenade/clusterbuster/smoke=50,/obj/item/clothing/suit/armor/laserproof=50,/obj/item/clothing/suit/armor/vest/combat=50,/obj/item/clothing/suit/armor/vest/combat=50,/obj/item/clothing/suit/armor/vest/combat=50,/obj/item/kitchen/knife/combat=50,/obj/item/kitchen/knife/combat=50,/obj/item/kitchen/knife/combat=50,/obj/item/fluff/desolate_baton_kit=50,/obj/item/storage/belt/military/assault=50,/obj/item/storage/belt/military/assault=50,/obj/item/storage/belt/military/assault=50,/obj/item/clothing/mask/gas/sechailer/swat=50,/obj/item/clothing/mask/gas/sechailer/swat=50,/obj/item/clothing/suit/space/swat=50,/obj/item/clothing/suit/space/swat=50,/obj/item/clothing/glasses/thermal=50,/obj/item/storage/box/enforcer_rubber=50,/obj/item/storage/box/enforcer_rubber=50,/obj/item/storage/box/enforcer_lethal=50,/obj/item/melee/classic_baton/telescopic=50,/obj/item/melee/classic_baton/telescopic=50,/obj/item/gun/projectile/shotgun/automatic/combat=50,/obj/item/gun/projectile/shotgun/automatic/combat=50,/obj/item/gun/projectile/shotgun/automatic/combat=50,/obj/item/gun/projectile/shotgun/automatic/dual_tube=50,/obj/item/gun/projectile/shotgun/automatic/dual_tube=50,/obj/item/storage/box/buck=50,/obj/item/storage/box/buck=50,/obj/item/storage/box/buck=50,/obj/item/ammo_box/shotgun/buck=50,/obj/item/ammo_box/shotgun/buck=50,/obj/item/grenade/clusterbuster=50,/obj/item/grenade/clusterbuster=50,/obj/item/grenade/clusterbuster/teargas=50,/obj/item/grenade/clusterbuster/n2o=50);
 	lootcount = 10;
 	name = "1. Sec. gear"
 	},
@@ -8596,7 +8598,7 @@
 /area/crew_quarters/serviceyard)
 "aSc" = (
 /obj/effect/spawner/lootdrop/trade_sol/largeitem{
-	loot = list(/obj/machinery/floodlight = 50, /obj/machinery/disco = 50, /obj/mecha/combat/durand/old = 50, /obj/machinery/snow_machine = 50);
+	loot = list(/obj/machinery/floodlight=50,/obj/machinery/disco=50,/obj/mecha/combat/durand/old=50,/obj/machinery/snow_machine=50);
 	name = "3. Large item"
 	},
 /turf/simulated/floor/wood,
@@ -10543,7 +10545,7 @@
 	name = "Medical gear"
 	},
 /obj/effect/spawner/lootdrop/trade_sol/med{
-	loot = list(/obj/item/storage/fancy/cigarettes/cigpack_med = 50, /obj/item/stack/nanopaste = 50, /obj/item/storage/pill_bottle/random_meds/labelled = 50, /obj/item/reagent_containers/glass/bottle/reagent/omnizine = 50, /obj/item/reagent_containers/glass/bottle/reagent/strange_reagent = 50, /obj/item/scalpel/laser/manager = 50, /obj/item/organ/internal/heart/gland/ventcrawling = 50, /obj/item/organ/internal/heart/gland/heals = 50, /obj/item/dnainjector/regenerate = 50, /obj/item/dnainjector/nobreath = 50, /obj/item/dnainjector/telemut = 50, /obj/item/reagent_containers/glass/bottle/regeneration = 50, /obj/item/reagent_containers/glass/bottle/sensory_restoration = 50, /obj/item/autopsy_scanner = 50, /obj/item/organ/internal/cyberimp/eyes/hud/medical = 50, /obj/item/gun/medbeam = 50, /obj/item/reagent_containers/applicator/dual/syndi = 50, /obj/item/reagent_containers/glass/bottle/retrovirus = 50, /obj/item/reagent_containers/glass/bottle/reagent/strange_reagent = 50, /obj/item/reagent_containers/glass/bottle/tuberculosiscure = 50, /obj/item/reagent_containers/glass/bottle/gbs = 50, /obj/item/bodyanalyzer/advanced = 50);
+	loot = list(/obj/item/storage/fancy/cigarettes/cigpack_med=50,/obj/item/stack/nanopaste=50,/obj/item/storage/pill_bottle/random_meds/labelled=50,/obj/item/reagent_containers/glass/bottle/reagent/omnizine=50,/obj/item/reagent_containers/glass/bottle/reagent/strange_reagent=50,/obj/item/scalpel/laser/manager=50,/obj/item/organ/internal/heart/gland/ventcrawling=50,/obj/item/organ/internal/heart/gland/heals=50,/obj/item/dnainjector/regenerate=50,/obj/item/dnainjector/nobreath=50,/obj/item/dnainjector/telemut=50,/obj/item/reagent_containers/glass/bottle/regeneration=50,/obj/item/reagent_containers/glass/bottle/sensory_restoration=50,/obj/item/autopsy_scanner=50,/obj/item/organ/internal/cyberimp/eyes/hud/medical=50,/obj/item/gun/medbeam=50,/obj/item/reagent_containers/applicator/dual/syndi=50,/obj/item/reagent_containers/glass/bottle/retrovirus=50,/obj/item/reagent_containers/glass/bottle/reagent/strange_reagent=50,/obj/item/reagent_containers/glass/bottle/tuberculosiscure=50,/obj/item/reagent_containers/glass/bottle/gbs=50,/obj/item/bodyanalyzer/advanced=50);
 	lootcount = 8;
 	name = "5. Medical gear"
 	},
@@ -10745,7 +10747,7 @@
 	name = "Service gear"
 	},
 /obj/effect/spawner/lootdrop/trade_sol/serv{
-	loot = list(/obj/item/storage/box/beakers/bluespace = 50, /obj/item/storage/box/monkeycubes = 50, /obj/item/storage/box/monkeycubes = 50, /obj/item/storage/box/stockparts/deluxe = 50, /obj/item/storage/box/rndboards = 50, /obj/item/reagent_containers/spray/cleaner = 50, /obj/item/soap = 50, /obj/item/clothing/under/syndicate/combat = 50, /obj/item/soap/syndie = 50, /obj/item/lighter/zippo/gonzofist = 50, /obj/item/clothing/under/psyjump = 50, /obj/item/immortality_talisman = 50, /obj/item/t_scanner/adv_mining_scanner = 50, /obj/item/storage/box/bartender_rare_ingredients_kit = 50, /obj/item/storage/box/chef_rare_ingredients_kit = 50, /obj/item/grenade/clusterbuster/cleaner = 50, /obj/item/mining_voucher = 50, /obj/item/gun/energy/kinetic_accelerator/experimental = 50, /obj/item/borg/upgrade/modkit/aoe/turfs/andmobs = 50, /obj/item/seeds/random/labelled = 50, /obj/item/seeds/random/labelled = 50, /obj/item/seeds/random/labelled = 50, /obj/item/grenade/clusterbuster/honk = 50, /obj/item/bikehorn/golden = 50);
+	loot = list(/obj/item/storage/box/beakers/bluespace=50,/obj/item/storage/box/monkeycubes=50,/obj/item/storage/box/monkeycubes=50,/obj/item/storage/box/stockparts/deluxe=50,/obj/item/storage/box/rndboards=50,/obj/item/reagent_containers/spray/cleaner=50,/obj/item/soap=50,/obj/item/clothing/under/syndicate/combat=50,/obj/item/soap/syndie=50,/obj/item/lighter/zippo/gonzofist=50,/obj/item/clothing/under/psyjump=50,/obj/item/immortality_talisman=50,/obj/item/t_scanner/adv_mining_scanner=50,/obj/item/storage/box/bartender_rare_ingredients_kit=50,/obj/item/storage/box/chef_rare_ingredients_kit=50,/obj/item/grenade/clusterbuster/cleaner=50,/obj/item/mining_voucher=50,/obj/item/gun/energy/kinetic_accelerator/experimental=50,/obj/item/borg/upgrade/modkit/aoe/turfs/andmobs=50,/obj/item/seeds/random/labelled=50,/obj/item/seeds/random/labelled=50,/obj/item/seeds/random/labelled=50,/obj/item/grenade/clusterbuster/honk=50,/obj/item/bikehorn/golden=50);
 	lootcount = 8;
 	name = "7. Service gear"
 	},
@@ -15022,7 +15024,7 @@
 /area/quartermaster/storage)
 "bza" = (
 /obj/effect/spawner/lootdrop/trade_sol/vehicle{
-	loot = list(/obj/vehicle/motorcycle = 50, /obj/vehicle/snowmobile/key = 50, /obj/vehicle/snowmobile/blue/key = 50, /obj/vehicle/space/speedbike/red = 50, /obj/vehicle/space/speedbike = 50);
+	loot = list(/obj/vehicle/motorcycle=50,/obj/vehicle/snowmobile/key=50,/obj/vehicle/snowmobile/blue/key=50,/obj/vehicle/space/speedbike/red=50,/obj/vehicle/space/speedbike=50);
 	name = "4. Vehicle"
 	},
 /turf/simulated/floor/wood,
@@ -15100,7 +15102,7 @@
 "bzu" = (
 /obj/machinery/light/spot,
 /obj/effect/spawner/lootdrop/trade_sol/largeitem{
-	loot = list(/obj/machinery/floodlight = 50, /obj/machinery/disco = 50, /obj/mecha/combat/durand/old = 50, /obj/machinery/snow_machine = 50);
+	loot = list(/obj/machinery/floodlight=50,/obj/machinery/disco=50,/obj/mecha/combat/durand/old=50,/obj/machinery/snow_machine=50);
 	name = "3. Large item"
 	},
 /turf/simulated/floor/wood,
@@ -15323,9 +15325,9 @@
 /area/medical/virology/lab)
 "bAl" = (
 /obj/machinery/vending/sustenance{
-	contraband = list(/obj/item/kitchen/knife = 2);
+	contraband = list(/obj/item/kitchen/knife=2);
 	desc = "Какого этот автомат тут оказался?!";
-	products = list(/obj/item/reagent_containers/food/snacks/tofu = 12, /obj/item/reagent_containers/food/drinks/ice = 6, /obj/item/reagent_containers/food/snacks/candy/candy_corn = 6)
+	products = list(/obj/item/reagent_containers/food/snacks/tofu=12,/obj/item/reagent_containers/food/drinks/ice=6,/obj/item/reagent_containers/food/snacks/candy/candy_corn=6)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -21951,7 +21953,7 @@
 	input_tag = "co2_in";
 	name = "Carbon Dioxide Supply Control";
 	output_tag = "co2_out";
-	sensors = list("co2_sensor" = "Tank")
+	sensors = list("co2_sensor"="Tank")
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -36503,7 +36505,7 @@
 	frequency = 1443;
 	level = 3;
 	name = "Distribution and Waste Monitor";
-	sensors = list("mair_in_meter" = "Mixed Air In", "air_sensor" = "Mixed Air Supply Tank", "mair_out_meter" = "Mixed Air Out", "dloop_atm_meter" = "Distribution Loop", "wloop_atm_meter" = "Waste Loop")
+	sensors = list("mair_in_meter"="Mixed Air In","air_sensor"="Mixed Air Supply Tank","mair_out_meter"="Mixed Air Out","dloop_atm_meter"="Distribution Loop","wloop_atm_meter"="Waste Loop")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -42430,7 +42432,7 @@
 	input_tag = "o2_in";
 	name = "Oxygen Supply Control";
 	output_tag = "o2_out";
-	sensors = list("o2_sensor" = "Tank")
+	sensors = list("o2_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
@@ -45669,7 +45671,7 @@
 	input_tag = "n2_in";
 	name = "Nitrogen Supply Control";
 	output_tag = "n2_out";
-	sensors = list("n2_sensor" = "Tank")
+	sensors = list("n2_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
@@ -51047,13 +51049,13 @@
 "eEb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor{
-	armor = list("melee" = 60, "bullet" = 70, "laser" = 70, "energy" = 70, "bomb" = 40, "bio" = 100, "rad" = 100, "fire" = 70, "acid" = 100);
+	armor = list("melee"=60,"bullet"=70,"laser"=70,"energy"=70,"bomb"=40,"bio"=100,"rad"=100,"fire"=70,"acid"=100);
 	dir = 2;
 	name = "Secure Armory";
 	req_access_txt = "1"
 	},
 /obj/machinery/door/window/brigdoor{
-	armor = list("melee" = 60, "bullet" = 70, "laser" = 70, "energy" = 70, "bomb" = 40, "bio" = 100, "rad" = 100, "fire" = 70, "acid" = 100);
+	armor = list("melee"=60,"bullet"=70,"laser"=70,"energy"=70,"bomb"=40,"bio"=100,"rad"=100,"fire"=70,"acid"=100);
 	dir = 1;
 	name = "Secure Armory";
 	req_access_txt = "3"
@@ -51808,7 +51810,7 @@
 	name = "Mixed Air Supply Control";
 	output_tag = "air_out";
 	pressure_setting = 2000;
-	sensors = list("air_sensor" = "Tank")
+	sensors = list("air_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
@@ -59571,6 +59573,14 @@
 	icon_state = "dark"
 	},
 /area/chapel/office)
+"gGF" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	frequency = 1331;
+	id_tag = "vox_east_vent";
+	dir = 1
+	},
+/turf/simulated/shuttle/plating/vox,
+/area/shuttle/vox)
 "gGI" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/scrubber,
@@ -61635,7 +61645,7 @@
 	name = "Engineering gear"
 	},
 /obj/effect/spawner/lootdrop/trade_sol/eng{
-	loot = list(/obj/item/pickaxe/drill/jackhammer = 50, /obj/item/storage/belt/utility/chief/full = 50, /obj/item/clothing/glasses/welding = 50, /obj/item/storage/belt/utility/full/multitool = 50, /obj/item/clothing/shoes/magboots = 50, /obj/item/rcd/combat = 50, /obj/item/rpd/bluespace = 50, /obj/item/tank/internals/emergency_oxygen/double = 50, /obj/item/storage/backpack/holding = 50, /obj/item/clothing/glasses/meson/night = 50, /obj/item/clothing/glasses/material = 50, /obj/item/grenade/clusterbuster/metalfoam = 50, /obj/item/crowbar/power = 50, /obj/item/screwdriver/power = 50, /obj/item/t_scanner/extended_range = 50, /obj/item/borg/upgrade/abductor_engi = 50);
+	loot = list(/obj/item/pickaxe/drill/jackhammer=50,/obj/item/storage/belt/utility/chief/full=50,/obj/item/clothing/glasses/welding=50,/obj/item/storage/belt/utility/full/multitool=50,/obj/item/clothing/shoes/magboots=50,/obj/item/rcd/combat=50,/obj/item/rpd/bluespace=50,/obj/item/tank/internals/emergency_oxygen/double=50,/obj/item/storage/backpack/holding=50,/obj/item/clothing/glasses/meson/night=50,/obj/item/clothing/glasses/material=50,/obj/item/grenade/clusterbuster/metalfoam=50,/obj/item/crowbar/power=50,/obj/item/screwdriver/power=50,/obj/item/t_scanner/extended_range=50,/obj/item/borg/upgrade/abductor_engi=50);
 	lootcount = 8;
 	name = "8. Eng. gear"
 	},
@@ -66430,7 +66440,7 @@
 	input_tag = "tox_in";
 	name = "Toxin Supply Control";
 	output_tag = "tox_out";
-	sensors = list("tox_sensor" = "Tank")
+	sensors = list("tox_sensor"="Tank")
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -72448,7 +72458,7 @@
 /area/security/lobby)
 "jIc" = (
 /obj/machinery/camera{
-	armor = list("melee" = 50, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 100, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 50);
+	armor = list("melee"=50,"bullet"=20,"laser"=20,"energy"=20,"bomb"=100,"bio"=0,"rad"=0,"fire"=90,"acid"=50);
 	c_tag = "Research Toxins Test Chamber North";
 	network = list("Toxins","Research","SS13")
 	},
@@ -78589,7 +78599,7 @@
 	input_tag = "n2o_in";
 	name = "Nitrous Oxide Supply Control";
 	output_tag = "n2o_out";
-	sensors = list("n2o_sensor" = "Tank")
+	sensors = list("n2o_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
@@ -89532,7 +89542,7 @@
 	input_tag = "mix_in";
 	name = "Gas Mix Tank Control";
 	output_tag = "mix_out";
-	sensors = list("mix_sensor" = "Tank")
+	sensors = list("mix_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
@@ -92697,7 +92707,7 @@
 "oFK" = (
 /obj/item/radio/beacon,
 /obj/machinery/camera{
-	armor = list("melee" = 50, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 100, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 50);
+	armor = list("melee"=50,"bullet"=20,"laser"=20,"energy"=20,"bomb"=100,"bio"=0,"rad"=0,"fire"=90,"acid"=50);
 	c_tag = "Research Toxins Test Chamber East";
 	dir = 4;
 	network = list("Toxins","Research","SS13")
@@ -103813,6 +103823,14 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/bridge/checkpoint/south)
+"reZ" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	frequency = 1331;
+	id_tag = "vox_west_vent";
+	dir = 1
+	},
+/turf/simulated/shuttle/plating/vox,
+/area/shuttle/vox)
 "rfm" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -105387,6 +105405,10 @@
 	icon_state = "dark"
 	},
 /area/chapel/office)
+"rxO" = (
+/obj/machinery/atmospherics/unary/tank/nitrogen,
+/turf/simulated/shuttle/plating/vox,
+/area/shuttle/vox)
 "rye" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/decal/warning_stripes/south,
@@ -106033,7 +106055,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	armor = list("melee" = 50, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 100, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 50);
+	armor = list("melee"=50,"bullet"=20,"laser"=20,"energy"=20,"bomb"=100,"bio"=0,"rad"=0,"fire"=90,"acid"=50);
 	c_tag = "Research Toxins Test Chamber West";
 	dir = 4;
 	network = list("Toxins","Research","SS13")
@@ -120453,7 +120475,7 @@
 /obj/machinery/computer/general_air_control{
 	frequency = 1222;
 	name = "Bomb Mix Monitor";
-	sensors = list("burn_sensor" = "Burn Mix")
+	sensors = list("burn_sensor"="Burn Mix")
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
@@ -122688,6 +122710,16 @@
 /area/shuttle/escape{
 	parallax_movedir = 2
 	})
+"vDG" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	frequency = 1331;
+	id_tag = "synd_pump";
+	dir = 1
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
 "vDO" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8;
@@ -123476,7 +123508,7 @@
 /area/space/nearstation)
 "vOV" = (
 /obj/machinery/camera{
-	armor = list("melee" = 50, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 100, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 50);
+	armor = list("melee"=50,"bullet"=20,"laser"=20,"energy"=20,"bomb"=100,"bio"=0,"rad"=0,"fire"=90,"acid"=50);
 	c_tag = "Research Toxins Test Chamber South";
 	dir = 1;
 	network = list("Toxins","Research","SS13")
@@ -142396,7 +142428,7 @@ aaa
 aaa
 aaa
 anx
-aft
+vDG
 afq
 afY
 anx
@@ -190981,8 +191013,8 @@ aaa
 aaa
 aaa
 aaf
-aer
-aer
+rxO
+reZ
 abX
 aer
 aer
@@ -195093,8 +195125,8 @@ aaa
 aaa
 aaa
 aaf
-aer
-aer
+rxO
+gGF
 acJ
 aer
 aer


### PR DESCRIPTION
## What Does This PR Do
Исправляет обе шлюзовых камеры на шаттле воксов, добавляет венту, баки с азотом и исправляет все настройки

## Why It's Good For The Game
Режим воксов конечно не в ротации, но теперь педалям не надо будет кнопками чинить этот шатл если они захотят этот режим форсануть

## Images of changes
![image](https://user-images.githubusercontent.com/1918858/183273982-33854e51-51c4-48e6-a70b-41788d9388e7.png)


## Changelog
Исправлено поведение шлюзовых камер на шаттле воксов.
Добавлено 2 бака с азотом и 2 венты, назначены все настройки
