### PR TITLE
Приемная РнД/Ангар мехов/Робототехника(kerberos/дельта/керберос) [TEST MERGE]

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -87493,8 +87493,7 @@
 	},
 /area/security/range)
 "nsS" = (
-/obj/effect/decal/warning_stripes/arrow,
-/obj/effect/decal/warning_stripes/yellow/partial,
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "nsT" = (

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -1971,7 +1971,9 @@
 	pixel_y = 3
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
 /area/toxins/lab)
 "aiL" = (
@@ -2915,21 +2917,11 @@
 /turf/simulated/shuttle/floor,
 /area/shuttle/administration)
 "anP" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
+	icon_state = "white"
 	},
-/area/medical/research/shallway)
+/area/toxins/lab)
 "anQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -11534,19 +11526,12 @@
 	},
 /area/toxins/mixing)
 "biZ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stock_parts/cell/high/plus{
-	pixel_x = 5;
-	pixel_y = -5
-	},
-/obj/item/stock_parts/cell/high/plus{
-	pixel_x = 5;
-	pixel_y = 6
-	},
+/obj/machinery/mecha_part_fabricator,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
 /area/assembly/robotics)
 "bjc" = (
@@ -12587,6 +12572,15 @@
 /obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
+"boy" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id_tag = "RoboPrivat";
+	name = "Robotics Privacy Shutter"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/assembly/robotics)
 "boD" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/warning_stripes/yellow,
@@ -21781,11 +21775,8 @@
 /turf/simulated/floor/carpet/black,
 /area/bridge/vip)
 "cbI" = (
-/obj/effect/decal/warning_stripes/northeastcorner,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/landmark/start{
+	name = "Roboticist"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -23322,6 +23313,17 @@
 	icon_state = "neutral"
 	},
 /area/maintenance/engrooms)
+"cii" = (
+/obj/machinery/optable,
+/obj/structure/sign/science{
+	pixel_y = -32
+	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel{
+	icon_state = "whiteblue";
+	tag = "icon-whitehall (WEST)"
+	},
+/area/assembly/robotics)
 "cij" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -34045,7 +34047,9 @@
 	pixel_x = 30
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 6;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (SOUTHEAST)"
 	},
 /area/toxins/lab)
 "cYk" = (
@@ -34112,14 +34116,14 @@
 /area/medical/reception)
 "cYB" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/dropper,
 /obj/effect/decal/warning_stripes/south,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -34400,6 +34404,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
 	name = "standard air scrubber";
@@ -34408,7 +34417,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "whitepurplefull"
 	},
 /area/toxins/lab)
 "cZw" = (
@@ -37734,6 +37743,21 @@
 	icon_state = "purple"
 	},
 /area/assembly/chargebay)
+"dlU" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	initialize_directions = 13
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/assembly/robotics)
 "dlY" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light,
@@ -38608,15 +38632,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "doP" = (
-/obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id_tag = "RoboDesk";
 	name = "Robotics Privacy Shutter"
 	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	d2 = 8;
+	icon_state = "0-8"
 	},
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/assembly/robotics)
 "doU" = (
@@ -39063,11 +39087,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/gambling_den)
 "dql" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 2;
-	name = "Robotics Junction";
-	sortType = 14
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "purple"
@@ -39276,21 +39296,19 @@
 	},
 /area/medical/research/nhallway)
 "drv" = (
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurple"
-	},
-/area/assembly/robotics)
-"drC" = (
-/obj/machinery/mecha_part_fabricator,
 /obj/effect/decal/warning_stripes/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/assembly/robotics)
+"drC" = (
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple"
+	},
+/area/toxins/lab)
 "drD" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -39387,7 +39405,6 @@
 	},
 /area/turret_protected/ai)
 "drN" = (
-/obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/item/folder,
 /obj/machinery/door/window/westleft{
@@ -39400,19 +39417,7 @@
 	id_tag = "RoboDesk";
 	name = "Robotics Privacy Shutter"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
 "drP" = (
@@ -39548,24 +39553,11 @@
 /turf/space,
 /area/space/nearstation)
 "dsu" = (
-/obj/effect/decal/warning_stripes/southwestcorner,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whitepurplecorner"
 	},
-/area/assembly/robotics)
+/area/toxins/lab)
 "dsw" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -39598,35 +39590,16 @@
 /area/crew_quarters/captain/bedroom)
 "dsE" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/assembly/robotics)
 "dsG" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "whitepurplefull"
 	},
 /area/assembly/robotics)
 "dsI" = (
@@ -40181,11 +40154,20 @@
 	},
 /area/hallway/primary/central/west)
 "dvg" = (
-/obj/effect/decal/warning_stripes/yellow,
-/obj/item/robot_parts/robot_suit,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
+/obj/structure/closet/secure_closet/roboticist,
+/obj/item/radio/headset/headset_sci{
+	pixel_x = -3
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurple"
+	},
 /area/assembly/robotics)
 "dvk" = (
 /obj/structure/disposalpipe/segment,
@@ -40387,13 +40369,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar/atrium)
-"dwk" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/assembly/robotics)
 "dwm" = (
 /obj/structure/girder,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -40759,44 +40734,36 @@
 	},
 /area/tcommsat/chamber)
 "dxu" = (
-/obj/machinery/newscaster{
-	pixel_y = -28
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/computer/operating{
-	name = "Robotics Operating Computer"
+/obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/status_display{
+	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "whitepurple"
-	},
-/area/assembly/robotics)
-"dxv" = (
-/obj/effect/decal/warning_stripes/northwestcorner,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
 	},
 /area/assembly/robotics)
 "dxw" = (
-/obj/item/radio/intercom{
-	dir = 1;
-	pixel_y = -28
-	},
 /obj/structure/table/reinforced,
-/obj/structure/sink{
-	dir = 1
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
 	},
-/obj/item/storage/toolbox/surgery{
-	pixel_x = -1;
-	pixel_y = 2
+/obj/item/storage/firstaid/regular{
+	empty = 1;
+	name = "First-Aid (empty)"
 	},
+/obj/item/storage/firstaid/regular{
+	empty = 1;
+	name = "First-Aid (empty)"
+	},
+/obj/item/storage/firstaid/regular{
+	empty = 1;
+	name = "First-Aid (empty)"
+	},
+/obj/item/healthanalyzer,
+/obj/item/healthanalyzer,
+/obj/item/healthanalyzer,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple";
 	tag = "icon-whitepurple (WEST)"
@@ -40804,20 +40771,22 @@
 /area/assembly/robotics)
 "dxx" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/box/gloves{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high/plus{
+	pixel_x = 5;
+	pixel_y = -5
 	},
-/obj/item/storage/box/masks,
-/obj/item/storage/box/bodybags{
-	pixel_x = -4;
-	pixel_y = -4
+/obj/item/stock_parts/cell/high/plus{
+	pixel_x = 5;
+	pixel_y = 6
 	},
-/obj/item/tank/internals/anesthetic,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner"
+/obj/machinery/newscaster{
+	pixel_y = -28
+	},
+/obj/machinery/light,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -41324,16 +41293,10 @@
 	name = "Engineering Maintenance"
 	})
 "dzQ" = (
-/obj/effect/decal/warning_stripes/south,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
 	icon_state = "whitepurplecorner"
 	},
-/area/assembly/robotics)
+/area/toxins/lab)
 "dzY" = (
 /obj/structure/table,
 /obj/structure/cable{
@@ -43481,12 +43444,17 @@
 	},
 /area/crew_quarters/hor)
 "dIi" = (
-/obj/machinery/disposal,
 /obj/machinery/light{
 	dir = 1;
 	on = 1
 	},
-/obj/structure/disposalpipe/trunk,
+/obj/machinery/r_n_d/protolathe{
+	pixel_x = 1
+	},
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "whitepurple";
@@ -45115,6 +45083,22 @@
 	tag = "icon-whitegreen (NORTHWEST)"
 	},
 /area/medical/virology)
+"dOG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurplefull"
+	},
+/area/assembly/robotics)
 "dOH" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
@@ -50030,23 +50014,17 @@
 	},
 /area/quartermaster/office)
 "eri" = (
-/obj/structure/table/reinforced,
-/obj/item/mmi,
-/obj/item/mmi,
-/obj/item/mmi,
-/obj/item/mmi/robotic_brain,
-/obj/item/robotanalyzer,
-/obj/machinery/status_display{
-	pixel_x = -32
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
 	},
-/obj/machinery/camera{
-	c_tag = "Robotics Lab";
-	dir = 4;
-	network = list("Research","SS13")
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurple"
+	icon_state = "whiteblue"
 	},
 /area/assembly/robotics)
 "erl" = (
@@ -50096,18 +50074,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8;
-	initialize_directions = 13
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -50417,10 +50383,8 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -28
 	},
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high,
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "purple"
@@ -51228,8 +51192,12 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "eGn" = (
@@ -53866,7 +53834,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/unres,
 /obj/machinery/door/airlock/research/glass{
 	name = "Robotics Lab";
 	req_access_txt = "29"
@@ -55208,13 +55175,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
-"fFf" = (
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurple"
-	},
-/area/assembly/robotics)
 "fFl" = (
 /obj/effect/spawner/random_barrier/obstruction,
 /turf/simulated/floor/plating,
@@ -55513,10 +55473,11 @@
 /turf/simulated/floor/wood,
 /area/security/hos)
 "fIC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "whitepurple"
+	},
+/area/toxins/lab)
 "fIE" = (
 /obj/machinery/vending/cart,
 /obj/structure/window/reinforced{
@@ -56156,21 +56117,20 @@
 	},
 /area/medical/medbay2)
 "fQT" = (
-/obj/structure/closet/secure_closet/roboticist,
-/obj/item/radio/headset/headset_sci{
-	pixel_x = -3
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/surgery{
+	pixel_x = -1;
+	pixel_y = 2
 	},
-/obj/machinery/firealarm{
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/item/radio/intercom{
 	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/window/reinforced{
-	dir = 4
+	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (SOUTHWEST)"
+	icon_state = "whiteblue";
+	tag = "icon-whiteblue (SOUTHEAST)"
 	},
 /area/assembly/robotics)
 "fRj" = (
@@ -56846,14 +56806,15 @@
 /turf/simulated/floor/wood,
 /area/security/detectives_office)
 "fXx" = (
-/obj/machinery/status_display{
-	pixel_y = -32
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/optable,
-/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "white"
 	},
 /area/assembly/robotics)
 "fXD" = (
@@ -56984,21 +56945,6 @@
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/storage)
-"fZf" = (
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/assembly/robotics)
 "fZm" = (
 /obj/item/radio/beacon/engine/tesling,
 /turf/simulated/floor/plating/airless,
@@ -57573,10 +57519,9 @@
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
 "gih" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/chair/office/light{
+	dir = 4;
+	pixel_y = 3
 	},
 /obj/effect/landmark/start{
 	name = "Roboticist"
@@ -57646,7 +57591,9 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
 /area/toxins/lab)
 "gkk" = (
@@ -61115,24 +61062,10 @@
 	},
 /area/medical/virology)
 "gVV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research/glass{
-	name = "Robotics Lab";
-	req_access_txt = "29"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/assembly/robotics)
+/area/toxins/lab)
 "gWh" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -62961,6 +62894,12 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/west)
+"hui" = (
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurple"
+	},
+/area/assembly/robotics)
 "hur" = (
 /obj/structure/toilet{
 	desc = "Старый грязный туалет, по какой-то причине стоящий в техах. У вас нет ни единого понятия откуда он здесь.";
@@ -63975,20 +63914,13 @@
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/landmark/start{
 	name = "Roboticist"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurple"
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
 	},
 /area/assembly/robotics)
 "hGs" = (
@@ -64263,20 +64195,6 @@
 	icon_state = "whitepurple"
 	},
 /area/toxins/mixing)
-"hJX" = (
-/obj/effect/decal/warning_stripes/southeastcorner,
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/effect/landmark/start{
-	name = "Roboticist"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTHWEST)"
-	},
-/area/assembly/robotics)
 "hJZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -65425,7 +65343,8 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 5;
+	icon_state = "whitepurple"
 	},
 /area/toxins/lab)
 "hXt" = (
@@ -65856,12 +65775,25 @@
 	},
 /area/chapel/main)
 "idx" = (
-/obj/effect/decal/warning_stripes/north,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/item/storage/box/gloves{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/box/masks,
+/obj/item/storage/box/bodybags{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/tank/internals/anesthetic,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whiteblue"
 	},
 /area/assembly/robotics)
 "idE" = (
@@ -70183,14 +70115,13 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "jhc" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Mech Bay";
-	req_access_txt = "29"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/east,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
@@ -73170,19 +73101,16 @@
 /turf/simulated/floor/plasteel,
 /area/bridge/vip)
 "jRH" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Robotics Maintenance";
-	req_access_txt = "29"
-	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+/obj/effect/decal/warning_stripes/yellow/partial{
+	dir = 1
 	},
-/area/maintenance/asmaint2)
+/turf/simulated/floor/plasteel,
+/area/assembly/chargebay)
 "jRL" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -74240,11 +74168,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -74516,19 +74439,16 @@
 	},
 /area/toxins/explab)
 "klr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/southwest,
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
 /area/assembly/robotics)
 "klv" = (
@@ -75924,7 +75844,23 @@
 	pixel_x = 24;
 	pixel_y = -22
 	},
-/turf/simulated/floor/plasteel,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 26;
+	pixel_y = 4
+	},
+/obj/effect/decal/warning_stripes/yellow/partial{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purple"
+	},
 /area/assembly/chargebay)
 "kCW" = (
 /obj/structure/cable{
@@ -76963,14 +76899,9 @@
 	},
 /area/medical/medbay2)
 "kSR" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whitepurplecorner"
 	},
 /area/toxins/lab)
 "kSU" = (
@@ -78314,18 +78245,16 @@
 	},
 /area/security/permabrig)
 "lmj" = (
-/obj/machinery/r_n_d/circuit_imprinter{
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/glass/beaker/sulphuric,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/table/reinforced,
+/obj/item/mmi,
+/obj/item/mmi,
+/obj/item/mmi,
+/obj/item/mmi/robotic_brain,
+/obj/item/robotanalyzer,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurple"
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
 	},
 /area/assembly/robotics)
 "lmz" = (
@@ -81442,6 +81371,20 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
+"mbg" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Robotics Maintenance";
+	req_access_txt = "29"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/assembly/robotics)
 "mbm" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -82567,7 +82510,9 @@
 	},
 /obj/machinery/disposal,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 9;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTHWEST)"
 	},
 /area/toxins/lab)
 "mnJ" = (
@@ -83812,14 +83757,10 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
 /area/toxins/lab)
 "mAV" = (
@@ -84561,9 +84502,6 @@
 	},
 /area/security/detectives_office)
 "mIZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
 	},
