### PR TITLE
Feat: add Laser arm implant craft

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -458,3 +458,14 @@
 	build_path = /obj/item/rcd_ammo/syndicate/large
 	locked = 0
 	category = list("ILLEGAL")
+
+/datum/design/laser_arm
+	name = "Laser arm implant"
+	desc = "An arm cannon implant that fires lethal laser beams. Come with a self-charge."
+	id = "laser_arm_imp"
+	req_tech = list("syndicate" = 4, "biotech" = 7, "combat" = 8, "plasmatech" = 5)
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 8000, MAT_URANIUM = 8000, MAT_TITANIUM = 1000, MAT_GOLD = 500, MAT_DIAMOND = 100)
+	build_path = /obj/item/organ/internal/cyberimp/arm/gun/laser
+	locked = 1
+	category = list("ILLEGAL")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Добавляет крафт лазерной-руки импланта в РнД.
Требуемые технологии: 4 нелегальные. 7 биотехнологии. 8 боевые. 5 плазмы.
Требуемые ресурсы: 8 тысяч метала (4 листа), восемь тысяч урана (4 листа), 1 тысяча титана (0.5 листов), 500 золота (0.25 листов) и 100 алмазов (0.05 листов)
Печатается в закрытом локере, доступ - оружейная (варден, ГСБ и выше могут открыть, или же тритор с емагом).

Предложка: https://discord.com/channels/617003227182792704/755125334097133628/975325773143638016
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Новый предмет на восьмые уровни
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
У персонажа:
![image](https://user-images.githubusercontent.com/74865061/183431410-e796ed1d-e53d-4615-a425-4c7dd89cbad8.png)
В руке, вставленный:
![image](https://user-images.githubusercontent.com/74865061/183431481-f876e62f-0d55-469a-a890-089724514094.png)
Да, спрайт на персонаже не очень хороший, но в случае желания можно взять спрайт с ТГ.
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: Крафт лазерного импланта
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
