### PR TITLE
fix: Shapeshift cast time and can_cast condition

### DIFF
--- a/code/datums/spells/shapeshift.dm
+++ b/code/datums/spells/shapeshift.dm
@@ -18,6 +18,15 @@
 		/mob/living/simple_animal/pet/dog/corgi,
 		/mob/living/simple_animal/hostile/construct/armoured)
 
+/obj/effect/proc_holder/spell/targeted/shapeshift/can_cast(mob/user, charge_check, show_message)
+	if(isliving(user))
+		var/mob/living/target = user
+		if(target.weakened || target.stunned)
+			return FALSE
+	if(!isturf(user.loc) && !length(current_casters)) //Can't use inside of things, such as a mecha
+		return FALSE
+	. = ..()
+
 /obj/effect/proc_holder/spell/targeted/shapeshift/cast(list/targets, mob/user = usr)
 	for(var/mob/living/M in targets)
 		if(!shapeshift_type)
@@ -35,21 +44,25 @@
 			Shapeshift(M)
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/proc/Shapeshift(mob/living/caster)
-	for(var/mob/living/M in caster)
-		if(M.status_flags & GODMODE)
-			to_chat(caster, "<span class='warning'>You're already shapeshifted!</span>")
-			return
+	if(do_after(caster, 2 SECONDS, target = caster))
+		for(var/mob/living/M in caster)
+			if(M.status_flags & GODMODE)
+				to_chat(caster, "<span class='warning'>You're already shapeshifted!</span>")
+				return
 
-	var/mob/living/shape = new shapeshift_type(caster.loc)
-	caster.loc = shape
-	caster.status_flags |= GODMODE
+		var/mob/living/shape = new shapeshift_type(caster.loc)
+		caster.loc = shape
+		caster.status_flags |= GODMODE
 
-	current_shapes |= shape
-	current_casters |= caster
-	clothes_req = 0
-	human_req = 0
+		current_shapes |= shape
+		current_casters |= caster
+		clothes_req = 0
+		human_req = 0
 
-	caster.mind.transfer_to(shape)
+		caster.mind.transfer_to(shape)
+	else
+		to_chat(caster, "<span class='warning'>You were interrupted!</span>")
+		charge_counter = charge_max
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/proc/Restore(mob/living/shape)
 	var/mob/living/caster


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Добавляет каст-тайм в две секунды, а также запрещает использовать полиморф в стане и в викенде

Из дискорда:
[Бездушное бессмертное тело](https://discord.com/channels/617003227182792704/1006247933148155986)

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Фикс багов

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Fast cast-time for shapeshift spells
fix: Can_cast condition for shapeshift spells
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
