### PR TITLE
Фикс проблем с буквенными ключами для радио

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -1,84 +1,107 @@
 GLOBAL_LIST_INIT(department_radio_keys, list(
-	  ":r" = "right ear",	"#r" = "right ear",		".r" = "right ear",
-	  ":l" = "left ear",	"#l" = "left ear",		".l" = "left ear",
-	  ":i" = "intercom",	"#i" = "intercom",		".i" = "intercom",
-	  ":h" = "department",	"#h" = "department",	".h" = "department",
-	  ":+" = "special",		"#+" = "special",		".+" = "special", //activate radio-specific special functions
-	  ":c" = "Command",		"#c" = "Command",		".c" = "Command",
-	  ":n" = "Science",		"#n" = "Science",		".n" = "Science",
-	  ":m" = "Medical",		"#m" = "Medical",		".m" = "Medical",
-	  ":x" = "Procedure",	"#x" = "Procedure",		".x" = "Procedure",
-	  ":e" = "Engineering", "#e" = "Engineering",	".e" = "Engineering",
-	  ":s" = "Security",	"#s" = "Security",		".s" = "Security",
-	  ":w" = "whisper",		"#w" = "whisper",		".w" = "whisper",
-	  ":t" = "Syndicate",	"#t" = "Syndicate",		".t" = "Syndicate",
-	  ":a" = "Spider Clan",	"#a" = "Spider Clan",	".a" = "Spider Clan",
-	  ":," = "SyndTaipan",	"#," ="SyndTaipan",		".," = "SyndTaipan",
-	  ":u" = "Supply",		"#u" = "Supply",		".u" = "Supply",
-	  ":z" = "Service",		"#z" = "Service",		".z" = "Service",
-	  ":p" = "AI Private",	"#p" = "AI Private",	".p" = "AI Private",
+/*
+	Busy letters by languages:
+	a b d f g j k o q v x y
+	aa as bo db fa fm fn fs vu
 
-	  ":R" = "right ear",	"#R" = "right ear",		".R" = "right ear",
-	  ":L" = "left ear",	"#L" = "left ear",		".L" = "left ear",
-	  ":I" = "intercom",	"#I" = "intercom",		".I" = "intercom",
-	  ":H" = "department",	"#H" = "department",	".H" = "department",
-	  ":C" = "Command",		"#C" = "Command",		".C" = "Command",
-	  ":N" = "Science",		"#N" = "Science",		".N" = "Science",
-	  ":M" = "Medical",		"#M" = "Medical",		".M" = "Medical",
-	  ":X" = "Procedure",	"#X" = "Procedure",		".X" = "Procedure",
-	  ":E" = "Engineering",	"#E" = "Engineering",	".E" = "Engineering",
-	  ":S" = "Security",	"#S" = "Security",		".S" = "Security",
-	  ":W" = "whisper",		"#W" = "whisper",		".W" = "whisper",
-	  ":T" = "Syndicate",	"#T" = "Syndicate",		".T" = "Syndicate",
-	  ":A" = "Spider Clan",	"#A" = "Spider Clan",	".A" = "Spider Clan",
-	  ":U" = "Supply",		"#U" = "Supply",		".U" = "Supply",
-	  ":Z" = "Service",		"#Z" = "Service",		".Z" = "Service",
-	  ":P" = "AI Private",	"#P" = "AI Private",	".P" = "AI Private",
-	  ":$" = "Response Team", "#$" = "Response Team", ".$" = "Response Team",
-	  ":-" = "Special Ops",	"#-" = "Special Ops",	".-" = "Special Ops",
-	  ":_" = "SyndTeam",	"#_" = "SyndTeam",		"._" = "SyndTeam",
-	  ":~" = "cords",		"#~" = "cords",			".~" = "cords",
+	Busy symbols by languages:
+	0 1 2 3 4 5 6 7 8 9
+	% ? ^
 
-	  ":к" = "right ear",	"№к" = "right ear",		".к" = "right ear",
-	  ":д" = "left ear",	"№д" = "left ear",		".д" = "left ear",
-	  ":ш" = "intercom",	"№ш" = "intercom",		".ш" = "intercom",
-	  ":р" = "department",	"№р" = "department",	".р" = "department",
-	  ":с" = "Command",		"№с" = "Command",		".с" = "Command",
-	  ":т" = "Science",		"№т" = "Science",		".т" = "Science",
-	  ":ь" = "Medical",		"№ь" = "Medical",		".ь" = "Medical",
-	  ":ч" = "Procedure",	"#ч" = "Procedure",		".ч" = "Procedure",
-	  ":у" = "Engineering", "№у" = "Engineering",	".у" = "Engineering",
-	  ":ы" = "Security",	"№ы" = "Security",		".ы" = "Security",
-	  ":ц" = "whisper",		"№ц" = "whisper",		".ц" = "whisper",
-	  ":е" = "Syndicate",	"№е" = "Syndicate",		".е" = "Syndicate",
-	  ":ф" = "Spider Clan",	"#ф" = "Spider Clan",	".ф" = "Spider Clan",
-	  ":б" = "SyndTaipan",	"#б" ="SyndTaipan",		".б" = "SyndTaipan",
-	  ":г" = "Supply",		"№г" = "Supply",		".г" = "Supply",
-	  ":я" = "Service",		"№я" = "Service",		".я" = "Service",
-	  ":з" = "AI Private",	"№з" = "AI Private",	".з" = "AI Private",
-	  ":ё" = "cords",		"№ё" = "cords",			".ё" = "cords",
+	Busy letters by radio(eng):
+	c e h i l m n p r s t u w x z
 
-	  ":К" = "right ear",	"№К" = "right ear",		".К" = "right ear",
-	  ":Д" = "left ear",	"№Д" = "left ear",		".Д" = "left ear",
-	  ":Ш" = "intercom",	"№Ш" = "intercom",		".Ш" = "intercom",
-	  ":Р" = "department",	"№Р" = "department",	".Р" = "department",
-	  ":С" = "Command",		"№С" = "Command",		".С" = "Command",
-	  ":Т" = "Science",		"№Т" = "Science",		".Т" = "Science",
-	  ":Ь" = "Medical",		"№Ь" = "Medical",		".Ь" = "Medical",
-	  ":У" = "Engineering",	"№У" = "Engineering",	".У" = "Engineering",
-	  ":Ы" = "Security",	"№Ы" = "Security",		".Ы" = "Security",
-	  ":Ц" = "whisper",		"№Ц" = "whisper",		".Ц" = "whisper",
-	  ":Е" = "Syndicate",	"№Е" = "Syndicate",		".Е" = "Syndicate",
-	  ":Ф" = "Spider Clan",	"#Ф" = "Spider Clan",	".Ф" = "Spider Clan",
-	  ":Б" = "SyndTaipan",	"#Б" ="SyndTaipan",		".Б" = "SyndTaipan",
-	  ":Г" = "Supply",		"№Г" = "Supply",		".Г" = "Supply",
-	  ":Я" = "Service",		"№Я" = "Service",		".Я" = "Service",
-	  ":З" = "AI Private",	"№З" = "AI Private",	".З" = "AI Private",
-	  ":Ё" = "cords",		"№Ё" = "cords",			".Ё" = "cords",
-	  						"№$" = "Response Team",
-	  						"№-" = "Special Ops",
-	  						"№_" = "SyndTeam",
-							"№+" = "special"
+	Busy letters by radio(rus):
+	б г д е ё з к р с т у ц ч ш ы ь я
+
+	Busy symbols by radio:
+	~ , $ _ - + *
+
+	CAUTION! The key must not repeat the key of the languages (language.dm)
+	and must not contain prohibited characters
+*/
+	// English text lowercase
+	  ":r" = "right ear",		"#r" = "right ear",		"№r" = "right ear",		".r" = "right ear",
+	  ":l" = "left ear",		"#l" = "left ear",		"№l" = "left ear",		".l" = "left ear",
+	  ":i" = "intercom",		"#i" = "intercom",		"№i" = "intercom",		".i" = "intercom",
+	  ":h" = "department",		"#h" = "department",	"№h" = "department",	".h" = "department",
+	  ":c" = "Command",			"#c" = "Command",		"№c" = "Command",		".c" = "Command",
+	  ":n" = "Science",			"#n" = "Science",		"№n" = "Science",		".n" = "Science",
+	  ":m" = "Medical",			"#m" = "Medical",		"№m" = "Medical",		".m" = "Medical",
+	  ":x" = "Procedure",		"#x" = "Procedure",		"№x" = "Procedure",		".x" = "Procedure",
+	  ":e" = "Engineering", 	"#e" = "Engineering",	"№e" = "Engineering",	".e" = "Engineering",
+	  ":s" = "Security",		"#s" = "Security",		"№s" = "Security",		".s" = "Security",
+	  ":w" = "whisper",			"#w" = "whisper",		"№w" = "whisper",		".w" = "whisper",
+	  ":t" = "Syndicate",		"#t" = "Syndicate",		"№t" = "Syndicate",		".t" = "Syndicate",
+	  ":u" = "Supply",			"#u" = "Supply",		"№u" = "Supply",		".u" = "Supply",
+	  ":z" = "Service",			"#z" = "Service",		"№z" = "Service",		".z" = "Service",
+	  ":p" = "AI Private",		"#p" = "AI Private",	"№p" = "AI Private",	".p" = "AI Private",
+
+	// English text uppercase
+	  ":R" = "right ear",		"#R" = "right ear",		"№R" = "right ear",		".R" = "right ear",
+	  ":L" = "left ear",		"#L" = "left ear",		"№L" = "left ear",		".L" = "left ear",
+	  ":I" = "intercom",		"#I" = "intercom",		"№I" = "intercom",		".I" = "intercom",
+	  ":H" = "department",		"#H" = "department",	"№H" = "department",	".H" = "department",
+	  ":C" = "Command",			"#C" = "Command",		"№C" = "Command",		".C" = "Command",
+	  ":N" = "Science",			"#N" = "Science",		"№N" = "Science",		".N" = "Science",
+	  ":M" = "Medical",			"#M" = "Medical",		"№M" = "Medical",		".M" = "Medical",
+	  ":X" = "Procedure",		"#X" = "Procedure",		"№X" = "Procedure",		".X" = "Procedure",
+	  ":E" = "Engineering",		"#E" = "Engineering",	"№E" = "Engineering",	".E" = "Engineering",
+	  ":S" = "Security",		"#S" = "Security",		"№S" = "Security",		".S" = "Security",
+	  ":W" = "whisper",			"#W" = "whisper",		"№W" = "whisper",		".W" = "whisper",
+	  ":T" = "Syndicate",		"#T" = "Syndicate",		"№T" = "Syndicate",		".T" = "Syndicate",
+	  ":U" = "Supply",			"#U" = "Supply",		"№U" = "Supply",		".U" = "Supply",
+	  ":Z" = "Service",			"#Z" = "Service",		"№Z" = "Service",		".Z" = "Service",
+	  ":P" = "AI Private",		"#P" = "AI Private",	"№P" = "AI Private",	".P" = "AI Private",
+
+	// Russian text lowercase
+	  ":к" = "right ear",		"#к" = "right ear",		"№к" = "right ear",		".к" = "right ear",
+	  ":д" = "left ear",		"#д" = "left ear",		"№д" = "left ear",		".д" = "left ear",
+	  ":ш" = "intercom",		"#ш" = "intercom",		"№ш" = "intercom",		".ш" = "intercom",
+	  ":р" = "department",		"#р" = "department",	"№р" = "department",	".р" = "department",
+	  ":с" = "Command",			"#с" = "Command",		"№с" = "Command",		".с" = "Command",
+	  ":т" = "Science",			"#т" = "Science",		"№т" = "Science",		".т" = "Science",
+	  ":ь" = "Medical",			"#ь" = "Medical",		"№ь" = "Medical",		".ь" = "Medical",
+	  ":ч" = "Procedure",		"#ч" = "Procedure",		"№ч" = "Procedure",		".ч" = "Procedure",
+	  ":у" = "Engineering", 	"#у" = "Engineering",	"№у" = "Engineering",	".у" = "Engineering",
+	  ":ы" = "Security",		"#ы" = "Security",		"№ы" = "Security",		".ы" = "Security",
+	  ":ц" = "whisper",			"#ц" = "whisper",		"№ц" = "whisper",		".ц" = "whisper",
+	  ":е" = "Syndicate",		"#е" = "Syndicate",		"№е" = "Syndicate",		".е" = "Syndicate",
+	  ":б" = "SyndTaipan",		"#б" = "SyndTaipan",	"№б" = "SyndTaipan",	".б" = "SyndTaipan",
+	  ":г" = "Supply",			"#г" = "Supply",		"№г" = "Supply",		".г" = "Supply",
+	  ":я" = "Service",			"#я" = "Service",		"№я" = "Service",		".я" = "Service",
+	  ":з" = "AI Private",		"#з" = "AI Private",	"№з" = "AI Private",	".з" = "AI Private",
+	  ":ё" = "cords",			"#ё" = "cords",			"№ё" = "cords",			".ё" = "cords",
+	// Russian text uppercase
+	  ":К" = "right ear",		"#К" = "right ear",		"№К" = "right ear",		".К" = "right ear",
+	  ":Д" = "left ear",		"#Д" = "left ear",		"№Д" = "left ear",		".Д" = "left ear",
+	  ":Ш" = "intercom",		"#Ш" = "intercom",		"№Ш" = "intercom",		".Ш" = "intercom",
+	  ":Р" = "department",		"#Р" = "department",	"№Р" = "department",	".Р" = "department",
+	  ":С" = "Command",			"#С" = "Command",		"№С" = "Command",		".С" = "Command",
+	  ":Т" = "Science",			"#Т" = "Science",		"№Т" = "Science",		".Т" = "Science",
+	  ":Ь" = "Medical",			"#Ь" = "Medical",		"№Ь" = "Medical",		".Ь" = "Medical",
+	  ":У" = "Engineering",		"#У" = "Engineering",	"№У" = "Engineering",	".У" = "Engineering",
+	  ":Ы" = "Security",		"#Ы" = "Security",		"№Ы" = "Security",		".Ы" = "Security",
+	  ":Ц" = "whisper",			"#Ц" = "whisper",		"№Ц" = "whisper",		".Ц" = "whisper",
+	  ":Е" = "Syndicate",		"#Е" = "Syndicate",		"№Е" = "Syndicate",		".Е" = "Syndicate",
+	  ":Б" = "SyndTaipan",		"#Б" = "SyndTaipan",	"№Б" = "SyndTaipan",	".Б" = "SyndTaipan",
+	  ":Г" = "Supply",			"#Г" = "Supply",		"№Г" = "Supply",		".Г" = "Supply",
+	  ":Я" = "Service",			"#Я" = "Service",		"№Я" = "Service",		".Я" = "Service",
+	  ":З" = "AI Private",		"#З" = "AI Private",	"№З" = "AI Private",	".З" = "AI Private",
+	  ":Ё" = "cords",			"#Ё" = "cords",			"№Ё" = "cords",			".Ё" = "cords",
+
+	// English symbols no case
+	  ":~" = "cords",			"#~" = "cords",			"№~" = "cords",			".~" = "cords",
+	  ":," = "SyndTaipan",		"#," = "SyndTaipan",	"№," = "SyndTaipan",	".," = "SyndTaipan",
+	// Russian symbols no case
+		// None yet.
+
+	// Special symbols only (that means that they don't have/use an english/russian analogue)
+ 	  ":*" = "Spider Clan",		"#*" = "Spider Clan",	"№*" = "Spider Clan",	".*" = "Spider Clan",
+	  ":$" = "Response Team",	"#$" = "Response Team", "№$" = "Response Team",	".$" = "Response Team",
+  	  ":_" = "SyndTeam",		"#_" = "SyndTeam",		"№_" = "SyndTeam",		"._" = "SyndTeam",
+	  ":-" = "Special Ops",		"#-" = "Special Ops",	"№-" = "Special Ops",	".-" = "Special Ops",
+	  ":+" = "special",			"#+" = "special",		"№+" = "special",		".+" = "special" //activate radio-specific special functions
 ))
 
 GLOBAL_LIST_EMPTY(channel_to_radio_key)


### PR DESCRIPTION
## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
* Изменение канала для ниндзя из-за конфликта с языком элиенов. с `:a` на `:*`
* Правка глобального листа всех ключей, чтобы он выглядел красиво и не терял нигде символа `#` или `№` Ибо ранее было, что один из двух символов либо вообще не используется, либо используются оба и одни частоты поддерживали два символа. Другие лишь один из них.

От себя добавляю, что этот мега лист на самом деле та ещё хрень и я совершенно не понимаю, что мешало сделать обработку спецсимволов `: . # №` через код. С языками так сделали(они вообще датумизированы), а радио почему то применяет лист с кучей повторений, который можно было бы сократить до листа лишь с используемыми буквами/символами самой частоты. Но делать такой большой рефактор у меня нет ни времени ни желания. Так что ограничусь этим.
## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Никаких конфликтов между языками и радио. Плюс нормальная поддержка всех 4-ёх спецсимволов для использования радио.

