### PR TITLE
Feat: apply weakened status on depressurization into open space

### DIFF
--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -372,10 +372,9 @@
 		move_prob = (pressure_difference / pressure_resistance * PROBABILITY_BASE_PRECENT) - PROBABILITY_OFFSET
 	move_prob += pressure_resistance_prob_delta
 	if(move_prob > PROBABILITY_OFFSET && prob(move_prob) && (move_resist != INFINITY) && (!anchored && (max_force >= (move_resist * MOVE_FORCE_PUSH_RATIO))) || (anchored && (max_force >= (move_resist * MOVE_FORCE_FORCEPUSH_RATIO))))
-		// Feature disabled until issue with effect stacking will be resolved
-		// if (iscarbon(src) && pressure_difference > 50)
-		// 	var/mob/living/carbon/carbon = src
-		// 	carbon.AdjustWeakened(3)
+		if (iscarbon(src) && pressure_difference > 50)
+			var/mob/living/carbon/carbon = src
+			carbon.AdjustWeakened(3)
 		step(src, direction)
 		last_high_pressure_movement_air_cycle = SSair.times_fired
 


### PR DESCRIPTION
## What Does This PR Do
This will actually work cause AdjustWeakened wont stack "Weakened" debuff