### PR TITLE
Добавление резни в бутылке в предметы мага

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -536,6 +536,15 @@
 	category = "Summons"
 	limit = 3
 
+/datum/spellbook_entry/item/mayhembottle
+	name = "Mayhem in a Bottle"
+	desc = "A magically infused bottle of blood, the scent of which will drive anyone nearby into a murderous frenzy."
+	item_path = /obj/item/mayhem
+	log_name = "MB"
+	category = "Artefacts"
+	limit = 1
+	cost = 2
+
 /datum/spellbook_entry/item/contract
 	name = "Contract of Apprenticeship"
 	desc = "A magical contract binding an apprentice wizard to your service, using it will summon them to your side."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Добавляет `Mayhem in a Bottle` в список артефактов мага:
- Все игроки в пределах одного игрового экрана (7 клеток) получают в руки бензопилу и приказ `RIP AND TEAR`;
- Попавшие под влияние игроки видят других карбонов в виде демонов, которых и пойдут резать на куски;
- Сам предмет одноразовый.

Музыка, механика, цветовой фильтр и всё остальное не затронуто, предмет изначально был в ротации Бабблгама.

## Why It's Good For The Game
[Предложка](https://discord.com/channels/617003227182792704/755125334097133628/971057311667879996) прошла авоут.
- Больше резни магу;
- Магу больше резни;
- Резни магу больше.

## Images of changes
Допустим, [ДЕМОНстрация](https://youtu.be/fORKjGwH16k)

![image](https://user-images.githubusercontent.com/4831847/189554015-4f7ff2e3-645a-468b-9742-738aa8917f48.png)

## Changelog
:cl:
add: Add Mayhem in a Bottle to Wizard's spellbook
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
