### PR TITLE
Tweak: Few interactions for cyborg grippers

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -285,7 +285,7 @@ to destroy them and players will be able to make replacements.
 		for(var/path in vending_names_paths)
 			display_vending_names_paths[vending_names_paths[path]] = path
 	var/choice =  input(user, "Choose a new brand","Select an Item") as null|anything in display_vending_names_paths
-	if(loc != user)
+	if(!(loc == user || (istype(loc, /obj/item/gripper) && loc && loc.loc == user)))
 		to_chat(user, "<span class='notice'>You need to keep [src] in your hands while doing that!</span>")
 		return
 	set_type(display_vending_names_paths[choice])

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -91,7 +91,7 @@
 /obj/item/gripper/attackby(obj/item/weapon, mob/user, params)
 	if(gripped_item)
 		gripped_item.attackby(weapon, user, params)
-		if (gripped_item.gc_destroyed) // if item was dissasembled we need to clear the pointer
+		if (QDELETED(gripped_item)) // if item was dissasembled we need to clear the pointer
 			drop_gripped_item(TRUE) // silent = TRUE to prevent "You drop X" message from appearing without actually dropping anything
 
 /obj/item/gripper/proc/drop_gripped_item(silent = FALSE)

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -83,23 +83,26 @@
 		to_chat(user, "<span class='warning'>[src] is empty.</span>")
 
 /obj/item/gripper/tool_act(mob/living/user, obj/item/tool, tool_type)
-	if(gripped_item)
-		gripped_item.tool_act(user, tool, tool_type)
-		if (QDELETED(gripped_item)) // if item was dissasembled we need to clear the pointer
-			drop_gripped_item(TRUE) // silent = TRUE to prevent "You drop X" message from appearing without actually dropping anything
+	if(!gripped_item)
+		return
+	gripped_item.tool_act(user, tool, tool_type)
+	if (QDELETED(gripped_item)) // if item was dissasembled we need to clear the pointer
+		drop_gripped_item(TRUE) // silent = TRUE to prevent "You drop X" message from appearing without actually dropping anything
 
 /obj/item/gripper/attackby(obj/item/weapon, mob/user, params)
-	if(gripped_item)
-		gripped_item.attackby(weapon, user, params)
-		if (QDELETED(gripped_item)) // if item was dissasembled we need to clear the pointer
-			drop_gripped_item(TRUE) // silent = TRUE to prevent "You drop X" message from appearing without actually dropping anything
+	if(!gripped_item)
+		return
+	gripped_item.attackby(weapon, user, params)
+	if (QDELETED(gripped_item)) // if item was dissasembled we need to clear the pointer
+		drop_gripped_item(TRUE) // silent = TRUE to prevent "You drop X" message from appearing without actually dropping anything
 
 /obj/item/gripper/proc/drop_gripped_item(silent = FALSE)
-	if(gripped_item)
-		if(!silent)
-			to_chat(loc, "<span class='warning'>You drop [gripped_item].</span>")
-		gripped_item.forceMove(get_turf(src))
-		gripped_item = null
+	if(!gripped_item)
+		return
+	if(!silent)
+		to_chat(loc, "<span class='warning'>You drop [gripped_item].</span>")
+	gripped_item.forceMove(get_turf(src))
+	gripped_item = null
 
 /obj/item/gripper/attack(mob/living/carbon/M, mob/living/carbon/user)
 	return

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -85,7 +85,7 @@
 /obj/item/gripper/tool_act(mob/living/user, obj/item/tool, tool_type)
 	if(gripped_item)
 		gripped_item.tool_act(user, tool, tool_type)
-		if (gripped_item.gc_destroyed) // if item was dissasembled we need to clear the pointer
+		if (QDELETED(gripped_item)) // if item was dissasembled we need to clear the pointer
 			drop_gripped_item(TRUE) // silent = TRUE to prevent "You drop X" message from appearing without actually dropping anything
 
 /obj/item/gripper/attackby(obj/item/weapon, mob/user, params)

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -82,6 +82,10 @@
 	else
 		to_chat(user, "<span class='warning'>[src] is empty.</span>")
 
+/obj/item/gripper/tool_act(mob/living/user, obj/item/tool, tool_type)
+	if(gripped_item)
+		gripped_item.tool_act(user, tool, tool_type)
+
 /obj/item/gripper/proc/drop_gripped_item(silent = FALSE)
 	if(gripped_item)
 		if(!silent)

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -85,10 +85,14 @@
 /obj/item/gripper/tool_act(mob/living/user, obj/item/tool, tool_type)
 	if(gripped_item)
 		gripped_item.tool_act(user, tool, tool_type)
+		if (gripped_item.gc_destroyed) // if item was dissasembled we need to clear the pointer
+			drop_gripped_item(TRUE) // silent = TRUE to prevent "You drop X" message from appearing without actually dropping anything
 
 /obj/item/gripper/attackby(obj/item/weapon, mob/user, params)
 	if(gripped_item)
 		gripped_item.attackby(weapon, user, params)
+		if (gripped_item.gc_destroyed) // if item was dissasembled we need to clear the pointer
+			drop_gripped_item(TRUE) // silent = TRUE to prevent "You drop X" message from appearing without actually dropping anything
 
 /obj/item/gripper/proc/drop_gripped_item(silent = FALSE)
 	if(gripped_item)

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -86,6 +86,10 @@
 	if(gripped_item)
 		gripped_item.tool_act(user, tool, tool_type)
 
+/obj/item/gripper/attackby(obj/item/weapon, mob/user, params)
+	if(gripped_item)
+		gripped_item.attackby(weapon, user, params)
+
 /obj/item/gripper/proc/drop_gripped_item(silent = FALSE)
 	if(gripped_item)
 		if(!silent)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Гриппер инженерного и медицинского борга теперь позволяют применять инструменты на предмет, который находится в гриппере.
Примеры: настройка платы вендомата (требует применения отвертки, пока плата в руке, ранее инженерный борг мог держать плату, но не мог её настроить), потрошение органов (требовали от медборга выложить орган на пол).
В проверку на нахождение платы в руке для вендомата добавлено условие на нахождение в гриппере борга, который применяет отвёртку.

_Не проходило предложку, автор сомневается в наличии неожиданных, не покрытых тестированием вариантов, однако они возможны. По этой причине ПР в драфте до:_
_1) получения разрешения на мёрж/прохождение воута_ **СДЕЛАНО**
_2) дополнительного ревью и тестирования на предмет нежелательных взаимодействий_ **СДЕЛАНО, НАСКОЛЬКО ВОЗМОЖНО**

upd: предложка прошла, https://discord.com/channels/617003227182792704/755125334097133628/1007964492577120317

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Предсказуемость поведения игры. Допустимые взаимодействия приносят ожидаемый результат.

## Changelog
:cl:
tweak: функционал гриппера борга дополнен взаимодействиями с инструментами.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
