### PR TITLE
Fix: disable user controlled emotes when human sleeping

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -28,6 +28,13 @@
 				else
 					return target
 
+/mob/proc/user_triggered_emote(act, type, message, force)
+	if(stat || !use_me && usr == src)
+		if(usr)
+			to_chat(usr, "You are unable to emote.")
+		return
+	emote(act, type, message, force)
+
 // All mobs should have custom emote, really..
 /mob/proc/custom_emote(var/m_type=EMOTE_VISUAL,var/message = null)
 	if(stat || !use_me && usr == src)

--- a/code/modules/mob/emote_panel_ru.dm
+++ b/code/modules/mob/emote_panel_ru.dm
@@ -1,451 +1,451 @@
 /mob/living/carbon/human/verb/emote_laugh()
 	set name = "> Смеяться "
 	set category = "Эмоции"
-	usr.emote("laugh")
+	usr.user_triggered_emote("laugh")
 
 /mob/living/carbon/human/verb/emote_giggle()
 	set name = "> Хихикать "
 	set category = "Эмоции"
-	usr.emote("giggle")
+	usr.user_triggered_emote("giggle")
 
 /mob/living/carbon/human/verb/emote_scream()
 	set name = "> Кричать "
 	set category = "Эмоции"
-	usr.emote("scream")
+	usr.user_triggered_emote("scream")
 
 /mob/living/carbon/human/verb/emote_scratch()
 	set name = "~ Почесаться "
 	set category = "Эмоции"
-	usr.emote("scratch")
+	usr.user_triggered_emote("scratch")
 
 /mob/living/carbon/human/verb/emote_blush()
 	set name = "~ Краснеть "
 	set category = "Эмоции"
-	usr.emote("blush")
+	usr.user_triggered_emote("blush")
 
 /mob/living/carbon/human/verb/emote_blink()
 	set name = "~ Моргать "
 	set category = "Эмоции"
-	usr.emote("blink")
+	usr.user_triggered_emote("blink")
 
 /mob/living/carbon/human/verb/emote_blink_r()
 	set name = "~ Моргать быстро "
 	set category = "Эмоции"
-	usr.emote("blink_r")
+	usr.user_triggered_emote("blink_r")
 
 /mob/living/carbon/human/verb/emote_bow()
 	set name = "~ Поклониться "
 	set category = "Эмоции"
-	usr.emote("bow")
+	usr.user_triggered_emote("bow")
 
 /mob/living/carbon/human/verb/emote_choke()
 	set name = "> Подавиться "
 	set category = "Эмоции"
-	usr.emote("choke")
+	usr.user_triggered_emote("choke")
 
 /mob/living/carbon/human/verb/emote_chuckle()
 	set name = "~ Усмехнуться "
 	set category = "Эмоции"
-	usr.emote("chuckle")
+	usr.user_triggered_emote("chuckle")
 
 /mob/living/carbon/human/verb/emote_collapse()
 	set name = "> Рухнуть "
 	set category = "Эмоции"
-	usr.emote("collapse")
+	usr.user_triggered_emote("collapse")
 
 /mob/living/carbon/human/verb/emote_cough()
 	set name = "> Кашлять "
 	set category = "Эмоции"
-	usr.emote("cough")
+	usr.user_triggered_emote("cough")
 
 /mob/living/carbon/human/verb/emote_cry()
 	set name = "> Плакать "
 	set category = "Эмоции"
-	usr.emote("cry")
+	usr.user_triggered_emote("cry")
 
 /mob/living/carbon/human/verb/emote_clap()
 	set name = "> Хлопать "
 	set category = "Эмоции"
-	usr.emote("clap")
+	usr.user_triggered_emote("clap")
 
 /mob/living/carbon/human/verb/emote_drool()
 	set name = "~ Нести чепуху "
 	set category = "Эмоции"
-	usr.emote("drool")
+	usr.user_triggered_emote("drool")
 
 /mob/living/carbon/human/verb/emote_faint()
 	set name = "> Потерять сознание "
 	set category = "Эмоции"
-	usr.emote("faint")
+	usr.user_triggered_emote("faint")
 
 /mob/living/carbon/human/verb/emote_frown()
 	set name = "~ Хмуриться "
 	set category = "Эмоции"
