### PR TITLE
Tweak: ash walker now has breath and lung adapted for lavalend

### DIFF
--- a/code/modules/mob/living/carbon/human/species/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/unathi.dm
@@ -134,7 +134,17 @@
 	default_language = "Sinta'unathi"
 
 	speed_mod = -0.80
-	species_traits = list(NO_BREATHE, NOGUNS)
+	species_traits = list(NOGUNS)
+
+	has_organ = list(
+		"heart" =    /obj/item/organ/internal/heart/unathi,
+		"lungs" =    /obj/item/organ/internal/lungs/unathi/ash_walker,
+		"liver" =    /obj/item/organ/internal/liver/unathi,
+		"kidneys" =  /obj/item/organ/internal/kidneys/unathi,
+		"brain" =    /obj/item/organ/internal/brain/unathi,
+		"appendix" = /obj/item/organ/internal/appendix,
+		"eyes" =     /obj/item/organ/internal/eyes/unathi
+		)
 
 /datum/species/unathi/on_species_gain(mob/living/carbon/human/H)
 	..()

--- a/code/modules/surgery/organs/subtypes/unathi.dm
+++ b/code/modules/surgery/organs/subtypes/unathi.dm
@@ -41,3 +41,7 @@
 	icon_name = "sogtail_s"
 	max_damage = 30
 	min_broken_damage = 20
+
+/obj/item/organ/internal/lungs/unathi/ash_walker
+	name = "ash walker lungs"
+	safe_oxygen_min = 8 // can breathe on lavaland


### PR DESCRIPTION
## What Does This PR Do
У эш волкеров теперь есть полноценное дыхание и легкие адаптированные к условиям лаваленда

## Why It's Good For The Game
Эши теперь будут получать урон от гипоксии и статусные эффекты вроде остановки сердца будут работать правильно

## Changelog
Добавлена вариация легкий для эшей
У легких эшей минимальный порог кислорода для дыхания в 2 раза ниже (8 КПа вместо 16 КПа)
У эшей убран флаг NO_BREATH
