### PR TITLE
Fix/Ref: Vending leaders fix. Vending filling ref

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -101,9 +101,15 @@
 	var/force_no_power_icon_state = FALSE
 
 /obj/machinery/vending/Initialize(mapload)
-	var/build_inv = FALSE
-	if(!refill_canister)
-		build_inv = TRUE
+	var/build_inv = TRUE
+	if(refill_canister)
+		build_inv = FALSE
+		component_parts = list()
+		var/obj/item/circuitboard/vendor/V = new(null)
+		V.set_type(type)
+		component_parts += V
+		component_parts += new refill_canister(null)
+		RefreshParts()
 	. = ..()
 	wires = new(src)
 	if(build_inv) //non-constructable vending machine
@@ -839,15 +845,6 @@
 	ads_list = list("Only the finest!","Have some tools.","The most robust equipment.","The finest gear in space!")
 	refill_canister = /obj/item/vending_refill/assist
 
-/obj/machinery/vending/assist/Initialize(mapload)
-	component_parts = list()
-	var/obj/item/circuitboard/vendor/V = new(null)
-	V.set_type(type)
-	component_parts += V
-	component_parts += new /obj/item/vending_refill/assist(null)
-	RefreshParts()
-	return ..()
-
 /obj/machinery/vending/boozeomat
 	name = "\improper Booze-O-Mat"
 	desc = "A technological marvel, supposedly able to mix just the mixture you'd like to drink the moment you ask for one."
@@ -886,16 +883,6 @@
 /obj/machinery/vending/boozeomat/syndicate_access
 	req_access = list(ACCESS_SYNDICATE)
 
-/obj/machinery/vending/boozeomat/Initialize(mapload)
-	component_parts = list()
-	var/obj/item/circuitboard/vendor/V = new(null)
-	V.set_type(type)
-	component_parts += V
-	component_parts += new /obj/item/vending_refill/boozeomat(null)
-	RefreshParts()
-	return ..()
-
-
 /obj/machinery/vending/coffee
 	name = "\improper Hot Drinks machine"
 	desc = "A vending machine which dispenses hot drinks."
@@ -915,15 +902,6 @@
 
 /obj/machinery/vending/coffee/free
 	prices = list()
-
-/obj/machinery/vending/coffee/Initialize(mapload)
-	component_parts = list()
-	var/obj/item/circuitboard/vendor/V = new(null)
-	V.set_type(type)
-	component_parts += V
-	component_parts += new /obj/item/vending_refill/coffee(null)
-	RefreshParts()
-	return ..()
 
 /obj/machinery/vending/coffee/item_slot_check(mob/user, obj/item/I)
 	if(!(istype(I, /obj/item/reagent_containers/glass) || istype(I, /obj/item/reagent_containers/food/drinks)))
@@ -981,15 +959,6 @@
 /obj/machinery/vending/snack/free
 	prices = list()
 
-/obj/machinery/vending/snack/Initialize(mapload)
-	component_parts = list()
-	var/obj/item/circuitboard/vendor/V = new(null)
-	V.set_type(type)
-	component_parts += V
-	component_parts += new /obj/item/vending_refill/snack(null)
-	RefreshParts()
-	return ..()
-
 /obj/machinery/vending/chinese
 	name = "\improper Mr. Chang"
 	desc = "A self-serving Chinese food machine, for all your Chinese food needs."
@@ -1003,15 +972,6 @@
 
 /obj/machinery/vending/chinese/free
 	prices = list()
-
-/obj/machinery/vending/chinese/Initialize(mapload)
-	component_parts = list()
-	var/obj/item/circuitboard/vendor/V = new(null)
-	V.set_type(type)
-	component_parts += V
-	component_parts += new /obj/item/vending_refill/chinese(null)
-	RefreshParts()
-	return ..()
 
 /obj/machinery/vending/cola
 	name = "\improper Robust Softdrinks"
@@ -1031,16 +991,6 @@
 /obj/machinery/vending/cola/free
 	prices = list()
 