-	usr.emote("frown")
+	usr.user_triggered_emote("frown")
 
 /mob/living/carbon/human/verb/emote_gasp()
 	set name = "> Задыхаться "
 	set category = "Эмоции"
-	usr.emote("gasp")
+	usr.user_triggered_emote("gasp")
 
 /mob/living/carbon/human/verb/emote_glare()
 	set name = "~ Смотреть с ненавистью "
 	set category = "Эмоции"
-	usr.emote("glare")
+	usr.user_triggered_emote("glare")
 
 /mob/living/carbon/human/verb/emote_groan()
 	set name = "~ Болезненный вздох "
 	set category = "Эмоции"
-	usr.emote("groan")
+	usr.user_triggered_emote("groan")
 
 /mob/living/carbon/human/verb/emote_grin()
 	set name = "~ Оскалиться в улыбке "
 	set category = "Эмоции"
-	usr.emote("grin")
+	usr.user_triggered_emote("grin")
 
 /mob/living/carbon/human/verb/emote_look()
 	set name = "~ Посмотреть "
 	set category = "Эмоции"
-	usr.emote("look")
+	usr.user_triggered_emote("look")
 
 /mob/living/carbon/human/verb/emote_nod()
 	set name = "~ Кивнуть "
 	set category = "Эмоции"
-	usr.emote("nod")
+	usr.user_triggered_emote("nod")
 
 /mob/living/carbon/human/verb/emote_moan()
 	set name = "~ Стонать "
 	set category = "Эмоции"
-	usr.emote("moan")
+	usr.user_triggered_emote("moan")
 
 /mob/living/carbon/human/verb/emote_shake()
 	set name = "~ Трясти головой "
 	set category = "Эмоции"
-	usr.emote("shake")
+	usr.user_triggered_emote("shake")
 
 /mob/living/carbon/human/verb/emote_sigh()
 	set name = "> Вздыхать "
 	set category = "Эмоции"
-	usr.emote("sigh")
+	usr.user_triggered_emote("sigh")
 
 /mob/living/carbon/human/verb/emote_smile()
 	set name = "~ Улыбнуться "
 	set category = "Эмоции"
-	usr.emote("smile")
+	usr.user_triggered_emote("smile")
 
 /mob/living/carbon/human/verb/emote_sneeze()
 	set name = "> Чихнуть "
 	set category = "Эмоции"
-	usr.emote("sneeze")
+	usr.user_triggered_emote("sneeze")
 
 /mob/living/carbon/human/verb/emote_grunt()
 	set name = "~ Ворчать "
 	set category = "Эмоции"
-	usr.emote("grumble")
+	usr.user_triggered_emote("grumble")
 
 /mob/living/carbon/human/verb/emote_sniff()
 	set name = "~ Понюхать "
 	set category = "Эмоции"
-	usr.emote("sniff")
+	usr.user_triggered_emote("sniff")
 
 /mob/living/carbon/human/verb/emote_snuffle()
 	set name = "~ Шмыгать носом "
 	set category = "Эмоции"
-	usr.emote("snuffle")
+	usr.user_triggered_emote("snuffle")
 
 /mob/living/carbon/human/verb/emote_snore()
 	set name = "> Храпеть "
 	set category = "Эмоции"
-	usr.emote("snore")
+	usr.user_triggered_emote("snore")
 
 /mob/living/carbon/human/verb/emote_shrug()
 	set name = "~ Пожать плечами "
 	set category = "Эмоции"
-	usr.emote("shrug")
+	usr.user_triggered_emote("shrug")
 
 /mob/living/carbon/human/verb/emote_stare()
 	set name = "~ Пялиться "
 	set category = "Эмоции"
-	usr.emote("stare")
+	usr.user_triggered_emote("stare")
 
 /mob/living/carbon/human/verb/emote_tremble()
 	set name = "~ Дрожать в ужасе "
 	set category = "Эмоции"
-	usr.emote("tremble")
+	usr.user_triggered_emote("tremble")
 
 /mob/living/carbon/human/verb/emote_twitch_v()
 	set name = "~ Сильно дёргаться "
 	set category = "Эмоции"
