### PR TITLE
Tweak: changes in revolution mode, win conditions, descriptions

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -104,19 +104,25 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 /datum/objective/mutiny/find_target()
 	..()
 	if(target && target.current)
-		explanation_text = "Assassinate [target.current.real_name], the [target.assigned_role]."
+		explanation_text = "Exile or assassinate [target.current.real_name], the [target.assigned_role]."
 	else
 		explanation_text = "Free Objective"
 	return target
 
 /datum/objective/mutiny/check_completion()
 	if(target && target.current)
-		if(target.current.stat == DEAD || !ishuman(target.current) || !target.current.ckey || !target.current.client)
+		if(target.current.stat == DEAD)
+			return 1
+		if(!target.current.ckey)
+			return 1
+		if(issilicon(target.current))
+			return 1
+		if(isbrain(target.current))
 			return 1
 		var/turf/T = get_turf(target.current)
-		if(T && !is_station_level(T.z))			//If they leave the station they count as dead for this
-			return 1
-		return 0
+		if(is_admin_level(T.z))
+			return 0
+		return 1
 	return 1
 
 /datum/objective/mutiny/on_target_cryo()

--- a/code/game/objects/items/weapons/implants/implant_mindshield.dm
+++ b/code/game/objects/items/weapons/implants/implant_mindshield.dm
@@ -19,15 +19,15 @@
 
 /obj/item/implant/mindshield/implant(mob/target)
 	if(..())
-		if(target.mind in SSticker.mode.head_revolutionaries || is_shadow_or_thrall(target))
+		if(is_shadow_or_thrall(target))
 			target.visible_message("<span class='warning'>[target] seems to resist the implant!</span>", "<span class='warning'>You feel the corporate tendrils of Nanotrasen try to invade your mind!</span>")
 			removed(target, 1)
 			qdel(src)
 			return -1
-		if(target.mind in SSticker.mode.revolutionaries)
-			SSticker.mode.remove_revolutionary(target.mind)
-		if(target.mind in SSticker.mode.cult)
+		if((target.mind in SSticker.mode.cult) || (target.mind in SSticker.mode.head_revolutionaries))
 			to_chat(target, "<span class='warning'>You feel the corporate tendrils of Nanotrasen try to invade your mind!</span>")
+		else if(target.mind in SSticker.mode.revolutionaries)
+			SSticker.mode.remove_revolutionary(target.mind)
 		else
 			to_chat(target, "<span class='notice'>Your mind feels hardened - more resistant to brainwashing.</span>")
 		return 1


### PR DESCRIPTION
## What Does This PR Do
Меняет режим ревы согласно предложкам:

https://discord.com/channels/617003227182792704/755125334097133628/1007288726860353617
https://discord.com/channels/617003227182792704/755125334097133628/1006877789519089797

## Why It's Good For The Game
Все расписано в предложках

## Changelog
Шатл больше не заблокирован при режиме революции
Новые условия победы - если ни один глава не попал на ЦК революция побеждает, в противном случае побеждают лоялисты НТ
Из описаний в чате и из целей персонажей убрано однозначное требование убийства глав, у хедрев цель теперь "Exile or assasinate", у обычных рев "foloww orders given by revolution leaders"
Майндшилд больше не позволяет определять рев и хедрев, никак не мешает роли хедревы, впрочем он все еще снимает роль обычного революционера
Исправлено некоторое количество багов с выдачей экшена рекрутинга больше одного раза, убран дублирующийся код
