### PR TITLE
Make Korobka Great Again | Part 5

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -19,6 +19,12 @@
 	tag = "icon-whiteblue (NORTH)"
 	},
 /area/shuttle/escape)
+"aaK" = (
+/obj/machinery/vending/autodrobe,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/dorms)
 "aaQ" = (
 /obj/docking_port/stationary/whiteship{
 	dir = 8;
@@ -17968,9 +17974,13 @@
 	},
 /area/security/detectives_office)
 "aIh" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/mimeoffice)
+/obj/machinery/light,
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "escape"
+	},
+/area/crew_quarters/dorms)
 "aIi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -18187,7 +18197,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "aIF" = (
-/turf/simulated/wall/r_wall,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "aIG" = (
 /obj/machinery/door/airlock/external{
@@ -18273,6 +18289,9 @@
 /area/hallway/primary/fore)
 "aIP" = (
 /obj/structure/closet/secure_closet/clown,
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
 /turf/simulated/floor/wood,
 /area/clownoffice)
 "aIQ" = (
@@ -19122,13 +19141,8 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "aKR" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 8;
-	name = "8maintenance loot spawner"
-	},
-/turf/simulated/floor/plating,
+/obj/structure/lattice,
+/turf/simulated/wall,
 /area/maintenance/fsmaint2)
 "aKS" = (
 /obj/structure/cable{
@@ -19152,6 +19166,12 @@
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/structure/table,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -19755,10 +19775,11 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "aMi" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -20384,16 +20405,13 @@
 	},
 /area/hallway/primary/fore)
 "aNL" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/dorms)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2)
 "aNM" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4;
@@ -20431,9 +20449,9 @@
 	},
 /area/crew_quarters/courtroom)
 "aNQ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "caution"
 	},
 /area/crew_quarters/dorms)
 "aNR" = (
@@ -21080,19 +21098,22 @@
 /turf/simulated/wall,
 /area/maintenance/fpmaint)
 "aPk" = (
-/obj/structure/chair/stool,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "caution"
 	},
 /area/crew_quarters/dorms)
 "aPm" = (
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "aPn" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
+/obj/structure/punching_bag,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "aPs" = (
 /obj/effect/landmark/burnturf,
@@ -22123,17 +22144,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "aRv" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
+/obj/structure/weightmachine/stacklifter,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/dorms)
 "aRw" = (
 /turf/simulated/wall/r_wall,
 /area/ai_monitored/storage/eva)
@@ -22226,19 +22239,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
-"aRH" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
-	},
-/area/mimeoffice)
 "aRI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -22754,10 +22754,9 @@
 	},
 /area/crew_quarters/dorms)
 "aSR" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -22944,17 +22943,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "aTq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -23325,8 +23314,8 @@
 /area/medical/reception)
 "aTZ" = (
 /obj/structure/closet,
-/obj/effect/decal/cleanable/cobweb,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/item/toy/figure/botanist,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "aUa" = (
@@ -23937,8 +23926,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -23952,17 +23941,13 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "aVw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Dormitory East";
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "caution"
+	},
 /area/crew_quarters/dorms)
 "aVx" = (
 /obj/item/twohanded/required/kirbyplants,
@@ -23995,9 +23980,7 @@
 	},
 /area/medical/chemistry)
 "aVz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -24188,19 +24171,15 @@
 	},
 /area/ai_monitored/storage/eva)
 "aVP" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/structure/grille/broken,
-/obj/structure/window/basic{
-	dir = 4
+/obj/structure/closet/boxinggloves,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "caution"
 	},
-/obj/structure/window/basic,
-/obj/effect/landmark/burnturf,
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
+/area/crew_quarters/dorms)
 "aVQ" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -24231,7 +24210,9 @@
 "aVU" = (
 /obj/machinery/light,
 /obj/machinery/light_switch{
-	pixel_y = -25
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
@@ -24755,12 +24736,9 @@
 	},
 /area/crew_quarters/dorms)
 "aWX" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/vending/artvend,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	icon_state = "caution"
 	},
 /area/crew_quarters/dorms)
 "aWY" = (
@@ -24887,13 +24865,6 @@
 	icon_state = "darkblue"
 	},
 /area/chapel/main)
-"aXi" = (
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
-	},
-/area/mimeoffice)
 "aXj" = (
 /obj/structure/morgue,
 /obj/machinery/camera{
@@ -25216,35 +25187,6 @@
 	icon_state = "vault"
 	},
 /area/security/nuke_storage)
-"aXU" = (
-/obj/item/flag/mime,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
-	},
-/area/mimeoffice)
-"aXV" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
-	},
-/area/mimeoffice)
 "aXW" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -26079,10 +26021,7 @@
 	},
 /area/crew_quarters/dorms)
 "aZH" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/vending/autodrobe,
+/obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -26094,8 +26033,7 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "aZJ" = (
-/obj/machinery/light,
-/obj/structure/closet/boxinggloves,
+/obj/machinery/vending/artvend,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -26103,34 +26041,10 @@
 "aZK" = (
 /obj/structure/closet/masks,
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 6;
+	icon_state = "caution"
 	},
 /area/crew_quarters/dorms)
-"aZL" = (
-/obj/structure/table/wood,
-/obj/item/pen/red{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/item/paper_bin,
-/obj/item/toy/crayon/mime,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
-	},
-/area/mimeoffice)
-"aZM" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
-	},
-/area/mimeoffice)
 "aZN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -27029,28 +26943,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
-"bbA" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
-	},
-/area/mimeoffice)
 "bbB" = (
-/obj/structure/closet/secure_closet/mime,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
-	},
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
 /area/mimeoffice)
 "bbC" = (
 /obj/structure/cable{
@@ -27071,32 +26966,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bbD" = (
-/obj/effect/landmark/start{
-	name = "Mime"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/tranquillite{
+	name = "Mime's Office";
+	req_access_txt = "46"
 	},
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
 "bbE" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/spawner/random_spawners/grille_often,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/barricade/wooden,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bbF" = (
@@ -27222,23 +27105,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "bbU" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
-"bbV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -27256,6 +27122,16 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
+"bbV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/dorms)
 "bbW" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -27275,14 +27151,19 @@
 	sortType = 21;
 	tag = "icon-pipe-j1s (EAST)"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
-"bbY" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2)
+"bbY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -27291,6 +27172,11 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -27315,11 +27201,6 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "bcb" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
 	icon_state = "pipe-j2s";
@@ -27331,6 +27212,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -27965,36 +27851,21 @@
 /turf/simulated/floor/wood,
 /area/clownoffice)
 "bds" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/spray/waterflower,
-/obj/machinery/light_switch{
-	pixel_y = -25
-	},
-/obj/machinery/camera{
-	c_tag = "Mime's Office";
-	dir = 1
-	},
+/obj/item/flag/mime,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
 "bdt" = (
-/obj/structure/statue/tranquillite/mime,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/toy/crayon/mime,
+/obj/item/pen/red{
+	pixel_x = 2;
+	pixel_y = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -28833,17 +28704,10 @@
 	},
 /area/crew_quarters/dorms)
 "bfa" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/tranquillite{
-	name = "Mime's Office";
-	req_access_txt = "46"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
+	icon_state = "cafeteria"
 	},
-/area/mimeoffice)
+/area/crew_quarters/dorms)
 "bfb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -29216,31 +29080,9 @@
 	},
 /area/crew_quarters/kitchen)
 "bfG" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
-"bfH" = (
-/obj/machinery/hydroponics/soil,
-/turf/simulated/floor/grass,
-/area/hydroponics)
-"bfI" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "46"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -29248,6 +29090,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
+"bfH" = (
+/obj/machinery/hydroponics/soil,
+/turf/simulated/floor/grass,
+/area/hydroponics)
+"bfI" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
 "bfJ" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -29321,11 +29174,6 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bfP" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/plating,
@@ -29922,6 +29770,9 @@
 /area/clownoffice)
 "bhj" = (
 /obj/structure/table/wood,
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
 /obj/item/clothing/under/soldieruniform,
 /obj/machinery/firealarm{
 	dir = 4;
@@ -29942,10 +29793,16 @@
 /turf/simulated/floor/wood,
 /area/clownoffice)
 "bhl" = (
-/obj/item/clothing/suit/hooded/hoodie/nt,
-/obj/structure/table,
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
+/obj/machinery/camera{
+	c_tag = "Mime's Office";
+	dir = 4
+	},
+/obj/structure/statue/tranquillite/mime,
+/turf/simulated/floor/plasteel{
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
 "bhm" = (
 /turf/simulated/floor/carpet,
 /area/hallway/secondary/entry)
@@ -29956,26 +29813,31 @@
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "bho" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light_switch{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
+/obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 4;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
 "bhp" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/dorms)
 "bhq" = (
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
@@ -31208,11 +31070,17 @@
 	},
 /area/chapel/main)
 "bjM" = (
-/obj/item/clothing/suit/ianshirt,
-/obj/structure/table,
-/obj/item/clothing/under/mime,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
+/area/maintenance/fsmaint)
 "bjN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -31301,14 +31169,11 @@
 	},
 /area/hydroponics)
 "bjX" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -31566,6 +31431,12 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/spawner/random_spawners/grille_maybe,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -81953,11 +81824,16 @@
 /turf/space,
 /area/solar/starboard)
 "ddF" = (
-/obj/structure/sign/biohazard{
-	pixel_x = 32
+/obj/machinery/camera{
+	c_tag = "Dormitories East";
+	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/genetics)
+/obj/structure/table/wood,
+/obj/item/deck/cards,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/dorms)
 "ddG" = (
 /obj/machinery/field/generator,
 /turf/simulated/floor/plating,
@@ -89197,6 +89073,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/range)
+"fQj" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel{
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
 "fQq" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -90135,14 +90023,10 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/dorms)
 "ibE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
+/obj/structure/table/wood,
+/obj/item/storage/pill_bottle/dice,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "bar"
 	},
 /area/crew_quarters/dorms)
 "ikF" = (
@@ -90241,6 +90125,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/xenozoo)
+"isX" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/spray/waterflower,
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
 "itd" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -90270,13 +90169,12 @@
 	},
 /area/hallway/primary/central/sw)
 "iya" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/machinery/vending/cola,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "caution"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
+/area/crew_quarters/dorms)
 "iyW" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
@@ -90515,6 +90413,10 @@
 	icon_state = "bot"
 	},
 /area/shuttle/escape)
+"jeA" = (
+/obj/structure/rack,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2)
 "jgn" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -90608,6 +90510,17 @@
 	icon_state = "darkredcorners"
 	},
 /area/security/brig)
+"jEp" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/plasteel{
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
 "jFT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/constructable_frame/machine_frame,
@@ -90837,13 +90750,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
-"kiu" = (
-/obj/structure/table/wood,
-/obj/item/deck/cards,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/dorms)
 "kiV" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -90965,6 +90871,19 @@
 /obj/structure/sign/botany,
 /turf/simulated/wall,
 /area/hydroponics)
+"kxp" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "43"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2)
 "kxS" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -91720,6 +91639,27 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/administration)
+"mrw" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/landmark/start{
+	name = "Mime"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
 "msR" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
@@ -92209,6 +92149,15 @@
 "nCT" = (
 /turf/simulated/floor/plasteel,
 /area/security/customs)
+"nEG" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/obj/item/toy/figure/mime,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2)
 "nEH" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -92746,14 +92695,14 @@
 	},
 /area/library/abandoned)
 "oXI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "caution"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
+/area/crew_quarters/dorms)
 "oZV" = (
 /obj/machinery/mecha_part_fabricator/upgraded,
 /turf/simulated/shuttle/floor{
@@ -92970,6 +92919,23 @@
 	icon_state = "white"
 	},
 /area/library/abandoned)
+"pGH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2)
 "pGQ" = (
 /obj/structure/closet/walllocker/emerglocker/east,
 /turf/simulated/floor/plasteel{
@@ -93092,6 +93058,10 @@
 	icon_state = "grimy"
 	},
 /area/library/abandoned)
+"pWb" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/dorms)
 "pXp" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -93942,6 +93912,12 @@
 	tag = "icon-whitebluefull"
 	},
 /area/security/medbay)
+"rDc" = (
+/obj/structure/sign/biohazard{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/genetics)
 "rEw" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "swall1";
@@ -94185,6 +94161,20 @@
 	icon_state = "blue"
 	},
 /area/hydroponics)
+"syQ" = (
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "escape"
+	},
+/area/crew_quarters/dorms)
+"szi" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 8;
+	name = "8maintenance loot spawner"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2)
 "szV" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
@@ -94350,6 +94340,19 @@
 	tag = "icon-browncorner (EAST)"
 	},
 /area/quartermaster/office)
+"sSa" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "44"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2)
 "sUp" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/machinery/camera{
@@ -94710,6 +94713,16 @@
 	icon_state = "neutralfull"
 	},
 /area/security/customs)
+"tCN" = (
+/obj/structure/closet/secure_closet/mime,
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/simulated/floor/plasteel{
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
 "tEM" = (
 /obj/machinery/light/spot{
 	dir = 4;
@@ -95128,8 +95141,12 @@
 /turf/simulated/wall/rust,
 /area/library/abandoned)
 "uXj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "uXX" = (
@@ -95176,6 +95193,15 @@
 	icon_state = "blue"
 	},
 /area/hydroponics)
+"vcL" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/dorms)
 "veJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
@@ -95596,7 +95622,6 @@
 "wgy" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/item/toy/figure/mime,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "whv" = (
@@ -95687,17 +95712,11 @@
 /turf/simulated/floor/wood,
 /area/library/abandoned)
 "wrE" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/structure/chair/stool,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
