### PR TITLE
BALANCE: Изменение заряда растения-батарейки от потенции

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -370,7 +370,7 @@
 			to_chat(user, "<span class='notice'>You add some cable to [G] and slide it inside the battery encasing.</span>")
 			var/obj/item/stock_parts/cell/potato/pocell = new /obj/item/stock_parts/cell/potato(user.loc)
 			pocell.icon_state = G.icon_state
-			pocell.maxcharge = G.seed.potency * 20
+			pocell.maxcharge = G.seed.potency * 4
 
 			// The secret of potato supercells!
 			var/datum/plant_gene/trait/cell_charge/CG = G.seed.get_gene(/datum/plant_gene/trait/cell_charge)


### PR DESCRIPTION
Авоут пройден:
 https://discord.com/channels/617003227182792704/755125334097133628/1028295419010236466

## What Does This PR Do
Данная батарея выращивается за десятки минут из ничего, в то время, как самая лучшая блюспейс батарея из РНД может не появляться часами из-за нехватки технологий,ресурсов и имеет заряд всего 40 000.

Самое страшное, когда СБ киборг получает нелегальный модуль. После этого он превращается в щиткуритрона 4000, он убивает всё живое под ноль. Он становится ночным кошмаром блоба, ибо в одно лицо убивает блоба любого размера за счёт бесконечного лазера. Он ночной кошмар для всех терроров. Просто отступая и стреляя в них, не подставляясь, он убивает их в любом количестве. Он убивает даже ксеноморфов с дебаффом на эти же лазеры, хотя иногда может получить стан.
Картошко-батарея это бесконечный заряд для МЕХа, который позволяет им управлять часами без перезарядки, совершая те же рывки на гигаксе до бесконечности.
Расчёты: Лазер Ган киборга с нелегальным модулем расходует 200 энергии за выстрел при 20 единицах термического урона. Получаем такую статистику = 2 000 выстрелов при батарее на 400 000. 500 выстрелов при батарее на 100 000. 400 выстрелов при батарее на 80 000. 300 выстрелов при батарее на 60 000

## Why It's Good For The Game
Плюсы: СБ киборгов не вырежут из билда, поскольку вырезан главный корень проблемы. РНД узнает, что станцию зарядки МЕХов можно улучшать. Киборги будут разговаривать с учёными и просить их улучшить зарядники по всей станции.