-/obj/machinery/vending/cola/Initialize(mapload)
-	component_parts = list()
-	var/obj/item/circuitboard/vendor/V = new(null)
-	V.set_type(type)
-	component_parts += V
-	component_parts += new /obj/item/vending_refill/cola(null)
-	RefreshParts()
-	return ..()
-
-
 /obj/machinery/vending/cart
 	name = "\improper PTech"
 	desc = "Cartridges for PDA's."
@@ -1058,15 +1008,6 @@
 
 /obj/machinery/vending/cart/free
 	prices = list()
-
-/obj/machinery/vending/cart/Initialize(mapload)
-	component_parts = list()
-	var/obj/item/circuitboard/vendor/V = new(null)
-	V.set_type(type)
-	component_parts += V
-	component_parts += new /obj/item/vending_refill/cart(null)
-	RefreshParts()
-	return ..()
 
 /obj/machinery/vending/liberationstation
 	name = "\improper Liberation Station"
@@ -1160,15 +1101,6 @@
 				   /obj/item/lighter/zippo = 3)
 	prices = list()
 
-/obj/machinery/vending/cigarette/Initialize(mapload)
-	component_parts = list()
-	var/obj/item/circuitboard/vendor/V = new(null)
-	V.set_type(type)
-	component_parts += V
-	component_parts += new /obj/item/vending_refill/cigarette(null)
-	RefreshParts()
-	return ..()
-
 /obj/machinery/vending/medical
 	name = "\improper NanoMed Plus"
 	desc = "Medical drug dispenser."
@@ -1199,15 +1131,6 @@
 /obj/machinery/vending/medical/syndicate_access/beamgun
 	premium = list(/obj/item/gun/medbeam = 1)
 
-/obj/machinery/vending/medical/Initialize(mapload)
-	component_parts = list()
-	var/obj/item/circuitboard/vendor/V = new(null)
-	V.set_type(type)
-	component_parts += V
-	component_parts += new /obj/item/vending_refill/medical(null)
-	RefreshParts()
-	return ..()
-
 /obj/machinery/vending/plasmaresearch
 	name = "\improper Toximate 3000"
 	desc = "All the fine parts you need in one vending machine!"
@@ -1227,15 +1150,6 @@
 	armor = list(melee = 100, bullet = 100, laser = 100, energy = 100, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 50)
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/wallmed
-
-/obj/machinery/vending/wallmed/Initialize(mapload)
-	component_parts = list()
-	var/obj/item/circuitboard/vendor/V = new(null)
-	V.set_type(type)
-	component_parts += V
-	component_parts += new /obj/item/vending_refill/wallmed(null)
-	RefreshParts()
-	return ..()
 
 /obj/machinery/vending/wallmed/syndicate
 	name = "\improper SyndiMed Plus"
@@ -1260,15 +1174,6 @@
 	contraband = list(/obj/item/clothing/glasses/sunglasses = 2,/obj/item/storage/fancy/donut_box = 2,/obj/item/hailer = 5)
 	refill_canister = /obj/item/vending_refill/security
 
-/obj/machinery/vending/security/Initialize(mapload)
-	component_parts = list()
-	var/obj/item/circuitboard/vendor/V = new(null)
-	V.set_type(type)
-	component_parts += V
-	component_parts += new /obj/item/vending_refill/security(null)
-	RefreshParts()
-	return ..()
-
 /obj/machinery/vending/security/training
 	name = "\improper SecTech Training"
 	desc = "A security training equipment vendor."
@@ -1281,15 +1186,6 @@
 	contraband = list(/obj/item/toy/figure/secofficer = 1)
 	refill_canister = /obj/item/vending_refill/security
 
-/obj/machinery/vending/security/training/Initialize(mapload)
-	component_parts = list()
-	var/obj/item/circuitboard/vendor/V = new(null)
-	V.set_type(type)
-	component_parts += V
-	component_parts += new /obj/item/vending_refill/security(null)
-	RefreshParts()
-	return ..()
-
 /obj/machinery/vending/hydronutrients
 	name = "\improper NutriMax"
 	desc = "A plant nutrients vendor"