+/area/crew_quarters/dorms)
 "wsj" = (
 /obj/machinery/vending/medical,
 /turf/simulated/floor/plasteel{
@@ -95865,12 +95884,26 @@
 	},
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology)
-"wHt" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+"wFB" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/crew_quarters/dorms)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plasteel{
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/mimeoffice)
+"wHt" = (
+/obj/structure/table/wood,
+/obj/item/bikehorn/rubberducky,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2)
 "wHx" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -96183,9 +96216,14 @@
 	},
 /area/shuttle/escape)
 "xoJ" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/toy/figure/botanist,
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/effect/decal/remains/human{
+	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
+	name = "human remains"
+	},
+/obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "xrD" = (
@@ -96416,10 +96454,8 @@
 /turf/simulated/floor/engine,
 /area/maintenance/server)
 "xVt" = (
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
+/obj/structure/weightmachine/weightlifter,
+/turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "xWg" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -133904,7 +133940,7 @@ jPN
 lkw
 fho
 aTb
-ibE
+aTb
 aSR
 aVu
 aWY
@@ -134160,11 +134196,11 @@ tbC
 tbC
 tbC
 aPm
-aTb
-bdN
-aTb
+aPm
+aPm
+aPm
 aVt
-aWX
+aXf
 aZH
 aIc
 aIc
@@ -134418,11 +134454,11 @@ ibg
 ibg
 dVs
 aPk
-bdN
-aTb
+aVw
+aVP
 aVt
 aXf
-aXf
+ibE
 aIe
 bdo
 aIP
@@ -134674,9 +134710,9 @@ sHt
 sHt
 sHt
 aOh
-kiu
-bdN
-wHt
+xVt
+aPm
+aSM
 aVv
 aXf
 aXf
@@ -134932,16 +134968,16 @@ sHt
 sHt
 aOh
 xVt
-bdN
+pWb
 aNQ
 aVz
 aXf
-aZK
+aXf
 aIe
 bdr
 aUA
 bhk
-bfI
+kxp
 bbC
 aGY
 beb
@@ -135188,10 +135224,10 @@ sHt
 sHt
 sHt
 kjf
-aPn
-aVt
-aNL
-aVw
+aPm
+aPm
+aSM
+aVv
 aXf
 aZJ
 aIc
@@ -135445,17 +135481,17 @@ sHt
 sHt
 sHt
 aOI
-aOI
-wrE
-aOI
-aLA
-bfa
+aPn
+aPm
+aSM
+bbV
+syQ
 aIh
 aLA
 aLA
 aLA
-aGX
-aGX
+aLA
+aLA
 bbh
 aGY
 beb
@@ -135702,17 +135738,17 @@ sHt
 sHt
 sHt
 aOI
-aHb
-aSg
-aGY
-aLA
-aXi
-aZL
-bbA
+aPm
+aPm
+aSM
+aVv
+bfa
+aaK
+bbB
 bds
-aLA
+tCN
 bhl
-bjM
+aLA
 bbI
 aGY
 beb
@@ -135959,18 +135995,18 @@ aOI
 aOI
 aOI
 aOI
-aQL
-aSg
-aGY
-aLA
-aXV
-aRH
+aRv
+vcL
+aWX
+bhp
+bfa
+bfa
 bbD
 aTq
 bfI
 bho
-bho
-bbV
+aLA
+bbI
 aGY
 beb
 bfJ
@@ -136214,19 +136250,19 @@ nqX
 vFZ
 aOI
 aUW
-wgy
-aGX
-aHP
+nEG
+aOI
 aRv
-aGY
-aLA
-aXU
-aZM
+aPm
+aSM
+aVv
+bfa
+bfa
 bbB
 bdt
-aLA
-aGY
-aGY
+fQj
+wFB
+sSa
 bbU
 aGY
 beb
@@ -136471,21 +136507,21 @@ xcB
 mzv
 fbF
 uXj
-uXj
-uXj
+aGY
+aOI
 iya
 oXI
-aGY
+aZK
+aVv
+ddF
+wrE
 aLA
+jEp
+mrw
+isX
 aLA
-aLA
-aLA
-aLA
-aLA
-aQI
-aGY
 bbY
-aOE
+aGY
 beb
 bib
 bjN
@@ -136729,18 +136765,18 @@ aOI
 aOI
 aIF
 aHb
-aHb
-aGX
-aGY
-aGY
-aGY
-aGY
-aGY
-aGY
-aGY
-aGY
-aGY
-aGX
+aOI
+aOI
+aOI
+aOI
+bjM
+aOI
+aOI
+aLA
+aLA
+aLA
+aLA
+aLA
 bbX
 bfG
 bhu
@@ -136983,23 +137019,23 @@ aaa
 aab
 aab
 aab
-aab
-aIF
-aIF
-aIF
-aGX
-aGX
-aGX
-aGX
+aKR
+aMi
+aNL
+aRX
+aRX
+aRX
+bbE
+bjX
 aGY
+wHt
+xoJ
+aGX
+wgy
+jeA
+aQL
+bbY
 aGY
-aGX
-aGX
-aGX
-aMz
-aGX
-bcg
-hQC
 beb
 bif
 bjW
@@ -137242,19 +137278,19 @@ aGT
 aGT
 aGT
 aGT
-aKR
-aMi
-aMo
-aOF
+aGX
+aGX
+aMn
+aGX
 aHP
 aQC
 aGY
 aGY
-aGX
-xoJ
 aGY
-bhp
-bjX
+aGY
+aGY
+aGY
+bjk
 bcb
 bfP
 beb
@@ -137500,19 +137536,19 @@ aHK
 aIB
 aGT
 aKT
+szi
 aGY
-aKX
-aGY
+aOF
 aHP
 aVA
 aXW
 aZQ
-bbE
 aZQ
 aZQ
-aVP
+aZQ
+aZQ
 bkD
-bcm
+pGH
 beb
 beb
 bif
@@ -140923,7 +140959,7 @@ cJK
 cBR
 cIt
 thk
-ddF
+rDc
 bQX
 bQX
 xTp

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -40,11 +40,8 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/xenozoo)
 "abG" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/genetics)
 "abH" = (
@@ -60239,7 +60236,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
-/area/medical/surgery1)
+/area/medical/surgery/north)
 "cnZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -63505,7 +63502,7 @@
 "cts" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/maintenance/genetics)
+/area/maintenance/server)
 "ctt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -65886,11 +65883,11 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/genetics)
@@ -67842,18 +67839,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
-"cBG" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/genetics)
 "cBH" = (
 /obj/structure/table,
+/obj/item/healthanalyzer,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
 /area/maintenance/genetics)
 "cBI" = (
@@ -68715,11 +68704,11 @@
 /turf/simulated/wall,
 /area/medical/surgery/south)
 "cDg" = (
-/obj/structure/table,
-/obj/item/healthanalyzer,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/maintenance/genetics)
+/area/maintenance/server)
 "cDh" = (
 /obj/structure/table,
 /obj/item/pda,
@@ -81965,9 +81954,9 @@
 /area/solar/starboard)
 "ddF" = (
 /obj/structure/sign/biohazard{
-	pixel_y = 32
+	pixel_x = 32
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/floor/plating,
 /area/maintenance/genetics)
 "ddG" = (
 /obj/machinery/field/generator,
@@ -88527,6 +88516,15 @@
 	icon_state = "bluecorner"
 	},
 /area/hallway/secondary/entry)
+"emF" = (
+/obj/effect/decal/cleanable/dust,
+/obj/structure/table/glass,
+/obj/item/paper_bin,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/server)
 "enD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -88828,6 +88826,14 @@
 /obj/machinery/smartfridge/secure/extract,
 /turf/simulated/floor/plating,
 /area/maintenance/xenozoo)
+"eXa" = (
+/obj/effect/decal/cleanable/dust,
+/obj/structure/chair/sofa/corp/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple/corner,
+/turf/simulated/floor/carpet/purple,
+/area/maintenance/server)
 "eXI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -89215,6 +89221,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
+"fSf" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/decal/cleanable/dust,
+/turf/simulated/floor/engine,
+/area/maintenance/server)
 "fSB" = (
 /obj/machinery/door/morgue{
 	name = "Occult Study"
@@ -89568,6 +89580,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
+"gRs" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/transparent/glass,
+/area/maintenance/server)
 "gSF" = (
 /obj/structure/bookcase,
 /turf/simulated/floor/wood,
@@ -89679,6 +89700,17 @@
 	icon_state = "cafeteria"
 	},
 /area/toxins/xenobiology)
+"gXh" = (
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/purple,
+/turf/simulated/floor/carpet/purple,
+/area/maintenance/server)
 "gYt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -89897,6 +89929,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"hBi" = (
+/obj/effect/decal/cleanable/dust,
+/obj/item/twohanded/required/kirbyplants,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/purple,
+/area/maintenance/server)
 "hFD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -89912,6 +89953,11 @@
 	icon_state = "yellow"
 	},
 /area/hallway/primary/aft)
+"hFN" = (
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/constructable_frame/machine_frame,
+/turf/simulated/floor/engine,
+/area/maintenance/server)
 "hHo" = (
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
@@ -90026,6 +90072,14 @@
 	icon_state = "escape"
 	},
 /area/security/customs2)
+"hSk" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'SERVER ROOM'.";
+	name = "SERVER ROOM";
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/genetics)
 "hTt" = (
 /obj/effect/decal/cleanable/dust,
 /obj/effect/decal/cleanable/cobweb2,
@@ -90254,6 +90308,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/library/abandoned)
+"iGx" = (
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dust,
+/turf/simulated/floor/transparent/glass,
+/area/maintenance/server)
 "iHj" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/effect/decal/cleanable/dirt,
@@ -90335,6 +90396,22 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/toxins/launch)
+"iOg" = (
+/obj/effect/decal/cleanable/dust,
+/obj/structure/chair/sofa/corp/right{
+	dir = 4
+	},
+/obj/machinery/light_construct{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/structure/sign/nosmoking_2{
+	pixel_x = -32
+	},
+/turf/simulated/floor/carpet/purple,
+/area/maintenance/server)
 "iOx" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
@@ -90390,6 +90467,15 @@
 "iVV" = (
 /turf/simulated/wall/r_wall,
 /area/server)
+"iVY" = (
+/obj/effect/decal/cleanable/dust,
+/obj/structure/table/glass,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/item/reagent_containers/glass/beaker/waterbottle/empty,
+/turf/simulated/floor/plating,
+/area/maintenance/server)
 "iZs" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
@@ -90441,6 +90527,14 @@
 	icon_state = "blue"
 	},
 /area/hydroponics)
+"jib" = (
+/obj/effect/turf_decal/stripes{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/light_construct/small,
+/turf/simulated/floor/transparent/glass,
+/area/maintenance/server)
 "jjW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -90451,6 +90545,9 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/xenozoo)
+"jnc" = (
+/turf/simulated/wall,
+/area/maintenance/server)
 "jnJ" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "swall12"
@@ -90915,6 +91012,15 @@
 	},
 /turf/simulated/floor/carpet,
 /area/civilian/vacantoffice)
+"kGe" = (
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/light_construct{
+	dir = 1
+	},
+/obj/item/tank/internals/oxygen/empty,
+/obj/effect/turf_decal/siding/purple,
+/turf/simulated/floor/carpet/purple,
+/area/maintenance/server)
 "kHU" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
@@ -91233,6 +91339,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
+"luR" = (
+/obj/effect/decal/cleanable/dust,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/purple,
+/area/maintenance/server)
+"lww" = (
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/light_construct{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/ash,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/purple,
+/area/maintenance/server)
 "lxD" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -91388,6 +91513,14 @@
 	tag = "icon-swall_f6"
 	},
 /area/shuttle/pod_3)
+"lRV" = (
+/obj/effect/decal/cleanable/dust,
+/obj/item/twohanded/required/kirbyplants,
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/purple,
+/area/maintenance/server)
 "lSf" = (
 /obj/effect/decal/warning_stripes/northeast,
 /obj/effect/decal/cleanable/blood/xeno,
@@ -91661,6 +91794,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/medbay)
+"mxl" = (
+/obj/effect/decal/cleanable/dust,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/item/reagent_containers/glass/bucket,
+/turf/simulated/floor/engine,
+/area/maintenance/server)
 "mxT" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
@@ -91705,6 +91844,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
+"mEo" = (
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/purple,
+/turf/simulated/floor/carpet/purple,
+/area/maintenance/server)
 "mGt" = (
 /obj/item/flag/med,
 /turf/simulated/floor/plasteel{
@@ -91814,6 +91964,13 @@
 /obj/machinery/slot_machine,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
+"naz" = (
+/obj/effect/turf_decal/stripes{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dust,
+/turf/simulated/floor/transparent/glass,
+/area/maintenance/server)
 "naH" = (
 /obj/structure/bed/roller,
 /turf/simulated/floor/plasteel{
@@ -91823,6 +91980,9 @@
 "nbH" = (
 /turf/simulated/shuttle/floor,
 /area/shuttle/administration)
+"ndH" = (
+/turf/simulated/wall/r_wall,
+/area/maintenance/server)
 "neg" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -91906,6 +92066,12 @@
 	icon_state = "dark"
 	},
 /area/library/abandoned)
+"njA" = (
+/obj/effect/decal/cleanable/ash,
+/obj/item/extinguisher,
+/obj/effect/turf_decal/siding/purple,
+/turf/simulated/floor/plating,
+/area/maintenance/server)
 "njX" = (
 /obj/structure/foodcart,
 /turf/simulated/floor/plasteel{
@@ -92467,6 +92633,15 @@
 	icon_state = "darkred"
 	},
 /area/security/warden)
+"oLr" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/cobweb2,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/genetics)
 "oLU" = (
 /obj/machinery/vending/coffee,
 /obj/effect/decal/cleanable/dirt,
@@ -93021,6 +93196,13 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads)
+"qfz" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dust,
+/turf/simulated/floor/transparent/glass,
+/area/maintenance/server)
 "qfS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
@@ -93101,6 +93283,13 @@
 	icon_state = "dark"
 	},
 /area/library/abandoned)
+"quo" = (
+/obj/effect/decal/cleanable/dust,
+/obj/structure/chair/sofa/corp/left,
+/obj/effect/turf_decal/siding/purple,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/server)
 "qus" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -93256,6 +93445,20 @@
 	icon_state = "whitegreencorner"
 	},
 /area/toxins/xenobiology)
+"qIL" = (
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/obj/machinery/light_construct/small{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/maintenance/server)
 "qIM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -93353,6 +93556,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
+"qSQ" = (
+/obj/effect/decal/cleanable/dust,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/item/screwdriver,
+/turf/simulated/floor/engine,
+/area/maintenance/server)
 "qST" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "redcorner"
@@ -93447,6 +93656,12 @@
 	},
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology)
+"rhs" = (
+/obj/effect/decal/cleanable/dust,
+/obj/effect/decal/cleanable/shreds,
+/obj/item/chair/stool,
+/turf/simulated/floor/engine,
+/area/maintenance/server)
 "rig" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -93567,6 +93782,11 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/crew_quarters/dorms)
+"rns" = (
+/obj/effect/decal/cleanable/dust,
+/obj/structure/computerframe,
+/turf/simulated/floor/engine,
+/area/maintenance/server)
 "roO" = (
 /obj/machinery/door/window/southright{
 	name = "Containment Pen";
@@ -93588,6 +93808,17 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/administration)
+"rsV" = (
+/obj/effect/turf_decal/stripes{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/light_construct/small{
+	dir = 4
+	},
+/obj/item/shard,
+/turf/simulated/floor/transparent/glass,
+/area/maintenance/server)
 "rtv" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -93917,6 +94148,14 @@
 	icon_state = "carpet"
 	},
 /area/library/abandoned)
+"skM" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE"
+	},
+/turf/simulated/wall/r_wall,
+/area/maintenance/server)
 "snu" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "swall_s6"
@@ -94543,6 +94782,26 @@
 	icon_state = "white"
 	},
 /area/security/medbay)
+"tVy" = (
+/obj/structure/door_assembly/door_assembly_mai{
+	anchored = 1
+	},
+/obj/structure/firelock_frame{
+	anchored = 1
+	},
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/engine,
+/area/maintenance/server)
+"uaN" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/genetics)
 "uew" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -94672,6 +94931,14 @@
 	tag = "icon-whitehall (WEST)"
 	},
 /area/security/medbay)
+"uBA" = (
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/server)
 "uBM" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8;
