### PR TITLE
Fix/Feat/Ref: Atmos QoL

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -35,7 +35,6 @@ Thus, the two variables affect pump operation are set in New():
 	if(!ishuman(usr) && !issilicon(usr))
 		return
 	toggle()
-	return ..()
 
 /obj/machinery/atmospherics/binary/pump/AICtrlClick()
 	toggle()
@@ -50,7 +49,6 @@ Thus, the two variables affect pump operation are set in New():
 	if(!ishuman(usr) && !issilicon(usr))
 		return
 	set_max()
-	return
 
 /obj/machinery/atmospherics/binary/pump/AIAltClick()
 	set_max()

--- a/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
@@ -35,7 +35,6 @@ Thus, the two variables affect pump operation are set in New():
 	if(!ishuman(usr) && !issilicon(usr))
 		return
 	toggle()
-	return ..()
 
 /obj/machinery/atmospherics/binary/volume_pump/AICtrlClick()
 	toggle()
@@ -50,7 +49,6 @@ Thus, the two variables affect pump operation are set in New():
 	if(!ishuman(usr) && !issilicon(usr))
 		return
 	set_max()
-	return
 
 /obj/machinery/atmospherics/binary/volume_pump/AIAltClick()
 	set_max()

--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -40,7 +40,6 @@
 	if(!ishuman(usr) && !issilicon(usr))
 		return
 	toggle()
-	return ..()
 
 /obj/machinery/atmospherics/trinary/filter/AICtrlClick()
 	toggle()
@@ -55,7 +54,6 @@
 	if(!ishuman(usr) && !issilicon(usr))
 		return
 	set_max()
-	return
 
 /obj/machinery/atmospherics/trinary/filter/AIAltClick()
 	set_max()

--- a/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
@@ -21,7 +21,6 @@
 	if(!ishuman(usr) && !issilicon(usr))
 		return
 	toggle()
-	return ..()
 
 /obj/machinery/atmospherics/trinary/mixer/AICtrlClick()
 	toggle()
@@ -36,7 +35,6 @@
 	if(!ishuman(usr) && !issilicon(usr))
 		return
 	set_max()
-	return
 
 /obj/machinery/atmospherics/trinary/mixer/AIAltClick()
 	set_max()

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -146,6 +146,9 @@
 	else
 		return ..()
 
+/obj/item/pipe/AltClick(mob/user)
+	rotate()
+
 /obj/item/pipe/proc/update(var/obj/machinery/atmospherics/make_from)
 	name = "[get_pipe_name(pipe_type, PIPETYPE_ATMOS)] fitting"
 	icon_state = get_pipe_icon(pipe_type)

--- a/code/game/objects/items/weapons/rpd.dm
+++ b/code/game/objects/items/weapons/rpd.dm
@@ -7,6 +7,7 @@
 #define RPD_MENU_ROTATE "Rotate pipes" //Stuff for radial menu
 #define RPD_MENU_FLIP "Flip pipes" //Stuff for radial menu
 #define RPD_MENU_DELETE "Delete pipes" //Stuff for radial menu
+#define RPD_MENU_WRENCH "Toggle auto-wrenching"
 
 /obj/item/rpd
 	name = "rapid pipe dispenser"
@@ -38,6 +39,8 @@
 	var/ranged = FALSE
 	var/primary_sound = 'sound/machines/click.ogg'
 	var/alt_sound = null
+	var/obj/item/wrench/integrated_wrench = new
+	var/auto_wrench = FALSE
 
 	//Lists of things
 	var/list/mainmenu = list(
@@ -114,6 +117,8 @@
 			P.dir = user.dir
 	to_chat(user, "<span class='notice'>[src] rapidly dispenses [P]!</span>")
 	activate_rpd(TRUE)
+	if(auto_wrench)
+		P.wrench_act(user, integrated_wrench)
 
 /obj/item/rpd/proc/create_disposals_pipe(mob/user, turf/T) //Make a disposals pipe / construct
 	if(!can_dispense_pipe(whatdpipe, RPD_DISPOSALS_MODE))
@@ -126,6 +131,8 @@
 		P.flip()
 	to_chat(user, "<span class='notice'>[src] rapidly dispenses [P]!</span>")
 	activate_rpd(TRUE)
+	if(auto_wrench)
+		P.wrench_act(user, integrated_wrench)
 
 /obj/item/rpd/proc/rotate_all_pipes(mob/user, turf/T) //Rotate all pipes on a turf
 	for(var/obj/item/pipe/P in T)
@@ -229,6 +236,7 @@
 		RPD_MENU_ROTATE = image(icon = 'icons/obj/interface.dmi', icon_state = "rpd_rotate"),
 		RPD_MENU_FLIP = image(icon = 'icons/obj/interface.dmi', icon_state = "rpd_flip"),
 		RPD_MENU_DELETE = image(icon = 'icons/obj/interface.dmi', icon_state = "rpd_delete"),
+		RPD_MENU_WRENCH = image(icon = 'icons/obj/tools.dmi', icon_state = "wrench"),
 		"UI" = image(icon = 'icons/obj/interface.dmi', icon_state = "ui_interact")
 	)
 	var/selected_mode = show_radial_menu(user, src, choices, custom_check = CALLBACK(src, .proc/check_menu, user))
