### PR TITLE
Исправление вардена-антагониста (#1161)

### DIFF
--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -3,7 +3,6 @@
 	config_tag = "traitorchan"
 	traitors_possible = 3 //hard limit on traitors if scaling is turned off
 	restricted_jobs = list("AI", "Cyborg")
-	protected_jobs = list("Captain", "Head of Security", "Head of Personnel", "Chief Engineer", "Research Director", "Chief Medical Officer")
 	required_players = 10
 	required_enemies = 1	// how many of each type are required
 	recommended_enemies = 3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Исправляет перезапись ролей. Больше не должно возникать ситуаций, когда защищённая от антага ролька становилась антагом.

## Why It's Good For The Game
Исправляет предыдущий ПР, из-за которого на Прайме возник варден-трейтор

## Changelog
:cl:
fix: warden can not longer become roundstart antag
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