-	usr.emote("twitch")
+	usr.user_triggered_emote("twitch")
 
 /mob/living/carbon/human/verb/emote_twitch()
 	set name = "~ Дёргаться "
 	set category = "Эмоции"
-	usr.emote("twitch_s")
+	usr.user_triggered_emote("twitch_s")
 
 /mob/living/carbon/human/verb/emote_wave()
 	set name = "~ Махать "
 	set category = "Эмоции"
-	usr.emote("wave")
+	usr.user_triggered_emote("wave")
 
 /mob/living/carbon/human/verb/emote_whimper()
 	set name = "~ Хныкать "
 	set category = "Эмоции"
-	usr.emote("whimper")
+	usr.user_triggered_emote("whimper")
 
 /mob/living/carbon/human/verb/emote_whistle()
 	set name = "> Свистеть "
 	set category = "Эмоции"
-	usr.emote("whistle")
+	usr.user_triggered_emote("whistle")
 
 /mob/living/carbon/human/verb/emote_wink()
 	set name = "~ Подмигнуть "
 	set category = "Эмоции"
-	usr.emote("wink")
+	usr.user_triggered_emote("wink")
 
 /mob/living/carbon/human/verb/emote_yawn()
 	set name = "> Зевать "
 	set category = "Эмоции"
-	usr.emote("yawn")
+	usr.user_triggered_emote("yawn")
 
 /mob/living/carbon/human/verb/emote_salute()
 	set name = "> Сделать воинское приветствие "
 	set category = "Эмоции"
-	usr.emote("salute")
+	usr.user_triggered_emote("salute")
 
 /mob/living/carbon/human/verb/emote_eyebrow()
 	set name = "~ Приподнять бровь "
 	set category = "Эмоции"
-	usr.emote("eyebrow")
+	usr.user_triggered_emote("eyebrow")
 
 /mob/living/carbon/human/verb/emote_fart()
 	set name = "~ Пернуть "
 	set category = "Эмоции"
-	usr.emote("fart")
+	usr.user_triggered_emote("fart")
 
 /mob/living/carbon/human/verb/emote_airguitar()
 	set name = "~ Воображаемая гитара "
 	set category = "Эмоции"
-	usr.emote("airguitar")
+	usr.user_triggered_emote("airguitar")
 
 /mob/living/carbon/human/verb/emote_dance()
 	set name = "~ Танцевать "
 	set category = "Эмоции"
-	usr.emote("dance")
+	usr.user_triggered_emote("dance")
 
 /mob/living/carbon/human/verb/emote_jump()
 	set name = "~ Прыгать "
 	set category = "Эмоции"
-	usr.emote("jump")
+	usr.user_triggered_emote("jump")
 
 /mob/living/carbon/human/verb/emote_burp()
 	set name = "~ Рыгнуть "
 	set category = "Эмоции"
-	usr.emote("burp")
+	usr.user_triggered_emote("burp")
 /*
 /mob/living/carbon/human/verb/emote_flap()
 	set name = "~ Махать крыльями "
 	set category = "Эмоции"
-	usr.emote("flap")
+	usr.user_triggered_emote("flap")
 
 /mob/living/carbon/human/verb/emote_aflap()
 	set name = "~ Махать крыльями агрессивно "
 	set category = "Эмоции"
-	usr.emote("aflap")
+	usr.user_triggered_emote("aflap")
 
 /mob/living/carbon/human/verb/emote_deathgasp()
 	set name = "> Предсмертный вздох "
 	set category = "Эмоции"
-	usr.emote("deathgasp")
+	usr.user_triggered_emote("deathgasp")
 
 /mob/living/carbon/human/verb/emote_dap()
 	set name = "~ dap "
 	set category = "Эмоции"
-	usr.emote("dap")
+	usr.user_triggered_emote("dap")
 */
 /mob/living/carbon/human/verb/emote_flip()
 	set name = "> Сделать кувырок "
 	set category = "Эмоции"
