### PR TITLE
Fix: wielded weapons now properly displays on back

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -89,6 +89,11 @@
 	user.put_in_inactive_hand(O)
 	return TRUE
 
+/obj/item/twohanded/mob_can_equip(mob/M, slot) //Unwields twohanded items when they're attempted to be equipped to another slot
+	if(wielded)
+		unwield(M)
+	return ..()
+
 /obj/item/twohanded/dropped(mob/user)
 	..()
 	//handles unwielding a twohanded weapon when dropped as well as clearing up the offhand


### PR DESCRIPTION
[Исправляет баг, когда топор не отображался на спине, когда был взят в обе руки.](https://discord.com/channels/617003227182792704/617004034405957642/1009534973398753300)

![image](https://user-images.githubusercontent.com/20109643/185371508-0c906525-ed66-4685-8345-4d139b860ab5.png)

[_Фикс позаимствован с оффов_](https://github.com/ParadiseSS13/Paradise/pull/16711)
