### PR TITLE
FIX: Блобернаут больше не спавнится без госта

### DIFF
--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -7,6 +7,7 @@
 	var/list/spores = list()
 	var/max_spores = 3
 	var/spore_delay = 0
+	var/is_waiting_spawn = FALSE
 
 /obj/structure/blob/factory/Destroy()
 	for(var/mob/living/simple_animal/hostile/blob/blobspore/spore in spores)

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -219,34 +219,37 @@
 	var/obj/structure/blob/B = locate(/obj/structure/blob) in T
 	if(!B)
 		to_chat(src, "You must be on a blob!")
-		return
+		return FALSE
 
 	if(!istype(B, /obj/structure/blob/factory))
 		to_chat(src, "Unable to use this blob, find a factory blob.")
-		return
+		return FALSE
 
 	if(!can_buy(60))
-		return
+		return FALSE
 
-	var/mob/living/simple_animal/hostile/blob/blobbernaut/blobber = new /mob/living/simple_animal/hostile/blob/blobbernaut (get_turf(B))
-	if(blobber)
-		qdel(B)
-	blobber.color = blob_reagent_datum.complementary_color
-	blobber.overmind = src
-	blob_mobs.Add(blobber)
-	blobber.AIStatus = AI_OFF
-	blobber.LoseTarget()
+	var/mob/C
 	spawn()
-		var/list/candidates = SSghost_spawns.poll_candidates("Do you want to play as a blobbernaut?", ROLE_BLOB, TRUE, 10 SECONDS, source = blobber)
-		if(candidates.len)
-			var/mob/C = pick(candidates)
-			if(C)
-				blobber.key = C.key
-				to_chat(blobber, "<span class='biggerdanger'>You are a blobbernaut! You must assist all blob lifeforms in their mission to consume everything!</span>")
-				to_chat(blobber, "<span class='danger'>You heal while standing on blob structures, however you will decay slowly if you are damaged outside of the blob.</span>")
-		if(!blobber.ckey)
-			blobber.AIStatus = AI_ON
-	return
+		var/list/candidates = SSghost_spawns.poll_candidates("Do you want to play as a blobbernaut?", ROLE_BLOB, TRUE, 10 SECONDS, source = /mob/living/simple_animal/hostile/blob/blobbernaut)
+		if(length(candidates))
+			C = pick(candidates)
+
+		if(!C)
+			add_points(60)
+
+		if(B)	//Если фабрика цела и её не разрушили во время голосования
+			var/mob/living/simple_animal/hostile/blob/blobbernaut/blobber = new /mob/living/simple_animal/hostile/blob/blobbernaut (get_turf(B))
+			qdel(B)
+			blobber.key = C.key
+			to_chat(blobber, "<span class='biggerdanger'>You are a blobbernaut! You must assist all blob lifeforms in their mission to consume everything!</span>")
+			to_chat(blobber, "<span class='danger'>You heal while standing on blob structures, however you will decay slowly if you are damaged outside of the blob.</span>")
+
+			blobber.color = blob_reagent_datum.complementary_color
+			blobber.overmind = src
+			blob_mobs.Add(blobber)
+			blobber.AIStatus = AI_OFF
+			blobber.LoseTarget()
+	return TRUE
 
 
 /mob/camera/blob/verb/relocate_core()

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -224,22 +224,29 @@
 	if(!istype(B, /obj/structure/blob/factory))
 		to_chat(src, "Unable to use this blob, find a factory blob.")
 		return FALSE
+	var/obj/structure/blob/factory/b_fac = B
+
+	if(b_fac.is_waiting_spawn)
+		return FALSE
 
 	if(!can_buy(60))
 		return FALSE
 
-	var/mob/C
 	spawn()
+		var/mob/C
+		b_fac.is_waiting_spawn = TRUE
+
 		var/list/candidates = SSghost_spawns.poll_candidates("Do you want to play as a blobbernaut?", ROLE_BLOB, TRUE, 10 SECONDS, source = /mob/living/simple_animal/hostile/blob/blobbernaut)
 		if(length(candidates))
 			C = pick(candidates)
 
 		if(!C)
 			add_points(60)
+			b_fac.is_waiting_spawn = FALSE
 
-		if(B)	//Если фабрика цела и её не разрушили во время голосования
-			var/mob/living/simple_animal/hostile/blob/blobbernaut/blobber = new /mob/living/simple_animal/hostile/blob/blobbernaut (get_turf(B))
-			qdel(B)
+		if(b_fac && b_fac.is_waiting_spawn)	//Если фабрика цела и её не разрушили во время голосования
+			var/mob/living/simple_animal/hostile/blob/blobbernaut/blobber = new (get_turf(b_fac))
+			qdel(b_fac)
 			blobber.key = C.key
 			to_chat(blobber, "<span class='biggerdanger'>You are a blobbernaut! You must assist all blob lifeforms in their mission to consume everything!</span>")
 			to_chat(blobber, "<span class='danger'>You heal while standing on blob structures, however you will decay slowly if you are damaged outside of the blob.</span>")


### PR DESCRIPTION
## What Does This PR Do
Фабрика теперь не спавнит блобернаута, пока не будет госта-добровольца.
Она забирает 60 очков на спавн блобернаута, и если гост не найден, то возвращает эти очки.

## Why It's Good For The Game
Фикс старой бесящей ошибки, когда блобернауты бродили без гостов.
Просьба педалей выполнена. Педали довольны. Госты довольны.

Конкретный алгоритм действий:
Запускает голосовалку, отбирает 60 поинтов, даем факторке понять что голосовалка запущена.
Если кандидаты и факторка не пропала, то уничтожаем факторку и отдаем блобернаута кандидату.
Если что-то нарушилось, то возвращаем 60 поинтов, разрешаем запускать голосовалку повторно.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![image](https://user-images.githubusercontent.com/41479614/193805635-14575ea9-a0dc-4f02-bf90-7636bc19848c.png)
