### PR TITLE
Догоняем ОФФы: Fixes one handed dswords && Makes defib shocks dangerous

### DIFF
--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -69,11 +69,10 @@
 		overlays += "[icon_state]-emagged"
 
 /obj/item/defibrillator/proc/update_charge()
-	if(powered) //so it doesn't show charge if it's unpowered
-		if(cell)
-			var/ratio = cell.charge / cell.maxcharge
-			ratio = CEILING(ratio*4, 1) * 25
-			overlays += "[icon_state]-charge[ratio]"
+	if(powered && cell) //so it doesn't show charge if it's unpowered
+		var/ratio = cell.charge / cell.maxcharge
+		ratio = CEILING(ratio*4, 1) * 25
+		overlays += "[icon_state]-charge[ratio]"
 
 /obj/item/defibrillator/CheckParts(list/parts_list)
 	..()
@@ -443,6 +442,13 @@
 						H.emote("gasp")
 						if(tplus > tloss)
 							H.setBrainLoss( max(0, min(99, ((tlimit - tplus) / tlimit * 100))))
+
+						if(ishuman(H.pulledby)) // for some reason, pulledby isnt a list despite it being possible to be pulled by multiple people
+							excess_shock(user, H, H.pulledby)
+						for(var/obj/item/grab/G in H.grabbed_by)
+							if(ishuman(G.assailant))
+								excess_shock(user, H, G.assailant)
+
 						H.shock_internal_organs(100)
 						H.med_hud_set_health()
 						H.med_hud_set_status()
@@ -473,6 +479,21 @@
 					playsound(get_turf(src), 'sound/machines/defib_failed.ogg', 50, 0)
 		busy = FALSE
 		update_icon()
+/*
+ * user = the person using the defib
+ * origin = person being revived
+ * affecting = person being shocked with excess energy from the defib
+*/
+/obj/item/twohanded/shockpaddles/proc/excess_shock(mob/user, mob/living/carbon/human/origin, mob/living/carbon/human/affecting)
+	if(user == affecting)
+		return
+
+	if(electrocute_mob(affecting, defib.cell, origin)) // shock anyone touching them >:)
+		var/obj/item/organ/internal/heart/HE = affecting.get_organ_slot("heart")
+		if(HE.parent_organ == "chest" && affecting.has_both_hands()) // making sure the shock will go through their heart (drask hearts are in their head), and that they have both arms so the shock can cross their heart inside their chest
+			affecting.visible_message("<span class='danger'>[affecting]'s entire body shakes as a shock travels up their arm!</span>", \
+							"<span class='userdanger'>You feel a powerful shock travel up your [affecting.hand ? affecting.get_organ("l_arm") : affecting.get_organ("r_arm")] and back down your [affecting.hand ? affecting.get_organ("r_arm") : affecting.get_organ("l_arm")]!</span>")
+			affecting.set_heartattack(TRUE)
 
 /obj/item/borg_defib
 	name = "defibrillator paddles"

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -68,6 +68,9 @@
 	if(user.get_inactive_hand())
 		to_chat(user, "<span class='warning'>You need your other hand to be empty!</span>")
 		return FALSE
+	if(!user.has_both_hands())
+		to_chat(user, "<span class='warning'>You need both hands to wield this!</span>")
+		return FALSE
 	wielded = TRUE
 	force = force_wielded
 	if(sharp_when_wielded)

--- a/code/modules/surgery/organs/helpers.dm
+++ b/code/modules/surgery/organs/helpers.dm
@@ -66,6 +66,13 @@
 		return TRUE
 	return FALSE
 
+/mob/proc/has_both_hands()
+	return TRUE
+
+/mob/living/carbon/human/has_both_hands()
+	if(has_left_hand() && has_right_hand())
+		return TRUE
+	return FALSE
 
 //Limb numbers
 /mob/proc/get_num_arms()


### PR DESCRIPTION
2 ПРа с ОФФов:
https://github.com/ParadiseSS13/Paradise/pull/15289
https://github.com/ParadiseSS13/Paradise/pull/18809

ПРы взаимосвязаны и не могут быть разделены.

## What Does This PR Do

Исправлен эксплойт/ошибка, обнаруженная в прошлом раунде, которая позволяла ядерному игроку владеть своим мечом без одной руки.

Это также должно исправить ту же ошибку для всего другого доступного оружия.

Любой, кто потянет/схватит кого-нибудь, кто успешно реанимирован с помощью дефибриллятора, будет шокирован и может остановить свое сердце. Примечательно, что у Драсков нет сердца в груди, и их нельзя убить чрезмерным шоком, останавливающим их сердце. Это относится только к большим синим дефибрилляторам и происходит только тогда, когда тело возвращается из мертвых.

## Why It's Good For The Game
Фикс незапланированного поведения.

Это делает игру более захватывающей и с большей вероятностью вводит ролевую игру с врачами, кричащими «Чисто!» и тому подобное.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
fix: Исправлена ​​возможность держать меч без руки.

add: Если вы схватите или вытащите мертвое тело во время его дефибрилляции, вернув его к жизни с помощью большого синего дефибриллятора, это вызовет у вас шок, если вы не будете тем, кто его дефибрилирует.
добавить: шок от избыточной энергии от дефибриллятора остановит ваше сердце, если он находится в груди
. настройка: дефибрилляторы Cyborg теперь имеют специальную технологию защиты от шока, которая предотвратит любой чрезмерный шок
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
