### PR TITLE
Ребаланс глоушрумов

### DIFF
--- a/code/__DEFINES/span.dm
+++ b/code/__DEFINES/span.dm
@@ -1,3 +1,4 @@
 #define SPAN_HEAR(str) ("<span class='hear'>" + str + "</span>")
 #define SPAN_WARNING(str) ("<span class='warning'>" + str + "</span>")
 #define SPAN_ALERT(str) ("<span class='alert>" + str + "</span>")
+#define SPAN_DANGER(str) ("<span class='danger>" + str + "</span>")

--- a/code/__DEFINES/span.dm
+++ b/code/__DEFINES/span.dm
@@ -1,4 +1,6 @@
 #define SPAN_HEAR(str) ("<span class='hear'>" + str + "</span>")
 #define SPAN_WARNING(str) ("<span class='warning'>" + str + "</span>")
-#define SPAN_ALERT(str) ("<span class='alert>" + str + "</span>")
-#define SPAN_DANGER(str) ("<span class='danger>" + str + "</span>")
+#define SPAN_ALERT(str) ("<span class='alert'>" + str + "</span>")
+#define SPAN_DANGER(str) ("<span class='danger'>" + str + "</span>")
+#define SPAN_NOTICE(str) ("<span class='notice'>" + str + "</span>")
+

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -123,18 +123,8 @@
 		if(!prob(chance_generation))
 			continue
 
-		var/turf/new_loc = null
-		//Try three random locations to spawn before giving up tradeoff
-		//between running view(1, earth) on every single collected possibleLoc
-		//and failing to spread if we get 3 bad picks, which should only be a problem
-		//if there's a lot of glow shroom clustered about
-		for(var/idx in 1 to 3)
-			var/turf/possible_loc = pick(possible_locs)
-			new_loc = possible_loc
-			break
+		var/turf/new_loc = pick(possible_locs)
 		//We failed to find any location, skip trying to yield
-		if(new_loc == null)
-			break
 		var/shroom_count = 0
 		var/place_count = 1
 		for(var/obj/structure/glowshroom/shroom in new_loc)

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -10,10 +10,10 @@
 	//replaced in Initialize()
 	icon_state = "glowshroom"
 	layer = ABOVE_NORMAL_TURF_LAYER
-	/// Time interval between glowshroom "spreads"
-	var/delay_spread = 2 MINUTES
+	/// Time interval between glowshroom "spreads". Made it as a constant for better control.
+	var/delay_spread = 13 SECONDS
 	/// Time interval between glowshroom decay checks
-	var/delay_decay = 30 SECONDS
+	var/delay_decay = 60 SECONDS
 	/// Boolean to indicate if the shroom is on the floor/wall
 	var/floor = FALSE
 	/// Mushroom generation number
@@ -70,12 +70,7 @@
 		myseed.adjust_yield(rand(-3, 2))
 		myseed.adjust_production(rand(-3, 3))
 		// adjust_endurance has a min value of 10, need to edit directly
-		myseed.endurance = clamp(myseed.endurance + rand(-3, 2), 0, 100)
-
-	//In case production is varedited to -1 or less which would cause unlimited or negative delay.
-	if(myseed.production >= 1)
-		//Because lower production speed stat gives faster production speed, which should give faster mushroom spread. Range 0 — idk-how-many deciseconds.
-		delay_spread = delay_spread ** (1 / (2 - myseed.production / 10))
+		myseed.endurance = clamp(myseed.endurance, 30, 30)
 
 	if(myseed.get_gene(/datum/plant_gene/trait/glow))
 		var/datum/plant_gene/trait/glow/glow_gene = myseed.get_gene(/datum/plant_gene/trait/glow)
@@ -124,12 +119,12 @@
 
 	for(var/i in 1 to myseed.yield)
 		// Chance of generating a new mushroom based on stats
