### PR TITLE
fix: chrono_eraser animation on simulated turfs

### DIFF
--- a/code/game/objects/items/weapons/chrono_eraser.dm
+++ b/code/game/objects/items/weapons/chrono_eraser.dm
@@ -155,7 +155,7 @@
 	anchored = TRUE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 	move_resist = INFINITY
-	blend_mode = BLEND_MULTIPLY
+	blend_mode = BLEND_ADD
 	var/mob/living/captured = null
 	var/obj/item/gun/energy/chrono_gun/gun = null
 	var/tickstokill = 15


### PR DESCRIPTION
Исправление переменной blend_mode для отображения эффекта structure/chrono_field на симулированных турфах
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Исправляет баг с отображением эффекта structure/chrono_field на симулированных турфах
## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Теперь у эффекта будет полноценная анимация не только на z2
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![image](https://user-images.githubusercontent.com/85886313/191058363-e59850f7-796b-4320-91fa-0350e54e6655.png)
![image](https://user-images.githubusercontent.com/85886313/191058375-246fc60b-17ac-4054-bc78-d63f9cee9024.png)

## Changelog
:cl:
fix: Исправлено отображение анимации structure/chrono_field на симулированных турфах
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