@@ -244,6 +252,10 @@
 				mode = RPD_FLIP_MODE
 			if(RPD_MENU_DELETE)
 				mode = RPD_DELETE_MODE
+			if(RPD_MENU_WRENCH)
+				auto_wrench = !auto_wrench
+				to_chat(user, "<span class='notice'>You [auto_wrench ? "enable" : "disable"] auto-wrenching new-placed pipes.</span>")
+				return
 			else
 				return //Either nothing was selected, or an invalid mode was selected
 		to_chat(user, "<span class='notice'>You set [src]'s mode.</span>")
@@ -288,3 +300,4 @@
 #undef RPD_MENU_ROTATE
 #undef RPD_MENU_FLIP
 #undef RPD_MENU_DELETE
+#undef RPD_MENU_WRENCH

--- a/code/game/objects/items/weapons/rpd.dm
+++ b/code/game/objects/items/weapons/rpd.dm
@@ -198,6 +198,7 @@
 	data["pipe_category"] = pipe_category
 	data["whatdpipe"] = whatdpipe
 	data["whatpipe"] = whatpipe
+	data["auto_wrench"] = auto_wrench
 	return data
 
 /obj/item/rpd/ui_act(action, list/params)
@@ -217,6 +218,8 @@
 			pipe_category = text2num(sanitize(params["pipe_category"]))
 		if("mode")
 			mode = text2num(sanitize(params["mode"]))
+		if("auto_wrench")
+			auto_wrench = !auto_wrench
 
 //RPD radial menu
 /obj/item/rpd/proc/check_menu(mob/living/user)

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -2,7 +2,6 @@
 // This is the pipe that you drag around, not the attached ones.
 
 /obj/structure/disposalconstruct
-
 	name = "disposal pipe segment"
 	desc = "A huge pipe segment used for constructing disposal systems."
 	icon = 'icons/obj/pipes/disposal.dmi'
@@ -15,6 +14,8 @@
 	var/ptype = PIPE_DISPOSALS_STRAIGHT //Use the defines
 	var/base_state
 	var/dpdir = 0	// directions as disposalpipe
+	var/nicetype = "pipe"
+	var/ispipe = 0 // Indicates if we should change the level of this pipe
 
 /obj/structure/disposalconstruct/Initialize(mapload, pipe_type, direction)
 	. = ..()
@@ -140,15 +141,7 @@
 			return /obj/structure/disposalpipe/sortjunction
 	return
 
-
-
-// attackby item
-// wrench: (un)anchor
-// weldingtool: convert to real pipe
-
-/obj/structure/disposalconstruct/attackby(var/obj/item/I, var/mob/user, params)
-	var/nicetype = "pipe"
-	var/ispipe = 0 // Indicates if we should change the level of this pipe
+/obj/structure/disposalconstruct/proc/pipe_check(mob/user)
 	src.add_fingerprint(user)
 	switch(ptype)
 		if(PIPE_DISPOSALS_BIN)
@@ -163,39 +156,15 @@
 		else
 			nicetype = "pipe"
 			ispipe = 1
-
 	var/turf/T = src.loc
 	if(T.intact)
 		to_chat(user, "You can only attach the [nicetype] if the floor plating is removed.")
-		return
-
-	if(istype(I, /obj/item/wrench))
-		if(anchored)
-			anchored = 0
-			if(ispipe)
-				level = 2
-				density = 0
-			else
-				density = 1
-			to_chat(user, "You detach the [nicetype] from the underfloor.")
-		else
-			anchored = 1
-			if(ispipe)
-				level = 1 // We don't want disposal bins to disappear under the floors
-				density = 0
-			else
-				density = 1 // We don't want disposal bins or outlets to go density 0
-			to_chat(user, "You attach the [nicetype] to the underfloor.")
-		playsound(src.loc, I.usesound, 100, 1)
-		update()
-		return
-
-
+		return FALSE
 	if(ptype in list(PIPE_DISPOSALS_BIN, PIPE_DISPOSALS_OUTLET, PIPE_DISPOSALS_CHUTE)) // Disposal or outlet
 		var/obj/structure/disposalpipe/trunk/CP = locate() in T
 		if(!CP) // There's no trunk
 			to_chat(user, "The [nicetype] requires a trunk underneath it in order to work.")
-			return
+			return FALSE
 	else
 		for(var/obj/structure/disposalpipe/CP in T)
 			if(CP)
@@ -205,55 +174,72 @@
 					pdir = CP.dir
 				if(pdir & dpdir)
 					to_chat(user, "There is already a [nicetype] at that location.")
-					return
+					return FALSE
+	return TRUE
 
-	if(istype(I, /obj/item/weldingtool))
-		if(anchored)
-			if(I.tool_use_check(user, 0))
-				to_chat(user, "Welding the [nicetype] in place.")
-				if(I.use_tool(src, user, 20, volume = I.tool_volume))
-					to_chat(user, "The [nicetype] has been welded in place!")
-					update() // TODO: Make this neat
-					if(ispipe) // Pipe
-
-						var/pipetype = dpipetype()
-						var/obj/structure/disposalpipe/P = new pipetype(src.loc)
-						src.transfer_fingerprints_to(P)
-						P.base_icon_state = base_state
-						P.dir = dir
-						P.dpdir = dpdir
-						P.update_icon()
-
-						//Needs some special treatment ;)
-						if(ptype == PIPE_DISPOSALS_SORT_RIGHT || ptype == PIPE_DISPOSALS_SORT_LEFT)
-							var/obj/structure/disposalpipe/sortjunction/SortP = P
-							SortP.updatedir()
-
-					else if(ptype == PIPE_DISPOSALS_BIN) // Disposal bin
-						var/obj/machinery/disposal/P = new /obj/machinery/disposal(src.loc)
-						src.transfer_fingerprints_to(P)
-						P.mode = 0 // start with pump off
-
-					else if(ptype == PIPE_DISPOSALS_OUTLET) // Disposal outlet
-
-						var/obj/structure/disposaloutlet/P = new /obj/structure/disposaloutlet(src.loc)
-						src.transfer_fingerprints_to(P)
-						P.dir = dir
-
-					else if(ptype==PIPE_DISPOSALS_CHUTE) // Disposal outlet
-
-						var/obj/machinery/disposal/deliveryChute/P = new /obj/machinery/disposal/deliveryChute(src.loc)
-						src.transfer_fingerprints_to(P)
-						P.dir = dir
-
-					qdel(src)
-					return
-			else
-				to_chat(user, "You need more welding fuel to complete this task.")
-				return
+/obj/structure/disposalconstruct/wrench_act(mob/living/user, obj/item/I)
+	. = TRUE
+	if(!pipe_check(user))
+		return
+	if(anchored)
+		anchored = 0
+		if(ispipe)
+			level = 2
+			density = 0
 		else