-		var/chance_stats = ((myseed.potency + myseed.endurance * 2) * 0.2)
+		// var/chance_stats = ((myseed.potency + myseed.endurance * 2) * 0.2)
 		// This formula gives you diminishing returns based on generation. 100% with 1st gen, decreasing to 25%, 11%, 6, 4, 2...
-		var/chance_generation = (100 / (generation * generation))
+		var/chance_generation = 100 / generation - 10
 
 		// Whatever is the higher chance we use it (this is really stupid as the diminishing returns are effectively pointless???)
-		if(prob(max(chance_stats, chance_generation)))
+		if(prob(chance_generation))
 			var/spread_to_adjacent = prob(adjacent_spread_chance)
 			var/turf/new_loc = null
 			//Try three random locations to spawn before giving up tradeoff

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -122,42 +122,44 @@
 		var/chance_generation = 100 / generation - 10
 
 		// Whatever is the higher chance we use it (this is really stupid as the diminishing returns are effectively pointless???)
-		if(prob(chance_generation))
-			var/spread_to_adjacent = prob(adjacent_spread_chance)
-			var/turf/new_loc = null
-			//Try three random locations to spawn before giving up tradeoff
-			//between running view(1, earth) on every single collected possibleLoc
-			//and failing to spread if we get 3 bad picks, which should only be a problem
-			//if there's a lot of glow shroom clustered about
-			for(var/idx in 1 to 3)
-				var/turf/possible_loc = pick(possible_locs)
-				if(spread_to_adjacent || !locate(/obj/structure/glowshroom) in view(1, possible_loc))
-					new_loc = possible_loc
-					break
-			//We failed to find any location, skip trying to yield
-			if(new_loc == null)
+		if(!prob(chance_generation))
+			continue
+			
+		var/spread_to_adjacent = prob(adjacent_spread_chance)
+		var/turf/new_loc = null
+		//Try three random locations to spawn before giving up tradeoff
+		//between running view(1, earth) on every single collected possibleLoc
+		//and failing to spread if we get 3 bad picks, which should only be a problem
+		//if there's a lot of glow shroom clustered about
+		for(var/idx in 1 to 3)
+			var/turf/possible_loc = pick(possible_locs)
+			if(spread_to_adjacent || !locate(/obj/structure/glowshroom) in view(1, possible_loc))
+				new_loc = possible_loc
 				break
-			var/shroom_count = 0
-			var/place_count = 1
-			for(var/obj/structure/glowshroom/shroom in new_loc)
-				shroom_count++
-			for(var/wall_dir in GLOB.cardinal)
-				var/turf/is_wall = get_step(new_loc, wall_dir)
-				if(is_wall.density)
-					place_count++
-			if(shroom_count >= place_count)
-				continue
+		//We failed to find any location, skip trying to yield
+		if(new_loc == null)
+			break
+		var/shroom_count = 0
+		var/place_count = 1
+		for(var/obj/structure/glowshroom/shroom in new_loc)
+			shroom_count++
+		for(var/wall_dir in GLOB.cardinal)
+			var/turf/is_wall = get_step(new_loc, wall_dir)
+			if(is_wall.density)
+				place_count++
+		if(shroom_count >= place_count)
+			continue
 
-			// Decay before spawning new mushrooms to reduce their endurance
-			Decay(TRUE, 3)
+		// Decay before spawning new mushrooms to reduce their endurance
+		Decay(TRUE, 3)
 
-			//Decay can end us
-			if(QDELETED(src))
-				return
+		//Decay can end us
+		if(QDELETED(src))
+			return
 
-			var/obj/structure/glowshroom/child = new type(new_loc, myseed, TRUE, TRUE)
-			child.generation = generation + 1
-			shrooms_planted++
+		var/obj/structure/glowshroom/child = new type(new_loc, myseed, TRUE, TRUE)
+		child.generation = generation + 1
+		shrooms_planted++
 
 	if(!shrooms_planted)
 		max_failed_spreads--

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -11,7 +11,7 @@
 	icon_state = "glowshroom"
 	layer = ABOVE_NORMAL_TURF_LAYER
 	/// Time interval between glowshroom "spreads"
