### PR TITLE
QoL: Cyberiad standardization

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -707,8 +707,7 @@
 /obj/structure/table,
 /obj/item/storage/box/prisoner,
 /obj/machinery/camera{
-	c_tag = "Brig Labor Camp Airlock North";
-	network = list("SS13")
+	c_tag = "Brig Labor Camp Airlock North"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -772,7 +771,6 @@
 	id_tag = "synd_inner";
 	locked = 1;
 	name = "Ship External Access";
-	req_access = null;
 	req_access_txt = "150"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -1059,7 +1057,6 @@
 	icon_state = "door_locked";
 	id_tag = "synd_outer";
 	name = "Ship External Access";
-	req_access = null;
 	req_access_txt = "150"
 	},
 /obj/machinery/door/poddoor{
@@ -1078,7 +1075,6 @@
 	icon_state = "door_locked";
 	id_tag = "synd_outer";
 	name = "Ship External Access";
-	req_access = null;
 	req_access_txt = "150"
 	},
 /obj/machinery/door/poddoor{
@@ -1340,8 +1336,7 @@
 	icon_state = "door_locked";
 	id_tag = "vox_southwest_lock";
 	locked = 1;
-	req_access_txt = "152";
-	req_one_access = null
+	req_access_txt = "152"
 	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -1548,8 +1543,7 @@
 	icon_state = "door_locked";
 	id_tag = "vox_southeast_lock";
 	locked = 1;
-	req_access_txt = "152";
-	req_one_access = null
+	req_access_txt = "152"
 	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -1667,9 +1661,7 @@
 /area/security/warden)
 "aez" = (
 /obj/machinery/camera{
-	c_tag = "Brig Medbay";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Brig Medbay"
 	},
 /obj/machinery/newscaster{
 	pixel_y = 34;
@@ -1808,7 +1800,6 @@
 "aeL" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/machinery/power/apc{
@@ -1879,7 +1870,6 @@
 	id_tag = "synd_inner";
 	locked = 1;
 	name = "Ship External Access";
-	req_access = null;
 	req_access_txt = "150"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -2229,7 +2219,6 @@
 /area/security/medbay)
 "afs" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -2499,9 +2488,7 @@
 "afY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Brig Medical Bay";
-	req_access_txt = "0";
 	req_one_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2530,8 +2517,7 @@
 	icon_state = "door_locked";
 	id_tag = "vox_northwest_lock";
 	locked = 1;
-	req_access_txt = "152";
-	req_one_access = null
+	req_access_txt = "152"
 	},
 /obj/machinery/access_button{
 	command = "cycle_exterior";
@@ -2575,8 +2561,7 @@
 	icon_state = "door_locked";
 	id_tag = "vox_northeast_lock";
 	locked = 1;
-	req_access_txt = "152";
-	req_one_access = null
+	req_access_txt = "152"
 	},
 /obj/docking_port/mobile{
 	dir = 2;
@@ -5053,7 +5038,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/command/glass{
 	id = "hos_room";
-	id_tag = null;
 	name = "Head of Security Room";
 	req_access_txt = "58"
 	},
@@ -5098,7 +5082,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Evidence Storage";
-	req_access = null;
 	req_access_txt = "63"
 	},
 /turf/simulated/floor/plasteel{
@@ -5770,7 +5753,6 @@
 "alL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
-	id_tag = null;
 	name = "Brig";
 	req_access_txt = "63"
 	},
@@ -10825,7 +10807,6 @@
 	id_tag = "dorms_maint_inner";
 	locked = 1;
 	name = "External Access";
-	req_access = null;
 	req_access_txt = "13"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -11770,7 +11751,6 @@
 "awa" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
-	id_tag = null;
 	name = "Brig";
 	req_access_txt = "63"
 	},
@@ -11860,7 +11840,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Prisoner Processing";
-	req_access = null;
 	req_access_txt = "63"
 	},
 /turf/simulated/floor/plasteel{
@@ -12379,7 +12358,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Execution Room";
-	req_access = null;
 	req_access_txt = "1"
 	},
 /obj/structure/cable{
@@ -12423,7 +12401,6 @@
 	id_tag = "dorms_maint_inner";
 	locked = 1;
 	name = "External Access";
-	req_access = null;
 	req_access_txt = "13"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden,
@@ -12648,7 +12625,6 @@
 	},
 /obj/machinery/door/airlock/security{
 	name = "Evidence Storage";
-	req_access = null;
 	req_access_txt = "63"
 	},
 /turf/simulated/floor/plasteel{
@@ -12746,7 +12722,6 @@
 "axI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
-	id_tag = null;
 	name = "Brig";
 	req_access_txt = "63"
 	},
@@ -12819,7 +12794,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Prisoner Processing";
-	req_access = null;
 	req_access_txt = "63"
 	},
 /turf/simulated/floor/plasteel{
@@ -13624,7 +13598,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Interrogation";
-	req_access = null;
 	req_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -14097,7 +14070,6 @@
 	id_tag = "dorms_maint_outer";
 	locked = 1;
 	name = "External Access";
-	req_access = null;
 	req_access_txt = "13"
 	},
 /turf/simulated/floor/plating,
@@ -14251,7 +14223,6 @@
 	id_tag = "solar_tool_outer";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "10;13"
 	},
 /obj/structure/cable{
@@ -15418,7 +15389,6 @@
 	id_tag = "solar_tool_inner";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "13"
 	},
 /obj/structure/cable{
@@ -15983,7 +15953,6 @@
 	id_tag = "solar_chapel_outer";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "10;13"
 	},
 /turf/simulated/floor/plating,
@@ -17067,7 +17036,6 @@
 	id_tag = "eva_outer";
 	locked = 1;
 	name = "EVA External Access";
-	req_access = null;
 	req_access_txt = "13"
 	},
 /turf/simulated/floor/plating/airless,
@@ -17084,7 +17052,6 @@
 	id_tag = "solar_chapel_inner";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "13"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -18060,7 +18027,6 @@
 	id_tag = "eva_inner";
 	locked = 1;
 	name = "EVA Internal Access";
-	req_access = null;
 	req_access_txt = "13"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -18245,7 +18211,6 @@
 	id_tag = "arrivals_outer";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "10;13"
 	},
 /turf/simulated/floor/plating,
@@ -18648,7 +18613,6 @@
 	id_tag = "bar_maint_outer";
 	locked = 1;
 	name = "External Access";
-	req_access = null;
 	req_access_txt = "13"
 	},
 /turf/simulated/floor/plating,
@@ -18685,7 +18649,6 @@
 	id_tag = "eva_inner";
 	locked = 1;
 	name = "EVA Internal Access";
-	req_access = null;
 	req_access_txt = "13"
 	},
 /turf/simulated/floor/plating,
@@ -19309,7 +19272,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Detective";
-	req_access = null;
 	req_access_txt = "4"
 	},
 /turf/simulated/floor/plasteel{
@@ -19503,7 +19465,6 @@
 	id_tag = "arrivals_inner";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "13"
 	},
 /turf/simulated/floor/plating,
@@ -19786,7 +19747,6 @@
 	id_tag = "bar_maint_inner";
 	locked = 1;
 	name = "External Access";
-	req_access = null;
 	req_access_txt = "13"
 	},
 /turf/simulated/floor/plating,
@@ -21967,8 +21927,7 @@
 	icon_state = "door_locked";
 	id_tag = "sol_outer";
 	locked = 1;
-	name = "Arrivals External Access";
-	req_access = null
+	name = "Arrivals External Access"
 	},
 /obj/machinery/access_button{
 	command = "cycle_exterior";
@@ -24366,8 +24325,7 @@
 	icon_state = "door_locked";
 	id_tag = "sol_inner";
 	locked = 1;
-	name = "Arrivals External Access";
-	req_access = null
+	name = "Arrivals External Access"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
@@ -27747,7 +27705,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Security Checkpoint";
-	req_access = null;
 	req_access_txt = "1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -29019,7 +28976,6 @@
 	id_tag = "ai_outer";
 	locked = 1;
 	name = "MiniSat External Access";
-	req_access = null;
 	req_access_txt = "75;13"
 	},
 /turf/simulated/floor/plating,
@@ -30012,7 +29968,6 @@
 	id_tag = "ai_inner";
 	locked = 1;
 	name = "MiniSat External Access";
-	req_access = null;
 	req_access_txt = "75;13"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -38174,14 +38129,11 @@
 /area/bridge/meeting_room)
 "byJ" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
 /obj/machinery/camera{
-	c_tag = "Bridge Conference Room";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Bridge Conference Room"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -39798,7 +39750,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Conference Room";
-	req_access = null;
 	req_access_txt = "19"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -39843,7 +39794,6 @@
 /obj/machinery/door/airlock/command{
 	id_tag = "captainofficedoor";
 	name = "Captain's Office";
-	req_access = null;
 	req_access_txt = "20"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -41458,7 +41408,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Paramedic";
 	req_access_txt = "66"
 	},
@@ -43965,7 +43914,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Conference Room";
-	req_access = null;
 	req_access_txt = "19"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -44783,12 +44731,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
 "bMD" = (
-/obj/machinery/computer/account_database{
-	anchored = 1
-	},
+/obj/machinery/computer/account_database,
 /obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -45914,8 +45859,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Accounts Uplink Terminal";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -45974,7 +45918,6 @@
 "bOx" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
-	req_access = null;
 	req_access_txt = "20"
 	},
 /obj/structure/cable{
@@ -45993,9 +45936,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/command{
-	id_tag = null;
 	name = "Captain's Office";
-	req_access = null;
 	req_access_txt = "20"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -46934,16 +46875,13 @@
 	},
 /obj/machinery/door/window/brigdoor{
 	base_state = "rightsecure";
-	dir = 4;
 	icon_state = "rightsecure";
 	name = "Head of Personnel's Desk";
 	req_access_txt = "57"
 	},
 /obj/machinery/door/window/northleft{
 	dir = 8;
-	icon_state = "left";
-	name = "Head of Personnel's Desk";
-	req_access_txt = "0"
+	name = "Head of Personnel's Desk"
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/heads)
@@ -47016,7 +46954,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel";
-	req_access = null;
 	req_access_txt = "57"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -47248,7 +47185,6 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/medical/morgue)
@@ -47264,7 +47200,6 @@
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/medical/morgue)
@@ -47274,7 +47209,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/medical/morgue)
@@ -47328,7 +47262,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Paramedic";
 	req_access_txt = "66"
 	},
@@ -48159,7 +48092,6 @@
 "bSt" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Medbay Reception";
 	req_access_txt = "5"
 	},
@@ -48209,7 +48141,6 @@
 "bSx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Chemistry Lab";
 	req_access_txt = "33"
 	},
@@ -50876,9 +50807,7 @@
 	},
 /area/crew_quarters/heads)
 "bXb" = (
-/obj/machinery/computer/security/mining{
-	network = list("Mining Outpost")
-	},
+/obj/machinery/computer/security/mining,
 /obj/machinery/keycard_auth{
 	pixel_x = -24
 	},
@@ -51919,8 +51848,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Head of Personnel's Office";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads)
@@ -52684,7 +52612,6 @@
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 4;
 	icon_state = "shutter0";
 	id_tag = "rdprivacy";
 	name = "Research Director Office Shutters";
@@ -54571,7 +54498,6 @@
 /obj/machinery/door/airlock/command{
 	id_tag = "hopofficedoor";
 	name = "Head of Personnel";
-	req_access = null;
 	req_access_txt = "57"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -54636,7 +54562,6 @@
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 4;
 	icon_state = "shutter0";
 	id_tag = "rdprivacy";
 	name = "Research Director Office Shutters";
@@ -54673,7 +54598,6 @@
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 4;
 	icon_state = "shutter0";
 	id_tag = "rdprivacy";
 	name = "Research Director Office Shutters";
@@ -54847,7 +54771,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Server Room";
-	req_access = null;
 	req_access_txt = "30"
 	},
 /obj/structure/cable{
@@ -55100,7 +55023,6 @@
 "cee" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Observation Room"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -55118,7 +55040,6 @@
 "cef" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Observation Room"
 	},
 /turf/simulated/floor/plasteel{
@@ -56692,13 +56613,11 @@
 /obj/machinery/door/window/brigdoor{
 	base_state = "rightsecure";
 	icon_state = "rightsecure";
-	name = "Server Exterior Door";
-	req_access = null
+	name = "Server Exterior Door"
 	},
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
-	name = "Server Interior Door";
-	req_access = null
+	name = "Server Interior Door"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
@@ -59444,7 +59363,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Virology Lobby Hallway"
 	},
 /turf/simulated/floor/plasteel{
@@ -60034,7 +59952,6 @@
 "cnw" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Virology Lobby Hallway"
 	},
 /turf/simulated/floor/plasteel{
@@ -63360,7 +63277,6 @@
 "csX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Monkey Pen";
 	req_access_txt = "39"
 	},
@@ -64643,8 +64559,7 @@
 /area/toxins/mixing)
 "cvf" = (
 /obj/machinery/atmospherics/trinary/mixer{
-	dir = 8;
-	req_access = null
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -64953,7 +64868,6 @@
 "cvO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Isolation B";
 	req_access_txt = "39"
 	},
@@ -64971,7 +64885,6 @@
 "cvQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Isolation B";
 	req_access_txt = "39"
 	},
@@ -65046,7 +64959,6 @@
 "cvX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Secondary Storage";
 	req_access_txt = "5"
 	},
@@ -65163,7 +65075,6 @@
 "cwh" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Isolation A";
 	req_access_txt = "39"
 	},
@@ -70622,7 +70533,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westright{
 	name = "Mechanic's Desk";
-	req_access = null;
 	req_access_txt = "70"
 	},
 /obj/machinery/cell_charger,
@@ -73225,7 +73135,6 @@
 "cLo" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Mechanic Workshop Maintenance";
-	req_access = null;
 	req_access_txt = "70"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -76027,7 +75936,6 @@
 	id_tag = "engineering_west_inner";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "10;13"
 	},
 /obj/structure/cable/yellow{
@@ -76130,7 +76038,6 @@
 	id_tag = "engineering_east_inner";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "10;13"
 	},
 /obj/structure/cable/yellow{
@@ -76850,7 +76757,6 @@
 	id_tag = "engineering_west_outer";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "10;13"
 	},
 /obj/structure/cable/yellow{
@@ -76876,7 +76782,6 @@
 	id_tag = "engineering_east_outer";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "10;13"
 	},
 /obj/structure/cable/yellow{
@@ -77669,7 +77574,6 @@
 	id_tag = "robotics_solar_outer";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "10;13"
 	},
 /turf/simulated/floor/plating,
@@ -77711,7 +77615,6 @@
 	id_tag = "robotics_solar_inner";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "13"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -82954,7 +82857,6 @@
 	id_tag = "solar_xeno_inner";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "13"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -83180,7 +83082,6 @@
 	id_tag = "solar_xeno_outer";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "10;13"
 	},
 /turf/simulated/floor/plating,
@@ -85559,7 +85460,6 @@
 	id_tag = "south_maint_outer";
 	locked = 1;
 	name = "External Access";
-	req_access = null;
 	req_access_txt = "13"
 	},
 /turf/simulated/floor/plating,
@@ -86840,7 +86740,6 @@
 	id_tag = "south_maint_inner";
 	locked = 1;
 	name = "External Access";
-	req_access = null;
 	req_access_txt = "13"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -86875,7 +86774,6 @@
 	id_tag = "sci_inner";
 	locked = 1;
 	name = "External Access";
-	req_access = null;
 	req_access_txt = "13"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -87102,7 +87000,6 @@
 	id_tag = "sci_outer";
 	locked = 1;
 	name = "External Access";
-	req_access = null;
 	req_access_txt = "13"
 	},
 /turf/simulated/floor/plating,
@@ -87953,7 +87850,6 @@
 /obj/machinery/door/window/southright{
 	dir = 1;
 	name = "AI Core Door";
-	req_access = null;
 	req_access_txt = "16"
 	},
 /turf/simulated/floor/bluegrid,
@@ -90250,12 +90146,10 @@
 "hNI" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
-	id = null;
 	name = "Creature Pen";
 	req_access_txt = "47"
 	},
 /obj/machinery/door/window/brigdoor{
-	id = null;
 	name = "Creature Pen";
 	req_access_txt = "47"
 	},
@@ -90659,7 +90553,6 @@
 /area/crew_quarters/dorms)
 "iPr" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/medical/morgue)
@@ -91995,7 +91888,6 @@
 /area/mimeoffice)
 "msR" = (
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Escape Shuttle Infirmary"
 	},
 /turf/simulated/floor/plasteel{
@@ -92267,7 +92159,6 @@
 /area/library/abandoned)
 "nel" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_x = 32
 	},
@@ -93350,7 +93241,6 @@
 "pSJ" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -25264,13 +25264,6 @@
 /obj/item/tank/internals/emergency_oxygen,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
-"aYc" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bluecorner"
-	},
-/area/hallway/primary/fore)
 "aYd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -25535,25 +25528,12 @@
 	icon_state = "dark"
 	},
 /area/chapel/main)
-"aYC" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/fore)
 "aYD" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
 	icon_state = "swall_f6"
 	},
 /area/shuttle/escape)
-"aYE" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
-	},
-/area/hallway/primary/fore)
 "aYF" = (
 /obj/structure/closet/coffin,
 /turf/simulated/floor/plasteel{
@@ -25971,6 +25951,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "blue"
@@ -26495,12 +26476,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
 "baF" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "blue"
@@ -26879,13 +26862,6 @@
 /obj/structure/sign/securearea,
 /turf/simulated/wall/r_wall,
 /area/security/nuke_storage)
-"bbr" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "bluecorner"
-	},
-/area/hallway/primary/central/north)
 "bbs" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -27802,7 +27778,6 @@
 /obj/structure/sign/securearea{
 	pixel_x = 32
 	},
-/obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/bridge)
@@ -27911,15 +27886,14 @@
 	},
 /area/hallway/primary/central/north)
 "bdw" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/item/flag/nt,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
+/obj/structure/sign/directions/science{
+	dir = 4;
+	pixel_y = 32
+	},
+/obj/structure/sign/directions/medical{
+	dir = 4;
+	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -28130,7 +28104,6 @@
 /obj/structure/sign/securearea{
 	pixel_x = -32
 	},
-/obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/bridge)
@@ -28432,18 +28405,6 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/chapel/office)
-"beu" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/central/north)
-"bev" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "bluecorner"
-	},
-/area/hallway/primary/central/north)
 "bew" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -28757,10 +28718,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
-"bfc" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/port)
 "bfd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -29402,15 +29359,13 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/sign/directions/evac{
+/obj/structure/sign/directions/security{
 	dir = 4;
-	pixel_y = 24;
-	tag = "icon-direction_evac (EAST)"
+	pixel_y = 39
 	},
-/obj/structure/sign/directions/medical{
+/obj/structure/sign/directions/cargo{
 	dir = 4;
-	pixel_y = 32;
-	tag = "icon-direction_med (EAST)"
+	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -29710,11 +29665,6 @@
 	},
 /area/hallway/primary/central/nw)
 "bgW" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "L11"
 	},
@@ -30669,6 +30619,11 @@
 	},
 /area/ai_monitored/storage/eva)
 "biO" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	desc = "";
 	icon_state = "L13"
@@ -31395,10 +31350,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
-"bkq" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/central/nw)
 "bkr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -31411,6 +31362,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
 "bkt" = (
@@ -31502,7 +31454,7 @@
 	dir = 8;
 	icon_state = "bluecorner"
 	},
-/area/hallway/primary/central/north)
+/area/hallway/primary/central/ne)
 "bkH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -31583,7 +31535,6 @@
 	name = "Bridge Blast Doors";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/bridge)
@@ -31929,7 +31880,6 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "blF" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -32396,7 +32346,6 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/kitchen)
 "bmz" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -32424,24 +32373,6 @@
 	icon_state = "dark"
 	},
 /area/hydroponics)
-"bmB" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/central/nw)
 "bmC" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -32460,6 +32391,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
 "bmD" = (
@@ -32803,11 +32735,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "L12"
 	},
@@ -32844,6 +32771,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plasteel{
 	desc = "";
 	icon_state = "L14"
@@ -32878,20 +32810,19 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
 "bno" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/sign/directions/medical{
+	dir = 4;
+	pixel_y = -25
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/sign/directions/science{
+	dir = 4;
+	pixel_y = -32
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/sign/directions/engineering{
+	pixel_y = -39
 	},
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/central/ne)
+/area/hallway/primary/central/se)
 "bnp" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
@@ -35069,7 +35000,6 @@
 	name = "HIGH VOLTAGE";
 	pixel_y = 32
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "blue"
@@ -35112,6 +35042,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/bridge)
 "bsv" = (
@@ -35243,7 +35174,6 @@
 	name = "HIGH VOLTAGE";
 	pixel_y = 32
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "blue"
@@ -36798,7 +36728,6 @@
 /turf/simulated/floor/plasteel,
 /area/bridge/meeting_room)
 "bwf" = (
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "blue"
@@ -36807,6 +36736,7 @@
 "bwg" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/bridge)
 "bwh" = (
@@ -37050,18 +36980,19 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "bwN" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/sign/directions/engineering{
+	pixel_y = -39
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/sign/directions/cargo{
+	dir = 8;
+	pixel_y = -32
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/sign/directions/medical{
+	dir = 4;
+	pixel_y = -25
 	},
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/central/nw)
+/area/hallway/primary/central/south)
 "bwO" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/warning_stripes/northwest,
@@ -37102,7 +37033,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -37139,6 +37069,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "bwT" = (
@@ -37812,7 +37743,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -37941,18 +37871,12 @@
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "byr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/central/ne)
+/area/hallway/primary/central/se)
 "bys" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
@@ -37986,6 +37910,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "byu" = (
@@ -38328,18 +38253,12 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
 "bzc" = (
-/obj/structure/sign/directions/evac{
-	dir = 4
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "bluecorner"
 	},
-/obj/structure/sign/directions/medical{
-	dir = 4;
-	pixel_y = 7
-	},
-/obj/structure/sign/directions/science{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/crew_quarters/bar)
+/area/hallway/primary/central/se)
 "bzd" = (
 /obj/structure/flora/tree/jungle/small,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -38849,6 +38768,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/west)
 "bAi" = (
@@ -38972,7 +38892,6 @@
 	},
 /area/hallway/primary/central/nw)
 "bAA" = (
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "blue"
@@ -40601,10 +40520,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
-"bEn" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/central/se)
 "bEo" = (
 /turf/simulated/wall/r_wall,
 /area/medical/chemistry)
@@ -40962,9 +40877,16 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bFn" = (
-/obj/machinery/status_display{
-	layer = 4;
+/obj/structure/sign/directions/evac{
+	dir = 4;
+	pixel_y = 39
+	},
+/obj/structure/sign/directions/medical{
+	dir = 8;
 	pixel_y = 32
+	},
+/obj/structure/sign/directions/science{
+	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
@@ -42003,16 +41925,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
-"bHr" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/central/se)
 "bHs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -42022,16 +41934,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
-"bHt" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/starboard/west)
 "bHu" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -42042,6 +41944,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/west)
 "bHv" = (
@@ -43439,6 +43342,10 @@
 /area/medical/chemistry)
 "bKa" = (
 /obj/item/twohanded/required/kirbyplants,
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_x = -32
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
 "bKb" = (
@@ -44588,19 +44495,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
-"bMl" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/central/south)
 "bMm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -51908,9 +51802,6 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
 "bYX" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bluecorner"
 	},