@@ -85861,8 +85799,18 @@
 	dir = 4;
 	pixel_x = -23
 	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -26
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 10;
+	icon_state = "whitepurple"
 	},
 /area/toxins/lab)
 "nab" = (
@@ -85918,7 +85866,11 @@
 	},
 /area/hallway/primary/central/ne)
 "nan" = (
-/obj/structure/reagent_dispensers/oil,
+/obj/machinery/r_n_d/circuit_imprinter{
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/glass/beaker/sulphuric,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
@@ -85927,6 +85879,11 @@
 "naq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -87020,8 +86977,8 @@
 	},
 /area/crew_quarters/fitness)
 "nom" = (
-/obj/machinery/recharge_station,
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/reagent_dispensers/oil,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "purple"
@@ -87589,6 +87546,15 @@
 	icon_state = "neutralfull"
 	},
 /area/maintenance/electrical)
+"ntB" = (
+/mob/living/simple_animal/pet/dog/corgi/borgi,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurplefull"
+	},
+/area/assembly/robotics)
 "ntG" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -88043,14 +88009,9 @@
 /turf/simulated/floor/plating,
 /area/security/execution)
 "nzN" = (
-/obj/effect/decal/warning_stripes/east,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whiteblue"
 	},
 /area/assembly/robotics)
 "nzR" = (
@@ -90360,6 +90321,18 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
+"odX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
+	},
+/area/toxins/lab)
 "oee" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -90405,20 +90378,15 @@
 	},
 /area/chapel/office)
 "ofk" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -26
-	},
 /obj/effect/decal/warning_stripes/southeast,
-/obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/stack/cable_coil/random,
 /obj/item/stack/cable_coil/random,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -90772,7 +90740,9 @@
 	},
 /obj/item/clipboard,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
 	},
 /area/toxins/lab)
 "ohL" = (
@@ -91012,16 +90982,11 @@
 	},
 /area/maintenance/xenozoo)
 "okH" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
@@ -91199,11 +91164,20 @@
 	},
 /area/medical/surgery/south)
 "omU" = (
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurple"
+/obj/machinery/light{
+	dir = 8
 	},
+/obj/effect/decal/warning_stripes/west,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -26
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/mech_bay_recharge_floor,
 /area/assembly/robotics)
 "onj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -93480,8 +93454,12 @@
 	},
 /area/security/main)
 "oNS" = (
-/obj/structure/sign/science,
-/turf/simulated/wall,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/item/robot_parts/robot_suit,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/assembly/robotics)
 "oNV" = (
 /turf/simulated/floor/plasteel{
@@ -94297,7 +94275,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "whitepurplefull"
 	},
 /area/toxins/lab)
 "oYk" = (
@@ -94343,7 +94321,9 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
 	},
 /area/toxins/lab)
 "oYL" = (
@@ -95301,8 +95281,23 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8;
+	initialize_directions = 13
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "purplefull"
+	},
+/area/medical/research/shallway)
 "plJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -96745,8 +96740,17 @@
 	dir = 1;
 	pixel_y = 3
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whitepurplecorner"
 	},
 /area/toxins/lab)
 "pCr" = (
@@ -96776,13 +96780,10 @@
 /turf/simulated/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "pCx" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
 	},
 /area/toxins/lab)
 "pCz" = (
@@ -98867,7 +98868,7 @@
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "whitepurple"
 	},
 /area/toxins/lab)
 "pYL" = (
@@ -100432,35 +100433,6 @@
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/storage)
-"qqe" = (
-/obj/structure/closet,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/stack/sheet/plasteel{
-	amount = 15
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/assembly/robotics)
 "qqA" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -101158,16 +101130,6 @@
 /obj/effect/landmark{
 	name = "JoinLateCyborg"
 	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 26;
-	pixel_y = 4
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "purple"
@@ -101586,7 +101548,8 @@
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 10;
+	icon_state = "whitepurple"
 	},
 /area/toxins/lab)
 "qEC" = (
@@ -101733,7 +101696,7 @@
 	},
 /obj/structure/chair/office/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "whitepurple"
 	},
 /area/toxins/lab)
 "qGf" = (
@@ -102398,15 +102361,33 @@
 /turf/simulated/floor/plating,
 /area/medical/genetics)
 "qNZ" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurplecorner"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
 /area/assembly/robotics)
 "qOh" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research/glass{
+	name = "Robotics Lab";
+	req_access_txt = "29"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/assembly/robotics)
 "qOo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
@@ -104599,30 +104580,11 @@
 	},
 /area/bridge)
 "roU" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/stack/sheet/plasteel{
-	amount = 10
-	},
-/obj/item/stack/cable_coil,
-/obj/item/multitool{
-	pixel_x = 3
-	},
-/obj/item/flash,
-/obj/item/flash,
-/obj/item/flash,
-/obj/item/flash,
-/obj/item/flash,
-/obj/item/flash,
-/obj/structure/sign/poster/random{
-	pixel_x = -32
-	},
-/obj/item/clothing/suit/fire/firefighter,
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurple"
+	dir = 9;
+	icon_state = "whiteblue";
+	tag = "icon-whiteblue (NORTHWEST)"
 	},
 /area/assembly/robotics)
 "roX" = (
@@ -104821,9 +104783,6 @@
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/office)
-"rru" = (
-/turf/simulated/floor/mech_bay_recharge_floor,
-/area/assembly/robotics)
 "rrz" = (
 /turf/simulated/floor/plasteel,
 /area/bridge/vip)
@@ -105481,12 +105440,8 @@
 /turf/simulated/floor/wood,
 /area/maintenance/gambling_den)
 "rzT" = (
-/obj/machinery/mecha_part_fabricator,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/mech_bay_recharge_floor,
 /area/assembly/robotics)
 "rzU" = (
 /turf/simulated/floor/wood,
@@ -106542,7 +106497,6 @@
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
 "rLk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
 	dir = 1;
@@ -106552,7 +106506,6 @@
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
 "rLl" = (
@@ -107214,11 +107167,6 @@
 	on = 1
 	},
 /obj/structure/table/reinforced,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/item/stock_parts/matter_bin{
 	pixel_x = 3;
 	pixel_y = 3
@@ -111933,7 +111881,6 @@
 	},
 /area/engine/engineering)
 "tdA" = (
-/obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id_tag = "RoboPrivat";
 	name = "Robotics Privacy Shutter"
@@ -111942,6 +111889,10 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/assembly/robotics)
 "tdC" = (
@@ -113647,6 +113598,10 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
+"tAb" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/assembly/robotics)
 "tAz" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/ai_status_display{
@@ -114196,13 +114151,14 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "tHC" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plasteel,
-/area/assembly/chargebay)
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/assembly/robotics)
 "tHH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -118187,7 +118143,9 @@
 "uDz" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 6;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (SOUTHEAST)"
 	},
 /area/toxins/lab)
 "uDH" = (
@@ -119262,34 +119220,22 @@
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "uQL" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/glasses/hud/diagnostic{
-	pixel_x = 2;
-	pixel_y = 5
+/obj/machinery/camera{
+	c_tag = "Robotics Lab";
+	dir = 4;
+	network = list("Research","SS13")
 	},
-/obj/item/clothing/glasses/hud/diagnostic{
-	pixel_x = 2;
-	pixel_y = 5
-	},
-/obj/item/clothing/glasses/hud/diagnostic{
-	pixel_x = 2;
-	pixel_y = 5
-	},
-/obj/item/clothing/glasses/welding,
-/obj/item/clothing/glasses/welding,
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
+/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/decal/warning_stripes/west,
+/obj/machinery/requests_console{
+	department = "Robotics";
+	departmentType = 2;
+	name = "Robotics Requests Console";
+	pixel_x = -30
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
 /area/assembly/robotics)
 "uQO" = (
@@ -120246,6 +120192,27 @@
 "vbw" = (
 /turf/simulated/floor/plating,
 /area/maintenance/gambling_den)
+"vbH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurplefull"
+	},
+/area/assembly/robotics)
 "vbJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
@@ -121800,10 +121767,8 @@
 /turf/simulated/floor/plating,
 /area/security/checkpoint/south)
 "vuD" = (
-/obj/effect/decal/warning_stripes/yellow/partial,
-/mob/living/simple_animal/pet/dog/corgi/borgi,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -121811,10 +121776,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/assembly/robotics)
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurplecorner"
+	},
+/area/medical/research/shallway)
 "vuE" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -123394,9 +123361,33 @@
 /turf/simulated/wall/r_wall,
 /area/security/processing)
 "vMV" = (
+/obj/machinery/door_control{
+	id = "RoboPrivat";
+	name = "Robotics Privacy Shutters Control";
+	pixel_x = 24;
+	pixel_y = -6
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/door_control{
+	id = "RoboDesk";
+	name = "Robotics Desc Privacy Shutters Control";
+	pixel_x = 24;
+	pixel_y = 6
+	},
+/obj/structure/table/reinforced,
+/obj/item/book/manual/sop_science,
+/obj/item/clipboard,
+/obj/item/book/manual/robotics_cyborgs{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/toy/figure/roboticist,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurple"
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
 	},
 /area/assembly/robotics)
 "vMY" = (
@@ -123481,24 +123472,42 @@
 	name = "AI Maintenance"
 	})
 "vNU" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id_tag = "RoboDesk";
-	name = "Robotics Privacy Shutter"
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/simulated/floor/plating,
+/obj/machinery/door/airlock/research{
+	name = "Mech Bay";
+	req_access_txt = "29"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/assembly/robotics)
 "vNX" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/securearmory)
 "vNZ" = (
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plasteel{
-	icon_state = "purplefull"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/area/hallway/primary/aft)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurple"
+	},
+/area/assembly/robotics)
 "vOa" = (
 /obj/item/paper_bin{
 	pixel_x = -2;
@@ -124322,6 +124331,28 @@
 	icon_state = "darkred"
 	},
 /area/security/warden)
+"vWr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurplefull"
+	},
+/area/assembly/robotics)
 "vWy" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -125305,26 +125336,16 @@
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
 "wiW" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/assembly/robotics)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "wiY" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/firealarm{
@@ -125355,31 +125376,20 @@
 	},
 /area/engine/break_room)
 "wjc" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	cell_type = 5000;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28;
-	pixel_y = 6
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
+	d1 = 1;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "1-8"
 	},
-/obj/machinery/door_control{
-	id = "RoboPrivat";
-	name = "Robotics Privacy Shutters Control";
-	pixel_x = 24;
-	pixel_y = -9
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurple"
-	},
-/area/assembly/robotics)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "wjh" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/conveyor/south/ccw{
@@ -125709,16 +125719,18 @@
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "wnh" = (
-/obj/structure/closet/wardrobe/robotics_black,
-/obj/item/radio/headset/headset_sci{
-	pixel_x = -3
+/obj/machinery/computer/operating{
+	name = "Robotics Operating Computer"
 	},
-/obj/structure/closet/walllocker/emerglocker{
+/obj/structure/sign/poster/random{
 	pixel_y = -32
 	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whitepurple"
+	icon_state = "whiteblue";
+	tag = "icon-whitehall (WEST)"
 	},
 /area/assembly/robotics)
 "wns" = (
@@ -126066,16 +126078,16 @@
 	},
 /area/crew_quarters/courtroom)
 "wrd" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/disposalpipe/sortjunction{
+	dir = 2;
+	name = "Robotics Junction";
+	sortType = 14
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
 	},
-/turf/simulated/floor/plasteel,
-/area/assembly/chargebay)
+/area/hallway/primary/aft)
 "wrm" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -127571,11 +127583,15 @@
 	},
 /area/medical/sleeper)
 "wJB" = (
-/obj/effect/decal/warning_stripes/west,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -127590,24 +127606,19 @@
 /area/aisat/maintenance{
 	name = "\improper AI Satellite Service"
 	})
-"wJG" = (
+"wJK" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 27
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner"
-	},
-/area/assembly/robotics)
-"wJK" = (
-/obj/machinery/computer/rdconsole/robotics,
-/obj/machinery/requests_console{
-	department = "Robotics";
-	departmentType = 2;
-	name = "Robotics Requests Console";
-	pixel_x = 30
-	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "whitepurple";
-	tag = "icon-whitepurple (SOUTHWEST)"
+	tag = "icon-whitepurple (EAST)"
 	},
 /area/assembly/robotics)
 "wJP" = (
@@ -129188,25 +129199,11 @@
 	},
 /area/library/abandoned)
 "xdb" = (
-/obj/effect/decal/warning_stripes/east,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
 /area/assembly/robotics)
 "xdo" = (
@@ -129410,10 +129407,20 @@
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "xeT" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/machine{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/firstaid/machine{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/storage/firstaid/machine,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	dir = 5;
+	icon_state = "whiteblue";
+	tag = "icon-whiteblue (NORTHEAST)"
 	},
 /area/assembly/robotics)
 "xfd" = (
@@ -129661,17 +129668,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "xhi" = (
-/obj/effect/decal/warning_stripes/west,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -129976,16 +129984,19 @@
 /area/maintenance/bar)
 "xlY" = (
 /obj/machinery/door/window/westleft{
-	dir = 1;
+	dir = 4;
 	name = "Robotic Delivery";
 	req_access_txt = "29"
 	},
 /obj/effect/decal/warning_stripes/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "whitepurplefull"
 	},
 /area/assembly/robotics)
 "xmf" = (
@@ -130597,18 +130608,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
 "xsv" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/robotics_cyborgs{
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/obj/item/clipboard,
-/obj/item/toy/figure/roboticist,
-/obj/machinery/door_control{
-	id = "RoboDesk";
-	name = "Robotics Desc Privacy Shutters Control";
-	pixel_x = 24;
-	pixel_y = 24
+/obj/machinery/computer/rdconsole/robotics,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -131773,30 +131778,33 @@
 /turf/simulated/floor/carpet,
 /area/lawoffice)
 "xDU" = (
-/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/assembly/robotics)
 "xEf" = (
+/obj/item/clothing/suit/fire/firefighter,
+/obj/item/multitool{
+	pixel_x = 3
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/flash,
+/obj/item/flash,
+/obj/item/flash,
+/obj/item/flash,
+/obj/item/flash,
+/obj/item/flash,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/crowbar,
 /obj/structure/table/reinforced,
-/obj/item/storage/firstaid/machine{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/storage/firstaid/machine{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/storage/firstaid/machine,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurple"
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
 	},
 /area/assembly/robotics)
 "xEr" = (
@@ -131852,17 +131860,40 @@
 	},
 /area/hallway/primary/central/west)
 "xFd" = (
-/obj/effect/decal/warning_stripes/north,
-/obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 1
+/obj/structure/closet/wardrobe/robotics_black,
+/obj/item/radio/headset/headset_sci{
+	pixel_x = -3
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4;
-	initialize_directions = 13
+/obj/item/clothing/glasses/hud/diagnostic{
+	pixel_x = 2;
+	pixel_y = 5
 	},
+/obj/item/clothing/glasses/hud/diagnostic{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/item/clothing/glasses/hud/diagnostic{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/storage/belt/utility,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whitepurple"
 	},
 /area/assembly/robotics)
 "xFk" = (
@@ -133032,13 +133063,6 @@
 /turf/simulated/floor/wood,
 /area/blueshield)
 "xQB" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/sop_science,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/storage/belt/utility,
 /obj/item/radio/intercom{
 	dir = 1;
 	pixel_y = 28
@@ -133047,8 +133071,12 @@
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/machinery/mecha_part_fabricator,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
 /area/assembly/robotics)
 "xQE" = (
@@ -133333,29 +133361,36 @@
 	},
 /area/medical/genetics)
 "xUz" = (
-/obj/structure/table/reinforced,
-/obj/item/crowbar,
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
+/obj/structure/closet,
+/obj/item/stack/sheet/metal{
+	amount = 50
 	},
-/obj/item/storage/firstaid/regular{
-	empty = 1;
-	name = "First-Aid (empty)"
+/obj/item/stack/sheet/metal{
+	amount = 50
 	},
-/obj/item/storage/firstaid/regular{
-	empty = 1;
-	name = "First-Aid (empty)"
+/obj/item/stack/sheet/metal{
+	amount = 50
 	},
-/obj/item/storage/firstaid/regular{
-	empty = 1;
-	name = "First-Aid (empty)"
+/obj/item/stack/sheet/metal{
+	amount = 50
 	},
-/obj/item/healthanalyzer,
-/obj/item/healthanalyzer,
-/obj/item/healthanalyzer,
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/stack/sheet/plasteel{
+	amount = 15
+	},
+/obj/item/stack/sheet/plasteel{
+	amount = 10
+	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
 /area/assembly/robotics)
 "xUA" = (
@@ -168828,7 +168863,7 @@ dqb
 jmL
 dqb
 esa
-xDv
+plG
 dvd
 xDv
 hYi
@@ -169084,8 +169119,8 @@ eCO
 xDD
 mEE
 xDD
-anP
 xDD
+vuD
 xDD
 xDD
 mSh
@@ -169340,10 +169375,10 @@ vEo
 tXf
 tXf
 tXf
-qOh
-gVV
-qOh
 tXf
+tAb
+qOh
+tAb
 tXf
 tXf
 ykx
@@ -169585,7 +169620,7 @@ pBD
 pBD
 mnh
 iLA
-oIq
+fIC
 ntS
 vEo
 uhl
@@ -169599,7 +169634,7 @@ xQB
 uQL
 omU
 klr
-fFf
+vbH
 roU
 eri
 wnh
@@ -169840,7 +169875,7 @@ oJF
 mZM
 clb
 ofk
-oIq
+drC
 iLA
 qFV
 oXm
@@ -169853,15 +169888,15 @@ wUw
 lKt
 utT
 xUz
-hJX
 qNZ
+oNS
 xdb
-nzN
+dOG
 nzN
 cbI
-uQV
-jRH
-plG
+cii
+ykx
+fGj
 khf
 aKq
 yjo
@@ -170095,11 +170130,11 @@ xXi
 cRb
 cYB
 pCn
-oIq
 pCx
-oIq
+pCx
+dsu
 oXK
-oIq
+gVV
 poO
 rjs
 dfh
@@ -170113,7 +170148,7 @@ biZ
 drv
 rzT
 dsE
-rru
+dOG
 xeT
 idx
 fQT
@@ -170353,10 +170388,10 @@ cTB
 rTF
 naq
 daC
-kSR
+daC
 daC
 naR
-oIq
+kSR
 qEx
 vEo
 vQY
@@ -170365,17 +170400,17 @@ tjR
 eUq
 dfn
 uIQ
-oNS
+tXf
 dIi
-dzQ
-qqe
-vuD
-dwk
+hui
+hui
+hui
+vNZ
 dvg
 xFd
 xlY
 rLk
-fIC
+fGj
 eGb
 uBY
 lJs
@@ -170624,11 +170659,11 @@ hFn
 wdk
 utT
 nan
-fZf
-drC
+xDU
+xDU
 dsG
-rru
-xeT
+dlU
+ntB
 xDU
 dxu
 ykx
@@ -170865,7 +170900,7 @@ iQQ
 tot
 iVt
 gjV
-oIq
+anP
 cTU
 dkQ
 oIq
@@ -170874,23 +170909,23 @@ rSk
 nIS
 hXg
 sWC
-wrd
+sWC
 rKW
 sWC
-sWC
+jhc
 sWC
 fno
+wJB
 uQV
-dsu
-wJB
-wiW
-wJB
+uQV
+uQV
+vWr
 xhi
-dxv
 fXx
-ykx
-wKr
-kVJ
+fXx
+mbg
+wiW
+wjc
 uBY
 hVe
 ivw
@@ -171125,23 +171160,23 @@ aiF
 oIq
 cUY
 cVs
-oIq
+dzQ
 oYt
-pCx
+odX
 uDz
 rjs
 nom
-tHC
+hFn
 rwB
 sPZ
-hFn
+jRH
 lsc
 dcu
 xsv
 hGm
 vMV
-wjc
-wJG
+xDU
+xDU
 xus
 gih
 dxw
@@ -171396,8 +171431,8 @@ evO
 ykx
 doP
 drN
-vNU
 ykx
+tHC
 wJK
 lmj
 xEf
@@ -171648,16 +171683,16 @@ dfm
 dfm
 sio
 dpY
-jhc
+dfm
 dfm
 ykx
 mJJ
 mIZ
-vNZ
 ykx
+vNU
 ykx
 tdA
-tdA
+boy
 ykx
 ykx
 mhL
@@ -171911,7 +171946,7 @@ xUN
 uRI
 dql
 xHs
-xUN
+wrd
 dim
 xUN
 xUN

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -12589,12 +12589,12 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "boy" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id_tag = "RoboPrivat";
-	name = "Robotics Privacy Shutter"
-	},
 /obj/structure/cable,
 /obj/effect/spawner/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id_tag = "RoboDesk";
+	name = "Robotics Privacy Shutter"
+	},
 /turf/simulated/floor/plating,
 /area/assembly/robotics)
 "boD" = (
@@ -63497,7 +63497,7 @@
 	dir = 9;
 	icon_state = "purple"
 	},
-/area/toxins/lab)
+/area/hallway/primary/aft)
 "hCc" = (
 /obj/machinery/light/spot{
 	dir = 4;
@@ -112002,10 +112002,6 @@
 	},
 /area/engine/engineering)
 "tdA" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id_tag = "RoboPrivat";
-	name = "Robotics Privacy Shutter"
-	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -112014,6 +112010,10 @@
 	icon_state = "2-8"
 	},
 /obj/effect/spawner/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id_tag = "RoboDesk";
+	name = "Robotics Privacy Shutter"
+	},
 /turf/simulated/floor/plating,
 /area/assembly/robotics)
 "tdC" = (
@@ -123466,7 +123466,7 @@
 	id = "RoboPrivat";
 	name = "Robotics Privacy Shutters Control";
 	pixel_x = 24;
-	pixel_y = -6
+	pixel_y = 6
 	},
 /obj/machinery/light{
 	dir = 4
@@ -123475,7 +123475,7 @@
 	id = "RoboDesk";
 	name = "Robotics Desc Privacy Shutters Control";
 	pixel_x = 24;
-	pixel_y = 6
+	pixel_y = -6
 	},
 /obj/structure/table/reinforced,
 /obj/item/book/manual/sop_science,

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -8369,6 +8369,18 @@
 /area/maintenance/fore{
 	name = "Hangar Maintenance"
 	})
+"aQA" = (
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery";
+	dir = 1;
+	location = "Robotics"
+	},
+/turf/simulated/floor/plasteel,
+/area/assembly/robotics)
 "aQF" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -11532,7 +11544,7 @@
 "biZ" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -23328,11 +23340,11 @@
 	},
 /area/maintenance/engrooms)
 "cii" = (
-/obj/machinery/optable,
 /obj/structure/sign/science{
 	pixel_y = -32
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/optable,
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue";
 	tag = "icon-whitehall (WEST)"
@@ -34121,8 +34133,10 @@
 	icon_state = "1-2"
 	},
 /obj/item/storage/belt/utility,
-/obj/item/wrench,
+/obj/item/storage/belt/utility,
 /obj/item/clothing/glasses/welding,
+/obj/item/clothing/glasses/welding,
+/obj/item/wrench,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple";
@@ -36729,7 +36743,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "purplecorner"
 	},
 /area/hallway/primary/aft)
 "dio" = (
@@ -37456,14 +37470,9 @@
 "dkQ" = (
 /obj/effect/decal/warning_stripes/southwest,
 /obj/structure/table/reinforced,
-/obj/item/disk/tech_disk{
-	pixel_x = -6
-	},
-/obj/item/disk/tech_disk{
-	pixel_y = 6
-	},
-/obj/item/disk/tech_disk{
-	pixel_x = 6
+/obj/machinery/recharger{
+	pixel_x = 1;
+	pixel_y = 3
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -37757,10 +37766,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	initialize_directions = 13
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -39097,8 +39107,7 @@
 "dql" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purple"
+	dir = 1
 	},
 /area/hallway/primary/aft)
 "dqq" = (
@@ -39303,14 +39312,6 @@
 	tag = "icon-whitepurple (EAST)"
 	},
 /area/medical/research/nhallway)
-"drv" = (
-/obj/effect/decal/warning_stripes/yellow,
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/assembly/robotics)
 "drC" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -39606,18 +39607,11 @@
 	icon_state = "grimy"
 	},
 /area/crew_quarters/captain/bedroom)
-"dsE" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+"dsG" = (
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
-	},
-/area/assembly/robotics)
-"dsG" = (
-/obj/machinery/atmospherics/unary/vent_scrubber,
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurplefull"
 	},
 /area/assembly/robotics)
 "dsI" = (
@@ -40172,19 +40166,24 @@
 	},
 /area/hallway/primary/central/west)
 "dvg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/closet/secure_closet/roboticist,
-/obj/item/radio/headset/headset_sci{
-	pixel_x = -3
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/machine{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/firstaid/machine{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/storage/firstaid/machine,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurple"
+	dir = 5;
+	icon_state = "whiteblue";
+	tag = "icon-whiteblue (NORTHEAST)"
 	},
 /area/assembly/robotics)
 "dvk" = (
@@ -40753,40 +40752,32 @@
 /area/tcommsat/chamber)
 "dxu" = (
 /obj/effect/decal/warning_stripes/yellow,
-/obj/machinery/status_display{
-	pixel_y = -32
+/obj/machinery/door/window/westleft{
+	dir = 4;
+	name = "Robotic Delivery";
+	req_access_txt = "29"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	dir = 10;
+	icon_state = "whitepurple"
 	},
 /area/assembly/robotics)
 "dxw" = (
-/obj/structure/table/reinforced,
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/item/storage/firstaid/regular{
-	empty = 1;
-	name = "First-Aid (empty)"
-	},
-/obj/item/storage/firstaid/regular{
-	empty = 1;
-	name = "First-Aid (empty)"
-	},
-/obj/item/storage/firstaid/regular{
-	empty = 1;
-	name = "First-Aid (empty)"
-	},
-/obj/item/healthanalyzer,
-/obj/item/healthanalyzer,
-/obj/item/healthanalyzer,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	dir = 8;
+	icon_state = "purplecorner"
 	},
-/area/assembly/robotics)
+/area/hallway/primary/aft)
 "dxx" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -40805,6 +40796,25 @@
 /obj/machinery/light,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 28
+	},
+/obj/item/storage/firstaid/regular{
+	empty = 1;
+	name = "First-Aid (empty)"
+	},
+/obj/item/storage/firstaid/regular{
+	empty = 1;
+	name = "First-Aid (empty)"
+	},
+/obj/item/storage/firstaid/regular{
+	empty = 1;
+	name = "First-Aid (empty)"
+	},
+/obj/item/healthanalyzer,
+/obj/item/healthanalyzer,
+/obj/item/healthanalyzer,
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -43480,10 +43490,10 @@
 	pixel_y = 32
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTHWEST)"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
 /area/assembly/robotics)
 "dIj" = (
@@ -45108,22 +45118,6 @@
 	tag = "icon-whitegreen (NORTHWEST)"
 	},
 /area/medical/virology)
-"dOG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurplefull"
-	},
-/area/assembly/robotics)
 "dOH" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