@@ -1301,15 +1197,6 @@
 					/obj/item/reagent_containers/syringe = 5,/obj/item/storage/bag/plants = 5,/obj/item/cultivator = 3,/obj/item/shovel/spade = 3,/obj/item/plant_analyzer = 4)
 	contraband = list(/obj/item/reagent_containers/glass/bottle/ammonia = 10,/obj/item/reagent_containers/glass/bottle/diethylamine = 5)
 	refill_canister = /obj/item/vending_refill/hydronutrients
-
-/obj/machinery/vending/hydronutrients/Initialize(mapload)
-	component_parts = list()
-	var/obj/item/circuitboard/vendor/V = new(null)
-	V.set_type(type)
-	component_parts += V
-	component_parts += new /obj/item/vending_refill/hydronutrients(null)
-	RefreshParts()
-	return ..()
 
 /obj/machinery/vending/hydroseeds
 	name = "\improper MegaSeed Servitor"
@@ -1370,15 +1257,6 @@
 					  /obj/item/seeds/random = 2)
 	premium = list(/obj/item/reagent_containers/spray/waterflower = 1)
 	refill_canister = /obj/item/vending_refill/hydroseeds
-
-/obj/machinery/vending/hydroseeds/Initialize(mapload)
-	component_parts = list()
-	var/obj/item/circuitboard/vendor/V = new(null)
-	V.set_type(type)
-	component_parts += V
-	component_parts += new /obj/item/vending_refill/hydroseeds(null)
-	RefreshParts()
-	return ..()
 
 /obj/machinery/vending/magivend
 	name = "\improper MagiVend"
@@ -1542,15 +1420,6 @@
 				   /obj/item/clothing/head/cuban_hat = 1)
 	refill_canister = /obj/item/vending_refill/autodrobe
 
-/obj/machinery/vending/autodrobe/Initialize(mapload)
-	component_parts = list()
-	var/obj/item/circuitboard/vendor/V = new(null)
-	V.set_type(type)
-	component_parts += V
-	component_parts += new /obj/item/vending_refill/autodrobe(null)
-	RefreshParts()
-	return ..()
-
 /obj/machinery/vending/dinnerware
 	name = "\improper Plasteel Chef's Dinnerware Vendor"
 	desc = "A kitchen and restaurant equipment vendor."
@@ -1573,15 +1442,6 @@
 	contraband = list(/obj/item/kitchen/rollingpin = 2, /obj/item/kitchen/knife/butcher = 2)
 	refill_canister = /obj/item/vending_refill/dinnerware
 
-/obj/machinery/vending/dinnerware/Initialize(mapload)
-	component_parts = list()
-	var/obj/item/circuitboard/vendor/V = new(null)
-	V.set_type(type)
-	component_parts += V
-	component_parts += new /obj/item/vending_refill/dinnerware(null)
-	RefreshParts()
-	return ..()
-
 /obj/machinery/vending/sovietsoda
 	name = "\improper BODA"
 	desc = "Old sweet water vending machine."
@@ -1591,15 +1451,6 @@
 	contraband = list(/obj/item/reagent_containers/food/drinks/drinkingglass/cola = 20)
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/sovietsoda
-
-/obj/machinery/vending/sovietsoda/Initialize(mapload)
-	component_parts = list()
-	var/obj/item/circuitboard/vendor/V = new(null)
-	V.set_type(type)
-	component_parts += V
-	component_parts += new /obj/item/vending_refill/sovietsoda(null)
-	RefreshParts()
-	return ..()
 
 /obj/machinery/vending/tool
 	name = "\improper YouTool"
@@ -1624,15 +1475,6 @@
 	premium = list(/obj/item/storage/belt/utility = 3)
 	refill_canister = /obj/item/vending_refill/engivend
 
-/obj/machinery/vending/engivend/Initialize(mapload)
-	component_parts = list()
-	var/obj/item/circuitboard/vendor/V = new(null)
-	V.set_type(type)
-	component_parts += V
-	component_parts += new /obj/item/vending_refill/engivend(null)
-	RefreshParts()
-	return ..()
-
 /obj/machinery/vending/engineering
 	name = "\improper Robco Tool Maker"
 	desc = "Everything you need for do-it-yourself station repair."
