### PR TITLE
Feat: Add syndicate encryption key to contractor starter kit

### DIFF
--- a/code/modules/antagonists/traitor/contractor/items/contractor_kit.dm
+++ b/code/modules/antagonists/traitor/contractor/items/contractor_kit.dm
@@ -58,6 +58,7 @@
 	new /obj/item/card/id/syndicate(src)
 	new /obj/item/storage/fancy/cigarettes/cigpack_syndicate(src)
 	new /obj/item/lighter/zippo(src)
+	new /obj/item/encryptionkey/syndicate(src)
 
 /obj/item/paper/contractor_guide
 	name = "contractor guide"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Добавляет в стартовую коробку контрактника гарантированный спавн ключа-шифратора Синдиката. [Предложка](https://discord.com/channels/617003227182792704/755125334097133628/1007382767023182036) прошла.

## Why It's Good For The Game
+ Больше взаимодействий контрактника с предателями
+ Экономит контрактнику всего 2ТК, но при этом увеличивает его шансы не слиться в начале

## Changelog
:cl:
add: Added syndicate encryption key to contractor starter kit
/:cl:
