### PR TITLE
FIX: Обновление слаймов, фиксы некритических ошибок.

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -281,10 +281,7 @@
 	var/new_colour = pick("red", "orange")
 	var/mob/living/simple_animal/slime/random/S = new(T, new_colour)
 	S.rabid = TRUE
-	S.amount_grown = S.age_state.amount_grown_for_split
-	S.Evolve()
-	var/datum/action/innate/slime/reproduce/A = new
-	A.Grant(S)
+	S.set_nutrition(S.get_max_nutrition())
 
 	var/list/mob/dead/observer/candidates = SSghost_spawns.poll_candidates("Do you want to play as a pyroclastic anomaly slime?", ROLE_SENTIENT, FALSE, 100, source = S, role_cleanname = "pyroclastic anomaly slime")
 	if(LAZYLEN(candidates))

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -279,9 +279,9 @@
 	if(istype(T))
 		T.atmos_spawn_air(LINDA_SPAWN_HEAT | LINDA_SPAWN_TOXINS | LINDA_SPAWN_OXYGEN, 500) //Make it hot and burny for the new slime
 	var/new_colour = pick("red", "orange")
-	var/mob/living/simple_animal/slime/S = new(T, new_colour)
+	var/mob/living/simple_animal/slime/random/S = new(T, new_colour)
 	S.rabid = TRUE
-	S.amount_grown = SLIME_EVOLUTION_THRESHOLD
+	S.amount_grown = S.age_state.amount_grown_for_split
 	S.Evolve()
 	var/datum/action/innate/slime/reproduce/A = new
 	A.Grant(S)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -841,6 +841,8 @@ REAGENT SCANNER
 	if(T.cores > 1)
 		to_chat(user, "Multiple cores detected")
 	to_chat(user, "Growth progress: [clamp(T.amount_grown, 0, T.age_state.amount_grown)]/[T.age_state.amount_grown]")
+	to_chat(user, "Split progress: [clamp(T.amount_grown, 0, T.age_state.amount_grown_for_split)]/[T.age_state.amount_grown_for_split]")
+	to_chat(user, "Evolve: preparing for [(T.amount_grown < T.age_state.amount_grown_for_split) ? (T.age_state.stat_text) : (T.age_state.age != SLIME_ELDER ? T.age_state.stat_text_evolve : T.age_state.stat_text)]")
 	if(T.effectmod)
 		to_chat(user, "<span class='notice'>Core mutation in progress: [T.effectmod]</span>")
 		to_chat(user, "<span class='notice'>Progress in core mutation: [T.applied] / [SLIME_EXTRACT_CROSSING_REQUIRED]</span>")

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -186,8 +186,8 @@
 
 	if(iscarbon(M))
 		var/mob/living/carbon/C = M
