### PR TITLE
FEAT OFFICIAL: Несокрушимый стержень создаёт пробоины в корпусе

### DIFF
--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -76,7 +76,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 
 	if(istype(clong, /turf) || istype(clong, /obj))
 		if(clong.density)
-			clong.ex_act(2)
+			clong.ex_act(EXPLODE_HEAVY)
 
 	else if(istype(clong, /mob))
 		if(istype(clong, /mob/living/carbon/human))
@@ -84,14 +84,22 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 			H.visible_message("<span class='danger'>[H.name] пронизан незыблемым стержнем!</span>" , "<span class='userdanger'>Стержень пронзает тебя!</span>" , "<span class ='danger'>Вы слышите ЛЯЗГ!</span>")
 			H.adjustBruteLoss(160)
 		if(clong.density || prob(10))
-			clong.ex_act(2)
+			clong.ex_act(EXPLODE_HEAVY)
 
 /obj/effect/immovablerod/event
 	var/tiles_moved = 0
+
+	// The base chance to "damage" the floor when passing. This is not guaranteed to cause a full on hull breach.
+	// Chance to expose the tile to space is like 60% of this value.
+	var/floor_rip_chance = 40
 
 /obj/effect/immovablerod/event/Move()
 	var/atom/oldloc = loc
 	. = ..()
 	tiles_moved++
+	if(prob(floor_rip_chance))
+		var/turf/simulated/floor/T = get_turf(oldloc)
+		if(istype(T))
+			T.ex_act(EXPLODE_HEAVY)
 	if(get_dist(oldloc, loc) > 2 && tiles_moved > 10) // We went on a journey, commit sudoku
 		qdel(src)

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -91,7 +91,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 
 	// The base chance to "damage" the floor when passing. This is not guaranteed to cause a full on hull breach.
 	// Chance to expose the tile to space is like 60% of this value.
-	var/floor_rip_chance = 40
+	var/floor_rip_chance = 5
 
 /obj/effect/immovablerod/event/Move()
 	var/atom/oldloc = loc

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -74,12 +74,12 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 		x = clong.x
 		y = clong.y
 
-	if(istype(clong, /turf) || istype(clong, /obj))
+	if(isturf(clong) || isobj(clong))
 		if(clong.density)
 			clong.ex_act(EXPLODE_HEAVY)
 
-	else if(istype(clong, /mob))
-		if(istype(clong, /mob/living/carbon/human))
+	else if(ismob(clong))
+		if(ishuman(clong))
 			var/mob/living/carbon/human/H = clong
 			H.visible_message("<span class='danger'>[H.name] пронизан незыблемым стержнем!</span>" , "<span class='userdanger'>Стержень пронзает тебя!</span>" , "<span class ='danger'>Вы слышите ЛЯЗГ!</span>")
 			H.adjustBruteLoss(160)


### PR DESCRIPTION
## What Does This PR Do
Перенос [#17675](https://github.com/ParadiseSS13/Paradise/pull/17675)
> Makes the Immovable rod sometimes rip off the floors causing hull breaches, in addition to its current behaviour of decimating walls, machinery, and the haples sods that happen to get in the way.
> Also, I M M E R S I O N or something.

## Changelog
:cl:
tweak: Теперь несокрушимый стержень имеет 40% шанс проломить пол под собой, что создаёт множество разгерметизаций по всей станции (по всему маршруту стержня)
/:cl: