### PR TITLE
Tweak: change required access to join on admin jobs from event to admin

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -288,7 +288,7 @@
 	if(jobban_isbanned(src,rank))	return 0
 	if(!is_job_whitelisted(src, rank))	 return 0
 	if(!job.player_old_enough(client))	return 0
-	if(job.admin_only && !(check_rights(R_EVENT, 0))) return 0
+	if(job.admin_only && !(check_rights(R_ADMIN, 0))) return 0
 	if(job.available_in_playtime(client))
 		return 0
 


### PR DESCRIPTION
## What Does This PR Do
Меняет доступ к роли ССО, нави капитана и синдикат офицера с эвент на админ

## Why It's Good For The Game
Позволит триалам заходить за эти роли

## Changelog
Изменен доступ к спавну на админпрофах с эвент на админ