### PR TITLE
Fix: cryoxadone condition (turf temp -> mob temp)

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -122,14 +122,7 @@
 
 /datum/reagent/medicine/cryoxadone/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	var/external_temp
-	if(istype(M.loc, /obj/machinery/atmospherics/unary/cryo_cell))
-		var/obj/machinery/atmospherics/unary/cryo_cell/C = M.loc
-		external_temp = C.temperature_archived
-	else
-		var/turf/T = get_turf(M)
-		external_temp = T.temperature
-	if(external_temp < TCRYO)
+	if(iscarbon(M) && M.bodytemperature < TCRYO)
 		update_flags |= M.adjustCloneLoss(-1, FALSE)
 		update_flags |= M.adjustOxyLoss(-2, FALSE)
 		update_flags |= M.adjustToxLoss(-0.5, FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Починил условие активации криоксадона, теперь определяющей является температура моба, а не турфа под ним.
\+ лечение криоксадоном с криостиланом/фрост оилом
\- лечение криоксадоном в космосе/криокапсуле/холодильнике, пока носишь риг

## Why It's Good For The Game
Логика, которой нам отчаянно не хватает

Ветка, где текущее положение вещей признано асоставом багом, а не фичей: https://discord.com/channels/617003227182792704/1005821829748895875/1008702225314480201

## Changelog
:cl: nopeucant
fix: fixed cryoxadone activation conditions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