-			to_chat(user, "You need to attach it to the plating first!")
-			return
+			density = 1
+		to_chat(user, "You detach the [nicetype] from the underfloor.")
+	else
+		anchored = 1
+		if(ispipe)
+			level = 1 // We don't want disposal bins to disappear under the floors
+			density = 0
+		else
+			density = 1 // We don't want disposal bins or outlets to go density 0
+		to_chat(user, "You attach the [nicetype] to the underfloor.")
+	playsound(src.loc, I.usesound, 100, 1)
+	update()
+
+/obj/structure/disposalconstruct/welder_act(mob/living/user, obj/item/I)
+	. = TRUE
+	if(!pipe_check(user))
+		return
+	if(!anchored)
+		to_chat(user, "You need to attach it to the plating first!")
+		return
+	if(!I.tool_use_check(user, 0))
+		to_chat(user, "You need more welding fuel to complete this task.")
+		return
+	to_chat(user, "Welding the [nicetype] in place.")
+	if(I.use_tool(src, user, 20, volume = I.tool_volume))
+		to_chat(user, "The [nicetype] has been welded in place!")
+		update() // TODO: Make this neat
+		if(ispipe) // Pipe
+			var/pipetype = dpipetype()
+			var/obj/structure/disposalpipe/P = new pipetype(src.loc)
+			src.transfer_fingerprints_to(P)
+			P.base_icon_state = base_state
+			P.dir = dir
+			P.dpdir = dpdir
+			P.update_icon()
+			//Needs some special treatment ;)
+			if(ptype == PIPE_DISPOSALS_SORT_RIGHT || ptype == PIPE_DISPOSALS_SORT_LEFT)
+				var/obj/structure/disposalpipe/sortjunction/SortP = P
+				SortP.updatedir()
+		else if(ptype == PIPE_DISPOSALS_BIN) // Disposal bin
+			var/obj/machinery/disposal/P = new /obj/machinery/disposal(src.loc)
+			src.transfer_fingerprints_to(P)
+			P.mode = 0 // start with pump off
+		else if(ptype == PIPE_DISPOSALS_OUTLET) // Disposal outlet
+			var/obj/structure/disposaloutlet/P = new /obj/structure/disposaloutlet(src.loc)
+			src.transfer_fingerprints_to(P)
+			P.dir = dir
+		else if(ptype==PIPE_DISPOSALS_CHUTE) // Disposal outlet
+			var/obj/machinery/disposal/deliveryChute/P = new /obj/machinery/disposal/deliveryChute(src.loc)
+			src.transfer_fingerprints_to(P)
+			P.dir = dir
+		qdel(src)
+		return
 
 /obj/structure/disposalconstruct/rpd_act(mob/user, obj/item/rpd/our_rpd)
 	. = TRUE

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -74,7 +74,8 @@
 	C.update()
 	C.anchored = 0
 	C.density = 1
-	qdel(src)
+	if(!QDELING(src))
+		qdel(src)
 
 /obj/machinery/disposal/Destroy()
 	eject()

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -6,6 +6,11 @@
 // Can hold items and human size things, no other draggables
 // Toilets are a type of disposal bin for small objects only and work on magic. By magic, I mean torque rotation
 #define SEND_PRESSURE 0.05*ONE_ATMOSPHERE
+#define UNSCREWED -1
+#define OFF 0
+#define SCREWED 1
+#define CHARGING 1
+#define CHARGED 2
 
 /obj/machinery/disposal
 	name = "disposal unit"
@@ -19,14 +24,13 @@
 	max_integrity = 200
 	resistance_flags = FIRE_PROOF
 	var/datum/gas_mixture/air_contents	// internal reservoir
-	var/mode = 1	// item mode 0=off 1=charging 2=charged
-	var/flush = 0	// true if flush handle is pulled
+	var/mode = CHARGING	// item mode 0=off 1=charging 2=charged
+	var/flush = FALSE	// true if flush handle is pulled
 	var/obj/structure/disposalpipe/trunk/trunk = null // the attached pipe trunk
-	var/flushing = 0	// true if flushing in progress
+	var/flushing = FALSE	// true if flushing in progress
 	var/flush_every_ticks = 30 //Every 30 ticks it will look whether it is ready to flush
 	var/flush_count = 0 //this var adds 1 once per tick. When it reaches flush_every_ticks it resets and tries to flush.
 	var/last_sound = 0
-	var/required_mode_to_deconstruct = -1
 	var/deconstructs_to = PIPE_DISPOSALS_BIN
 	var/storage_slots = 50 //The number of storage slots in this container.
 	var/max_combined_w_class = 50 //The sum of the w_classes of all the items in this storage item.
@@ -45,8 +49,8 @@
 /obj/machinery/disposal/proc/trunk_check()
 	var/obj/structure/disposalpipe/trunk/T = locate() in loc
 	if(!T)
-		mode = 0
-		flush = 0
+		mode = OFF
+		flush = FALSE
 	else
 		mode = initial(mode)
 		flush = initial(flush)
@@ -186,7 +190,7 @@
 
 
 /obj/machinery/disposal/screwdriver_act(mob/user, obj/item/I)
-	if(mode>0) // It's on
+	if(mode > OFF) // It's on
 		return
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
@@ -194,15 +198,15 @@
 	if(contents.len > 0)
 		to_chat(user, "Eject the items first!")
 		return
-	if(mode==0) // It's off but still not unscrewed
-		mode=-1 // Set it to doubleoff l0l
-	else if(mode==-1)
-		mode=0
+	if(mode == OFF) // It's off but still not unscrewed
+		mode = UNSCREWED // Set it to doubleoff l0l
+	else if(mode == UNSCREWED)
+		mode = OFF
 	to_chat(user, "You [mode ? "unfasten": "fasten"] the screws around the power connection.")
 
 /obj/machinery/disposal/welder_act(mob/user, obj/item/I)
 	. = TRUE
