### PR TITLE
fix official: cigs.dm refactor

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -432,6 +432,17 @@ GLOBAL_DATUM_INIT(fire_overlay, /image, image("icon" = 'icons/goonstation/effect
 	in_storage = TRUE
 	return
 
+/**
+  * Called to check if this item can be put into a storage item.
+  *
+  * Return `FALSE` if `src` can't be inserted, and `TRUE` if it can.
+  * Arguments:
+  * * S - The [/obj/item/storage] that `src` is being inserted into.
+  * * user - The mob trying to insert the item.
+  */
+/obj/item/proc/can_enter_storage(obj/item/storage/S, mob/user)
+	return TRUE
+
 // called when "found" in pockets and storage items. Returns 1 if the search should end.
 /obj/item/proc/on_found(mob/finder as mob)
 	return

--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -30,6 +30,12 @@
 	else i = 3
 	icon_state = "candle[i][lit ? "_lit" : ""]"
 
+/obj/item/candle/can_enter_storage(obj/item/storage/S, mob/user)
+	if(lit)
+		to_chat(user, "<span class='warning'>[S] can't hold [src] while it's lit!</span>")
+		return FALSE
+	else
+		return TRUE
 
 /obj/item/candle/attackby(obj/item/W, mob/user, params)
 	if(is_hot(W))

--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -51,6 +51,13 @@
 	user.visible_message("<span class='suicide'>[user] welds [user.p_their()] every orifice closed! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return FIRELOSS
 
+/obj/item/weldingtool/can_enter_storage(obj/item/storage/S, mob/user)
+	if(tool_enabled)
+		to_chat(user, "<span class='warning'>[S] can't hold [src] while it's lit!</span>")
+		return FALSE
+	else
+		return TRUE
+
 /obj/item/weldingtool/process()
 	if(tool_enabled)
 		var/turf/T = get_turf(src)

--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -18,7 +18,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 	icon_state = "cigoff"
 	throw_speed = 0.5
 	item_state = "cigoff"
-	slot_flags = SLOT_EARS|SLOT_MASK
+	slot_flags = SLOT_MASK
 	w_class = WEIGHT_CLASS_TINY
 	body_parts_covered = null
 	attack_verb = null
@@ -46,8 +46,8 @@ LIGHTERS ARE IN LIGHTERS.DM
 	)
 
 
-/obj/item/clothing/mask/cigarette/New()
-	..()
+/obj/item/clothing/mask/cigarette/Initialize(mapload)
+	. = ..()
 	create_reagents(chem_volume) // making the cigarrete a chemical holder with a maximum volume of 30
 	reagents.set_reacting(FALSE) // so it doesn't react until you light it
 	if(list_reagents)
@@ -67,6 +67,12 @@ LIGHTERS ARE IN LIGHTERS.DM
 	else
 		return ..()
 
+/obj/item/clothing/mask/cigarette/can_enter_storage(obj/item/storage/S, mob/user)
+	if(lit)
+		to_chat(user, "<span class='warning'>[S] can't hold [initial(name)] while it's lit!</span>") // initial(name) so it doesn't say "lit" twice in a row
+		return FALSE
+	else
+		return TRUE
 
 /obj/item/clothing/mask/cigarette/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume, global_overlay = TRUE)
 	..()
@@ -170,6 +176,10 @@ LIGHTERS ARE IN LIGHTERS.DM
 		if(flavor_text)
 			var/turf/T = get_turf(src)
 			T.visible_message(flavor_text)
+		if(iscarbon(loc))
+			var/mob/living/carbon/C = loc
+			if(C.wear_mask == src) // Don't update if it's just in their hand
+				C.wear_mask_update(src)
 		set_light(2, 0.25, "#E38F46")
 		START_PROCESSING(SSobj, src)
 
@@ -257,8 +267,8 @@ LIGHTERS ARE IN LIGHTERS.DM
 	throw_speed = 0.5
 	item_state = "spliffoff"
 
-/obj/item/clothing/mask/cigarette/rollie/New()
-	..()
+/obj/item/clothing/mask/cigarette/rollie/Initialize(mapload)
+	. = ..()
 	pixel_x = rand(-5, 5)
 	pixel_y = rand(-5, 5)
 
@@ -268,8 +278,8 @@ LIGHTERS ARE IN LIGHTERS.DM
 	desc = "A manky old roach, or for non-stoners, a used rollup."
 	icon_state = "roach"
 
-/obj/item/cigbutt/roach/New()
-	..()
+/obj/item/cigbutt/roach/Initialize(mapload)
+	. = ..()
 	pixel_x = rand(-5, 5)
 	pixel_y = rand(-5, 5)
 
@@ -316,8 +326,8 @@ LIGHTERS ARE IN LIGHTERS.DM
 	w_class = WEIGHT_CLASS_TINY
 	throwforce = 1
 
-/obj/item/cigbutt/New()
-	..()
+/obj/item/cigbutt/Initialize(mapload)
+	. = ..()
 	pixel_x = rand(-10,10)
 	pixel_y = rand(-10,10)
 	transform = turn(transform,rand(0,360))

--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -18,7 +18,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 	icon_state = "cigoff"
 	throw_speed = 0.5
 	item_state = "cigoff"
-	slot_flags = SLOT_MASK
+	slot_flags = SLOT_EARS|SLOT_MASK
 	w_class = WEIGHT_CLASS_TINY
 	body_parts_covered = null
 	attack_verb = null

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -64,6 +64,13 @@
 		M.update_inv_l_hand()
 		M.update_inv_r_hand()
 
+/obj/item/flamethrower/can_enter_storage(obj/item/storage/S, mob/user)
+	if(lit)
+		to_chat(user, "<span class='warning'>[S] can't hold [src] while it's lit!</span>")
+		return FALSE
+	else
+		return TRUE
+
 /obj/item/flamethrower/afterattack(atom/target, mob/user, flag)
 	. = ..()
 	if(flag)

--- a/code/game/objects/items/weapons/lighters.dm
+++ b/code/game/objects/items/weapons/lighters.dm
@@ -104,6 +104,13 @@
 	var/next_on_message
 	var/next_off_message
 
+/obj/item/lighter/can_enter_storage(obj/item/storage/S, mob/user)
+	if(lit)
+		to_chat(user, "<span class='warning'>[S] can't hold [src] while it's lit!</span>")
+		return FALSE
+	else
+		return TRUE
+
 /obj/item/lighter/zippo/turn_on_lighter(mob/living/user)
 	. = ..()
 	if(world.time > next_on_message)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -270,6 +270,10 @@
 
 	if(loc == W)
 		return FALSE //Means the item is already in the storage item
+
+	if(!W.can_enter_storage(src, usr))
+		return FALSE
+
 	if(contents.len >= storage_slots)
 		if(!stop_messages)
 			to_chat(usr, "<span class='warning'>[W] won't fit in [src], make some space!</span>")


### PR DESCRIPTION
## What Does This PR Do
### [#15635](https://github.com/ParadiseSS13/Paradise/pull/15635)
> Stops users from putting Welding tools, Lighters, Flamethrowers, Candles, (...), Cigarettes, and Cigars into a storage container while they're lit.
> Also adds the can_enter_storage() proc, which can be overridden with failure conditions.

Оно вроде как должно работать со спичками, но при попытке убрать спичку из руки у неё срабатывает затухание через `dropped()`, так что решил не переносить этот фрагмент.

### [#16936](https://github.com/ParadiseSS13/Paradise/pull/16936)
> Fixes the mob overlays for cigars and cigarettes not updating when they get lit.

Фиксит наш багрепорт: https://discord.com/channels/617003227182792704/617004034405957642/1028219753623474176

### [#18294](https://github.com/ParadiseSS13/Paradise/pull/18294)
> Converts /obj/item/clothing to use /Initialize rather than /New

Применил только к файлу `cigs.dm`

## Why It's Good For The Game
ФИКСЫ!

## Changelog
:cl:
tweak: Горящие сварочные инструменты, зажигалки, огнеметы, свечи, сигареты и сигары больше нельзя засунуть в рюкзак (и прочие storage)
fix: Спрайт сигар/сигарет не обновлялся при их зажигании во рту.
/:cl:
