### PR TITLE
Fix: Generalists Cleaner Spray refill

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -197,6 +197,11 @@
 	fix_modules()
 	handle_storages()
 
+/obj/item/robot_module/standard/respawn_consumable(mob/living/silicon/robot/R)
+	var/obj/item/reagent_containers/spray/cleaner/C = locate() in modules
+	C.reagents.add_reagent("cleaner", 3)
+	..()
+
 /obj/item/robot_module/medical
 	name = "medical robot module"
 	module_type = "Medical"


### PR DESCRIPTION
## What Does This PR Do
Cleaner spray on Standard cyborg module didn't refill itself in cyborgs recharger. Now it does.
Forgot this thing, sry eh, here we go