-		C.adjustCloneLoss(rand(2, 4) + round(age_state.feed/2))
-		C.adjustToxLoss(rand(1, 2) + round(age_state.feed/2))
+		C.adjustCloneLoss(rand(2, 4) + round(age_state.feed/3))
+		C.adjustToxLoss(rand(1, 2) + round(age_state.feed/3))
 
 		if(prob(10) && C.client)
 			to_chat(C, "<span class='userdanger'>[pick("You can feel your body becoming weak!", \
@@ -202,8 +202,8 @@
 		var/mob/living/simple_animal/SA = M
 
 		var/totaldamage = 0 //total damage done to this unfortunate animal
-		totaldamage += SA.adjustCloneLoss(rand(2, 4 + round(age_state.feed/2)))
-		totaldamage += SA.adjustToxLoss(rand(1, 2 + round(age_state.feed/2)))
+		totaldamage += SA.adjustCloneLoss(rand(2, 4 + round(age_state.feed/3)))
+		totaldamage += SA.adjustToxLoss(rand(1, 2 + round(age_state.feed/3)))
 
 		if(totaldamage <= 0) //if we did no(or negative!) damage to it, stop
 			Feedstop(0, 0)
@@ -216,10 +216,10 @@
 	//Передача нутриентов, + небольшое поедание внутренних запасов, не смотря на поедание плоти (урон)
 	var/nutrition_rand = rand(7 + age_state.feed, 15 + age_state.feed * 2)
 	add_nutrition(nutrition_rand)
-	M.adjust_nutrition(round(nutrition_rand / 2))
+	M.adjust_nutrition(round(nutrition_rand / 3))
 
 	//Heal yourself.
-	adjustBruteLoss(-(3 + round(nutrition_rand / 4)))
+	adjustBruteLoss(-(3 + round(nutrition_rand / 3)))
 
 /mob/living/simple_animal/slime/proc/handle_nutrition()
 
@@ -240,14 +240,19 @@
 		amount_grown++
 		update_action_buttons_icon()
 
-	if(amount_grown >= age_state.amount_grown && !buckled && !Target && !ckey)
-		if(age_state.age != SLIME_BABY)
-			if(prob(20) && age_state.age != SLIME_ELDER)
-				Evolve()
-			else
-				Reproduce()
-		else
+	if (buckled || Target || ckey)
+		return FALSE
+
+	var/chance_reproduce = 80
+	if(amount_grown == age_state.amount_grown_for_split)
+		if(age_state.age != SLIME_BABY && prob(chance_reproduce) || age_state.age == SLIME_ELDER)
+			Reproduce()
+
+	if(amount_grown >= age_state.amount_grown)
+		if(age_state.age != SLIME_ELDER)
 			Evolve()
+		else
+			Reproduce()	//Если вдруг игрок за древнего слайма гостанулся, а у него приличное созревание, то он разделится
 
 /mob/living/simple_animal/slime/proc/add_nutrition(nutrition_to_add = 0)
 	set_nutrition(min((nutrition + nutrition_to_add), get_max_nutrition()))

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -214,12 +214,12 @@
 		return
 
 	//Передача нутриентов, + небольшое поедание внутренних запасов, не смотря на поедание плоти (урон)
-	var/nutrition_rand = rand(7 + age_state.feed, 15 + age_state.feed * 2)
+	var/nutrition_rand = rand(7 + age_state.feed * 2, 15 + age_state.feed * 4)
 	add_nutrition(nutrition_rand)
-	M.adjust_nutrition(round(nutrition_rand / 3))
+	M.adjust_nutrition(round(nutrition_rand / 4))
 
 	//Heal yourself.
-	adjustBruteLoss(-(3 + round(nutrition_rand / 3)))
+	adjustBruteLoss(-(3 + round(nutrition_rand / 4)))
 
 /mob/living/simple_animal/slime/proc/handle_nutrition()
 

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -5,16 +5,22 @@
 #define NO_GROWTH_NEEDED	0
 #define GROWTH_NEEDED		1
 
+#define NO_SPLIT_NEEDED		0
+#define SPLIT_NEEDED		1
+
 /datum/action/innate/slime
 	check_flags = AB_CHECK_CONSCIOUS
 	icon_icon = 'icons/mob/actions/actions_slime.dmi'
 	background_icon_state = "bg_alien"
 	var/needs_growth = NO_GROWTH_NEEDED
+	var/needs_split = NO_SPLIT_NEEDED
 
 /datum/action/innate/slime/IsAvailable()
 	if(..())
 		var/mob/living/simple_animal/slime/S = owner
 		if(needs_growth == GROWTH_NEEDED)
+			if(needs_split == SPLIT_NEEDED && S.amount_grown >= S.age_state.amount_grown_for_split)
+				return 1
 			if(S.amount_grown >= S.age_state.amount_grown)
 				return 1
 			return 0
@@ -255,6 +261,7 @@
 	name = "Reproduce"
 	button_icon_state = "slimesplit"
 	needs_growth = GROWTH_NEEDED
+	needs_split = SPLIT_NEEDED
 
 /datum/action/innate/slime/reproduce/Activate()
 	var/mob/living/simple_animal/slime/S = owner

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -184,7 +184,7 @@
 		return
 
 	if(age_state.age != SLIME_BABY)
-		if(amount_grown >= SLIME_EVOLUTION_THRESHOLD)
+		if(amount_grown >=	age_state.amount_grown_for_split)
 			if(stat)
 				to_chat(src, "<i>I must be conscious to do this...</i>")
 				return
@@ -241,10 +241,10 @@
 		child_colour = slime_mutation[rand(1,4)]
 	else
 		child_colour = colour
-	var/mob/living/simple_animal/slime/M = new(loc, child_colour, new baby_type)
+	var/mob/living/simple_animal/slime/M = new(loc, child_colour, new baby_type, new_nutrition)
 
 	if(ckey)
-		M.set_nutrition(new_nutrition) //Player slimes are more robust at spliting. Once an oversight of poor copypasta, now a feature!
+		M.set_nutrition(new_nutrition * 1.25) //Player slimes are more robust at spliting. Once an oversight of poor copypasta, now a feature!
 	M.powerlevel = new_powerlevel
 	M.Friends = Friends.Copy()
 	babies += M

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -479,7 +479,9 @@
 	else if (prob(50))
 		age_state_new = new /datum/slime_age/adult
 		new_set_nutrition = 900
-	. = ..(mapload, pick(slime_colours), age_state_new, new_set_nutrition)
+	if (!new_colour)
+		new_colour = pick(slime_colours)
+	. = ..(mapload, new_colour, age_state_new, new_set_nutrition)
 
 /mob/living/simple_animal/slime/adult/Initialize(mapload, new_colour, age_state_new, new_set_nutrition)
 	. = ..(mapload, pick(slime_colours), age_state_new = new /datum/slime_age/adult, new_set_nutrition = 900)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -82,6 +82,9 @@
 	if (!(locate(/datum/action/innate/slime/feed) in actions))
 		var/datum/action/innate/slime/feed/F = new
 		F.Grant(src)
+	if(age_state.age != SLIME_BABY && !(locate(/datum/action/innate/slime/reproduce) in actions))
+		var/datum/action/innate/slime/reproduce/R = new
+		R.Grant(src)
 	if (!(locate(/datum/action/innate/slime/evolve) in actions))
 		var/datum/action/innate/slime/evolve/E = new
 		E.Grant(src)
@@ -89,10 +92,6 @@
 	age_state = age_state_new
 	health = age_state.health
 	update_state()
-
-	if(age_state.age != SLIME_BABY && !(locate(/datum/action/innate/slime/reproduce) in actions))
-		var/datum/action/innate/slime/reproduce/R = new
-		R.Grant(src)
 
 	create_reagents(100)
 	set_colour(new_colour)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -60,7 +60,7 @@
 	var/mutator_used = FALSE //So you can't shove a dozen mutators into a single slime
 	var/force_stasis = FALSE
 
-	var/static/regex/slime_name_regex = new("\\w+ (baby|adult) slime \\(\\d+\\)")
+	var/static/regex/slime_name_regex = new("\\w+ (baby|adult|old|elder) slime \\(\\d+\\)")
 	///////////TIME FOR SUBSPECIES
 
 	var/colour = "grey"
@@ -78,7 +78,7 @@
 	var/applied = 0 //How many extracts of the modtype have been applied.
 
 
-/mob/living/simple_animal/slime/Initialize(mapload, new_colour = "grey", age_state_new = new /datum/slime_age/baby)
+/mob/living/simple_animal/slime/Initialize(mapload, new_colour = "grey", age_state_new = new /datum/slime_age/baby, new_set_nutrition = 700)
 	if (!(locate(/datum/action/innate/slime/feed) in actions))
 		var/datum/action/innate/slime/feed/F = new
 		F.Grant(src)
@@ -97,7 +97,7 @@
 	create_reagents(100)
 	set_colour(new_colour)
 	. = ..()
-	set_nutrition(700)
+	set_nutrition(new_set_nutrition)
 	add_language("Bubblish")
 
 /mob/living/simple_animal/slime/Destroy()
@@ -242,8 +242,8 @@
 		if(!docile)
 			stat(null, "Nutrition: [nutrition]/[get_max_nutrition()]")
 
-		if(amount_grown >= age_state.amount_grown)
-			stat(null, age_state.stat_text)
+		if(amount_grown >= age_state.amount_grown_for_split)
+			stat(null, "You can [age_state.stat_text][amount_grown >= age_state.amount_grown ? " [age_state.stat_text_evolve]" : ""]!")
 
 		if(stat == UNCONSCIOUS)
 			stat(null,"You are knocked out by high levels of BZ!")
@@ -467,17 +467,28 @@
 	if(..())
 		return 3
 
-/mob/living/simple_animal/slime/random/Initialize(mapload, new_colour, age_state_new)
-	. = ..(mapload, pick(slime_colours), prob(50) ? (age_state_new = new /datum/slime_age/baby) : (age_state_new = new /datum/slime_age/adult))
+/mob/living/simple_animal/slime/random/Initialize(mapload, new_colour, age_state_new, new_set_nutrition)
+	age_state_new = new /datum/slime_age/baby
+	new_set_nutrition = 700
+	if (prob(10))
+		age_state_new = new /datum/slime_age/elder
+		new_set_nutrition = 2000
+	else if (prob(30))
+		age_state_new = new /datum/slime_age/old
+		new_set_nutrition = 1200
+	else if (prob(50))
+		age_state_new = new /datum/slime_age/adult
+		new_set_nutrition = 900
+	. = ..(mapload, pick(slime_colours), age_state_new, new_set_nutrition)
 
-/mob/living/simple_animal/slime/adult/Initialize(mapload, new_colour, age_state_new)
-	. = ..(mapload, pick(slime_colours), age_state_new = new /datum/slime_age/adult)
+/mob/living/simple_animal/slime/adult/Initialize(mapload, new_colour, age_state_new, new_set_nutrition)
+	. = ..(mapload, pick(slime_colours), age_state_new = new /datum/slime_age/adult, new_set_nutrition = 900)
 
-/mob/living/simple_animal/slime/old/Initialize(mapload, new_colour, age_state_new)
-	. = ..(mapload, pick(slime_colours), age_state_new = new /datum/slime_age/old)
+/mob/living/simple_animal/slime/old/Initialize(mapload, new_colour, age_state_new, new_set_nutrition)
+	. = ..(mapload, pick(slime_colours), age_state_new = new /datum/slime_age/old, new_set_nutrition = 1200)
 
-/mob/living/simple_animal/slime/elder/Initialize(mapload, new_colour, age_state_new)
-	. = ..(mapload, pick(slime_colours), age_state_new = new /datum/slime_age/elder)
+/mob/living/simple_animal/slime/elder/Initialize(mapload, new_colour, age_state_new, new_set_nutrition)
+	. = ..(mapload, pick(slime_colours), age_state_new = new /datum/slime_age/elder, new_set_nutrition = 2000)
 
 /mob/living/simple_animal/slime/handle_ventcrawl(atom/A)
 	if(buckled)

--- a/code/modules/mob/living/simple_animal/slime/subtypes.dm
+++ b/code/modules/mob/living/simple_animal/slime/subtypes.dm
@@ -3,8 +3,10 @@
 	var/health
 	var/damage
 	var/attacked			//доп. урон наносимый слайму
-	var/stat_text
-	var/amount_grown
+	var/stat_text			//Текст для игрока что готов делиться
+	var/stat_text_evolve	//Доп. текст для игрока, что готов эволюционировать
+	var/amount_grown		//созревание для эволюции, максимальное значение созревания
+	var/amount_grown_for_split	//созревание для деления
 	var/max_nutrition		//Can't go above it
 	var/grow_nutrition		//Above it we grow, below it we can eat
 	var/hunger_nutrition	//Below it we will always eat
@@ -21,8 +23,10 @@
 	health = 150
 	damage = 3
 	attacked = -2
-	stat_text = "You can evolve!"
+	stat_text = ""
+	stat_text_evolve = "evolve to adult form"
 	amount_grown = SLIME_EVOLUTION_THRESHOLD
+	amount_grown_for_split = SLIME_EVOLUTION_THRESHOLD
 	max_nutrition = 1000
 	grow_nutrition = 800
 	hunger_nutrition = 500
@@ -32,15 +36,17 @@
 	matrix_size = matrix(1, 0, 0, 0, 1, 0)
 	baby_counts	= 0
 	cores = 1
-	feed = 0
+	feed = 2
 
 /datum/slime_age/adult
 	age = SLIME_ADULT
 	health = 200
 	damage = 5
 	attacked = 0
-	stat_text = "You can reproduce and evolve!"
+	stat_text = "reproduce"
+	stat_text_evolve = "evolve to old form"
 	amount_grown = SLIME_EVOLUTION_THRESHOLD_OLD
+	amount_grown_for_split = SLIME_EVOLUTION_THRESHOLD
 	max_nutrition = 1200
 	grow_nutrition = 1000
 	hunger_nutrition = 600
@@ -50,15 +56,17 @@
 	matrix_size = matrix(1, 0, 0, 0, 1, 0)
 	baby_counts	= 4
 	cores = 1
-	feed = 1
+	feed = 4
 
 /datum/slime_age/old
 	age = SLIME_OLD
 	health = 300
 	damage = 7
 	attacked = 2
-	stat_text = "You can reproduce and evolve to elder form!"
+	stat_text = "big reproduce"
+	stat_text_evolve = "evolve to elder form"
 	amount_grown = SLIME_EVOLUTION_THRESHOLD_EVOLVE
+	amount_grown_for_split = SLIME_EVOLUTION_THRESHOLD_OLD
 	max_nutrition = 3000
 	grow_nutrition = 2000
 	hunger_nutrition = 800
@@ -68,15 +76,17 @@
 	matrix_size = matrix(1.25, 0, 0, 0, 1.25, 2)
 	baby_counts	= 9
 	cores = 4
-	feed = 2
+	feed = 8
 
 /datum/slime_age/elder
 	age = SLIME_ELDER
 	health = 400
 	damage = 10
 	attacked = 5
-	stat_text = "You can reproduce and evolve to slimeman!"
+	stat_text = "huge reproduce"
+	stat_text_evolve = "evolve to slimeman"
 	amount_grown = SLIME_EVOLUTION_THRESHOLD_EVOLVE_SLIMEMAN
+	amount_grown_for_split = SLIME_EVOLUTION_THRESHOLD_OLD
 	max_nutrition = 6000
 	grow_nutrition = 3200
 	hunger_nutrition = 1200
@@ -86,7 +96,7 @@
 	matrix_size = matrix(1.75, 0, 0, 0, 1.75, 4)
 	baby_counts	= 18
 	cores = 8
-	feed = 4
+	feed = 10
 
 /datum/slime_age/slimeman
 	age = SLIME_SLIMEMAN


### PR DESCRIPTION
Оригинальный ПР:
https://github.com/ss220-space/Paradise/pull/1358

## What Does This PR Do
После багрепортов были обнаружены новые визуальные баги, также сканер, показывающий не совсем правдивую информацию. Обнаружились баги при делении не передающие нутриенты детишкам (по причине того что у него нет сикея, а в коде это якобы "фича" О.о)

### Исправлен баг с делением нутриентов на детей
Очень старый баг.
Детям слаймов "изниоткуда" передавалось 700 нутриентов, из-за чего слаймы-родители/слаймы-игроки могли это абузить и жрать своих детей чтобы накопить поболее нутриентов. 
К сожалению, этот фикс теперь замедлит работу ксенобиологов. На это были неоднократные багрепорты и просьбы педалей это исправить.
Больше никаких халявных нутриентов из воздуха. Но слаймодетей всё еще можно жрать!

### Увеличение скорости набирания массы
Теперь взрослый слайм отпочковавшийся на 4-х детей, передает им по 250 нутриентов, а не 700. В связи с этим увеличилась скорость их кормежки, дабы стабилизировать скорость набирания массы как и раньше. Чем старее слайм, тем больше у него скорость "высасывания" нутриентов.
Эти изменения относятся ко всем этапам слаймов.

### Этап "деления"
У слаймов появился этап деления, в котором они могут поделиться. Но если слайм "не захотел", то он дорастет дальше и эволюционирует. Это увеличит скорость выращивания слаймов как и раньше. Теперь условному взрослому слайму не нужно копить 30 очков "зрелости" **Amount Growth**, ему теперь как и раньше достаточно накопить 10. Но он по прежнему с небольшим шансом можем продолжить набирать массу и эволюционировать.
Древний слайм по прежнему при достижении максимального созревания, поделится на слаймов. Поэтому успейте его изолировать или дать ему разум, чтобы такого не случилось.

### Сканер слаймов
Сканер слаймов был улучшен, у него исправлена математика подсчетов, а также корректно теперь отображаются состояния делений, эволюции и третьей строчкой выписывается на каком этапе сейчас находится слайм и к чему он готовится (к делению/эволюции)

### Фикс именования слаймов
ДРЕВНИЕ elder-слаймы теперь корректно именуются.

### Щитспавн рандомных слаймов
Теперь через Game Panel -- Mobs можно заспавнить слайма рандомного типа и возраста.

### Расширение субтипов и статов
Теперь игрок-слайм может видеть на каком этапе он сейчас находится и что может проделать!
И теперь эти надписи находятся в субтипах слайма.
Аналогично там же находятся значения созревания для деление

### Обновление пирослайма
Код пирослайма подчищен, теперь он не делится до того как игрок-кандидат зайдет в него. 
Игрок-кандидат может самостоятельно репродуцироваться (его текущие нутриенты затрачиваются на "созревание").

### Иконки
В соответствии с этапами "созревания" изменен порядок расположения иконок.
Иконка теперь корректно активируется при достижении необходимых значений.

И прочие мелочи рефактора в коде для баланса.

## Why It's Good For The Game
Баланс поправлен, исправлены старые баги, починен сканер. Сканер теперь более полезней.