-	var/delay_spread = 1 MINUTES
+	var/delay_spread = 2 MINUTES
 	/// Time interval between glowshroom decay checks
 	var/delay_decay = 30 SECONDS
 	/// Boolean to indicate if the shroom is on the floor/wall
@@ -75,7 +75,7 @@
 	//In case production is varedited to -1 or less which would cause unlimited or negative delay.
 	if(myseed.production >= 1)
 		//Because lower production speed stat gives faster production speed, which should give faster mushroom spread. Range 200-1100 deciseconds.
-		delay_spread = delay_spread - (11 - myseed.production) * 100
+		delay_spread = delay_spread ^ (1 / (2 - myseed.production) / 10)
 
 	if(myseed.get_gene(/datum/plant_gene/trait/glow))
 		var/datum/plant_gene/trait/glow/glow_gene = myseed.get_gene(/datum/plant_gene/trait/glow)
@@ -276,4 +276,3 @@
 		// Hacky I guess
 		return myseed.attackby(analyzer, user, params)
 	return ..()
-

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -7,7 +7,8 @@
 	opacity = 0
 	density = FALSE
 	icon = 'icons/obj/lighting.dmi'
-	icon_state = "glowshroom" //replaced in New
+	//replaced in Initialize()
+	icon_state = "glowshroom"
 	layer = ABOVE_NORMAL_TURF_LAYER
 	/// Time interval between glowshroom "spreads"
 	var/delay_spread = 1 MINUTES
@@ -18,7 +19,7 @@
 	/// Mushroom generation number
 	var/generation = 1
 	/// Chance to spread into adjacent tiles (0-100)
-	var/adjacent_spread_chance = 75
+	var/adjacent_spread_chance = 80
 	/// If we fail to spread this many times we stop trying to spread
 	var/max_failed_spreads = 5
 	/// Turfs where the glowshroom cannot spread to

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -9,11 +9,23 @@
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "glowshroom" //replaced in New
 	layer = ABOVE_NORMAL_TURF_LAYER
-	max_integrity = 30
-	var/delay = 1200
-	var/floor = 0
+	/// Time interval between glowshroom "spreads"
+	var/delay_spread = 1 MINUTES
+	/// Time interval between glowshroom decay checks
+	var/delay_decay = 30 SECONDS
+	/// Boolean to indicate if the shroom is on the floor/wall
+	var/floor = FALSE
+	/// Mushroom generation number
 	var/generation = 1
-	var/spreadIntoAdjacentChance = 60
+	/// Chance to spread into adjacent tiles (0-100)
+	var/adjacent_spread_chance = 75
+	/// If we fail to spread this many times we stop trying to spread
+	var/max_failed_spreads = 5
+	/// Turfs where the glowshroom cannot spread to
+	var/static/list/blacklisted_glowshroom_turfs = typecacheof(list(
+		/turf/simulated/floor/plating/lava,
+		/turf/simulated/floor/beach/water))
+	/// Internal seed of the glowshroom, stats are stored here
 	var/obj/item/seeds/myseed = /obj/item/seeds/glowshroom
 
 /obj/structure/glowshroom/glowcap
@@ -33,34 +45,45 @@
 
 /obj/structure/glowshroom/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'>This is a [generation]\th generation [name]!</span>"
+	. += "This is a [generation]\th generation [name]!"
 
-/obj/structure/glowshroom/Destroy()
-	QDEL_NULL(myseed)
-	return ..()
+/**
+  *	Creates a new glowshroom structure.
+  *
+  * Arguments:
+  * * newseed - Seed of the shroom
+  * * mutate_stats - If the plant needs to mutate their stats
+  * * spread - If the plant is a result of spreading, reduce its stats
+  */
 
-/obj/structure/glowshroom/New(loc, obj/item/seeds/newseed, mutate_stats)
-	..()
+/obj/structure/glowshroom/Initialize(mapload, obj/item/seeds/newseed, mutate_stats, spread)
+	. = ..()
 	if(newseed)
 		myseed = newseed.Copy()
 		myseed.forceMove(src)
 	else
 		myseed = new myseed(src)