@@ -94703,6 +94970,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/xenozoo)
+"uKx" = (
+/obj/effect/decal/cleanable/dust,
+/obj/item/cigbutt,
+/obj/effect/landmark{
+	name = "xeno_spawn";
+	pixel_x = -1
+	},
+/turf/simulated/floor/engine,
+/area/maintenance/server)
 "uKK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -94975,6 +95251,20 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
+"vxL" = (
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/generic,
+/obj/structure/mecha_wreckage/ripley/firefighter,
+/turf/simulated/floor/engine,
+/area/maintenance/server)
+"vyb" = (
+/obj/effect/decal/cleanable/fungus,
+/turf/simulated/wall,
+/area/maintenance/server)
 "vzG" = (
 /obj/structure/chair/office/dark,
 /obj/effect/decal/cleanable/dust,
@@ -95313,6 +95603,21 @@
 /obj/machinery/computer/HolodeckControl,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
+"wiX" = (
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/maintenance/server)
+"wje" = (
+/obj/effect/decal/cleanable/dust,
+/obj/structure/table_frame/wood,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/purple,
+/area/maintenance/server)
 "wkg" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Escape Shuttle Cockpit";
@@ -96046,6 +96351,15 @@
 	},
 /turf/simulated/floor/greengrid,
 /area/maintenance/xenozoo)
+"xMY" = (
+/obj/effect/decal/cleanable/dust,
+/obj/structure/table/reinforced,
+/obj/item/stack/rods{
+	amount = 8
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/engine,
+/area/maintenance/server)
 "xPv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -96093,6 +96407,14 @@
 	tag = "icon-whiteblue"
 	},
 /area/shuttle/escape)
+"xTY" = (
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/landmark{
+	name = "blobstart"
+	},
+/turf/simulated/floor/engine,
+/area/maintenance/server)
 "xVt" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -137499,10 +137821,10 @@ bUx
 ctq
 cuC
 bQX
-bQX
+uaN
 cAa
 cAa
-bQX
+cpH
 chf
 chf
 chf
@@ -138267,16 +138589,16 @@ cpR
 cpR
 cxD
 bQX
-cep
-cep
-cep
+jnc
+vyb
+jnc
 cts
 cts
 cts
-cep
-cep
-cep
-cep
+jnc
+jnc
+jnc
+bQX
 bQX
 cjk
 bQX
@@ -138524,17 +138846,17 @@ cwj
 cpR
 cxD
 bQX
-cep
-aab
-aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cep
-cBG
+jnc
+eXa
+iOg
+emF
+iVY
+uBA
+lww
+lRV
+jnc
+cKF
+bQX
 cNp
 cOm
 cOm
@@ -138781,18 +139103,18 @@ cpl
 cpR
 cxD
 bQX
-cep
-aab
-aab
-aab
-aaa
-aaa
-aaa
-aaa
-aaa
-cep
+jnc
+quo
+naz
+iGx
+iGx
+iGx
+rsV
+wje
+jnc
+oLr
 cBH
-cDg
+bQX
 bQX
 bQX
 bQX
@@ -139038,16 +139360,16 @@ cwq
 cpR
 cxK
 bQX
-cep
-aaa
-aab
-aab
-aab
-aaa
-aaa
-aaa
-cep
-cep
+cts
+njA
+qfz
+cts
+cts
+fSf
+skM
+ndH
+jnc
+ciY
 ciY
 ciY
 ciY
@@ -139295,15 +139617,15 @@ cwl
 cxc
 cxQ
 abG
-cep
-aaa
-aaa
-aab
-aab
-aab
-aaa
-aaa
-cep
+cDg
+gXh
+qfz
+cts
+wiX
+uKx
+rhs
+xMY
+jnc
 bQX
 bQX
 bQX
@@ -139551,16 +139873,16 @@ cuK
 cvT
 cpR
 cxO
-cAc
+hSk
 cts
-aaa
-aaa
-aaa
-aab
-aab
-aab
-aaa
-cep
+mEo
+gRs
+tVy
+vxL
+xTY
+qIL
+rns
+jnc
 cAE
 cBI
 cDh
@@ -139809,25 +140131,25 @@ crL
 cpR
 cxO
 cAe
-cts
-aaa
-aaa
-aaa
-aaa
-aab
-cep
-cep
-cep
-cep
-cep
-cep
-cep
-cep
-cep
-cep
-cep
-cep
-cep
+jnc
+kGe
+jib
+skM
+mxl
+qSQ
+cBR
+cBR
+cBR
+cBR
+cBR
+cBR
+cBR
+cBR
+cBR
+cBR
+cBR
+cBR
+cBR
 cIs
 bQX
 cKF
@@ -140065,13 +140387,13 @@ cuN
 cwm
 cpR
 cxR
-cpH
-cts
-aaa
-aaa
-aaa
-aaa
-aaa
+cAc
+jnc
+hBi
+luR
+ndH
+hFN
+hFN
 cBR
 cKP
 cJK
@@ -140084,7 +140406,7 @@ cxN
 cKP
 cJK
 cJK
-cep
+cBR
 ciY
 ciY
 ciY
@@ -140341,7 +140663,7 @@ cxN
 cKQ
 cMg
 cJK
-cep
+cBR
 cIu
 cJz
 cKG
@@ -140598,10 +140920,10 @@ cxN
 cKR
 cJK
 cJK
-cep
+cBR
 cIt
 thk
-bQX
+ddF
 bQX
 bQX
 xTp
@@ -140855,14 +141177,14 @@ cxN
 cTJ
 cVe
 cWi
-cep
-cep
-cep
-cep
-cep
-cep
-cep
-ddF
+cBR
+cBR
+cBR
+cBR
+cBR
+cBR
+cBR
+cBR
 aaa
 aaa
 aaa

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -40,11 +40,8 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/xenozoo)
 "abG" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/genetics)
 "abH" = (
@@ -1392,8 +1389,20 @@
 	},
 /area/security/main)
 "adZ" = (
-/turf/space,
-/area/security/prisonershuttle)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "redcorner"
+	},
+/area/security/prison/cell_block/A)
 "aea" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -3558,7 +3567,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "darkred"
+	icon_state = "darkredcorners"
 	},
 /area/security/brig)
 "ahR" = (
@@ -4562,7 +4571,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	dir = 1;
 	icon_state = "darkredcorners"
 	},
 /area/security/brig)
@@ -4685,7 +4694,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	dir = 1;
 	icon_state = "darkredcorners"
 	},
 /area/security/brig)
@@ -5638,7 +5647,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/security/lobby)
+/area/security/brig)
 "alu" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -5757,7 +5766,7 @@
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
 /turf/simulated/floor/plating,
-/area/security/lobby)
+/area/security/brig)
 "alL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -7101,7 +7110,7 @@
 /obj/structure/table,
 /obj/item/book/manual/security_space_law,
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	dir = 5;
 	icon_state = "red"
 	},
 /area/security/lobby)
@@ -8430,7 +8439,6 @@
 "aqE" = (
 /obj/item/shard,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -9037,14 +9045,9 @@
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "arC" = (
-/obj/item/radio/intercom/department/security{
-	pixel_y = 25
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkredcorners"
-	},
-/area/security/brig)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/dorms)
 "arD" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -15807,7 +15810,7 @@
 /area/maintenance/auxsolarport)
 "aDv" = (
 /turf/simulated/wall,
-/area/security/lobby)
+/area/security/brig)
 "aDw" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/auxsolarport)
@@ -21452,7 +21455,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -21471,10 +21474,7 @@
 	icon_state = "pipe-j2";
 	tag = "icon-pipe-j2 (EAST)"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
+/turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "aQn" = (
 /obj/item/radio/intercom{
@@ -21484,7 +21484,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -21568,10 +21568,7 @@
 	dir = 8;
 	tag = "icon-pipe-j1 (EAST)"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
+/turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "aQu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -21615,7 +21612,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -21670,11 +21667,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bluered";
-	tag = "icon-siding1 (NORTH)"
-	},
+/turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "aQC" = (
 /obj/structure/closet/crate,
@@ -21708,10 +21701,7 @@
 	name = "Emergency NanoMed";
 	pixel_y = 28
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
+/turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "aQG" = (
 /obj/machinery/newscaster{
@@ -21721,10 +21711,7 @@
 	dir = 1;
 	in_use = 1
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
+/turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "aQH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -22853,6 +22840,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -22902,7 +22890,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	dir = 1;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -23974,9 +23962,7 @@
 	c_tag = "Dormitory East";
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
+/turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "aVx" = (
 /obj/item/twohanded/required/kirbyplants,
@@ -26105,9 +26091,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
+/turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "aZJ" = (
 /obj/machinery/light,
@@ -26898,7 +26882,7 @@
 	c_tag = "Dormitories North-West"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	dir = 1;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -27328,10 +27312,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
+/turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "bcb" = (
 /obj/structure/cable{
@@ -28394,10 +28375,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
+/turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "beb" = (
 /turf/simulated/wall,
@@ -28812,6 +28790,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -29026,7 +29005,9 @@
 	dir = 4;
 	tag = "icon-pipe-j1 (EAST)"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
 /area/crew_quarters/dorms)
 "bfp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -29034,7 +29015,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/crew_quarters/dorms)
 "bfq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -29051,6 +29035,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -29070,9 +29055,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
+/turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "bfs" = (
 /obj/machinery/light{
@@ -29117,6 +29100,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -29857,7 +29841,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 8;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -29877,9 +29861,7 @@
 /area/storage/office)
 "bgZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
+/turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "bha" = (
 /turf/simulated/floor/plasteel{
@@ -29907,13 +29889,15 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 6;
+	icon_state = "neutral"
 	},
 /area/crew_quarters/dorms)
 "bhf" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 10;
+	icon_state = "neutral"
 	},
 /area/crew_quarters/dorms)
 "bhg" = (
@@ -30871,7 +30855,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 8;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -31538,9 +31522,9 @@
 "bkw" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "bluecorner"
+	icon_state = "neutralcorner"
 	},
-/area/hallway/primary/central/nw)
+/area/crew_quarters/dorms)
 "bkx" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
@@ -31554,7 +31538,6 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/central/nw)
@@ -31568,8 +31551,7 @@
 "bkB" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "bluecorner"
+	icon_state = "blue"
 	},
 /area/hallway/primary/central/north)
 "bkC" = (
@@ -33165,7 +33147,7 @@
 /area/hallway/primary/central/ne)
 "bnO" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	dir = 1;
 	icon_state = "browncorner"
 	},
 /area/hallway/primary/central/nw)
@@ -33864,7 +33846,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/central/nw)
@@ -33927,8 +33908,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "bluecorner"
+	icon_state = "blue"
 	},
 /area/hallway/primary/central/north)
 "bpw" = (
@@ -33954,8 +33934,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "bluecorner"
+	icon_state = "blue"
 	},
 /area/hallway/primary/central/north)
 "bpz" = (
@@ -35979,7 +35958,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	dir = 1;
 	icon_state = "browncorner"
 	},
 /area/hallway/primary/central/nw)
@@ -36284,7 +36263,6 @@
 	pixel_x = 22
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -36840,6 +36818,7 @@
 "bwc" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel{
+	dir = 10;
 	icon_state = "blue"
 	},
 /area/bridge)
@@ -36850,7 +36829,7 @@
 	sortType = 15
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	dir = 1;
 	icon_state = "browncorner"
 	},
 /area/hallway/primary/central/west)
@@ -37126,10 +37105,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "blue"
-	},
+/turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
 "bwO" = (
 /obj/structure/closet/emcloset,
@@ -37374,7 +37350,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	dir = 1;
 	icon_state = "browncorner"
 	},
 /area/hallway/primary/central/nw)
@@ -37507,10 +37483,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
+/turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "bxz" = (
 /obj/structure/flora/ausbushes/leafybush,
@@ -37544,9 +37517,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "blue"
-	},
+/turf/simulated/floor/plasteel,
 /area/bridge)
 "bxD" = (
 /obj/machinery/camera{
@@ -37567,7 +37538,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "blue"
+	dir = 8;
+	icon_state = "bluecorner"
 	},
 /area/bridge)
 "bxE" = (
@@ -37712,7 +37684,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "blue"
+	icon_state = "bluecorner"
 	},
 /area/bridge)
 "bxP" = (
@@ -37947,14 +37919,20 @@
 "byk" = (
 /obj/structure/chair/stool,
 /obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "brown"
+	},
 /area/quartermaster/office)
 "byl" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "packageSort2"
 	},
 /obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "brown"
+	},
 /area/quartermaster/office)
 "bym" = (
 /obj/effect/decal/cleanable/fungus,
@@ -38016,10 +37994,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "blue"
-	},
+/turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
 "bys" = (
 /obj/structure/disposalpipe/segment,
@@ -38102,7 +38077,10 @@
 /area/quartermaster/office)
 "byz" = (
 /obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "brown"
+	},
 /area/quartermaster/office)
 "byA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -38666,7 +38644,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	dir = 1;
 	icon_state = "browncorner"
 	},
 /area/hallway/primary/central/west)
@@ -38678,7 +38656,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "brown"
+	},
 /area/quartermaster/office)
 "bzH" = (
 /obj/structure/table,
@@ -38741,7 +38722,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	dir = 1;
 	icon_state = "browncorner"
 	},
 /area/hallway/primary/central/west)
@@ -39050,9 +39031,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "blue"
-	},
+/turf/simulated/floor/plasteel,
 /area/bridge)
 "bAD" = (
 /obj/structure/cable{
@@ -39104,9 +39083,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "blue"
-	},
+/turf/simulated/floor/plasteel,
 /area/bridge)
 "bAH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -39371,7 +39348,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	dir = 1;
 	icon_state = "browncorner"
 	},
 /area/hallway/primary/central/west)
@@ -39896,7 +39873,7 @@
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	dir = 1;
 	icon_state = "browncorner"
 	},
 /area/hallway/primary/central/west)
@@ -40424,7 +40401,10 @@
 /area/maintenance/disposal)
 "bDN" = (
 /obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "brown"
+	},
 /area/quartermaster/office)
 "bDO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -40625,7 +40605,7 @@
 /area/quartermaster/storage)
 "bEj" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	dir = 1;
 	icon_state = "browncorner"
 	},
 /area/hallway/primary/central/west)
@@ -43294,7 +43274,9 @@
 "bJJ" = (
 /obj/machinery/computer/crew,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whitebluecorner";
+	tag = "icon-whitebluecorner"
 	},
 /area/medical/paramedic)
 "bJK" = (
@@ -43385,7 +43367,7 @@
 	pixel_y = 22
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	dir = 1;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -44656,7 +44638,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	dir = 1;
 	icon_state = "browncorner"
 	},
 /area/hallway/primary/central/west)
@@ -44825,7 +44807,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	dir = 1;
 	icon_state = "browncorner"
 	},
 /area/hallway/primary/central/sw)