@@ -55056,7 +55050,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "purplecorner"
 	},
 /area/hallway/primary/aft)
 "fDB" = (
@@ -56143,20 +56137,18 @@
 	},
 /area/medical/medbay2)
 "fQT" = (
+/obj/item/radio/intercom{
+	dir = 1;
+	pixel_y = -28
+	},
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/surgery{
 	pixel_x = -1;
 	pixel_y = 2
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/item/radio/intercom{
-	dir = 1;
-	pixel_y = -28
-	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHEAST)"
+	tag = "icon-whitehall (WEST)"
 	},
 /area/assembly/robotics)
 "fRj" = (
@@ -62924,12 +62916,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/west)
-"hui" = (
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurple"
-	},
-/area/assembly/robotics)
 "hur" = (
 /obj/structure/toilet{
 	desc = "Старый грязный туалет, по какой-то причине стоящий в техах. У вас нет ни единого понятия откуда он здесь.";
@@ -64152,6 +64138,43 @@
 /obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
+"hJt" = (
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/closet/wardrobe/robotics_black,
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/storage/belt/utility,
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/glasses/hud/diagnostic{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/item/clothing/glasses/hud/diagnostic{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/item/clothing/glasses/hud/diagnostic{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/item/radio/headset/headset_sci{
+	pixel_x = -3
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurple"
+	},
+/area/assembly/robotics)
 "hJA" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -65809,25 +65832,11 @@
 	},
 /area/chapel/main)
 "idx" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/gloves{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/storage/box/masks,
-/obj/item/storage/box/bodybags{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/item/tank/internals/anesthetic,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner"
-	},
+/obj/effect/decal/warning_stripes/east,
+/obj/effect/decal/warning_stripes/yellow/partial,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whiteblue"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
 /area/assembly/robotics)
 "idE" = (
@@ -74473,7 +74482,6 @@
 	},
 /area/toxins/explab)
 "klr" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/decal/warning_stripes/southwest,
 /obj/structure/cable{
 	d1 = 1;
@@ -76820,9 +76828,12 @@
 	},
 /area/medical/research/restroom)
 "kQV" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/aft)
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/assembly/robotics)
 "kQW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -76934,9 +76945,14 @@
 /area/medical/medbay2)
 "kSR" = (
 /obj/structure/table/reinforced,
-/obj/machinery/recharger{
-	pixel_x = 1;
-	pixel_y = 3
+/obj/item/disk/tech_disk{
+	pixel_x = -6
+	},
+/obj/item/disk/tech_disk{
+	pixel_x = 6
+	},
+/obj/item/disk/tech_disk{
+	pixel_y = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -78284,11 +78300,12 @@
 /area/security/permabrig)
 "lmj" = (
 /obj/structure/table/reinforced,
-/obj/item/mmi,
-/obj/item/mmi,
-/obj/item/mmi,
 /obj/item/mmi/robotic_brain,
-/obj/item/robotanalyzer,
+/obj/item/multitool{
+	pixel_x = 3
+	},
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurple";
@@ -81410,10 +81427,6 @@
 /turf/space,
 /area/space/nearstation)
 "mbg" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Robotics Maintenance";
-	req_access_txt = "29"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -81421,7 +81434,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/r_wall,
 /area/assembly/robotics)
 "mbm" = (
 /obj/machinery/light/small{
@@ -84539,7 +84552,8 @@
 /area/security/detectives_office)
 "mIZ" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "purplefull"
+	dir = 10;
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft)
 "mJu" = (
@@ -84579,7 +84593,8 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
-	icon_state = "purplefull"
+	dir = 9;
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft)
 "mJK" = (
@@ -85915,10 +85930,11 @@
 	pixel_y = 3
 	},
 /obj/item/reagent_containers/glass/beaker/sulphuric,
+/obj/effect/decal/warning_stripes/northeast,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurple"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
 /area/assembly/robotics)
 "naq" = (
@@ -87539,7 +87555,10 @@
 /area/security/range)
 "nsS" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "purple"
+	},
 /area/hallway/primary/aft)
 "nsT" = (
 /obj/structure/cable/yellow{
@@ -87592,11 +87611,17 @@
 /area/maintenance/electrical)
 "ntB" = (
 /mob/living/simple_animal/pet/dog/corgi/borgi,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/closet/secure_closet/roboticist,
+/obj/item/radio/headset/headset_sci{
+	pixel_x = -3
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplefull"
+	dir = 8;
+	icon_state = "whitepurple"
 	},
 /area/assembly/robotics)
 "ntG" = (
@@ -91220,7 +91245,10 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/mech_bay_recharge_floor,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/assembly/robotics)
 "onj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -91316,6 +91344,13 @@
 	icon_state = "dark"
 	},
 /area/security/permabrig)
+"ooM" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Robotics Maintenance";
+	req_access_txt = "29"
+	},
+/turf/simulated/floor/plating,
+/area/assembly/robotics)
 "ooO" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -93498,7 +93533,6 @@
 	},
 /area/security/main)
 "oNS" = (
-/obj/effect/decal/warning_stripes/yellow,
 /obj/item/robot_parts/robot_suit,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -98981,6 +99015,22 @@
 /obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
+"pZn" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/status_display{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
+	},
+/area/assembly/robotics)
 "pZq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -102445,7 +102495,7 @@
 /turf/simulated/floor/plating,
 /area/medical/genetics)
 "qNZ" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/decal/warning_stripes/yellow/partial,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -104664,7 +104714,9 @@
 	},
 /area/bridge)
 "roU" = (
-/obj/item/twohanded/required/kirbyplants,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "whiteblue";
@@ -105524,8 +105576,10 @@
 /turf/simulated/floor/wood,
 /area/maintenance/gambling_den)
 "rzT" = (
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/mech_bay_recharge_floor,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/assembly/robotics)
 "rzU" = (
 /turf/simulated/floor/wood,
@@ -106579,16 +106633,17 @@
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
 "rLk" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	dir = 1;
-	location = "Robotics"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/yellow,
-/obj/structure/plasticflaps{
-	opacity = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/assembly/robotics)
 "rLl" = (
 /obj/machinery/suit_storage_unit/security/secure,
@@ -108326,7 +108381,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
 /area/hallway/primary/aft)
 "siJ" = (
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -119298,7 +119356,6 @@
 	dir = 4;
 	network = list("Research","SS13")
 	},
-/obj/effect/decal/warning_stripes/yellow,
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/requests_console{
 	department = "Robotics";
@@ -119306,6 +119363,7 @@
 	name = "Robotics Requests Console";
 	pixel_x = -30
 	},
+/obj/effect/decal/warning_stripes/yellow/partial,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -120276,7 +120334,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplefull"
+	icon_state = "white"
 	},
 /area/assembly/robotics)
 "vbJ" = (
@@ -123557,8 +123615,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurple"
+	icon_state = "white"
 	},
 /area/assembly/robotics)
 "vOa" = (
@@ -124393,15 +124450,16 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4;
+	initialize_directions = 13
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
 	},
@@ -125772,14 +125830,14 @@
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "wnh" = (
-/obj/machinery/computer/operating{
-	name = "Robotics Operating Computer"
-	},
 /obj/structure/sign/poster/random{
 	pixel_y = -32
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/light,
+/obj/machinery/computer/operating{
+	name = "Robotics Operating Computer"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "whiteblue";
@@ -126138,7 +126196,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "purplecorner"
 	},
 /area/hallway/primary/aft)
 "wrm" = (
@@ -129255,7 +129313,6 @@
 	},
 /area/library/abandoned)
 "xdb" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -129463,20 +129520,12 @@
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "xeT" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/machine{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8;
+	on = 1
 	},
-/obj/item/storage/firstaid/machine{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/storage/firstaid/machine,
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHEAST)"
+	icon_state = "whitepurplefull"
 	},
 /area/assembly/robotics)
 "xfd" = (
@@ -129735,7 +129784,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8;
+	initialize_directions = 13
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -130039,20 +130091,19 @@
 /turf/simulated/floor/wood,
 /area/maintenance/bar)
 "xlY" = (
-/obj/machinery/door/window/westleft{
-	dir = 4;
-	name = "Robotic Delivery";
-	req_access_txt = "29"
+/obj/structure/table/reinforced,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/item/multitool{
+	pixel_x = 3
 	},
-/obj/effect/decal/warning_stripes/yellow,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+/obj/item/robotanalyzer,
+/obj/item/mmi,
+/obj/item/mmi,
+/obj/item/mmi,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplefull"
+	dir = 6;
+	icon_state = "whiteblue";
+	tag = "icon-whiteblue (SOUTHEAST)"
 	},
 /area/assembly/robotics)
 "xmf" = (
@@ -130861,8 +130912,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "whitepurplefull"
 	},
 /area/assembly/robotics)
 "xut" = (
@@ -131840,9 +131894,6 @@
 /area/assembly/robotics)
 "xEf" = (
 /obj/item/clothing/suit/fire/firefighter,
-/obj/item/multitool{
-	pixel_x = 3
-	},
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = -2;
 	pixel_y = -1
@@ -131853,8 +131904,6 @@
 /obj/item/flash,
 /obj/item/flash,
 /obj/item/flash,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
 /obj/item/crowbar,
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
@@ -131916,40 +131965,26 @@
 	},
 /area/hallway/primary/central/west)
 "xFd" = (
-/obj/structure/closet/wardrobe/robotics_black,
-/obj/item/radio/headset/headset_sci{
-	pixel_x = -3
-	},
-/obj/item/clothing/glasses/hud/diagnostic{
-	pixel_x = 2;
-	pixel_y = 5
-	},
-/obj/item/clothing/glasses/hud/diagnostic{
-	pixel_x = 2;
-	pixel_y = 5
-	},
-/obj/item/clothing/glasses/hud/diagnostic{
-	pixel_x = 2;
-	pixel_y = 5
-	},
-/obj/item/clothing/glasses/welding,
-/obj/item/clothing/glasses/welding,
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/item/storage/belt/utility,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/table/reinforced,
+/obj/item/storage/box/gloves{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/box/masks,
+/obj/item/storage/box/bodybags{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/clothing/mask/breath/medical,
+/obj/item/tank/internals/anesthetic,
+/obj/item/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner"
+	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurple"
+	dir = 4;
+	icon_state = "whiteblue"
 	},
 /area/assembly/robotics)
 "xFk" = (
@@ -135065,7 +135100,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "purplecorner"
 	},
 /area/hallway/primary/aft)
 "ylW" = (
@@ -169947,7 +169982,7 @@ xUz
 qNZ
 oNS
 xdb
-dOG
+vNZ
 nzN
 cbI
 cii
@@ -170201,12 +170236,12 @@ rii
 dnn
 utT
 biZ
-drv
+qNZ
 rzT
-dsE
-dOG
-xeT
-idx
+xdb
+vNZ
+nzN
+xDU
 fQT
 ykx
 wKr
@@ -170458,14 +170493,14 @@ dfn
 uIQ
 tXf
 dIi
-hui
-hui
-hui
+qNZ
+rzT
+xdb
 vNZ
 dvg
 xFd
 xlY
-rLk
+ykx
 fGj
 eGb
 uBY
@@ -170715,14 +170750,14 @@ hFn
 wdk
 utT
 nan
-xDU
-xDU
+idx
+kQV
 dsG
 dlU
 ntB
-xDU
+hJt
 dxu
-ykx
+aQA
 pYt
 kVJ
 uBY
@@ -170974,11 +171009,11 @@ fno
 wJB
 uQV
 uQV
-uQV
+rLk
 vWr
 xhi
 fXx
-fXx
+pZn
 mbg
 wiW
 wjc
@@ -171231,12 +171266,12 @@ dcu
 xsv
 hGm
 vMV
-xDU
+xeT
 xDU
 xus
 gih
-dxw
-ykx
+xDU
+ooM
 fGj
 kVJ
 uBY
@@ -171989,24 +172024,24 @@ xUN
 anP
 ayU
 ayU
+dql
 xHs
-xUN
 dim
 fDj
-kQV
+xHs
 siH
 miw
-kQV
-mCD
-xUN
+xHs
+dxw
+xHs
 uRI
-dql
+xHs
 xHs
 wrd
 dim
-xUN
-xUN
-xUN
+xHs
+xHs
+xHs
 ylQ
 xUN
 xpj

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -4380,11 +4380,15 @@
 	})
 "avZ" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/landmark/start{
-	name = "Cyborg"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/assembly/chargebay)
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
 "awb" = (
 /obj/structure/table,
 /obj/item/storage/box/chemimp{
@@ -23279,6 +23283,9 @@
 /area/security/medbay)
 "chO" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atm{
+	pixel_x = -28
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "purple"
@@ -23888,15 +23895,23 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "clb" = (
-/obj/structure/table/reinforced,
 /obj/item/radio/intercom{
 	dir = 8;
 	pixel_x = -28
 	},
-/obj/effect/decal/warning_stripes/east,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/dropper,
+/obj/effect/decal/warning_stripes/northeast,
+/obj/structure/table/reinforced,
+/obj/item/storage/belt/utility,
+/obj/item/wrench,
+/obj/item/clothing/glasses/welding,
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/stack/sheet/metal{
+	amount = 50;
+	pixel_x = 2;
+	pixel_y = -2
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -30369,14 +30384,21 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "cJT" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/spawner/window/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id_tag = "researchdesk1";
+	name = "Research Desk Shutters";
+	opacity = 0
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/area/medical/research/shallway)
+/turf/simulated/floor/plating,
+/area/toxins/lab)
 "cJY" = (
 /obj/machinery/light/small,
 /obj/structure/closet/radiation,
@@ -32129,13 +32151,7 @@
 	},
 /area/medical/genetics)
 "cRb" = (
-/obj/machinery/autolathe,
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	id = "Autolathe";
-	name = "Autolathe Access";
-	req_access_txt = "47"
-	},
+/obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
 	dir = 2;
@@ -32144,17 +32160,21 @@
 	name = "Research Desk Shutters";
 	opacity = 0
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/door/firedoor,
-/obj/item/stack/sheet/metal{
-	amount = 10
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/item/stack/sheet/glass{
-	amount = 10
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
+/turf/simulated/floor/plating,
 /area/toxins/lab)
 "cRe" = (
 /obj/machinery/door/poddoor/shutters{
@@ -32767,10 +32787,20 @@
 	},
 /area/toxins/xenobiology)
 "cTB" = (
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/effect/spawner/window/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id_tag = "researchdesk1";
+	name = "Research Desk Shutters";
+	opacity = 0
 	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
 /area/toxins/lab)
 "cTE" = (
 /obj/machinery/light/small,
@@ -32847,11 +32877,20 @@
 	},
 /area/hallway/secondary/entry/lounge)
 "cTR" = (
-/obj/effect/decal/warning_stripes/northwest,
-/obj/machinery/computer/rdconsole/core,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id_tag = "researchdesk1";
+	name = "Research Desk Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
 /area/toxins/lab)
 "cTS" = (
 /obj/machinery/computer/monitor{
@@ -32867,15 +32906,13 @@
 	},
 /area/engine/engineering/monitor)
 "cTU" = (
-/obj/effect/decal/warning_stripes/southwest,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/r_n_d/destructive_analyzer{
-	pixel_y = 2
-	},
+/obj/effect/decal/warning_stripes/northwest,
+/obj/machinery/computer/rdconsole/core,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -33141,30 +33178,25 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "cUY" = (
-/obj/effect/decal/warning_stripes/south,
-/obj/effect/landmark/start{
-	name = "Scientist"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/toxins/lab)
 "cUZ" = (
-/obj/machinery/r_n_d/circuit_imprinter{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/glass/beaker/sulphuric,
-/obj/effect/decal/warning_stripes/southeast,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/northeast,
+/obj/machinery/r_n_d/protolathe{
+	pixel_y = 2
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -33199,16 +33231,17 @@
 /area/toxins/xenobiology)
 "cVc" = (
 /obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	icon_state = "shutter0";
-	id_tag = "researchdesk2";
-	name = "Research Desk Shutters";
-	opacity = 0
-	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id_tag = "researchdesk1";
+	name = "Research Desk Shutters";
+	opacity = 0
 	},
 /turf/simulated/floor/plating,
 /area/toxins/lab)
@@ -33251,19 +33284,12 @@
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "cVs" = (
-/obj/machinery/camera{
-	c_tag = "Research and Development";
-	dir = 9;
-	network = list("Research","SS13")
-	},
-/obj/machinery/requests_console{
-	department = "Science";
-	departmentType = 2;
-	name = "Research Request Console";
-	pixel_x = 30
+/obj/effect/decal/warning_stripes/south,
+/obj/effect/landmark/start{
+	name = "Scientist"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "dark"
 	},
 /area/toxins/lab)
 "cVy" = (
@@ -34004,19 +34030,17 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/mrchangs)
 "cYj" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	icon_state = "shutter0";
-	id_tag = "researchdesk2";
-	name = "Research Desk Shutters";
-	opacity = 0
+/obj/machinery/camera{
+	c_tag = "Research and Development";
+	dir = 9;
+	network = list("Research","SS13")
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/photocopier{
+	pixel_y = 5
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/toxins/lab)
 "cYk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -34081,16 +34105,17 @@
 /turf/simulated/wall,
 /area/medical/reception)
 "cYB" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
+/obj/structure/table/reinforced,
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/dropper,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "dark"
 	},
 /area/toxins/lab)
 "cYJ" = (
@@ -34354,11 +34379,6 @@
 	icon_state = "neutralfull"
 	},
 /area/storage/tech)
-"cZr" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "purplefull"
-	},
-/area/hallway/primary/aft)
 "cZt" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -34369,8 +34389,21 @@
 	},
 /area/quartermaster/delivery)
 "cZu" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/toxins/lab)
 "cZw" = (
 /obj/structure/cable{
@@ -34621,53 +34654,25 @@
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "daC" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/warning_stripes/north,
-/obj/item/wrench,
-/obj/item/storage/belt/utility,
-/obj/item/clothing/glasses/welding,
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/stack/sheet/metal{
-	amount = 50;
-	pixel_x = 2;
-	pixel_y = -2
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/toxins/lab)
-"daE" = (
-/obj/machinery/light,
-/obj/machinery/door_control{
-	id = "researchdesk2";
-	name = "Secondary Research Shutters";
-	pixel_x = 8;
-	pixel_y = -26
-	},
-/obj/machinery/door_control{
-	id = "researchdesk1";
-	name = "Primary Research Shutters";
-	pixel_x = -8;
-	pixel_y = -26
-	},
-/obj/machinery/computer/rdconsole/core,
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "white"
 	},
 /area/toxins/lab)
 "daF" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
+	dir = 2;
 	icon_state = "shutter0";
-	id_tag = "researchdesk2";
+	id_tag = "researchdesk1";
 	name = "Research Desk Shutters";
 	opacity = 0
 	},