-	if(mutate_stats) //baby mushrooms have different stats :3
-		myseed.adjust_potency(rand(-3,6))
-		myseed.adjust_yield(rand(-1,2))
-		myseed.adjust_production(rand(-3,6))
-		myseed.adjust_endurance(rand(-3,6))
-	delay = delay - myseed.production * 75 //So the delay goes DOWN with better stats instead of up. :I
-	obj_integrity = round(myseed.endurance/4)
-	max_integrity = round(myseed.endurance/4)
+	//baby mushrooms have different stats :3
+	if(mutate_stats)
+		myseed.adjust_potency(rand(-4, 3))
+		myseed.adjust_yield(rand(-3, 2))
+		myseed.adjust_production(rand(-3, 3))
+		// adjust_endurance has a min value of 10, need to edit directly
+		myseed.endurance = clamp(myseed.endurance + rand(-3, 2), 0, 100)
+
+	//In case production is varedited to -1 or less which would cause unlimited or negative delay.
+	if(myseed.production >= 1)
+		//Because lower production speed stat gives faster production speed, which should give faster mushroom spread. Range 200-1100 deciseconds.
+		delay_spread = delay_spread - (11 - myseed.production) * 100
+
 	if(myseed.get_gene(/datum/plant_gene/trait/glow))
-		var/datum/plant_gene/trait/glow/G = myseed.get_gene(/datum/plant_gene/trait/glow)
-		set_light(G.glow_range(myseed), G.glow_power(myseed), G.glow_color)
-	setDir(CalcDir())
+		var/datum/plant_gene/trait/glow/glow_gene = myseed.get_gene(/datum/plant_gene/trait/glow)
+		set_light(glow_gene.glow_range(myseed), glow_gene.glow_power(myseed), glow_gene.glow_color)
+	setDir(calc_dir())
 	var/base_icon_state = initial(icon_state)
 	if(!floor)
-		switch(dir) //offset to make it be on the wall rather than on the floor
+		//offset to make it be on the wall rather than on the floor
+		switch(dir)
 			if(NORTH)
 				pixel_y = 32
 			if(SOUTH)
@@ -70,91 +93,149 @@
 			if(WEST)
 				pixel_x = -32
 		icon_state = "[base_icon_state][rand(1,3)]"
-	else //if on the floor, glowshroom on-floor sprite
+	else
+		//if on the floor, glowshroom on-floor sprite
 		icon_state = "[base_icon_state]f"
 
-	addtimer(CALLBACK(src, .proc/Spread), delay)
+	addtimer(CALLBACK(src, .proc/Spread), delay_spread, TIMER_UNIQUE|TIMER_NO_HASH_WAIT)
+	addtimer(CALLBACK(src, .proc/Decay), delay_decay, TIMER_UNIQUE|TIMER_NO_HASH_WAIT)	// Start decaying the plant
 
 /obj/structure/glowshroom/proc/Spread()
+	//We could be deleted at any point and the timers might not be cleaned up
+	if(QDELETED(src))
+		return
 	var/turf/ownturf = get_turf(src)
 	var/shrooms_planted = 0
+	var/list/possible_locs = list()
+	//Lets collect a list of possible viewable turfs BEFORE we iterate for yield so we don't call view multiple
+	//times when there's no real chance of the viewable range changing, really you could do this once on item
+	//spawn and most people probably would not notice.
+	for(var/turf/simulated/floor/earth in view(1, src))
+		if(is_type_in_typecache(earth, blacklisted_glowshroom_turfs))
+			continue
+		if(!ownturf.CanAtmosPass(earth))
+			continue
+		possible_locs += earth
+
+	//Lets not even try to spawn again if somehow we have ZERO possible locations
+	if(!length(possible_locs))
+		return
+
 	for(var/i in 1 to myseed.yield)
