### PR TITLE
[PRIME] EMP Shield Implant

### DIFF
--- a/code/game/objects/items/weapons/implants/implant_emp_shield.dm
+++ b/code/game/objects/items/weapons/implants/implant_emp_shield.dm
@@ -1,0 +1,113 @@
+/obj/item/implantcase/emp_shield
+	name = "implant case - 'EMP Shield'"
+	desc = "A glass case containing an EMP Shield implant."
+
+/obj/item/implantcase/emp_shield/New()
+	imp = new /obj/item/implant/emp_shield(src)
+	. = ..()
+
+/obj/item/implanter/emp_shield
+	name = "implanter (EMP Shield)"
+
+/obj/item/implanter/emp_shield/New()
+	imp = new /obj/item/implant/emp_shield(src)
+	. = ..()
+
+/datum/uplink_item/implants/emp_shield
+	name = "EMP Shield Implant"
+	desc = "Nullifies EMP effects, protecting user's organs. Tested on non-combat organs only. Three time use, recharges slowly overtime."
+	reference = "ESI"
+	item = /obj/item/implanter/emp_shield
+	cost = 2
+
+/obj/item/implant/emp_shield
+	name = "EMP Shield implant"
+	desc = "Protects the user from three EMPs. Recharges fast after a long delay."
+	icon_state = "lighting_bolt"
+	origin_tech = "materials=2;biotech=4;combat=3;syndicate=2"
+	activated = TRUE
+	allow_multiple = FALSE
+	var/list/restricted_organs = list(
+		/obj/item/organ/internal/cyberimp/brain/anti_drop,
+		/obj/item/organ/internal/cyberimp/brain/anti_stun,
+		/obj/item/organ/internal/cyberimp/brain/anti_sleep)
+	var/active = FALSE
+	var/current_charges = 3
+	var/max_charges = 3 //How many charges total the shielding has
+	var/recharge_delay = 30 SECONDS //How long after we've been EMPd before we can start recharging
+	var/recharge_cooldown = 0 //Time since we've last been EMPd
+	var/recharge_rate = 1 //How quickly the shield recharges once it starts charging
+
+/obj/item/implant/emp_shield/get_data()
+	var/dat = {"<b>Implant Specifications:</b><BR>
+				<b>Name:</b> Cybersun Industries EMP Shield Implant<BR>
+				<b>Life:</b> Three days.<BR>
+				<b>Important Notes:</b> <font color='red'>Illegal</font><BR>
+				<HR>
+				<b>Implant Details:</b> Subjects injected with implant are more resistable to EMPs. Need to be reactivated for new organs.<BR>
+				<b>Function:</b> Nullifies EMP effects, protecting user's organs. Tested on non-combat organs only.<BR>
+				<b>Integrity:</b> Implant can only be used three times before reserves are depleted. Recharges overtime slowly."}
+	return dat
+
+/obj/item/implant/emp_shield/proc/enable_shielding(mob/user, intentional = FALSE)
+	if(active && !intentional)
+		return
+	if(iscarbon(user))
+		var/mob/living/carbon/implanted_user = user
+		for(var/obj/item/organ/internal/i_organ in implanted_user.internal_organs)
+			if(locate(i_organ) in restricted_organs)
+				continue
+			i_organ.emp_proof = TRUE
+	active = TRUE
+
+/obj/item/implant/emp_shield/proc/disable_shielding(mob/user)
+	if(iscarbon(user))
+		var/mob/living/carbon/implanted_user = user
+		for(var/obj/item/organ/internal/i_organ in implanted_user.internal_organs)
+			i_organ.emp_proof = initial(i_organ.emp_proof)
+	active = FALSE
+
+/obj/item/implant/emp_shield/activate()
+	if(!imp_in)
+		return
+	if(current_charges)
+		to_chat(imp_in, "<span class='syndradio'>[current_charges] charges left.</span>")
+		to_chat(imp_in, "<span class='syndradio'>Updating a list of protected organs.</span>")
+		enable_shielding(imp_in, intentional = TRUE)
+	else
+		to_chat(imp_in, "<span class='syndradio'>Implant is depleted, wait for a recharge.</span>")
+
+/obj/item/implant/emp_shield/emp_act(severity)
+	. = ..()
+	recharge_cooldown = world.time + recharge_delay
+	if(current_charges > 0)
+		current_charges--
+	if(recharge_rate)
+		START_PROCESSING(SSobj, src)
+	if(current_charges <= 0 && active)
+		to_chat(imp_in, "<span class='syndradio'>EMP Shield depleted!</span>")
+		addtimer(CALLBACK(src, .proc/disable_shielding, imp_in), 1)
+
+/obj/item/implant/emp_shield/process()
+	if(world.time > recharge_cooldown && current_charges < max_charges)
+		current_charges = clamp((current_charges + recharge_rate), 0, max_charges)
+		enable_shielding(imp_in)
+		playsound(loc, 'sound/magic/charge.ogg', 50, TRUE)
+		if(current_charges == max_charges)
+			playsound(loc, 'sound/machines/ding.ogg', 50, TRUE)
+			to_chat(imp_in, "<span class='syndradio'>EMP Shield fully recharged.")
+			STOP_PROCESSING(SSobj, src)
+
+/obj/item/implant/emp_shield/removed(mob/source)
+	. = ..()
+	disable_shielding(source)
+	src.audible_message("EMP Shield removed. Thank you for using our services.", "", 1)
+
+/obj/item/implant/emp_shield/implant(mob/source, mob/user)
+	. = ..()
+	enable_shielding(source)
+	to_chat(source, "<span class='syndradio'>EMP Shield implanted. Thank you for using Cybersun Industries!</span>")
+
+/obj/item/implant/emp_shield/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	. = ..()

--- a/paradise.dme
+++ b/paradise.dme
@@ -1128,6 +1128,7 @@
 #include "code\game\objects\items\weapons\implants\implant_abductor.dm"
 #include "code\game\objects\items\weapons\implants\implant_chem.dm"
 #include "code\game\objects\items\weapons\implants\implant_death_alarm.dm"
+#include "code\game\objects\items\weapons\implants\implant_emp_shield.dm"
 #include "code\game\objects\items\weapons\implants\implant_explosive.dm"
 #include "code\game\objects\items\weapons\implants\implant_freedom.dm"
 #include "code\game\objects\items\weapons\implants\implant_krav_maga.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Добавление импланта защиты от ЭМИ. Можно получить из Аплинка за 2ТК.

Пока что характеристики следующие:
- У импланта 3 заряда
- Если имплант активен (имеет заряды), то он защищает все органы от ЭМИ, кроме боевых (anti_stun, anti_sleep, anti_drop)
- Если заряды источились, то возвращаются значения по умолчанию на защиту от ЭМИ (у большинства защиты нет, то есть защита от ЭМИ уходит)
- Через 30 секунд после последнего ЭМИ начинается перезарядка зарядов, раз в одну секунду. Каждое восполнение заряда имеет звук, который имеется и у щитов на хардсьютах.
- Активная кнопка указывает на количество доступных зарядов, а также вручную обновляет защищаемые органы.
- !!ПОСЛЕ ИМПЛАНТАЦИИ НОВЫМИ ОРГАНАМИ, НЕОБХОДИМО АКТИВИРОВАТЬ ВРУЧНУЮ!!

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Запрос от стримеров

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![image](https://user-images.githubusercontent.com/31931237/186151158-da61af5e-5315-4e43-a192-5ff6a2acc4a4.png)


## Changelog
:cl:
add: EMP Shield Implant
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
