### PR TITLE
feat: Добавление бумаги для самокруток в биогенератор

### DIFF
--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -210,3 +210,11 @@
 	materials = list(MAT_BIOMASS = 300)
 	build_path = /obj/item/clothing/head/rice_hat
 	category = list("initial","Leather and Cloth")
+
+/datum/design/rollingpapers
+	name = "Rolling paper pack"
+	id = "rolling_paper_pack"
+	build_type = BIOGENERATOR
+	materials = list(MAT_BIOMASS = 50)
+	build_path = /obj/item/storage/fancy/rollingpapers
+	category = list("initial","Organic Materials")


### PR DESCRIPTION
Авоут пройден: https://discord.com/channels/617003227182792704/755125334097133628/981857195878653982

## What Does This PR Do
Добавление бумаги для самокруток в биогенератор

Добавить упаковку с бумагой для самокруток в биогенератор ботаники.
Это упростит создание больших партий самокруток, меньше беготни до автоматов, возможно увеличение количества взаимодействий в связи с тем, что теперь проще продавать самокрутки, а не просто высушенные листы.
Цена: 50 биоматерии.

## Why It's Good For The Game
- Упрощение создания большого количества самокруток;
- Меньше беготни до автоматов.