-		if(prob(1/(generation * generation) * 70))//This formula gives you diminishing returns based on generation. 100% with 1st gen, decreasing to 25%, 11%, 6, 4, 2...
-			var/list/possibleLocs = list()
-			var/spreadsIntoAdjacent = FALSE
+		// Chance of generating a new mushroom based on stats
+		var/chance_stats = ((myseed.potency + myseed.endurance * 2) * 0.2)
+		// This formula gives you diminishing returns based on generation. 100% with 1st gen, decreasing to 25%, 11%, 6, 4, 2...
+		var/chance_generation = (100 / (generation * generation))
 
-			if(prob(spreadIntoAdjacentChance))
-				spreadsIntoAdjacent = TRUE
-
-			for(var/turf/simulated/floor/earth in view(3,src))
-				if(!ownturf.CanAtmosPass(earth))
-					continue
-				if(spreadsIntoAdjacent || !locate(/obj/structure/glowshroom) in view(1,earth))
-					possibleLocs += earth
-				CHECK_TICK
-
-			if(!possibleLocs.len)
+		// Whatever is the higher chance we use it (this is really stupid as the diminishing returns are effectively pointless???)
+		if(prob(max(chance_stats, chance_generation)))
+			var/spread_to_adjacent = prob(adjacent_spread_chance)
+			var/turf/new_loc = null
+			//Try three random locations to spawn before giving up tradeoff
+			//between running view(1, earth) on every single collected possibleLoc
+			//and failing to spread if we get 3 bad picks, which should only be a problem
+			//if there's a lot of glow shroom clustered about
+			for(var/idx in 1 to 3)
+				var/turf/possible_loc = pick(possible_locs)
+				if(spread_to_adjacent || !locate(/obj/structure/glowshroom) in view(1, possible_loc))
+					new_loc = possible_loc
+					break
+			//We failed to find any location, skip trying to yield
+			if(new_loc == null)
 				break
-
-			var/turf/newLoc = pick(possibleLocs)
-
-			var/shroomCount = 0 //hacky
-			var/placeCount = 1
-			for(var/obj/structure/glowshroom/shroom in newLoc)
-				shroomCount++
-			for(var/wallDir in GLOB.cardinal)
-				var/turf/isWall = get_step(newLoc,wallDir)
-				if(isWall.density)
-					placeCount++
-			if(shroomCount >= placeCount)
+			var/shroom_count = 0
+			var/place_count = 1
+			for(var/obj/structure/glowshroom/shroom in new_loc)
+				shroom_count++
+			for(var/wall_dir in GLOB.cardinal)
+				var/turf/is_wall = get_step(new_loc, wall_dir)
+				if(is_wall.density)
+					place_count++
+			if(shroom_count >= place_count)
 				continue
 
-			var/obj/structure/glowshroom/child = new type(newLoc, myseed, TRUE)
+			// Decay before spawning new mushrooms to reduce their endurance
+			Decay(TRUE, 1)
+
+			//Decay can end us
+			if(QDELETED(src))
+				return
+
+			var/obj/structure/glowshroom/child = new type(new_loc, myseed, TRUE, TRUE)
 			child.generation = generation + 1
 			shrooms_planted++
 
-			CHECK_TICK
-		else
-			shrooms_planted++ //if we failed due to generation, don't try to plant one later
-	if(shrooms_planted < myseed.yield) //if we didn't get all possible shrooms planted, try again later
-		myseed.yield -= shrooms_planted
-		addtimer(CALLBACK(src, .proc/Spread), delay)
+	if(!shrooms_planted)
+		max_failed_spreads--
 
-/obj/structure/glowshroom/proc/CalcDir(turf/location = loc)
+	//if we didn't get all possible shrooms planted or we haven't failed to spread at least 5 times then try to spread again later
+	if((shrooms_planted <= myseed.yield) && (max_failed_spreads >= 0))
+		myseed.adjust_yield(-shrooms_planted)
+		//Lets make this a unique hash
+		addtimer(CALLBACK(src, .proc/Spread), delay_spread, TIMER_UNIQUE|TIMER_NO_HASH_WAIT)
+
+/obj/structure/glowshroom/proc/calc_dir(turf/location = loc)
 	var/direction = 16
 
