### PR TITLE
m1911 для ОБР

### DIFF
--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -58,14 +58,15 @@
 	suit = /obj/item/clothing/suit/armor/vest/ert/command
 	glasses = /obj/item/clothing/glasses/sunglasses
 	mask = /obj/item/clothing/mask/gas/sechailer
-
+	head = /obj/item/clothing/head/helmet/ert/command
+	suit_store = /obj/item/gun/projectile/automatic/pistol/m1911
 	belt = /obj/item/gun/energy/gun
 
 	backpack_contents = list(
-		/obj/item/clothing/head/helmet/ert/command = 1,
 		/obj/item/restraints/handcuffs = 1,
 		/obj/item/storage/lockbox/mindshield = 1,
-		/obj/item/flashlight = 1
+		/obj/item/flashlight = 1,
+		/obj/item/ammo_box/magazine/m45 = 2
 	)
 
 /datum/outfit/job/centcom/response_team/commander/red
@@ -75,10 +76,7 @@
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/commander
 	glasses = /obj/item/clothing/glasses/sunglasses
 	mask = /obj/item/clothing/mask/gas/sechailer/swat
-	cybernetic_implants = list(
-		/obj/item/organ/internal/cyberimp/eyes/hud/security,
-		/obj/item/organ/internal/cyberimp/chest/nutriment
-	)
+	suit_store = /obj/item/gun/projectile/automatic/pistol/m1911
 	belt = /obj/item/gun/energy/gun/blueshield/pdw9
 
 	backpack_contents = list(
@@ -86,10 +84,16 @@
 		/obj/item/door_remote/omni = 1,
 		/obj/item/restraints/handcuffs = 1,
 		/obj/item/clothing/shoes/magboots = 1,
-		/obj/item/storage/lockbox/mindshield = 1
+		/obj/item/storage/lockbox/mindshield = 1,
+		/obj/item/ammo_box/magazine/m45 = 2
 	)
 