-	usr.emote("flip")
+	usr.user_triggered_emote("flip")
 
 /mob/living/carbon/human/verb/emote_quiver()
 	set name = "~ Трепетать "
 	set category = "Эмоции"
-	usr.emote("quiver")
+	usr.user_triggered_emote("quiver")
 
 /mob/living/carbon/human/verb/emote_mumble()
 	set name = "~ Бормотать "
 	set category = "Эмоции"
-	usr.emote("mumble")
+	usr.user_triggered_emote("mumble")
 
 /mob/living/carbon/human/verb/emote_point()
 	set name = "~ Показать пальцем "
 	set category = "Эмоции"
-	usr.emote("point")
+	usr.user_triggered_emote("point")
 
 /mob/living/carbon/human/verb/emote_raise()
 	set name = "~ Поднять руку "
 	set category = "Эмоции"
-	usr.emote("raise")
+	usr.user_triggered_emote("raise")
 
 /mob/living/carbon/human/verb/emote_signal()
 	set name = "~ Показать несколько пальцев "
 	set category = "Эмоции"
 	var/Cnt = input("Руки должны быть свободны", "Показать несколько пальцев", 1) in list(1,2,3,4,5,6,7,8,9,10)
-	usr.emote("signal-[Cnt]")
+	usr.user_triggered_emote("signal-[Cnt]")
 
 /mob/living/carbon/human/verb/emote_shiver()
 	set name = "~ Дрожать "
 	set category = "Эмоции"
-	usr.emote("shiver")
+	usr.user_triggered_emote("shiver")
 
 /mob/living/carbon/human/verb/emote_pale()
 	set name = "~ Бледнеть "
 	set category = "Эмоции"
-	usr.emote("pale")
+	usr.user_triggered_emote("pale")
 
 /mob/living/carbon/human/verb/emote_shudder()
 	set name = "~ Содрогаться "
 	set category = "Эмоции"
-	usr.emote("shudder")
+	usr.user_triggered_emote("shudder")
 
 /mob/living/carbon/human/verb/emote_bshake()
 	set name = "~ Трястись "
 	set category = "Эмоции"
-	usr.emote("bshake")
+	usr.user_triggered_emote("bshake")
 
 /mob/living/carbon/human/verb/emote_hug()
 	set name = "~ Обнимать "
 	set category = "Эмоции"
-	usr.emote("hug")
+	usr.user_triggered_emote("hug")
 
 /mob/living/carbon/human/verb/emote_handshake()
 	set name = "~ Пожать руку "
 	set category = "Эмоции"
-	usr.emote("handshake")
+	usr.user_triggered_emote("handshake")
 
 /mob/living/carbon/human/verb/emote_slap()
 	set name = "> Шлепнуть "
 	set category = "Эмоции"
-	usr.emote("slap")
+	usr.user_triggered_emote("slap")
 
 /mob/living/carbon/human/verb/emote_snap()
 	set name = "> Щелкнуть пальцами "
 	set category = "Эмоции"
-	usr.emote("snap")
+	usr.user_triggered_emote("snap")
 
 /mob/living/carbon/human/verb/emote_hem()
 	set name = "~ Хмыкнуть "
 	set category = "Эмоции"
-	usr.emote("hem")
+	usr.user_triggered_emote("hem")
 
 /mob/living/carbon/human/verb/emote_highfive()
 	set name = "> Дать пять "
 	set category = "Эмоции"
-	usr.emote("highfive")
+	usr.user_triggered_emote("highfive")
 
 
 /mob/living/carbon/human/proc/emote_wag()
 	set name = "< Махать хвостом >"
 	set category = "Эмоции"
-	usr.emote("wag")
+	usr.user_triggered_emote("wag")
 
 /mob/living/carbon/human/proc/emote_swag()
 	set name = "< Перестать махать хвостом >"
 	set category = "Эмоции"
-	usr.emote("swag")
+	usr.user_triggered_emote("swag")
 
 /mob/living/carbon/human/proc/emote_howl()
 	set name = "< Выть >"
 	set category = "Эмоции"
-	usr.emote("howl")
+	usr.user_triggered_emote("howl")
 
 /mob/living/carbon/human/proc/emote_growl()
 	set name = "< Рычать >"
 	set category = "Эмоции"