-/obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/toxins/lab)
 "daN" = (
@@ -35850,12 +35855,11 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "dfh" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
+/obj/effect/decal/warning_stripes/north,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -36179,17 +36183,6 @@
 /area/maintenance/storage{
 	name = "Perma Maintenance"
 	})
-"dgv" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/lab)
 "dgC" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -37437,25 +37430,14 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "dkQ" = (
-/obj/machinery/status_display{
-	pixel_x = -32
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/landmark/start{
-	name = "Cyborg"
-	},
-/turf/simulated/floor/plasteel,
-/area/assembly/chargebay)
-"dkS" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/effect/decal/warning_stripes/southwest,
+/obj/machinery/r_n_d/destructive_analyzer{
+	pixel_y = 2
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "dark"
 	},
-/area/assembly/chargebay)
+/area/toxins/lab)
 "dkX" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plating,
@@ -37722,10 +37704,6 @@
 /area/hallway/primary/port)
 "dlT" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Mech Bay";
-	req_access_txt = "29"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -37737,6 +37715,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "dlY" = (
@@ -38574,19 +38553,13 @@
 /area/maintenance/portsolar)
 "doK" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/landmark/start{
-	name = "Roboticist"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
+/turf/simulated/floor/bluegrid,
 /area/assembly/chargebay)
 "doO" = (
 /obj/structure/cable{
@@ -40833,21 +40806,16 @@
 	},
 /area/assembly/robotics)
 "dxF" = (
-/obj/machinery/door/poddoor/shutters{
-	id_tag = "roboticsshutters";
-	name = "Mech Bay Shutters"
+/obj/effect/decal/warning_stripes/southeast,
+/obj/item/reagent_containers/glass/beaker/sulphuric,
+/obj/machinery/r_n_d/circuit_imprinter{
+	pixel_x = -1;
+	pixel_y = 3
 	},
-/obj/machinery/door_control{
-	id = "roboticsshutters";
-	name = "Mech Bay Door Control";
-	pixel_y = 24;
-	req_access_txt = "29"
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/effect/decal/warning_stripes/east,
-/obj/effect/decal/warning_stripes/west,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/assembly/chargebay)
+/area/toxins/lab)
 "dxG" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -41080,7 +41048,9 @@
 /area/toxins/server)
 "dyI" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/landmark/start{
+	name = "Cyborg"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -50440,6 +50410,9 @@
 	pixel_x = 24;
 	pixel_y = -4
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -28
+	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
@@ -52485,6 +52458,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/gambling_den)
+"eUq" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/bluegrid,
+/area/assembly/chargebay)
 "eUt" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
@@ -56632,12 +56611,6 @@
 	icon_state = "dark"
 	},
 /area/maintenance/asmaint)
-"fVX" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/lab)
 "fWc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -59718,6 +59691,16 @@
 	icon_state = "darkred"
 	},
 /area/security/processing)
+"gHD" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/turf/simulated/floor/bluegrid,
+/area/assembly/chargebay)
 "gHM" = (
 /obj/machinery/door_control{
 	id = "stationawaygate";
@@ -60496,13 +60479,13 @@
 /area/security/permabrig)
 "gOq" = (
 /obj/structure/table/reinforced,
-/obj/item/folder,
-/obj/item/pen,
 /obj/machinery/door/window/southleft{
 	name = "Research Lab Desk";
 	req_access_txt = "47"
 	},
 /obj/machinery/door/window/northleft,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
 	dir = 2;
@@ -60511,8 +60494,6 @@
 	name = "Research Desk Shutters";
 	opacity = 0
 	},
-/obj/effect/decal/warning_stripes/yellow,
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/toxins/lab)
 "gOv" = (
@@ -62939,12 +62920,11 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
-	},
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/recharger{
+	pixel_x = 1;
+	pixel_y = 3
+	},
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "hsU" = (
@@ -69088,6 +69068,10 @@
 	dir = 1;
 	network = list("Research","SS13")
 	},
+/obj/item/radio/intercom{
+	pixel_y = -28
+	},
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
@@ -69357,6 +69341,10 @@
 	},
 /area/maintenance/xenozoo)
 "iVt" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
@@ -69365,10 +69353,6 @@
 	id_tag = "researchdesk1";
 	name = "Research Desk Shutters";
 	opacity = 0
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/toxins/lab)
@@ -69395,6 +69379,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/research/glass{
+	name = "Research and Development";
+	req_access_txt = "47"
+	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -70420,6 +70409,20 @@
 	},
 /turf/simulated/floor/engine,
 /area/toxins/test_chamber)
+"jjG" = (
+/obj/effect/decal/warning_stripes/north,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/assembly/chargebay)
 "jjT" = (
 /obj/machinery/dna_scannernew,
 /obj/structure/cable{
@@ -76796,12 +76799,7 @@
 	},
 /area/turret_protected/ai)
 "kPy" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "kPC" = (
@@ -76996,10 +76994,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (EAST)"
+	icon_state = "white"
 	},
 /area/toxins/lab)
 "kSU" = (
@@ -80087,6 +80084,15 @@
 /obj/structure/shuttle/engine/propulsion,
 /turf/simulated/shuttle/plating,
 /area/shuttle/siberia)
+"lKt" = (
+/obj/effect/decal/warning_stripes/northwest,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/assembly/chargebay)
 "lKE" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -82585,11 +82591,13 @@
 /turf/simulated/wall/r_wall,
 /area/toxins/storage)
 "mnh" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/disposal,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/toxins/lab)
 "mnJ" = (
 /obj/structure/cable{
@@ -83830,9 +83838,15 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/newscaster{
+/obj/machinery/status_display{
 	pixel_y = 32
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -85867,26 +85881,12 @@
 	},
 /area/security/reception)
 "mZM" = (
-/obj/structure/table/reinforced,
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/item/stock_parts/matter_bin{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/micro_laser,
-/obj/effect/decal/warning_stripes/northeast,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/scanning_module,
-/obj/item/stock_parts/capacitor,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "white"
 	},
 /area/toxins/lab)
 "nab" = (
@@ -85949,8 +85949,8 @@
 	},
 /area/assembly/robotics)
 "naq" = (
-/obj/effect/landmark/start{
-	name = "Scientist"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -86018,13 +86018,16 @@
 	},
 /area/security/prison/cell_block/A)
 "naR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -87041,9 +87044,18 @@
 	},
 /area/crew_quarters/fitness)
 "nom" = (
-/obj/effect/decal/warning_stripes/east,
 /obj/effect/landmark{
 	name = "JoinLateCyborg"
+	},
+/obj/effect/decal/warning_stripes/northeast,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 26
 	},
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
@@ -87556,11 +87568,10 @@
 	},
 /area/security/range)
 "nsS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/lab)
+/obj/effect/decal/warning_stripes/arrow,
+/obj/effect/decal/warning_stripes/yellow/partial,
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/aft)
 "nsT" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -87646,16 +87657,22 @@
 	},
 /area/hallway/primary/central/east)
 "ntS" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atm{
-	pixel_x = -28;
-	pixel_y = -30
+/obj/effect/decal/warning_stripes/northwest,
+/obj/structure/table/reinforced,
+/obj/item/toy/figure/scientist,
+/obj/item/disk/tech_disk{
+	pixel_x = -6
+	},
+/obj/item/disk/tech_disk{
+	pixel_y = 6
+	},
+/obj/item/disk/tech_disk{
+	pixel_x = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purplecorner"
+	icon_state = "dark"
 	},
-/area/hallway/primary/aft)
+/area/assembly/chargebay)
 "ntV" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -90420,15 +90437,16 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/structure/table/reinforced,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
 	pixel_x = -26
 	},
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high,
 /obj/effect/decal/warning_stripes/southeast,
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -90770,18 +90788,19 @@
 /turf/simulated/floor/plasteel,
 /area/medical/virology/lab)
 "ohz" = (
-/obj/machinery/ai_status_display{
-	pixel_x = 32
-	},
-/obj/machinery/r_n_d/protolathe{
-	pixel_y = 2
-	},
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/northeast,
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/folder,
+/obj/machinery/newscaster{
+	pixel_x = 30
+	},
+/obj/item/clipboard,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "white"
 	},
 /area/toxins/lab)
 "ohL" = (
@@ -91026,18 +91045,14 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/hologram/holopad{
-	pixel_x = -16
-	},
+/obj/machinery/hologram/holopad,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurplefull"
 	},
 /area/toxins/lab)
 "okI" = (
@@ -92056,6 +92071,10 @@
 	c_tag = "Research Central Hall";
 	dir = 8;
 	network = list("Research","SS13")
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplecorner"
@@ -93095,14 +93114,12 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "oJF" = (
-/obj/machinery/status_display{
-	pixel_y = 32
-	},
-/obj/machinery/photocopier{
-	pixel_y = 5
-	},
+/obj/structure/table/reinforced,
+/obj/effect/decal/warning_stripes/southwest,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "dark"
 	},
 /area/toxins/lab)
 "oJN" = (
@@ -94075,9 +94092,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "oVl" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 28
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -94246,24 +94260,17 @@
 	},
 /area/hallway/primary/starboard/east)
 "oXm" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research/glass{
-	name = "Research and Development";
-	req_access_txt = "47"
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/light,
+/obj/machinery/computer/rdconsole/core,
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/lab)
+/area/assembly/chargebay)
 "oXs" = (
 /obj/structure/closet/secure_closet/scientist,
 /obj/machinery/power/apc{
@@ -94295,13 +94302,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -94313,25 +94320,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/start{
-	name = "Scientist"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -94374,10 +94369,11 @@
 	},
 /area/medical/ward)
 "oYt" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/requests_console{
+	department = "Science";
+	departmentType = 2;
+	name = "Research Request Console";
+	pixel_x = 30
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -95678,14 +95674,14 @@
 	},
 /area/maintenance/electrical)
 "poO" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/r_n_d/protolathe{
+	pixel_x = 1
 	},
-/obj/machinery/disposal,
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "dark"
 	},
-/area/toxins/lab)
+/area/assembly/chargebay)
 "poX" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/manifold/visible/green,
@@ -96775,26 +96771,11 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/mixing)
 "pCn" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/light,