@@ -45295,7 +45277,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
+	dir = 10;
 	icon_state = "whitehall"
 	},
 /area/medical/research{
@@ -45938,7 +45920,7 @@
 	})
 "bOw" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	dir = 1;
 	icon_state = "browncorner"
 	},
 /area/hallway/primary/central/sw)
@@ -48154,9 +48136,9 @@
 	step_size = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	dir = 1;
 	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	tag = "icon-whiteblue (NORTH)"
 	},
 /area/medical/medbay2)
 "bSw" = (
@@ -48401,9 +48383,7 @@
 "bSP" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "white"
 	},
 /area/medical/medbay2)
 "bSQ" = (
@@ -48480,6 +48460,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -48510,9 +48491,6 @@
 	},
 /area/assembly/robotics)
 "bSZ" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitecorner"
@@ -48624,7 +48602,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 4;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -48758,7 +48736,7 @@
 "bTw" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 9;
+	dir = 10;
 	icon_state = "whitehall"
 	},
 /area/medical/research{
@@ -49583,10 +49561,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "browncorner"
-	},
+/turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
 "bVa" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -50280,8 +50255,9 @@
 "bWh" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	tag = "icon-whitebluecorner (WEST)"
 	},
 /area/medical/medbay2)
 "bWi" = (
@@ -50344,8 +50320,9 @@
 	name = "Medical Doctor"
 	},
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	tag = "icon-whitebluecorner (WEST)"
 	},
 /area/medical/medbay2)
 "bWn" = (
@@ -50375,8 +50352,9 @@
 	},
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	tag = "icon-whitebluecorner (WEST)"
 	},
 /area/medical/medbay2)
 "bWp" = (
@@ -50452,9 +50430,8 @@
 /obj/structure/table,
 /obj/item/soap/nanotrasen,
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whitebluecorner";
+	tag = "icon-whitebluecorner"
 	},
 /area/medical/medbay2)
 "bWt" = (
@@ -51271,9 +51248,9 @@
 	pixel_x = -25
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 8;
 	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	tag = "icon-whitebluecorner (WEST)"
 	},
 /area/medical/medbay2)
 "bXQ" = (
@@ -51462,18 +51439,10 @@
 	},
 /area/medical/medbay2)
 "bYf" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "bluecorner"
 	},
-/area/medical/medbay2)
+/area/hallway/primary/central/north)
 "bYg" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -53555,9 +53524,8 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	tag = "icon-whitebluecorner"
 	},
 /area/medical/medbay2)
 "cbw" = (
@@ -53709,8 +53677,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "white"
 	},
 /area/medical/medbay2)
 "cbO" = (
@@ -53723,9 +53690,8 @@
 "cbP" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	tag = "icon-whitebluecorner"
 	},
 /area/medical/medbay2)
 "cbQ" = (
@@ -53761,8 +53727,9 @@
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	tag = "icon-whitebluecorner (WEST)"
 	},
 /area/medical/medbay2)
 "cbU" = (
@@ -53777,8 +53744,9 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	tag = "icon-whitebluecorner (WEST)"
 	},
 /area/medical/medbay2)
 "cbW" = (
@@ -54271,9 +54239,9 @@
 "ccC" = (
 /obj/machinery/vending/medical,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	dir = 10;
+	icon_state = "whiteblue";
+	tag = "icon-whiteblue (SOUTHWEST)"
 	},
 /area/medical/medbay2)
 "ccD" = (
@@ -54636,8 +54604,9 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	tag = "icon-whitebluecorner (WEST)"
 	},
 /area/medical/medbay2)
 "cdi" = (
@@ -55946,7 +55915,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whiteblue";
+	tag = "icon-whiteblue (NORTH)"
 	},
 /area/medical/medbay2)
 "cfR" = (
@@ -56975,7 +56946,6 @@
 "chG" = (
 /obj/structure/table/glass,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/toy/figure/geneticist,
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -57051,8 +57021,7 @@
 	icon_state = "pipe-y"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "whitehall"
+	icon_state = "white"
 	},
 /area/medical/research{
 	name = "Research Division"
@@ -58225,9 +58194,17 @@
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "ckc" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plasteel/airless,
-/area/toxins/test_area)
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "redcorner"
+	},
+/area/security/prison/cell_block/A)
 "ckd" = (
 /obj/machinery/door/airlock/shuttle/glass{
 	name = "trader shuttle airlock";
@@ -59248,7 +59225,6 @@
 /area/janitor)
 "cmd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitered"
@@ -59352,9 +59328,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/medical/virology/lab{
-	name = "\improper Virology Lobby"
-	})
+/area/medical/ward)
 "cmn" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
@@ -60262,9 +60236,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
-/area/medical/virology/lab{
-	name = "\improper Virology Lobby"
-	})
+/area/medical/surgery/north)
 "cnZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -60305,9 +60277,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (SOUTHWEST)"
+	icon_state = "white"
 	},
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
@@ -60515,6 +60485,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -61122,7 +61093,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
+	dir = 8;
 	icon_state = "whitehall"
 	},
 /area/medical/research{
@@ -61233,17 +61204,23 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreen";
-	tag = "icon-whitehall (WEST)"
+	dir = 8;
+	icon_state = "white"
 	},
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
 	})
 "cpC" = (
-/turf/simulated/wall,
-/area/medical/virology/lab{
-	name = "\improper Virology Lobby"
-	})
+/obj/structure/toilet,
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/library/abandoned)
 "cpD" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -61340,9 +61317,9 @@
 "cpM" = (
 /obj/machinery/smartfridge/secure/chemistry/virology,
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 9;
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	tag = "icon-whitegreen (NORTHWEST)"
 	},
 /area/medical/virology)
 "cpN" = (
@@ -61354,9 +61331,9 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 5;
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	tag = "icon-whitegreen (NORTHEAST)"
 	},
 /area/medical/virology)
 "cpO" = (
@@ -61426,9 +61403,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	dir = 1;
 	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	tag = "icon-whitebluecorner"
 	},
 /area/medical/medbay2)
 "cpT" = (
@@ -61487,8 +61464,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurple"
+	icon_state = "white"
 	},
 /area/toxins/mixing)
 "cpY" = (
@@ -61574,8 +61550,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurple"
+	icon_state = "white"
 	},
 /area/toxins/mixing)
 "cqe" = (
@@ -62305,7 +62280,9 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 9;
+	icon_state = "whitegreen";
+	tag = "icon-whitegreen (NORTHWEST)"
 	},
 /area/medical/virology)
 "crq" = (
@@ -62700,6 +62677,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -63524,7 +63502,7 @@
 "cts" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/maintenance/genetics)
+/area/maintenance/server)
 "ctt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -63919,7 +63897,9 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 10;
+	icon_state = "whitegreen";
+	tag = "icon-whitegreen (SOUTHWEST)"
 	},
 /area/medical/virology)
 "cuh" = (
@@ -63998,8 +63978,9 @@
 	},
 /obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plasteel{
+	dir = 6;
 	icon_state = "whitegreen";
-	tag = "icon-whitehall (WEST)"
+	tag = "icon-whitegreen (SOUTHEAST)"
 	},
 /area/medical/virology)
 "cuo" = (
@@ -64092,7 +64073,7 @@
 "cuw" = (
 /obj/structure/closet/radiation,
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 9;
 	icon_state = "blue"
 	},
 /area/medical/cmostore)
@@ -65559,10 +65540,6 @@
 "cxh" = (
 /turf/simulated/wall,
 /area/medical/ward)
-"cxi" = (
-/obj/machinery/meter,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "cxj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -65863,7 +65840,7 @@
 "cxM" = (
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
-/area/maintenance/asmaint)
+/area/maintenance/genetics)
 "cxN" = (
 /turf/simulated/wall,
 /area/toxins/xenobiology)
@@ -65906,11 +65883,11 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/genetics)
@@ -65938,23 +65915,6 @@
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall,
 /area/maintenance/asmaint2)
-"cxT" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "cxU" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
@@ -65963,7 +65923,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/asmaint)
+/area/maintenance/genetics)
 "cxV" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -66718,7 +66678,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/asmaint)
+/area/maintenance/genetics)
 "czy" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -67234,8 +67194,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	dir = 6;
+	icon_state = "whiteblue";
+	tag = "icon-whitehall (WEST)"
 	},
 /area/medical/medbay2)
 "cAt" = (
@@ -67253,9 +67214,9 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	dir = 10;
+	icon_state = "whiteblue";
+	tag = "icon-whitehall (WEST)"
 	},
 /area/medical/medbay2)
 "cAu" = (
@@ -67820,12 +67781,8 @@
 	opacity = 0
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -67882,18 +67839,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
-"cBG" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/genetics)
 "cBH" = (
 /obj/structure/table,
+/obj/item/healthanalyzer,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
 /area/maintenance/genetics)
 "cBI" = (
@@ -68585,16 +68534,12 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 1;
 	icon_state = "pipe-y"
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -68759,11 +68704,11 @@
 /turf/simulated/wall,
 /area/medical/surgery/south)
 "cDg" = (
-/obj/structure/table,
-/obj/item/healthanalyzer,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/maintenance/genetics)
+/area/maintenance/server)
 "cDh" = (
 /obj/structure/table,
 /obj/item/pda,
@@ -69559,7 +69504,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	dir = 1;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
@@ -69584,7 +69529,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	dir = 1;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
@@ -69602,7 +69547,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	dir = 1;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
@@ -69617,7 +69562,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	dir = 1;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
@@ -69667,8 +69612,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "yellowcorner"
+	dir = 1;
+	icon_state = "yellow"
 	},
 /area/hallway/primary/aft)
 "cFh" = (
@@ -70278,9 +70223,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "yellowcorner"
-	},
+/obj/effect/decal/warning_stripes/southeastcorner,
+/turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cGk" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -70583,7 +70527,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "yellowcorner"
+	icon_state = "yellow"
 	},
 /area/hallway/primary/aft)
 "cGN" = (
@@ -70697,7 +70641,8 @@
 "cGW" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "yellowcorner"
+	dir = 8;
+	icon_state = "cautioncorner"
 	},
 /area/hallway/primary/aft)
 "cGX" = (
@@ -70796,7 +70741,8 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "yellowcorner"
+	dir = 8;
+	icon_state = "cautioncorner"
 	},
 /area/hallway/primary/aft)
 "cHd" = (
@@ -71994,10 +71940,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "yellowcorner"
-	},
+/turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cJm" = (
 /obj/structure/cable{
@@ -72585,8 +72528,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "yellowcorner"
+	dir = 8;
+	icon_state = "cautioncorner"
 	},
 /area/hallway/primary/aft)
 "cKl" = (
@@ -73420,7 +73363,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "arrival"
+	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
 "cLU" = (
@@ -73783,8 +73726,7 @@
 "cML" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "arrival"
+	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
 "cMM" = (
@@ -74350,7 +74292,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "yellowcorner"
+	icon_state = "yellow"
 	},
 /area/hallway/primary/aft)
 "cNT" = (
@@ -75280,8 +75222,8 @@
 "cPL" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "yellowcorner"
+	dir = 8;
+	icon_state = "cautioncorner"
 	},
 /area/hallway/primary/aft)
 "cPM" = (
@@ -77253,6 +77195,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/effect/decal/warning_stripes/northeastsouth,
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
 "cTA" = (
@@ -77284,6 +77227,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/effect/decal/warning_stripes/northwestsouth,
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
 "cTD" = (
@@ -79151,9 +79095,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "purple"
-	},
+/turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "cXh" = (
 /turf/simulated/floor/plasteel{
@@ -79182,10 +79124,9 @@
 /area/engine/engineering)
 "cXj" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purplecorner"
+	icon_state = "blue"
 	},
-/area/hallway/secondary/exit)
+/area/hallway/primary/central/north)
 "cXk" = (
 /obj/item/flag/nt,
 /obj/effect/decal/warning_stripes/southeast,
@@ -79212,10 +79153,7 @@
 	c_tag = "Departure Lounge West";
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purple"
-	},
+/turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "cXo" = (
 /obj/structure/chair{
@@ -79225,10 +79163,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purple"
-	},
+/turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "cXp" = (
 /obj/structure/chair,
@@ -79668,10 +79603,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purple"
-	},
+/turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "cYi" = (
 /obj/structure/disposalpipe/segment,
@@ -79743,10 +79675,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purple"
-	},
+/turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "cYq" = (
 /obj/structure/cable/yellow{
@@ -80220,10 +80149,7 @@
 /obj/item/clothing/mask/breath,
 /obj/item/tank/internals/emergency_oxygen,
 /obj/item/tank/internals/emergency_oxygen,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purple"
-	},
+/turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "cZr" = (
 /obj/structure/window/reinforced{
@@ -80470,10 +80396,7 @@
 /area/atmos)
 "cZT" = (
 /obj/machinery/vending/cigarette,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purple"
-	},
+/turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "cZV" = (
 /obj/machinery/power/apc{
@@ -80766,7 +80689,7 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	dir = 6;
 	icon_state = "blue"
 	},
 /area/medical/cmostore)
@@ -80783,7 +80706,6 @@
 	},
 /obj/item/storage/firstaid,
 /turf/simulated/floor/plasteel{
-	dir = 6;
 	icon_state = "blue"
 	},
 /area/medical/cmostore)
@@ -80805,6 +80727,7 @@
 	pixel_x = 27
 	},
 /obj/machinery/suit_storage_unit/engine,
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plating,
 /area/storage/secure)
 "daL" = (
@@ -82031,9 +81954,9 @@
 /area/solar/starboard)
 "ddF" = (
 /obj/structure/sign/biohazard{
-	pixel_y = 32
+	pixel_x = 32
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/floor/plating,
 /area/maintenance/genetics)
 "ddG" = (
 /obj/machinery/field/generator,
@@ -83548,10 +83471,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
+/turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "dhs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -84248,9 +84168,8 @@
 	},
 /area/turret_protected/aisat_interior)
 "diP" = (
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/turf/simulated/wall/r_wall,
+/area/hallway/primary/central/ne)
 "diQ" = (
 /obj/machinery/bluespace_beacon,
 /obj/effect/decal/warning_stripes/east,
@@ -84267,9 +84186,16 @@
 	},
 /area/turret_protected/aisat_interior)
 "diR" = (
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "whitehall"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
 "diV" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -88590,6 +88516,15 @@
 	icon_state = "bluecorner"
 	},
 /area/hallway/secondary/entry)
+"emF" = (
+/obj/effect/decal/cleanable/dust,
+/obj/structure/table/glass,
+/obj/item/paper_bin,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/server)
 "enD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -88891,6 +88826,14 @@
 /obj/machinery/smartfridge/secure/extract,
 /turf/simulated/floor/plating,
 /area/maintenance/xenozoo)
+"eXa" = (
+/obj/effect/decal/cleanable/dust,
+/obj/structure/chair/sofa/corp/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple/corner,
+/turf/simulated/floor/carpet/purple,
+/area/maintenance/server)
 "eXI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -89278,6 +89221,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
+"fSf" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/decal/cleanable/dust,
+/turf/simulated/floor/engine,
+/area/maintenance/server)
 "fSB" = (
 /obj/machinery/door/morgue{
 	name = "Occult Study"
@@ -89519,6 +89468,12 @@
 	icon_state = "red"
 	},
 /area/security/range)