@@ -54024,14 +53915,11 @@
 	tag = "icon-whitehall (WEST)"
 	},
 /area/medical/surgery/north)
-"ccl" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/central/south)
 "ccm" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
 "ccn" = (
@@ -54854,6 +54742,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
 "cdK" = (
@@ -54955,7 +54844,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
 "cdV" = (
@@ -54974,7 +54862,6 @@
 /obj/structure/sign/securearea{
 	pixel_y = 32
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "blue"
@@ -55561,7 +55448,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowcorner"
 	},
@@ -55640,7 +55526,6 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
 "cft" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -55693,24 +55578,6 @@
 	tag = "icon-whitehall (WEST)"
 	},
 /area/medical/surgery/north)
-"cfx" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/central/south)
 "cfy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -55742,7 +55609,6 @@
 	pixel_y = -30;
 	name = "south extinguisher cabinet"
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
 "cfC" = (
@@ -55994,6 +55860,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
 "cfU" = (
@@ -56262,7 +56129,6 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
 "cgo" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -56287,6 +56153,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
 "cgq" = (
@@ -56645,17 +56512,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "che" = (
-/obj/structure/sign/directions/engineering,
-/obj/structure/sign/directions/science{
-	dir = 4;
-	pixel_y = -7
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "bluecorner"
 	},
-/obj/structure/sign/directions/medical{
-	dir = 4;
-	pixel_y = 7
-	},
-/turf/simulated/wall,
-/area/janitor)
+/area/hallway/primary/central/ne)
 "chf" = (
 /turf/simulated/wall,
 /area/maintenance/asmaint)
@@ -57386,7 +57247,6 @@
 	c_tag = "Central Primary Hallway South-West";
 	dir = 1
 	},
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -57527,6 +57387,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowcorner"
 	},
@@ -58617,13 +58478,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/janitor)
-"ckQ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/central/south)
 "ckR" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
@@ -59106,12 +58960,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "clO" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "cautioncorner"
@@ -59637,13 +59493,6 @@
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
 	})
-"cmO" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/aft)
 "cmP" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/decal/warning_stripes/yellow,
@@ -84370,6 +84219,15 @@
 /area/space/nearstation)
 "dje" = (
 /obj/item/twohanded/required/kirbyplants,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "blue"
@@ -84706,13 +84564,6 @@
 	tag = "icon-vault (NORTHEAST)"
 	},
 /area/turret_protected/aisat_interior)
-"djL" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "blue"
-	},
-/area/hallway/primary/central/nw)
 "djM" = (
 /obj/item/shard,
 /obj/structure/disposalpipe/segment{
@@ -84733,6 +84584,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "bluecorner"
@@ -84968,8 +84820,9 @@
 	pixel_y = 28;
 	name = "north station intercom (General)"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/hallway/primary/central/north)
+/area/hallway/primary/central/ne)
 "dkm" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -84984,7 +84837,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
 "dko" = (
@@ -88449,6 +88301,21 @@
 	icon_state = "white"
 	},
 /area/library/abandoned)
+"dHG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/central/ne)
 "dHM" = (
 /obj/machinery/light/spot,
 /turf/simulated/floor/plasteel{
@@ -93177,6 +93044,10 @@
 	icon_state = "escape"
 	},
 /area/security/customs2)
+"pHK" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/central/se)
 "pIb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -93540,6 +93411,16 @@
 /obj/structure/barricade/wooden,
 /turf/simulated/floor/wood,
 /area/library/abandoned)
