### PR TITLE
Fix: headrev now cant be deconverted by harmbatoning them in head

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -469,7 +469,7 @@ emp_act
 											"<span class='combat userdanger'>[src] has been knocked down!</span>")
 							apply_effect(2, WEAKEN, armor)
 							AdjustConfused(15)
-						if(prob(I.force + ((100 - health)/2)) && src != user && I.damtype == BRUTE)
+						if(mind.special_role == SPECIAL_ROLE_REV && prob(I.force + ((100 - health)/2)) && src != user && I.damtype == BRUTE)
 							SSticker.mode.remove_revolutionary(mind)
 
 					if(bloody)//Apply blood


### PR DESCRIPTION
Исправлен баг с тем что хедрева может быть деконвертнут ударами по голове