-	implants = list(/obj/item/implant/mindshield/ert,
+	cybernetic_implants = list(
+		/obj/item/organ/internal/cyberimp/eyes/hud/security,
+		/obj/item/organ/internal/cyberimp/chest/nutriment
+	)
+	implants = list(
+		/obj/item/implant/mindshield/ert,
 		/obj/item/implant/death_alarm
 	)
 /datum/outfit/job/centcom/response_team/commander/gamma
@@ -99,15 +103,15 @@
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/commander/gamma
 	glasses = /obj/item/clothing/glasses/night
 	mask = /obj/item/clothing/mask/gas/sechailer/swat
-	suit_store = /obj/item/gun/energy/gun/blueshield/pdw9
-	belt = /obj/item/gun/projectile/automatic/pistol/enforcer/lethal
+	suit_store = /obj/item/gun/projectile/automatic/pistol/m1911
+	belt = /obj/item/gun/energy/gun/blueshield/pdw9
 
 	backpack_contents = list(
 		/obj/item/restraints/handcuffs = 1,
 		/obj/item/storage/lockbox/mindshield = 1,
 		/obj/item/camera_bug/ert = 1,
 		/obj/item/door_remote/omni = 1,
-		/obj/item/ammo_box/magazine/enforcer/lethal = 2
+		/obj/item/ammo_box/magazine/m45 = 2
 		)
 
 	cybernetic_implants = list(
@@ -117,7 +121,8 @@
 		/obj/item/organ/internal/cyberimp/arm/flash
 	)
 
-	implants = list(/obj/item/implant/mindshield/ert,
+	implants = list(
+		/obj/item/implant/mindshield/ert,
 		/obj/item/implant/death_alarm
 	)
 
@@ -138,22 +143,23 @@
 	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/combat
 	suit = /obj/item/clothing/suit/armor/vest/ert/security
-	suit_store = /obj/item/gun/energy/gun/advtaser
+	suit_store = /obj/item/gun/projectile/automatic/pistol/m1911
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	mask = /obj/item/clothing/mask/gas/sechailer
+	head = /obj/item/clothing/head/helmet/ert/security
 
-	r_hand = /obj/item/gun/energy/laser
 
 	backpack_contents = list(
-		/obj/item/clothing/head/helmet/ert/security = 1,
 		/obj/item/storage/box/zipties = 1,
 		/obj/item/storage/box/teargas = 1,
-		/obj/item/flashlight/seclite = 1
+		/obj/item/flashlight/seclite = 1,
+		/obj/item/ammo_box/magazine/m45 = 2,
+		/obj/item/gun/energy/gun/advtaser = 1,
+		/obj/item/gun/energy/laser = 1
 	)
 
 /datum/outfit/job/centcom/response_team/security/red
 	name = "RT Security (Red)"
-
 	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/combat
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/security
@@ -161,7 +167,15 @@
 	glasses = /obj/item/clothing/glasses/sunglasses
 	mask = /obj/item/clothing/mask/gas/sechailer
 
-	r_hand = /obj/item/gun/projectile/automatic/lasercarbine
+	backpack_contents = list(
+		/obj/item/clothing/shoes/magboots = 1,
+		/obj/item/storage/box/handcuffs = 1,
+		/obj/item/grenade/flashbang = 2,
+		/obj/item/ammo_box/magazine/laser = 2,
+		/obj/item/gun/projectile/automatic/lasercarbine = 1,
+		/obj/item/ammo_box/magazine/m45 = 2,
+		/obj/item/gun/projectile/automatic/pistol/m1911 = 1
+	)
 
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/arm/flash,
@@ -169,14 +183,8 @@
 		/obj/item/organ/internal/cyberimp/eyes/hud/security
 	)
 
-	backpack_contents = list(
-		/obj/item/clothing/shoes/magboots = 1,
-		/obj/item/storage/box/handcuffs = 1,
-		/obj/item/grenade/flashbang = 2,
-		/obj/item/ammo_box/magazine/laser = 2
-	)
-
-	implants = list(/obj/item/implant/mindshield/ert,
+	implants = list(
+		/obj/item/implant/mindshield/ert,
 		/obj/item/implant/death_alarm
 	)
 
@@ -192,13 +200,15 @@
 	l_pocket = /obj/item/restraints/legcuffs/bola/energy
 	r_pocket = /obj/item/extinguisher/mini
 
-	r_hand = /obj/item/gun/energy/immolator/multi
 
 	backpack_contents = list(
 		/obj/item/storage/box/handcuffs = 1,
 		/obj/item/storage/box/flashbangs = 1,
 		/obj/item/whetstone = 1,
-		/obj/item/storage/lockbox/t4 = 1
+		/obj/item/storage/lockbox/t4 = 1,
+		/obj/item/ammo_box/magazine/m45 = 2,
+		/obj/item/gun/energy/immolator/multi = 1,
+		/obj/item/gun/projectile/automatic/pistol/m1911 = 1
 	)
 
 	cybernetic_implants = list(
@@ -209,7 +219,8 @@
 		/obj/item/organ/internal/cyberimp/chest/reviver/hardened
 	)
 
-	implants = list(/obj/item/implant/mindshield/ert,
+	implants = list(
+		/obj/item/implant/mindshield/ert,
 		/obj/item/implant/death_alarm
 	)
 
@@ -221,7 +232,6 @@
 	rt_mob_job = "ERT Engineering"
 	back = /obj/item/storage/backpack/ert/engineer
 	uniform = /obj/item/clothing/under/rank/engineer
-
 	belt = /obj/item/storage/belt/utility/full/multitool
 	pda = /obj/item/pda/heads/ert/engineering
 	id = /obj/item/card/id/ert/engineering
@@ -254,10 +264,7 @@
 	suit_store = /obj/item/tank/internals/emergency_oxygen/engi
 	glasses = /obj/item/clothing/glasses/meson
 	mask = /obj/item/clothing/mask/gas
-	cybernetic_implants = list(
-	 /obj/item/organ/internal/cyberimp/eyes/shield,
-	 /obj/item/organ/internal/cyberimp/chest/nutriment
-	)
+
 	l_pocket = /obj/item/t_scanner/extended_range
 	r_pocket = /obj/item/melee/classic_baton/telescopic
 
@@ -267,7 +274,13 @@
 		/obj/item/gun/energy/gun = 1
 	)
 
-	implants = list(/obj/item/implant/mindshield/ert,
+	cybernetic_implants = list(
+		/obj/item/organ/internal/cyberimp/eyes/shield,
+		/obj/item/organ/internal/cyberimp/chest/nutriment
+	)
+
+	implants = list(
+		/obj/item/implant/mindshield/ert,
 		/obj/item/implant/death_alarm
 	)
 
@@ -297,7 +310,8 @@
 		/obj/item/organ/internal/cyberimp/arm/toolset
 	)
 
-	implants = list(/obj/item/implant/mindshield/ert,
+	implants = list(
+		/obj/item/implant/mindshield/ert,
 		/obj/item/implant/death_alarm
 	)
 
@@ -314,14 +328,14 @@
 
 /datum/outfit/job/centcom/response_team/medic/amber
 	name = "RT Medic (Amber)"
-
 	shoes = /obj/item/clothing/shoes/white
 	gloves = /obj/item/clothing/gloves/combat
 	suit = /obj/item/clothing/suit/armor/vest/ert/medical
 	suit_store = /obj/item/gun/energy/gun/mini
 	glasses = /obj/item/clothing/glasses/hud/health
-
 	belt = /obj/item/storage/belt/medical/surgery/loaded
+	head = /obj/item/clothing/head/helmet/ert/medical
+	mask = /obj/item/clothing/mask/surgical
 
 	l_pocket = /obj/item/reagent_containers/hypospray/safety/ert
 	r_pocket = /obj/item/melee/classic_baton/telescopic
@@ -329,15 +343,13 @@
 	l_hand = /obj/item/defibrillator/loaded
 
 	backpack_contents = list(
-		/obj/item/clothing/head/helmet/ert/medical = 1,
-		/obj/item/clothing/mask/surgical = 1,
 		/obj/item/storage/firstaid/adv = 1,
 		/obj/item/storage/firstaid/regular = 1,
 		/obj/item/storage/box/autoinjectors = 1,
 		/obj/item/roller = 1,
 		/obj/item/storage/pill_bottle/ert = 1,
 		/obj/item/flashlight = 1,
-		/obj/item/healthupgrade = 1,
+		/obj/item/healthanalyzer/advanced = 1,
 		/obj/item/handheld_defibrillator = 1
 	)
 
@@ -348,18 +360,14 @@
 	gloves = /obj/item/clothing/gloves/combat
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/medical
 	glasses = /obj/item/clothing/glasses/hud/health/sunglasses
+	mask = /obj/item/clothing/mask/surgical
 	suit_store = /obj/item/gun/energy/gun
-	cybernetic_implants = list(
-	 /obj/item/organ/internal/cyberimp/arm/surgery,
-	 /obj/item/organ/internal/cyberimp/chest/nutriment
-	)
 	belt = /obj/item/defibrillator/compact/loaded
 
 	l_pocket = /obj/item/reagent_containers/hypospray/safety/ert
 	r_pocket = /obj/item/melee/classic_baton/telescopic
 
 	backpack_contents = list(
-		/obj/item/clothing/mask/surgical = 1,
 		/obj/item/storage/firstaid/toxin = 1,
 		/obj/item/storage/firstaid/brute = 1,
 		/obj/item/storage/firstaid/fire = 1,
@@ -367,8 +375,13 @@
 		/obj/item/roller = 1,
 		/obj/item/clothing/shoes/magboots = 1,
 		/obj/item/bodyanalyzer = 1,
-		/obj/item/healthupgrade = 1,
+		/obj/item/healthanalyzer/advanced = 1,
 		/obj/item/handheld_defibrillator = 1
+	)
+
+	cybernetic_implants = list(
+	/obj/item/organ/internal/cyberimp/arm/surgery,
+	/obj/item/organ/internal/cyberimp/chest/nutriment
 	)
 
 	implants = list(/obj/item/implant/mindshield/ert,
@@ -383,7 +396,6 @@
 	glasses = /obj/item/clothing/glasses/night
 	mask = /obj/item/clothing/mask/gas/sechailer/swat
 	suit_store = /obj/item/gun/energy/gun/blueshield/pdw9
-
 	belt = /obj/item/defibrillator/compact/loaded
 
 	l_pocket = /obj/item/reagent_containers/hypospray/combat/nanites
@@ -395,7 +407,6 @@
 		/obj/item/roller = 1,
 		/obj/item/healthanalyzer/advanced = 1,
 		/obj/item/handheld_defibrillator = 1
-
 		)
 
 	cybernetic_implants = list(
@@ -406,7 +417,8 @@
 		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened
 	)
 
-	implants = list(/obj/item/implant/mindshield/ert,
+	implants = list(
+		/obj/item/implant/mindshield/ert,
 		/obj/item/implant/death_alarm
 	)
 
@@ -455,7 +467,8 @@
 		/obj/item/organ/internal/cyberimp/chest/nutriment
 	)
 
-	implants = list(/obj/item/implant/mindshield/ert,
+	implants = list(
+		/obj/item/implant/mindshield/ert,
 		/obj/item/implant/death_alarm
 	)
 
@@ -474,7 +487,8 @@
 		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened
 	)
 
-	implants = list(/obj/item/implant/mindshield/ert,
+	implants = list(
+		/obj/item/implant/mindshield/ert,
 		/obj/item/implant/death_alarm
 	)
 
@@ -507,7 +521,9 @@
 	head = /obj/item/clothing/head/helmet/ert/janitor
 	glasses = /obj/item/clothing/glasses/sunglasses
 
-	r_hand = /obj/item/gun/energy/disabler
+	backpack_contents = list(
+		/obj/item/gun/energy/disabler = 1
+	)
 
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/arm/advmop)
@@ -547,6 +563,7 @@
 		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened
 	)
 
-	implants = list(/obj/item/implant/mindshield/ert,
+	implants = list(
+		/obj/item/implant/mindshield/ert,
 		/obj/item/implant/death_alarm
 	)


### PR DESCRIPTION
Отобрал энфорсеры у комманд и секьюрити ОБРовцев. Вместо них теперь м1911.

+немного минорных измений: амбер обр спавнятся в шлемах, а не хранят их в сумке по какой-то причине; амбер медик сэкономит пару секунд своей жизни и теперь имеет полноценный улучшенный анализатор здоровья, а не просто улучшалку.
Отчет по голосовалке всё не публикуют и не публикуют...