-	if(mode != required_mode_to_deconstruct)
+	if(mode != UNSCREWED)
 		return
 	if(contents.len > 0)
 		to_chat(user, "Eject the items first!")
@@ -327,7 +331,7 @@
 		to_chat(usr, "<span class='warning'>You cannot reach the controls from inside.</span>")
 		return
 
-	if(mode==-1 && action != "eject") // If the mode is -1, only allow ejection
+	if(mode == UNSCREWED && action != "eject") // If the mode is -1, only allow ejection
 		to_chat(usr, "<span class='warning'>The disposal units power is disabled.</span>")
 		return
 
@@ -341,18 +345,18 @@
 
 	if(istype(src.loc, /turf))
 		if(action == "pumpOn")
-			mode = 1
+			mode = CHARGING
 			update()
 		if(action == "pumpOff")
-			mode = 0
+			mode = OFF
 			update()
 
 		if(!issilicon(usr))
 			if(action == "engageHandle")
-				flush = 1
+				flush = TRUE
 				update()
 			if(action == "disengageHandle")
-				flush = 0
+				flush = FALSE
 				update()
 
 			if(action == "eject")
@@ -372,8 +376,8 @@
 	overlays.Cut()
 	if(stat & BROKEN)
 		icon_state = "disposal-broken"
-		mode = 0
-		flush = 0
+		mode = OFF
+		flush = FALSE
 		return
 
 	// flush handle
@@ -389,9 +393,9 @@
 		overlays += image('icons/obj/pipes/disposal.dmi', "dispover-full")
 
 	// charging and ready light
-	if(mode == 1)
+	if(mode == CHARGING)
 		overlays += image('icons/obj/pipes/disposal.dmi', "dispover-charge")
-	else if(mode == 2)
+	else if(mode == CHARGED)
 		overlays += image('icons/obj/pipes/disposal.dmi', "dispover-ready")
 
 // timed process
@@ -404,7 +408,7 @@
 	flush_count++
 	if( flush_count >= flush_every_ticks )
 		if( contents.len )
-			if(mode == 2)
+			if(mode == CHARGED)
 				spawn(0)
 					flush()
 		flush_count = 0
@@ -419,7 +423,7 @@
 
 	use_power = IDLE_POWER_USE
 
-	if(mode != 1)		// if off or ready, no need to charge
+	if(mode != CHARGING)		// if off or ready, no need to charge
 		return
 
 	// otherwise charge
@@ -441,50 +445,47 @@
 
 	// if full enough, switch to ready mode
 	if(air_contents.return_pressure() >= SEND_PRESSURE)
-		mode = 2
+		mode = CHARGED
 		update()
 	return
 
 // perform a flush
 /obj/machinery/disposal/proc/flush()
-
-	flushing = 1
-	flick("[icon_state]-flush", src)
-
-	var/wrapcheck = 0
+	flushing = TRUE
+	flush_animation()
 	var/obj/structure/disposalholder/H = new()	// virtual holder object which actually
 												// travels through the pipes.
-	//Hacky test to get drones to mail themselves through disposals.
-	for(var/mob/living/silicon/robot/drone/D in src)
-		wrapcheck = 1
-
-	for(var/mob/living/silicon/robot/syndicate/saboteur/R in src)
-		wrapcheck = 1
-
-	for(var/obj/item/smallDelivery/O in src)
-		wrapcheck = 1
-
-	if(wrapcheck == 1)
-		H.tomail = 1
-
+	manage_wrapping(H)
 	sleep(10)
 	if(last_sound < world.time + 1)
 		playsound(src, 'sound/machines/disposalflush.ogg', 50, 0, 0)
 		last_sound = world.time
 	sleep(5) // wait for animation to finish
-
-
 	H.init(src)	// copy the contents of disposer to holder
 	air_contents = new() // The holder just took our gas; replace it
 	H.start(src) // start the holder processing movement
-	flushing = 0
+	flushing = FALSE
 	// now reset disposal state
-	flush = 0
-	if(mode == 2)	// if was ready,
-		mode = 1	// switch to charging
+	flush = FALSE
+	if(mode == CHARGED)	// if was ready,
+		mode = CHARGING	// switch to charging
 	update()
 	return
 
