### PR TITLE
Feat: Borer Buff(MedHud, separeted SalGlu)

### DIFF
--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -110,6 +110,7 @@
 	var/datum/action/innate/borer/give_back_control/give_back_control_action = new
 	var/datum/action/innate/borer/leave_body/leave_body_action = new
 	var/datum/action/innate/borer/make_chems/make_chems_action = new
+	var/datum/action/innate/borer/make_scan/make_scan_action = new
 	var/datum/action/innate/borer/make_larvae/make_larvae_action = new
 	var/datum/action/innate/borer/freeze_victim/freeze_victim_action = new
 	var/datum/action/innate/borer/torment/torment_action = new
@@ -377,6 +378,7 @@
 
 	RemoveBorerActions()
 	GrantInfestActions()
+	GrantMedicalHud()
 
 /mob/living/simple_animal/borer/verb/secrete_chemicals()
 	set category = "Borer"
@@ -589,6 +591,7 @@
 		detach()
 	GrantBorerActions()
 	RemoveInfestActions()
+	RemoveMedicalHud()
 	forceMove(get_turf(host))
 	machine = null
 
@@ -657,6 +660,8 @@
 		var/h2b_ip= host.lastKnownIP
 		host.computer_id = null
 		host.lastKnownIP = null
+
+		RemoveMedicalHud()
 
 		qdel(host_brain)
 		host_brain = new(src)
@@ -783,6 +788,7 @@
 	host.verbs -= /mob/living/proc/trapped_mind_comm
 
 	RemoveControlActions()
+	GrantMedicalHud()
 	talk_to_borer_action.Grant(host)
 	host.med_hud_set_status()
 
@@ -859,12 +865,14 @@
 	leave_body_action.Grant(src)
 	take_control_action.Grant(src)
 	make_chems_action.Grant(src)
+	make_scan_action.Grant(src)
 
 /mob/living/simple_animal/borer/proc/RemoveInfestActions()
 	talk_to_host_action.Remove(src)
 	take_control_action.Remove(src)
 	leave_body_action.Remove(src)
 	make_chems_action.Remove(src)
+	make_scan_action.Remove(src)
 
 /mob/living/simple_animal/borer/proc/GrantControlActions()
 	talk_to_brain_action.Grant(host)
@@ -877,6 +885,14 @@
 	make_larvae_action.Remove(host)
 	give_back_control_action.Remove(host)
 	torment_action.Remove(host)
+
+/mob/living/simple_animal/borer/proc/GrantMedicalHud()
+	var/datum/atom_hud/data/human/medical/advanced/A = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
+	A.add_hud_to(src)
+
+/mob/living/simple_animal/borer/proc/RemoveMedicalHud()
+	var/datum/atom_hud/data/human/medical/advanced/A = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
+	A.remove_hud_from(src)
 
 /datum/action/innate/borer
 	background_icon_state = "bg_alien"
@@ -962,11 +978,21 @@
 	name = "Secrete Chemicals"
 	desc = "Push some chemicals into your host's bloodstream."
 	icon_icon = 'icons/obj/chemical.dmi'
-	button_icon_state = "minidispenser"
+	button_icon_state = "dispenser"
 
 /datum/action/innate/borer/make_chems/Activate()
 	var/mob/living/simple_animal/borer/B = owner
 	B.secrete_chemicals()
+
+/datum/action/innate/borer/make_scan
+	name = "Perform Scan"
+	desc = "Scans the host's body."
+	icon_icon = 'icons/obj/device.dmi'
+	button_icon_state = "health"
+
+/datum/action/innate/borer/make_scan/Activate()
+	var/mob/living/simple_animal/borer/B = owner
+	healthscan(B, B.host, 1)
 
 /datum/action/innate/borer/make_larvae
 	name = "Reproduce"

--- a/code/game/gamemodes/miniantags/borer/borer_chemicals.dm
+++ b/code/game/gamemodes/miniantags/borer/borer_chemicals.dm
@@ -1,7 +1,7 @@
 /datum/borer_chem
 	var/chemname
 	var/chemdesc = "This is a chemical"
-	var/chemuse = 30
+	var/chemuse = 20
 	var/quantity = 10
 
 /datum/borer_chem/capulettium_plus
@@ -42,9 +42,20 @@
 	chemname = "salbutamol"
 	chemdesc = "Heals suffocation damage."
 
-/datum/borer_chem/salglu_solution
-	chemname = "salglu_solution"
-	chemdesc = "Slowly heals brute and burn damage, also slowly restores blood."
+/datum/borer_chem/bicaridine
+	chemname = "bicaridines"
+	chemdesc = "Heals brute damage."
+	chemuse = 30
+
+/datum/borer_chem/kelotane
+	chemname = "kelotane"
+	chemdesc = "Heals burn damage."
+	chemuse = 30
+
+/datum/borer_chem/iron
+	chemname = "iron"
+	chemdesc = "Slowly restores blood in organism."
+	chemuse = 40
 
 /datum/borer_chem/spaceacillin
 	chemname = "spaceacillin"

--- a/code/game/gamemodes/miniantags/borer/borer_chemicals.dm
+++ b/code/game/gamemodes/miniantags/borer/borer_chemicals.dm
@@ -43,7 +43,7 @@
 	chemdesc = "Heals suffocation damage."
 
 /datum/borer_chem/bicaridine
-	chemname = "bicaridines"
+	chemname = "bicaridine"
 	chemdesc = "Heals brute damage."
 	chemuse = 30
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Дать борерам, медхуд(когда внутри кого-то), способность на подобии медицинского сканнера(также только если внутри кого-то).
Уменьшить стоимость всех химикатов с 30 до 20 кроме флиптониум и мета(которые по 50)
Заменить Saline-Glucose Solution на kelotane(От ожогов) и bicardine(от брута) стоимость которых будут по 30 и железо(для крови) по 40.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Бореры будут полезны для своего носителя, понимая его тело ещё лучше. Нежели наугад через Examine что есть урон или в какой ситуации носитель.(космос, побили или паук прыскнул токсины)

## Changelog
:cl:
add: Med hud and med scan to borer while inside a host
tweak: SalGlu on kelotane(30chemuse) and bicaridine(30 chemuse) and iron(40 chemuse)
tweak: Decreases value of chems from 30 to 20
fix: action icon for making borer chems
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