-	for(var/wallDir in GLOB.cardinal)
-		var/turf/newTurf = get_step(location,wallDir)
-		if(newTurf.density)
-			direction |= wallDir
+	for(var/wall_dir in GLOB.cardinal)
+		var/turf/new_turf = get_step(location, wall_dir)
+		if(new_turf.density)
+			direction |= wall_dir
 
 	for(var/obj/structure/glowshroom/shroom in location)
 		if(shroom == src)
 			continue
-		if(shroom.floor) //special
+		//special
+		if(shroom.floor)
 			direction &= ~16
 		else
 			direction &= ~shroom.dir
 
-	var/list/dirList = list()
+	var/list/dir_list = list()
 
-	for(var/i=1,i<=16,i <<= 1)
+	for(var/i = 1, i <= 16, i <<= 1)
 		if(direction & i)
-			dirList += i
+			dir_list += i
 
-	if(dirList.len)
-		var/newDir = pick(dirList)
-		if(newDir == 16)
+	if(dir_list.len)
+		var/new_dir = pick(dir_list)
+		if(new_dir == 16)
 			floor = 1
-			newDir = 1
-		return newDir
+			new_dir = 1
+		return new_dir
 
 	floor = 1
 	return 1
 
+/**
+  * Causes the glowshroom to decay by decreasing its endurance.
+  *
+  * Arguments:
+  * * spread - Boolean to indicate if the decay is due to spreading or natural decay.
+  * * amount - Amount of endurance to be reduced due to spread decay.
+  */
+/obj/structure/glowshroom/proc/Decay(spread, amount)
+	// Decay due to spread
+	if(spread)
+		myseed.endurance -= amount
+	else
+		// Timed decay
+		myseed.endurance -= 1
+		if(myseed.endurance > 0)
+			addtimer(CALLBACK(src, .proc/Decay), delay_decay, TIMER_UNIQUE|TIMER_NO_HASH_WAIT) // Recall decay timer
+			return
+	// Plant is gone
+	if(myseed.endurance < 1)
+		qdel(src)
+
 /obj/structure/glowshroom/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
-	if(damage_type == BURN && damage_amount)
-		playsound(src.loc, 'sound/items/welder.ogg', 100, TRUE)
+	switch(damage_type)
+		if(BRUTE)
+			playsound(src, 'sound/weapons/slash.ogg', 50, TRUE)
+		if(BURN)
+			playsound(src.loc, 'sound/items/welder.ogg', 100, TRUE)
+		else
+			playsound(src, 'sound/weapons/tap.ogg', 50, TRUE)
 
 /obj/structure/glowshroom/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	..()
@@ -163,7 +244,34 @@
 
 /obj/structure/glowshroom/acid_act(acidpwr, acid_volume)
 	. = 1
-	visible_message("<span class='danger'>[src] melts away!</span>")
-	var/obj/effect/decal/cleanable/molten_object/I = new (get_turf(src))
-	I.desc = "Looks like this was \an [src] some time ago."
+	visible_message(SPAN_DANGER("[src] melts away!"))
+	var/obj/effect/decal/cleanable/molten_object/object = new (get_turf(src))
+	object.desc = "Looks like this was \an [src] some time ago."
 	qdel(src)