-	usr.emote("growl")
+	usr.user_triggered_emote("growl")
 
 /mob/living/carbon/human/proc/emote_purr()
 	set name = "< Мурчать >"
 	set category = "Эмоции"
-	usr.emote("purr")
+	usr.user_triggered_emote("purr")
 
 /mob/living/carbon/human/proc/emote_purrl()
 	set name = "< Мурчать дольше >"
 	set category = "Эмоции"
-	usr.emote("purrl")
+	usr.user_triggered_emote("purrl")
 
 /mob/living/carbon/human/proc/emote_hiss()
 	set name = "< Шипеть >"
 	set category = "Эмоции"
-	usr.emote("hiss")
+	usr.user_triggered_emote("hiss")
 
 /mob/living/carbon/human/proc/emote_hisses()
 	set name = "< Шипеть >"
 	set category = "Эмоции"
-	usr.emote("hisses")
+	usr.user_triggered_emote("hisses")
 
 /mob/living/carbon/human/proc/emote_quill()
 	set name = "< Шуршать перьями >"
 	set category = "Эмоции"
-	usr.emote("quill")
+	usr.user_triggered_emote("quill")
 
 /mob/living/carbon/human/proc/emote_creak()
 	set name = "< Скрипеть >"
 	set category = "Эмоции"
-	usr.emote("creak")
+	usr.user_triggered_emote("creak")
 
 /mob/living/carbon/human/proc/emote_warble()
 	set name = "< Трель >"
 	set category = "Эмоции"
-	usr.emote("warble")
+	usr.user_triggered_emote("warble")
 
 /mob/living/carbon/human/proc/emote_click()
 	set name = "< Щелкать >"
 	set category = "Эмоции"
-	usr.emote("click")
+	usr.user_triggered_emote("click")
 
 /mob/living/carbon/human/proc/emote_clack()
 	set name = "< Трещать >"
 	set category = "Эмоции"
-	usr.emote("clack")
+	usr.user_triggered_emote("clack")
 
 /mob/living/carbon/human/proc/emote_hum()
 	set name = "< Гудеть >"
 	set category = "Эмоции"
-	usr.emote("hum")
+	usr.user_triggered_emote("hum")
 
 /mob/living/carbon/human/proc/emote_squish()
 	set name = "< Хлюпать >"
 	set category = "Эмоции"
-	usr.emote("squish")
+	usr.user_triggered_emote("squish")
 
 /mob/living/carbon/human/proc/emote_ping()
 	set name = "< Звенеть >"
 	set category = "Эмоции"
-	usr.emote("ping")
+	usr.user_triggered_emote("ping")
 
 /mob/living/carbon/human/proc/emote_beep()
 	set name = "< Пищать >"
 	set category = "Эмоции"
-	usr.emote("beep")
+	usr.user_triggered_emote("beep")
 
 /mob/living/carbon/human/proc/emote_buzz()
 	set name = "< Жужжать >"
 	set category = "Эмоции"
-	usr.emote("buzz")
+	usr.user_triggered_emote("buzz")
 
 /mob/living/carbon/human/proc/emote_buzz2()
 	set name = "< Жужжать раздраженно >"
 	set category = "Эмоции"
-	usr.emote("buzz2")
+	usr.user_triggered_emote("buzz2")
 
 /mob/living/carbon/human/proc/emote_yes()
 	set name = "< Утвердительно >"
 	set category = "Эмоции"
-	usr.emote("yes")
+	usr.user_triggered_emote("yes")
 
 /mob/living/carbon/human/proc/emote_no()
 	set name = "< Отрицательно >"
 	set category = "Эмоции"
-	usr.emote("no")
+	usr.user_triggered_emote("no")


### PR DESCRIPTION
## What Does This PR Do
Эмоуты из эмоутпанели теперь нельзя прожимать когда кукла спит (проверка написана аналогично той что уже есть для me)

## Why It's Good For The Game
Теперь нельзя больше кричать во сне, меньше проблем антагам которые усыпили жертву и пытаются её скрытно унести

## Changelog
Эмоуты через эмоутпанель теперь нельзя прожимать во сне