+/obj/machinery/disposal/proc/flush_animation()
+	flick("[icon_state]-flush", src)
+
+/obj/machinery/disposal/proc/manage_wrapping(obj/structure/disposalholder/H)
+	var/wrap_check = FALSE
+	//Hacky test to get drones to mail themselves through disposals.
+	for(var/mob/living/silicon/robot/drone/D in src)
+		wrap_check = TRUE
+	for(var/mob/living/silicon/robot/syndicate/saboteur/R in src)
+		wrap_check = TRUE
+	for(var/obj/item/smallDelivery/O in src)
+		wrap_check = TRUE
+	if(wrap_check == TRUE)
+		H.tomail = 1
 
 // called when area power changes
 /obj/machinery/disposal/power_change()
@@ -1313,12 +1314,11 @@
 	var/active = 0
 	var/turf/target	// this will be where the output objects are 'thrown' to.
 	var/obj/structure/disposalpipe/trunk/linkedtrunk
-	var/mode = 0
+	var/mode = SCREWED
 
 /obj/structure/disposaloutlet/Initialize(mapload)
 	. = ..()
 	addtimer(CALLBACK(src, .proc/setup), 0) // Wait of 0, but this wont actually do anything until the MC is firing
-
 
 /obj/structure/disposaloutlet/proc/setup()
 	target = get_ranged_target_turf(src, dir, 10)
@@ -1331,7 +1331,6 @@
 		linkedtrunk.remove_trunk_links()
 	expel(FALSE)
 	return ..()
-
 
 // expel the contents of the outlet
 /obj/structure/disposaloutlet/proc/expel(animation = TRUE)
@@ -1350,25 +1349,19 @@
 				return
 			AM.throw_at(target, 3, 1)
 
-
-/obj/structure/disposaloutlet/attackby(var/obj/item/I, var/mob/user, params)
-	if(!I || !user)
-		return
-	src.add_fingerprint(user)
-	if(istype(I, /obj/item/screwdriver))
-		if(mode==0)
-			mode=1
-			playsound(src.loc, I.usesound, 50, 1)
-			to_chat(user, "You remove the screws around the power connection.")
-			return
-		else if(mode==1)
-			mode=0
-			playsound(src.loc, I.usesound, 50, 1)
-			to_chat(user, "You attach the screws around the power connection.")
-			return
+/obj/structure/disposaloutlet/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(mode == SCREWED)
+		mode = UNSCREWED
+	else
+		mode = SCREWED
+	playsound(src.loc, I.usesound, 50, 1)
+	to_chat(user, "You [mode == SCREWED ? "attach" : "remove"] the screws around the power connection.")
 
 /obj/structure/disposaloutlet/welder_act(mob/user, obj/item/I)
 	. = TRUE
+	if(mode != UNSCREWED)
+		return
 	if(!I.tool_use_check(user, 0))
 		return
 	WELDER_ATTEMPT_FLOOR_SLICE_MESSAGE
@@ -1423,3 +1416,10 @@
 		dirs = GLOB.alldirs.Copy()
 
 	src.streak(dirs)
+
+#undef SEND_PRESSURE
+#undef UNSCREWED
+#undef OFF
+#undef SCREWED
+#undef CHARGING
+#undef CHARGED

--- a/tgui/packages/tgui/interfaces/RPD.js
+++ b/tgui/packages/tgui/interfaces/RPD.js
@@ -8,6 +8,7 @@ export const RPD = (props, context) => {
   const {
     mainmenu,
     mode,
+    auto_wrench,
   } = data;
 
   const decideTab = index => {
@@ -41,6 +42,14 @@ export const RPD = (props, context) => {
                 () => act('mode', { mode: m.mode })
               } />
           ))}
+          <Button
+            fluid
+            textAlign="center"
+            content="Auto-wrench"
+            selected={auto_wrench === 1}
+            onClick={
+              () => act('auto_wrench', { auto_wrench: !auto_wrench })
+            } />
         </Tabs>
         {decideTab(mode)}
       </Window.Content>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Read Changelog

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Удобнее управлять трубами, добавлена возможность использования Chute для директировки посылок в Карго.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: Rotate pipes with AltClick!
add: Disposal Chute can be directed either directly to waste disposals (default) or to cargo disposals with destination tagger
add: Auto-wrench option for RPD! (AltClick/TGUI)
tweak: No pull message when CtrlClick is overriden
ref: Disposal unit and Disposal Chute are more unified, +standartization
ref: Disposal pipe wrench/welder acts

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
