### PR TITLE
[PRIME] Security id cards now gains almost full access on red alert

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -125,6 +125,10 @@ GLOBAL_LIST_EMPTY(id_cards)
 			SetOwnerInfo(H)
 	GLOB.id_cards += src
 
+/obj/item/card/id/Destroy()
+	GLOB.id_cards -= src
+	return ..()
+	
 /obj/item/card/id/examine(mob/user)
 	. = ..()
 	if(in_range(user, src))

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -80,6 +80,8 @@
 		return
 	A.emag_act(user)
 
+GLOBAL_LIST_EMPTY(id_cards)
+
 /obj/item/card/id
 	name = "identification card"
 	desc = "A card used to provide ID and determine access across the station."
@@ -87,6 +89,8 @@
 	item_state = "card-id"
 	var/mining_points = 0 //For redeeming at mining equipment lockers
 	var/list/access = list()
+	//accesses that were given on red alert
+	var/list/red_alert_given_access = list()
 	var/registered_name = "Unknown" // The name registered_name on the card
 	slot_flags = SLOT_ID
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 100)
@@ -119,6 +123,7 @@
 		if(ishuman(loc) && blood_type == "\[UNSET\]")
 			var/mob/living/carbon/human/H = loc
 			SetOwnerInfo(H)
+	GLOB.id_cards += src
 
 /obj/item/card/id/examine(mob/user)
 	. = ..()
@@ -227,6 +232,20 @@
 		return
 
 	name = "[(!registered_name)	? "identification card"	: "[registered_name]'s ID Card"][(!assignment) ? "" : " ([assignment])"]"
+
+/obj/item/card/id/proc/on_red_alert()
+	if(!has_access(list(), list(ACCESS_SECURITY), access))
+		return
+	red_alert_given_access = get_region_accesses(REGION_ALL) - get_region_accesses(REGION_COMMAND)
+	red_alert_given_access -= access
+
+	access += red_alert_given_access
+
+/obj/item/card/id/proc/after_red_alert()
+	if(!has_access(list(), list(ACCESS_SECURITY), access))
+		return
+	access -= red_alert_given_access
+	red_alert_given_access.Cut()
 
 /obj/item/card/id/attackby(obj/item/W as obj, mob/user as mob, params)
 	..()

--- a/code/modules/security_levels/security_levels.dm
+++ b/code/modules/security_levels/security_levels.dm
@@ -123,6 +123,7 @@ GLOBAL_DATUM_INIT(security_announcement_down, /datum/announcement/priority/secur
 
 		SSnightshift.check_nightshift(TRUE)
 		SSblackbox.record_feedback("tally", "security_level_changes", 1, level)
+		update_ids()
 
 		if(GLOB.sibsys_automode && !isnull(GLOB.guns_registry))
 			var/limit = SIBYL_NONLETHAL
@@ -144,6 +145,12 @@ GLOBAL_DATUM_INIT(security_announcement_down, /datum/announcement/priority/secur
 				mod.set_limit(limit)
 	else
 		return
+
+/proc/update_ids()
+	var/proc_to_call = (GLOB.security_level > SEC_LEVEL_BLUE) ? /obj/item/card/id/proc/on_red_alert : /obj/item/card/id/proc/after_red_alert
+
+	for(var/obj/item/card/id/card as anything in GLOB.id_cards)
+		call(card, proc_to_call)()
 
 /proc/get_security_level()
 	switch(GLOB.security_level)


### PR DESCRIPTION
## What Does This PR Do
При поднятии уровня угрозы до красного и выше все айди карты с доступом `ACCESS_SECURITY` получают расширение доступа до всех отсеков, кроме командных. По снижению кода доступ возвращается к тому, что был до его поднятия.

## Why It's Good For The Game
Запрошено Шуссом для прайм-сервера