-/obj/effect/decal/warning_stripes/northwest,
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/toy/figure/scientist,
-/obj/item/disk/tech_disk{
-	pixel_x = -6
-	},
-/obj/item/disk/tech_disk{
-	pixel_x = 6
-	},
-/obj/item/disk/tech_disk{
-	pixel_y = 6
+/obj/effect/landmark/start{
+	name = "Scientist"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "white"
 	},
 /area/toxins/lab)
 "pCr" = (
@@ -96824,21 +96805,13 @@
 /turf/simulated/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "pCx" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -6;
-	pixel_y = -30
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 7;
-	pixel_y = -30
-	},
-/obj/machinery/r_n_d/protolathe{
-	pixel_x = 1
-	},
-/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "white"
 	},
 /area/toxins/lab)
 "pCz" = (
@@ -98918,12 +98891,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Mech Bay";
-	req_access_txt = "29"
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "pYL" = (
 /obj/structure/cable{
@@ -99095,6 +99065,12 @@
 /area/security/permabrig)
 "qbx" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/computer/cryopod/robot{
+	pixel_y = 28
+	},
+/obj/machinery/status_display{
+	pixel_x = 32
+	},
 /obj/machinery/cryopod/robot,
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
@@ -101263,16 +101239,15 @@
 /area/security/prison/cell_block/A)
 "qzk" = (
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/machinery/door/airlock/research{
+	name = "Mech Bay";
+	req_access_txt = "29"
+	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "qzl" = (
@@ -101619,17 +101594,13 @@
 	},
 /area/toxins/explab)
 "qEx" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/status_display{
+	pixel_y = -32
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 26
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "qEC" = (
 /turf/simulated/wall,
@@ -101770,13 +101741,18 @@
 	},
 /area/medical/research/nhallway)
 "qFV" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 7;
+	pixel_y = -30
 	},
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -6;
+	pixel_y = -30
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/assembly/chargebay)
 "qGf" = (
 /obj/structure/disposalpipe/segment,
@@ -106526,6 +106502,15 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research/shallway)
+"rKW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/bluegrid,
+/area/assembly/chargebay)
 "rKX" = (
 /obj/structure/closet/fireaxecabinet{
 	pixel_x = 32
@@ -107136,6 +107121,9 @@
 	},
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
+"rSk" = (
+/turf/simulated/wall/r_wall,
+/area/hallway/primary/aft)
 "rSr" = (
 /obj/structure/toilet{
 	dir = 1
@@ -107217,8 +107205,27 @@
 	dir = 1;
 	on = 1
 	},
+/obj/structure/table/reinforced,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/item/stock_parts/matter_bin{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stock_parts/matter_bin,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stock_parts/capacitor,
+/obj/item/stock_parts/scanning_module,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/manipulator,
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "dark"
 	},
 /area/toxins/lab)
 "rTH" = (
@@ -108243,6 +108250,12 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door_control{
+	id = "roboticsshutters";
+	name = "Mech Bay Door Control";
+	pixel_y = 24;
+	req_access_txt = "29"
+	},
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "sip" = (
@@ -108322,11 +108335,13 @@
 	},
 /area/security/customs)
 "sjm" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	initialize_directions = 13
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -110815,6 +110830,12 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/effect/decal/warning_stripes/yellow/partial{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/arrow{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
@@ -110908,6 +110929,16 @@
 	icon_state = "red"
 	},
 /area/security/range)
+"sPE" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 1;
+	name = "Mech Bay";
+	req_access_txt = "29"
+	},
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/assembly/chargebay)
 "sPF" = (
 /obj/machinery/light/small,
 /obj/machinery/camera{
@@ -112409,13 +112440,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	initialize_directions = 13
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
+/turf/simulated/floor/bluegrid,
 /area/assembly/chargebay)
 "tjW" = (
 /obj/structure/cable{
@@ -112749,6 +112778,12 @@
 /area/turret_protected/aisat)
 "tot" = (
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/yellow/partial{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/arrow{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -116455,6 +116490,24 @@
 	icon_state = "neutralcorner"
 	},
 /area/bridge/vip)
+"uhl" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/item/radio/intercom{
+	dir = 1;
+	pixel_y = 28
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/assembly/chargebay)
 "uhI" = (
 /obj/machinery/mass_driver{
 	id_tag = "chapelgun"
@@ -118099,11 +118152,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "uDz" = (
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
+/obj/machinery/door_control{
+	id = "researchdesk1";
+	name = "Primary Research Shutters";
+	pixel_y = -26
 	},
-/area/medical/research/nhallway)
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/assembly/chargebay)
 "uDH" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -120021,10 +120079,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurplecorner"
-	},
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
 /area/medical/research/nhallway)
 "uZv" = (
 /obj/machinery/ai_status_display{
@@ -121103,7 +121159,6 @@
 /area/security/main)
 "vnI" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -121790,23 +121845,30 @@
 	},
 /area/hallway/primary/central/west)
 "vvY" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/door/window/brigdoor{
+	id = "Autolathe";
+	name = "Autolathe Access";
+	req_access_txt = "47"
 	},
-/obj/item/radio/intercom{
-	dir = 1;
-	pixel_y = 28
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id_tag = "researchdesk1";
+	name = "Research Desk Shutters";
+	opacity = 0
 	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -23
+/obj/machinery/door/firedoor,
+/obj/machinery/autolathe,
+/obj/item/stack/sheet/metal{
+	amount = 10
 	},
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/assembly/chargebay)
 "vvZ" = (
 /turf/simulated/floor/plasteel{
@@ -123700,11 +123762,13 @@
 	},
 /area/medical/medbay)
 "vQY" = (
-/obj/machinery/mech_bay_recharge_port{
-	dir = 8
+/obj/effect/decal/warning_stripes/north,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "vRb" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -124852,20 +124916,13 @@
 /turf/simulated/floor/wood,
 /area/maintenance/gambling_den)
 "wcO" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 32
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/computer/cryopod/robot{
-	pixel_y = 28
-	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/wall/r_wall,
 /area/assembly/chargebay)
 "wcP" = (
 /obj/machinery/recharge_station/ert,
@@ -125980,6 +126037,16 @@
 	icon_state = "blue"
 	},
 /area/crew_quarters/courtroom)
+"wrd" = (
+/obj/machinery/mech_bay_recharge_port{
+	dir = 8
+	},
+/obj/machinery/mech_bay_recharge_port{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/northeast,
+/turf/simulated/floor/plating,
+/area/assembly/chargebay)
 "wrm" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -127100,35 +127167,9 @@
 /turf/simulated/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "wEb" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/westleft{
-	name = "Research Lab Desk";
-	req_access_txt = "47"
-	},
-/obj/machinery/door/window/eastleft,
-/obj/item/folder,
-/obj/item/pen,
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	icon_state = "shutter0";
-	id_tag = "researchdesk2";
-	name = "Research Desk Shutters";
-	opacity = 0
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/door/firedoor,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/toxins/lab)
+/area/assembly/chargebay)
 "wEh" = (
 /turf/simulated/wall/r_wall,
 /area/medical/research/restroom)
@@ -133470,9 +133511,11 @@
 	},
 /area/medical/research/restroom)
 "xXi" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/item/radio/intercom{
-	pixel_y = -28
+/obj/effect/decal/warning_stripes/yellow/partial{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/arrow{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
@@ -134600,18 +134643,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "yjq" = (
-/obj/structure/table/reinforced,
-/obj/machinery/status_display{
-	pixel_y = -32
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 28
 	},
-/obj/item/storage/toolbox/mechanical,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "whitepurplecorner"
 	},
-/area/toxins/lab)
+/area/medical/research/shallway)
 "yjv" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -169000,9 +169038,9 @@ rJZ
 mNY
 mHX
 oVl
+yjq
 xDD
 xDD
-cJT
 wOF
 xDD
 xDD
@@ -169255,13 +169293,13 @@ srA
 rsV
 uZs
 iVI
-uDz
+pNO
+vEo
 vEo
 vEo
 rjs
-vEo
 dlT
-vEo
+sPE
 rjs
 vEo
 tXf
@@ -169505,20 +169543,20 @@ gRN
 jQt
 ugy
 iRd
-rot
+pBD
 uEZ
 pBD
 pBD
 pBD
 mnh
-oXm
-cZu
+iLA
+oIq
+ntS
 vEo
-vvY
+uhl
 xcG
-avZ
 die
-dkQ
+qxY
 xcG
 hsS
 tXf
@@ -169762,17 +169800,17 @@ oSZ
 dkn
 iQQ
 sDC
-pBD
+cJT
 oJF
 mZM
 clb
 ofk
-poO
+oIq
 iLA
 pCn
+oXm
 vEo
-qFV
-kaX
+lKt
 kaX
 gha
 kaX
@@ -170018,22 +170056,22 @@ ugy
 oBH
 hnE
 ugy
-iQQ
+xXi
 cRb
+cYB
+pCn
 oIq
-fVX
-nsS
-dgv
-nsS
+pCx
+oIq
 oXK
-daC
-rjs
+oIq
+poO
 kPy
 dfh
 dyI
 sjm
 vnI
-dkS
+dyI
 dnn
 utT
 biZ
@@ -170276,20 +170314,20 @@ qhT
 dkn
 iQQ
 xXi
-pBD
+cTB
 rTF
 naq
-oIq
+daC
 kSR
-oIq
+daC
 naR
-yjq
+oIq
+qEx
 vEo
-kPy
+vQY
 dfn
-wGs
 tjR
-wGs
+eUq
 dfn
 uIQ
 oNS
@@ -170535,16 +170573,16 @@ hyI
 sOE
 pBD
 mAO
-nIS
+cZu
 nGQ
 okH
 nIS
 oYj
-nIS
+nGQ
 pYJ
 qzk
+jjG
 hFn
-wGs
 doK
 wGs
 hFn
@@ -170792,18 +170830,18 @@ iQQ
 tot
 iVt
 gjV
-cTR
+oIq
 cTU
+dkQ
 oIq
 oIq
-oYt
 pCx
+qFV
 vEo
-kPy
 vQY
-wGs
-tjR
-wGs
+wrd
+rKW
+gHD
 krN
 sWC
 fno
@@ -171046,17 +171084,17 @@ ugy
 bJP
 vyT
 ugy
-tot
+avZ
 gOq
 aiF
-cTB
+oIq
 cUY
 cVs
 oIq
-cYB
-daE
+oYt
+pCx
+uDz
 vEo
-qEx
 nom
 tHC
 rwB
@@ -171304,15 +171342,15 @@ qhT
 dkn
 bNH
 wId
-iVt
+cTR
 hXm
 ohz
 cUZ
-pBD
+dxF
 cYj
-wEb
+pBD
 daF
-dfm
+vvY
 wcO
 qbx
 qxY
@@ -171564,15 +171602,15 @@ mDj
 pBD
 cVc
 pBD
-cVc
+daF
 rot
-mJJ
-cZr
-vNZ
+rSk
+rSk
+nsS
+wEb
 dfm
 dfm
 dfm
-dxF
 sio
 dpY
 jhc
@@ -171825,11 +171863,11 @@ xUN
 xUN
 ayU
 chO
-ntS
+xHs
 xUN
 dim
 fDj
-miw
+kQV
 siH
 miw
 kQV

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -2917,11 +2917,15 @@
 /turf/simulated/shuttle/floor,
 /area/shuttle/administration)
 "anP" = (
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atm{
+	pixel_x = -28
 	},
-/area/toxins/lab)
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/aft)
 "anQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -23273,15 +23277,25 @@
 	},
 /area/security/medbay)
 "chO" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atm{
-	pixel_x = -28
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purple"
+	icon_state = "white"
 	},
-/area/hallway/primary/aft)
+/area/toxins/lab)
 "chP" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -23901,21 +23915,13 @@
 	dir = 8;
 	pixel_x = -28
 	},
-/obj/effect/decal/warning_stripes/northeast,
 /obj/structure/table/reinforced,
-/obj/item/storage/belt/utility,
-/obj/item/wrench,
-/obj/item/clothing/glasses/welding,
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/stack/sheet/metal{
-	amount = 50;
-	pixel_x = 2;
-	pixel_y = -2
-	},
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/dropper,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
 	},
 /area/toxins/lab)
 "clj" = (
@@ -34037,20 +34043,13 @@
 	dir = 9;
 	network = list("Research","SS13")
 	},
-/obj/machinery/photocopier{
-	pixel_y = 5
-	},
 /obj/machinery/requests_console{
 	department = "Science";
 	departmentType = 2;
 	name = "Research Request Console";
 	pixel_x = 30
 	},
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (SOUTHEAST)"
-	},
+/turf/simulated/wall/r_wall,
 /area/toxins/lab)
 "cYk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -34116,16 +34115,18 @@
 /area/medical/reception)
 "cYB" = (
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/dropper,
-/obj/effect/decal/warning_stripes/south,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/storage/belt/utility,
+/obj/item/wrench,
+/obj/item/clothing/glasses/welding,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
 /area/toxins/lab)
 "cYJ" = (
@@ -37454,8 +37455,15 @@
 /area/crew_quarters/hor)
 "dkQ" = (
 /obj/effect/decal/warning_stripes/southwest,
-/obj/machinery/r_n_d/destructive_analyzer{
-	pixel_y = 2
+/obj/structure/table/reinforced,
+/obj/item/disk/tech_disk{
+	pixel_x = -6
+	},
+/obj/item/disk/tech_disk{
+	pixel_y = 6
+	},
+/obj/item/disk/tech_disk{
+	pixel_x = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -39306,7 +39314,7 @@
 "drC" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple"
+	icon_state = "whitepurplecorner"
 	},
 /area/toxins/lab)
 "drD" = (
@@ -39553,10 +39561,20 @@
 /turf/space,
 /area/space/nearstation)
 "dsu" = (
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurplecorner"
+/obj/effect/spawner/window/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id_tag = "researchdesk1";
+	name = "Research Desk Shutters";
+	opacity = 0
 	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
 /area/toxins/lab)
 "dsw" = (
 /obj/structure/window/reinforced,
@@ -41293,8 +41311,15 @@
 	name = "Engineering Maintenance"
 	})
 "dzQ" = (
+/obj/machinery/door_control{
+	id = "researchdesk1";
+	name = "Primary Research Shutters";
+	pixel_x = 28
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
 	},
 /area/toxins/lab)
 "dzY" = (
@@ -50384,7 +50409,7 @@
 	pixel_y = -28
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/recharge_station,
+/obj/structure/reagent_dispensers/oil,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "purple"
@@ -55473,9 +55498,10 @@
 /turf/simulated/floor/wood,
 /area/security/hos)
 "fIC" = (
+/obj/machinery/computer/rdconsole/core,
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "whitepurple"
+	icon_state = "dark"
 	},
 /area/toxins/lab)
 "fIE" = (
@@ -61062,8 +61088,12 @@
 	},
 /area/medical/virology)
 "gVV" = (
+/obj/machinery/r_n_d/protolathe{
+	pixel_x = 1
+	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple"
+	icon_state = "dark"
 	},
 /area/toxins/lab)
 "gWh" = (
@@ -63475,15 +63505,13 @@
 /turf/simulated/floor/carpet,
 /area/maintenance/fsmaint)
 "hBX" = (
-/obj/effect/decal/warning_stripes/west,
-/obj/effect/landmark/start{
-	name = "Scientist"
-	},
+/obj/effect/decal/warning_stripes/arrow,
+/obj/effect/decal/warning_stripes/yellow/partial,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutral"
+	dir = 9;
+	icon_state = "purple"
 	},
-/area/toxins/mixing)
+/area/toxins/lab)
 "hCc" = (
 /obj/machinery/light/spot{
 	dir = 4;
@@ -63534,10 +63562,6 @@
 	},
 /area/hydroponics)
 "hCs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
 	initialize_directions = 13
@@ -63554,6 +63578,12 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	name = "Research Junction";
+	sortType = 12;
+	tag = "icon-pipe-j1s (EAST)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -65333,14 +65363,18 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/recharger{
-	pixel_x = 1;
-	pixel_y = 3
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/item/stack/sheet/metal{
+	amount = 20;
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/stack/sheet/glass{
+	amount = 20
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -69304,6 +69338,9 @@
 	req_access_txt = "47"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -73309,9 +73346,6 @@
 	},
 /area/medical/genetics)
 "jTZ" = (
-/obj/effect/landmark/start{
-	name = "Scientist"
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
 	name = "standard air scrubber";
@@ -76899,9 +76933,13 @@
 	},
 /area/medical/medbay2)
 "kSR" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_x = 1;
+	pixel_y = 3
+	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurplecorner"
+	icon_state = "white"
 	},
 /area/toxins/lab)
 "kSU" = (
@@ -82505,9 +82543,7 @@
 /turf/simulated/wall/r_wall,
 /area/toxins/storage)
 "mnh" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
