### PR TITLE
fix: radio_desc

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -49,7 +49,7 @@
 	. = ..()
 	if(in_range(src, user) && radio_desc)
 		. += "<span class='notice'>The following channels are available:</span>"
-		. += "<span class='info'>radio_desc</span>"
+		. += "<span class='info'>[radio_desc]</span>"
 /obj/item/radio/headset/handle_message_mode(mob/living/M as mob, list/message_pieces, channel)
 	if(channel == "special")
 		if(translate_binary)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Чинит описание к наушнику

## Images of changes
Было
![image](https://cdn.discordapp.com/attachments/981470952061804604/1010944420184596630/unknown.png)

Стало
![image](https://user-images.githubusercontent.com/87372121/185801816-ae2daba5-2df9-4ebf-8edc-91cf9007f785.png)

## Changelog
:cl:
fix: examine for headsets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