@@ -1647,15 +1489,6 @@
 					/obj/item/stock_parts/matter_bin = 5,/obj/item/stock_parts/manipulator = 5)
 	refill_canister = /obj/item/vending_refill/engineering
 
-/obj/machinery/vending/engineering/Initialize(mapload)
-	component_parts = list()
-	var/obj/item/circuitboard/vendor/V = new(null)
-	V.set_type(type)
-	component_parts += V
-	component_parts += new /obj/item/vending_refill/engineering(null)
-	RefreshParts()
-	return ..()
-
 /obj/machinery/vending/robotics
 	name = "\improper Robotech Deluxe"
 	desc = "All the tools you need to create your own robot army."
@@ -1667,15 +1500,6 @@
 					/obj/item/scalpel = 2,/obj/item/circular_saw = 2,/obj/item/tank/internals/anesthetic = 2,/obj/item/clothing/mask/breath/medical = 5,
 					/obj/item/screwdriver = 5,/obj/item/crowbar = 5)
 	refill_canister = /obj/item/vending_refill/robotics
-
-/obj/machinery/vending/robotics/Initialize(mapload)
-	component_parts = list()
-	var/obj/item/circuitboard/vendor/V = new(null)
-	V.set_type(type)
-	component_parts += V
-	component_parts += new /obj/item/vending_refill/robotics(null)
-	RefreshParts()
-	return ..()
 
 /obj/machinery/vending/sustenance
 	name = "\improper Sustenance Vendor"
@@ -1692,15 +1516,6 @@
 					  /obj/item/clothing/mask/breath = 6)
 	refill_canister = /obj/item/vending_refill/sustenance
 
-/obj/machinery/vending/sustenance/Initialize(mapload)
-	component_parts = list()
-	var/obj/item/circuitboard/vendor/V = new(null)
-	V.set_type(type)
-	component_parts += V
-	component_parts += new /obj/item/vending_refill/sustenance(null)
-	RefreshParts()
-	return ..()
-
 /obj/machinery/vending/hatdispenser
 	name = "\improper Hatlord 9000"
 	desc = "It doesn't seem the slightest bit unusual. This frustrates you immensely."
@@ -1716,15 +1531,6 @@
 	premium = list(/obj/item/clothing/head/soft/rainbow = 1)
 	refill_canister = /obj/item/vending_refill/hatdispenser
 
-/obj/machinery/vending/hatdispenser/Initialize(mapload)
-	component_parts = list()
-	var/obj/item/circuitboard/vendor/V = new(null)
-	V.set_type(type)
-	component_parts += V
-	component_parts += new /obj/item/vending_refill/hatdispenser(null)
-	RefreshParts()
-	return ..()
-
 /obj/machinery/vending/suitdispenser
 	name = "\improper Suitlord 9000"
 	desc = "You wonder for a moment why all of your shirts and pants come conjoined. This hurts your head and you stop thinking about it."
@@ -1737,15 +1543,6 @@
 	premium = list(/obj/item/clothing/under/rainbow = 1)
 	refill_canister = /obj/item/vending_refill/suitdispenser
 
-/obj/machinery/vending/suitdispenser/Initialize(mapload)
-	component_parts = list()
-	var/obj/item/circuitboard/vendor/V = new(null)
-	V.set_type(type)
-	component_parts += V
-	component_parts += new /obj/item/vending_refill/suitdispenser(null)
-	RefreshParts()
-	return ..()
-
 /obj/machinery/vending/shoedispenser
 	name = "\improper Shoelord 9000"
 	desc = "Wow, hatlord looked fancy, suitlord looked streamlined, and this is just normal. The guy who designed these must be an idiot."
@@ -1755,15 +1552,6 @@
 	contraband = list(/obj/item/clothing/shoes/orange = 5)
 	premium = list(/obj/item/clothing/shoes/rainbow = 1)
 	refill_canister = /obj/item/vending_refill/shoedispenser