+/obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -84936,10 +84972,6 @@
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "mNY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -84953,6 +84985,9 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
@@ -85795,10 +85830,6 @@
 	},
 /area/security/reception)
 "mZM" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -85808,9 +85839,23 @@
 	name = "west bump";
 	pixel_x = -26
 	},
+/obj/structure/table/reinforced,
+/obj/item/stock_parts/matter_bin{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/capacitor,
+/obj/item/stock_parts/scanning_module,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "whitepurple"
+	dir = 8;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
 	},
 /area/toxins/lab)
 "nab" = (
@@ -86978,7 +87023,7 @@
 /area/crew_quarters/fitness)
 "nom" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/structure/reagent_dispensers/oil,
+/obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "purple"
@@ -87493,7 +87538,7 @@
 	},
 /area/security/range)
 "nsS" = (
-/obj/item/twohanded/required/kirbyplants,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "nsT" = (
@@ -87590,22 +87635,14 @@
 	},
 /area/hallway/primary/central/east)
 "ntS" = (
-/obj/effect/decal/warning_stripes/northwest,
-/obj/structure/table/reinforced,
-/obj/item/toy/figure/scientist,
-/obj/item/disk/tech_disk{
-	pixel_x = -6
-	},
-/obj/item/disk/tech_disk{
-	pixel_y = 6
-	},
-/obj/item/disk/tech_disk{
-	pixel_x = 6
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -26
 	},
+/obj/machinery/r_n_d/destructive_analyzer{
+	pixel_y = 2
+	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -90377,7 +90414,6 @@
 	},
 /area/chapel/office)
 "ofk" = (
-/obj/effect/decal/warning_stripes/southeast,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/stack/cable_coil/random,
 /obj/item/stack/cable_coil/random,
@@ -90386,8 +90422,18 @@
 	pixel_x = -23
 	},
 /obj/structure/table/reinforced,
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/stack/sheet/metal{
+	amount = 50;
+	pixel_x = 2;
+	pixel_y = -2
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
 	},
 /area/toxins/lab)
 "ofn" = (
@@ -90733,11 +90779,9 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/item/folder,
 /obj/machinery/newscaster{
 	pixel_x = 30
 	},
-/obj/item/clipboard,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurple";
@@ -93060,11 +93104,12 @@
 /area/hallway/secondary/exit)
 "oJF" = (
 /obj/structure/table/reinforced,
-/obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 9;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTHWEST)"
 	},
 /area/toxins/lab)
 "oJN" = (
@@ -94210,8 +94255,7 @@
 /area/hallway/primary/starboard/east)
 "oXm" = (
 /obj/machinery/light,
-/obj/machinery/computer/rdconsole/core,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -94314,11 +94358,7 @@
 	},
 /area/medical/ward)
 "oYt" = (
-/obj/machinery/door_control{
-	id = "researchdesk1";
-	name = "Primary Research Shutters";
-	pixel_x = 28
-	},
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurple";
@@ -95635,10 +95675,12 @@
 	},
 /area/maintenance/electrical)
 "poO" = (
-/obj/machinery/r_n_d/protolathe{
-	pixel_x = 1
+/obj/machinery/r_n_d/circuit_imprinter{
+	pixel_x = -1;
+	pixel_y = 3
 	},
-/obj/effect/decal/warning_stripes/northeast,
+/obj/item/reagent_containers/glass/beaker/sulphuric,
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -96538,6 +96580,10 @@
 	dir = 1;
 	on = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
@@ -96748,8 +96794,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurplecorner"
+	icon_state = "white"
 	},
 /area/toxins/lab)
 "pCr" = (
@@ -96779,11 +96824,36 @@
 /turf/simulated/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "pCx" = (
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/brigdoor{
+	id = "Autolathe";
+	name = "Autolathe Access";
+	req_access_txt = "47"
 	},
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
+/obj/item/stack/sheet/metal{
+	amount = 10
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/autolathe,
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id_tag = "researchdesk1";
+	name = "Research Desk Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
 /area/toxins/lab)
 "pCz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -98490,6 +98560,9 @@
 /obj/structure/chair/office/light{
 	dir = 8
 	},
+/obj/effect/landmark/start{
+	name = "Scientist"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -98865,6 +98938,12 @@
 	name = "Emergency NanoMed";
 	pixel_x = 7;
 	pixel_y = -30
+	},
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Scientist"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
@@ -101129,6 +101208,7 @@
 /obj/effect/landmark{
 	name = "JoinLateCyborg"
 	},
+/obj/effect/decal/warning_stripes/yellow/partial,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "purple"
@@ -101545,9 +101625,11 @@
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
-/obj/item/twohanded/required/kirbyplants,
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/folder,
+/obj/item/toy/figure/scientist,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "whitepurple"
 	},
 /area/toxins/lab)
@@ -101693,9 +101775,12 @@
 /obj/effect/landmark/start{
 	name = "Scientist"
 	},
-/obj/structure/chair/office/light,
+/obj/effect/decal/warning_stripes/north,
+/obj/structure/chair/office/light{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple"
+	icon_state = "dark"
 	},
 /area/toxins/lab)
 "qGf" = (
@@ -104559,9 +104644,9 @@
 	},
 /area/hallway/primary/central/east)
 "rot" = (
-/obj/structure/sign/science,
-/turf/simulated/wall/r_wall,
-/area/toxins/lab)
+/obj/effect/decal/warning_stripes/yellow/partial,
+/turf/simulated/floor/plasteel,
+/area/assembly/chargebay)
 "roC" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -106364,11 +106449,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 1;
-	name = "Research Junction";
-	sortType = 12;
-	tag = "icon-pipe-j1s (EAST)"
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -107165,22 +107248,13 @@
 	dir = 1;
 	on = 1
 	},
-/obj/structure/table/reinforced,
-/obj/item/stock_parts/matter_bin{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/machinery/photocopier{
+	pixel_y = 5
 	},
-/obj/item/stock_parts/matter_bin,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stock_parts/capacitor,
-/obj/item/stock_parts/scanning_module,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/manipulator,
-/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
 /area/toxins/lab)
 "rTH" = (
@@ -118141,10 +118215,10 @@
 /area/maintenance/fsmaint)
 "uDz" = (
 /obj/machinery/light,
+/obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (SOUTHEAST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/lab)
 "uDH" = (
@@ -120046,13 +120120,6 @@
 	tag = "icon-whitehall (WEST)"
 	},
 /area/medical/ward)
-"uZs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/toxins/lab)
 "uZv" = (
 /obj/machinery/ai_status_display{
 	pixel_y = 32
@@ -121835,11 +121902,7 @@
 	},
 /area/hallway/primary/central/west)
 "vvY" = (
-/obj/machinery/door/window/brigdoor{
-	id = "Autolathe";
-	name = "Autolathe Access";
-	req_access_txt = "47"
-	},
+/obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
 	dir = 2;
@@ -121848,17 +121911,8 @@
 	name = "Research Desk Shutters";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/autolathe,
-/obj/item/stack/sheet/metal{
-	amount = 10
-	},
-/obj/item/stack/sheet/glass{
-	amount = 10
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
+/obj/structure/cable,
+/turf/simulated/floor/plating,
 /area/toxins/lab)
 "vvZ" = (
 /turf/simulated/floor/plasteel{
@@ -127207,8 +127261,11 @@
 /turf/simulated/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "wEb" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "purple"
+	},
 /area/hallway/primary/aft)
 "wEh" = (
 /turf/simulated/wall/r_wall,
@@ -165261,7 +165318,7 @@ jTZ
 oDB
 oDB
 vsA
-hBX
+dkF
 iKy
 oDB
 iqD
@@ -169360,7 +169417,7 @@ oEk
 cKr
 srA
 rsV
-uZs
+qzk
 iVI
 qzk
 sdu
@@ -169618,7 +169675,7 @@ pBD
 pBD
 pBD
 mnh
-iLA
+chO
 fIC
 ntS
 vEo
@@ -170129,9 +170186,9 @@ xXi
 cRb
 cYB
 pCn
-pCx
-pCx
-dsu
+oIq
+oIq
+oIq
 oXK
 gVV
 poO
@@ -170899,7 +170956,7 @@ iQQ
 tot
 iVt
 gjV
-anP
+oIq
 cTU
 dkQ
 oIq
@@ -171165,7 +171222,7 @@ odX
 uDz
 rjs
 nom
-hFn
+rot
 rwB
 sPZ
 jRH
@@ -171417,8 +171474,8 @@ ohz
 cUZ
 dxF
 cYj
-pBD
-daF
+dsu
+pCx
 vvY
 wcO
 qbx
@@ -171672,9 +171729,9 @@ pBD
 cVc
 pBD
 daF
-rot
 pBD
 pBD
+hBX
 nsS
 wEb
 dfm
@@ -171929,9 +171986,9 @@ lZA
 xUN
 mCD
 xUN
-xUN
+anP
 ayU
-chO
+ayU
 xHs
 xUN
 dim

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -34038,6 +34038,12 @@
 /obj/machinery/photocopier{
 	pixel_y = 5
 	},
+/obj/machinery/requests_console{
+	department = "Science";
+	departmentType = 2;
+	name = "Research Request Console";
+	pixel_x = 30
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -35018,6 +35024,15 @@
 	icon_state = "dark"
 	},
 /area/security/permabrig)
+"dcu" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "RoboPrivat";
+	name = "Robotics Privacy Shutter"
+	},
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/assembly/robotics)
 "dcw" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/vending/wallmed{
@@ -35855,16 +35870,11 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "dfh" = (
-/obj/effect/decal/warning_stripes/north,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/mech_bay_recharge_port{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plating,
 /area/assembly/chargebay)
 "dfj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -35891,8 +35901,10 @@
 /turf/simulated/wall/r_wall,
 /area/assembly/chargebay)
 "dfn" = (
-/obj/machinery/computer/mech_bay_power_console,
-/turf/simulated/floor/bluegrid,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "purple"
+	},
 /area/assembly/chargebay)
 "dfo" = (
 /obj/structure/window/reinforced{
@@ -36665,7 +36677,6 @@
 	pixel_x = -24;
 	pixel_y = 24
 	},
-/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -36677,7 +36688,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purple"
+	},
 /area/assembly/chargebay)
 "dil" = (
 /obj/structure/cable{
@@ -37715,8 +37729,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purple"
+	},
 /area/assembly/chargebay)
 "dlY" = (
 /obj/structure/table/reinforced,
@@ -38161,13 +38177,11 @@
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
 "dnn" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/decal/warning_stripes/east,
+/obj/machinery/mech_bay_recharge_port{
+	dir = 8
 	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
 /area/assembly/chargebay)
 "dns" = (
 /turf/simulated/floor/plasteel{
@@ -38552,14 +38566,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
 "doK" = (
-/obj/machinery/hologram/holopad,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	initialize_directions = 13
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/bluegrid,
+/turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "doO" = (
 /obj/structure/cable{
@@ -41047,14 +41066,8 @@
 	},
 /area/toxins/server)
 "dyI" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/landmark/start{
-	name = "Cyborg"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
+/obj/effect/decal/warning_stripes/southeast,
+/turf/simulated/floor/bluegrid,
 /area/assembly/chargebay)
 "dza" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -50290,15 +50303,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
-"etO" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
-/area/assembly/chargebay)
 "etQ" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -50413,8 +50417,14 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -28
 	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "purple"
+	},
 /area/assembly/chargebay)
 "evQ" = (
 /obj/structure/table,
@@ -52459,10 +52469,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/gambling_den)
 "eUq" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "purplecorner"
 	},
-/turf/simulated/floor/bluegrid,
 /area/assembly/chargebay)
 "eUt" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -53856,11 +53866,11 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/unres,
 /obj/machinery/door/airlock/research/glass{
 	name = "Robotics Lab";
 	req_access_txt = "29"
 	},
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
 "fnq" = (
@@ -57496,26 +57506,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/medical/virology)
-"gha" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/warning_stripes/west,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/assembly/chargebay)
 "ghg" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small{
@@ -59691,16 +59681,6 @@
 	icon_state = "darkred"
 	},
 /area/security/processing)
-"gHD" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
-/turf/simulated/floor/bluegrid,
-/area/assembly/chargebay)
 "gHM" = (
 /obj/machinery/door_control{
 	id = "stationawaygate";
@@ -62916,16 +62896,11 @@
 	},
 /area/atmos)
 "hsS" = (
-/obj/structure/table,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/recharger{
-	pixel_x = 1;
-	pixel_y = 3
-	},
-/turf/simulated/floor/plasteel,
+/obj/machinery/computer/mech_bay_power_console,
+/turf/simulated/floor/bluegrid,
 /area/assembly/chargebay)
 "hsU" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -63944,7 +63919,7 @@
 	},
 /area/hallway/primary/central/nw)
 "hFn" = (
-/turf/simulated/floor/mech_bay_recharge_floor,
+/turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "hFv" = (
 /obj/effect/decal/warning_stripes/west{
@@ -65420,6 +65395,19 @@
 	icon_state = "white"
 	},
 /area/security/medbay)
+"hXg" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/research{
+	name = "Mech Bay";
+	req_access_txt = "29"
+	},
+/turf/simulated/floor/plasteel,
+/area/assembly/chargebay)
 "hXm" = (
 /obj/structure/table,
 /obj/structure/cable{
@@ -69387,7 +69375,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/medical/research/nhallway)
+/area/toxins/lab)
 "iVJ" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -70410,18 +70398,14 @@
 /turf/simulated/floor/engine,
 /area/toxins/test_chamber)
 "jjG" = (
-/obj/effect/decal/warning_stripes/north,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/landmark/start{
+	name = "Cyborg"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purple"
 	},
-/turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "jjT" = (
 /obj/machinery/dna_scannernew,
@@ -73916,15 +73900,6 @@
 	icon_state = "dark"
 	},
 /area/crew_quarters/courtroom)
-"kaX" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/assembly/chargebay)
 "kbT" = (
 /obj/structure/chair,
 /obj/structure/cable{
@@ -74323,6 +74298,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "khY" = (
@@ -75187,13 +75163,6 @@
 	icon_state = "red"
 	},
 /area/security/processing)
-"krN" = (
-/obj/machinery/mech_bay_recharge_port{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/southeast,
-/turf/simulated/floor/plating,
-/area/assembly/chargebay)
 "krY" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
@@ -75955,7 +75924,6 @@
 	pixel_x = 24;
 	pixel_y = -22
 	},
-/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "kCW" = (
@@ -76799,9 +76767,15 @@
 	},
 /area/turret_protected/ai)
 "kPy" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plasteel,