+
+/obj/structure/glowshroom/attacked_by(obj/item/tool, mob/living/user)
+	var/damage_dealt = tool.force
+	if(istype(tool, /obj/item/scythe))
+		var/obj/item/scythe/weapon = tool
+
+		//so folded telescythes won't get damage boosts / insta-clears (they instead will be treated like non-scythes)
+		if(weapon.extend)
+			damage_dealt *= 10
+			for(var/obj/structure/glowshroom/shroom in view(1, src))
+				shroom.take_damage(damage_dealt, tool.damtype, "melee", 1)
+			return
+
+	if(is_sharp(tool))
+		damage_dealt *= 4
+	if(tool.damtype == BURN)
+		damage_dealt *= 4
+
+	take_damage(damage_dealt, tool.damtype, "melee", 1)
+
+//Way to check glowshroom stats using plant analyzer
+/obj/structure/glowshroom/attackby(obj/item/analyzer, mob/living/user, params)
+	if(istype(analyzer, /obj/item/plant_analyzer))
+		// Hacky I guess
+		return myseed.attackby(analyzer, user, params)
+	return ..()
+

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -74,8 +74,8 @@
 
 	//In case production is varedited to -1 or less which would cause unlimited or negative delay.
 	if(myseed.production >= 1)
-		//Because lower production speed stat gives faster production speed, which should give faster mushroom spread. Range 200-1100 deciseconds.
-		delay_spread = delay_spread ^ (1 / (2 - myseed.production) / 10)
+		//Because lower production speed stat gives faster production speed, which should give faster mushroom spread. Range 0 — idk-how-many deciseconds.
+		delay_spread = delay_spread ** (1 / (2 - myseed.production / 10))
 
 	if(myseed.get_gene(/datum/plant_gene/trait/glow))
 		var/datum/plant_gene/trait/glow/glow_gene = myseed.get_gene(/datum/plant_gene/trait/glow)

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -69,7 +69,7 @@
 		myseed.adjust_potency(rand(-4, 3))
 		myseed.adjust_yield(rand(-3, 2))
 		myseed.adjust_production(rand(-3, 3))
-		// adjust_endurance has a min value of 10, need to edit directly
+		// babies endurance has a min/max value of 30 to prevent endurance loss/boost by botany department
 		myseed.endurance = clamp(myseed.endurance, 30, 30)
 
 	if(myseed.get_gene(/datum/plant_gene/trait/glow))
@@ -118,9 +118,7 @@
 		return
 
 	for(var/i in 1 to myseed.yield)
-		// Chance of generating a new mushroom based on stats
-		// var/chance_stats = ((myseed.potency + myseed.endurance * 2) * 0.2)
-		// This formula gives you diminishing returns based on generation. 100% with 1st gen, decreasing to 25%, 11%, 6, 4, 2...
+		// This formula gives you diminishing returns based on generation. 90% with 1st gen, decreasing to 40%, 23.3(3)%, 15, 10, 6...
 		var/chance_generation = 100 / generation - 10
 
 		// Whatever is the higher chance we use it (this is really stupid as the diminishing returns are effectively pointless???)

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -18,8 +18,6 @@
 	var/is_on_floor = FALSE
 	/// Mushroom generation number
 	var/generation = 1
-	/// Chance to spread into adjacent tiles (0-100)
-	var/adjacent_spread_chance = 80
 	/// If we fail to spread this many times we stop trying to spread
 	var/max_failed_spreads = 5
 	/// Turfs where the glowshroom cannot spread to
@@ -70,7 +68,7 @@
 		myseed.adjust_yield(rand(-3, 2))
 		myseed.adjust_production(rand(-3, 3))
 		// babies endurance has a min/max value of 30 to prevent endurance loss/boost by botany department
-		myseed.endurance = clamp(myseed.endurance, 30, 30)
+		myseed.endurance = clamp(myseed.endurance, 45, 45)
 
 	if(myseed.get_gene(/datum/plant_gene/trait/glow))
 		var/datum/plant_gene/trait/glow/glow_gene = myseed.get_gene(/datum/plant_gene/trait/glow)
@@ -124,8 +122,7 @@
 		// Whatever is the higher chance we use it (this is really stupid as the diminishing returns are effectively pointless???)
 		if(!prob(chance_generation))
 			continue
-			
-		var/spread_to_adjacent = prob(adjacent_spread_chance)
+
 		var/turf/new_loc = null
 		//Try three random locations to spawn before giving up tradeoff
 		//between running view(1, earth) on every single collected possibleLoc
