### PR TITLE
Feat: add more tools to ghetto surgery

### DIFF
--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -151,7 +151,8 @@
 	/obj/item/cautery = 100,			\
 	/obj/item/clothing/mask/cigarette = 90,	\
 	/obj/item/lighter = 60,			\
-	/obj/item/weldingtool = 30
+	/obj/item/weldingtool = 30,     \
+	/obj/item/flashlight/flare/torch = 30
 	)
 
 	time = 24

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -8,7 +8,8 @@
 								/obj/item/cautery = 100,			\
 								/obj/item/clothing/mask/cigarette = 90,	\
 								/obj/item/lighter = 60,			\
-								/obj/item/weldingtool = 30
+								/obj/item/weldingtool = 30,     \
+								/obj/item/flashlight/flare/torch = 30
 								)
 
 		if(istype(M, /mob/living/carbon/human))

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -62,7 +62,8 @@
 	name = "mend internal bleeding"
 	allowed_tools = list(
 	/obj/item/FixOVein = 100, \
-	/obj/item/stack/cable_coil = 90
+	/obj/item/stack/cable_coil = 90, \
+	/obj/item/stack/sheet/sinew = 90
 	)
 	can_infect = 1
 	blood_level = 1


### PR DESCRIPTION
Добавляет факел как альтернативу каутеру, и связку вотчера как альтернативу fix-o-vein для того чтобы эшволкеры могли себя лечить не прибегая к использованию инструментов которые им нельзя иметь
