### PR TITLE
Fix: drone now not receive antag huds, mind objectives, etc, from player previous life

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -305,11 +305,13 @@
 
 	if(!player) return
 
-	if(player.mob && player.mob.mind)
-		player.mob.mind.transfer_to(src)
-		player.mob.mind.assigned_role = "Drone"
-	else
-		ckey = player.ckey
+	mind = new
+	mind.current = src
+	mind.original = src
+	mind.assigned_role = "Drone"
+	SSticker.minds += mind
+	mind.key = player.key
+	key = player.key
 
 	lawupdate = 0
 	to_chat(src, "<b>Systems rebooted</b>. Loading base pattern maintenance protocol... <b>loaded</b>.")


### PR DESCRIPTION
## What Does This PR Do
Теперь при заходе за ремонтного дрона ему создаётся полностью новый майнд вместо переноса старого

## Why It's Good For The Game
Теперь дроны больше не будут получать антаг худ, цели тритора и прочую дичь если игрок который зашел за дрончика их имел в предыдущей жизни

## Changelog
Исправлен баг с дронами получающими антаг худ, цели тритора и майнд целиком от предыдущей инкарнации игрока