+"gwS" = (
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "yellow"
+	},
+/area/hallway/primary/aft)
 "gyR" = (
 /obj/item/radio/intercom{
 	dir = 4;
@@ -89530,6 +89485,13 @@
 	icon_state = "neutralfull"
 	},
 /area/shuttle/escape)
+"gzL" = (
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "blue"
+	},
+/area/bridge)
 "gBG" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -89618,6 +89580,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
+"gRs" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/transparent/glass,
+/area/maintenance/server)
 "gSF" = (
 /obj/structure/bookcase,
 /turf/simulated/floor/wood,
@@ -89729,6 +89700,17 @@
 	icon_state = "cafeteria"
 	},
 /area/toxins/xenobiology)
+"gXh" = (
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/purple,
+/turf/simulated/floor/carpet/purple,
+/area/maintenance/server)
 "gYt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -89947,6 +89929,35 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"hBi" = (
+/obj/effect/decal/cleanable/dust,
+/obj/item/twohanded/required/kirbyplants,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/purple,
+/area/maintenance/server)
+"hFD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "yellow"
+	},
+/area/hallway/primary/aft)
+"hFN" = (
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/constructable_frame/machine_frame,
+/turf/simulated/floor/engine,
+/area/maintenance/server)
 "hHo" = (
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
@@ -90061,6 +90072,14 @@
 	icon_state = "escape"
 	},
 /area/security/customs2)
+"hSk" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'SERVER ROOM'.";
+	name = "SERVER ROOM";
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/genetics)
 "hTt" = (
 /obj/effect/decal/cleanable/dust,
 /obj/effect/decal/cleanable/cobweb2,
@@ -90126,13 +90145,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
-"idb" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/aisat{
-	name = "\improper AI Satellite Hallway"
-	})
 "ikF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb2,
@@ -90251,6 +90263,12 @@
 	icon_state = "darkyellow"
 	},
 /area/shuttle/escape)
+"iwR" = (
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "browncorner"
+	},
+/area/hallway/primary/central/sw)
 "iya" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -90290,6 +90308,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/library/abandoned)
+"iGx" = (
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dust,
+/turf/simulated/floor/transparent/glass,
+/area/maintenance/server)
 "iHj" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/effect/decal/cleanable/dirt,
@@ -90348,6 +90373,15 @@
 	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit)
+"iMD" = (
+/obj/effect/spawner/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/aisat{
+	name = "\improper AI Satellite Hallway"
+	})
 "iNl" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -90362,6 +90396,22 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/toxins/launch)
+"iOg" = (
+/obj/effect/decal/cleanable/dust,
+/obj/structure/chair/sofa/corp/right{
+	dir = 4
+	},
+/obj/machinery/light_construct{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/structure/sign/nosmoking_2{
+	pixel_x = -32
+	},
+/turf/simulated/floor/carpet/purple,
+/area/maintenance/server)
 "iOx" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
@@ -90405,9 +90455,27 @@
 "iUc" = (
 /turf/simulated/wall/r_wall,
 /area/tcommsat/chamber)
+"iUC" = (
+/obj/effect/spawner/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/aisat{
+	name = "\improper AI Satellite Hallway"
+	})
 "iVV" = (
 /turf/simulated/wall/r_wall,
 /area/server)
+"iVY" = (
+/obj/effect/decal/cleanable/dust,
+/obj/structure/table/glass,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/item/reagent_containers/glass/beaker/waterbottle/empty,
+/turf/simulated/floor/plating,
+/area/maintenance/server)
 "iZs" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
@@ -90459,6 +90527,14 @@
 	icon_state = "blue"
 	},
 /area/hydroponics)
+"jib" = (
+/obj/effect/turf_decal/stripes{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/light/small,
+/turf/simulated/floor/transparent/glass,
+/area/maintenance/server)
 "jjW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -90469,6 +90545,9 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/xenozoo)
+"jnc" = (
+/turf/simulated/wall,
+/area/maintenance/server)
 "jnJ" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "swall12"
@@ -90807,26 +90886,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/dorms)
-"koQ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
-	},
-/area/aisat{
-	name = "\improper AI Satellite Hallway"
-	})
 "kqe" = (
 /obj/machinery/door_control{
 	id = "ArmorySecAccess";
@@ -90953,6 +91012,15 @@
 	},
 /turf/simulated/floor/carpet,
 /area/civilian/vacantoffice)
+"kGe" = (
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/light_construct{
+	dir = 1
+	},
+/obj/item/tank/internals/oxygen/empty,
+/obj/effect/turf_decal/siding/purple,
+/turf/simulated/floor/carpet/purple,
+/area/maintenance/server)
 "kHU" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
@@ -91271,6 +91339,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
+"luR" = (
+/obj/effect/decal/cleanable/dust,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/purple,
+/area/maintenance/server)
+"lww" = (
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/light_construct{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/ash,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/purple,
+/area/maintenance/server)
 "lxD" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -91426,6 +91513,14 @@
 	tag = "icon-swall_f6"
 	},
 /area/shuttle/pod_3)
+"lRV" = (
+/obj/effect/decal/cleanable/dust,
+/obj/item/twohanded/required/kirbyplants,
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/purple,
+/area/maintenance/server)
 "lSf" = (
 /obj/effect/decal/warning_stripes/northeast,
 /obj/effect/decal/cleanable/blood/xeno,
@@ -91499,6 +91594,15 @@
 /obj/item/hand_labeler,
 /turf/simulated/floor/carpet,
 /area/civilian/vacantoffice)
+"mac" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "browncorner"
+	},
+/area/quartermaster/office)
 "mbr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random_spawners/blood_often,
@@ -91690,6 +91794,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/medbay)
+"mxl" = (
+/obj/effect/decal/cleanable/dust,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/item/reagent_containers/glass/bucket,
+/turf/simulated/floor/engine,
+/area/maintenance/server)
 "mxT" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
@@ -91734,6 +91844,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
+"mEo" = (
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/purple,
+/turf/simulated/floor/carpet/purple,
+/area/maintenance/server)
 "mGt" = (
 /obj/item/flag/med,
 /turf/simulated/floor/plasteel{
@@ -91843,6 +91964,13 @@
 /obj/machinery/slot_machine,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
+"naz" = (
+/obj/effect/turf_decal/stripes{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dust,
+/turf/simulated/floor/transparent/glass,
+/area/maintenance/server)
 "naH" = (
 /obj/structure/bed/roller,
 /turf/simulated/floor/plasteel{
@@ -91852,6 +91980,9 @@
 "nbH" = (
 /turf/simulated/shuttle/floor,
 /area/shuttle/administration)
+"ndH" = (
+/turf/simulated/wall/r_wall,
+/area/maintenance/server)
 "neg" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -91935,6 +92066,12 @@
 	icon_state = "dark"
 	},
 /area/library/abandoned)
+"njA" = (
+/obj/effect/decal/cleanable/ash,
+/obj/item/extinguisher,
+/obj/effect/turf_decal/siding/purple,
+/turf/simulated/floor/plating,
+/area/maintenance/server)
 "njX" = (
 /obj/structure/foodcart,
 /turf/simulated/floor/plasteel{
@@ -92072,6 +92209,15 @@
 "nCT" = (
 /turf/simulated/floor/plasteel,
 /area/security/customs)
+"nEH" = (
+/obj/effect/spawner/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/aisat{
+	name = "\improper AI Satellite Hallway"
+	})
 "nEQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -92316,6 +92462,19 @@
 	icon_state = "purple"
 	},
 /area/maintenance/xenozoo)
+"olB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/southwestcorner,
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/aft)
 "onN" = (
 /obj/machinery/kitchen_machine/microwave{
 	pixel_x = -3;
@@ -92474,6 +92633,15 @@
 	icon_state = "darkred"
 	},
 /area/security/warden)
+"oLr" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/cobweb2,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/genetics)
 "oLU" = (
 /obj/machinery/vending/coffee,
 /obj/effect/decal/cleanable/dirt,
@@ -92609,6 +92777,13 @@
 	},
 /turf/simulated/shuttle/floor4,
 /area/shuttle/escape)
+"pea" = (
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whiteblue";
+	tag = "icon-whitehall (WEST)"
+	},
+/area/medical/medbay2)
 "pee" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -92631,6 +92806,17 @@
 	tag = "icon-whiteblue (NORTHWEST)"
 	},
 /area/security/medbay)
+"pjs" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "yellow"
+	},
+/area/hallway/primary/aft)
 "plh" = (
 /obj/structure/closet/secure_closet/warden,
 /turf/simulated/floor/plasteel{
@@ -92687,15 +92873,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/range)
-"ptB" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/plating,
-/area/aisat{
-	name = "\improper AI Satellite Hallway"
-	})
 "pwN" = (
 /obj/machinery/door_control{
 	id = "adminshuttleblast";
@@ -92862,6 +93039,16 @@
 /turf/space,
 /turf/simulated/floor/plating,
 /area/shuttle/administration)
+"pSv" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitebluecorner";
+	tag = "icon-whitebluecorner (WEST)"
+	},
+/area/medical/medbay2)
 "pSJ" = (
 /obj/structure/sink{
 	dir = 8;
@@ -92900,6 +93087,7 @@
 /obj/effect/decal/cleanable/dust,
 /obj/structure/table/wood,
 /obj/item/clipboard,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -93008,6 +93196,13 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads)
+"qfz" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dust,
+/turf/simulated/floor/transparent/glass,
+/area/maintenance/server)
 "qfS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
@@ -93088,6 +93283,13 @@
 	icon_state = "dark"
 	},
 /area/library/abandoned)
+"quo" = (
+/obj/effect/decal/cleanable/dust,
+/obj/structure/chair/sofa/corp/left,
+/obj/effect/turf_decal/siding/purple,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/server)
 "qus" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -93243,6 +93445,20 @@
 	icon_state = "whitegreencorner"
 	},
 /area/toxins/xenobiology)
+"qIL" = (
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/maintenance/server)
 "qIM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -93300,6 +93516,13 @@
 	icon_state = "neutral"
 	},
 /area/security/customs)
+"qOW" = (
+/obj/effect/spawner/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/aisat{
+	name = "\improper AI Satellite Hallway"
+	})
 "qPG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -93333,6 +93556,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
+"qSQ" = (
+/obj/effect/decal/cleanable/dust,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/item/screwdriver,
+/turf/simulated/floor/engine,
+/area/maintenance/server)
 "qST" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "redcorner"
@@ -93427,6 +93656,12 @@
 	},
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology)
+"rhs" = (
+/obj/effect/decal/cleanable/dust,
+/obj/effect/decal/cleanable/shreds,
+/obj/item/chair/stool,
+/turf/simulated/floor/engine,
+/area/maintenance/server)
 "rig" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -93452,18 +93687,6 @@
 	icon_state = "white"
 	},
 /area/security/medbay)
-"riB" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
-	},
-/area/security/prison/cell_block/A)
 "rjA" = (
 /mob/living/simple_animal/pet/dog/security,
 /obj/structure/bed/dogbed,
@@ -93559,6 +93782,11 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/crew_quarters/dorms)
+"rns" = (
+/obj/effect/decal/cleanable/dust,
+/obj/structure/computerframe,
+/turf/simulated/floor/engine,
+/area/maintenance/server)
 "roO" = (
 /obj/machinery/door/window/southright{
 	name = "Containment Pen";
@@ -93580,6 +93808,17 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/administration)
+"rsV" = (
+/obj/effect/turf_decal/stripes{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/light_construct/small{
+	dir = 4
+	},
+/obj/item/shard,
+/turf/simulated/floor/transparent/glass,
+/area/maintenance/server)
 "rtv" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -93861,6 +94100,26 @@
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/administration)
+"rYr" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "dark";
+	tag = "icon-vault (NORTHEAST)"
+	},
+/area/aisat{
+	name = "\improper AI Satellite Hallway"
+	})
 "sbp" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "wall3"
@@ -93889,6 +94148,14 @@
 	icon_state = "carpet"
 	},
 /area/library/abandoned)
+"skM" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE"
+	},
+/turf/simulated/wall/r_wall,
+/area/maintenance/server)
 "snu" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "swall_s6"
@@ -93993,6 +94260,19 @@
 	icon_state = "darkblue"
 	},
 /area/security/detectives_office)
+"sEL" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitebluecorner";
+	tag = "icon-whiteblue (NORTH)"
+	},
+/area/medical/medbay2)
 "sGi" = (
 /obj/structure/table,
 /obj/item/storage/box/handcuffs,
@@ -94063,6 +94343,13 @@
 	icon_state = "brown"
 	},
 /area/shuttle/escape)
+"sQD" = (
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "browncorner";
+	tag = "icon-browncorner (EAST)"
+	},
+/area/quartermaster/office)
 "sUp" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/machinery/camera{
@@ -94097,15 +94384,6 @@
 	icon_state = "bot"
 	},
 /area/shuttle/escape)
-"sXG" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/aisat{
-	name = "\improper AI Satellite Hallway"
-	})
 "sYE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -94177,6 +94455,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
+"tcA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/aft)
 "tdh" = (
 /obj/structure/closet/crate/engineering,
 /obj/item/storage/toolbox/electrical{
@@ -94268,6 +94559,14 @@
 "tmi" = (
 /turf/simulated/wall,
 /area/security/range)
+"tml" = (
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "whitehall"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
 "tmG" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -94282,13 +94581,13 @@
 	},
 /area/shuttle/escape)
 "tou" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -94359,23 +94658,19 @@
 	},
 /area/security/customs)
 "tvO" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 5;
+	icon_state = "dark";
+	tag = "icon-vault (NORTHEAST)"
 	},
-/area/toxins/xenobiology)
+/area/aisat{
+	name = "\improper AI Satellite Hallway"
+	})
 "tzT" = (
 /obj/machinery/computer/card,
 /turf/simulated/shuttle/floor,
@@ -94487,6 +94782,26 @@
 	icon_state = "white"
 	},
 /area/security/medbay)
+"tVy" = (
+/obj/structure/door_assembly/door_assembly_mai{
+	anchored = 1
+	},
+/obj/structure/firelock_frame{
+	anchored = 1
+	},
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/engine,
+/area/maintenance/server)
+"uaN" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/genetics)
 "uew" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -94616,6 +94931,14 @@
 	tag = "icon-whitehall (WEST)"
 	},
 /area/security/medbay)
+"uBA" = (
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/server)
 "uBM" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8;
@@ -94647,6 +94970,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/xenozoo)
+"uKx" = (
+/obj/effect/decal/cleanable/dust,
+/obj/item/cigbutt,
+/obj/effect/landmark{
+	name = "xeno_spawn";
+	pixel_x = -1
+	},
+/turf/simulated/floor/engine,
+/area/maintenance/server)
 "uKK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -94734,21 +95066,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/medbay)