-/area/assembly/chargebay)
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/lab)
 "kPC" = (
 /obj/item/shard{
 	icon_state = "medium";
@@ -78818,8 +78792,11 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "lsc" = (
-/obj/effect/decal/warning_stripes/southeast,
-/turf/simulated/floor/plasteel,
+/obj/machinery/recharge_station,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel{
+	icon_state = "purple"
+	},
 /area/assembly/chargebay)
 "lsh" = (
 /turf/simulated/floor/plating,
@@ -80085,13 +80062,7 @@
 /turf/simulated/shuttle/plating,
 /area/shuttle/siberia)
 "lKt" = (
-/obj/effect/decal/warning_stripes/northwest,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/mech_bay_recharge_floor,
 /area/assembly/chargebay)
 "lKE" = (
 /obj/structure/cable{
@@ -85108,6 +85079,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/ntrep)
+"mOV" = (
+/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel,
+/area/assembly/chargebay)
 "mPs" = (
 /obj/machinery/power/rad_collector{
 	anchored = 1
@@ -87044,20 +87020,12 @@
 	},
 /area/crew_quarters/fitness)
 "nom" = (
-/obj/effect/landmark{
-	name = "JoinLateCyborg"
-	},
-/obj/effect/decal/warning_stripes/northeast,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
+/obj/machinery/recharge_station,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel{
 	dir = 1;
-	name = "north bump";
-	pixel_y = 26
+	icon_state = "purple"
 	},
-/turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "nop" = (
 /obj/machinery/light,
@@ -87669,10 +87637,14 @@
 /obj/item/disk/tech_disk{
 	pixel_x = 6
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/assembly/chargebay)
+/area/toxins/lab)
 "ntV" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -94260,17 +94232,13 @@
 	},
 /area/hallway/primary/starboard/east)
 "oXm" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/machinery/light,
 /obj/machinery/computer/rdconsole/core,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/assembly/chargebay)
+/area/toxins/lab)
 "oXs" = (
 /obj/structure/closet/secure_closet/scientist,
 /obj/machinery/power/apc{
@@ -94316,14 +94284,14 @@
 /area/toxins/lab)
 "oYj" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	d1 = 2;
+	d1 = 1;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -94369,11 +94337,10 @@
 	},
 /area/medical/ward)
 "oYt" = (
-/obj/machinery/requests_console{
-	department = "Science";
-	departmentType = 2;
-	name = "Research Request Console";
-	pixel_x = 30
+/obj/machinery/door_control{
+	id = "researchdesk1";
+	name = "Primary Research Shutters";
+	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -95681,7 +95648,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/assembly/chargebay)
+/area/toxins/lab)
 "poX" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/manifold/visible/green,
@@ -96773,6 +96740,10 @@
 "pCn" = (
 /obj/effect/landmark/start{
 	name = "Scientist"
+	},
+/obj/structure/chair/office/light{
+	dir = 1;
+	pixel_y = 3
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -98886,15 +98857,19 @@
 	},
 /area/security/brig)
 "pYJ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -6;
+	pixel_y = -30
+	},
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 7;
+	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/assembly/chargebay)
+/area/toxins/lab)
 "pYL" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -99072,7 +99047,13 @@
 	pixel_x = 32
 	},
 /obj/machinery/cryopod/robot,
-/turf/simulated/floor/plasteel,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "purple"
+	},
 /area/assembly/chargebay)
 "qbE" = (
 /obj/structure/window/reinforced{
@@ -101174,8 +101155,23 @@
 /turf/simulated/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "qxY" = (
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
+/obj/effect/landmark{
+	name = "JoinLateCyborg"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 26;
+	pixel_y = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purple"
+	},
 /area/assembly/chargebay)
 "qyg" = (
 /obj/machinery/teleport/station,
@@ -101238,18 +101234,9 @@
 	},
 /area/security/prison/cell_block/A)
 "qzk" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/research{
-	name = "Mech Bay";
-	req_access_txt = "29"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/assembly/chargebay)
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/toxins/lab)
 "qzl" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
@@ -101601,7 +101588,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/assembly/chargebay)
+/area/toxins/lab)
 "qEC" = (
 /turf/simulated/wall,
 /area/crew_quarters/fitness)
@@ -101741,19 +101728,14 @@
 	},
 /area/medical/research/nhallway)
 "qFV" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 7;
-	pixel_y = -30
+/obj/effect/landmark/start{
+	name = "Scientist"
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -6;
-	pixel_y = -30
-	},
+/obj/structure/chair/office/light,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/assembly/chargebay)
+/area/toxins/lab)
 "qGf" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -104096,6 +104078,10 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
+"rii" = (
+/obj/effect/decal/warning_stripes/northeast,
+/turf/simulated/floor/bluegrid,
+/area/assembly/chargebay)
 "riA" = (
 /obj/structure/chair/comfy/teal,
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -105175,12 +105161,11 @@
 	},
 /area/maintenance/electrical)
 "rwB" = (
-/obj/effect/decal/warning_stripes/east,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
@@ -106506,10 +106491,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/bluegrid,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "rKX" = (
 /obj/structure/closet/fireaxecabinet{
@@ -107122,8 +107118,20 @@
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "rSk" = (
-/turf/simulated/wall/r_wall,
-/area/hallway/primary/aft)
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/lab)
 "rSr" = (
 /obj/structure/toilet{
 	dir = 1
@@ -107913,6 +107921,9 @@
 	icon_state = "yellowfull"
 	},
 /area/maintenance/electrical)
+"sdu" = (
+/turf/simulated/wall,
+/area/toxins/lab)
 "sdz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -108335,16 +108346,20 @@
 	},
 /area/security/customs)
 "sjm" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	dir = 1;
+	icon_state = "purple"
 	},
 /area/assembly/chargebay)
 "sjs" = (
@@ -110936,8 +110951,9 @@
 	name = "Mech Bay";
 	req_access_txt = "29"
 	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "purple"
+	},
 /area/assembly/chargebay)
 "sPF" = (
 /obj/machinery/light/small,
@@ -110987,6 +111003,16 @@
 	icon_state = "dark"
 	},
 /area/bridge)
+"sPZ" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/assembly/chargebay)
 "sQd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -111459,11 +111485,10 @@
 /area/lawoffice)
 "sWC" = (
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "sWN" = (
@@ -112437,14 +112462,21 @@
 	},
 /area/crew_quarters/captain/bedroom)
 "tjR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	initialize_directions = 13
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/bluegrid,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purplecorner"
+	},
 /area/assembly/chargebay)
 "tjW" = (
 /obj/structure/cable{
@@ -114164,7 +114196,11 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "tHC" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "tHH" = (
@@ -116495,10 +116531,6 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high,
-/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/radio/intercom{
 	dir = 1;
 	pixel_y = 28
@@ -116506,7 +116538,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/obj/machinery/computer/mech_bay_power_console,
+/turf/simulated/floor/bluegrid,
 /area/assembly/chargebay)
 "uhI" = (
 /obj/machinery/mass_driver{
@@ -118152,16 +118185,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "uDz" = (
-/obj/machinery/door_control{
-	id = "researchdesk1";
-	name = "Primary Research Shutters";
-	pixel_y = -26
-	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/assembly/chargebay)
+/area/toxins/lab)
 "uDH" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -118609,18 +118637,16 @@
 	},
 /area/crew_quarters/chief)
 "uIQ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/camera{
 	c_tag = "Mech Lab";
 	dir = 1;
 	network = list("Research","SS13")
 	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "purple"
+	},
 /area/assembly/chargebay)
 "uIT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -120081,7 +120107,7 @@
 	},
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/medical/research/nhallway)
+/area/toxins/lab)
 "uZv" = (
 /obj/machinery/ai_status_display{
 	pixel_y = 32
@@ -121158,10 +121184,8 @@
 	},
 /area/security/main)
 "vnI" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "purple"
 	},
 /area/assembly/chargebay)
 "vnQ" = (
@@ -121869,7 +121893,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/assembly/chargebay)
+/area/toxins/lab)
 "vvZ" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -123762,13 +123786,11 @@
 	},
 /area/medical/medbay)
 "vQY" = (
-/obj/effect/decal/warning_stripes/north,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "purple"
 	},
-/turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "vRb" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -124916,9 +124938,6 @@
 /turf/simulated/floor/wood,
 /area/maintenance/gambling_den)
 "wcO" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 32
 	},
@@ -124946,6 +124965,15 @@
 	icon_state = "chapel"
 	},
 /area/chapel/main)
+"wdk" = (
+/obj/effect/landmark/start{
+	name = "Cyborg"
+	},
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel{
+	icon_state = "purple"
+	},
+/area/assembly/chargebay)
 "wds" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
@@ -126038,14 +126066,15 @@
 	},
 /area/crew_quarters/courtroom)
 "wrd" = (
-/obj/machinery/mech_bay_recharge_port{
-	dir = 8
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/mech_bay_recharge_port{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "wrm" = (
 /obj/structure/cable{
@@ -127169,7 +127198,7 @@
 "wEb" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/assembly/chargebay)
+/area/hallway/primary/aft)
 "wEh" = (
 /turf/simulated/wall/r_wall,
 /area/medical/research/restroom)
@@ -127364,7 +127393,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "wGs" = (
-/turf/simulated/floor/bluegrid,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "wGH" = (
 /obj/structure/cable{
@@ -128501,6 +128533,10 @@
 /obj/item/stack/tape_roll,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
+"wUw" = (
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/bluegrid,
+/area/assembly/chargebay)
 "wUB" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -129126,9 +129162,8 @@
 	parallax_movedir = 2
 	})
 "xcG" = (
-/obj/machinery/recharge_station,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/bluegrid,
 /area/assembly/chargebay)
 "xcU" = (
 /obj/structure/cable{
@@ -169293,8 +169328,8 @@ srA
 rsV
 uZs
 iVI
-pNO
-vEo
+qzk
+sdu
 vEo
 vEo
 rjs
@@ -169556,8 +169591,8 @@ vEo
 uhl
 xcG
 die
-qxY
-xcG
+vnI
+wUw
 hsS
 tXf
 xQB
@@ -169807,15 +169842,15 @@ clb
 ofk
 oIq
 iLA
-pCn
+qFV
 oXm
-vEo
+rjs
 lKt
-kaX
-gha
-kaX
-kaX
-etO
+xcG
+sjm
+vnI
+wUw
+lKt
 utT
 xUz
 hJX
@@ -170066,12 +170101,12 @@ oIq
 oXK
 oIq
 poO
-kPy
+rjs
 dfh
 dyI
 sjm
 vnI
-dyI
+rii
 dnn
 utT
 biZ
@@ -170578,15 +170613,15 @@ nGQ
 okH
 nIS
 oYj
-nGQ
+oIq
 pYJ
-qzk
+vEo
 jjG
 hFn
 doK
 wGs
 hFn
-dnn
+wdk
 utT
 nan
 fZf
@@ -170834,15 +170869,15 @@ oIq
 cTU
 dkQ
 oIq
-oIq
-pCx
-qFV
-vEo
-vQY
+kPy
+rSk
+nIS
+hXg
+sWC
 wrd
 rKW
-gHD
-krN
+sWC
+sWC
 sWC
 fno
 uQV
@@ -171094,14 +171129,14 @@ oIq
 oYt
 pCx
 uDz
-vEo
+rjs
 nom
 tHC
 rwB
-tHC
-tHC
+sPZ
+hFn
 lsc
-utT
+dcu
 xsv
 hGm
 vMV
@@ -171355,7 +171390,7 @@ wcO
 qbx
 qxY
 khT
-qxY
+mOV
 kCV
 evO
 ykx
@@ -171604,8 +171639,8 @@ cVc
 pBD
 daF
 rot
-rSk
-rSk
+pBD
+pBD
 nsS
 wEb
 dfm

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -2923,7 +2923,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "purplecorner"
 	},
 /area/hallway/primary/aft)
 "anQ" = (
@@ -81313,7 +81313,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "purplecorner"
 	},
 /area/hallway/primary/aft)
 "lZU" = (
@@ -84001,16 +84001,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
-"mCD" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/aft)
 "mCK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
@@ -172015,14 +172005,14 @@ xUN
 xUN
 xQG
 xUN
-xUN
-xUN
+xHs
+xHs
 lZA
-xUN
-mCD
-xUN
+xHs
+dxw
+xHs
 anP
-ayU
+xHs
 ayU
 dql
 xHs


### PR DESCRIPTION
_По итогам второго этапа закрытого голосования среди админ состава проект публикуется._
**Цель изменений**
1. Решить проблему второго окна приемной, которым по сути не пользовались
2. Реорганизовать работу приемной РНД на зону исследования и зону обслуживания
3. Реорганизовать местоположение ключевых элементов на рабочих местах, из-за излишней громоздкости. 
4. Решить вопрос с посещением отдела робототехники для персонала Не отдела РнД, исключающий транзит через ангар мехов.
5. Визуально разделить рабочие места в отделе робототехники, особенно зону для хирургии.
6. Изменить размеры помещений в соответствии с их значимостью и актуальностью. 
**Список изменений**
1. Изменен размер ангара для мехов (стал меньше) и приемной РнД (стала больше)
2. Приемная РНД
2.1. Убрано второе окно для приема посетителей из-за своей неэффективности.
2.2. Оставшееся окно приема РнД снабжено всем необходимым для быстрой и комфортной работы персонала, в том числе создана разметка для ожидания, которая поможет перенаправить очередь вдоль стены.
2.3. Протолат приемной перенесен вглубь помещения для нужд отдела РнД.
2.4. Автолат перенесен на восточную часть приемной РнД.
2.5. Объедены ставни в приемной РнД
3. Ангар мехов.
3.1. Разделены зоны обслуживания мехов и распределены в углы для компактности.
3.2. Убран шлюз в коридор, из-за отсутствия необходимости в нем.
3.3. Зоны для хранения мехов выделены, проход будет оставаться свободным для удобства.
3.4. Изменен шлюз в ангар мехов со стороны РнД для симметрии.
4. Робототехника.
4.1. Перенесена зона сборки боргов и мехов в угол помещений для компактности.
4.2. Выделено место для хирургии
4.3. Выделено большое рабочее пространство для сборки ботов и иных занятий.
4.4. Добавлен шлюз в холл для удобства обслуживания посетителей.
4.5. Добавлен протолат в робототехнику для удобства в работе. 
5. Перестановка ключевых объектов в отделах в соответствии с их новыми размерами. 
6. Отдел РнД с восточной стороны коридора теперь сопровождается цветом отдела.
7. Ресурсы в приемной РнД перераспределены. Добавлены 20 ед стали и 20 ед стекла для начального обслуживания. Имеющиеся 50 ед стали и 50 ед стекла выделены для исследований.
8. Ресурсы в отделе робототехники перераспределены, так как стало меньше столов. Новых ресурсов не добавлялось.