+"qAG" = (
+/obj/structure/sign/directions/security{
+	dir = 4;
+	pixel_y = -25
+	},
+/obj/structure/sign/directions/cargo{
+	pixel_y = -39
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/central/nw)
 "qAN" = (
 /obj/structure/chair/comfy{
 	dir = 8
@@ -93840,6 +93721,17 @@
 /obj/structure/closet/walllocker/emerglocker/west,
 /turf/simulated/shuttle/floor4,
 /area/shuttle/escape)
+"rgv" = (
+/obj/structure/sign/directions/security{
+	dir = 1;
+	pixel_y = 39
+	},
+/obj/structure/sign/directions/evac{
+	dir = 4;
+	pixel_y = 25
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/central/se)
 "rgI" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -94446,6 +94338,12 @@
 	icon_state = "white"
 	},
 /area/toxins/xenobiology)
+"sCv" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/central/sw)
 "sDa" = (
 /obj/structure/window/plasmareinforced{
 	color = "#FF0000";
@@ -112599,9 +112497,9 @@ aVe
 bdu
 bgM
 beP
-bfc
+bgz
 blF
-bfc
+bgz
 blK
 bnv
 bnw
@@ -120566,9 +120464,9 @@ aSA
 aSA
 aSA
 aSA
-bfc
+bgz
 bmz
-bfc
+bgz
 blK
 bnS
 bsW
@@ -121080,9 +120978,9 @@ bam
 cGT
 aUF
 din
-djL
-bmB
-bkq
+bgP
+bmV
+qAG
 blZ
 bnS
 bnT
@@ -121619,8 +121517,8 @@ bST
 bJg
 bUY
 ciy
-ciy
 bYW
+ciy
 ciy
 ciy
 ciy
@@ -121876,7 +121774,7 @@ bSU
 bQh
 bRZ
 bTy
-bTy
+sCv
 bYX
 bYR
 caw
@@ -122630,7 +122528,7 @@ aaa
 aaa
 bqN
 bsp
-bwN
+aSV
 bAA
 bxl
 byH
@@ -123680,8 +123578,8 @@ bXa
 uoE
 bMG
 cdX
-cfx
-ccl
+cgj
+cdN
 cgW
 cgW
 cgW
@@ -125444,9 +125342,9 @@ atc
 aST
 bdF
 jgn
-aYc
+jgn
 aZx
-bbr
+bkC
 dcb
 bdv
 bhc
@@ -125481,9 +125379,9 @@ bFC
 cew
 cgl
 cdN
-ccl
+cdN
 clO
-cmQ
+ckO
 ckO
 cpi
 ckO
@@ -125701,9 +125599,9 @@ aSb
 aSS
 aUp
 aVT
-aYC
+aVT
 baE
-beu
+bhd
 bhd
 bhd
 biI
@@ -125738,9 +125636,9 @@ cda
 cev
 cgk
 cjj
-ckQ
+cjj
 clN
-cmO
+coq
 coq
 cpg
 cqv
@@ -125958,9 +125856,9 @@ aSc
 aFF
 aUq
 oOv
-aYE
+oOv
 baF
-bev
+bYf
 bhh
 bhV
 biK
@@ -125995,7 +125893,7 @@ bFC
 cey
 cgm
 cdN
-ccl
+cdN
 ciN
 cfn
 clZ
@@ -126251,8 +126149,8 @@ iVV
 iVV
 cex
 bKQ
-cdN
-che
+bwN
+chc
 chc
 chc
 chc
@@ -126992,8 +126890,8 @@ cUi
 dhp
 aDN
 dkl
-bna
-bYf
+dHG
+che
 bma
 boh
 bpB
@@ -127248,8 +127146,8 @@ bpR
 cSX
 dgH
 aDN
-bdD
-bna
+bhq
+bnn
 bkE
 bmc
 bmc
@@ -127506,8 +127404,8 @@ bez
 dhq
 aDN
 dkn
-bno
-bza
+bnn
+dnC
 bmi
 aaa
 bmc
@@ -127791,9 +127689,9 @@ bXw
 bXl
 bZa
 bSi
-ccl
-bMl
-ccl
+cdN
+bKQ
+cdN
 chc
 cde
 cmU
@@ -128305,7 +128203,7 @@ bXy
 bXl
 bZc
 bSi
-bEn
+bFO
 cgo
 cfB
 chf
@@ -128798,7 +128696,7 @@ aaa
 aaa
 diP
 bsJ
-byr
+byu
 bwf
 bxv
 byX
@@ -129576,7 +129474,7 @@ bza
 bFU
 bBF
 bCY
-bFU
+bzc
 bFU
 bFU
 bMT
@@ -129833,7 +129731,7 @@ bEg
 bFi
 bHo
 bIR
-bKN
+byr
 bKN
 bKN
 bKN
@@ -130090,7 +129988,7 @@ bzb
 bFO
 bHs
 bFO
-bFO
+pHK
 bFW
 bLg
 bFO
@@ -130343,10 +130241,10 @@ bsN
 aUS
 bsN
 aUS
-bzc
-bEn
-bHr
-bEn
+aUS
+rgv
+bHs
+bno
 bEp
 bEp
 bEp
@@ -130858,9 +130756,9 @@ byD
 bmq
 bmq
 aUS
-bAi
-bHt
-bAi
+bAk
+bHy
+bAk
 bEp
 aTS
 bBM
@@ -137028,7 +136926,7 @@ bxL
 bzj
 bAr
 bHy
-bAk
+buW
 bEu
 qzo
 bMZ

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -120,9 +120,9 @@
 /area/security/securearmory)
 "abP" = (
 /obj/item/radio/intercom{
-	dir = 8;
-	pixel_x = 30;
-	pixel_y = 30
+	pixel_x = 28;
+	pixel_y = 28;
+	name = "custom station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -237,8 +237,7 @@
 /area/security/securearmory)
 "acd" = (
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -254,8 +253,7 @@
 /area/shuttle/syndicate)
 "acf" = (
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -310,8 +308,7 @@
 /area/security/securearmory)
 "ack" = (
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -598,19 +595,15 @@
 /obj/item/taperecorder,
 /obj/machinery/light_switch{
 	pixel_x = -25;
-	pixel_y = -8
-	},
-/obj/item/radio/intercom/department/security{
-	pixel_x = -29;
-	pixel_y = 3
+	pixel_y = -8;
+	name = "custom light switch"
 	},
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "acM" = (
 /obj/machinery/suit_storage_unit/security/secure,
 /obj/machinery/light{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -657,6 +650,10 @@
 "acS" = (
 /obj/machinery/computer/mech_bay_power_console,
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/firealarm{
+	pixel_y = 24;
+	name = "north fire alarm"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -680,7 +677,7 @@
 /obj/item/storage/fancy/cigarettes/cigpack_robust,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /obj/machinery/light{
 	dir = 8
@@ -738,12 +735,11 @@
 /area/security/prisonershuttle)
 "ada" = (
 /obj/machinery/light{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -905,11 +901,6 @@
 	dir = 8
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 27;
-	pixel_y = 28
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -974,8 +965,7 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
 /obj/machinery/light{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /obj/item/toy/figure/hos,
 /obj/item/lighter/zippo/hos,
@@ -1021,7 +1011,8 @@
 "adw" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /obj/structure/table/wood,
 /obj/item/paper_bin/nanotrasen,
@@ -1211,8 +1202,7 @@
 	pixel_y = 4
 	},
 /obj/machinery/light{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -1262,7 +1252,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
@@ -1319,8 +1309,7 @@
 /area/security/warden)
 "adS" = (
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/structure/table,
 /obj/machinery/kitchen_machine/microwave,
@@ -1336,8 +1325,7 @@
 /area/shuttle/syndicate)
 "adU" = (
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -1452,12 +1440,12 @@
 "aed" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 8
+	dir = 4
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
@@ -1594,7 +1582,7 @@
 "aeq" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -1604,14 +1592,13 @@
 /area/security/medbay)
 "aer" = (
 /obj/machinery/light{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
 /obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -1685,7 +1672,8 @@
 	network = list("SS13")
 	},
 /obj/machinery/newscaster{
-	pixel_y = 34
+	pixel_y = 34;
+	name = "north newscaster"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -1734,7 +1722,8 @@
 "aeD" = (
 /obj/machinery/computer/secure_data,
 /obj/item/radio/intercom/department/security{
-	pixel_x = 25
+	pixel_x = 28;
+	name = "east station intercom (Security)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -1743,7 +1732,8 @@
 "aeE" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /obj/effect/decal/warning_stripes/east,
 /obj/structure/rack,
@@ -1795,7 +1785,8 @@
 /obj/item/reagent_containers/syringe/charcoal,
 /obj/item/reagent_containers/glass/bottle/epinephrine,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -24
+	pixel_x = -27;
+	name = "west extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -1950,11 +1941,13 @@
 	dir = 8
 	},
 /obj/machinery/light_switch{
-	pixel_x = -25
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -1971,7 +1964,8 @@
 	icon_state = "4-8"
 	},
 /obj/item/radio/intercom{
-	pixel_x = 25
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -2036,9 +2030,8 @@
 /area/security/prisonershuttle)
 "afa" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	name = "station intercom (General)";
-	pixel_y = -27
+	name = "south station intercom (General)";
+	pixel_y = -28
 	},
 /obj/structure/table,
 /obj/item/clothing/under/color/orange/prison,
@@ -2097,8 +2090,7 @@
 /obj/item/reagent_containers/food/drinks/flask/barflask,
 /obj/item/megaphone,
 /obj/machinery/light{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -2222,10 +2214,11 @@
 /obj/item/storage/box/gloves,
 /obj/item/radio/intercom/department/security{
 	pixel_x = -28;
-	pixel_y = -10
+	pixel_y = -10;
+	name = "custom station intercom (Security)"
 	},
 /obj/item/radio/intercom{
-	dir = 8;
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -2427,8 +2420,7 @@
 	req_access_txt = "150"
 	},
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -2440,8 +2432,7 @@
 	req_access_txt = "150"
 	},
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -2615,8 +2606,7 @@
 /area/shuttle/vox)
 "agf" = (
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/machinery/sleeper/syndie{
 	dir = 4
@@ -2816,8 +2806,7 @@
 	req_access_txt = "152"
 	},
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
@@ -2859,8 +2848,7 @@
 	req_access_txt = "152"
 	},
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -3039,8 +3027,7 @@
 /area/crew_quarters/courtroom)
 "agO" = (
 /obj/machinery/light{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -3049,7 +3036,8 @@
 /area/security/brig)
 "agP" = (
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -3181,7 +3169,8 @@
 /area/shuttle/vox)
 "ahd" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 30
+	pixel_x = 27;
+	name = "east extinguisher cabinet"
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -3233,7 +3222,7 @@
 /area/maintenance/fpmaint)
 "ahk" = (
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -3432,8 +3421,7 @@
 	req_access_txt = "1"
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -3565,7 +3553,7 @@
 /area/shuttle/syndicate)
 "ahQ" = (
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /obj/machinery/camera{
 	c_tag = "Brig Main Hall East 1"
@@ -3647,7 +3635,8 @@
 /area/security/hos)
 "ahW" = (
 /obj/item/radio/intercom/department/security{
-	pixel_y = 25
+	pixel_y = 25;
+	name = "north station intercom (Security)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -3689,7 +3678,8 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/decal/warning_stripes/northeastcorner,
 /obj/machinery/light_switch{
-	pixel_x = -25
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -3773,11 +3763,11 @@
 "aik" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /obj/item/radio/intercom{
-	dir = 8;
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -3853,7 +3843,8 @@
 /area/security/securearmory)
 "aix" = (
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	name = "standard air scrubber";
@@ -4117,7 +4108,8 @@
 	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_y = -25
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -4138,7 +4130,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4215,7 +4208,8 @@
 /area/security/brig)
 "aja" = (
 /obj/machinery/light_switch{
-	pixel_y = 25
+	pixel_y = 24;
+	name = "north light switch"
 	},
 /obj/structure/table,
 /obj/machinery/light{
@@ -4285,7 +4279,8 @@
 /obj/machinery/computer/library/public,
 /obj/structure/table,
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = 34;
+	name = "north newscaster"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -4369,8 +4364,7 @@
 	pixel_y = 6
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -4435,13 +4429,14 @@
 /obj/effect/decal/warning_stripes/east,
 /obj/item/clothing/glasses/welding,
 /obj/item/radio/intercom/department/security{
-	pixel_x = -28
+	pixel_x = -28;
+	name = "west station intercom (Security)"
 	},
 /turf/simulated/floor/plasteel,
 /area/security/podbay)
 "ajt" = (
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/engine,
 /area/security/podbay)
@@ -4460,8 +4455,7 @@
 /area/security/podbay)
 "ajv" = (
 /obj/machinery/light{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /obj/machinery/status_display{
 	layer = 4;
@@ -4752,8 +4746,7 @@
 /obj/item/clothing/head/helmet/space/vox/medic,
 /obj/item/clothing/mask/breath,
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
@@ -4766,8 +4759,7 @@
 /obj/item/harpoon,
 /obj/item/tank/internals/nitrogen,
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
@@ -4801,7 +4793,8 @@
 /obj/item/clothing/suit/jacket/pilot,
 /obj/item/clothing/head/beret/sec,
 /obj/machinery/light_switch{
-	pixel_x = -25
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /obj/item/spacepod_key{
 	id = 100000
@@ -4872,8 +4865,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = -30
+	pixel_y = -30;
+	name = "south extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -5159,7 +5152,8 @@
 	name = "Security Officer"
 	},
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -5188,7 +5182,7 @@
 /area/security/hos)
 "akK" = (
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /obj/structure/table/wood,
 /obj/machinery/photocopier/faxmachine/longrange{
@@ -5879,6 +5873,7 @@
 "alS" = (
 /obj/structure/closet,
 /obj/item/radio/intercom{
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/light/small{
@@ -6034,7 +6029,8 @@
 /obj/item/folder/red,
 /obj/item/pen,
 /obj/item/radio/intercom/department/security{
-	pixel_y = -28
+	pixel_y = -28;
+	name = "south station intercom (Security)"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
@@ -6542,7 +6538,8 @@
 "ani" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/machinery/light_switch{
-	pixel_x = -25
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
@@ -6558,7 +6555,8 @@
 "ank" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
@@ -6867,8 +6865,7 @@
 /area/security/customs2)
 "anK" = (
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
@@ -6902,7 +6899,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -6947,8 +6944,7 @@
 /area/security/main)
 "anW" = (
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
@@ -6991,12 +6987,11 @@
 	department = "Internal Affairs Office"
 	},
 /obj/item/radio/intercom{
-	dir = 8;
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult";
@@ -7016,7 +7011,7 @@
 "aoc" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /obj/machinery/light{
 	dir = 8
@@ -7163,7 +7158,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
-	pixel_x = -25
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -7708,7 +7704,7 @@
 /obj/structure/closet,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -7722,12 +7718,13 @@
 	},
 /obj/item/pen,
 /obj/item/radio/intercom{
-	dir = 8;
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/item/radio/intercom/department/security{
 	pixel_x = -28;
-	pixel_y = -10
+	pixel_y = -10;
+	name = "custom station intercom (Security)"
 	},
 /obj/item/stamp/warden{
 	pixel_x = -9;
@@ -7917,6 +7914,7 @@
 "apB" = (
 /obj/machinery/autolathe/security,
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -7961,8 +7959,7 @@
 /area/security/medbay)
 "apG" = (
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -7980,6 +7977,10 @@
 "apI" = (
 /obj/structure/closet/wardrobe/red,
 /obj/effect/decal/warning_stripes/red/hollow,
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	name = "west light switch"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "darkredfull"
@@ -8012,19 +8013,15 @@
 	},
 /area/security/evidence)
 "apL" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 5;
-	pixel_y = -24
-	},
-/obj/machinery/light_switch{
-	pixel_x = -9;
-	pixel_y = -25
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /obj/machinery/disposal,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24;
+	name = "south fire alarm"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "darkredfull"
@@ -8156,7 +8153,8 @@
 	},
 /obj/machinery/disposal,
 /obj/machinery/light_switch{
-	pixel_y = -25
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -8186,8 +8184,7 @@
 "apY" = (
 /obj/structure/bed,
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -8230,8 +8227,7 @@
 /area/shuttle/trade/sol)
 "aqg" = (
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/structure/closet{
 	icon_closed = "red";
@@ -8239,7 +8235,7 @@
 	name = "Sec. gear"
 	},
 /obj/effect/spawner/lootdrop/trade_sol/sec{
-	loot = list(/obj/item/clothing/gloves/combat = 50, /obj/item/grenade/clusterbuster/smoke = 50, /obj/item/clothing/suit/armor/laserproof = 50, /obj/item/clothing/suit/armor/vest/combat = 50, /obj/item/clothing/suit/armor/vest/combat = 50, /obj/item/clothing/suit/armor/vest/combat = 50, /obj/item/kitchen/knife/combat = 50, /obj/item/kitchen/knife/combat = 50, /obj/item/kitchen/knife/combat = 50, /obj/item/fluff/desolate_baton_kit = 50, /obj/item/storage/belt/military/assault = 50, /obj/item/storage/belt/military/assault = 50, /obj/item/storage/belt/military/assault = 50, /obj/item/clothing/mask/gas/sechailer/swat = 50, /obj/item/clothing/mask/gas/sechailer/swat = 50, /obj/item/clothing/suit/space/swat = 50, /obj/item/clothing/suit/space/swat = 50, /obj/item/clothing/glasses/thermal = 50, /obj/item/storage/box/enforcer_rubber = 50, /obj/item/storage/box/enforcer_rubber = 50, /obj/item/storage/box/enforcer_lethal = 50, /obj/item/melee/classic_baton/telescopic = 50, /obj/item/melee/classic_baton/telescopic = 50, /obj/item/gun/projectile/shotgun/automatic/combat = 50, /obj/item/gun/projectile/shotgun/automatic/combat = 50, /obj/item/gun/projectile/shotgun/automatic/combat = 50, /obj/item/gun/projectile/shotgun/automatic/dual_tube = 50, /obj/item/gun/projectile/shotgun/automatic/dual_tube = 50, /obj/item/storage/box/buck = 50, /obj/item/storage/box/buck = 50, /obj/item/storage/box/buck = 50, /obj/item/ammo_box/shotgun/buck = 50, /obj/item/ammo_box/shotgun/buck = 50, /obj/item/grenade/clusterbuster = 50, /obj/item/grenade/clusterbuster = 50, /obj/item/grenade/clusterbuster/teargas = 50, /obj/item/grenade/clusterbuster/n2o = 50);
+	loot = list(/obj/item/clothing/gloves/combat=50,/obj/item/grenade/clusterbuster/smoke=50,/obj/item/clothing/suit/armor/laserproof=50,/obj/item/clothing/suit/armor/vest/combat=50,/obj/item/clothing/suit/armor/vest/combat=50,/obj/item/clothing/suit/armor/vest/combat=50,/obj/item/kitchen/knife/combat=50,/obj/item/kitchen/knife/combat=50,/obj/item/kitchen/knife/combat=50,/obj/item/fluff/desolate_baton_kit=50,/obj/item/storage/belt/military/assault=50,/obj/item/storage/belt/military/assault=50,/obj/item/storage/belt/military/assault=50,/obj/item/clothing/mask/gas/sechailer/swat=50,/obj/item/clothing/mask/gas/sechailer/swat=50,/obj/item/clothing/suit/space/swat=50,/obj/item/clothing/suit/space/swat=50,/obj/item/clothing/glasses/thermal=50,/obj/item/storage/box/enforcer_rubber=50,/obj/item/storage/box/enforcer_rubber=50,/obj/item/storage/box/enforcer_lethal=50,/obj/item/melee/classic_baton/telescopic=50,/obj/item/melee/classic_baton/telescopic=50,/obj/item/gun/projectile/shotgun/automatic/combat=50,/obj/item/gun/projectile/shotgun/automatic/combat=50,/obj/item/gun/projectile/shotgun/automatic/combat=50,/obj/item/gun/projectile/shotgun/automatic/dual_tube=50,/obj/item/gun/projectile/shotgun/automatic/dual_tube=50,/obj/item/storage/box/buck=50,/obj/item/storage/box/buck=50,/obj/item/storage/box/buck=50,/obj/item/ammo_box/shotgun/buck=50,/obj/item/ammo_box/shotgun/buck=50,/obj/item/grenade/clusterbuster=50,/obj/item/grenade/clusterbuster=50,/obj/item/grenade/clusterbuster/teargas=50,/obj/item/grenade/clusterbuster/n2o=50);
 	lootcount = 10;
 	name = "1. Sec. gear"
 	},
@@ -8252,7 +8248,7 @@
 	name = "Donksoft gear"
 	},
 /obj/effect/spawner/lootdrop/trade_sol/donksoft{
-	loot = list(/obj/item/gun/projectile/automatic/c20r/toy = 50, /obj/item/gun/projectile/automatic/c20r/toy = 50, /obj/item/gun/projectile/automatic/c20r/toy = 50, /obj/item/gun/projectile/automatic/l6_saw/toy = 50, /obj/item/gun/projectile/automatic/l6_saw/toy = 50, /obj/item/gun/projectile/automatic/toy/pistol = 100, /obj/item/gun/projectile/automatic/toy/pistol = 100, /obj/item/gun/projectile/automatic/toy/pistol/enforcer = 50, /obj/item/gun/projectile/automatic/toy/pistol/enforcer = 50, /obj/item/gun/projectile/shotgun/toy = 50, /obj/item/gun/projectile/shotgun/toy = 50, /obj/item/gun/projectile/shotgun/toy/crossbow = 50, /obj/item/gun/projectile/shotgun/toy/crossbow = 50, /obj/item/gun/projectile/shotgun/toy/tommygun = 50, /obj/item/gun/projectile/shotgun/toy/tommygun = 50, /obj/item/gun/projectile/automatic/sniper_rifle/toy = 50, /obj/item/gun/projectile/automatic/sniper_rifle/toy = 50, /obj/item/ammo_box/foambox/sniper = 50, /obj/item/ammo_box/foambox = 50, /obj/item/ammo_box/foambox = 50, /obj/item/ammo_box/foambox = 50, /obj/item/ammo_box/foambox/riot = 50, /obj/item/ammo_box/foambox/riot = 50, /obj/item/ammo_box/foambox/sniper/riot = 50, /obj/item/twohanded/toy/chainsaw = 50, /obj/item/twohanded/dualsaber/toy = 50);
+	loot = list(/obj/item/gun/projectile/automatic/c20r/toy=50,/obj/item/gun/projectile/automatic/c20r/toy=50,/obj/item/gun/projectile/automatic/c20r/toy=50,/obj/item/gun/projectile/automatic/l6_saw/toy=50,/obj/item/gun/projectile/automatic/l6_saw/toy=50,/obj/item/gun/projectile/automatic/toy/pistol=100,/obj/item/gun/projectile/automatic/toy/pistol=100,/obj/item/gun/projectile/automatic/toy/pistol/enforcer=50,/obj/item/gun/projectile/automatic/toy/pistol/enforcer=50,/obj/item/gun/projectile/shotgun/toy=50,/obj/item/gun/projectile/shotgun/toy=50,/obj/item/gun/projectile/shotgun/toy/crossbow=50,/obj/item/gun/projectile/shotgun/toy/crossbow=50,/obj/item/gun/projectile/shotgun/toy/tommygun=50,/obj/item/gun/projectile/shotgun/toy/tommygun=50,/obj/item/gun/projectile/automatic/sniper_rifle/toy=50,/obj/item/gun/projectile/automatic/sniper_rifle/toy=50,/obj/item/ammo_box/foambox/sniper=50,/obj/item/ammo_box/foambox=50,/obj/item/ammo_box/foambox=50,/obj/item/ammo_box/foambox=50,/obj/item/ammo_box/foambox/riot=50,/obj/item/ammo_box/foambox/riot=50,/obj/item/ammo_box/foambox/sniper/riot=50,/obj/item/twohanded/toy/chainsaw=50,/obj/item/twohanded/dualsaber/toy=50);
 	lootcount = 8;
 	name = "2. Donksoft gear"
 	},
@@ -8265,8 +8261,7 @@
 /area/shuttle/trade/sol)
 "aqj" = (
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/item/flag/species/human,
 /turf/simulated/floor/plasteel{
@@ -8317,8 +8312,7 @@
 	dir = 8
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 8
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -8458,6 +8452,7 @@
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
 /obj/item/radio/intercom{
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -8604,8 +8599,7 @@
 	},
 /obj/item/pen,
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/security/permabrig)
@@ -8746,7 +8740,7 @@
 	name = "Science gear"
 	},
 /obj/effect/spawner/lootdrop/trade_sol/sci{
-	loot = list(/obj/item/mmi/robotic_brain = 50, /obj/item/assembly/signaler/anomaly = 50, /obj/item/mecha_parts/mecha_equipment/weapon/energy/xray = 50, /obj/item/mecha_parts/mecha_equipment/teleporter/precise = 50, /obj/item/autoimplanter/old = 50, /obj/item/paper/researchnotes = 50, /obj/item/paper/researchnotes = 50, /obj/item/slimepotion/fireproof = 50, /obj/item/slimepotion/speed = 50, /obj/item/slimepotion/enhancer = 50,/obj/item/slimepotion/slime/mutator = 50, /obj/item/slimepotion/transference = 50, /obj/item/slimepotion/slime/steroid = 50, /obj/item/slimepotion/slime/stabilizer = 50, /obj/item/slimepotion/slime/docility = 50, /obj/item/slime_extract/bluespace = 50, /obj/item/slime_extract/adamantine = 50, /obj/item/slime_extract/rainbow = 50, /obj/item/slime_extract/sepia = 50, /obj/item/assembly/signaler/anomaly/vortex = 50, /obj/item/assembly/signaler/anomaly/bluespace = 50, /obj/item/assembly/signaler/anomaly/flux = 50, /obj/item/assembly/signaler/anomaly/grav = 50, /obj/item/assembly/signaler/anomaly/pyro = 50);
+	loot = list(/obj/item/mmi/robotic_brain=50,/obj/item/assembly/signaler/anomaly=50,/obj/item/mecha_parts/mecha_equipment/weapon/energy/xray=50,/obj/item/mecha_parts/mecha_equipment/teleporter/precise=50,/obj/item/autoimplanter/old=50,/obj/item/paper/researchnotes=50,/obj/item/paper/researchnotes=50,/obj/item/slimepotion/fireproof=50,/obj/item/slimepotion/speed=50,/obj/item/slimepotion/enhancer=50,/obj/item/slimepotion/slime/mutator=50,/obj/item/slimepotion/transference=50,/obj/item/slimepotion/slime/steroid=50,/obj/item/slimepotion/slime/stabilizer=50,/obj/item/slimepotion/slime/docility=50,/obj/item/slime_extract/bluespace=50,/obj/item/slime_extract/adamantine=50,/obj/item/slime_extract/rainbow=50,/obj/item/slime_extract/sepia=50,/obj/item/assembly/signaler/anomaly/vortex=50,/obj/item/assembly/signaler/anomaly/bluespace=50,/obj/item/assembly/signaler/anomaly/flux=50,/obj/item/assembly/signaler/anomaly/grav=50,/obj/item/assembly/signaler/anomaly/pyro=50);
 	lootcount = 8;
 	name = "6. Science gear"
 	},
@@ -8754,7 +8748,7 @@
 /area/shuttle/trade/sol)
 "arh" = (
 /obj/effect/spawner/lootdrop/trade_sol/largeitem{
-	loot = list(/obj/machinery/floodlight = 50, /obj/machinery/disco = 50, /obj/mecha/combat/durand/old = 50, /obj/machinery/snow_machine = 50);
+	loot = list(/obj/machinery/floodlight=50,/obj/machinery/disco=50,/obj/mecha/combat/durand/old=50,/obj/machinery/snow_machine=50);
 	name = "3. Large item"
 	},
 /turf/simulated/floor/wood,
@@ -8901,7 +8895,7 @@
 	icon_state = "1-4"
 	},
 /obj/item/radio/intercom{
-	dir = 8;
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9065,8 +9059,8 @@
 	dir = 1
 	},
 /obj/machinery/light_switch{
-	pixel_x = 25;
-	pixel_y = -7
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -9476,7 +9470,8 @@
 "ass" = (
 /obj/machinery/computer/area_atmos/area,
 /obj/item/radio/intercom/department/security{
-	pixel_x = -28
+	pixel_x = -28;
+	name = "west station intercom (Security)"
 	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
@@ -9553,7 +9548,8 @@
 "asx" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
@@ -9573,6 +9569,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -9844,7 +9841,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -9902,11 +9899,13 @@
 /obj/structure/chair/office/dark,
 /obj/item/radio/intercom{
 	pixel_x = -28;
-	pixel_y = -28
+	pixel_y = -28;
+	name = "custom station intercom (General)"
 	},
 /obj/item/radio/intercom/department/security{
 	pixel_x = 28;
-	pixel_y = -28
+	pixel_y = -28;
+	name = "custom station intercom (Security)"
 	},
 /obj/machinery/door_control{
 	desc = "A remote control switch for the brig foyer.";
@@ -9986,7 +9985,8 @@
 "atc" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -10251,6 +10251,7 @@
 	},
 /obj/machinery/light,
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /obj/structure/cable{
@@ -10443,7 +10444,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -10453,7 +10454,8 @@
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -10607,8 +10609,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/light{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -11001,6 +11002,7 @@
 	req_access_txt = "2"
 	},
 /obj/item/radio/intercom{
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11047,7 +11049,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/item/radio/intercom{
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -11112,7 +11115,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light_switch{
-	pixel_x = -25
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -11140,7 +11144,8 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/department/security{
-	pixel_x = -28
+	pixel_x = -28;
+	name = "west station intercom (Security)"
 	},
 /turf/simulated/floor/plasteel,
 /area/security/processing)
@@ -11173,7 +11178,8 @@
 "auY" = (
 /obj/structure/table,
 /obj/machinery/light_switch{
-	pixel_y = -25
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /obj/item/hand_labeler,
 /obj/machinery/light/small,
@@ -11371,7 +11377,8 @@
 /area/security/permabrig)
 "avp" = (
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -12092,7 +12099,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /obj/machinery/camera{
 	c_tag = "Brig Prisoner Processing East";
@@ -12290,7 +12298,8 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = -5;
-	pixel_y = -25
+	pixel_y = -24;
+	name = "custom light switch"
 	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
@@ -12305,14 +12314,14 @@
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "awZ" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -12533,7 +12542,8 @@
 /area/security/processing)
 "axu" = (
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -31;
+	name = "south newscaster"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redcorner"
@@ -12612,7 +12622,8 @@
 "axB" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /obj/machinery/camera{
 	c_tag = "Brig Lobby East";
@@ -12818,6 +12829,7 @@
 /area/security/processing)
 "axQ" = (
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -12858,7 +12870,7 @@
 "axU" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /obj/machinery/light{
 	dir = 4
@@ -13092,7 +13104,8 @@
 /obj/item/storage/box/evidence,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
@@ -13118,7 +13131,8 @@
 	scrub_Toxins = 1
 	},
 /obj/item/radio/intercom{
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -13392,7 +13406,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	dir = 8;
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -13467,6 +13481,7 @@
 	req_access_txt = "2"
 	},
 /obj/item/radio/intercom{
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -13498,7 +13513,8 @@
 	req_access_txt = "2"
 	},
 /obj/item/radio/intercom{
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13528,7 +13544,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /obj/machinery/door_timer/cell_5{
 	dir = 4;
@@ -13542,6 +13559,7 @@
 /area/security/prison/cell_block/A)
 "ayX" = (
 /obj/item/radio/intercom{
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/structure/cable{
@@ -13622,8 +13640,7 @@
 /area/security/interrogation)
 "aze" = (
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -13634,8 +13651,7 @@
 /area/shuttle/syndicate_elite)
 "azf" = (
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/structure/window/reinforced,
 /obj/structure/chair/comfy/shuttle{
@@ -13828,7 +13844,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -14331,7 +14348,7 @@
 /obj/item/clothing/glasses/sunglasses/blindfold,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -14367,7 +14384,8 @@
 "aAB" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
@@ -14382,7 +14400,8 @@
 /area/security/interrogation)
 "aAC" = (
 /obj/machinery/light_switch{
-	pixel_y = -25
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -14418,11 +14437,13 @@
 	dir = 8
 	},
 /obj/machinery/light_switch{
-	pixel_x = -25
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult";
@@ -14460,7 +14481,7 @@
 /obj/item/pen,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /obj/item/paper_bin/nanotrasen,
 /turf/simulated/floor/plasteel{
@@ -14484,7 +14505,8 @@
 "aAL" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /obj/structure/chair/stool/bar,
 /turf/simulated/floor/wood,
@@ -14508,11 +14530,13 @@
 /obj/item/megaphone,
 /obj/item/radio/intercom/department/security{
 	pixel_x = 28;
-	pixel_y = -7
+	pixel_y = -7;
+	name = "custom station intercom (Security)"
 	},
 /obj/item/radio/intercom{
 	pixel_x = 28;
-	pixel_y = 5
+	pixel_y = 5;
+	name = "custom station intercom (General)"
 	},
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
@@ -14676,6 +14700,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -14684,8 +14709,7 @@
 /area/security/prison/cell_block/A)
 "aBb" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
@@ -14782,7 +14806,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -14938,8 +14962,7 @@
 "aBH" = (
 /obj/item/soap,
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -15131,7 +15154,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult";
@@ -15426,7 +15449,8 @@
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/light/small,
 /obj/machinery/light_switch{
-	pixel_x = -25
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -15529,8 +15553,7 @@
 /area/maintenance/bar)
 "aCT" = (
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -15573,8 +15596,7 @@
 /area/shuttle/syndicate_elite)
 "aCY" = (
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -15736,7 +15758,8 @@
 	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_x = 25
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /obj/machinery/camera{
 	c_tag = "Brig Cell Block A South";
@@ -15757,7 +15780,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -15894,14 +15917,15 @@
 "aDE" = (
 /obj/item/seeds/ambrosia,
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /obj/structure/toilet{
 	dir = 4
 	},
 /obj/machinery/newscaster{
-	pixel_x = 32
+	pixel_x = 32;
+	name = "east newscaster";
+	pixel_y = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -15919,6 +15943,7 @@
 /area/maintenance/fpmaint)
 "aDH" = (
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -16156,8 +16181,7 @@
 /area/hallway/primary/fore)
 "aEn" = (
 /obj/machinery/light{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /obj/machinery/door_control{
 	id = "brig_detprivacy";
@@ -16176,7 +16200,8 @@
 "aEo" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -16196,8 +16221,8 @@
 	network = list("SS13","Research Outpost","Mining Outpost")
 	},
 /obj/item/radio/intercom{
-	dir = 8;
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -16452,14 +16477,14 @@
 	pixel_y = -3
 	},
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Departure Lounge Supplies"
 	},
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -16555,7 +16580,8 @@
 "aEZ" = (
 /obj/machinery/light,
 /obj/machinery/light_switch{
-	pixel_y = -25
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
@@ -16666,12 +16692,14 @@
 /area/security/interrogation)
 "aFo" = (
 /obj/machinery/light_switch{
-	pixel_x = -25
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult";
@@ -16744,7 +16772,8 @@
 	dir = 4
 	},
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -31;
+	name = "south newscaster"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult";
@@ -16863,7 +16892,8 @@
 /obj/item/storage/fancy/cigarettes/dromedaryco,
 /obj/item/ashtray/bronze,
 /obj/item/radio/intercom/department/security{
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (Security)"
 	},
 /obj/item/reagent_containers/food/drinks/flask/detflask,
 /turf/simulated/floor/plasteel{
@@ -17412,7 +17442,7 @@
 /obj/machinery/dye_generator,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "barber"
@@ -17433,13 +17463,15 @@
 	c_tag = "Arcade"
 	},
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
 "aGQ" = (
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = 34;
+	name = "north newscaster"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
@@ -17551,8 +17583,7 @@
 "aHd" = (
 /obj/item/toy/crayon/white,
 /obj/machinery/light/small{
-	dir = 8;
-	tag = "icon-bulb1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -17696,6 +17727,7 @@
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /obj/item/radio/intercom{
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -17734,11 +17766,11 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -18038,7 +18070,8 @@
 /obj/structure/dresser,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -18060,7 +18093,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
@@ -18278,7 +18311,8 @@
 "aIO" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -18290,6 +18324,7 @@
 "aIP" = (
 /obj/structure/closet/secure_closet/clown,
 /obj/item/radio/intercom{
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/wood,
@@ -18326,7 +18361,8 @@
 "aIW" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/courtroom)
@@ -18459,7 +18495,8 @@
 /obj/item/storage/box/evidence,
 /obj/structure/table/wood,
 /obj/item/radio/intercom/department/security{
-	pixel_y = -28
+	pixel_y = -28;
+	name = "south station intercom (Security)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -18478,7 +18515,8 @@
 "aJl" = (
 /obj/machinery/vending/cigarette/free,
 /obj/machinery/light_switch{
-	pixel_y = -25
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -18498,7 +18536,7 @@
 "aJn" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -19047,7 +19085,9 @@
 /area/civilian/barber)
 "aKG" = (
 /obj/machinery/newscaster{
-	pixel_x = 30
+	pixel_x = 32;
+	name = "east newscaster";
+	pixel_y = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -19124,7 +19164,8 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
@@ -19543,7 +19584,8 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel,
@@ -19770,7 +19812,8 @@
 "aMh" = (
 /obj/machinery/vending/cola,
 /obj/item/radio/intercom{
-	pixel_y = 28
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -19819,8 +19862,8 @@
 /area/maintenance/fsmaint2)
 "aMp" = (
 /obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -19838,8 +19881,8 @@
 /area/hallway/secondary/entry)
 "aMt" = (
 /obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -19860,7 +19903,8 @@
 /area/maintenance/fpmaint)
 "aMw" = (
 /obj/item/radio/intercom{
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -19965,7 +20009,8 @@
 "aMJ" = (
 /obj/machinery/vending/snack,
 /obj/machinery/light_switch{
-	pixel_x = 25
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
@@ -20101,8 +20146,8 @@
 /area/crew_quarters/courtroom)
 "aNc" = (
 /obj/item/radio/intercom{
-	dir = 8;
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -20177,7 +20222,8 @@
 	icon_state = "1-8"
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_x = 27;
+	name = "east extinguisher cabinet"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -20393,7 +20439,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /obj/machinery/camera{
 	c_tag = "Fore Primary Hallway South";
@@ -20551,7 +20597,8 @@
 "aNX" = (
 /obj/machinery/disposal,
 /obj/machinery/light_switch{
-	pixel_x = -23
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -20862,7 +20909,8 @@
 /obj/item/storage/toolbox/electrical,
 /obj/item/multitool,
 /obj/item/radio/intercom{
-	pixel_x = 25
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -21022,7 +21070,8 @@
 /area/hallway/secondary/exit)
 "aPd" = (
 /obj/machinery/light_switch{
-	pixel_y = 27
+	pixel_y = 24;
+	name = "north light switch"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -21142,7 +21191,7 @@
 "aPx" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/courtroom)
@@ -21195,6 +21244,7 @@
 /area/crew_quarters/courtroom)
 "aPE" = (
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/light,
@@ -21216,7 +21266,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "blue"
@@ -21347,7 +21397,7 @@
 /area/maintenance/electrical)
 "aPT" = (
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -21499,7 +21549,8 @@
 /area/crew_quarters/dorms)
 "aQn" = (
 /obj/item/radio/intercom{
-	pixel_y = 28
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21553,8 +21604,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/light{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /obj/structure/table,
 /obj/item/stack/tape_roll,
@@ -21664,8 +21714,7 @@
 "aQA" = (
 /obj/machinery/vending/snack,
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21719,18 +21768,18 @@
 /area/hallway/primary/fore)
 "aQE" = (
 /obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_y = 28
+	name = "North Emergency NanoMed";
+	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "aQG" = (
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = 34;
+	name = "north newscaster"
 	},
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -21839,7 +21888,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /obj/machinery/light{
 	dir = 4
@@ -21901,7 +21950,8 @@
 /area/crew_quarters/sleep)
 "aRa" = (
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -21963,7 +22013,8 @@
 /area/hallway/secondary/entry)
 "aRf" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_x = 27;
+	name = "east extinguisher cabinet"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -22042,7 +22093,7 @@
 "aRn" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -22293,13 +22344,15 @@
 /obj/structure/table,
 /obj/item/storage/box/cups,
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/courtroom)
 "aRN" = (
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -22408,7 +22461,8 @@
 /area/hallway/primary/fore)
 "aSc" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_x = 27;
+	name = "east extinguisher cabinet"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -22816,6 +22870,7 @@
 /area/hallway/secondary/entry)
 "aSZ" = (
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -22824,7 +22879,8 @@
 /area/crew_quarters/dorms)
 "aTa" = (
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
@@ -22847,7 +22903,8 @@
 /obj/machinery/light,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -22922,7 +22979,8 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/light_switch{
-	pixel_y = -25
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
@@ -23239,8 +23297,8 @@
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
+	pixel_y = 30;
+	name = "north extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -23260,7 +23318,8 @@
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/britcup,
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = 34;
+	name = "north newscaster"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull";
@@ -23272,7 +23331,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/department/medbay{
-	pixel_y = 25
+	pixel_y = 28
 	},
 /obj/structure/chair/comfy/teal{
 	dir = 4
@@ -23305,7 +23364,7 @@
 	dir = 8
 	},
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull";
@@ -23458,8 +23517,8 @@
 	})
 "aUs" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
+	pixel_y = 30;
+	name = "north extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/construction{
@@ -23633,15 +23692,14 @@
 /area/crew_quarters/dorms)
 "aUN" = (
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
 "aUO" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Lobby West"
@@ -23657,8 +23715,7 @@
 	dir = 4
 	},
 /obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = -5;
+	name = "North Emergency NanoMed";
 	pixel_y = 30
 	},
 /obj/structure/table,
@@ -23827,7 +23884,7 @@
 	dir = 1
 	},
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -23952,8 +24009,7 @@
 "aVx" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -24210,9 +24266,8 @@
 "aVU" = (
 /obj/machinery/light,
 /obj/machinery/light_switch{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
@@ -24294,7 +24349,8 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -24358,7 +24414,8 @@
 "aWi" = (
 /obj/structure/table,
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /obj/item/wirecutters,
 /obj/item/flashlight{
@@ -24410,7 +24467,7 @@
 "aWn" = (
 /obj/structure/table,
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /obj/item/t_scanner,
 /turf/simulated/floor/plasteel,
@@ -24418,7 +24475,8 @@
 "aWo" = (
 /obj/structure/table,
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /obj/item/assembly/signaler,
 /obj/item/assembly/signaler,
@@ -24443,7 +24501,8 @@
 "aWq" = (
 /obj/structure/table,
 /obj/machinery/light_switch{
-	pixel_y = 28
+	pixel_y = 24;
+	name = "north light switch"
 	},
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
@@ -24651,15 +24710,14 @@
 /obj/item/stack/packageWrap,
 /obj/item/reagent_scanner/adv,
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Chemistry North"
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
+	pixel_y = 30;
+	name = "north extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -24841,7 +24899,8 @@
 "aXg" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -24881,7 +24940,7 @@
 /area/chapel/office)
 "aXk" = (
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult";
@@ -25023,7 +25082,8 @@
 /area/security/checkpoint/south)
 "aXE" = (
 /obj/item/radio/intercom/department/security{
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (Security)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -25136,6 +25196,7 @@
 	pixel_y = -2
 	},
 /obj/item/radio/intercom{
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/item/storage/belt/champion,
@@ -25320,7 +25381,8 @@
 /obj/item/scalpel,
 /obj/item/autopsy_scanner,
 /obj/machinery/light_switch{
-	pixel_x = -23
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /obj/machinery/status_display{
 	layer = 4;
@@ -25354,8 +25416,7 @@
 	c_tag = "Medbay Coroner"
 	},
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /obj/structure/closet/wardrobe/coroner,
 /obj/item/reagent_containers/dropper,
@@ -25384,7 +25445,8 @@
 /area/medical/morgue)
 "aYr" = (
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
@@ -25394,7 +25456,8 @@
 "aYs" = (
 /obj/machinery/cryopod/right,
 /obj/machinery/light_switch{
-	pixel_y = -25
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -25576,7 +25639,7 @@
 /area/crew_quarters/sleep)
 "aYJ" = (
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/carpet,
@@ -25601,8 +25664,7 @@
 /area/maintenance/fsmaint2)
 "aYL" = (
 /obj/machinery/light{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -25727,7 +25789,8 @@
 "aZb" = (
 /obj/item/radio,
 /obj/item/radio/intercom/department/security{
-	pixel_y = -28
+	pixel_y = -28;
+	name = "south station intercom (Security)"
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -25888,7 +25951,8 @@
 	known_by = list("captain")
 	},
 /obj/machinery/light_switch{
-	pixel_y = -23
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /obj/item/clothing/head/bearpelt,
 /obj/item/folder/documents,
@@ -26061,7 +26125,8 @@
 "aZO" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/sign/bobross{
@@ -26143,7 +26208,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -26161,7 +26226,7 @@
 "bab" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /obj/machinery/camera{
 	c_tag = "Garden";
@@ -26369,7 +26434,8 @@
 /area/library)
 "bav" = (
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /obj/structure/table/wood,
 /obj/item/dice/d20,
@@ -26495,8 +26561,8 @@
 	pixel_y = -3
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
+	pixel_y = 30;
+	name = "north extinguisher cabinet"
 	},
 /obj/effect/decal/warning_stripes/east,
 /obj/effect/decal/cleanable/dirt,
@@ -26590,7 +26656,7 @@
 /area/escapepodbay)
 "baQ" = (
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/engine,
 /area/escapepodbay)
@@ -27182,8 +27248,7 @@
 /area/maintenance/fsmaint2)
 "bbZ" = (
 /obj/machinery/light{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -27347,7 +27412,8 @@
 /obj/structure/closet/secure_closet/chaplain,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /obj/machinery/status_display{
 	layer = 4;
@@ -27394,8 +27460,7 @@
 /obj/item/pen,
 /obj/item/reagent_containers/food/drinks/bottle/holywater,
 /obj/machinery/light{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /turf/simulated/floor/carpet/black,
 /area/chapel/office)
@@ -27418,7 +27483,7 @@
 /area/maintenance/fpmaint)
 "bcw" = (
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel Chaplain's Office"
@@ -27466,7 +27531,8 @@
 	},
 /obj/item/storage/fancy/crayons,
 /obj/machinery/light_switch{
-	pixel_y = 25
+	pixel_y = 24;
+	name = "north light switch"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -27474,8 +27540,8 @@
 /area/chapel/office)
 "bcC" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
+	pixel_y = 30;
+	name = "north extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -27551,8 +27617,8 @@
 /area/shuttle/escape)
 "bcM" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
+	pixel_y = 30;
+	name = "north extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -27565,7 +27631,8 @@
 /area/shuttle/arrival/station)
 "bcO" = (
 /obj/item/radio/intercom{
-	pixel_y = 28
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	name = "standard air scrubber";
@@ -27589,12 +27656,12 @@
 /obj/item/storage/bag/plants/portaseeder,
 /obj/item/plant_analyzer,
 /obj/machinery/light_switch{
-	name = "light switch ";
-	pixel_x = -6;
-	pixel_y = -25
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /obj/item/radio/intercom{
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -27657,7 +27724,7 @@
 "bcW" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -27813,7 +27880,8 @@
 "bdn" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -27827,7 +27895,7 @@
 /obj/item/flashlight/lamp/bananalamp,
 /obj/item/reagent_containers/food/snacks/pie,
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/wood,
 /area/clownoffice)
@@ -27976,8 +28044,7 @@
 /area/hallway/primary/central/north)
 "bdE" = (
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /obj/structure/rack,
 /obj/item/tank/internals/emergency_oxygen,
@@ -28031,7 +28098,8 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /obj/structure/closet/chefcloset,
 /turf/simulated/floor/plasteel{
@@ -28161,7 +28229,7 @@
 /area/crew_quarters/dorms)
 "bdV" = (
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /obj/machinery/camera{
 	c_tag = "Hydroponics Storage"
@@ -28369,7 +28437,9 @@
 /area/library)
 "bep" = (
 /obj/machinery/newscaster{
-	pixel_x = 30
+	pixel_x = 32;
+	name = "east newscaster";
+	pixel_y = 1
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -28391,6 +28461,7 @@
 /area/chapel/office)
 "bes" = (
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/shuttle/floor,
@@ -28474,7 +28545,8 @@
 	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_x = 25
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
@@ -28506,7 +28578,8 @@
 /area/crew_quarters/bar)
 "beI" = (
 /obj/item/radio/intercom{
-	pixel_y = -30
+	name = "south station intercom (General)";
+	pixel_y = -28
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
@@ -28683,7 +28756,8 @@
 	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_y = -25
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28785,6 +28859,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/camera{
@@ -28807,7 +28882,8 @@
 	},
 /obj/machinery/light,
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -31;
+	name = "south newscaster"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28989,7 +29065,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -29022,7 +29098,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -29060,7 +29137,8 @@
 /area/crew_quarters/kitchen)
 "bfD" = (
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/structure/cable{
@@ -29103,7 +29181,8 @@
 /area/mimeoffice)
 "bfJ" = (
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /obj/machinery/hydroponics/soil,
 /turf/simulated/floor/grass,
@@ -29144,7 +29223,8 @@
 /area/hydroponics)
 "bfM" = (
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = 34;
+	name = "north newscaster"
 	},
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -29279,7 +29359,8 @@
 "bgc" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /turf/simulated/floor/engine,
 /area/escapepodbay)
@@ -29434,8 +29515,8 @@
 /area/hallway/secondary/entry)
 "bgw" = (
 /obj/item/radio/intercom{
-	dir = 1;
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -29517,6 +29598,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/effect/decal/warning_stripes/west,
@@ -29535,7 +29617,8 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
@@ -29582,7 +29665,8 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -29660,7 +29744,8 @@
 /area/hallway/primary/central/north)
 "bgV" = (
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
@@ -29771,12 +29856,14 @@
 "bhj" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -31;
+	name = "south newscaster"
 	},
 /obj/item/clothing/under/soldieruniform,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /turf/simulated/floor/wood,
 /area/clownoffice)
@@ -29814,9 +29901,8 @@
 /area/space/nearstation)
 "bho" = (
 /obj/machinery/light_switch{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -29853,7 +29939,8 @@
 "bhs" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /obj/machinery/camera{
 	c_tag = "Dormitories Toilets";
@@ -29939,7 +30026,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -30216,7 +30303,8 @@
 "bia" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -30272,7 +30360,7 @@
 "bih" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /obj/machinery/light{
 	dir = 8
@@ -30417,7 +30505,8 @@
 /area/hallway/secondary/entry)
 "biw" = (
 /obj/machinery/newscaster{
-	pixel_y = -30
+	pixel_y = -31;
+	name = "south newscaster"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -30594,8 +30683,7 @@
 	},
 /obj/effect/decal/warning_stripes/white/hollow,
 /obj/machinery/light{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -30613,7 +30701,8 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_x = 27;
+	name = "east extinguisher cabinet"
 	},
 /obj/effect/decal/warning_stripes/white/hollow,
 /obj/item/storage/toolbox/mechanical{
@@ -30749,7 +30838,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -30774,7 +30864,8 @@
 	pixel_y = 2
 	},
 /obj/machinery/light_switch{
-	pixel_x = -25
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -30803,7 +30894,7 @@
 /area/turret_protected/aisat_interior)
 "bjc" = (
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /obj/structure/closet/secure_closet/bar{
 	req_access_txt = "25"
@@ -30862,7 +30953,8 @@
 	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -30988,8 +31080,7 @@
 /area/clownoffice)
 "bjA" = (
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /obj/machinery/status_display{
 	layer = 4;
@@ -31037,7 +31128,8 @@
 "bjI" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light_switch{
-	pixel_y = 25
+	pixel_y = 24;
+	name = "north light switch"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -31130,15 +31222,16 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -24
+	pixel_x = -27;
+	name = "west extinguisher cabinet"
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "bjV" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = -31
+	pixel_y = -30;
+	name = "south extinguisher cabinet"
 	},
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
@@ -31179,8 +31272,8 @@
 /area/maintenance/fsmaint2)
 "bjY" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = -32
+	pixel_y = -30;
+	name = "south extinguisher cabinet"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31209,6 +31302,7 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /obj/structure/disposalpipe/segment{
@@ -31236,7 +31330,8 @@
 "bke" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31306,6 +31401,7 @@
 /area/hallway/primary/port)
 "bkm" = (
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /obj/structure/disposalpipe/segment{
@@ -31607,7 +31703,8 @@
 "bkY" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /turf/simulated/floor/grass,
 /area/hydroponics)
@@ -31656,7 +31753,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -31734,7 +31832,8 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -31795,6 +31894,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -31828,7 +31928,7 @@
 	dir = 1
 	},
 /obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
+	name = "Custom Emergency NanoMed";
 	pixel_x = 26
 	},
 /turf/simulated/floor/plasteel{
@@ -32194,7 +32294,8 @@
 "bmk" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -32260,7 +32361,8 @@
 /area/hallway/primary/port)
 "bmt" = (
 /obj/machinery/light_switch{
-	pixel_y = 25
+	pixel_y = 24;
+	name = "north light switch"
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -32425,7 +32527,8 @@
 "bmF" = (
 /obj/structure/cult/archives,
 /obj/machinery/light_switch{
-	pixel_y = -25
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult";
@@ -32471,7 +32574,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -32618,7 +32721,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	dir = 8;
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/shuttle/floor4,
@@ -32706,6 +32809,7 @@
 /area/hallway/primary/central/north)
 "bng" = (
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/hologram/holopad,
@@ -32798,7 +32902,8 @@
 /area/crew_quarters/bar)
 "bnm" = (
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = 34;
+	name = "north newscaster"
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/wood,
@@ -32851,7 +32956,8 @@
 /area/maintenance/port)
 "bnr" = (
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
@@ -32887,7 +32993,7 @@
 /area/hallway/primary/central/ne)
 "bnu" = (
 /obj/machinery/atm{
-	pixel_x = 24
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -32910,7 +33016,8 @@
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
 /obj/machinery/light_switch{
-	pixel_y = 28
+	pixel_y = 24;
+	name = "north light switch"
 	},
 /turf/simulated/floor/plating,
 /area/storage/emergency2)
@@ -32933,7 +33040,8 @@
 /area/storage/emergency2)
 "bnA" = (
 /obj/machinery/light_switch{
-	pixel_y = 28
+	pixel_y = 24;
+	name = "north light switch"
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
@@ -33113,7 +33221,7 @@
 /area/bridge)
 "bob" = (
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -33235,7 +33343,8 @@
 	c_tag = "Kitchen"
 	},
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /obj/machinery/kitchen_machine/candy_maker,
 /turf/simulated/floor/plasteel{
@@ -33291,7 +33400,8 @@
 /obj/effect/decal/warning_stripes/white/hollow,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -33299,7 +33409,8 @@
 /area/ai_monitored/storage/eva)
 "bos" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_x = 27;
+	name = "east extinguisher cabinet"
 	},
 /obj/machinery/kitchen_machine/oven,
 /turf/simulated/floor/plasteel{
@@ -33318,7 +33429,8 @@
 /area/crew_quarters/bar)
 "bov" = (
 /obj/machinery/newscaster{
-	pixel_x = 27;
+	pixel_x = 32;
+	name = "east newscaster";
 	pixel_y = 1
 	},
 /obj/machinery/hydroponics/constructable,
@@ -33485,7 +33597,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -33573,6 +33686,7 @@
 "bpa" = (
 /obj/structure/closet/wardrobe/mixed,
 /obj/item/radio/intercom{
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel,
@@ -33580,7 +33694,7 @@
 "bpb" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /obj/structure/table,
 /obj/item/storage/box/lights/mixed,
@@ -33590,7 +33704,8 @@
 "bpc" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33644,7 +33759,7 @@
 "bpj" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33664,7 +33779,8 @@
 "bpl" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -33856,7 +33972,7 @@
 "bpF" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bluecorner"
@@ -34060,7 +34176,8 @@
 	})
 "bqc" = (
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = 34;
+	name = "north newscaster"
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -34071,7 +34188,8 @@
 	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -34127,7 +34245,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atm{
-	pixel_x = 24
+	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -34241,7 +34359,7 @@
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /obj/machinery/camera{
 	c_tag = "Locker Room East";
@@ -34301,7 +34419,8 @@
 /area/civilian/pet_store)
 "bqG" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -24
+	pixel_x = -27;
+	name = "west extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel,
 /area/storage/tools)
@@ -34365,7 +34484,7 @@
 "bqP" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -34493,7 +34612,7 @@
 "brf" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /obj/machinery/camera{
 	c_tag = "Bar West";
@@ -34515,7 +34634,8 @@
 	specialfunctions = 4
 	},
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = 34;
+	name = "north newscaster"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -34632,7 +34752,8 @@
 "brt" = (
 /obj/machinery/hydroponics/constructable,
 /obj/item/radio/intercom{
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
@@ -34686,7 +34807,8 @@
 /area/library)
 "brB" = (
 /obj/item/radio/intercom{
-	pixel_x = 25
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /obj/machinery/libraryscanner,
 /turf/simulated/floor/wood,
@@ -34708,7 +34830,7 @@
 "brE" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /turf/simulated/floor/carpet,
 /area/civilian/pet_store)
@@ -34943,7 +35065,8 @@
 /obj/machinery/fishtank/bowl,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /turf/simulated/floor/wood,
 /area/civilian/pet_store)
@@ -34972,7 +35095,7 @@
 "bsm" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel,
 /area/storage/tools)
@@ -35188,7 +35311,8 @@
 /area/hallway/primary/central/ne)
 "bsM" = (
 /obj/machinery/light_switch{
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
@@ -35220,7 +35344,8 @@
 /area/hallway/secondary/exit)
 "bsQ" = (
 /obj/item/radio/intercom{
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -35291,7 +35416,8 @@
 /area/crew_quarters/kitchen)
 "bsW" = (
 /obj/machinery/light_switch{
-	pixel_y = 28
+	pixel_y = 24;
+	name = "north light switch"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -35302,7 +35428,8 @@
 /obj/machinery/processor,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -35312,7 +35439,7 @@
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
@@ -35375,10 +35502,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "btg" = (
-/obj/item/radio/intercom/department/security{
-	pixel_x = -29;
-	pixel_y = 3
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -35453,13 +35576,11 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = -30
+	name = "west station intercom (General)";
+	pixel_x = -28
 	},
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (NORTH)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -35474,8 +35595,7 @@
 /area/shuttle/escape)
 "btv" = (
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -35512,8 +35632,7 @@
 /area/shuttle/transport)
 "btz" = (
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -35700,7 +35819,8 @@
 /area/library)
 "btX" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -30
+	pixel_y = -30;
+	name = "south extinguisher cabinet"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
@@ -35950,8 +36070,8 @@
 /area/chapel/main)
 "buC" = (
 /obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
@@ -36043,7 +36163,8 @@
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
@@ -36131,7 +36252,7 @@
 "buU" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -36186,7 +36307,8 @@
 "bvb" = (
 /obj/structure/chair/comfy/black,
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = 34;
+	name = "north newscaster"
 	},
 /turf/simulated/floor/carpet,
 /area/civilian/vacantoffice)
@@ -36306,8 +36428,9 @@
 	pixel_y = -2
 	},
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+	dir = 4;
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /turf/simulated/floor/carpet,
 /area/civilian/vacantoffice)
@@ -36582,6 +36705,7 @@
 /area/crew_quarters/locker)
 "bvU" = (
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -36597,7 +36721,8 @@
 /obj/item/pen,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -36688,6 +36813,10 @@
 /area/crew_quarters/locker)
 "bwc" = (
 /obj/structure/closet/emcloset,
+/obj/machinery/light_switch{
+	pixel_y = -24;
+	name = "south light switch"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "blue"
@@ -36784,7 +36913,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria";
@@ -36866,6 +36995,7 @@
 /area/storage/tools)
 "bwA" = (
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /obj/structure/rack{
@@ -36914,8 +37044,7 @@
 /area/shuttle/transport)
 "bwF" = (
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/sign/nosmoking_2{
@@ -37281,12 +37410,8 @@
 /area/turret_protected/ai_upload)
 "bxr" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = -32
-	},
-/obj/machinery/light_switch{
-	pixel_x = -5;
-	pixel_y = -25
+	pixel_y = -30;
+	name = "south extinguisher cabinet"
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -37311,7 +37436,8 @@
 	c_tag = "AI Upload Chamber"
 	},
 /obj/machinery/light_switch{
-	pixel_y = 27
+	pixel_y = 24;
+	name = "north light switch"
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_upload)
@@ -37421,7 +37547,8 @@
 /area/crew_quarters/bar)
 "bxF" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -30
+	pixel_y = -30;
+	name = "south extinguisher cabinet"
 	},
 /obj/machinery/vending/dinnerware,
 /turf/simulated/floor/plasteel{
@@ -37535,7 +37662,8 @@
 	},
 /obj/item/reagent_containers/glass/bucket,
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -37624,13 +37752,14 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /turf/simulated/floor/wood,
 /area/library)
 "bxY" = (
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -31;
+	name = "south newscaster"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -37750,6 +37879,7 @@
 /area/civilian/vacantoffice)
 "byh" = (
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /obj/structure/chair/office/dark{
@@ -37781,6 +37911,7 @@
 	},
 /obj/machinery/light/small,
 /obj/machinery/vending/wallmed{
+	name = "South Emergency NanoMed";
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
@@ -37917,7 +38048,8 @@
 "byv" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -38030,7 +38162,8 @@
 /area/bridge/meeting_room)
 "byI" = (
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = 34;
+	name = "north newscaster"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -38061,7 +38194,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
-	pixel_y = 27
+	pixel_y = 24;
+	name = "north light switch"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -38152,7 +38286,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
-	pixel_y = 27
+	pixel_y = 24;
+	name = "north light switch"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
@@ -38222,7 +38357,8 @@
 "byZ" = (
 /obj/machinery/light,
 /obj/machinery/light_switch{
-	pixel_y = -25
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -38291,7 +38427,8 @@
 /area/hallway/primary/starboard/west)
 "bzi" = (
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -38322,7 +38459,8 @@
 /area/hydroponics)
 "bzl" = (
 /obj/machinery/newscaster{
-	pixel_y = -30
+	pixel_y = -31;
+	name = "south newscaster"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -38374,6 +38512,7 @@
 /area/shuttle/escape)
 "bzr" = (
 /obj/item/radio/intercom{
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel,
@@ -38560,7 +38699,8 @@
 /obj/item/storage/box,
 /obj/item/storage/box,
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -38808,13 +38948,15 @@
 /area/hallway/primary/starboard/west)
 "bAp" = (
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/west)
 "bAq" = (
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/west)
@@ -39016,8 +39158,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -39169,6 +39310,7 @@
 /area/quartermaster/storage)
 "bBk" = (
 /obj/item/radio/intercom{
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/structure/cable{
@@ -39294,7 +39436,7 @@
 "bBy" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /obj/machinery/porta_turret{
 	dir = 4
@@ -39412,7 +39554,8 @@
 /area/medical/reception)
 "bBN" = (
 /obj/machinery/light_switch{
-	pixel_y = 28
+	pixel_y = 24;
+	name = "north light switch"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -39636,7 +39779,7 @@
 "bCv" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -39709,7 +39852,8 @@
 /area/crew_quarters/captain)
 "bCB" = (
 /obj/item/radio/intercom{
-	pixel_y = -30
+	name = "south station intercom (General)";
+	pixel_y = -28
 	},
 /obj/machinery/light/small,
 /obj/structure/chair/wood/wings{
@@ -39741,7 +39885,7 @@
 "bCF" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -39832,7 +39976,8 @@
 "bCO" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /obj/machinery/camera{
 	c_tag = "Library South";
@@ -39896,7 +40041,7 @@
 	pixel_y = 6
 	},
 /obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
+	name = "West Emergency NanoMed";
 	pixel_x = -25
 	},
 /obj/item/roller,
@@ -39914,7 +40059,7 @@
 "bCY" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -39923,7 +40068,8 @@
 /area/hallway/primary/central/se)
 "bCZ" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -30
+	pixel_y = -30;
+	name = "south extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/west)
@@ -40052,8 +40198,8 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /obj/machinery/chem_dispenser,
 /turf/simulated/floor/plasteel,
@@ -40125,7 +40271,8 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_x = 27;
+	name = "east extinguisher cabinet"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -40202,8 +40349,7 @@
 /area/toxins/xenobiology)
 "bDG" = (
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/machinery/computer/camera_advanced/shuttle_docker/ert,
 /turf/simulated/shuttle/floor{
@@ -40494,7 +40640,7 @@
 "bEm" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -40840,7 +40986,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -40897,14 +41044,14 @@
 /area/quartermaster/storage)
 "bFr" = (
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
 "bFs" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
+	pixel_y = 30;
+	name = "north extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
@@ -40932,7 +41079,8 @@
 /area/hallway/primary/starboard/east)
 "bFv" = (
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
@@ -40960,7 +41108,8 @@
 /area/quartermaster/office)
 "bFz" = (
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
@@ -41033,7 +41182,7 @@
 "bFI" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /obj/item/flag/nt,
 /turf/simulated/floor/wood,
@@ -41097,8 +41246,7 @@
 /area/hallway/secondary/entry)
 "bFN" = (
 /obj/machinery/light{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -41178,7 +41326,8 @@
 "bFW" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
@@ -41434,7 +41583,7 @@
 "bGu" = (
 /obj/machinery/computer/rdconsole/robotics,
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -41496,7 +41645,8 @@
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /obj/machinery/chem_heater,
 /turf/simulated/floor/plasteel,
@@ -42061,7 +42211,8 @@
 "bHJ" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -42079,7 +42230,7 @@
 "bHL" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -42104,7 +42255,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /turf/simulated/floor/bluegrid,
 /area/assembly/chargebay)
@@ -42253,8 +42405,7 @@
 	c_tag = "Engineering Equipment North"
 	},
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
@@ -42310,7 +42461,8 @@
 /area/maintenance/port)
 "bIf" = (
 /obj/machinery/light_switch{
-	pixel_x = -23
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
@@ -42514,7 +42666,8 @@
 /area/shuttle/escape)
 "bIy" = (
 /obj/item/radio/intercom{
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -42567,7 +42720,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /obj/machinery/telepad_cargo,
 /turf/simulated/floor/plasteel{
@@ -42604,7 +42758,8 @@
 /obj/machinery/light,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -42732,7 +42887,8 @@
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -42741,7 +42897,7 @@
 	dir = 1
 	},
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -42886,6 +43042,7 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel,
@@ -42904,7 +43061,8 @@
 /area/hallway/secondary/exit)
 "bJs" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_x = 27;
+	name = "east extinguisher cabinet"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -43017,7 +43175,8 @@
 	dir = 8
 	},
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = 34;
+	name = "north newscaster"
 	},
 /obj/effect/landmark/start{
 	name = "Civilian"
@@ -43088,7 +43247,7 @@
 "bJE" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -43186,6 +43345,7 @@
 	req_access_txt = "20"
 	},
 /obj/item/radio/intercom{
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/item/paper_bin/nanotrasen,
@@ -43213,7 +43373,8 @@
 /obj/machinery/light,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -43235,7 +43396,7 @@
 	dir = 8
 	},
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -43362,7 +43523,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -43473,7 +43635,7 @@
 "bKo" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /obj/machinery/r_n_d/destructive_analyzer,
 /obj/effect/decal/warning_stripes/northwest,
@@ -43488,7 +43650,7 @@
 "bKq" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -43628,7 +43790,7 @@
 "bKJ" = (
 /obj/machinery/light,
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /obj/item/twohanded/required/kirbyplants,
@@ -43642,7 +43804,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -44109,8 +44272,8 @@
 /area/medical/reception)
 "bLC" = (
 /obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -44223,7 +44386,7 @@
 /obj/machinery/reagentgrinder,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -44245,11 +44408,11 @@
 	},
 /obj/item/storage/firstaid/brute,
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull";
@@ -44328,10 +44491,12 @@
 /obj/item/storage/firstaid/o2,
 /obj/structure/table,
 /obj/machinery/light_switch{
-	pixel_x = -23
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull";
@@ -44499,7 +44664,8 @@
 "bMn" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
@@ -44531,7 +44697,8 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	pixel_y = 27
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/segment{
@@ -44657,8 +44824,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -44685,7 +44851,7 @@
 "bMK" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -44886,7 +45052,7 @@
 	},
 /obj/item/storage/firstaid/regular,
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Medicine Storage"
@@ -44975,7 +45141,8 @@
 /area/assembly/robotics)
 "bNg" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+	pixel_x = -27;
+	name = "west extinguisher cabinet"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -45007,7 +45174,8 @@
 "bNj" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /obj/structure/rack{
 	dir = 8;
@@ -45159,8 +45327,9 @@
 	dir = 4
 	},
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+	dir = 4;
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -45226,7 +45395,7 @@
 /obj/machinery/light,
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -45248,7 +45417,8 @@
 /area/medical/reception)
 "bNz" = (
 /obj/item/radio/intercom{
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -45260,13 +45430,15 @@
 /obj/effect/decal/warning_stripes/northeast,
 /obj/item/radio/intercom{
 	pixel_x = -28;
-	pixel_y = 22
+	pixel_y = 22;
+	name = "custom station intercom (General)"
 	},
 /turf/simulated/floor/plasteel,
 /area/medical/chemistry)
 "bNB" = (
 /obj/machinery/light_switch{
-	pixel_x = 30
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /obj/machinery/camera{
 	c_tag = "Disposals";
@@ -45300,7 +45472,8 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /obj/machinery/chem_heater,
 /turf/simulated/floor/plasteel,
@@ -45399,7 +45572,8 @@
 /area/medical/biostorage)
 "bNM" = (
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -45418,7 +45592,8 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high/plus,
 /obj/item/radio/intercom{
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -45498,8 +45673,8 @@
 /area/quartermaster/office)
 "bNW" = (
 /obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_y = -32
+	name = "South Emergency NanoMed";
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -45580,8 +45755,7 @@
 /area/shuttle/supply)
 "bOf" = (
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/supply)
@@ -45718,7 +45892,7 @@
 /area/quartermaster/office)
 "bOq" = (
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/door/window{
@@ -45752,7 +45926,8 @@
 "bOs" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -45762,7 +45937,8 @@
 "bOt" = (
 /obj/machinery/computer/supplycomp/public,
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
@@ -45830,7 +46006,7 @@
 "bOz" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
-	pixel_y = 1
+	name = "west extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
@@ -45857,7 +46033,8 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = -4;
-	pixel_y = 36
+	pixel_y = 36;
+	name = "custom light switch"
 	},
 /obj/machinery/door_control/ticket_machine_button{
 	pixel_x = -22;
@@ -46067,7 +46244,8 @@
 /obj/item/storage/firstaid/toxin,
 /obj/structure/table,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 25
+	pixel_x = 27;
+	name = "east extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull";
@@ -46103,7 +46281,7 @@
 "bOZ" = (
 /obj/machinery/mech_bay_recharge_port,
 /obj/item/radio/intercom{
-	dir = 8;
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/camera{
@@ -46161,8 +46339,9 @@
 "bPf" = (
 /obj/structure/closet/secure_closet/paramedic,
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+	dir = 4;
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /obj/item/defibrillator/loaded,
 /obj/item/clothing/glasses/hud/health,
@@ -46402,7 +46581,8 @@
 /area/assembly/robotics)
 "bPz" = (
 /obj/machinery/newscaster{
-	pixel_x = -27;
+	pixel_x = -32;
+	name = "west newscaster";
 	pixel_y = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -46432,7 +46612,7 @@
 /obj/structure/cable,
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /obj/structure/closet,
 /obj/item/toy/figure/cargotech,
@@ -46483,7 +46663,8 @@
 /obj/machinery/light/small,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -46638,8 +46819,8 @@
 "bPX" = (
 /obj/structure/closet/emcloset,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = 30
+	pixel_y = 30;
+	name = "north extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -46846,11 +47027,11 @@
 /area/crew_quarters/heads)
 "bQq" = (
 /obj/machinery/light_switch{
-	pixel_x = -23
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -46884,8 +47065,8 @@
 	},
 /obj/machinery/hologram/holopad,
 /obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -46915,7 +47096,8 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/light_switch{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north light switch"
 	},
 /obj/structure/dresser,
 /obj/machinery/power/apc{
@@ -46928,6 +47110,7 @@
 "bQw" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /obj/item/storage/box/matches,
@@ -47215,7 +47398,8 @@
 "bQW" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/light_switch{
-	pixel_x = -23
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Chemistry South";
@@ -47391,7 +47575,8 @@
 /obj/item/healthanalyzer,
 /obj/item/healthanalyzer,
 /obj/machinery/newscaster{
-	pixel_x = 26;
+	pixel_x = 32;
+	name = "east newscaster";
 	pixel_y = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -47559,7 +47744,8 @@
 "bRE" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
@@ -47569,7 +47755,8 @@
 	pixel_y = 3
 	},
 /obj/machinery/light_switch{
-	pixel_y = -25
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /obj/structure/table/glass,
 /turf/simulated/floor/plasteel{
@@ -47635,14 +47822,16 @@
 /area/quartermaster/storage)
 "bRL" = (
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bRM" = (
 /obj/machinery/autolathe,
 /obj/machinery/light_switch{
-	pixel_x = -27
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
@@ -47868,8 +48057,8 @@
 	icon_state = "0-8"
 	},
 /obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
@@ -48092,7 +48281,7 @@
 "bSC" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer,
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Cloning"
@@ -48104,7 +48293,8 @@
 "bSD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -48152,8 +48342,7 @@
 /area/medical/genetics)
 "bSH" = (
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1
@@ -48262,7 +48451,8 @@
 	dir = 8
 	},
 /obj/machinery/firealarm{
-	pixel_y = 27
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -48314,8 +48504,8 @@
 /area/hallway/primary/central/sw)
 "bSU" = (
 /obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redcorner"
@@ -48466,11 +48656,11 @@
 /area/toxins/lab)
 "bTh" = (
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -48513,8 +48703,7 @@
 /area/hallway/primary/central/sw)
 "bTl" = (
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -48551,8 +48740,7 @@
 /area/shuttle/administration)
 "bTo" = (
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -48615,8 +48803,7 @@
 	})
 "bTx" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -48661,7 +48848,7 @@
 /obj/item/bedsheet/captain,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain/bedroom)
@@ -48745,8 +48932,9 @@
 	req_access_txt = "66"
 	},
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = -8
+	pixel_x = -24;
+	pixel_y = -8;
+	name = "custom light switch"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -48809,7 +48997,8 @@
 /area/teleporter)
 "bTP" = (
 /obj/machinery/light_switch{
-	pixel_y = -23
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /obj/machinery/camera{
 	c_tag = "Gravity Generator Room South";
@@ -48831,13 +49020,15 @@
 /area/medical/reception)
 "bTR" = (
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /turf/simulated/floor/plasteel,
 /area/teleporter)
 "bTS" = (
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /obj/structure/closet/crate,
 /obj/item/crowbar,
@@ -48867,7 +49058,7 @@
 	c_tag = "Teleporter Room"
 	},
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/teleporter)
@@ -48888,12 +49079,12 @@
 "bTY" = (
 /obj/machinery/disposal,
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -48917,8 +49108,8 @@
 	icon_state = "1-2"
 	},
 /obj/item/radio/intercom{
-	pixel_x = 29;
-	pixel_y = -1
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -49074,7 +49265,8 @@
 /obj/structure/chair/office/dark,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
@@ -49084,8 +49276,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /obj/structure/table/tray,
 /turf/simulated/floor/plasteel{
@@ -49124,7 +49315,7 @@
 "bUy" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /obj/machinery/power/terminal,
 /obj/structure/cable{
@@ -49198,7 +49389,8 @@
 /obj/structure/closet/secure_closet/captains,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain/bedroom)
@@ -49225,7 +49417,8 @@
 "bUG" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
@@ -49246,7 +49439,8 @@
 	c_tag = "Medbay Genetics"
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 25
+	pixel_x = 27;
+	name = "east extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplecorner"
@@ -49297,7 +49491,7 @@
 "bUN" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -49560,15 +49754,13 @@
 /area/quartermaster/storage)
 "bVm" = (
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/supply)
 "bVn" = (
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /obj/machinery/door_control{
 	id = "QMLoaddoor2";
@@ -49633,7 +49825,8 @@
 /obj/structure/table,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /obj/item/folder/yellow,
 /obj/item/eftpos,
@@ -49669,7 +49862,7 @@
 "bVw" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
@@ -49680,7 +49873,8 @@
 	icon_state = "1-2"
 	},
 /obj/item/radio/intercom{
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
@@ -49724,7 +49918,8 @@
 	pixel_y = 32
 	},
 /obj/machinery/light_switch{
-	pixel_x = -27
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hop)
@@ -49882,7 +50077,7 @@
 "bVP" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
-	pixel_y = 1
+	name = "west extinguisher cabinet"
 	},
 /obj/structure/table,
 /obj/item/radio/beacon,
@@ -49909,7 +50104,8 @@
 /area/maintenance/fsmaint)
 "bVR" = (
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -50109,7 +50305,8 @@
 /area/medical/cloning)
 "bWe" = (
 /obj/machinery/light_switch{
-	pixel_x = -23
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /obj/structure/closet/secure_closet/roboticist,
 /turf/simulated/floor/plasteel{
@@ -50219,7 +50416,8 @@
 	})
 "bWo" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -30
+	pixel_y = -30;
+	name = "south extinguisher cabinet"
 	},
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
@@ -50503,7 +50701,7 @@
 	name = "Medical gear"
 	},
 /obj/effect/spawner/lootdrop/trade_sol/med{
-	loot = list(/obj/item/storage/fancy/cigarettes/cigpack_med = 50, /obj/item/stack/nanopaste = 50, /obj/item/storage/pill_bottle/random_meds/labelled = 50, /obj/item/reagent_containers/glass/bottle/reagent/omnizine = 50, /obj/item/reagent_containers/glass/bottle/reagent/strange_reagent = 50, /obj/item/scalpel/laser/manager = 50, /obj/item/organ/internal/heart/gland/ventcrawling = 50, /obj/item/organ/internal/heart/gland/heals = 50, /obj/item/dnainjector/regenerate = 50, /obj/item/dnainjector/nobreath = 50, /obj/item/dnainjector/telemut = 50, /obj/item/reagent_containers/glass/bottle/regeneration = 50, /obj/item/reagent_containers/glass/bottle/sensory_restoration = 50, /obj/item/autopsy_scanner = 50, /obj/item/organ/internal/cyberimp/eyes/hud/medical = 50, /obj/item/gun/medbeam = 50, /obj/item/reagent_containers/applicator/dual/syndi = 50, /obj/item/reagent_containers/glass/bottle/retrovirus = 50, /obj/item/reagent_containers/glass/bottle/reagent/strange_reagent = 50, /obj/item/reagent_containers/glass/bottle/tuberculosiscure = 50, /obj/item/reagent_containers/glass/bottle/gbs = 50, /obj/item/bodyanalyzer/advanced = 50);
+	loot = list(/obj/item/storage/fancy/cigarettes/cigpack_med=50,/obj/item/stack/nanopaste=50,/obj/item/storage/pill_bottle/random_meds/labelled=50,/obj/item/reagent_containers/glass/bottle/reagent/omnizine=50,/obj/item/reagent_containers/glass/bottle/reagent/strange_reagent=50,/obj/item/scalpel/laser/manager=50,/obj/item/organ/internal/heart/gland/ventcrawling=50,/obj/item/organ/internal/heart/gland/heals=50,/obj/item/dnainjector/regenerate=50,/obj/item/dnainjector/nobreath=50,/obj/item/dnainjector/telemut=50,/obj/item/reagent_containers/glass/bottle/regeneration=50,/obj/item/reagent_containers/glass/bottle/sensory_restoration=50,/obj/item/autopsy_scanner=50,/obj/item/organ/internal/cyberimp/eyes/hud/medical=50,/obj/item/gun/medbeam=50,/obj/item/reagent_containers/applicator/dual/syndi=50,/obj/item/reagent_containers/glass/bottle/retrovirus=50,/obj/item/reagent_containers/glass/bottle/reagent/strange_reagent=50,/obj/item/reagent_containers/glass/bottle/tuberculosiscure=50,/obj/item/reagent_containers/glass/bottle/gbs=50,/obj/item/bodyanalyzer/advanced=50);
 	lootcount = 8;
 	name = "5. Medical gear"
 	},
@@ -50511,8 +50709,7 @@
 /area/shuttle/trade/sol)
 "bWN" = (
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/structure/closet{
 	icon_closed = "green";
@@ -50520,7 +50717,7 @@
 	name = "Service gear"
 	},
 /obj/effect/spawner/lootdrop/trade_sol/serv{
-	loot = list(/obj/item/storage/box/beakers/bluespace = 50, /obj/item/storage/box/monkeycubes = 50, /obj/item/storage/box/monkeycubes = 50, /obj/item/storage/box/stockparts/deluxe = 50, /obj/item/storage/box/rndboards = 50, /obj/item/reagent_containers/spray/cleaner = 50, /obj/item/soap = 50, /obj/item/clothing/under/syndicate/combat = 50, /obj/item/soap/syndie = 50, /obj/item/lighter/zippo/gonzofist = 50, /obj/item/clothing/under/psyjump = 50, /obj/item/immortality_talisman = 50, /obj/item/t_scanner/adv_mining_scanner = 50, /obj/item/storage/box/bartender_rare_ingredients_kit = 50, /obj/item/storage/box/chef_rare_ingredients_kit = 50, /obj/item/grenade/clusterbuster/cleaner = 50, /obj/item/mining_voucher = 50, /obj/item/gun/energy/kinetic_accelerator/experimental = 50, /obj/item/borg/upgrade/modkit/aoe/turfs/andmobs = 50, /obj/item/seeds/random/labelled = 50, /obj/item/seeds/random/labelled = 50, /obj/item/seeds/random/labelled = 50, /obj/item/grenade/clusterbuster/honk = 50, /obj/item/bikehorn/golden = 50);
+	loot = list(/obj/item/storage/box/beakers/bluespace=50,/obj/item/storage/box/monkeycubes=50,/obj/item/storage/box/monkeycubes=50,/obj/item/storage/box/stockparts/deluxe=50,/obj/item/storage/box/rndboards=50,/obj/item/reagent_containers/spray/cleaner=50,/obj/item/soap=50,/obj/item/clothing/under/syndicate/combat=50,/obj/item/soap/syndie=50,/obj/item/lighter/zippo/gonzofist=50,/obj/item/clothing/under/psyjump=50,/obj/item/immortality_talisman=50,/obj/item/t_scanner/adv_mining_scanner=50,/obj/item/storage/box/bartender_rare_ingredients_kit=50,/obj/item/storage/box/chef_rare_ingredients_kit=50,/obj/item/grenade/clusterbuster/cleaner=50,/obj/item/mining_voucher=50,/obj/item/gun/energy/kinetic_accelerator/experimental=50,/obj/item/borg/upgrade/modkit/aoe/turfs/andmobs=50,/obj/item/seeds/random/labelled=50,/obj/item/seeds/random/labelled=50,/obj/item/seeds/random/labelled=50,/obj/item/grenade/clusterbuster/honk=50,/obj/item/bikehorn/golden=50);
 	lootcount = 8;
 	name = "7. Service gear"
 	},
@@ -50625,7 +50822,7 @@
 /obj/structure/table,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /obj/item/storage/belt/utility,
 /turf/simulated/floor/plasteel,
@@ -50830,7 +51027,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/hop,
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hop)
@@ -50880,7 +51077,8 @@
 /obj/item/storage/box/syringes,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -50979,7 +51177,8 @@
 /area/medical/sleeper)
 "bXF" = (
 /obj/machinery/light_switch{
-	pixel_x = -21
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /obj/machinery/sleeper{
 	dir = 4
@@ -51067,7 +51266,8 @@
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -51115,7 +51315,7 @@
 /area/medical/cryo)
 "bXP" = (
 /obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
+	name = "West Emergency NanoMed";
 	pixel_x = -25
 	},
 /turf/simulated/floor/plasteel{
@@ -51182,7 +51382,7 @@
 /obj/item/roller,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /obj/machinery/light{
 	dir = 8
@@ -51358,7 +51558,8 @@
 /obj/item/storage/box/beakers,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -51491,6 +51692,7 @@
 "bYx" = (
 /obj/machinery/light,
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /obj/effect/decal/warning_stripes/north,
@@ -51599,7 +51801,8 @@
 	pixel_y = -5
 	},
 /obj/machinery/newscaster{
-	pixel_x = -27;
+	pixel_x = -32;
+	name = "west newscaster";
 	pixel_y = 1
 	},
 /turf/simulated/floor/plasteel,
@@ -51672,7 +51875,7 @@
 	dir = 4
 	},
 /obj/machinery/atm{
-	pixel_x = -24
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -51723,8 +51926,7 @@
 /area/crew_quarters/heads)
 "bYT" = (
 /obj/item/radio/intercom{
-	dir = 8;
-	name = "station intercom (General)";
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/item/twohanded/required/kirbyplants,
@@ -51739,7 +51941,7 @@
 /obj/item/pen/multi/fountain,
 /obj/item/toy/figure/hop,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/carpet,
@@ -51747,7 +51949,8 @@
 "bYV" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /obj/machinery/door_control{
 	id = "hopofficedoor";
@@ -51837,8 +52040,7 @@
 /area/crew_quarters/heads/hop)
 "bZe" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
@@ -51871,7 +52073,8 @@
 /area/engine/gravitygenerator)
 "bZg" = (
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
@@ -51896,7 +52099,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -51951,10 +52155,8 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "station intercom (General)";
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
@@ -52054,7 +52256,8 @@
 	},
 /obj/item/radio/intercom{
 	pixel_x = -32;
-	pixel_y = -8
+	pixel_y = -8;
+	name = "custom station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -52063,8 +52266,7 @@
 /area/medical/cmo)
 "bZx" = (
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -52104,7 +52306,8 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = -10;
-	pixel_y = 28
+	pixel_y = 26;
+	name = "custom light switch"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -52597,8 +52800,7 @@
 /area/medical/cloning)
 "cab" = (
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -52616,7 +52818,8 @@
 /area/maintenance/asmaint2)
 "cad" = (
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -52674,8 +52877,8 @@
 /area/shuttle/administration)
 "cal" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
+	pixel_y = 30;
+	name = "north extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -52973,7 +53176,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -30
+	pixel_y = -30;
+	name = "south extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -53191,11 +53395,11 @@
 /area/escapepodbay)
 "cbc" = (
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -53220,7 +53424,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hop)
@@ -53238,7 +53443,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /obj/structure/closet/radiation,
 /obj/machinery/light,
@@ -53254,7 +53459,8 @@
 "cbi" = (
 /obj/structure/closet/radiation,
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -53392,6 +53598,7 @@
 /area/medical/medbay2)
 "cbv" = (
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -53513,7 +53720,8 @@
 	dir = 1
 	},
 /obj/machinery/light_switch{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north light switch"
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -53580,8 +53788,8 @@
 /area/medical/medbay2)
 "cbR" = (
 /obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
@@ -53612,6 +53820,7 @@
 "cbV" = (
 /obj/machinery/light,
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -53879,7 +54088,8 @@
 "cck" = (
 /obj/structure/table/glass,
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /obj/item/reagent_containers/iv_bag/salglu,
 /turf/simulated/floor/plasteel{
@@ -53905,7 +54115,8 @@
 /area/hallway/primary/central/se)
 "cco" = (
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = 34;
+	name = "north newscaster"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
@@ -53970,6 +54181,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -54003,7 +54215,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /obj/machinery/bodyscanner,
 /turf/simulated/floor/plasteel{
@@ -54019,11 +54231,12 @@
 	dir = 1
 	},
 /obj/machinery/light_switch{
-	pixel_x = -23
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -54038,8 +54251,7 @@
 	dir = 1
 	},
 /obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = -5;
+	name = "South Emergency NanoMed";
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
@@ -54075,7 +54287,8 @@
 /obj/machinery/light,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/radio/intercom{
-	pixel_y = -25
+	name = "south station intercom (General)";
+	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -54257,7 +54470,7 @@
 /area/maintenance/asmaint2)
 "ccN" = (
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /obj/structure/closet/l3closet/janitor,
 /turf/simulated/floor/plasteel,
@@ -54265,7 +54478,8 @@
 "ccO" = (
 /obj/structure/closet/jcloset,
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /turf/simulated/floor/plasteel,
 /area/janitor)
@@ -54406,7 +54620,8 @@
 	on = 1
 	},
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/toxins/server)
@@ -54808,7 +55023,8 @@
 /area/hallway/primary/central/sw)
 "cdT" = (
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = 34;
+	name = "north newscaster"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
@@ -54821,7 +55037,8 @@
 /area/hallway/primary/central/sw)
 "cdV" = (
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
@@ -54930,7 +55147,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light_switch{
-	pixel_x = -23
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -54973,7 +55191,8 @@
 /obj/item/clothing/glasses/hud/health,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -55030,7 +55249,8 @@
 /area/hallway/primary/central/south)
 "ceu" = (
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
@@ -55085,7 +55305,7 @@
 /area/hallway/primary/central/south)
 "ceC" = (
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
@@ -55106,7 +55326,8 @@
 /area/quartermaster/storage)
 "ceF" = (
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
@@ -55163,7 +55384,8 @@
 "ceM" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -55201,7 +55423,8 @@
 /area/crew_quarters/hor)
 "ceP" = (
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /turf/simulated/floor/wood,
 /area/ntrep)
@@ -55217,7 +55440,7 @@
 "ceS" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /obj/machinery/suit_storage_unit/rd/secure,
 /turf/simulated/floor/plasteel{
@@ -55325,6 +55548,7 @@
 "cff" = (
 /obj/machinery/computer/security/mining,
 /obj/item/radio/intercom{
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/camera{
@@ -55336,7 +55560,7 @@
 "cfg" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
@@ -55359,7 +55583,7 @@
 /area/hallway/primary/central/sw)
 "cfi" = (
 /obj/item/radio/intercom{
-	dir = 1;
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel,
@@ -55594,8 +55818,8 @@
 /area/medical/surgery/north)
 "cfB" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = -32
+	pixel_y = -30;
+	name = "south extinguisher cabinet"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
@@ -55603,7 +55827,7 @@
 "cfC" = (
 /obj/structure/table/glass,
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /obj/item/reagent_containers/iv_bag/salglu,
 /turf/simulated/floor/plasteel{
@@ -55708,8 +55932,7 @@
 /area/medical/surgery/south)
 "cfM" = (
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /obj/machinery/status_display{
 	layer = 4;
@@ -55921,13 +56144,12 @@
 	},
 /area/medical/cmo)
 "cfY" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = -25
+/obj/item/radio/intercom/department/security{
+	pixel_y = 25;
+	name = "north station intercom (Security)"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/genetics)
+/turf/simulated/floor/plasteel,
+/area/security/main)
 "cfZ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -55986,7 +56208,8 @@
 "cgf" = (
 /obj/machinery/computer/rdservercontrol,
 /obj/machinery/light_switch{
-	pixel_y = -23
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/toxins/server)
@@ -56151,6 +56374,7 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -56426,7 +56650,8 @@
 /area/ntrep)
 "cgX" = (
 /obj/machinery/light_switch{
-	pixel_y = -23
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel,
@@ -56687,7 +56912,8 @@
 "chw" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -56713,7 +56939,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -56795,7 +57022,7 @@
 "chE" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
@@ -56804,7 +57031,7 @@
 /area/medical/cmo)
 "chF" = (
 /obj/item/radio/intercom{
-	dir = 8;
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -56818,6 +57045,10 @@
 /obj/structure/table/glass,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/toy/figure/geneticist,
+/obj/machinery/vending/wallmed{
+	name = "East Emergency NanoMed";
+	pixel_x = 25
+	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "whitered"
@@ -56826,7 +57057,7 @@
 "chH" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /turf/simulated/floor/wood,
 /area/ntrep)
@@ -56856,7 +57087,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -56866,7 +57097,7 @@
 "chM" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -57013,7 +57244,8 @@
 "chU" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /obj/machinery/camera{
 	c_tag = "Research Toxins Storage Room";
@@ -57051,8 +57283,7 @@
 	dir = 6
 	},
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -57135,8 +57366,7 @@
 /area/quartermaster/miningdock)
 "ciq" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 8
+	dir = 4
 	},
 /obj/item/stack/ore/iron,
 /obj/effect/decal/warning_stripes/north,
@@ -57422,7 +57652,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluecorner";
@@ -57437,7 +57667,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
+	name = "West Emergency NanoMed";
 	pixel_x = -25
 	},
 /obj/machinery/door/firedoor,
@@ -57640,6 +57870,7 @@
 /area/hallway/primary/central/south)
 "cjm" = (
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel,
@@ -57660,7 +57891,8 @@
 /area/hallway/primary/central/se)
 "cjp" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_x = 27;
+	name = "east extinguisher cabinet"
 	},
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel,
@@ -57724,7 +57956,8 @@
 "cjw" = (
 /obj/machinery/light_switch{
 	pixel_x = -23;
-	pixel_y = -5
+	pixel_y = -5;
+	name = "custom light switch"
 	},
 /obj/machinery/holosign_switch{
 	id = "surgery1";
@@ -57913,8 +58146,7 @@
 	network = list("Telepad","Research","SS13")
 	},
 /obj/machinery/light{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /obj/structure/sign/nosmoking_2{
 	pixel_y = 32
@@ -57924,7 +58156,8 @@
 "cjJ" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
@@ -57934,7 +58167,7 @@
 "cjK" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -57964,7 +58197,8 @@
 "cjO" = (
 /obj/structure/cable,
 /obj/machinery/light_switch{
-	pixel_y = -23
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -58017,7 +58251,8 @@
 /obj/structure/closet/secure_closet/RD,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -58177,7 +58412,7 @@
 "cko" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -58247,7 +58482,8 @@
 /area/blueshield)
 "cku" = (
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /turf/simulated/floor/wood,
 /area/blueshield)
@@ -58339,7 +58575,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell,
@@ -58520,6 +58757,7 @@
 "ckW" = (
 /obj/structure/closet/secure_closet/medical2,
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -58538,7 +58776,8 @@
 "ckY" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -58593,7 +58832,8 @@
 /obj/machinery/bodyscanner,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -58616,7 +58856,8 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = 23;
-	pixel_y = -5
+	pixel_y = -5;
+	name = "custom light switch"
 	},
 /obj/machinery/holosign_switch{
 	id = "surgery2";
@@ -58635,6 +58876,7 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/light,
@@ -58662,7 +58904,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -30
+	pixel_x = -27;
+	name = "west extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -58698,7 +58941,7 @@
 /obj/machinery/washing_machine,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria";
@@ -58758,7 +59001,8 @@
 "clr" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -58776,7 +59020,7 @@
 "clt" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /turf/simulated/floor/engine,
 /area/toxins/explab_chamber)
@@ -58789,14 +59033,16 @@
 "clv" = (
 /obj/structure/closet,
 /obj/machinery/light_switch{
-	pixel_x = -27
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "clw" = (
 /obj/machinery/atmospherics/binary/valve,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_x = 27;
+	name = "east extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -58854,8 +59100,7 @@
 /area/shuttle/administration)
 "clE" = (
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/structure/closet/crate,
 /turf/simulated/shuttle/floor,
@@ -58868,7 +59113,8 @@
 "clG" = (
 /obj/machinery/vending/wallmed{
 	pixel_x = -30;
-	pixel_y = 30
+	pixel_y = 30;
+	name = "Custom Emergency NanoMed"
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -58876,7 +59122,7 @@
 /area/shuttle/specops)
 "clH" = (
 /obj/machinery/camera{
-	armor = list("melee" = 50, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 100, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 50);
+	armor = list("melee"=50,"bullet"=20,"laser"=20,"energy"=20,"bomb"=100,"bio"=0,"rad"=0,"fire"=90,"acid"=50);
 	c_tag = "Research Toxins Test Chamber North";
 	network = list("Toxins","Research","SS13")
 	},
@@ -58888,7 +59134,8 @@
 "clI" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 30;
-	pixel_y = 30
+	pixel_y = 30;
+	name = "custom extinguisher cabinet"
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -58953,7 +59200,8 @@
 /area/hallway/primary/aft)
 "clP" = (
 /obj/machinery/newscaster{
-	pixel_y = 30
+	pixel_y = 34;
+	name = "north newscaster"
 	},
 /obj/vehicle/janicart,
 /turf/simulated/floor/plasteel,
@@ -58997,8 +59245,8 @@
 /area/toxins/explab_chamber)
 "clU" = (
 /obj/item/radio/intercom{
-	dir = 1;
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -59007,8 +59255,8 @@
 /area/toxins/explab_chamber)
 "clV" = (
 /obj/item/radio/intercom{
-	pixel_x = 29;
-	pixel_y = -1
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /turf/simulated/floor/wood,
 /area/blueshield)
@@ -59025,7 +59273,7 @@
 "clX" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -59056,7 +59304,8 @@
 "clZ" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowcorner"
@@ -59104,7 +59353,8 @@
 "cme" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /obj/structure/janitorialcart,
 /turf/simulated/floor/plasteel,
@@ -59122,7 +59372,8 @@
 /obj/structure/closet/secure_closet/ntrep,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /turf/simulated/floor/wood,
 /area/ntrep)
@@ -59547,8 +59798,8 @@
 /area/toxins/storage)
 "cmW" = (
 /obj/item/radio/intercom{
-	dir = 1;
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel{
@@ -59561,8 +59812,7 @@
 /obj/item/extinguisher,
 /obj/item/clothing/mask/gas,
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /obj/item/grenade/chem_grenade/firefighting,
 /turf/simulated/floor/plasteel{
@@ -59583,7 +59833,7 @@
 /area/toxins/mixing)
 "cmZ" = (
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /obj/effect/decal/warning_stripes/southwestcorner,
 /obj/machinery/portable_atmospherics/canister,
@@ -59831,11 +60081,11 @@
 /area/hallway/primary/aft)
 "cnB" = (
 /obj/machinery/light{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -59882,8 +60132,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/light{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -59974,7 +60223,8 @@
 	dir = 1
 	},
 /obj/machinery/light_switch{
-	pixel_y = -27
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria";
@@ -60005,6 +60255,7 @@
 "cnR" = (
 /obj/structure/chair/stool,
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -60308,8 +60559,8 @@
 /area/ntrep)
 "cop" = (
 /obj/item/radio/intercom{
-	pixel_x = 29;
-	pixel_y = -1
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
@@ -60381,7 +60632,8 @@
 /area/toxins/explab_chamber)
 "cox" = (
 /obj/machinery/light_switch{
-	pixel_y = -23
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -60401,7 +60653,8 @@
 "coz" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -60430,7 +60683,8 @@
 /area/toxins/storage)
 "coC" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -24
+	pixel_x = -27;
+	name = "west extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -60493,7 +60747,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
@@ -60589,7 +60843,7 @@
 "coT" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
@@ -60770,7 +61024,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreen";
@@ -60915,8 +61170,7 @@
 /area/medical/surgery/south)
 "cpp" = (
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -60942,7 +61196,7 @@
 /area/toxins/explab_chamber)
 "cpr" = (
 /obj/item/radio/intercom{
-	dir = 8;
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -61052,7 +61306,8 @@
 "cpA" = (
 /obj/effect/decal/warning_stripes/southwestcorner,
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /obj/structure/sink{
 	dir = 4;
@@ -61170,7 +61425,8 @@
 /obj/structure/bed,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -61199,7 +61455,8 @@
 /obj/item/pen/red,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -61443,8 +61700,7 @@
 /area/toxins/mixing)
 "cqg" = (
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /obj/machinery/status_display{
 	layer = 4;
@@ -61477,7 +61733,7 @@
 /obj/machinery/computer/general_air_control{
 	frequency = 1222;
 	name = "Bomb Mix Monitor";
-	sensors = list("burn_sensor" = "Burn Mix")
+	sensors = list("burn_sensor"="Burn Mix")
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
@@ -61503,8 +61759,7 @@
 /area/toxins/mixing)
 "cql" = (
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/unary/cold_sink/freezer,
 /obj/effect/decal/warning_stripes/northwestcorner,
@@ -61566,7 +61821,8 @@
 	dir = 8
 	},
 /obj/machinery/light_switch{
-	pixel_x = -23
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -61974,7 +62230,8 @@
 /area/maintenance/asmaint)
 "cqZ" = (
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel,
@@ -62083,7 +62340,8 @@
 /area/toxins/storage)
 "crj" = (
 /obj/machinery/light_switch{
-	pixel_y = -23
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -62143,8 +62401,9 @@
 "crp" = (
 /obj/effect/decal/warning_stripes/southwestcorner,
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 24
+	pixel_x = -24;
+	pixel_y = 24;
+	name = "custom light switch"
 	},
 /obj/machinery/status_display{
 	layer = 4;
@@ -62236,7 +62495,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
-	pixel_x = -23
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -62297,11 +62557,11 @@
 /obj/structure/closet/l3closet,
 /obj/item/clothing/mask/gas,
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -62408,7 +62668,8 @@
 /area/toxins/explab)
 "crP" = (
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -62495,7 +62756,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -62521,11 +62783,12 @@
 /area/medical/ward)
 "crZ" = (
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
@@ -62584,7 +62847,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -24
+	pixel_x = -27;
+	name = "west extinguisher cabinet"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -62784,7 +63048,8 @@
 /obj/structure/closet/secure_closet/blueshield,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /turf/simulated/floor/wood,
 /area/blueshield)
@@ -62899,7 +63164,7 @@
 	})
 "csI" = (
 /obj/item/radio/intercom{
-	dir = 8;
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/camera{
@@ -62950,7 +63215,8 @@
 "csN" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /obj/structure/closet/firecloset,
 /obj/machinery/status_display{
@@ -62961,7 +63227,8 @@
 /area/engine/controlroom)
 "csO" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_y = 30
+	pixel_y = 30;
+	name = "north extinguisher cabinet"
 	},
 /obj/structure/closet/firecloset,
 /obj/structure/cable{
@@ -63026,7 +63293,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /obj/machinery/light{
 	dir = 8
@@ -63731,8 +63998,8 @@
 	},
 /obj/item/pen,
 /obj/item/radio/intercom{
-	dir = 1;
-	pixel_x = -25
+	name = "west station intercom (General)";
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -63763,9 +64030,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/warning_stripes/northwestcorner,
 /obj/item/radio/intercom{
-	dir = 8;
 	pixel_x = -28;
-	pixel_y = -28
+	pixel_y = -28;
+	name = "custom station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -63785,7 +64052,8 @@
 /area/medical/virology)
 "cui" = (
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /obj/machinery/computer/security/engineering,
 /turf/simulated/floor/plasteel{
@@ -63868,7 +64136,7 @@
 /obj/item/storage/box/syringes,
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -63882,7 +64150,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
@@ -63891,7 +64160,7 @@
 /area/medical/virology)
 "cur" = (
 /obj/item/radio/intercom{
-	dir = 8;
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/structure/closet/l3closet,
@@ -63930,7 +64199,8 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel,
@@ -63982,7 +64252,7 @@
 /area/medical/cmostore)
 "cuB" = (
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	name = "standard air scrubber";
@@ -64075,7 +64345,7 @@
 "cuJ" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -64205,7 +64475,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -64219,7 +64490,8 @@
 /area/toxins/explab)
 "cuT" = (
 /obj/machinery/light_switch{
-	pixel_y = -23
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -64383,6 +64655,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -64400,7 +64673,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -64470,7 +64744,7 @@
 /area/storage/tech)
 "cvv" = (
 /obj/machinery/camera{
-	armor = list("melee" = 50, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 100, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 50);
+	armor = list("melee"=50,"bullet"=20,"laser"=20,"energy"=20,"bomb"=100,"bio"=0,"rad"=0,"fire"=90,"acid"=50);
 	c_tag = "Research Toxins Test Chamber East";
 	dir = 8;
 	network = list("Toxins","Research","SS13")
@@ -64536,7 +64810,7 @@
 	dir = 1
 	},
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -64562,7 +64836,8 @@
 "cvD" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -64657,7 +64932,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -64738,6 +65013,7 @@
 /area/medical/surgery/north)
 "cvT" = (
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -65016,7 +65292,8 @@
 /area/toxins/explab)
 "cwr" = (
 /obj/machinery/light_switch{
-	pixel_x = -23
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /obj/structure/table,
 /obj/item/storage/box/pillbottles{
@@ -65162,7 +65439,7 @@
 "cwJ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
-	pixel_y = 1
+	name = "west extinguisher cabinet"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -65401,7 +65678,7 @@
 /obj/machinery/computer/general_air_control{
 	frequency = 1441;
 	name = "Tank Monitor";
-	sensors = list("n2_sensor" = "Nitrogen", "o2_sensor" = "Oxygen", "co2_sensor" = "Carbon Dioxide", "tox_sensor" = "Toxins", "n2o_sensor" = "Nitrous Oxide", "waste_sensor" = "Gas Mix Tank")
+	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous Oxide","waste_sensor"="Gas Mix Tank")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -65452,8 +65729,7 @@
 /area/construction)
 "cxl" = (
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -65474,7 +65750,8 @@
 /area/maintenance/asmaint)
 "cxo" = (
 /obj/item/radio/intercom{
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
@@ -65557,8 +65834,9 @@
 "cxx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+	dir = 4;
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -65572,7 +65850,7 @@
 /obj/item/flashlight/lamp/green,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /turf/simulated/floor/carpet,
 /area/medical/psych)
@@ -65603,7 +65881,7 @@
 	frequency = 1443;
 	level = 3;
 	name = "Distribution and Waste Monitor";
-	sensors = list("mair_in_meter" = "Mixed Air In", "air_sensor" = "Mixed Air Supply Tank", "mair_out_meter" = "Mixed Air Out", "dloop_atm_meter" = "Distribution Loop", "wloop_atm_meter" = "Waste Loop")
+	sensors = list("mair_in_meter"="Mixed Air In","air_sensor"="Mixed Air Supply Tank","mair_out_meter"="Mixed Air Out","dloop_atm_meter"="Distribution Loop","wloop_atm_meter"="Waste Loop")
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -65811,8 +66089,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -65944,7 +66221,7 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -66096,8 +66373,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -66214,7 +66490,8 @@
 /obj/item/pen/multi,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /turf/simulated/floor/carpet,
 /area/medical/psych)
@@ -66273,7 +66550,8 @@
 "cyU" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -30
+	pixel_y = -30;
+	name = "south extinguisher cabinet"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -66300,7 +66578,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -66601,6 +66880,7 @@
 /area/hallway/primary/aft)
 "czB" = (
 /obj/item/radio/intercom{
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -66818,7 +67098,7 @@
 "czW" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /obj/structure/sink{
 	dir = 8;
@@ -66933,7 +67213,7 @@
 	frequency = 1443;
 	level = 3;
 	name = "Distribution and Waste Monitor";
-	sensors = list("mair_in_meter" = "Mixed Air In", "air_sensor" = "Mixed Air Supply Tank", "mair_out_meter" = "Mixed Air Out", "dloop_atm_meter" = "Distribution Loop", "wloop_atm_meter" = "Waste Loop")
+	sensors = list("mair_in_meter"="Mixed Air In","air_sensor"="Mixed Air Supply Tank","mair_out_meter"="Mixed Air Out","dloop_atm_meter"="Distribution Loop","wloop_atm_meter"="Waste Loop")
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
@@ -67277,7 +67557,8 @@
 "cAO" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -67479,7 +67760,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -67493,7 +67775,8 @@
 /area/maintenance/apmaint)
 "cBp" = (
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -67684,7 +67967,7 @@
 "cBE" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -67720,8 +68003,7 @@
 /obj/structure/table,
 /obj/item/clothing/under/color/grey,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 8
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/genetics)
@@ -67846,7 +68128,7 @@
 /area/engine/controlroom)
 "cBZ" = (
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /obj/structure/table,
 /obj/item/radio/electropack,
@@ -67894,7 +68176,8 @@
 /area/toxins/misc_lab)
 "cCd" = (
 /obj/machinery/light_switch{
-	pixel_x = -23
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /obj/structure/rack,
 /turf/simulated/floor/plasteel{
@@ -67903,8 +68186,7 @@
 /area/toxins/misc_lab)
 "cCe" = (
 /obj/machinery/light{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /obj/structure/closet/bombcloset,
 /turf/simulated/floor/plasteel{
@@ -67957,8 +68239,7 @@
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/light{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /obj/machinery/status_display{
 	layer = 4;
@@ -67993,11 +68274,11 @@
 /area/toxins/misc_lab)
 "cCl" = (
 /obj/machinery/newscaster{
-	pixel_y = 34
+	pixel_y = 34;
+	name = "north newscaster"
 	},
 /obj/machinery/light{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -68008,8 +68289,8 @@
 "cCm" = (
 /obj/machinery/chem_master,
 /obj/item/radio/intercom{
-	dir = 1;
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -68045,7 +68326,7 @@
 /area/maintenance/asmaint2)
 "cCp" = (
 /obj/item/radio/intercom{
-	dir = 8;
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/structure/dispenser,
@@ -68342,7 +68623,7 @@
 "cCP" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -68523,7 +68804,8 @@
 /area/toxins/misc_lab)
 "cDc" = (
 /obj/machinery/light_switch{
-	pixel_x = -23
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -68587,10 +68869,11 @@
 /area/maintenance/genetics)
 "cDi" = (
 /obj/machinery/light_switch{
-	pixel_y = 27
+	pixel_y = 24;
+	name = "north light switch"
 	},
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -68617,8 +68900,8 @@
 	name = "Дыхательную смесь в отходы"
 	},
 /obj/item/radio/intercom{
-	dir = 1;
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics North-East"
@@ -68726,7 +69009,7 @@
 /area/toxins/misc_lab)
 "cDx" = (
 /obj/item/radio/intercom{
-	dir = 8;
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -68755,6 +69038,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -68803,8 +69087,8 @@
 "cDE" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_y = -32
+	name = "South Emergency NanoMed";
+	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
@@ -68836,6 +69120,7 @@
 /area/toxins/misc_lab)
 "cDI" = (
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/computer/drone_control,
@@ -68880,7 +69165,7 @@
 /area/toxins/test_area)
 "cDN" = (
 /obj/machinery/camera{
-	armor = list("melee" = 50, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 100, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 50);
+	armor = list("melee"=50,"bullet"=20,"laser"=20,"energy"=20,"bomb"=100,"bio"=0,"rad"=0,"fire"=90,"acid"=50);
 	c_tag = "Research Toxins Test Chamber South";
 	dir = 1;
 	network = list("Toxins","Research","SS13")
@@ -68918,6 +69203,7 @@
 	pixel_y = 5
 	},
 /obj/item/radio/intercom{
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -68966,7 +69252,8 @@
 "cDX" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -68978,6 +69265,7 @@
 /area/storage/tech)
 "cDZ" = (
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -68991,7 +69279,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -69110,7 +69399,7 @@
 "cEl" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /obj/machinery/light,
 /obj/effect/decal/warning_stripes/southwestcorner,
@@ -69182,7 +69471,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /obj/item/stack/rods{
 	amount = 50
@@ -69599,13 +69888,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
-"cFv" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/genetics)
 "cFw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -69621,7 +69903,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -69794,7 +70077,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -70032,13 +70316,6 @@
 	tag = "icon-vault (NORTHEAST)"
 	},
 /area/toxins/misc_lab)
-"cGe" = (
-/obj/machinery/light{
-	dir = 1;
-	on = 1
-	},
-/turf/simulated/floor/engine,
-/area/engine/mechanic_workshop)
 "cGg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -70064,7 +70341,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /obj/effect/turf_decal/siding/white/end{
 	dir = 1
@@ -70186,7 +70464,8 @@
 /area/engine/break_room)
 "cGt" = (
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = 34;
+	name = "north newscaster"
 	},
 /obj/machinery/computer/station_alert,
 /turf/simulated/floor/plasteel,
@@ -70271,7 +70550,7 @@
 	pixel_y = 2
 	},
 /obj/item/radio/intercom{
-	dir = 8;
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/effect/decal/warning_stripes/northwest,
@@ -70459,7 +70738,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -70472,7 +70752,8 @@
 /obj/structure/table,
 /obj/item/camera,
 /obj/machinery/light_switch{
-	pixel_x = 25
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -70501,6 +70782,7 @@
 "cGV" = (
 /obj/structure/closet/secure_closet/exile,
 /obj/item/radio/intercom{
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/effect/decal/warning_stripes/white/hollow,
@@ -70723,7 +71005,7 @@
 	pixel_y = -2
 	},
 /obj/item/radio/intercom{
-	dir = 1;
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -70833,7 +71115,7 @@
 /obj/structure/closet/l3closet/scientist,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /obj/machinery/light{
 	dir = 4
@@ -71133,10 +71415,10 @@
 /obj/machinery/computer/general_air_control{
 	frequency = 1441;
 	name = "Tank Monitor";
-	sensors = list("n2_sensor" = "Nitrogen", "o2_sensor" = "Oxygen", "co2_sensor" = "Carbon Dioxide", "tox_sensor" = "Toxins", "n2o_sensor" = "Nitrous Oxide", "waste_sensor" = "Gas Mix Tank")
+	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous Oxide","waste_sensor"="Gas Mix Tank")
 	},
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
@@ -71164,7 +71446,7 @@
 /obj/item/wrench,
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /obj/machinery/light{
 	dir = 8
@@ -71403,7 +71685,8 @@
 /area/maintenance/asmaint)
 "cIA" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_x = 27;
+	name = "east extinguisher cabinet"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -71546,7 +71829,7 @@
 "cIM" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -71979,7 +72262,7 @@
 /obj/item/paper/pamphlet,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /obj/item/stack/tape_roll,
 /obj/machinery/camera/motion{
@@ -72132,7 +72415,8 @@
 	},
 /obj/structure/closet/secure_closet/atmos_personal,
 /obj/machinery/light_switch{
-	pixel_x = -25
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /obj/item/storage/briefcase/inflatable,
@@ -72508,7 +72792,8 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = -6;
-	pixel_y = 26
+	pixel_y = 24;
+	name = "custom light switch"
 	},
 /obj/effect/decal/warning_stripes/northeastcorner,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -72565,7 +72850,8 @@
 	icon_state = "0-8"
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_x = 27;
+	name = "east extinguisher cabinet"
 	},
 /obj/effect/decal/warning_stripes/northwestcorner,
 /obj/machinery/power/apc{
@@ -72764,10 +73050,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 7
-	},
 /obj/structure/rack{
 	dir = 8;
 	layer = 2.9
@@ -72818,7 +73100,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
@@ -72829,7 +73112,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/newscaster{
-	pixel_y = 34
+	pixel_y = 34;
+	name = "north newscaster"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -72991,8 +73275,8 @@
 /area/engine/mechanic_workshop)
 "cLs" = (
 /obj/machinery/light_switch{
-	name = "light switch ";
-	pixel_y = -22
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -73003,7 +73287,7 @@
 "cLt" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
@@ -73012,6 +73296,7 @@
 /area/engine/mechanic_workshop)
 "cLu" = (
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/computer/rdconsole/mechanics,
@@ -73027,6 +73312,7 @@
 /area/assembly/assembly_line)
 "cLw" = (
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /obj/structure/closet/secure_closet/atmos_personal,
@@ -73067,7 +73353,7 @@
 /area/assembly/assembly_line)
 "cLB" = (
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /obj/machinery/light{
 	dir = 1
@@ -73109,7 +73395,8 @@
 "cLH" = (
 /obj/structure/closet/crate,
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -73132,7 +73419,8 @@
 "cLK" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -73367,6 +73655,7 @@
 	icon_state = "2-4"
 	},
 /obj/item/radio/intercom{
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/effect/decal/warning_stripes/east,
@@ -73590,7 +73879,7 @@
 /area/hallway/secondary/exit)
 "cMK" = (
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/west)
@@ -73668,7 +73957,7 @@
 "cMR" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -73718,6 +74007,10 @@
 /area/hallway/primary/aft)
 "cMX" = (
 /obj/item/twohanded/required/kirbyplants,
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	name = "east light switch"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cMY" = (
@@ -74087,8 +74380,7 @@
 /area/assembly/assembly_line)
 "cNL" = (
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -74256,7 +74548,7 @@
 "cOc" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -74292,7 +74584,8 @@
 /obj/structure/table,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /obj/item/storage/toolbox/mechanical,
 /obj/item/t_scanner,
@@ -74364,7 +74657,8 @@
 	dir = 4
 	},
 /obj/machinery/firealarm{
-	pixel_y = 27
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -74478,7 +74772,7 @@
 	icon_state = "1-4"
 	},
 /obj/item/radio/intercom{
-	dir = 1;
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/engine,
@@ -74538,7 +74832,8 @@
 "cOE" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -74686,7 +74981,7 @@
 "cOY" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /obj/structure/sink{
 	dir = 8;
@@ -74694,8 +74989,8 @@
 	pixel_y = 2
 	},
 /obj/item/radio/intercom{
-	dir = 1;
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
@@ -74795,7 +75090,7 @@
 	input_tag = "tox_in";
 	name = "Toxin Supply Control";
 	output_tag = "tox_out";
-	sensors = list("tox_sensor" = "Tank")
+	sensors = list("tox_sensor"="Tank")
 	},
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -74929,8 +75224,8 @@
 	pixel_y = -22
 	},
 /obj/item/radio/intercom{
-	dir = 1;
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -74943,7 +75238,7 @@
 "cPv" = (
 /obj/structure/table,
 /obj/item/radio/intercom{
-	dir = 1;
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -74974,7 +75269,8 @@
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /obj/item/clipboard,
 /obj/item/hand_labeler,
@@ -74984,7 +75280,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /obj/item/clothing/mask/gas,
 /obj/machinery/atmospherics/pipe/simple/hidden/purple,
@@ -75274,8 +75570,7 @@
 	target_pressure = 303.325
 	},
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
@@ -75286,7 +75581,7 @@
 	},
 /obj/machinery/meter,
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
@@ -75449,8 +75744,8 @@
 	dir = 8
 	},
 /obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_y = -32
+	name = "South Emergency NanoMed";
+	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -75533,7 +75828,8 @@
 	req_access_txt = "11"
 	},
 /obj/machinery/light_switch{
-	pixel_y = 38
+	pixel_y = 37;
+	name = "custom light switch"
 	},
 /obj/machinery/door_control{
 	id = "ceofficedoor";
@@ -75604,7 +75900,8 @@
 "cQR" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /obj/structure/table,
 /obj/item/storage/box/syringes{
@@ -76179,7 +76476,8 @@
 /obj/effect/decal/warning_stripes/white/hollow,
 /obj/item/multitool,
 /obj/item/radio/intercom{
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -76766,7 +77064,8 @@
 /obj/structure/statue/chickenstatue,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/mrchangs)
@@ -76853,7 +77152,8 @@
 /area/maintenance/storage)
 "cTf" = (
 /obj/machinery/newscaster{
-	pixel_y = 30
+	pixel_y = 34;
+	name = "north newscaster"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -76885,7 +77185,7 @@
 /area/atmos)
 "cTi" = (
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -77005,7 +77305,7 @@
 	input_tag = "waste_in";
 	name = "Gas Mix Tank Control";
 	output_tag = "waste_out";
-	sensors = list("waste_sensor" = "Tank")
+	sensors = list("waste_sensor"="Tank")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -77293,10 +77593,12 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /obj/machinery/light_switch{
-	pixel_y = 27
+	pixel_y = 24;
+	name = "north light switch"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/disposal,
@@ -77982,7 +78284,8 @@
 "cVg" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -77991,7 +78294,8 @@
 "cVh" = (
 /obj/machinery/computer/security/engineering,
 /obj/machinery/light_switch{
-	pixel_x = -27
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -78177,7 +78481,8 @@
 	},
 /obj/item/crowbar,
 /obj/machinery/light_switch{
-	pixel_x = -27
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -78217,7 +78522,8 @@
 "cVA" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /obj/structure/closet/crate/internals,
 /obj/effect/decal/warning_stripes/west,
@@ -78577,9 +78883,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cWr" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 27
-	},
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplecorner"
@@ -78654,6 +78957,7 @@
 /area/engine/engineering)
 "cWz" = (
 /obj/item/radio/intercom{
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/computer/monitor{
@@ -78679,7 +78983,8 @@
 /area/engine/equipmentstorage)
 "cWC" = (
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -78814,8 +79119,7 @@
 /obj/structure/flora/tree/palm,
 /obj/item/clothing/head/soft/rainbow,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 8
+	dir = 4
 	},
 /turf/simulated/floor/beach/sand,
 /area/hallway/secondary/exit)
@@ -78855,7 +79159,8 @@
 	layer = 2.9
 	},
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /obj/item/grenade/chem_grenade/metalfoam,
 /obj/item/grenade/chem_grenade/metalfoam,
@@ -78880,8 +79185,7 @@
 	name = "Газ на обработку"
 	},
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -78957,7 +79261,8 @@
 /area/atmos)
 "cXf" = (
 /obj/machinery/newscaster{
-	pixel_y = -30
+	pixel_y = -31;
+	name = "south newscaster"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
@@ -79032,7 +79337,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -79213,12 +79518,14 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/disposal,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -79273,7 +79580,8 @@
 "cXL" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor/plasteel,
@@ -79427,7 +79735,7 @@
 	input_tag = "n2o_in";
 	name = "Nitrous Oxide Supply Control";
 	output_tag = "n2o_out";
-	sensors = list("n2o_sensor" = "Tank")
+	sensors = list("n2o_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
@@ -79442,8 +79750,7 @@
 "cYd" = (
 /obj/structure/chair,
 /obj/machinery/light{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -79533,8 +79840,9 @@
 /area/hallway/secondary/exit)
 "cYo" = (
 /obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = 8
+	pixel_x = -24;
+	pixel_y = 8;
+	name = "custom light switch"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -79691,7 +79999,8 @@
 "cYF" = (
 /obj/structure/closet/radiation,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_x = 27;
+	name = "east extinguisher cabinet"
 	},
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
@@ -79707,6 +80016,7 @@
 "cYH" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/item/radio/intercom{
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -79763,7 +80073,7 @@
 /obj/structure/closet/l3closet/scientist,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /obj/machinery/light,
 /obj/machinery/light{
@@ -79968,7 +80278,8 @@
 /area/atmos)
 "cZj" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_x = 27;
+	name = "east extinguisher cabinet"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -79981,7 +80292,8 @@
 /area/hallway/primary/central/west)
 "cZl" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+	pixel_x = -27;
+	name = "west extinguisher cabinet"
 	},
 /obj/effect/decal/warning_stripes/southwestcorner,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -80303,6 +80615,7 @@
 /area/atmos)
 "daa" = (
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -80404,7 +80717,8 @@
 /area/engine/engineering)
 "dam" = (
 /obj/machinery/newscaster{
-	pixel_y = -30
+	pixel_y = -31;
+	name = "south newscaster"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -80414,7 +80728,8 @@
 "dan" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -80568,7 +80883,7 @@
 /obj/structure/table,
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /obj/item/storage/firstaid/o2{
 	layer = 2.8;
@@ -80595,7 +80910,8 @@
 /area/maintenance/genetics)
 "daK" = (
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /obj/machinery/suit_storage_unit/engine,
 /obj/effect/decal/warning_stripes/northwest,
@@ -80657,8 +80973,7 @@
 /area/engine/engineering)
 "daS" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 8
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
@@ -80820,7 +81135,8 @@
 /area/maintenance/genetics)
 "dbo" = (
 /obj/machinery/light_switch{
-	pixel_x = -23
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -80868,7 +81184,8 @@
 "dbv" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light_switch{
-	pixel_y = -25
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /obj/effect/decal/warning_stripes/white/hollow,
 /obj/structure/cable{
@@ -81006,7 +81323,8 @@
 /area/space/nearstation)
 "dbJ" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 28
+	pixel_x = 27;
+	name = "east extinguisher cabinet"
 	},
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -81062,7 +81380,8 @@
 	},
 /obj/effect/decal/warning_stripes/white/hollow,
 /obj/machinery/light_switch{
-	pixel_y = -25
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -81342,7 +81661,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -81406,7 +81725,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	dir = 8;
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel,
@@ -81651,7 +81970,8 @@
 /obj/structure/reagent_dispensers/fueltank,
 /obj/item/storage/toolbox/emergency,
 /obj/item/radio/intercom{
-	pixel_y = -30
+	name = "south station intercom (General)";
+	pixel_y = -28
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -81660,7 +81980,8 @@
 /obj/structure/reagent_dispensers/watertank,
 /obj/item/extinguisher,
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -30
+	pixel_y = -30;
+	name = "south extinguisher cabinet"
 	},
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -82345,7 +82666,8 @@
 "deO" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -82399,7 +82721,7 @@
 	input_tag = "co2_in";
 	name = "Carbon Dioxide Supply Control";
 	output_tag = "co2_out";
-	sensors = list("co2_sensor" = "Tank")
+	sensors = list("co2_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
@@ -82689,7 +83011,8 @@
 /area/engine/engineering)
 "dfA" = (
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /obj/structure/transit_tube{
 	dir = 4;
@@ -82709,8 +83032,8 @@
 /area/atmos)
 "dfC" = (
 /obj/item/radio/intercom{
-	dir = 1;
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -82829,8 +83152,8 @@
 /area/maintenance/asmaint2)
 "dfQ" = (
 /obj/machinery/light_switch{
-	name = "light switch ";
-	pixel_y = -22
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -83055,7 +83378,8 @@
 /area/maintenance/storage)
 "dgH" = (
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -31;
+	name = "south newscaster"
 	},
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/mug,
@@ -83089,7 +83413,7 @@
 	name = "Engineering gear"
 	},
 /obj/effect/spawner/lootdrop/trade_sol/eng{
-	loot = list(/obj/item/pickaxe/drill/jackhammer = 50, /obj/item/storage/belt/utility/chief/full = 50, /obj/item/clothing/glasses/welding = 50, /obj/item/storage/belt/utility/full/multitool = 50, /obj/item/clothing/shoes/magboots = 50, /obj/item/rcd/combat = 50, /obj/item/rpd/bluespace = 50, /obj/item/tank/internals/emergency_oxygen/double = 50, /obj/item/storage/backpack/holding = 50, /obj/item/clothing/glasses/meson/night = 50, /obj/item/clothing/glasses/material = 50, /obj/item/grenade/clusterbuster/metalfoam = 50, /obj/item/crowbar/power = 50, /obj/item/screwdriver/power = 50, /obj/item/t_scanner/extended_range = 50, /obj/item/borg/upgrade/abductor_engi = 50);
+	loot = list(/obj/item/pickaxe/drill/jackhammer=50,/obj/item/storage/belt/utility/chief/full=50,/obj/item/clothing/glasses/welding=50,/obj/item/storage/belt/utility/full/multitool=50,/obj/item/clothing/shoes/magboots=50,/obj/item/rcd/combat=50,/obj/item/rpd/bluespace=50,/obj/item/tank/internals/emergency_oxygen/double=50,/obj/item/storage/backpack/holding=50,/obj/item/clothing/glasses/meson/night=50,/obj/item/clothing/glasses/material=50,/obj/item/grenade/clusterbuster/metalfoam=50,/obj/item/crowbar/power=50,/obj/item/screwdriver/power=50,/obj/item/t_scanner/extended_range=50,/obj/item/borg/upgrade/abductor_engi=50);
 	lootcount = 8;
 	name = "8. Eng. gear"
 	},
@@ -83283,14 +83607,14 @@
 "dhl" = (
 /obj/machinery/light/spot,
 /obj/effect/spawner/lootdrop/trade_sol/largeitem{
-	loot = list(/obj/machinery/floodlight = 50, /obj/machinery/disco = 50, /obj/mecha/combat/durand/old = 50, /obj/machinery/snow_machine = 50);
+	loot = list(/obj/machinery/floodlight=50,/obj/machinery/disco=50,/obj/mecha/combat/durand/old=50,/obj/machinery/snow_machine=50);
 	name = "3. Large item"
 	},
 /turf/simulated/floor/wood,
 /area/shuttle/trade/sol)
 "dhm" = (
 /obj/effect/spawner/lootdrop/trade_sol/vehicle{
-	loot = list(/obj/vehicle/motorcycle = 50, /obj/vehicle/snowmobile/key = 50, /obj/vehicle/snowmobile/blue/key = 50, /obj/vehicle/space/speedbike/red = 50, /obj/vehicle/space/speedbike = 50);
+	loot = list(/obj/vehicle/motorcycle=50,/obj/vehicle/snowmobile/key=50,/obj/vehicle/snowmobile/blue/key=50,/obj/vehicle/space/speedbike/red=50,/obj/vehicle/space/speedbike=50);
 	name = "4. Vehicle"
 	},
 /turf/simulated/floor/wood,
@@ -83313,7 +83637,8 @@
 /area/engine/engineering)
 "dhp" = (
 /obj/machinery/light_switch{
-	pixel_y = -25
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/condiment/peppermill{
@@ -83328,6 +83653,7 @@
 "dhq" = (
 /obj/machinery/light,
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /obj/structure/chair/wood{
@@ -83445,7 +83771,7 @@
 	input_tag = "n2_in";
 	name = "Nitrogen Supply Control";
 	output_tag = "n2_out";
-	sensors = list("n2_sensor" = "Tank")
+	sensors = list("n2_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
@@ -83489,7 +83815,7 @@
 	input_tag = "o2_in";
 	name = "Oxygen Supply Control";
 	output_tag = "o2_out";
-	sensors = list("o2_sensor" = "Tank")
+	sensors = list("o2_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
@@ -83533,7 +83859,7 @@
 	name = "Mixed Air Supply Control";
 	output_tag = "air_out";
 	pressure_setting = 2000;
-	sensors = list("air_sensor" = "Tank")
+	sensors = list("air_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
@@ -83593,6 +83919,7 @@
 /area/atmos)
 "dhK" = (
 /obj/item/radio/intercom{
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -83614,7 +83941,7 @@
 "dhN" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -83828,7 +84155,8 @@
 	c_tag = "Central Hallway North"
 	},
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -83838,7 +84166,7 @@
 "dix" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /obj/machinery/light{
 	dir = 1
@@ -83914,7 +84242,8 @@
 /obj/item/screwdriver,
 /obj/item/radio,
 /obj/machinery/light_switch{
-	pixel_y = 27
+	pixel_y = 24;
+	name = "north light switch"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -83944,8 +84273,8 @@
 /area/turret_protected/aisat_interior)
 "diG" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
+	pixel_y = 30;
+	name = "north extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -84169,7 +84498,8 @@
 /area/crew_quarters/dorms)
 "djh" = (
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /obj/structure/table/reinforced,
 /obj/item/stack/packageWrap,
@@ -84185,7 +84515,8 @@
 /area/crew_quarters/bar)
 "dji" = (
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /obj/machinery/camera{
 	c_tag = "Bar North"
@@ -84306,7 +84637,7 @@
 	dir = 8
 	},
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /obj/machinery/camera{
 	c_tag = "Hydroponics Pasture"
@@ -84321,7 +84652,8 @@
 "djx" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/grass,
@@ -84572,8 +84904,8 @@
 	c_tag = "Central Hallway North-West"
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = 30
+	pixel_y = 30;
+	name = "north extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -84624,7 +84956,8 @@
 /area/storage/secure)
 "dkd" = (
 /obj/machinery/light_switch{
-	pixel_y = 27
+	pixel_y = 24;
+	name = "north light switch"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -84634,12 +84967,11 @@
 "dke" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 8
+	dir = 4
 	},
 /obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/cable{
@@ -84732,7 +85064,8 @@
 /area/atmos)
 "dkl" = (
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/north)
@@ -84863,7 +85196,8 @@
 /area/space/nearstation)
 "dkD" = (
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = 34;
+	name = "north newscaster"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
@@ -84877,8 +85211,7 @@
 /area/crew_quarters/bar)
 "dkH" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 8
+	dir = 4
 	},
 /obj/machinery/turretid/stun{
 	control_area = "\improper AI Satellite Service";
@@ -84917,7 +85250,7 @@
 	name = "JoinLateCyborg"
 	},
 /obj/item/radio/intercom{
-	dir = 8;
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/computer/cryopod/robot{
@@ -85006,7 +85339,7 @@
 "dkR" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -85973,7 +86306,7 @@
 "dmS" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /obj/machinery/camera/motion{
 	c_tag = "AI Satellite Hallway";
@@ -86122,7 +86455,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
@@ -86625,7 +86959,8 @@
 	pixel_x = 11
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_x = 27;
+	name = "east extinguisher cabinet"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -86646,7 +86981,7 @@
 "dob" = (
 /obj/machinery/light/small,
 /obj/item/radio/intercom{
-	dir = 1;
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -86705,8 +87040,8 @@
 "doi" = (
 /obj/machinery/computer/card,
 /obj/item/radio/intercom{
-	dir = 1;
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -86718,7 +87053,8 @@
 /area/security/checkpoint/south)
 "doj" = (
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -86887,7 +87223,7 @@
 /obj/structure/table/wood,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /obj/item/camera,
 /obj/item/storage/photo_album{
@@ -86919,7 +87255,8 @@
 /area/turret_protected/aisat_interior)
 "doI" = (
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -86957,7 +87294,7 @@
 /obj/machinery/computer/station_alert,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -87026,8 +87363,7 @@
 /area/turret_protected/aisat_interior)
 "dpg" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 8
+	dir = 4
 	},
 /obj/machinery/teleport/station,
 /turf/simulated/floor/plating,
@@ -87040,7 +87376,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -87094,7 +87431,7 @@
 "dpw" = (
 /obj/machinery/light/small,
 /obj/item/radio/intercom{
-	dir = 1;
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -87124,7 +87461,8 @@
 "dpC" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
@@ -87156,8 +87494,8 @@
 	name = "Grid Power Monitoring Computer"
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
+	pixel_y = 30;
+	name = "north extinguisher cabinet"
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -87170,8 +87508,8 @@
 "dpK" = (
 /obj/machinery/cryopod/robot,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
+	pixel_y = 30;
+	name = "north extinguisher cabinet"
 	},
 /turf/simulated/floor/plating,
 /area/aisat/maintenance{
@@ -87180,7 +87518,8 @@
 "dpL" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /obj/structure/table,
 /obj/item/stack/sheet/metal{
@@ -87203,7 +87542,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /obj/machinery/space_heater,
 /obj/machinery/camera{
@@ -87240,12 +87579,11 @@
 	})
 "dpV" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 8
+	dir = 4
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical{
@@ -87449,7 +87787,8 @@
 "dqT" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /turf/simulated/floor/bluegrid,
 /area/aisat{
@@ -87500,7 +87839,7 @@
 /area/turret_protected/ai)
 "drq" = (
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /obj/structure/chair{
 	dir = 8
@@ -87535,7 +87874,8 @@
 /area/turret_protected/ai)
 "drA" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_x = 27;
+	name = "east extinguisher cabinet"
 	},
 /obj/structure/chair/office/dark,
 /turf/simulated/floor/plasteel{
@@ -87671,6 +88011,7 @@
 	pixel_y = -28
 	},
 /obj/item/radio/intercom{
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/effect/landmark{
@@ -87688,7 +88029,7 @@
 	pixel_y = -10
 	},
 /obj/item/radio/intercom{
-	dir = 1;
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/requests_console{
@@ -87715,7 +88056,8 @@
 	pixel_y = -28
 	},
 /obj/item/radio/intercom{
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /obj/effect/landmark{
 	name = "tripai"
@@ -87789,7 +88131,7 @@
 "dsh" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -87801,7 +88143,8 @@
 "dsi" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -87911,8 +88254,8 @@
 /area/engine/engineering)
 "dsL" = (
 /obj/item/radio/intercom{
-	dir = 1;
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plasteel,
@@ -88055,7 +88398,7 @@
 "dtq" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /obj/structure/table,
 /obj/item/stack/sheet/mineral/plasma{
@@ -88085,7 +88428,7 @@
 /area/storage/secure)
 "dtt" = (
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /obj/effect/decal/warning_stripes/south,
 /obj/structure/reagent_dispensers/fueltank,
@@ -88211,9 +88554,7 @@
 	},
 /area/library/abandoned)
 "dHM" = (
-/obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)"
-	},
+/obj/machinery/light/spot,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
 	},
@@ -88249,8 +88590,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
@@ -88269,7 +88609,8 @@
 /area/maintenance/xenozoo)
 "dSc" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 28
+	pixel_x = 27;
+	name = "east extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -88324,7 +88665,8 @@
 /area/security/customs2)
 "ecb" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -28
+	pixel_x = -27;
+	name = "west extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "brown"
@@ -88497,7 +88839,8 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+	pixel_x = -27;
+	name = "west extinguisher cabinet"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -88544,7 +88887,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -88556,8 +88899,7 @@
 "eHd" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/machinery/light{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -88606,7 +88948,8 @@
 	specialfunctions = 4
 	},
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = 34;
+	name = "north newscaster"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -88667,7 +89010,7 @@
 "eRE" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = 24
 	},
 /obj/machinery/photocopier/faxmachine/longrange{
 	department = "Head of Personnel's Office"
@@ -88801,8 +89144,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -88820,7 +89162,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/xenozoo)
@@ -88844,7 +89186,8 @@
 /area/shuttle/administration)
 "fho" = (
 /obj/machinery/light_switch{
-	pixel_x = -27
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -88918,7 +89261,8 @@
 /area/security/main)
 "fxo" = (
 /obj/machinery/light_switch{
-	pixel_y = -25
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /obj/machinery/camera{
 	c_tag = "Messaging Server";
@@ -88959,9 +89303,8 @@
 /area/shuttle/administration)
 "fzb" = (
 /obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_y = 30
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -89030,7 +89373,7 @@
 "fHH" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /turf/simulated/floor/carpet,
 /area/civilian/vacantoffice)
@@ -89105,6 +89448,7 @@
 /area/security/prisonershuttle)
 "fRL" = (
 /obj/item/radio/intercom{
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel,
@@ -89196,9 +89540,7 @@
 /area/library/abandoned)
 "fZO" = (
 /obj/machinery/computer/mech_bay_power_console,
-/obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)"
-	},
+/obj/machinery/light/spot,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -89224,8 +89566,7 @@
 "gdm" = (
 /obj/machinery/clonepod/upgraded,
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor3"
@@ -89264,8 +89605,7 @@
 	dir = 10
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 8
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -89364,9 +89704,8 @@
 /area/hallway/primary/aft)
 "gyR" = (
 /obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_y = 30
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -89547,7 +89886,8 @@
 "gWl" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -89607,7 +89947,8 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	pixel_y = -27
+	name = "south station intercom (General)";
+	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -89765,8 +90106,7 @@
 /area/tcommsat/chamber)
 "hyR" = (
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor3"
@@ -89979,14 +90319,13 @@
 	},
 /area/library/abandoned)
 "hTU" = (
-/obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)"
-	},
+/obj/machinery/light/spot,
 /turf/simulated/floor/mech_bay_recharge_floor,
 /area/shuttle/escape)
 "hVB" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_x = 27;
+	name = "east extinguisher cabinet"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -90002,9 +90341,7 @@
 	},
 /area/hydroponics)
 "iau" = (
-/obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)"
-	},
+/obj/machinery/light/spot,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -90038,18 +90375,10 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/medic,
 /obj/item/storage/belt/medical,
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 29;
-	pixel_y = -30
-	},
 /obj/machinery/defibrillator_mount/loaded{
 	pixel_y = -30
 	},
-/obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)"
-	},
+/obj/machinery/light/spot,
 /turf/simulated/floor/plasteel{
 	icon_state = "cmo"
 	},
@@ -90098,7 +90427,8 @@
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 26
+	pixel_x = 26;
+	name = "custom extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -90129,11 +90459,13 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/spray/waterflower,
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -31;
+	name = "south newscaster"
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	icon_regular_floor = "yellowsiding";
@@ -90194,8 +90526,7 @@
 "iCr" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/shuttle/floor4,
 /area/shuttle/escape)
@@ -90337,7 +90668,8 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -26
+	pixel_x = -26;
+	name = "custom extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -90406,7 +90738,8 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 26
+	pixel_x = 26;
+	name = "custom extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -90503,7 +90836,8 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/light_switch{
-	pixel_y = -25
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -90514,7 +90848,7 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_regular_floor = "yellowsiding";
@@ -90531,7 +90865,8 @@
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -26
+	pixel_x = -26;
+	name = "custom extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -90601,8 +90936,7 @@
 /area/maintenance/aft)
 "jSX" = (
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -90816,9 +91150,8 @@
 	},
 /obj/item/clothing/ears/earmuffs,
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	name = "station intercom (General)";
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -90833,7 +91166,7 @@
 	dir = 4
 	},
 /obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
+	name = "Custom Emergency NanoMed";
 	pixel_x = -26
 	},
 /turf/simulated/floor/plasteel{
@@ -90916,8 +91249,7 @@
 /area/storage/secure)
 "kCR" = (
 /obj/machinery/light{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/plasteel{
@@ -90976,7 +91308,7 @@
 	dir = 8
 	},
 /obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
+	name = "Custom Emergency NanoMed";
 	pixel_x = 26
 	},
 /turf/simulated/floor/plasteel{
@@ -90986,7 +91318,7 @@
 /area/shuttle/escape)
 "kNZ" = (
 /obj/machinery/door/poddoor/multi_tile/two_tile_hor{
-	armor = list("melee" = 30, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 70);
+	armor = list("melee"=30,"bullet"=30,"laser"=20,"energy"=20,"bomb"=10,"bio"=100,"rad"=100,"fire"=80,"acid"=70);
 	damage_deflection = 30;
 	explosion_block = 2;
 	id_tag = "SecureArmory";
@@ -91058,7 +91390,7 @@
 "kVW" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /turf/simulated/floor/bluegrid,
 /area/server)
@@ -91137,9 +91469,8 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 30
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -91196,7 +91527,7 @@
 /area/shuttle/escape)
 "lmH" = (
 /obj/item/radio/intercom{
-	dir = 8;
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /obj/effect/decal/warning_stripes/northwest,
@@ -91368,7 +91699,8 @@
 "lNp" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	name = "east fire alarm"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -91544,13 +91876,14 @@
 /area/library/abandoned)
 "mcq" = (
 /obj/item/radio/intercom{
-	dir = 1;
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /obj/item/storage/box/donkpockets,
 /obj/structure/table,
 /obj/machinery/newscaster{
-	pixel_y = 30
+	pixel_y = 34;
+	name = "north newscaster"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -91742,7 +92075,7 @@
 /area/maintenance/server)
 "mxT" = (
 /obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
+	name = "Custom Emergency NanoMed";
 	pixel_x = 26
 	},
 /turf/simulated/floor/plasteel{
@@ -91939,8 +92272,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/bed/dogbed/ian,
 /mob/living/simple_animal/pet/dog/corgi/Ian,
@@ -92032,6 +92364,10 @@
 /obj/machinery/camera{
 	c_tag = "Brig Firing Range";
 	dir = 1
+	},
+/obj/item/radio/intercom/department/security{
+	pixel_y = -28;
+	name = "south station intercom (Security)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
@@ -92173,7 +92509,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -92454,13 +92791,10 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_y = -30
+	name = "south station intercom (General)";
+	pixel_y = -28
 	},
-/obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)"
-	},
+/obj/machinery/light/spot,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -92533,8 +92867,7 @@
 /area/shuttle/escape)
 "oEZ" = (
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/machinery/door_control{
 	id = "adminshuttleblast";
@@ -92575,7 +92908,7 @@
 /obj/structure/bed/dogbed,
 /mob/living/simple_animal/pet/dog/security/warden,
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -92885,9 +93218,8 @@
 "pCX" = (
 /obj/machinery/computer/crew,
 /obj/item/radio/intercom{
-	dir = 8;
-	name = "station intercom (General)";
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -93094,8 +93426,7 @@
 "qbK" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -93199,15 +93530,16 @@
 "qju" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 7
+	pixel_x = -24;
+	name = "west light switch"
 	},
 /turf/simulated/floor/wood,
 /area/civilian/vacantoffice)
 "qlm" = (
 /obj/machinery/message_server,
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /turf/simulated/floor/bluegrid,
 /area/server)
@@ -93411,6 +93743,10 @@
 /area/security/customs)
 "qIc" = (
 /obj/effect/decal/warning_stripes/southeastcorner,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30;
+	name = "south extinguisher cabinet"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreencorner"
 	},
@@ -93480,7 +93816,8 @@
 	dir = 9
 	},
 /obj/machinery/light_switch{
-	pixel_y = -27
+	pixel_y = -24;
+	name = "south light switch"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -93600,10 +93937,6 @@
 	pixel_x = -24;
 	req_access_txt = "63"
 	},
-/obj/machinery/light_switch{
-	pixel_x = -22;
-	pixel_y = 28
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whiteblue";
@@ -93679,7 +94012,8 @@
 /area/maintenance/xenozoo)
 "rkj" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 30
+	pixel_x = 27;
+	name = "east extinguisher cabinet"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -93870,7 +94204,7 @@
 /obj/item/stock_parts/cell/high,
 /obj/machinery/cell_charger,
 /obj/item/radio/intercom{
-	dir = 8;
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -93972,9 +94306,8 @@
 /area/library/abandoned)
 "rIF" = (
 /obj/item/radio/intercom{
-	dir = 8;
-	name = "station intercom (General)";
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /obj/machinery/flasher{
 	id = "brigmedflash";
@@ -94036,7 +94369,7 @@
 	dir = 10
 	},
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
@@ -94071,8 +94404,7 @@
 "rYq" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/administration)
@@ -94267,8 +94599,7 @@
 /obj/structure/table,
 /obj/item/storage/box/handcuffs,
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -94311,7 +94642,7 @@
 /area/hallway/secondary/exit)
 "sPb" = (
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -94445,8 +94776,8 @@
 /area/security/securearmory)
 "taM" = (
 /obj/item/radio/intercom{
-	dir = 1;
-	pixel_x = 28
+	pixel_x = 28;
+	name = "east station intercom (General)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -94608,8 +94939,10 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)"
+/obj/machinery/light/spot,
+/obj/item/radio/intercom{
+	name = "south station intercom (General)";
+	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -94716,6 +95049,7 @@
 "tCN" = (
 /obj/structure/closet/secure_closet/mime,
 /obj/item/radio/intercom{
+	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -94725,8 +95059,7 @@
 /area/mimeoffice)
 "tEM" = (
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -95000,7 +95333,8 @@
 /area/maintenance/xenozoo)
 "uLe" = (
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
@@ -95130,7 +95464,8 @@
 	scrub_Toxins = 1
 	},
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -31;
+	name = "south newscaster"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -95154,9 +95489,8 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = -30
+	name = "west station intercom (General)";
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -95353,8 +95687,7 @@
 /area/toxins/xenobiology)
 "vFf" = (
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -95369,7 +95702,7 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
+	name = "south station intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/light/small,
@@ -95418,7 +95751,8 @@
 /obj/item/clothing/gloves/color/latex/nitrile,
 /obj/item/clothing/mask/breath,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 28
+	pixel_x = 27;
+	name = "east extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cmo"
@@ -95434,7 +95768,7 @@
 /area/maintenance/xenozoo)
 "vMh" = (
 /obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
+	name = "Custom Emergency NanoMed";
 	pixel_x = -26
 	},
 /turf/simulated/floor/plasteel{
@@ -95763,7 +96097,8 @@
 "wwy" = (
 /obj/machinery/light_switch{
 	pixel_x = -25;
-	pixel_y = -8
+	pixel_y = -8;
+	name = "custom light switch"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -95782,13 +96117,10 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_y = -30
+	name = "south station intercom (General)";
+	pixel_y = -28
 	},
-/obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)"
-	},
+/obj/machinery/light/spot,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -95839,7 +96171,8 @@
 /area/library/abandoned)
 "wCS" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 25
+	pixel_x = 27;
+	name = "east extinguisher cabinet"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -95909,7 +96242,7 @@
 	dir = 1
 	},
 /obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
+	name = "Custom Emergency NanoMed";
 	pixel_x = -26
 	},
 /turf/simulated/floor/plasteel{
@@ -95961,7 +96294,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -95977,7 +96311,8 @@
 	icon_state = "4-8"
 	},
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 28;
+	name = "north station intercom (General)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -96038,7 +96373,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	name = "west fire alarm"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -96051,8 +96387,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /obj/machinery/status_display{
 	pixel_y = 32
@@ -96076,7 +96411,8 @@
 /obj/machinery/vending/chinese,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+	pixel_x = -27;
+	name = "west extinguisher cabinet"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -96113,7 +96449,8 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	pixel_y = 27
+	pixel_y = 24;
+	name = "north fire alarm"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -96188,7 +96525,9 @@
 /area/library/abandoned)
 "xlo" = (
 /obj/machinery/firealarm{
-	pixel_y = -24
+	dir = 1;
+	pixel_y = -24;
+	name = "south fire alarm"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -96230,7 +96569,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_x = 24;
+	name = "east light switch"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -96262,8 +96602,7 @@
 	pixel_y = 7
 	},
 /obj/machinery/light{
-	dir = 1;
-	in_use = 1
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -96495,6 +96834,10 @@
 	c_tag = "Brig Medbay North";
 	dir = 8
 	},
+/obj/machinery/light_switch{
+	pixel_y = -24;
+	name = "south light switch"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "whiteblue";
@@ -96556,7 +96899,7 @@
 /obj/effect/decal/cleanable/dust,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
 /obj/structure/chair/comfy/brown,
 /turf/simulated/floor/plasteel{
@@ -115499,7 +115842,7 @@ cBn
 cCD
 cDO
 cEW
-cGe
+cEv
 cFX
 cFX
 cIG
@@ -130567,7 +130910,7 @@ vZX
 nCT
 qFz
 wxU
-aoJ
+cfY
 adY
 amm
 amN
@@ -137843,7 +138186,7 @@ ccQ
 caW
 bWg
 ceo
-cfY
+cga
 chF
 ciY
 ckJ
@@ -139154,7 +139497,7 @@ bQX
 bQX
 bQX
 bQX
-cFv
+cfZ
 bQX
 bQX
 bQX
@@ -139925,7 +140268,7 @@ cDh
 bQX
 ciY
 cEE
-cFv
+cfZ
 bQX
 cHf
 cep
@@ -139935,7 +140278,7 @@ cKE
 ciY
 bQX
 cNh
-cFv
+cfZ
 cep
 aaa
 aaa


### PR DESCRIPTION
diff: https://mdb.affectedarc07.co.uk/Files/365505203/8616879692/0/diff.png

## What Does This PR Do
[global standarization](https://github.com/ss220-space/Paradise/commit/7a9cc71e4d43dc594c69ad0f6d6ee4253325e32a)
improves mapping experience by standardize commonly used instances

[sanitize variables](https://github.com/ss220-space/Paradise/commit/0c18432fbab40b10adec4fff94fa7c9dbaa4c904)
removes default-used var's that creates unnecessary instances and +1 line of code

[fixes and improvements](https://github.com/ss220-space/Paradise/commit/308c53ae9d3794ac719624a4b728c0058119e928) :
- propper directional signs
- remove double firedoors in hallways (we don't need it)
- additional light near hydroponics, move up scrubber near HoP