-"uRP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
-	},
-/area/security/prison/cell_block/A)
 "uTI" = (
 /turf/space,
 /turf/simulated/shuttle/floor{
@@ -94934,6 +95251,20 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
+"vxL" = (
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/generic,
+/obj/structure/mecha_wreckage/ripley/firefighter,
+/turf/simulated/floor/engine,
+/area/maintenance/server)
+"vyb" = (
+/obj/effect/decal/cleanable/fungus,
+/turf/simulated/wall,
+/area/maintenance/server)
 "vzG" = (
 /obj/structure/chair/office/dark,
 /obj/effect/decal/cleanable/dust,
@@ -95272,6 +95603,21 @@
 /obj/machinery/computer/HolodeckControl,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
+"wiX" = (
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/maintenance/server)
+"wje" = (
+/obj/effect/decal/cleanable/dust,
+/obj/structure/table_frame/wood,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/purple,
+/area/maintenance/server)
 "wkg" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Escape Shuttle Cockpit";
@@ -95372,20 +95718,6 @@
 	icon_state = "darkred"
 	},
 /area/security/brig)
-"wuJ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
-	},
-/area/aisat{
-	name = "\improper AI Satellite Hallway"
-	})
 "wuR" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/shuttle/floor{
@@ -95877,15 +96209,6 @@
 	icon_state = "neutralfull"
 	},
 /area/shuttle/escape)
-"xxY" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/aisat{
-	name = "\improper AI Satellite Hallway"
-	})
 "xyo" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -96028,6 +96351,15 @@
 	},
 /turf/simulated/floor/greengrid,
 /area/maintenance/xenozoo)
+"xMY" = (
+/obj/effect/decal/cleanable/dust,
+/obj/structure/table/reinforced,
+/obj/item/stack/rods{
+	amount = 8
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/engine,
+/area/maintenance/server)
 "xPv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -96075,6 +96407,14 @@
 	tag = "icon-whiteblue"
 	},
 /area/shuttle/escape)
+"xTY" = (
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/landmark{
+	name = "blobstart"
+	},
+/turf/simulated/floor/engine,
+/area/maintenance/server)
 "xVt" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -118885,7 +119225,7 @@ aaa
 atM
 auy
 atM
-adZ
+aaa
 atM
 auy
 atM
@@ -119142,7 +119482,7 @@ aab
 atN
 auB
 atN
-adZ
+aaa
 atN
 ayo
 atN
@@ -119199,7 +119539,7 @@ bnS
 bxd
 bDN
 bBn
-bPS
+mac
 bIG
 bJE
 bKI
@@ -119236,8 +119576,8 @@ cCA
 cwF
 cvo
 cER
-cGi
-cnA
+hFD
+ckO
 cJZ
 cLy
 cLi
@@ -119399,7 +119739,7 @@ aab
 atN
 auC
 atN
-adZ
+aaa
 atN
 auC
 atN
@@ -119455,7 +119795,7 @@ bud
 bnS
 bxd
 byl
-bBn
+sQD
 bPS
 bBn
 bBn
@@ -119656,7 +119996,7 @@ aab
 atN
 auB
 atN
-adZ
+aaa
 atN
 ayo
 aBA
@@ -120752,14 +121092,14 @@ bMJ
 bOw
 bOw
 bUZ
-bOw
-bOw
-bOw
+bTy
+iwR
+iwR
 bYO
-bOw
-bOw
+iwR
+iwR
 cfj
-bOw
+iwR
 bTk
 cgQ
 ckp
@@ -120778,7 +121118,7 @@ cFT
 cvo
 cvo
 cER
-cGj
+tcA
 cGU
 ctT
 cLz
@@ -121034,8 +121374,8 @@ cyg
 cCH
 coL
 cqF
-cER
-cGj
+pjs
+olB
 cJZ
 cKb
 cLB
@@ -121293,7 +121633,7 @@ cly
 cHR
 cFg
 cGm
-cnA
+ckO
 cKb
 cLA
 cMt
@@ -121501,7 +121841,7 @@ aSA
 aSA
 djV
 bmW
-bkw
+bAz
 bmb
 bmb
 bmb
@@ -121758,7 +122098,7 @@ aPi
 bCq
 bgS
 aNG
-bkw
+bAz
 bmb
 aaa
 aaa
@@ -121807,7 +122147,7 @@ aaa
 cFa
 cFk
 cGi
-cnA
+ckO
 cKf
 pKG
 cMw
@@ -122015,7 +122355,7 @@ aRw
 aRw
 djZ
 aNG
-bkw
+bAz
 bmb
 aaa
 aaa
@@ -122064,7 +122404,7 @@ aaa
 cFa
 cFt
 cGi
-cnA
+ckO
 cKb
 cLE
 cMz
@@ -122321,7 +122661,7 @@ aaa
 cFa
 cFl
 cGi
-cnA
+ckO
 cKb
 cKb
 cMD
@@ -122529,7 +122869,7 @@ aSC
 beX
 bgP
 aNG
-bkw
+bAz
 bmb
 aaa
 aaa
@@ -122578,7 +122918,7 @@ aaa
 cFa
 cFt
 cGi
-cnA
+ckO
 cKf
 cLD
 cJx
@@ -122786,7 +123126,7 @@ das
 bfg
 bgP
 aNG
-bkw
+bAz
 bmb
 aaa
 bmc
@@ -122835,7 +123175,7 @@ cvq
 cvq
 cFt
 cGi
-cnA
+ckO
 cKf
 cLG
 cMx
@@ -123007,7 +123347,7 @@ aqX
 aie
 ajR
 alo
-axL
+aAz
 axL
 axL
 axL
@@ -123043,7 +123383,7 @@ bdz
 beX
 bgP
 aNG
-bkw
+bAz
 bmb
 aaa
 bmc
@@ -123119,7 +123459,7 @@ cSU
 cSU
 dho
 dib
-diP
+dib
 djv
 dib
 dib
@@ -123127,7 +123467,7 @@ dib
 dib
 dib
 dmj
-diP
+dib
 cUH
 cUL
 cUR
@@ -123300,7 +123640,7 @@ dbv
 bfh
 bgP
 aNG
-bkw
+bAz
 bmb
 aaa
 bmc
@@ -123349,7 +123689,7 @@ cDW
 cvx
 cFk
 cGi
-cnA
+ckO
 cKb
 cJx
 cJi
@@ -123606,7 +123946,7 @@ cEe
 cvx
 cFt
 cGi
-cnA
+ckO
 cKb
 cJx
 cJh
@@ -123863,7 +124203,7 @@ cEe
 cvx
 cFt
 cGi
-cnA
+ckO
 cKb
 cLH
 cJi
@@ -124071,7 +124411,7 @@ aRw
 aRw
 bgU
 bna
-bkC
+bYf
 blU
 bnR
 bpo
@@ -124120,7 +124460,7 @@ cvx
 cvx
 cFo
 cGn
-cnA
+ckO
 cKb
 cKb
 cJj
@@ -124377,12 +124717,12 @@ cDY
 cvx
 cFt
 cGi
-cHD
+ckO
 cKk
-cMG
+ckO
 cJl
 cMG
-cMG
+gwS
 cPL
 cJZ
 cPj
@@ -124842,7 +125182,7 @@ dcb
 bdv
 bhc
 bnh
-bkC
+cXj
 bma
 bnY
 bpu
@@ -125356,7 +125696,7 @@ bhh
 bhV
 biK
 bnj
-bkC
+cXj
 bma
 boa
 bpw
@@ -125408,7 +125748,7 @@ cGq
 cHl
 cHO
 cfz
-cHD
+cnA
 cnA
 cnA
 cOc
@@ -125613,7 +125953,7 @@ dco
 bdw
 bgW
 bni
-bkC
+bYf
 bma
 aYf
 aYg
@@ -125860,8 +126200,8 @@ avq
 avq
 avq
 aHp
-aRx
-bdN
+aPm
+aVt
 aDN
 biQ
 bpQ
@@ -126384,7 +126724,7 @@ dhp
 aDN
 dkl
 bna
-bkC
+bYf
 bma
 boh
 bpB
@@ -126612,7 +126952,7 @@ auP
 avX
 axG
 ayU
-uRP
+adZ
 azx
 aCr
 aHE
@@ -126870,7 +127210,7 @@ aum
 axJ
 auQ
 azO
-riB
+ckc
 aCs
 aHE
 aEp
@@ -127145,7 +127485,7 @@ aPM
 aPM
 aYv
 aSl
-aRx
+aZs
 bdQ
 aDN
 bgT
@@ -127162,7 +127502,7 @@ bmc
 bra
 bsG
 byb
-bwc
+gzL
 bxv
 byT
 bFg
@@ -127231,7 +127571,6 @@ cSU
 cSU
 dhv
 dib
-diR
 dib
 dib
 dib
@@ -127239,7 +127578,8 @@ dib
 dib
 dib
 dib
-diR
+dib
+dib
 cUJ
 daR
 cUU
@@ -127402,7 +127742,7 @@ aSh
 aRc
 aYI
 aSl
-aRx
+aZs
 bea
 bgX
 biW
@@ -127662,9 +128002,9 @@ aLP
 aTi
 bdU
 aSe
-aRx
+aTb
 buU
-aRx
+aTb
 dhr
 djf
 dko
@@ -128187,7 +128527,7 @@ dnC
 bmi
 aaa
 aaa
-bqN
+diP
 bsJ
 byr
 bwf
@@ -129716,8 +130056,8 @@ aTJ
 aTJ
 aTJ
 aTJ
-bdN
-aTb
+aVt
+bkw
 aUQ
 bJz
 aUQ
@@ -131033,7 +131373,7 @@ bTM
 bPg
 bQS
 bIq
-bYd
+sEL
 bZI
 cbN
 bWs
@@ -131484,7 +131824,7 @@ ajV
 aiY
 apV
 aqG
-arC
+ahW
 asA
 aFL
 aFL
@@ -131741,7 +132081,7 @@ ahm
 aiY
 apU
 aqG
-ago
+aqX
 asA
 atg
 awl
@@ -131806,7 +132146,7 @@ bSq
 bEp
 crA
 bZJ
-cbO
+cuv
 bWt
 bXE
 bZk
@@ -132255,7 +132595,7 @@ aeV
 aoS
 apW
 aih
-aqX
+ago
 asd
 wyy
 ame
@@ -132512,7 +132852,7 @@ aih
 aih
 aih
 aih
-aqX
+ago
 asd
 akE
 amw
@@ -132536,7 +132876,7 @@ aKO
 aMJ
 aOg
 aFI
-aZs
+aPm
 aSM
 aVp
 aWT
@@ -132659,7 +132999,7 @@ dqw
 dqw
 dqw
 dmU
-sXG
+iMD
 dqw
 dqw
 drf
@@ -132834,7 +133174,7 @@ bOU
 bOU
 bSS
 bZJ
-cuv
+cbO
 bWu
 bXI
 bZm
@@ -132910,13 +133250,13 @@ dkf
 dkY
 dlt
 dlU
-wuJ
-wuJ
-wuJ
+tvO
+tvO
+tvO
 dms
 dmL
 dmT
-koQ
+rYr
 dmf
 dmV
 dmY
@@ -133050,7 +133390,7 @@ aSP
 aSP
 aSP
 aPU
-aQH
+arC
 aSQ
 aVs
 aWW
@@ -133171,9 +133511,9 @@ dqw
 dqw
 dqw
 dmG
-ptB
-idb
-xxY
+nEH
+qOW
+iUC
 dqw
 dqw
 dnc
@@ -133348,7 +133688,7 @@ bQU
 bSw
 bXA
 bZJ
-cuv
+cbO
 bWy
 bXK
 bZo
@@ -133605,7 +133945,7 @@ bQZ
 bSy
 bSX
 bZJ
-cuv
+cbO
 bWa
 bXM
 cgO
@@ -133862,7 +134202,7 @@ bQY
 bSx
 bRt
 bZM
-cuo
+cbO
 bWy
 bXL
 bZq
@@ -134117,9 +134457,9 @@ bDH
 bQA
 bRa
 bOQ
-bYf
+bYd
 bZI
-cbN
+pSv
 bWa
 bXM
 cgR
@@ -134376,7 +134716,7 @@ bLK
 bLK
 bTh
 bZJ
-cuv
+cbO
 bWy
 bXO
 bZs
@@ -134631,7 +134971,7 @@ bOR
 bQC
 bQC
 bNK
-bXA
+crA
 bZJ
 cbV
 bWa
@@ -134849,7 +135189,7 @@ sHt
 sHt
 kjf
 aPn
-bdN
+aVt
 aNL
 aVw
 aXf
@@ -134890,8 +135230,8 @@ bRb
 cbr
 bJR
 bZN
+cuo
 cbO
-bXA
 bXP
 cuo
 cuo
@@ -134905,10 +135245,10 @@ cDf
 cmo
 cnJ
 cpd
-cpC
-bQV
+cQn
+chf
 czY
-bQV
+chf
 crD
 cvR
 cwk
@@ -135405,7 +135745,7 @@ bLK
 bJS
 bZO
 cuo
-crA
+cuv
 bXR
 cuv
 cuv
@@ -135414,14 +135754,14 @@ ceh
 cfQ
 cou
 bSV
-cuv
+crA
 csa
 cmq
 cnL
 ciT
 cwT
-cuv
-cuv
+crA
+pea
 cAs
 cBw
 cCR
@@ -137481,10 +137821,10 @@ bUx
 ctq
 cuC
 bQX
-bQX
+uaN
 cAa
 cAa
-bQX
+cpH
 chf
 chf
 chf
@@ -138249,16 +138589,16 @@ cpR
 cpR
 cxD
 bQX
-cep
-cep
-cep
+jnc
+vyb
+jnc
 cts
 cts
 cts
-cep
-cep
-cep
-cep
+jnc
+jnc
+jnc
+bQX
 bQX
 cjk
 bQX
@@ -138506,17 +138846,17 @@ cwj
 cpR
 cxD
 bQX
-cep
-aab
-aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cep
-cBG
+jnc
+eXa
+iOg
+emF
+iVY
+uBA
+lww
+lRV
+jnc
+cKF
+bQX
 cNp
 cOm
 cOm
@@ -138763,18 +139103,18 @@ cpl
 cpR
 cxD
 bQX
-cep
-aab
-aab
-aab
-aaa
-aaa
-aaa
-aaa
-aaa
-cep
+jnc
+quo
+naz
+iGx
+iGx
+iGx
+rsV
+wje
+jnc
+oLr
 cBH
-cDg
+bQX
 bQX
 bQX
 bQX
@@ -139020,16 +139360,16 @@ cwq
 cpR
 cxK
 bQX
-cep
-aaa
-aab
-aab
-aab
-aaa
-aaa
-aaa
-cep
-cep
+cts
+njA
+qfz
+cts
+cts
+fSf
+skM
+ndH
+jnc
+ciY
 ciY
 ciY
 ciY
@@ -139277,15 +139617,15 @@ cwl
 cxc
 cxQ
 abG
-cep
-aaa
-aaa
-aab
-aab
-aab
-aaa
-aaa
-cep
+cDg
+gXh
+qfz
+cts
+wiX
+uKx
+rhs
+xMY
+jnc
 bQX
 bQX
 bQX