-
-/obj/machinery/vending/shoedispenser/Initialize(mapload)
-	component_parts = list()
-	var/obj/item/circuitboard/vendor/V = new(null)
-	V.set_type(type)
-	component_parts += V
-	component_parts += new /obj/item/vending_refill/shoedispenser(null)
-	RefreshParts()
-	return ..()
 
 /obj/machinery/vending/syndicigs
 	name = "\improper Suspicious Cigarette Machine"
@@ -1900,15 +1688,6 @@
 
 	refill_canister = /obj/item/vending_refill/clothing
 
-/obj/machinery/vending/clothing/Initialize(mapload)
-	component_parts = list()
-	var/obj/item/circuitboard/vendor/V = new(null)
-	V.set_type(type)
-	component_parts += V
-	component_parts += new /obj/item/vending_refill/clothing(null)
-	RefreshParts()
-	return ..()
-
 /obj/machinery/vending/artvend
 	name = "\improper ArtVend"
 	desc = "A vending machine for art supplies."
@@ -1947,12 +1726,3 @@
 
 /obj/machinery/vending/crittercare/free
 	prices = list()
-
-/obj/machinery/vending/crittercare/Initialize(mapload)
-	component_parts = list()
-	var/obj/item/circuitboard/vendor/V = new(null)
-	V.set_type(type)
-	component_parts += V
-	component_parts += new /obj/item/vending_refill/crittercare(null)
-	RefreshParts()
-	return ..()

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -17,17 +17,21 @@
 	GLOB.event_announcement.Announce("На борту станции [station_name()] зафиксировано распространение цифрового торгового вируса, пожалуйста, будьте наготове. Вирус, предположительно, берет начало от [originMachine.name].", "ВНИМАНИЕ: ЦИФРОВОЙ ВИРУС")
 
 /datum/event/brand_intelligence/start()
+	var/list/obj/machinery/vending/unrefillables = list()
 	for(var/obj/machinery/vending/V in GLOB.machines)
 		if(!is_station_level(V.z))
 			continue
 		RegisterSignal(V, COMSIG_PARENT_QDELETING, .proc/vendor_destroyed)
 		vendingMachines.Add(V)
+		if(!V.refill_canister)
+			unrefillables.Add(V)
 
-	if(!length(vendingMachines))
+	var/list/obj/machinery/vending/leaderables = vendingMachines - unrefillables
+	if(!length(leaderables))
 		kill()
 		return
 
-	originMachine = pick(vendingMachines)
+	originMachine = pick(leaderables)
 	vendingMachines.Remove(originMachine)
 	originMachine.shut_up = FALSE
 	originMachine.shoot_inventory = TRUE

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -17,16 +17,15 @@
 	GLOB.event_announcement.Announce("На борту станции [station_name()] зафиксировано распространение цифрового торгового вируса, пожалуйста, будьте наготове. Вирус, предположительно, берет начало от [originMachine.name].", "ВНИМАНИЕ: ЦИФРОВОЙ ВИРУС")
 
 /datum/event/brand_intelligence/start()
-	var/list/obj/machinery/vending/unrefillables = list()
+	var/list/obj/machinery/vending/leaderables = list()
 	for(var/obj/machinery/vending/V in GLOB.machines)
 		if(!is_station_level(V.z))
 			continue
 		RegisterSignal(V, COMSIG_PARENT_QDELETING, .proc/vendor_destroyed)
 		vendingMachines.Add(V)
-		if(!V.refill_canister)
-			unrefillables.Add(V)
+		if(V.refill_canister)
+			leaderables.Add(V)
 
-	var/list/obj/machinery/vending/leaderables = vendingMachines - unrefillables
 	if(!length(leaderables))
 		kill()
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Добавляет условие, которое не позволяет Цифровому вирусу выбрать лидером неразбираемый автомат.

Вынос условия разбора из всех дочерних объектов в основной.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Цифровой вирус больше не уничтожает навсегда невостанавливаемые объекты

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
fix: Un-deconstructable vendings can't be rev-leaders
ref: Vending with refilling canisters filling
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
