### PR TITLE
FIX: Амбиции выбирают карбонов только с Z уровня владельца.

### DIFF
--- a/code/game/ambitions/ambition_objective.dm
+++ b/code/game/ambitions/ambition_objective.dm
@@ -145,6 +145,10 @@
 	for(var/mob/living/carbon/human/player in GLOB.player_list)
 		if(!player.mind || player.mind.assigned_role == player.mind.special_role || player.client.inactivity > 10 MINUTES || player.mind == owner)
 			continue
+
+		if(owner.current.z != player.z)
+			continue
+
 		players += player.real_name
 	var/random_player = "Капитан"
 	if(players.len)


### PR DESCRIPTION
## What Does This PR Do
Амбиции выбирают карбонов только с Z уровня владельца.

Фикс по багрепорту:
https://discord.com/channels/617003227182792704/617004034405957642/1021865099155218523

## Why It's Good For The Game
Теперь в рандоме амбиций не выпадают големы лаваленда, если не находиться на лаваленде.