@@ -139533,16 +139873,16 @@ cuK
 cvT
 cpR
 cxO
-cAc
+hSk
 cts
-aaa
-aaa
-aaa
-aab
-aab
-aab
-aaa
-cep
+mEo
+gRs
+tVy
+vxL
+xTY
+qIL
+rns
+jnc
 cAE
 cBI
 cDh
@@ -139791,25 +140131,25 @@ crL
 cpR
 cxO
 cAe
-cts
-aaa
-aaa
-aaa
-aaa
-aab
-cep
-cep
-cep
-cep
-cep
-cep
-cep
-cep
-cep
-cep
-cep
-cep
-cep
+jnc
+kGe
+jib
+skM
+mxl
+qSQ
+cBR
+cBR
+cBR
+cBR
+cBR
+cBR
+cBR
+cBR
+cBR
+cBR
+cBR
+cBR
+cBR
 cIs
 bQX
 cKF
@@ -140047,13 +140387,13 @@ cuN
 cwm
 cpR
 cxR
-cpH
-cts
-aaa
-aaa
-aaa
-aaa
-aaa
+cAc
+jnc
+hBi
+luR
+ndH
+hFN
+hFN
 cBR
 cKP
 cJK
@@ -140066,7 +140406,7 @@ cxN
 cKP
 cJK
 cJK
-cep
+cBR
 ciY
 ciY
 ciY
@@ -140323,7 +140663,7 @@ cxN
 cKQ
 cMg
 cJK
-cep
+cBR
 cIu
 cJz
 cKG
@@ -140580,10 +140920,10 @@ cxN
 cKR
 cJK
 cJK
-cep
+cBR
 cIt
 thk
-bQX
+ddF
 bQX
 bQX
 xTp
@@ -140837,14 +141177,14 @@ cxN
 cTJ
 cVe
 cWi
-cep
-cep
-cep
-cep
-cep
-cep
-cep
-ddF
+cBR
+cBR
+cBR
+cBR
+cBR
+cBR
+cBR
+cBR
 aaa
 aaa
 aaa
@@ -141073,8 +141413,8 @@ csB
 bYm
 cuV
 bIi
-cxi
-cxT
+cAc
+cxO
 cBR
 qwN
 qbV
@@ -141331,7 +141671,7 @@ bLR
 cvF
 bIi
 cxU
-cxT
+cxO
 cBR
 onN
 ugD
@@ -141588,7 +141928,7 @@ ctC
 cvF
 bIi
 cxM
-cxT
+cxO
 cBR
 mcq
 qAN
@@ -142083,7 +142423,7 @@ bRP
 bPt
 bOv
 bSZ
-bUK
+diR
 bUK
 bUK
 ccj
@@ -142105,7 +142445,7 @@ cxN
 cxW
 cAf
 cBS
-tvO
+cDy
 tou
 cEk
 cBR
@@ -142606,9 +142946,9 @@ bJB
 chN
 bNq
 bTw
-cbn
-cbn
-cbn
+tml
+tml
+tml
 cpt
 crn
 bLR
@@ -143872,7 +144212,7 @@ khg
 bEl
 bwv
 bkL
-bDq
+bwv
 bED
 bED
 bIo
@@ -144129,7 +144469,7 @@ bya
 aYQ
 bwv
 bHR
-bDq
+bwv
 bED
 bGC
 bIp
@@ -144868,7 +145208,7 @@ aAf
 xkN
 aLc
 wxz
-kTK
+cpC
 nSi
 dGK
 wxz
@@ -144900,7 +145240,7 @@ aYP
 aYP
 bmm
 bHV
-cXj
+bmm
 cXn
 cXo
 cYh
@@ -154685,7 +155025,7 @@ aaa
 aaa
 aab
 cie
-ckc
+cie
 clH
 ckb
 ckb
@@ -154699,7 +155039,7 @@ ckb
 ckb
 ckb
 cDN
-ckc
+cie
 cie
 aab
 aaa
@@ -156491,7 +156831,7 @@ aab
 cie
 cie
 ckb
-ckc
+cie
 ckb
 cie
 cie

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -7882,9 +7882,6 @@
 	},
 /area/security/evidence)
 "apz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -8611,7 +8608,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4;
 	name = "standard air scrubber";
 	on = 1;
 	scrub_N2O = 1;
@@ -8812,9 +8808,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -8833,7 +8826,6 @@
 /area/security/prison/cell_block/A)
 "aro" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8;
 	name = "standard air scrubber";
 	on = 1;
 	scrub_N2O = 1;
@@ -9958,11 +9950,13 @@
 /area/security/prison/cell_block/A)
 "ata" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bcarpet05"
@@ -9972,6 +9966,9 @@
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 1";
 	name = "Cell 1 Locker"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bcarpet05"
@@ -9989,11 +9986,13 @@
 /area/hallway/primary/fore)
 "atd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -10004,6 +10003,9 @@
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 3";
 	name = "Cell 3 Locker"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redcorner"
@@ -13395,9 +13397,6 @@
 	},
 /area/security/permabrig)
 "ayR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -13423,7 +13422,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4;
+	dir = 1;
 	name = "standard air scrubber";
 	on = 1;
 	scrub_N2O = 1;
@@ -13794,9 +13793,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -13981,7 +13977,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "redcorner"
@@ -14011,6 +14009,9 @@
 /obj/machinery/camera{
 	c_tag = "Brig Cell 2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "redcorner"
@@ -14023,6 +14024,9 @@
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 4";
 	name = "Cell 4 Locker"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redcorner"
@@ -22958,11 +22962,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -25045,9 +25046,6 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /turf/simulated/floor/plasteel,
 /area/security/checkpoint/south)
 "aXB" = (
@@ -25061,15 +25059,9 @@
 /area/security/checkpoint/south)
 "aXC" = (
 /obj/structure/chair/office/dark,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
 /area/security/checkpoint/south)
 "aXD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
 /area/security/checkpoint/south)
 "aXE" = (
@@ -25082,9 +25074,7 @@
 	},
 /area/security/checkpoint/south)
 "aXF" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
 /area/security/checkpoint/south)
 "aXG" = (
@@ -25799,6 +25789,9 @@
 	pixel_y = 9
 	},
 /obj/item/pen,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
@@ -25857,6 +25850,9 @@
 /area/storage/primary)
 "aZf" = (
 /obj/structure/table/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
@@ -25874,6 +25870,9 @@
 	pixel_y = 4
 	},
 /obj/structure/table/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
@@ -26223,7 +26222,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
@@ -28003,6 +28004,13 @@
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -53039,8 +53047,10 @@
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -65782,6 +65792,9 @@
 	layer = 4;
 	pixel_y = -32
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "whitegreen";
@@ -69797,9 +69810,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitegreen";
@@ -71360,6 +71371,9 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -77335,9 +77349,6 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cTI" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -77388,11 +77399,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "cTM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -85156,10 +85167,10 @@
 /obj/machinery/ai_slipper{
 	icon_state = "motion0"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "dark";
@@ -85220,13 +85231,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -85272,14 +85276,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -85309,8 +85313,8 @@
 /obj/machinery/ai_slipper{
 	icon_state = "motion0"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "dark";
@@ -85507,6 +85511,13 @@
 /mob/living/simple_animal/bot/floorbot{
 	on = 0
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluecorners"
 	},
@@ -85526,8 +85537,6 @@
 	pixel_y = -24;
 	req_access_txt = "75"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "dark";
@@ -85710,8 +85719,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "dark";
@@ -85910,8 +85917,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "dark";
@@ -86091,8 +86096,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "dark";
@@ -86130,9 +86133,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/bluegrid,
 /area/aisat{
 	name = "\improper AI Satellite Hallway"
@@ -86190,8 +86191,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
 	name = "standard air scrubber";
@@ -86209,8 +86208,8 @@
 	})
 "dmU" = (
 /obj/effect/spawner/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/aisat{
@@ -90127,6 +90126,13 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
+"idb" = (
+/obj/effect/spawner/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/aisat{
+	name = "\improper AI Satellite Hallway"
+	})
 "ikF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb2,
@@ -90801,6 +90807,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/dorms)
+"koQ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "dark";
+	tag = "icon-vault (NORTHEAST)"
+	},
+/area/aisat{
+	name = "\improper AI Satellite Hallway"
+	})
 "kqe" = (
 /obj/machinery/door_control{
 	id = "ArmorySecAccess";
@@ -92661,6 +92687,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/range)
+"ptB" = (
+/obj/effect/spawner/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/aisat{
+	name = "\improper AI Satellite Hallway"
+	})
 "pwN" = (
 /obj/machinery/door_control{
 	id = "adminshuttleblast";
@@ -93417,6 +93452,18 @@
 	icon_state = "white"
 	},
 /area/security/medbay)
+"riB" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "redcorner"
+	},
+/area/security/prison/cell_block/A)
 "rjA" = (
 /mob/living/simple_animal/pet/dog/security,
 /obj/structure/bed/dogbed,
@@ -94050,6 +94097,15 @@
 	icon_state = "bot"
 	},
 /area/shuttle/escape)
+"sXG" = (
+/obj/effect/spawner/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/aisat{
+	name = "\improper AI Satellite Hallway"
+	})
 "sYE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -94678,6 +94734,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/medbay)
+"uRP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "redcorner"
+	},
+/area/security/prison/cell_block/A)
 "uTI" = (
 /turf/space,
 /turf/simulated/shuttle/floor{
@@ -95301,6 +95372,20 @@
 	icon_state = "darkred"
 	},
 /area/security/brig)
+"wuJ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "dark";
+	tag = "icon-vault (NORTHEAST)"
+	},
+/area/aisat{
+	name = "\improper AI Satellite Hallway"
+	})
 "wuR" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/shuttle/floor{
@@ -95792,6 +95877,15 @@
 	icon_state = "neutralfull"
 	},
 /area/shuttle/escape)
+"xxY" = (
+/obj/effect/spawner/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/aisat{
+	name = "\improper AI Satellite Hallway"
+	})
 "xyo" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -126518,7 +126612,7 @@ auP
 avX
 axG
 ayU
-atd
+uRP
 azx
 aCr
 aHE
@@ -126776,7 +126870,7 @@ aum
 axJ
 auQ
 azO
-aro
+riB
 aCs
 aHE
 aEp
@@ -132565,7 +132659,7 @@ dqw
 dqw
 dqw
 dmU
-dqw
+sXG
 dqw
 dqw
 drf
@@ -132816,13 +132910,13 @@ dkf
 dkY
 dlt
 dlU
-dmf
-dmf
-dmf
+wuJ
+wuJ
+wuJ
 dms
 dmL
 dmT
-dmf
+koQ
 dmf
 dmV
 dmY
@@ -133077,9 +133171,9 @@ dqw
 dqw
 dqw
 dmG
-dqw
-dqw
-dqw
+ptB
+idb
+xxY
 dqw
 dqw
 dnc

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -40,8 +40,11 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/xenozoo)
 "abG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/genetics)
 "abH" = (
@@ -60236,7 +60239,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
-/area/medical/surgery/north)
+/area/medical/surgery1)
 "cnZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -63502,7 +63505,7 @@
 "cts" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/maintenance/server)
+/area/maintenance/genetics)
 "ctt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -65883,11 +65886,11 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/genetics)
@@ -67839,10 +67842,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
+"cBG" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/genetics)
 "cBH" = (
 /obj/structure/table,
-/obj/item/healthanalyzer,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
 /area/maintenance/genetics)
 "cBI" = (
@@ -68704,11 +68715,11 @@
 /turf/simulated/wall,
 /area/medical/surgery/south)
 "cDg" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/table,
+/obj/item/healthanalyzer,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/server)
+/area/maintenance/genetics)
 "cDh" = (
 /obj/structure/table,
 /obj/item/pda,
@@ -81954,9 +81965,9 @@
 /area/solar/starboard)
 "ddF" = (
 /obj/structure/sign/biohazard{
-	pixel_x = 32
+	pixel_y = 32
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall/r_wall,
 /area/maintenance/genetics)
 "ddG" = (
 /obj/machinery/field/generator,
@@ -88516,15 +88527,6 @@
 	icon_state = "bluecorner"
 	},
 /area/hallway/secondary/entry)
-"emF" = (
-/obj/effect/decal/cleanable/dust,
-/obj/structure/table/glass,
-/obj/item/paper_bin,
-/obj/effect/turf_decal/siding/purple{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/server)
 "enD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -88826,14 +88828,6 @@
 /obj/machinery/smartfridge/secure/extract,
 /turf/simulated/floor/plating,
 /area/maintenance/xenozoo)
-"eXa" = (
-/obj/effect/decal/cleanable/dust,
-/obj/structure/chair/sofa/corp/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/purple/corner,
-/turf/simulated/floor/carpet/purple,
-/area/maintenance/server)
 "eXI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -89221,12 +89215,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
-"fSf" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/decal/cleanable/dust,
-/turf/simulated/floor/engine,
-/area/maintenance/server)
 "fSB" = (
 /obj/machinery/door/morgue{
 	name = "Occult Study"
@@ -89580,15 +89568,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
-"gRs" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dust,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/transparent/glass,
-/area/maintenance/server)
 "gSF" = (
 /obj/structure/bookcase,
 /turf/simulated/floor/wood,
@@ -89700,17 +89679,6 @@
 	icon_state = "cafeteria"
 	},
 /area/toxins/xenobiology)
-"gXh" = (
-/obj/effect/decal/cleanable/dust,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/effect/turf_decal/siding/purple,
-/turf/simulated/floor/carpet/purple,
-/area/maintenance/server)
 "gYt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -89929,15 +89897,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
-"hBi" = (
-/obj/effect/decal/cleanable/dust,
-/obj/item/twohanded/required/kirbyplants,
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/turf_decal/siding/purple/corner{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/purple,
-/area/maintenance/server)
 "hFD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -89953,11 +89912,6 @@
 	icon_state = "yellow"
 	},
 /area/hallway/primary/aft)
-"hFN" = (
-/obj/effect/decal/cleanable/dust,
-/obj/machinery/constructable_frame/machine_frame,
-/turf/simulated/floor/engine,
-/area/maintenance/server)
 "hHo" = (
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
@@ -90072,14 +90026,6 @@
 	icon_state = "escape"
 	},
 /area/security/customs2)
-"hSk" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'SERVER ROOM'.";
-	name = "SERVER ROOM";
-	pixel_y = -32
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/genetics)
 "hTt" = (
 /obj/effect/decal/cleanable/dust,
 /obj/effect/decal/cleanable/cobweb2,
@@ -90308,13 +90254,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/library/abandoned)
-"iGx" = (
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dust,
-/turf/simulated/floor/transparent/glass,
-/area/maintenance/server)
 "iHj" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/effect/decal/cleanable/dirt,