@@ -133,9 +130,8 @@
 		//if there's a lot of glow shroom clustered about
 		for(var/idx in 1 to 3)
 			var/turf/possible_loc = pick(possible_locs)
-			if(spread_to_adjacent || !locate(/obj/structure/glowshroom) in view(1, possible_loc))
-				new_loc = possible_loc
-				break
+			new_loc = possible_loc
+			break
 		//We failed to find any location, skip trying to yield
 		if(new_loc == null)
 			break
@@ -151,7 +147,7 @@
 			continue
 
 		// Decay before spawning new mushrooms to reduce their endurance
-		Decay(TRUE, 3)
+		Decay(TRUE, 2)
 
 		//Decay can end us
 		if(QDELETED(src))
@@ -215,7 +211,7 @@
 		myseed.endurance -= amount
 	else
 		// Timed decay
-		myseed.endurance -= 1
+		myseed.endurance -= 2
 		if(myseed.endurance > 0)
 			addtimer(CALLBACK(src, .proc/Decay), DECAY_DELAY, TIMER_UNIQUE|TIMER_NO_HASH_WAIT) // Recall decay timer
 			return

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -106,7 +106,7 @@
 	//Lets collect a list of possible viewable turfs BEFORE we iterate for yield so we don't call view multiple
 	//times when there's no real chance of the viewable range changing, really you could do this once on item
 	//spawn and most people probably would not notice.
-	for(var/turf/simulated/floor/earth in view(1, src))
+	for(var/turf/simulated/floor/earth in RANGE_TURFS(1, src))
 		if(is_type_in_typecache(earth, blacklisted_glowshroom_turfs))
 			continue
 		if(!ownturf.CanAtmosPass(earth))

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -231,11 +231,12 @@
 /obj/structure/glowshroom/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
 	switch(damage_type)
 		if(BRUTE)
-			playsound(src, 'sound/weapons/slash.ogg', 50, TRUE)
+			if(damage_amount)
+				playsound(src, 'sound/weapons/slash.ogg', 50, TRUE)
+			else
+				playsound(src, 'sound/weapons/tap.ogg', 50, TRUE)
 		if(BURN)
 			playsound(src.loc, 'sound/items/welder.ogg', 100, TRUE)
-		else
-			playsound(src, 'sound/weapons/tap.ogg', 50, TRUE)
 
 /obj/structure/glowshroom/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Частичный порт глоушрумов с /tg/

Изменения:
- Грибы не растут через 3 тайла, только в пределах 1 соседнего.
- Скорость распространения грибов изменена до 13 секунд (каждый гриб даёт потомство раз в 13 с.).
- Грибы можно срезать косой (как телескопической, так и обычной) в области 3х3.
- Любое острое оружие и оружие с типом урона `BURN` наносит х4 урона грибам (косы наносят х10).
- Спустя время грибы сгнивают, самовычищаясь с карты. При базовом значении `endurance` гриб умрёт за ~20 минут.
- Характеристики растущих на полу грибов можно узнать через `Seed Analyzer`.
- Каждый гриб имеет 5 попыток на размножение, после чего прекращает любые попытки.

## Why It's Good For The Game
Сделано по просьбе автора [предложки](https://discord.com/channels/617003227182792704/755125334097133628/996877311213314138)
- Грибы больше не засрут всю станцию из-за одного ботаника.
- Тени всё ещё способны уничтожать грибы 3х3 раз в N секунд своей способностью.
- Больше работы траллам, потому что грибы растут чуть быстрее и ковром.
- Меньше страданий серверу (но это не точно).
- Если траллы захотят косы, есть причина пойти получить по башке в карго.
- Скорость распространения грибов станет проще регулировать.

## Images of changes
[Демонстрация](https://youtu.be/LDtHzlikFmY) немного устарела, но общая концепция осталось той же.

## Changelog
:cl:
add: Glowshrooms will now decay preventing from overtaking the entire station by a random shroom cluster
tweak: Tweaked glowhsrooms spread speed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