@@ -90396,22 +90335,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/toxins/launch)
-"iOg" = (
-/obj/effect/decal/cleanable/dust,
-/obj/structure/chair/sofa/corp/right{
-	dir = 4
-	},
-/obj/machinery/light_construct{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/purple{
-	dir = 4
-	},
-/obj/structure/sign/nosmoking_2{
-	pixel_x = -32
-	},
-/turf/simulated/floor/carpet/purple,
-/area/maintenance/server)
 "iOx" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
@@ -90467,15 +90390,6 @@
 "iVV" = (
 /turf/simulated/wall/r_wall,
 /area/server)
-"iVY" = (
-/obj/effect/decal/cleanable/dust,
-/obj/structure/table/glass,
-/obj/effect/turf_decal/siding/purple{
-	dir = 4
-	},
-/obj/item/reagent_containers/glass/beaker/waterbottle/empty,
-/turf/simulated/floor/plating,
-/area/maintenance/server)
 "iZs" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
@@ -90527,14 +90441,6 @@
 	icon_state = "blue"
 	},
 /area/hydroponics)
-"jib" = (
-/obj/effect/turf_decal/stripes{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dust,
-/obj/machinery/light/small,
-/turf/simulated/floor/transparent/glass,
-/area/maintenance/server)
 "jjW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -90545,9 +90451,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/xenozoo)
-"jnc" = (
-/turf/simulated/wall,
-/area/maintenance/server)
 "jnJ" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "swall12"
@@ -91012,15 +90915,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/civilian/vacantoffice)
-"kGe" = (
-/obj/effect/decal/cleanable/dust,
-/obj/machinery/light_construct{
-	dir = 1
-	},
-/obj/item/tank/internals/oxygen/empty,
-/obj/effect/turf_decal/siding/purple,
-/turf/simulated/floor/carpet/purple,
-/area/maintenance/server)
 "kHU" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
@@ -91339,25 +91233,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
-"luR" = (
-/obj/effect/decal/cleanable/dust,
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/turf_decal/siding/purple{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/purple,
-/area/maintenance/server)
-"lww" = (
-/obj/effect/decal/cleanable/dust,
-/obj/machinery/light_construct{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/ash,
-/obj/effect/turf_decal/siding/purple{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/purple,
-/area/maintenance/server)
 "lxD" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -91513,14 +91388,6 @@
 	tag = "icon-swall_f6"
 	},
 /area/shuttle/pod_3)
-"lRV" = (
-/obj/effect/decal/cleanable/dust,
-/obj/item/twohanded/required/kirbyplants,
-/obj/effect/turf_decal/siding/purple/corner{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/purple,
-/area/maintenance/server)
 "lSf" = (
 /obj/effect/decal/warning_stripes/northeast,
 /obj/effect/decal/cleanable/blood/xeno,
@@ -91794,12 +91661,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/medbay)
-"mxl" = (
-/obj/effect/decal/cleanable/dust,
-/obj/effect/decal/warning_stripes/yellow,
-/obj/item/reagent_containers/glass/bucket,
-/turf/simulated/floor/engine,
-/area/maintenance/server)
 "mxT" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
@@ -91844,17 +91705,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
-"mEo" = (
-/obj/effect/decal/cleanable/dust,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding/purple,
-/turf/simulated/floor/carpet/purple,
-/area/maintenance/server)
 "mGt" = (
 /obj/item/flag/med,
 /turf/simulated/floor/plasteel{
@@ -91964,13 +91814,6 @@
 /obj/machinery/slot_machine,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
-"naz" = (
-/obj/effect/turf_decal/stripes{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dust,
-/turf/simulated/floor/transparent/glass,
-/area/maintenance/server)
 "naH" = (
 /obj/structure/bed/roller,
 /turf/simulated/floor/plasteel{
@@ -91980,9 +91823,6 @@
 "nbH" = (
 /turf/simulated/shuttle/floor,
 /area/shuttle/administration)
-"ndH" = (
-/turf/simulated/wall/r_wall,
-/area/maintenance/server)
 "neg" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -92066,12 +91906,6 @@
 	icon_state = "dark"
 	},
 /area/library/abandoned)
-"njA" = (
-/obj/effect/decal/cleanable/ash,
-/obj/item/extinguisher,
-/obj/effect/turf_decal/siding/purple,
-/turf/simulated/floor/plating,
-/area/maintenance/server)
 "njX" = (
 /obj/structure/foodcart,
 /turf/simulated/floor/plasteel{
@@ -92633,15 +92467,6 @@
 	icon_state = "darkred"
 	},
 /area/security/warden)
-"oLr" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/cleanable/cobweb2,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/genetics)
 "oLU" = (
 /obj/machinery/vending/coffee,
 /obj/effect/decal/cleanable/dirt,
@@ -93196,13 +93021,6 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads)
-"qfz" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dust,
-/turf/simulated/floor/transparent/glass,
-/area/maintenance/server)
 "qfS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
@@ -93283,13 +93101,6 @@
 	icon_state = "dark"
 	},
 /area/library/abandoned)
-"quo" = (
-/obj/effect/decal/cleanable/dust,
-/obj/structure/chair/sofa/corp/left,
-/obj/effect/turf_decal/siding/purple,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/server)
 "qus" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -93445,20 +93256,6 @@
 	icon_state = "whitegreencorner"
 	},
 /area/toxins/xenobiology)
-"qIL" = (
-/obj/effect/decal/cleanable/dust,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/engine,
-/area/maintenance/server)
 "qIM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -93556,12 +93353,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
-"qSQ" = (
-/obj/effect/decal/cleanable/dust,
-/obj/effect/decal/warning_stripes/yellow,
-/obj/item/screwdriver,
-/turf/simulated/floor/engine,
-/area/maintenance/server)
 "qST" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "redcorner"
@@ -93656,12 +93447,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology)
-"rhs" = (
-/obj/effect/decal/cleanable/dust,
-/obj/effect/decal/cleanable/shreds,
-/obj/item/chair/stool,
-/turf/simulated/floor/engine,
-/area/maintenance/server)
 "rig" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -93782,11 +93567,6 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/crew_quarters/dorms)
-"rns" = (
-/obj/effect/decal/cleanable/dust,
-/obj/structure/computerframe,
-/turf/simulated/floor/engine,
-/area/maintenance/server)
 "roO" = (
 /obj/machinery/door/window/southright{
 	name = "Containment Pen";
@@ -93808,17 +93588,6 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/administration)
-"rsV" = (
-/obj/effect/turf_decal/stripes{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dust,
-/obj/machinery/light_construct/small{
-	dir = 4
-	},
-/obj/item/shard,
-/turf/simulated/floor/transparent/glass,
-/area/maintenance/server)
 "rtv" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -94148,14 +93917,6 @@
 	icon_state = "carpet"
 	},
 /area/library/abandoned)
-"skM" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
-	icon_state = "shock";
-	name = "HIGH VOLTAGE"
-	},
-/turf/simulated/wall/r_wall,
-/area/maintenance/server)
 "snu" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "swall_s6"
@@ -94782,26 +94543,6 @@
 	icon_state = "white"
 	},
 /area/security/medbay)
-"tVy" = (
-/obj/structure/door_assembly/door_assembly_mai{
-	anchored = 1
-	},
-/obj/structure/firelock_frame{
-	anchored = 1
-	},
-/obj/effect/decal/cleanable/dust,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/engine,
-/area/maintenance/server)
-"uaN" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/genetics)
 "uew" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -94931,14 +94672,6 @@
 	tag = "icon-whitehall (WEST)"
 	},
 /area/security/medbay)
-"uBA" = (
-/obj/effect/decal/cleanable/dust,
-/obj/machinery/space_heater,
-/obj/effect/turf_decal/siding/purple{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/server)
 "uBM" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8;
@@ -94970,15 +94703,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/xenozoo)
-"uKx" = (
-/obj/effect/decal/cleanable/dust,
-/obj/item/cigbutt,
-/obj/effect/landmark{
-	name = "xeno_spawn";
-	pixel_x = -1
-	},
-/turf/simulated/floor/engine,
-/area/maintenance/server)
 "uKK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -95251,20 +94975,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
-"vxL" = (
-/obj/effect/decal/cleanable/dust,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/generic,
-/obj/structure/mecha_wreckage/ripley/firefighter,
-/turf/simulated/floor/engine,
-/area/maintenance/server)
-"vyb" = (
-/obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall,
-/area/maintenance/server)
 "vzG" = (
 /obj/structure/chair/office/dark,
 /obj/effect/decal/cleanable/dust,
@@ -95603,21 +95313,6 @@
 /obj/machinery/computer/HolodeckControl,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
-"wiX" = (
-/obj/effect/decal/cleanable/dust,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/engine,
-/area/maintenance/server)
-"wje" = (
-/obj/effect/decal/cleanable/dust,
-/obj/structure/table_frame/wood,
-/obj/effect/turf_decal/siding/purple{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/purple,
-/area/maintenance/server)
 "wkg" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Escape Shuttle Cockpit";
@@ -96351,15 +96046,6 @@
 	},
 /turf/simulated/floor/greengrid,
 /area/maintenance/xenozoo)
-"xMY" = (
-/obj/effect/decal/cleanable/dust,
-/obj/structure/table/reinforced,
-/obj/item/stack/rods{
-	amount = 8
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/engine,
-/area/maintenance/server)
 "xPv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -96407,14 +96093,6 @@
 	tag = "icon-whiteblue"
 	},
 /area/shuttle/escape)
-"xTY" = (
-/obj/effect/decal/cleanable/dust,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/landmark{
-	name = "blobstart"
-	},
-/turf/simulated/floor/engine,
-/area/maintenance/server)
 "xVt" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -137821,10 +137499,10 @@ bUx
 ctq
 cuC
 bQX
-uaN
+bQX
 cAa
 cAa
-cpH
+bQX
 chf
 chf
 chf
@@ -138589,16 +138267,16 @@ cpR
 cpR
 cxD
 bQX
-jnc
-vyb
-jnc
+cep
+cep
+cep
 cts
 cts
 cts
-jnc
-jnc
-jnc
-bQX
+cep
+cep
+cep
+cep
 bQX
 cjk
 bQX
@@ -138846,17 +138524,17 @@ cwj
 cpR
 cxD
 bQX
-jnc
-eXa
-iOg
-emF
-iVY
-uBA
-lww
-lRV
-jnc
-cKF
-bQX
+cep
+aab
+aab
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cep
+cBG
 cNp
 cOm
 cOm
@@ -139103,18 +138781,18 @@ cpl
 cpR
 cxD
 bQX
-jnc
-quo
-naz
-iGx
-iGx
-iGx
-rsV
-wje
-jnc
-oLr
+cep
+aab
+aab
+aab
+aaa
+aaa
+aaa
+aaa
+aaa
+cep
 cBH
-bQX
+cDg
 bQX
 bQX
 bQX
@@ -139360,16 +139038,16 @@ cwq
 cpR
 cxK
 bQX
-cts
-njA
-qfz
-cts
-cts
-fSf
-skM
-ndH
-jnc
-ciY
+cep
+aaa
+aab
+aab
+aab
+aaa
+aaa
+aaa
+cep
+cep
 ciY
 ciY
 ciY
@@ -139617,15 +139295,15 @@ cwl
 cxc
 cxQ
 abG
-cDg
-gXh
-qfz
-cts
-wiX
-uKx
-rhs
-xMY
-jnc
+cep
+aaa
+aaa
+aab
+aab
+aab
+aaa
+aaa
+cep
 bQX
 bQX
 bQX
@@ -139873,16 +139551,16 @@ cuK
 cvT
 cpR
 cxO
-hSk
+cAc
 cts
-mEo
-gRs
-tVy
-vxL
-xTY
-qIL
-rns
-jnc
+aaa
+aaa
+aaa
+aab
+aab
+aab
+aaa
+cep
 cAE
 cBI
 cDh
@@ -140131,25 +139809,25 @@ crL
 cpR
 cxO
 cAe
-jnc
-kGe
-jib
-skM
-mxl
-qSQ
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
+cts
+aaa
+aaa
+aaa
+aaa
+aab
+cep
+cep
+cep
+cep
+cep
+cep
+cep
+cep
+cep
+cep
+cep
+cep
+cep
 cIs
 bQX
 cKF
@@ -140387,13 +140065,13 @@ cuN
 cwm
 cpR
 cxR
-cAc
-jnc
-hBi
-luR
-ndH
-hFN
-hFN
+cpH
+cts
+aaa
+aaa
+aaa
+aaa
+aaa
 cBR
 cKP
 cJK
@@ -140406,7 +140084,7 @@ cxN
 cKP
 cJK
 cJK
-cBR
+cep
 ciY
 ciY
 ciY
@@ -140663,7 +140341,7 @@ cxN
 cKQ
 cMg
 cJK
-cBR
+cep
 cIu
 cJz
 cKG
@@ -140920,10 +140598,10 @@ cxN
 cKR
 cJK
 cJK
-cBR
+cep
 cIt
 thk
-ddF
+bQX
 bQX
 bQX
 xTp
@@ -141177,14 +140855,14 @@ cxN
 cTJ
 cVe
 cWi
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
+cep
+cep
+cep
+cep
+cep
+cep
+cep
+ddF
 aaa
 aaa
 aaa

--- a/code/game/area/ss13_areas.dm
+++ b/code/game/area/ss13_areas.dm
@@ -760,6 +760,10 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "Backstage"
 	icon_state = "yellow"
 
+/area/maintenance/server
+	name = "Abandoned Server Room"
+	icon_state = "yellow"
+
 //Hallway
 
 /area/hallway


### PR DESCRIPTION
## Изменения (самые актуальные представлены с редактора карт)
_Пре-апдейт перед большой чисткой и стандаризации_

Прошедшие предложки:
https://discord.com/channels/617003227182792704/930740675350233098/1018674784625762344
https://discord.com/channels/617003227182792704/930740675350233098/1018701539935793172

Diff:
https://mdb.affectedarc07.co.uk/Files/365505203/8386043923/0/diff.png

**Дормы**
 - Добавлена качалка в дормах
 - Изменены позиции кабинетов клоуна и мима
 - Немного изменены тех. тоннели справа от дорм
 - Скорректированы точки с лутом в тех. тоннелях (на 1 точку с 1 лутом меньше)
 
![kachalka](https://user-images.githubusercontent.com/20109643/190549043-b2897962-2dce-45f4-b230-8ab721a720de.png)

**Технические тоннели**
 - Добавлена новая заброшка под Экспериментатором - заброшенная серверная
 - Туда добавлены 2 спавнера лута по 1 предмету
 - Туда добавлены по 1 спавн-поинту для ксеноморфа и блоба
 
![rnd1](https://user-images.githubusercontent.com/20109643/190549221-b8352ea0-ca9d-4630-8111-c546f13d06ad.png)
![rnd2](https://user-images.githubusercontent.com/20109643/190548927-e086998b-0ea4-4b25-b94a-4ead238c1ea2.png)

**Фиксы**
 - Выравнены и исправлены плитки по всей карте
 - Исправлены декали
 - Исправлены некоторые "выдающиеся" зоны
 - Фиксы скрабберов и вентиляции (где-то не подключен, где-то накладывается поверх)
 - Добавлены две точки лута в заброшенной библиотеке (забыл добавить)