### PR TITLE
Fix: Medbay Maintenance Upgrade (Delta/Kerberos) 

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -3168,6 +3168,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/window/brigdoor/southright{
+	dir = 8;
+	name = "Security Checkpoint";
+	pixel_x = -8;
+	req_access_txt = "1"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/chair/office/dark{
@@ -5058,10 +5064,10 @@
 /area/hallway/secondary/entry/additional)
 "aAh" = (
 /obj/effect/decal/warning_stripes/blue,
+/obj/effect/decal/warning_stripes/southwest,
 /obj/structure/sink{
 	pixel_y = 22
 	},
-/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
@@ -8193,7 +8199,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "aOV" = (
 /obj/machinery/door_control{
 	desc = "A remote control-switch for the pod doors.";
@@ -9470,7 +9478,9 @@
 "aVo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "aVz" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -9686,7 +9696,7 @@
 /obj/item/folder,
 /obj/item/pen,
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/library)
 "aXc" = (
 /obj/machinery/light{
 	dir = 4
@@ -10240,9 +10250,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Abandoned scape Shuttle Hallway"
-	})
+/area/hallway/secondary/exit/maint)
 "baf" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -12657,7 +12665,9 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "bmG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -13385,7 +13395,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "bru" = (
 /obj/structure/closet,
 /obj/item/toy/crayon/spraycan,
@@ -18919,6 +18931,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/window/brigdoor/southright{
+	dir = 8;
+	name = "Customs Desk";
+	pixel_x = 32;
+	req_access_txt = "19"
+	},
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
@@ -20254,7 +20272,7 @@
 /obj/structure/table/wood,
 /obj/item/storage/fancy/crayons,
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/library)
 "bTR" = (
 /obj/structure/sign/pods,
 /turf/simulated/wall,
@@ -20523,9 +20541,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/storage{
-	name = "Perma Maintenance"
-	})
+/area/maintenance/perma)
 "bUH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -23063,9 +23079,7 @@
 "ceu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/hallway/secondary/exit{
-	name = "\improper Abandoned scape Shuttle Hallway"
-	})
+/area/hallway/secondary/exit/maint)
 "cew" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Hall Center"
@@ -23269,9 +23283,7 @@
 "cfs" = (
 /obj/item/wirecutters,
 /turf/simulated/floor/plating,
-/area/maintenance/storage{
-	name = "Perma Maintenance"
-	})
+/area/maintenance/perma)
 "cft" = (
 /obj/machinery/camera{
 	c_tag = "Supermatter Pump Airlock";
@@ -24672,9 +24684,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/secondary/exit{
-	name = "\improper Abandoned scape Shuttle Hallway"
-	})
+/area/hallway/secondary/exit/maint)
 "cmh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -26627,7 +26637,9 @@
 "cvi" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "cvj" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -27158,7 +27170,9 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "cxb" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/emcloset,
@@ -27329,9 +27343,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "cxP" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -29558,7 +29570,9 @@
 "cET" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "cFb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	name = "Из скрабберов на фильтрацию"
@@ -29572,7 +29586,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "cFd" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -30956,9 +30972,7 @@
 "cJM" = (
 /obj/item/stack/cable_coil,
 /turf/simulated/floor/plating,
-/area/maintenance/storage{
-	name = "Perma Maintenance"
-	})
+/area/maintenance/perma)
 "cJN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -31592,7 +31606,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "cMP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -31681,7 +31697,7 @@
 /obj/structure/chair/office/dark,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "cNB" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -33061,7 +33077,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "cSp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/closet/crate,
@@ -36148,9 +36164,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Abandoned scape Shuttle Hallway"
-	})
+/area/hallway/secondary/exit/maint)
 "deA" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -36768,9 +36782,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/storage{
-	name = "Perma Maintenance"
-	})
+/area/maintenance/perma)
 "dgv" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -39229,9 +39241,7 @@
 	pixel_x = 26
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "dpa" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/grown/banana{
@@ -42996,9 +43006,7 @@
 /area/security/prisonershuttle)
 "dEP" = (
 /turf/simulated/wall/r_wall,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "dEV" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -43018,9 +43026,7 @@
 	network = list("SS13","MiniSat")
 	},
 /turf/space,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "dFa" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -43070,7 +43076,7 @@
 /area/civilian/barber)
 "dFg" = (
 /turf/simulated/wall,
-/area/library/abandoned)
+/area/maintenance/library)
 "dFh" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
@@ -43255,13 +43261,15 @@
 /area/crew_quarters/courtroom)
 "dFG" = (
 /turf/simulated/wall/rust,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "dFK" = (
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "dFM" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -43397,7 +43405,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "carpet"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "dGD" = (
 /obj/structure/chair/sofa/right,
 /turf/simulated/floor/carpet,
@@ -43714,7 +43722,7 @@
 "dHt" = (
 /obj/structure/bookcase,
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/library)
 "dHx" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -44684,7 +44692,7 @@
 	name = "blobstart"
 	},
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "dKM" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
@@ -45050,7 +45058,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "dMg" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -48679,7 +48687,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "dYa" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -49456,7 +49464,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/library)
 "eaZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -50295,9 +50303,7 @@
 	dir = 1
 	},
 /turf/space,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "ejN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -50450,9 +50456,7 @@
 	dir = 10;
 	icon_state = "escape"
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Abandoned scape Shuttle Hallway"
-	})
+/area/hallway/secondary/exit/maint)
 "ekW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -50904,7 +50908,7 @@
 /obj/structure/bookcase,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/library)
 "erJ" = (
 /obj/machinery/ai_status_display{
 	pixel_y = 32
@@ -51848,10 +51852,6 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
-"eBY" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/maintenance/storage)
 "eCf" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/structure/cable{
@@ -52883,9 +52883,7 @@
 /obj/effect/decal/warning_stripes/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Abandoned scape Shuttle Hallway"
-	})
+/area/hallway/secondary/exit/maint)
 "eNt" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
@@ -53689,16 +53687,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
-"eWD" = (
-/obj/item/clothing/mask/facehugger/toy,
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/reagent_containers/food/snacks/monstermeat/xenomeat,
-/obj/item/reagent_containers/food/snacks/monstermeat/xenomeat,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint{
-	name = "Virology Maintenance"
-	})
 "eWN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -54319,11 +54307,15 @@
 "fdc" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "fdB" = (
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall/rust,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "fdD" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -54382,7 +54374,9 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "fed" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -54771,7 +54765,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "fju" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -54857,7 +54853,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "fjY" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -54990,7 +54988,9 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "flH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -55095,7 +55095,9 @@
 "fmV" = (
 /obj/structure/closet/l3closet/virology,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "fnm" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -55283,9 +55285,7 @@
 	pixel_y = -6
 	},
 /turf/simulated/floor/plating,
-/area/hallway/secondary/exit{
-	name = "\improper Abandoned scape Shuttle Hallway"
-	})
+/area/hallway/secondary/exit/maint)
 "fpN" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/disposalpipe/segment{
@@ -55589,9 +55589,7 @@
 /area/hallway/primary/central/west)
 "ftc" = (
 /turf/simulated/wall/r_wall,
-/area/maintenance/storage{
-	name = "Perma Maintenance"
-	})
+/area/maintenance/perma)
 "ftj" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/door/firedoor,
@@ -55633,9 +55631,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/girder,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "ftP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55855,7 +55851,7 @@
 	},
 /area/bridge/vip)
 "fvQ" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/medical/virology/lab)
 "fvU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -55897,7 +55893,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "carpet"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "fwt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -56990,7 +56986,9 @@
 	name = "2maintenance loot spawner"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "fKQ" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/machinery/door/poddoor{
@@ -57647,7 +57645,9 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "fTd" = (
 /turf/simulated/floor/wood/fancy/birch{
 	icon_state = "fancy-wood-birch-broken3"
@@ -57825,7 +57825,9 @@
 /obj/structure/rack,
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "fUO" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt,
@@ -57975,7 +57977,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "fVX" = (
 /obj/effect/landmark/start{
 	name = "Scientist"
@@ -58171,9 +58175,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "escape"
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Abandoned scape Shuttle Hallway"
-	})
+/area/hallway/secondary/exit/maint)
 "fXt" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -59667,7 +59669,9 @@
 	name = "3maintenance loot spawner"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "gpV" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/light,
@@ -59770,7 +59774,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "grm" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -59790,7 +59794,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "grQ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -60116,7 +60122,9 @@
 	},
 /mob/living/simple_animal/mouse/brown,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "gwx" = (
 /obj/structure/table,
 /obj/item/pen{
@@ -60257,7 +60265,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "gxI" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
@@ -60917,7 +60925,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "gFf" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -62498,7 +62508,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "gTh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -62930,7 +62942,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "gXM" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/item/radio/intercom{
@@ -63515,7 +63527,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "hgg" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -63643,7 +63655,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "hhq" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood/fancy/light,
@@ -64608,9 +64622,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/storage{
-	name = "Perma Maintenance"
-	})
+/area/maintenance/perma)
 "hsQ" = (
 /obj/machinery/light{
 	dir = 8
@@ -64734,7 +64746,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "huw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -65650,9 +65664,7 @@
 /obj/item/chair,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/hallway/secondary/exit{
-	name = "\improper Abandoned scape Shuttle Hallway"
-	})
+/area/hallway/secondary/exit/maint)
 "hEY" = (
 /obj/machinery/door/morgue{
 	name = "Private Study";
@@ -67087,7 +67099,9 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "hVC" = (
 /obj/effect/turf_decal/bot/left,
 /turf/simulated/floor/plasteel{
@@ -67352,10 +67366,6 @@
 /area/maintenance/starboard{
 	name = "Engineering Maintenance"
 	})
-"hYI" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/storage)
 "hYL" = (
 /obj/machinery/door/morgue{
 	name = "Chapel Morgue";
@@ -67421,9 +67431,7 @@
 	pixel_x = -26
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/storage{
-	name = "Perma Maintenance"
-	})
+/area/maintenance/perma)
 "iaa" = (
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -67578,7 +67586,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "ibM" = (
 /obj/machinery/light{
 	dir = 1;
@@ -67695,7 +67703,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "idt" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
@@ -68482,7 +68490,9 @@
 	req_one_access_txt = "5;12"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "imH" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -68563,7 +68573,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "inl" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -69758,9 +69768,7 @@
 "iBE" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
-/area/maintenance/storage{
-	name = "Perma Maintenance"
-	})
+/area/maintenance/perma)
 "iBT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -69796,9 +69804,7 @@
 /area/chapel/main)
 "iCk" = (
 /turf/simulated/floor/plating,
-/area/maintenance/storage{
-	name = "Perma Maintenance"
-	})
+/area/maintenance/perma)
 "iCu" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -69939,15 +69945,11 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "iEb" = (
 /obj/machinery/power/port_gen/pacman,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "iEi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -70004,7 +70006,7 @@
 "iFi" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "iFq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -70672,15 +70674,14 @@
 	},
 /area/shuttle/syndicate)
 "iLn" = (
-/obj/effect/decal/warning_stripes/blue,
-/obj/effect/decal/warning_stripes/southwest,
-/obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
-	},
-/turf/simulated/floor/plasteel,
-/area/medical/virology/lab{
-	name = "\improper Virology Lobby"
+/obj/item/clothing/mask/facehugger/toy,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/reagent_containers/food/snacks/monstermeat/xenomeat,
+/obj/item/reagent_containers/food/snacks/monstermeat/xenomeat,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint{
+	name = "Virology Maintenance"
 	})
 "iLo" = (
 /turf/simulated/floor/wood,
@@ -71027,7 +71028,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/library)
 "iPD" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -71510,7 +71511,9 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "iWM" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -71898,7 +71901,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/library)
 "jaP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -71951,7 +71954,13 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "jbE" = (
-/turf/simulated/wall/r_wall,
+/obj/effect/decal/warning_stripes/blue,
+/obj/effect/decal/warning_stripes/northeast,
+/obj/machinery/shower{
+	dir = 4;
+	tag = "icon-shower (EAST)"
+	},
+/turf/simulated/floor/plasteel,
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
 	})
@@ -72542,7 +72551,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "jjA" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -72911,9 +72922,7 @@
 /obj/item/clothing/shoes/orange,
 /obj/item/wrench,
 /turf/simulated/floor/plating,
-/area/maintenance/storage{
-	name = "Perma Maintenance"
-	})
+/area/maintenance/perma)
 "jot" = (
 /obj/item/stack/medical/bruise_pack,
 /obj/item/stack/medical/bruise_pack/advanced,
@@ -74708,7 +74717,9 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "jIv" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -74968,7 +74979,9 @@
 	},
 /obj/item/storage/briefcase/inflatable,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "jKj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/food/snacks/candy/gummyworm,
@@ -76061,7 +76074,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "jZj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -76397,9 +76410,7 @@
 /obj/structure/table,
 /obj/item/multitool,
 /turf/simulated/floor/plating,
-/area/maintenance/storage{
-	name = "Perma Maintenance"
-	})
+/area/maintenance/perma)
 "keL" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
@@ -76418,9 +76429,7 @@
 "kfc" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
-/area/maintenance/storage{
-	name = "Perma Maintenance"
-	})
+/area/maintenance/perma)
 "kff" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
@@ -76466,9 +76475,7 @@
 	dir = 1;
 	icon_state = "escape"
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Abandoned scape Shuttle Hallway"
-	})
+/area/hallway/secondary/exit/maint)
 "kfn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -76545,9 +76552,7 @@
 	dir = 4
 	},
 /turf/space,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "kgk" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -76557,9 +76562,7 @@
 "kgz" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "kgB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -76758,9 +76761,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "kjT" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
@@ -76886,9 +76887,7 @@
 	dir = 8
 	},
 /turf/space,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "klw" = (
 /turf/simulated/floor/engine/n20,
 /area/atmos)
@@ -77945,7 +77944,9 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "kyY" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -78432,7 +78433,7 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "kEg" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -78459,9 +78460,7 @@
 	name = "Странные записи"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "kEp" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -79219,9 +79218,7 @@
 	network = list("SS13","MiniSat")
 	},
 /turf/space,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "kNU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
@@ -79848,7 +79845,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "kZv" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -80707,9 +80704,7 @@
 	network = list("SS13","MiniSat")
 	},
 /turf/space,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "liE" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -81271,7 +81266,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "loX" = (
 /obj/machinery/chem_master{
 	pixel_x = -1
@@ -82517,7 +82512,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "lER" = (
 /turf/simulated/floor/engine{
 	name = "Holodeck Projector Floor"
@@ -83611,12 +83608,14 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "lQa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "lQm" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -84579,7 +84578,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "mbJ" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -85736,7 +85735,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "mnh" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
@@ -86296,9 +86297,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/girder,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "mto" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -86645,7 +86644,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "mxH" = (
 /obj/structure/closet/crate/engineering,
 /obj/item/apc_electronics,
@@ -86736,7 +86735,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "myO" = (
 /obj/item/radio/intercom{
 	pixel_y = 22
@@ -87043,7 +87042,7 @@
 	pixel_x = -26
 	},
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "mBj" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -87089,9 +87088,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair,
 /turf/simulated/floor/plating,
-/area/hallway/secondary/exit{
-	name = "\improper Abandoned scape Shuttle Hallway"
-	})
+/area/hallway/secondary/exit/maint)
 "mBu" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -87343,9 +87340,7 @@
 	dir = 9;
 	icon_state = "escape"
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Abandoned scape Shuttle Hallway"
-	})
+/area/hallway/secondary/exit/maint)
 "mDw" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
@@ -87367,7 +87362,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "mDI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -87885,7 +87880,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "mJH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -87936,7 +87931,7 @@
 "mJU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/library)
 "mJY" = (
 /obj/structure/grille,
 /obj/machinery/meter,
@@ -88471,7 +88466,9 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "mPC" = (
 /obj/machinery/light{
 	dir = 4
@@ -89115,9 +89112,7 @@
 "mXt" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "mXF" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -89226,7 +89221,9 @@
 	tag = "plant-dead"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "mYW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -89266,7 +89263,9 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "mZk" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -89449,7 +89448,7 @@
 	layer = 2.8;
 	pixel_y = 3
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
 	})
@@ -89711,7 +89710,7 @@
 /obj/effect/spawner/window/reinforced,
 /obj/structure/barricade/wooden,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "ndp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
@@ -90204,7 +90203,9 @@
 "njy" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "njF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -90753,7 +90754,9 @@
 "npC" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "npH" = (
 /obj/machinery/bodyscanner{
 	dir = 4
@@ -91171,9 +91174,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "nsR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -91469,7 +91470,7 @@
 "nvU" = (
 /obj/structure/bookcase,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "nvV" = (
 /turf/simulated/floor/plasteel{
 	dir = 0;
@@ -91486,7 +91487,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "nwh" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -91614,7 +91615,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "nyk" = (
 /obj/effect/landmark/start{
 	name = "Life Support Specialist"
@@ -91956,9 +91957,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar/atrium)
-"nCP" = (
-/turf/simulated/wall,
-/area/maintenance/storage)
 "nCX" = (
 /obj/structure/bed,
 /obj/item/radio/intercom{
@@ -92166,7 +92164,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "nFf" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -92264,7 +92262,9 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "nGj" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -92394,7 +92394,9 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "nHu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -93102,7 +93104,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "nOT" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -93192,9 +93194,7 @@
 "nQv" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "nQx" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
@@ -93290,9 +93290,7 @@
 /obj/item/wrench,
 /obj/item/crowbar,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "nRp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -93441,9 +93439,7 @@
 	dir = 6;
 	icon_state = "escape"
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Abandoned scape Shuttle Hallway"
-	})
+/area/hallway/secondary/exit/maint)
 "nSA" = (
 /obj/structure/table,
 /obj/item/paicard,
@@ -94468,13 +94464,13 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/secondary/exit{
-	name = "\improper Abandoned scape Shuttle Hallway"
-	})
+/area/hallway/secondary/exit/maint)
 "ogi" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "ogj" = (
 /obj/structure/chair/comfy/black,
 /obj/effect/decal/cleanable/dirt,
@@ -94667,7 +94663,7 @@
 	pixel_x = -1
 	},
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "oht" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -94749,7 +94745,9 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "oiF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -95294,7 +95292,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "opx" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1
@@ -95369,7 +95367,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "oqa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -96698,7 +96696,7 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "oET" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=A31";
@@ -97001,7 +96999,9 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "oIy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -97247,9 +97247,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "oLb" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -98036,10 +98034,9 @@
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
-"oTm" = (
-/turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "oTu" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -98181,7 +98178,9 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "oVl" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -99163,9 +99162,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
-/area/hallway/secondary/exit{
-	name = "\improper Abandoned scape Shuttle Hallway"
-	})
+/area/hallway/secondary/exit/maint)
 "phA" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -100076,7 +100073,7 @@
 "prs" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "prC" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -101706,9 +101703,7 @@
 "pIb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "pId" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -102452,9 +102447,7 @@
 "pOi" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/hallway/secondary/exit{
-	name = "\improper Abandoned scape Shuttle Hallway"
-	})
+/area/hallway/secondary/exit/maint)
 "pOC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -102516,7 +102509,7 @@
 "pPp" = (
 /obj/effect/landmark/burnturf,
 /obj/effect/landmark/damageturf,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
 	})
@@ -102913,7 +102906,9 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "pUz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -103077,7 +103072,9 @@
 	dir = 6;
 	icon_state = "yellow"
 	},
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "pWo" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -103167,12 +103164,12 @@
 "pWR" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/library)
 "pWT" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "pXd" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -103756,7 +103753,9 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "qdI" = (
 /obj/machinery/disposal,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -104500,7 +104499,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "qkv" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -105124,7 +105123,7 @@
 "qqV" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "qqW" = (
 /obj/structure/chair/comfy/red,
 /obj/item/radio/intercom{
@@ -105315,7 +105314,7 @@
 	})
 "qsF" = (
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "qsX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -105464,9 +105463,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit{
-	name = "\improper Abandoned scape Shuttle Hallway"
-	})
+/area/hallway/secondary/exit/maint)
 "qug" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -105685,7 +105682,9 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "qwo" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/palebush,
@@ -105834,7 +105833,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "carpet"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "qxo" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -106232,7 +106231,9 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "qCl" = (
 /obj/item/chair/wood/wings,
 /obj/effect/decal/cleanable/dirt,
@@ -106296,9 +106297,7 @@
 	dir = 4;
 	icon_state = "escape"
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Abandoned scape Shuttle Hallway"
-	})
+/area/hallway/secondary/exit/maint)
 "qDm" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -107375,7 +107374,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "qPr" = (
 /obj/machinery/door/airlock/security/glass{
 	id = "execution";
@@ -107664,7 +107663,9 @@
 	dir = 6;
 	icon_state = "yellow"
 	},
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "qTt" = (
 /obj/structure/girder,
 /obj/structure/disposalpipe/segment{
@@ -108955,9 +108956,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Abandoned scape Shuttle Hallway"
-	})
+/area/hallway/secondary/exit/maint)
 "rgA" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced{
@@ -109717,7 +109716,7 @@
 /obj/item/folder,
 /obj/item/pen,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "rpb" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -110287,7 +110286,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "rwB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -111880,7 +111881,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "carpet"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "rMN" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -112169,11 +112170,6 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/red,
 /obj/item/pen,
-/obj/machinery/door/window/brigdoor/southright{
-	dir = 4;
-	name = "Security Checkpoint";
-	req_access_txt = "1"
-	},
 /turf/simulated/floor/plasteel,
 /area/security/checkpoint)
 "rQI" = (
@@ -112512,7 +112508,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "rUC" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -113387,7 +113383,9 @@
 "seJ" = (
 /obj/effect/spawner/random_spawners/oil_maybe,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "seM" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
@@ -113536,7 +113534,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "shu" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -115016,9 +115016,7 @@
 	glass = 1
 	},
 /turf/simulated/floor/plating,
-/area/hallway/secondary/exit{
-	name = "\improper Abandoned scape Shuttle Hallway"
-	})
+/area/hallway/secondary/exit/maint)
 "sxk" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -115765,9 +115763,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "sEK" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
@@ -116184,7 +116180,9 @@
 /obj/structure/girder,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "sLl" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -116644,7 +116642,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "sQt" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -116981,7 +116979,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "sUb" = (
 /obj/structure/target_stake,
 /obj/machinery/magnetic_module,
@@ -117358,7 +117358,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "sZN" = (
 /obj/structure/chair/sofa/pew/left,
 /turf/simulated/floor/plasteel{
@@ -117505,7 +117507,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "tbX" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -118222,7 +118224,9 @@
 	name = "2maintenance loot spawner"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "tiJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -118251,7 +118255,7 @@
 "tiU" = (
 /obj/item/flag/cult,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "tja" = (
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel/airless,
@@ -119599,7 +119603,9 @@
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "tAG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -120046,9 +120052,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Abandoned scape Shuttle Hallway"
-	})
+/area/hallway/secondary/exit/maint)
 "tGd" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
@@ -120058,7 +120062,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/library)
 "tGi" = (
 /obj/structure/closet/chefcloset,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -120514,9 +120518,7 @@
 	network = list("SS13","MiniSat")
 	},
 /turf/space,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "tKW" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Electrical Maintenance";
@@ -120945,11 +120947,6 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/blue,
 /obj/item/pen,
-/obj/machinery/door/window/brigdoor/southright{
-	dir = 8;
-	name = "Customs Desk";
-	req_access_txt = "19"
-	},
 /turf/simulated/floor/plasteel,
 /area/bridge/checkpoint/north)
 "tNI" = (
@@ -121231,7 +121228,9 @@
 	},
 /mob/living/simple_animal/mouse/gray,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "tQF" = (
 /obj/machinery/light{
 	dir = 4
@@ -121794,7 +121793,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "tXQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -122165,7 +122164,9 @@
 "ubV" = (
 /obj/machinery/atmospherics/unary/tank/air,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "ucf" = (
 /obj/machinery/disposal,
 /obj/machinery/alarm{
@@ -122190,9 +122191,7 @@
 	name = "ninja_teleport"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/storage{
-	name = "Perma Maintenance"
-	})
+/area/maintenance/perma)
 "ucJ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
@@ -122795,7 +122794,9 @@
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "uhP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -122931,7 +122932,9 @@
 /area/maintenance/starboard)
 "ujB" = (
 /turf/simulated/wall,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "ujV" = (
 /obj/structure/toilet/secret{
 	dir = 1
@@ -123264,7 +123267,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "uob" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -123669,9 +123674,7 @@
 	dir = 5;
 	icon_state = "escape"
 	},
-/area/hallway/secondary/exit{
-	name = "\improper Abandoned scape Shuttle Hallway"
-	})
+/area/hallway/secondary/exit/maint)
 "utI" = (
 /obj/structure/sign/greencross,
 /turf/simulated/wall/r_wall,
@@ -124845,7 +124848,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "uGu" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -125481,7 +125484,7 @@
 /obj/structure/chair/office/dark,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "uMD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -126101,7 +126104,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/library)
 "uTp" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -126579,7 +126582,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "uYS" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -126878,7 +126881,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "vcb" = (
 /obj/machinery/status_display{
 	pixel_y = 32
@@ -126982,7 +126987,9 @@
 "vdW" = (
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "vdX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -127397,7 +127404,7 @@
 /area/library)
 "vjf" = (
 /obj/structure/sign/biohazard,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
 	})
@@ -128322,9 +128329,7 @@
 	network = list("SS13","MiniSat")
 	},
 /turf/space,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "vtR" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -128339,9 +128344,7 @@
 /obj/item/stack/sheet/mineral/plasma,
 /obj/item/clothing/head/welding,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "vtW" = (
 /obj/machinery/atmospherics/trinary/filter{
 	desc = "Отфильтровывает азот из трубы и отправляет его в камеру хранения";
@@ -128553,9 +128556,7 @@
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "vwH" = (
 /obj/structure/table/wood,
 /obj/machinery/requests_console{
@@ -128652,9 +128653,7 @@
 	network = list("SS13","MiniSat")
 	},
 /turf/space,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "vxk" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -128816,9 +128815,7 @@
 /area/security/processing)
 "vyk" = (
 /turf/simulated/floor/plating,
-/area/hallway/secondary/exit{
-	name = "\improper Abandoned scape Shuttle Hallway"
-	})
+/area/hallway/secondary/exit/maint)
 "vyq" = (
 /obj/effect/landmark/start{
 	name = "Security Officer"
@@ -129351,9 +129348,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
-/area/hallway/secondary/exit{
-	name = "\improper Abandoned scape Shuttle Hallway"
-	})
+/area/hallway/secondary/exit/maint)
 "vCL" = (
 /obj/structure/safe/floor,
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
@@ -129563,7 +129558,9 @@
 /obj/structure/closet/crate/engineering,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "vEZ" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -129673,7 +129670,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "vGv" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -130198,9 +130197,7 @@
 "vNP" = (
 /obj/structure/computerframe,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "vNU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/glass{
@@ -130430,7 +130427,7 @@
 /area/solar/starboard)
 "vQl" = (
 /obj/effect/landmark/burnturf,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
 	})
@@ -131397,7 +131394,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "vZo" = (
 /obj/structure/ore_box,
 /obj/machinery/newscaster/security_unit{
@@ -131527,9 +131524,7 @@
 	dir = 4
 	},
 /turf/space,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "waS" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -131659,9 +131654,7 @@
 	dir = 8
 	},
 /turf/space,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "wcl" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -131807,7 +131800,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "wdz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -132193,7 +132186,7 @@
 /area/quartermaster/storage)
 "wjj" = (
 /turf/simulated/wall/rust,
-/area/library/abandoned)
+/area/maintenance/library)
 "wjl" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/structure/chair/comfy/brown{
@@ -132357,9 +132350,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "wlx" = (
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker/locker_toilet)
@@ -132464,15 +132455,13 @@
 /obj/item/wrench,
 /obj/item/clothing/head/welding,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "wmL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "wmW" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -132626,7 +132615,9 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "woE" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -132940,7 +132931,9 @@
 	req_access_txt = "5"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "wsa" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -133377,7 +133370,7 @@
 	name = "ninja_teleport"
 	},
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "wwI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -133548,7 +133541,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "wyv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -134140,7 +134133,9 @@
 /area/quartermaster/storage)
 "wEP" = (
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "wEY" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -134231,7 +134226,9 @@
 "wGm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "wGp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -134475,15 +134472,6 @@
 	icon_state = "white"
 	},
 /area/assembly/robotics)
-"wJC" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "MiniSat Maintenance";
-	req_access_txt = "75"
-	},
-/turf/simulated/floor/plating,
-/area/aisat/maintenance{
-	name = "\improper AI Satellite Service"
-	})
 "wJG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -134550,9 +134538,7 @@
 	req_access_txt = "75"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "wKe" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -134931,9 +134917,7 @@
 /area/engine/engineering/monitor)
 "wOp" = (
 /turf/simulated/wall,
-/area/hallway/secondary/exit{
-	name = "\improper Abandoned scape Shuttle Hallway"
-	})
+/area/hallway/secondary/exit/maint)
 "wOF" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -135019,9 +135003,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "wQj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -135314,7 +135296,9 @@
 	},
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "wSW" = (
 /obj/machinery/computer/med_data,
 /turf/simulated/floor/plasteel{
@@ -135349,9 +135333,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "wTs" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/warning_stripes/yellow,
@@ -135380,7 +135362,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "wTX" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -135570,9 +135552,7 @@
 	network = list("SS13","MiniSat")
 	},
 /turf/space,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "wWn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -136159,7 +136139,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "xdb" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/effect/decal/warning_stripes/south,
@@ -136335,7 +136315,7 @@
 	pixel_x = -22
 	},
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/library)
 "xeE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -137233,7 +137213,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "xpr" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/plasteel{
@@ -137489,7 +137471,9 @@
 "xrA" = (
 /obj/machinery/atmospherics/binary/valve,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "xrC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -137747,7 +137731,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/cult/archives,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "xuj" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -138144,7 +138128,7 @@
 /obj/structure/bookcase,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/library)
 "xwX" = (
 /obj/machinery/suit_storage_unit/captain,
 /obj/machinery/light{
@@ -138769,7 +138753,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "xDp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -139285,9 +139269,7 @@
 /area/crew_quarters/chief)
 "xHS" = (
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "xHT" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -139329,9 +139311,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed,
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint{
-	name = "AI Maintenance"
-	})
+/area/maintenance/ai)
 "xIo" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright{
@@ -139423,7 +139403,9 @@
 "xJc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall,
-/area/maintenance/aft)
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "xJf" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/hologram/holopad,
@@ -140740,7 +140722,7 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/mouse/gray,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "xVg" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -141140,7 +141122,7 @@
 /area/medical/reception)
 "xZc" = (
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/library)
 "xZk" = (
 /obj/structure/morgue,
 /obj/effect/decal/warning_stripes/south,
@@ -141532,7 +141514,7 @@
 /obj/structure/table/wood,
 /obj/item/paper/deltainfo,
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/library)
 "ydL" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -141749,7 +141731,7 @@
 "yfs" = (
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall,
-/area/library/abandoned)
+/area/maintenance/library)
 "yfA" = (
 /obj/item/trash/syndi_cakes{
 	pixel_y = 7
@@ -149251,7 +149233,7 @@ dEP
 dEP
 vtR
 xHS
-wJC
+wJR
 xuL
 uty
 yeB
@@ -187613,8 +187595,8 @@ iQw
 naz
 bzb
 vjf
-eWD
-wTz
+vLr
+iLn
 fSq
 eSP
 vLr
@@ -187864,14 +187846,14 @@ mDI
 evk
 lvv
 lvv
-nCP
+ujB
 imF
-jbE
-jbE
+xFw
+xFw
 xGb
 jbE
-jbE
-jbE
+xFw
+vLr
 xtb
 xtb
 vLr
@@ -188122,13 +188104,13 @@ jJn
 eMN
 lvv
 gpT
-hYI
-jbE
+wGm
+xFw
 xxH
 bLY
 duV
 act
-jbE
+xFw
 abj
 abj
 aaa
@@ -188379,13 +188361,13 @@ kEp
 hPb
 lvv
 oVf
-eBY
-jbE
+fdc
+xFw
 xcN
 vfC
 evI
 uFl
-jbE
+xFw
 ngA
 snF
 abj
@@ -188636,18 +188618,18 @@ feD
 xYy
 lvv
 fSZ
-oTm
-jbE
+wEP
+xFw
 aAh
 mBu
 bXA
 egU
-jbE
+xFw
 qsZ
 gVU
-jbE
-jbE
-jbE
+xFw
+xFw
+xFw
 abj
 aaa
 aaa
@@ -188892,14 +188874,14 @@ elW
 eUt
 xYM
 lvv
-hYI
+wGm
 tiG
-jbE
-iLn
+xFw
+xFw
 tvZ
 uLW
-jbE
-jbE
+xFw
+xFw
 lbP
 qmz
 isF
@@ -189150,12 +189132,12 @@ xKL
 lvv
 lvv
 lEG
-nCP
-jbE
+ujB
+xFw
 vjf
 vpb
-jbE
-jbE
+xFw
+xFw
 dHg
 dLd
 dMx
@@ -189408,7 +189390,7 @@ lvv
 bmz
 fjt
 vEU
-jbE
+xFw
 jFH
 wGp
 xOy
@@ -189665,7 +189647,7 @@ pUl
 aOU
 xpo
 pWn
-jbE
+xFw
 erJ
 eaz
 lfv
@@ -189921,8 +189903,8 @@ jjv
 gFe
 sZC
 qTn
-ltW
-ltW
+ylm
+ylm
 sqB
 bWB
 xYw
@@ -190176,9 +190158,9 @@ rFn
 npC
 oiv
 jKh
-ltW
-ltW
-ltW
+ylm
+ylm
+ylm
 miT
 sVx
 wWW
@@ -190429,11 +190411,11 @@ sMH
 sxp
 mDP
 uSB
-nCP
-nCP
-nCP
-nCP
-ltW
+ujB
+ujB
+ujB
+ujB
+ylm
 rUO
 dbT
 qIo
@@ -190686,7 +190668,7 @@ cTg
 cTg
 cTg
 cTg
-nCP
+ujB
 ubV
 hVw
 fmV
@@ -191200,11 +191182,11 @@ xqk
 ygQ
 oxi
 ygQ
-nCP
-nCP
-nCP
-nCP
-ltW
+ujB
+ujB
+ujB
+ujB
+ylm
 dBO
 lGF
 dBO
@@ -191461,7 +191443,7 @@ abj
 abj
 abj
 abj
-ltW
+ylm
 hvy
 rvd
 fey
@@ -191975,7 +191957,7 @@ aaa
 aaa
 aaa
 aaa
-ltW
+ylm
 hpO
 jgk
 suu
@@ -191986,9 +191968,9 @@ ylm
 ylm
 umx
 sXT
-jbE
-jbE
-jbE
+xFw
+xFw
+xFw
 abj
 abj
 aaa
@@ -192232,7 +192214,7 @@ aaa
 aaa
 aaa
 aaa
-jbE
+xFw
 xFw
 xFw
 xFw
@@ -192243,7 +192225,7 @@ nAa
 eef
 nXf
 vCn
-jbE
+xFw
 vLh
 abj
 abj
@@ -192489,7 +192471,7 @@ aaa
 aaa
 aaa
 aaa
-jbE
+xFw
 vPn
 qgZ
 xPj
@@ -192500,7 +192482,7 @@ rZF
 tdh
 nmd
 dFA
-jbE
+xFw
 aaa
 aaa
 abj
@@ -192746,7 +192728,7 @@ aaa
 aaa
 aaa
 aaa
-jbE
+xFw
 pGk
 tjA
 kBk
@@ -192756,8 +192738,8 @@ qLz
 gTH
 ehT
 lKI
-jbE
-jbE
+xFw
+xFw
 aaa
 aaa
 aaa
@@ -193003,7 +192985,7 @@ aaa
 aaa
 aaa
 aaa
-jbE
+xFw
 dBr
 iiS
 cZf
@@ -193260,7 +193242,7 @@ aaa
 aaa
 aaa
 aaa
-jbE
+xFw
 uVl
 pbv
 qHl
@@ -193517,7 +193499,7 @@ abj
 aaa
 aaa
 abj
-jbE
+xFw
 tmt
 vai
 qxe
@@ -193774,17 +193756,17 @@ xZu
 abj
 abj
 abj
-jbE
-jbE
-jbE
+xFw
+xFw
+xFw
 pPp
 pPp
 vQl
 pwa
 qsE
 gLx
-jbE
-jbE
+xFw
+xFw
 abj
 abj
 aaa

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -383,14 +383,8 @@
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
 "abW" = (
-/obj/structure/closet/crate/medical,
-/obj/item/roller,
-/obj/item/roller{
-	pixel_x = 3;
-	pixel_y = 10
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse/white,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "abX" = (
@@ -3168,12 +3162,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/door/window/brigdoor/southright{
-	dir = 8;
-	name = "Security Checkpoint";
-	pixel_x = -8;
-	req_access_txt = "1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8504,7 +8492,10 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
 /area/maintenance/starboard)
 "aQF" = (
 /obj/structure/lattice/catwalk,
@@ -16121,11 +16112,6 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
-"bBD" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
 "bBF" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -18935,12 +18921,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/window/brigdoor/southright{
-	dir = 8;
-	name = "Customs Desk";
-	pixel_x = 32;
-	req_access_txt = "19"
-	},
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
@@ -27277,7 +27257,9 @@
 /area/maintenance/fpmaint)
 "cxB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/girder,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "cxE" = (
@@ -39677,8 +39659,8 @@
 /turf/simulated/wall/r_wall,
 /area/medical/cmo)
 "dqY" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
+/obj/item/flashlight/lamp,
 /turf/simulated/floor/plasteel{
 	icon_state = "bcarpet05"
 	},
@@ -40723,10 +40705,6 @@
 /area/medical/morgue)
 "dvy" = (
 /obj/structure/table/reinforced,
-/obj/machinery/kitchen_machine/microwave{
-	pixel_x = -1;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "tranquillite"
 	},
@@ -41295,6 +41273,17 @@
 	icon_state = "freezerfloor"
 	},
 /area/security/permabrig)
+"dxO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/communist_state{
+	pixel_x = 33
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/maintenance/consarea{
+	name = "Virology Maintenance Construction Area"
+	})
 "dxQ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -46716,29 +46705,14 @@
 	},
 /area/security/checkpoint/south)
 "dSm" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 1;
+/obj/machinery/door/airlock/external{
 	frequency = 1379;
-	id_tag = "vir_pump"
+	id_tag = "vir_outer";
+	locked = 1;
+	name = "Engineering External Access";
+	req_access_txt = "10;13"
 	},
-/obj/effect/decal/warning_stripes/yellow,
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	id_tag = "vir_airlock";
-	layer = 3.1;
-	pixel_x = 24;
-	pixel_y = -6;
-	req_access_txt = "13";
-	tag_airpump = "vir_pump";
-	tag_chamber_sensor = "vir_sensor";
-	tag_exterior_door = "vir_outer";
-	tag_interior_door = "vir_inner"
-	},
-/obj/machinery/airlock_sensor{
-	id_tag = "vir_sensor";
-	layer = 3.1;
-	pixel_x = 24;
-	pixel_y = 4
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "dSr" = (
@@ -50939,6 +50913,9 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
+"erT" = (
+/turf/simulated/wall/r_wall,
+/area/maintenance/detectives_office)
 "esa" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -51291,6 +51268,7 @@
 /area/construction/hallway)
 "evn" = (
 /obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/maintenance/starboard)
 "evo" = (
@@ -52745,7 +52723,10 @@
 	},
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/maintenance/starboard)
 "eMu" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
@@ -53865,6 +53846,11 @@
 /obj/structure/table/wood/poker,
 /turf/simulated/floor/plating,
 /area/maintenance/gambling_den)
+"eYB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "eYF" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -55766,7 +55752,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/barricade/sandbags,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
@@ -55846,7 +55831,7 @@
 	},
 /area/bridge/vip)
 "fvQ" = (
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/medical/virology/lab)
 "fvU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -59887,7 +59872,6 @@
 	name = "xeno_spawn";
 	pixel_x = -1
 	},
-/mob/living/simple_animal/mouse/gray,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
@@ -60852,10 +60836,14 @@
 /turf/simulated/floor/plasteel,
 /area/gateway)
 "gEK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "bcarpet05"
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
+/obj/effect/decal/remains/human{
+	layer = 3.1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "gEL" = (
 /turf/simulated/floor/plasteel{
@@ -60906,11 +60894,6 @@
 	},
 /area/quartermaster/office)
 "gFe" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -66253,11 +66236,8 @@
 	},
 /area/crew_quarters/kitchen)
 "hLL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/pods{
-	pixel_y = 32
-	},
-/turf/simulated/floor/plasteel,
+/obj/structure/grille/broken,
+/turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "hLZ" = (
 /obj/structure/cable{
@@ -66502,12 +66482,12 @@
 	name = "Tourist Area Maintenance"
 	})
 "hOZ" = (
-/obj/effect/decal/cleanable/blood/old,
-/mob/living/simple_animal/mouse/brown,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint{
-	name = "Virology Maintenance"
-	})
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/maintenance/starboard)
 "hPb" = (
 /obj/machinery/suit_storage_unit/cmo/secure/sec_storage,
 /obj/item/radio/intercom{
@@ -67035,10 +67015,12 @@
 	name = "Engineering Maintenance"
 	})
 "hUP" = (
-/turf/space,
-/area/maintenance/asmaint{
-	name = "Virology Maintenance"
-	})
+/obj/effect/landmark/burnturf,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/maintenance/starboard)
 "hUQ" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -70488,9 +70470,9 @@
 	},
 /area/security/checkpoint/south)
 "iJe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/grille/broken,
-/turf/simulated/floor/plasteel,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "iJg" = (
 /obj/machinery/light{
@@ -73237,7 +73219,10 @@
 	},
 /area/security/brigstaff)
 "jrD" = (
-/obj/structure/closet/emcloset,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "jrG" = (
@@ -74190,16 +74175,11 @@
 	},
 /area/crew_quarters/serviceyard)
 "jCp" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	id_tag = "vir_outer";
-	locked = 1;
-	name = "Engineering External Access";
-	req_access_txt = "10;13"
+/obj/structure/shuttle/engine/propulsion/burst{
+	dir = 8
 	},
-/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/area/shuttle/pod_3)
 "jCx" = (
 /mob/living/simple_animal/mouse/white,
 /turf/simulated/floor/plating,
@@ -74963,16 +74943,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 26
-	},
 /obj/item/storage/briefcase/inflatable,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft{
 	name = "Medbay Maintenance"
@@ -77155,8 +77126,10 @@
 	name = "Engineering Maintenance"
 	})
 "kov" = (
-/turf/simulated/floor/plasteel,
-/area/maintenance/starboard)
+/turf/simulated/shuttle/wall{
+	icon_state = "swall_f10"
+	},
+/area/shuttle/pod_3)
 "kow" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -78224,8 +78197,9 @@
 /turf/simulated/floor/wood,
 /area/security/hos)
 "kBt" = (
-/obj/structure/rack,
-/turf/simulated/floor/plasteel,
+/obj/structure/chair/stool,
+/obj/effect/landmark/burnturf,
+/turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "kBu" = (
 /obj/effect/spawner/window/reinforced,
@@ -79730,12 +79704,7 @@
 /turf/simulated/floor/plasteel,
 /area/medical/research/nhallway)
 "kXR" = (
-/obj/machinery/door/airlock/welded{
-	req_access_txt = "12"
-	},
-/obj/structure/barricade/wooden{
-	layer = 3.5
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "kXY" = (
@@ -82473,9 +82442,6 @@
 /turf/simulated/wall/r_wall,
 /area/civilian/barber)
 "lEG" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Maintenance"
-	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -82486,6 +82452,7 @@
 /obj/machinery/atmospherics/pipe/cap/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/aft{
 	name = "Medbay Maintenance"
@@ -86206,13 +86173,17 @@
 	},
 /area/security/podbay)
 "mrO" = (
-/obj/structure/sign/poster/contraband/communist_state{
-	pixel_x = 33
+/obj/docking_port/mobile/pod{
+	dir = 4;
+	id = "pod3";
+	name = "escape pod 3"
 	},
-/turf/simulated/wall,
-/area/maintenance/consarea{
-	name = "Virology Maintenance Construction Area"
-	})
+/obj/machinery/door/airlock/shuttle{
+	id_tag = "s_docking_airlock";
+	name = "Escape Pod Hatch"
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/pod_3)
 "mrU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -88873,7 +88844,10 @@
 	layer = 2.9
 	},
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whiteblue"
+	},
 /area/maintenance/starboard)
 "mUg" = (
 /obj/effect/spawner/window/reinforced,
@@ -89413,7 +89387,7 @@
 	layer = 2.8;
 	pixel_y = 3
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
 	})
@@ -92952,11 +92926,11 @@
 	},
 /area/crew_quarters/fitness)
 "nNJ" = (
-/obj/effect/landmark/burnturf,
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/official/anniversary_vintage_reprint{
+	pixel_y = 32
 	},
-/turf/simulated/floor/carpet/arcade,
+/turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "nNL" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -93505,10 +93479,8 @@
 	},
 /area/hallway/primary/port/west)
 "nTJ" = (
+/obj/structure/chair/comfy/black,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/official/anniversary_vintage_reprint{
-	pixel_y = 32
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "nTV" = (
@@ -93916,14 +93888,11 @@
 	},
 /area/security/brig)
 "oaQ" = (
-/obj/structure/chair/office/dark{
-	dir = 8
+/obj/structure/table/wood,
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "bcarpet05"
 	},
-/obj/effect/decal/remains/human{
-	layer = 3.1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "oaU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -94439,9 +94408,12 @@
 	name = "Medbay Maintenance"
 	})
 "ogj" = (
-/obj/structure/chair/comfy/black,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/structure/sign/poster/official/the_owl{
+	pixel_y = 32
+	},
+/obj/item/chair/stool,
+/turf/simulated/floor/carpet/arcade,
 /area/maintenance/starboard)
 "ogy" = (
 /obj/structure/chair/office/light{
@@ -94700,10 +94672,9 @@
 /area/security/permabrig)
 "oip" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/official/the_owl{
-	pixel_y = 32
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/item/chair/stool,
 /turf/simulated/floor/carpet/arcade,
 /area/maintenance/starboard)
 "oiv" = (
@@ -95715,14 +95686,10 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "oum" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/pods{
 	pixel_x = 32
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/carpet/arcade,
 /area/maintenance/starboard)
 "ouw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -96722,11 +96689,10 @@
 /turf/simulated/floor/plasteel/airless/indestructible,
 /area/toxins/test_area)
 "oFL" = (
-/obj/structure/shuttle/engine/propulsion/burst{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/pod_3)
+/obj/structure/chair/stool,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/arcade,
+/area/maintenance/starboard)
 "oFU" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "swall12";
@@ -97683,7 +97649,7 @@
 /area/engine/break_room)
 "oQg" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f10"
+	icon_state = "swall_f9"
 	},
 /area/shuttle/pod_3)
 "oQk" = (
@@ -98798,9 +98764,14 @@
 	},
 /area/security/permahallway)
 "peg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate,
+/obj/structure/closet/crate/medical,
+/obj/item/roller,
+/obj/item/roller{
+	pixel_x = 3;
+	pixel_y = 10
+	},
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/grille/broken,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "pei" = (
@@ -101247,8 +101218,13 @@
 /area/bridge)
 "pDt" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse/white,
-/turf/simulated/floor/plasteel,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
 /area/maintenance/starboard)
 "pDF" = (
 /obj/structure/sign/securearea,
@@ -101481,11 +101457,6 @@
 /area/shuttle/escape{
 	parallax_movedir = 2
 	})
-"pGt" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/burnturf,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
 "pGu" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Showers"
@@ -102410,7 +102381,16 @@
 /area/hallway/primary/starboard/east)
 "pOI" = (
 /obj/structure/table/wood,
-/obj/random/figure,
+/obj/item/storage/pill_bottle/dice{
+	pixel_y = 12
+	},
+/obj/item/toy/figure/wizard{
+	pixel_x = 7
+	},
+/obj/item/reagent_containers/food/drinks/cans/cola{
+	pixel_x = -12;
+	pixel_y = 13
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "pOP" = (
@@ -102461,7 +102441,7 @@
 "pPp" = (
 /obj/effect/landmark/burnturf,
 /obj/effect/landmark/damageturf,
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
 	})
@@ -102590,7 +102570,10 @@
 /area/bridge/vip)
 "pQl" = (
 /obj/structure/chair/sofa,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
 /area/maintenance/starboard)
 "pQs" = (
 /obj/machinery/iv_drip,
@@ -103357,7 +103340,6 @@
 	})
 "pZA" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp,
 /turf/simulated/floor/plasteel{
 	icon_state = "bcarpet05"
 	},
@@ -103892,16 +103874,7 @@
 /area/space/nearstation)
 "qfq" = (
 /obj/structure/table/wood,
-/obj/item/storage/pill_bottle/dice{
-	pixel_y = 12
-	},
-/obj/item/toy/figure/wizard{
-	pixel_x = 7
-	},
-/obj/item/reagent_containers/food/drinks/cans/cola{
-	pixel_x = -12;
-	pixel_y = 13
-	},
+/obj/random/figure,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "qfr" = (
@@ -105094,14 +105067,11 @@
 /turf/simulated/floor/carpet,
 /area/medical/psych)
 "qrH" = (
-/obj/docking_port/mobile/pod{
-	dir = 4;
-	id = "pod3";
-	name = "escape pod 3"
+/obj/item/radio/intercom{
+	pixel_y = 21
 	},
-/obj/machinery/door/airlock/shuttle{
-	id_tag = "s_docking_airlock";
-	name = "Escape Pod Hatch"
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/pod_3)
@@ -105584,9 +105554,10 @@
 	},
 /area/engine/aienter)
 "qvY" = (
-/obj/item/radio/intercom{
-	pixel_y = 21
+/obj/machinery/status_display{
+	pixel_y = 32
 	},
+/obj/machinery/light,
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
@@ -106785,14 +106756,9 @@
 	},
 /area/security/permabrig)
 "qJO" = (
-/obj/machinery/status_display{
-	pixel_y = 32
-	},
-/obj/machinery/light,
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/turf/simulated/shuttle/floor,
+/obj/structure/grille,
+/obj/structure/window/full/shuttle,
+/turf/simulated/shuttle/plating,
 /area/shuttle/pod_3)
 "qKh" = (
 /obj/item/trash/pistachios,
@@ -107354,18 +107320,14 @@
 /area/medical/surgery/south)
 "qQc" = (
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/grille,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
 /area/maintenance/starboard)
 "qQf" = (
 /obj/effect/decal/cleanable/fungus,
@@ -107614,19 +107576,15 @@
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
 "qTI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
+/obj/machinery/door/airlock/external{
 	frequency = 1379;
-	layer = 3.5;
-	master_tag = "vir_airlock";
-	name = "interior access button";
-	pixel_x = -23;
-	pixel_y = -26;
+	id_tag = "vir_inner";
+	locked = 1;
+	name = "Engineering External Access";
 	req_access_txt = "10;13"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "qTK" = (
@@ -107958,10 +107916,13 @@
 	name = "Virology Maintenance"
 	})
 "qXt" = (
-/obj/structure/grille,
-/obj/structure/window/full/shuttle,
-/turf/simulated/shuttle/plating,
-/area/shuttle/pod_3)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/maintenance/starboard)
 "qXu" = (
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
@@ -111957,7 +111918,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/maintenance/starboard)
 "rPE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -112087,6 +112051,11 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/red,
 /obj/item/pen,
+/obj/machinery/door/window/brigdoor/southright{
+	dir = 4;
+	name = "Security Checkpoint";
+	req_access_txt = "1"
+	},
 /turf/simulated/floor/plasteel,
 /area/security/checkpoint)
 "rQI" = (
@@ -112393,15 +112362,7 @@
 	},
 /area/engine/gravitygenerator)
 "rUr" = (
-/obj/structure/table/wood,
-/obj/random/figure{
-	pixel_x = -11;
-	pixel_y = 10
-	},
-/obj/random/figure{
-	pixel_x = 10;
-	pixel_y = 8
-	},
+/obj/structure/chair/stool,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "rUs" = (
@@ -112502,6 +112463,11 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/syndicate_sit)
+"rVs" = (
+/turf/simulated/wall/r_wall,
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "rVt" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -112951,8 +112917,8 @@
 /area/storage/tech)
 "sbp" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/cooker/deepfryer,
 /obj/machinery/light/small,
+/obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor/plating,
 /area/maintenance/kitchen)
 "sbq" = (
@@ -113081,7 +113047,11 @@
 	},
 /area/security/securehallway)
 "scS" = (
-/obj/structure/chair/stool,
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "scT" = (
@@ -113714,13 +113684,12 @@
 	},
 /area/hallway/primary/central/nw)
 "skZ" = (
-/obj/structure/sign/pods{
-	pixel_x = 32
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/arcade,
 /area/maintenance/starboard)
 "slb" = (
 /obj/structure/disposalpipe/segment,
@@ -114094,11 +114063,9 @@
 /area/security/execution)
 "soF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random_barrier/possibly_welded_airlock,
-/obj/structure/barricade/wooden{
-	layer = 3.5
+/turf/simulated/floor/plasteel{
+	icon_state = "bcarpet05"
 	},
-/turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "soL" = (
 /turf/simulated/floor/bluegrid,
@@ -114673,6 +114640,7 @@
 /area/medical/virology)
 "suE" = (
 /obj/machinery/light/small,
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "suJ" = (
@@ -114905,11 +114873,14 @@
 	},
 /area/medical/morgue)
 "swW" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 4
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
 	},
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "sxc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -116592,9 +116563,7 @@
 /obj/structure/disposalpipe/broken{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "tranquillite"
-	},
+/turf/simulated/floor/plating,
 /area/maintenance/kitchen)
 "sQF" = (
 /obj/structure/table/wood,
@@ -117153,8 +117122,11 @@
 	})
 "sYb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
+/obj/effect/spawner/random_barrier/possibly_welded_airlock,
+/obj/structure/barricade/wooden{
+	layer = 3.5
+	},
+/turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "sYB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -120023,10 +119995,11 @@
 	name = "Virology Maintenance"
 	})
 "tGA" = (
-/turf/simulated/shuttle/wall{
-	icon_state = "swall_f9"
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
-/area/shuttle/pod_3)
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "tGD" = (
 /obj/machinery/ai_status_display{
 	pixel_x = 32
@@ -120044,13 +120017,14 @@
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
 "tGG" = (
-/obj/machinery/light/small,
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-dead";
 	tag = "plant-dead"
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
 	},
 /area/maintenance/starboard)
 "tGK" = (
@@ -120836,6 +120810,11 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/blue,
 /obj/item/pen,
+/obj/machinery/door/window/brigdoor/southright{
+	dir = 8;
+	name = "Customs Desk";
+	req_access_txt = "19"
+	},
 /turf/simulated/floor/plasteel,
 /area/bridge/checkpoint/north)
 "tNI" = (
@@ -121340,6 +121319,9 @@
 	icon_state = "dark"
 	},
 /area/chapel/office)
+"tSQ" = (
+/turf/simulated/wall/r_wall,
+/area/maintenance/electrical)
 "tTu" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "Труба служит для подачу горючей смеси в турбину для её работы";
@@ -121580,9 +121562,16 @@
 	},
 /area/engine/break_room)
 "tWj" = (
-/obj/structure/chair/stool,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/arcade,
+/obj/structure/table/wood,
+/obj/random/figure{
+	pixel_x = -11;
+	pixel_y = 10
+	},
+/obj/random/figure{
+	pixel_x = 10;
+	pixel_y = 8
+	},
+/turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "tWn" = (
 /turf/simulated/wall,
@@ -122588,8 +122577,8 @@
 /area/security/permabrig)
 "ugT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/bed,
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
 /area/maintenance/starboard)
 "ugW" = (
 /obj/effect/landmark{
@@ -122811,10 +122800,9 @@
 /area/crew_quarters/courtroom)
 "uju" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "ujB" = (
 /turf/simulated/wall,
@@ -124266,10 +124254,8 @@
 /turf/simulated/floor/engine,
 /area/security/execution)
 "uAW" = (
-/obj/structure/table/wood,
-/turf/simulated/floor/plasteel{
-	icon_state = "bcarpet05"
-	},
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "uAX" = (
 /turf/simulated/wall/r_wall,
@@ -126267,9 +126253,20 @@
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "uWW" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1379;
+	layer = 3.5;
+	master_tag = "vir_airlock";
+	name = "interior access button";
+	pixel_x = -23;
+	pixel_y = -26;
+	req_access_txt = "10;13"
+	},
+/turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "uXc" = (
 /obj/structure/cable{
@@ -126669,8 +126666,11 @@
 	name = "Virology Maintenance"
 	})
 "vbc" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "bcarpet05"
+	},
 /area/maintenance/starboard)
 "vbh" = (
 /obj/structure/table,
@@ -127268,7 +127268,7 @@
 /area/library)
 "vjf" = (
 /obj/structure/sign/biohazard,
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
 	})
@@ -130278,7 +130278,7 @@
 /area/maintenance/casino)
 "vQl" = (
 /obj/effect/landmark/burnturf,
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
 	})
@@ -130797,15 +130797,29 @@
 	},
 /area/engine/engineering)
 "vUL" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1;
 	frequency = 1379;
-	id_tag = "vir_inner";
-	locked = 1;
-	name = "Engineering External Access";
-	req_access_txt = "10;13"
+	id_tag = "vir_pump"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	id_tag = "vir_airlock";
+	layer = 3.1;
+	pixel_x = 24;
+	pixel_y = -6;
+	req_access_txt = "13";
+	tag_airpump = "vir_pump";
+	tag_chamber_sensor = "vir_sensor";
+	tag_exterior_door = "vir_outer";
+	tag_interior_door = "vir_inner"
+	},
+/obj/machinery/airlock_sensor{
+	id_tag = "vir_sensor";
+	layer = 3.1;
+	pixel_x = 24;
+	pixel_y = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "vUU" = (
@@ -134200,7 +134214,10 @@
 "wHp" = (
 /obj/structure/chair/sofa/corner,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
 /area/maintenance/starboard)
 "wHz" = (
 /obj/structure/closet,
@@ -138867,7 +138884,7 @@
 	name = "Virology Maintenance"
 	})
 "xFw" = (
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
 	})
@@ -139664,11 +139681,9 @@
 	},
 /area/hallway/primary/central/south)
 "xMl" = (
-/obj/structure/table/wood,
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plasteel{
-	icon_state = "bcarpet05"
-	},
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "xMs" = (
 /obj/machinery/disposal,
@@ -139723,10 +139738,14 @@
 /area/hallway/secondary/exit)
 "xNb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-dead";
+	tag = "plant-dead"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
 /area/maintenance/starboard)
 "xNt" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -142161,8 +142180,15 @@
 	},
 /area/turret_protected/aisat)
 "ylm" = (
-/turf/simulated/wall,
-/area/medical/virology)
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "yellow"
+	},
+/area/maintenance/electrical)
 "ylo" = (
 /obj/machinery/door_control{
 	desiredstate = 1;
@@ -187187,7 +187213,7 @@ dXB
 dKU
 eQp
 eQp
-hOZ
+knp
 hoB
 ouK
 xNO
@@ -187434,7 +187460,7 @@ iQw
 naz
 bzb
 vjf
-vLr
+ucM
 iLn
 fSq
 eSP
@@ -187692,13 +187718,13 @@ xFw
 xGb
 jbE
 xFw
-vLr
+ucM
 xtb
 xtb
 vLr
 aaa
+aaa
 abj
-hUP
 vLr
 uCn
 muK
@@ -189219,7 +189245,7 @@ lnx
 ljV
 kff
 mYl
-ljV
+ylm
 kFU
 nnw
 lvv
@@ -189742,13 +189768,13 @@ jjv
 gFe
 sZC
 qTn
-ylm
-ylm
+ltW
+ltW
 sqB
 bWB
 xYw
-ylm
-ylm
+ltW
+ltW
 dHa
 tLO
 bEP
@@ -189977,9 +190003,9 @@ jVb
 cUf
 bKr
 mUc
+cUf
 xWh
-xWh
-yfp
+peg
 cTg
 wxH
 bct
@@ -189997,15 +190023,15 @@ rFn
 npC
 oiv
 jKh
-ylm
-ylm
-ylm
+ltW
+ltW
+ltW
 miT
 sVx
 wWW
 kEz
 hKG
-ylm
+ltW
 dOc
 lOI
 eMz
@@ -190236,7 +190262,7 @@ yfp
 plt
 xWh
 yfp
-yfp
+xWh
 cTg
 nlq
 rbY
@@ -190250,11 +190276,11 @@ sMH
 sxp
 mDP
 uSB
-ujB
-ujB
-ujB
-ujB
-ylm
+rVs
+rVs
+rVs
+rVs
+ltW
 rUO
 dbT
 qIo
@@ -190493,7 +190519,7 @@ mde
 mde
 jAn
 jmK
-abW
+xWh
 rFn
 wCS
 tYj
@@ -190506,8 +190532,8 @@ cTg
 cTg
 cTg
 cTg
-cTg
-ujB
+tSQ
+rVs
 ubV
 hVw
 fmV
@@ -190763,7 +190789,7 @@ poE
 kPc
 toZ
 sWE
-ygQ
+erT
 tAC
 xrA
 qBZ
@@ -191020,20 +191046,20 @@ siJ
 xqk
 ygQ
 oxi
-ygQ
-ujB
-ujB
-ujB
-ujB
-ylm
+erT
+rVs
+rVs
+rVs
+rVs
+ltW
 dBO
 lGF
 dBO
-ylm
+ltW
 gpI
 qIo
 jjb
-ylm
+ltW
 dIm
 tLO
 hme
@@ -191282,15 +191308,15 @@ abj
 abj
 abj
 abj
-ylm
+ltW
 hvy
 rvd
 fey
-ylm
+ltW
 wBW
 qIo
 qUW
-ylm
+ltW
 hbD
 tLO
 lSx
@@ -191543,11 +191569,11 @@ xdU
 vBt
 lcc
 sAN
-ylm
+ltW
 xSx
 jrY
 kzV
-ylm
+ltW
 oPH
 tLO
 orG
@@ -191796,15 +191822,15 @@ aaa
 aaa
 aaa
 aaa
-ylm
+ltW
 hpO
 jgk
 suu
-ylm
-ylm
-ylm
-ylm
-ylm
+ltW
+ltW
+ltW
+ltW
+ltW
 umx
 sXT
 xFw
@@ -192286,7 +192312,7 @@ kRE
 lov
 uWH
 imN
-xWh
+abW
 yfp
 mde
 nMD
@@ -192294,10 +192320,10 @@ mde
 rpb
 xWh
 xWh
-rEe
+gio
 xWh
 imN
-kov
+gio
 ker
 tVz
 tZg
@@ -192545,12 +192571,12 @@ rpb
 iFu
 knS
 knS
+rPv
+rPv
 knS
 knS
 knS
-knS
-knS
-knS
+qQc
 knS
 knS
 uOG
@@ -192803,12 +192829,12 @@ xfR
 xZu
 rpb
 yfp
-yfp
-pDt
-xWh
-yfp
-yfp
-yfp
+hLL
+rpb
+rEe
+rEe
+rEe
+xZu
 xZu
 xfR
 yfp
@@ -193059,14 +193085,14 @@ gYg
 xfR
 yfp
 xWh
+cxB
+hOZ
 xWh
-xWh
+yfp
+pDt
 yfp
 yfp
 yfp
-yfp
-yfp
-xZu
 nsH
 eMk
 ygQ
@@ -193317,16 +193343,16 @@ sGS
 yfp
 wqy
 xZu
-hLL
-yfp
-yfp
-uju
-rEe
+rxs
+jAn
+rxs
+xZu
+qXt
 xWh
-kov
-iJe
+rEe
+rEe
 xfR
-yfp
+pCL
 ygQ
 ygQ
 ygQ
@@ -193574,24 +193600,24 @@ hkp
 qEC
 qEC
 qEC
-rxs
-jAn
+xWh
+xWh
+rOm
 xZu
 xZu
-vbc
 xqm
 xWh
 rEe
 smR
 rEe
-yfp
-kBt
+skZ
 xZu
+uAW
 jrD
-swW
 xZu
 xZu
 xZu
+abj
 abj
 abj
 abj
@@ -193831,26 +193857,26 @@ nBI
 qdI
 kud
 qEC
-xWh
-xWh
+hUP
+kBt
+rOm
 rOm
 xZu
 xZu
-xZu
-ecf
-xZu
-qQc
+scS
 rEe
-yfp
+tLf
 rEe
-kXR
+gio
+tGA
 yfp
+uWW
 qTI
 vUL
 dSm
-jCp
 acF
 acF
+abj
 abj
 abj
 abj
@@ -194089,23 +194115,23 @@ nxK
 sil
 qEC
 nNJ
-pGt
-rOm
+qfq
+oFL
 qtz
-xZu
+rxs
 xNb
 rEe
 xWh
 tLf
 yfp
-yfp
-uWW
+swW
 xZu
 xZu
 xZu
 xZu
 xZu
 xZu
+abj
 abj
 abj
 abj
@@ -194354,15 +194380,15 @@ xQH
 evn
 aOr
 tLf
-cxB
-rEe
+xWh
 rEe
 tGG
 xZu
+vbc
 dqY
 pZA
-uAW
 rxs
+abj
 abj
 abj
 aaa
@@ -194612,16 +194638,16 @@ iNZ
 tTX
 tLf
 rEe
-rEe
 pCL
+ugT
 sYb
 soF
 gEK
 oaQ
-xMl
 rxs
 rxs
 abj
+aaa
 aaa
 aaa
 aaa
@@ -194860,26 +194886,26 @@ foa
 nop
 qEC
 oip
-pOI
-scS
+yfp
+rOm
 ukA
 vbJ
 wHp
 aQA
-rEe
+hOZ
 sGS
 cWd
 xWh
-xWh
-peg
+uju
 xZu
-bBD
-gEK
+xMl
+soF
 yfp
-ugT
+eYB
 xZu
 abj
-abj
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -195118,7 +195144,7 @@ wkE
 qEC
 oum
 yfp
-skZ
+yfp
 vzF
 vzF
 rsJ
@@ -195630,8 +195656,8 @@ tOb
 xyi
 mjk
 qEC
-xWh
-xWh
+iJe
+kXR
 suE
 vzF
 vkX
@@ -195887,9 +195913,9 @@ pVa
 pVa
 rHr
 csj
-qtz
-yfp
-yfp
+jCp
+mrO
+jCp
 vzF
 vnQ
 hjp
@@ -196144,9 +196170,9 @@ tON
 jMT
 mbs
 qEC
-oFL
+oFU
 qrH
-oFL
+oFU
 vzF
 vpV
 hvU
@@ -196658,9 +196684,9 @@ csj
 csj
 csj
 qEC
-oFU
+kov
 qJO
-oFU
+oQg
 vzF
 vFU
 pkr
@@ -196681,7 +196707,7 @@ jlW
 bmM
 txD
 qOp
-lqZ
+dxO
 wLN
 rSm
 edb
@@ -196915,9 +196941,9 @@ abj
 abj
 abj
 abj
-oQg
-qXt
-tGA
+aaa
+aaa
+aaa
 usN
 usN
 ppK
@@ -196938,7 +196964,7 @@ foZ
 tDG
 aAE
 aAE
-mrO
+aAE
 aAE
 aAE
 aAE

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -383,10 +383,15 @@
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
 "abW" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
+/obj/structure/closet/crate/medical,
+/obj/item/roller,
+/obj/item/roller{
+	pixel_x = 3;
+	pixel_y = 10
 	},
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/grille/broken,
+/turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "abX" = (
 /obj/machinery/door/airlock/hatch{
@@ -2026,12 +2031,8 @@
 	},
 /area/shuttle/syndicate)
 "aiY" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/lattice/catwalk,
+/obj/structure/cable,
 /turf/space,
 /area/solar/starboard)
 "aiZ" = (
@@ -13999,9 +14000,14 @@
 /turf/simulated/wall/r_wall,
 /area/security/nuke_storage)
 "btN" = (
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/wall/rust,
-/area/maintenance/engrooms)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/lattice/catwalk,
+/turf/space,
+/area/solar/starboard)
 "btO" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
@@ -16116,9 +16122,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "bBD" = (
-/obj/structure/closet/secure_closet/personal/cabinet{
-	opened = 1
-	},
+/obj/structure/closet/secure_closet/personal/cabinet,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
@@ -31987,14 +31991,13 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/sorting)
 "cOA" = (
-/obj/machinery/door/airlock/maintenance{
-	welded = 1
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/structure/barricade/wooden{
-	layer = 3.5
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/turf/space,
+/area/solar/starboard)
 "cOC" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -32838,7 +32841,6 @@
 /obj/item/clothing/head/surgery/green,
 /obj/item/clothing/head/surgery/purple,
 /obj/item/clothing/head/surgery/purple,
-/obj/item/clothing/suit/storage/fr_jacket,
 /obj/item/clothing/suit/storage/fr_jacket,
 /obj/item/clothing/suit/storage/fr_jacket,
 /obj/item/clothing/under/rank/medical/blue,
@@ -35412,15 +35414,13 @@
 	},
 /area/maintenance/starboard)
 "dbq" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/grass,
-/area/maintenance/starboard)
+/turf/space,
+/area/solar/starboard)
 "dbr" = (
 /obj/item/radio/intercom{
 	pixel_x = -28
@@ -36079,12 +36079,24 @@
 	},
 /area/storage/primary)
 "del" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/grass,
-/area/maintenance/starboard)
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/lattice/catwalk,
+/turf/space,
+/area/solar/starboard)
 "deo" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -36556,8 +36568,8 @@
 /area/magistrateoffice)
 "dfI" = (
 /obj/structure/chair/stool/bar,
-/obj/item/clothing/suit/storage/suragi_jacket/medic,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/suit/storage/fr_jacket,
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
@@ -37454,10 +37466,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "diR" = (
-/obj/effect/decal/warning_stripes/south,
-/obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall,
-/area/maintenance/engrooms)
+/obj/machinery/power/solar{
+	name = "Aft Starboard Solar Panel"
+	},
+/obj/structure/cable,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "solarpanel"
+	},
+/area/solar/starboard)
 "diS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -40626,13 +40642,6 @@
 	tag = "icon-whiteblue (NORTHEAST)"
 	},
 /area/assembly/robotics)
-"dvh" = (
-/obj/machinery/power/tracker,
-/obj/structure/cable,
-/turf/simulated/floor/plasteel/airless{
-	icon_state = "solarpanel"
-	},
-/area/solar/starboard)
 "dvk" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
@@ -43892,12 +43901,12 @@
 	parallax_movedir = 2
 	})
 "dHX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 8
+/obj/machinery/power/tracker,
+/obj/structure/cable,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "solarpanel"
 	},
-/turf/simulated/floor/plasteel,
-/area/maintenance/starboard)
+/area/solar/starboard)
 "dHY" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -50677,20 +50686,6 @@
 /obj/structure/chair/sofa/corner,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar/atrium)
-"eoQ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
 "epd" = (
 /obj/structure/cable,
 /obj/structure/cable{
@@ -66729,13 +66724,13 @@
 	},
 /area/security/processing)
 "hRd" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/structure/table,
 /obj/item/storage/briefcase{
 	pixel_x = 4;
 	pixel_y = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -69619,9 +69614,7 @@
 	},
 /area/crew_quarters/courtroom)
 "izq" = (
-/obj/item/stack/ore/bananium{
-	amount = 10
-	},
+/obj/item/stack/ore/bananium,
 /turf/space,
 /area/space)
 "izr" = (
@@ -70497,9 +70490,7 @@
 "iJe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/turf/simulated/floor/plasteel,
 /area/maintenance/starboard)
 "iJg" = (
 /obj/machinery/light{
@@ -74978,6 +74969,10 @@
 	pixel_x = 26
 	},
 /obj/item/storage/briefcase/inflatable,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft{
 	name = "Medbay Maintenance"
@@ -76553,12 +76548,6 @@
 	},
 /turf/space,
 /area/maintenance/ai)
-"kgk" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/maintenance/starboard)
 "kgz" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -77166,9 +77155,7 @@
 	name = "Engineering Maintenance"
 	})
 "kov" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken5"
-	},
+/turf/simulated/floor/plasteel,
 /area/maintenance/starboard)
 "kow" = (
 /turf/simulated/floor/plasteel{
@@ -82359,18 +82346,6 @@
 	icon_state = "grimy"
 	},
 /area/library)
-"lBI" = (
-/obj/machinery/power/solar{
-	name = "Aft Starboard Solar Panel"
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plasteel/airless{
-	icon_state = "solarpanel"
-	},
-/area/solar/starboard)
 "lCa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -84518,6 +84493,7 @@
 "maD" = (
 /obj/effect/landmark/burnturf,
 /obj/machinery/chem_heater,
+/obj/item/stock_parts/matter_bin,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
@@ -85523,19 +85499,8 @@
 "mlb" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
 /turf/space,
 /area/solar/starboard)
@@ -91164,9 +91129,7 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/turf/simulated/floor/plasteel,
 /area/maintenance/starboard)
 "nsP" = (
 /obj/machinery/portable_atmospherics/scrubber,
@@ -93076,14 +93039,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/electrical)
-"nOz" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/space,
-/area/solar/starboard)
 "nOK" = (
 /obj/machinery/power/solar{
 	name = "Aft Starboard Solar Panel"
@@ -93315,7 +93270,9 @@
 	},
 /area/crew_quarters/locker)
 "nRD" = (
-/obj/machinery/vending/dinnerware,
+/obj/machinery/vending/dinnerware{
+	products = list(/obj/item/storage/bag/tray = 1, /obj/item/kitchen/utensil/fork = 2, /obj/item/kitchen/knife = 0, /obj/item/kitchen/rollingpin = 0, /obj/item/kitchen/sushimat = 1, /obj/item/reagent_containers/food/drinks/drinkingglass = 2, /obj/item/clothing/suit/chef/classic = 1, /obj/item/storage/belt/chef = 0, /obj/item/reagent_containers/food/condiment/pack/ketchup = 1, /obj/item/reagent_containers/food/condiment/pack/hotsauce = 0, /obj/item/reagent_containers/food/condiment/saltshaker = 1, /obj/item/reagent_containers/food/condiment/peppermill = 2, /obj/item/whetstone = 1, /obj/item/mixing_bowl = 3, /obj/item/kitchen/mould/bear = 1, /obj/item/kitchen/mould/worm = 0, /obj/item/kitchen/mould/bean = 0, /obj/item/kitchen/mould/ball = 1, /obj/item/kitchen/mould/cane = 1, /obj/item/kitchen/mould/cash = 0, /obj/item/kitchen/mould/coin = 0, /obj/item/kitchen/mould/loli = 1, /obj/item/kitchen/cutter = 0, /obj/item/eftpos = 1)
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "tranquillite"
 	},
@@ -93996,13 +93953,23 @@
 	},
 /area/turret_protected/aisat)
 "obf" = (
-/obj/machinery/power/solar{
-	name = "Aft Starboard Solar Panel"
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/structure/cable,
-/turf/simulated/floor/plasteel/airless{
-	icon_state = "solarpanel"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/lattice/catwalk,
+/turf/space,
 /area/solar/starboard)
 "obl" = (
 /obj/structure/cable{
@@ -99316,18 +99283,6 @@
 	tag = "icon-redfull (NORTHWEST)"
 	},
 /area/security/processing)
-"pjV" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/corner,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
 "pkc" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -104091,25 +104046,6 @@
 	icon_state = "red"
 	},
 /area/security/brig)
-"qgJ" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/solar/starboard)
 "qgX" = (
 /obj/structure/lattice,
 /turf/simulated/wall/rust,
@@ -105858,23 +105794,16 @@
 	},
 /area/toxins/explab)
 "qxE" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/power/solar{
+	name = "Aft Starboard Solar Panel"
 	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "solarpanel"
 	},
-/obj/structure/lattice/catwalk,
-/turf/space,
 /area/solar/starboard)
 "qxP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -109098,7 +109027,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/structure/door_assembly/door_assembly_med,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "riE" = (
@@ -110806,12 +110734,6 @@
 	icon_state = "purplefull"
 	},
 /area/medical/research/nhallway)
-"rCi" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
 "rCs" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
@@ -112035,9 +111957,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/turf/simulated/floor/plasteel,
 /area/maintenance/starboard)
 "rPE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -112400,12 +112320,8 @@
 /area/crew_quarters/fitness)
 "rSS" = (
 /obj/effect/landmark/burnturf,
-/obj/machinery/constructable_frame/machine_frame{
-	desc = "Dispenser probably broken";
-	icon = 'icons/obj/chemical.dmi';
-	icon_state = "dispenser";
-	name = "chem dispenser"
-	},
+/obj/machinery/constructable_frame/machine_frame,
+/obj/item/stock_parts/cell,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
@@ -116867,10 +116783,10 @@
 	},
 /area/bridge/checkpoint/south)
 "sSC" = (
-/obj/machinery/gibber,
 /obj/item/reagent_containers/food/snacks/meat/human,
 /obj/item/reagent_containers/food/snacks/meat/human,
 /obj/effect/decal/warning_stripes/north,
+/obj/effect/spawner/random_spawners/blood_maybe,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -117182,10 +117098,10 @@
 "sWE" = (
 /obj/structure/safe/floor,
 /obj/item/clothing/mask/cigarette/pipe,
-/obj/item/clothing/suit/storage/det_suit/forensics,
-/obj/item/clothing/head/det_hat,
 /obj/item/storage/belt/holster,
+/obj/item/clothing/suit/jacket/leather/overcoat,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey,
+/obj/item/nullrod/fedora,
 /turf/simulated/floor/plating,
 /area/maintenance/detectives_office)
 "sWN" = (
@@ -120810,20 +120726,6 @@
 	icon_state = "whitebluecorner"
 	},
 /area/medical/surgery/south)
-"tMO" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
 "tMQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -120869,16 +120771,6 @@
 	icon_state = "red"
 	},
 /area/security/brig)
-"tMV" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/leafybush,
-/obj/machinery/door/window/eastleft{
-	dir = 1
-	},
-/turf/simulated/floor/grass,
-/area/maintenance/starboard)
 "tNa" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -122922,9 +122814,6 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/railing{
-	dir = 8
-	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/starboard)
 "ujB" = (
@@ -123689,14 +123578,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/assembly/robotics)
-"uud" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/genericbush,
-/mob/living/simple_animal/chicken,
-/turf/simulated/floor/grass,
-/area/maintenance/starboard)
 "uue" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -124602,17 +124483,6 @@
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
 	})
-"uDx" = (
-/obj/structure/closet/crate/medical,
-/obj/item/roller,
-/obj/item/roller{
-	pixel_x = 3;
-	pixel_y = 10
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/grille/broken,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
 "uDH" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -126661,13 +126531,6 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/port)
-"uZn" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/grass,
-/area/maintenance/starboard)
 "uZs" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -129549,11 +129412,6 @@
 	dir = 1
 	},
 /area/security/main)
-"vEN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
 "vEU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/engineering,
@@ -130418,14 +130276,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/casino)
-"vPY" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/space,
-/area/solar/starboard)
 "vQl" = (
 /obj/effect/landmark/burnturf,
 /turf/simulated/wall,
@@ -130965,6 +130815,9 @@
 "vUV" = (
 /obj/structure/sign/poster/contraband/ambrosia_vulgaris{
 	pixel_y = 30
+	},
+/obj/item/stack/cable_coil{
+	amount = 3
 	},
 /obj/item/clothing/mask/gas,
 /obj/effect/landmark/burnturf,
@@ -134489,14 +134342,6 @@
 	icon_state = "whitepurplefull"
 	},
 /area/assembly/robotics)
-"wJJ" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/space,
-/area/solar/starboard)
 "wJK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -134767,13 +134612,6 @@
 	icon_state = "dark"
 	},
 /area/turret_protected/ai_upload)
-"wMS" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/grass,
-/area/maintenance/starboard)
 "wMU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -135097,6 +134935,7 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/constructable_frame/machine_frame,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/stock_parts/manipulator,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -135756,13 +135595,6 @@
 	dir = 1
 	},
 /area/security/customs)
-"wYQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
 "wYX" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -136893,9 +136725,7 @@
 	},
 /area/security/permabrig)
 "xmh" = (
-/obj/structure/closet/secure_closet/personal/cabinet{
-	opened = 1
-	},
+/obj/structure/closet/secure_closet/personal/cabinet,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/wood/fancy/birch,
 /area/maintenance/fsmaint)
@@ -138148,7 +137978,21 @@
 /area/hallway/secondary/exit)
 "xxg" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/space,
 /area/solar/starboard)
 "xxi" = (
@@ -140032,11 +139876,6 @@
 	req_access_txt = "5"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -140485,7 +140324,6 @@
 /area/engine/engineering)
 "xSx" = (
 /obj/structure/closet/wardrobe/virology_white,
-/obj/item/clothing/suit/storage/suragi_jacket/virus,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitegreencorner"
@@ -171299,7 +171137,7 @@ cie
 aDg
 cNg
 bsA
-diR
+iOH
 cDk
 cEj
 mzQ
@@ -171556,7 +171394,7 @@ cNV
 cml
 aEp
 aHu
-btN
+ceP
 cDk
 bVS
 mzQ
@@ -188838,7 +188676,7 @@ bws
 uHf
 cyG
 cAg
-cOA
+cnP
 xWh
 rxr
 cUz
@@ -190397,8 +190235,8 @@ xWh
 yfp
 plt
 xWh
-mde
-uDx
+yfp
+yfp
 cTg
 nlq
 rbY
@@ -190654,8 +190492,8 @@ xZu
 mde
 mde
 jAn
-rpb
-xWh
+jmK
+abW
 rFn
 wCS
 tYj
@@ -192710,11 +192548,11 @@ knS
 knS
 knS
 knS
-pjV
-tMO
-tMO
-tMO
-eoQ
+knS
+knS
+knS
+knS
+knS
 uOG
 rPv
 iCQ
@@ -192967,10 +192805,10 @@ rpb
 yfp
 yfp
 pDt
-vEN
-dbq
-uud
-del
+xWh
+yfp
+yfp
+yfp
 xZu
 xfR
 yfp
@@ -193225,9 +193063,9 @@ xWh
 xWh
 yfp
 yfp
-tMV
-uZn
-wMS
+yfp
+yfp
+yfp
 xZu
 nsH
 eMk
@@ -193280,7 +193118,7 @@ aaa
 abj
 abj
 bqc
-bqc
+aaa
 aaa
 aaa
 aaa
@@ -193481,11 +193319,11 @@ wqy
 xZu
 hLL
 yfp
-rCi
+yfp
 uju
-dHX
-wYQ
-kgk
+rEe
+xWh
+kov
 iJe
 xfR
 yfp
@@ -193537,7 +193375,7 @@ acF
 acF
 abj
 abj
-bqc
+aaa
 aaa
 aaa
 aaa
@@ -193743,7 +193581,7 @@ xZu
 vbc
 xqm
 xWh
-abW
+rEe
 smR
 rEe
 yfp
@@ -194051,8 +193889,8 @@ acF
 acF
 abj
 abj
-bqc
-bqc
+abj
+aaa
 aaa
 aaa
 aaa
@@ -194304,13 +194142,13 @@ gtX
 vLr
 abj
 abj
+aaa
 abj
 aaa
 jmx
-aaa
+abj
 abj
 bvh
-aaa
 aaa
 aaa
 aaa
@@ -194562,12 +194400,12 @@ xtb
 abj
 abj
 aaa
+abj
 aaa
-aiY
+btN
 aaa
 aaa
 bvh
-aaa
 aaa
 aaa
 aaa
@@ -194819,12 +194657,12 @@ xtb
 abj
 abj
 abj
-lBI
-qgJ
+abj
+qxE
 obf
+diR
 abj
 abj
-aaa
 aaa
 aaa
 aaa
@@ -195076,12 +194914,12 @@ vLr
 abj
 aaa
 aaa
-lBI
-qgJ
+aaa
+qxE
 obf
+diR
 aaa
 bvh
-aaa
 aaa
 aaa
 aaa
@@ -195333,9 +195171,10 @@ itU
 abj
 abj
 aaa
-lBI
-qgJ
+aaa
+qxE
 obf
+diR
 aaa
 bvh
 bvh
@@ -195348,7 +195187,6 @@ bvh
 bvh
 abj
 abj
-aaa
 aaa
 aaa
 aaa
@@ -195590,9 +195428,10 @@ itU
 itU
 abj
 abj
-lBI
-qgJ
+abj
+qxE
 obf
+diR
 aaa
 abj
 aaa
@@ -195605,7 +195444,6 @@ aaa
 abj
 aaa
 abj
-aaa
 aaa
 aaa
 aaa
@@ -195847,9 +195685,10 @@ gvg
 itU
 aaa
 aaa
-lBI
-qgJ
+aaa
+qxE
 obf
+diR
 abj
 abj
 jmx
@@ -195862,7 +195701,6 @@ aaa
 abj
 aaa
 bvh
-aaa
 aaa
 aaa
 aaa
@@ -196105,22 +195943,22 @@ itU
 abj
 aaa
 aaa
-wJJ
-abj
-ilh
-nOz
-yie
-yie
-yie
-yie
-yie
-xxg
-ilh
-abj
-abj
-bvh
-bvh
 aaa
+cOA
+abj
+ilh
+mlb
+yie
+yie
+yie
+yie
+yie
+aiY
+ilh
+abj
+abj
+bvh
+bvh
 aaa
 aaa
 aaa
@@ -196362,6 +196200,7 @@ itU
 abj
 abj
 abj
+abj
 ilh
 ilh
 ilh
@@ -196377,7 +196216,6 @@ ilh
 abj
 abj
 bvh
-aaa
 aaa
 aaa
 aaa
@@ -196617,8 +196455,9 @@ qyS
 itU
 itU
 aaa
+aaa
 abj
-bvh
+bMw
 ilh
 ilh
 abj
@@ -196635,7 +196474,6 @@ ilh
 aaa
 bvh
 bvh
-aaa
 aaa
 aaa
 aaa
@@ -196875,24 +196713,24 @@ itU
 abj
 abj
 abj
-bvh
-ilh
-abj
-abj
-aaa
-aaa
-aaa
-abj
-aaa
-aaa
-aaa
 abj
 abj
 ilh
 abj
 abj
+aaa
+aaa
+aaa
 abj
 aaa
+aaa
+aaa
+abj
+abj
+ilh
+abj
+abj
+abj
 aaa
 aaa
 aaa
@@ -197131,6 +196969,7 @@ fWg
 nLF
 nLF
 nLF
+aaa
 abj
 aaa
 ilh
@@ -197150,7 +196989,6 @@ aaa
 aaa
 abj
 bvh
-aaa
 aaa
 aaa
 aaa
@@ -197389,25 +197227,25 @@ pkV
 rGz
 mZC
 kCy
+aiY
 ilh
 ilh
-nOz
-mlb
-yie
-yie
-yie
-yie
-yie
-yie
-yie
 mlb
 xxg
+yie
+yie
+yie
+yie
+yie
+yie
+yie
+xxg
+aiY
 ilh
-nOz
-dvh
+mlb
+dHX
 abj
 bvh
-aaa
 aaa
 aaa
 aaa
@@ -197645,6 +197483,7 @@ eqH
 nLF
 nLF
 nLF
+aaa
 abj
 aaa
 ilh
@@ -197664,7 +197503,6 @@ aaa
 aaa
 abj
 bvh
-aaa
 aaa
 aaa
 aaa
@@ -197903,7 +197741,8 @@ gOM
 abj
 abj
 abj
-bvh
+abj
+bMw
 ilh
 abj
 abj
@@ -197920,7 +197759,6 @@ ilh
 abj
 abj
 abj
-aaa
 aaa
 aaa
 aaa
@@ -198159,25 +197997,25 @@ abj
 aaa
 abj
 aaa
+aaa
 abj
+abj
+ilh
+ilh
+abj
+abj
+aaa
+aaa
+abj
+aaa
+aaa
+abj
+abj
+ilh
+ilh
+aaa
 bvh
-ilh
-ilh
-abj
-abj
-aaa
-aaa
-abj
-aaa
-aaa
-abj
-abj
-ilh
-ilh
-aaa
 bvh
-bvh
-aaa
 aaa
 aaa
 aaa
@@ -198418,6 +198256,7 @@ abj
 abj
 abj
 abj
+abj
 ilh
 ilh
 ilh
@@ -198433,7 +198272,6 @@ ilh
 abj
 abj
 bvh
-aaa
 aaa
 aaa
 aaa
@@ -198672,25 +198510,25 @@ aaa
 aaa
 aaa
 aaa
+aaa
 bvh
 aaa
 aaa
-vPY
+dbq
 abj
 ilh
-nOz
+mlb
 yie
 yie
 yie
 yie
 yie
-xxg
+aiY
 ilh
 abj
 abj
 bvh
 bvh
-aaa
 aaa
 aaa
 aaa
@@ -198929,11 +198767,12 @@ aaa
 aaa
 aaa
 aaa
+aaa
 bvh
 aaa
-lBI
 qxE
-obf
+del
+diR
 abj
 abj
 oID
@@ -198946,7 +198785,6 @@ aaa
 abj
 aaa
 bvh
-aaa
 aaa
 aaa
 aaa
@@ -199186,11 +199024,12 @@ aaa
 aaa
 aaa
 aaa
+aaa
 abj
 abj
-lBI
 qxE
-obf
+del
+diR
 aaa
 abj
 aaa
@@ -199203,7 +199042,6 @@ aaa
 abj
 aaa
 abj
-aaa
 aaa
 aaa
 aaa
@@ -199443,11 +199281,12 @@ aaa
 aaa
 aaa
 aaa
+aaa
 bvh
 aaa
-lBI
 qxE
-obf
+del
+diR
 aaa
 bvh
 bvh
@@ -199460,7 +199299,6 @@ bvh
 bvh
 abj
 abj
-aaa
 aaa
 aaa
 aaa
@@ -199700,14 +199538,14 @@ aaa
 aaa
 aaa
 aaa
+aaa
 bvh
 aaa
-lBI
 qxE
-obf
+del
+diR
 aaa
 bvh
-aaa
 aaa
 aaa
 aaa
@@ -199957,14 +199795,14 @@ aaa
 aaa
 aaa
 aaa
-abj
-abj
-lBI
-qxE
-obf
-abj
-abj
 aaa
+abj
+abj
+qxE
+del
+diR
+abj
+abj
 aaa
 aaa
 aaa
@@ -200214,14 +200052,14 @@ aaa
 aaa
 aaa
 aaa
-bvh
-aaa
-aaa
-aiY
-aaa
 aaa
 bvh
 aaa
+aaa
+btN
+aaa
+aaa
+bvh
 aaa
 aaa
 aaa
@@ -200471,6 +200309,7 @@ aaa
 aaa
 aaa
 aaa
+aaa
 bvh
 aaa
 aaa
@@ -200478,7 +200317,6 @@ oID
 aaa
 aaa
 bvh
-aaa
 aaa
 aaa
 aaa
@@ -200728,14 +200566,14 @@ aaa
 aaa
 aaa
 aaa
-bvh
-bvh
-aaa
-aaa
 aaa
 bvh
 bvh
 aaa
+aaa
+aaa
+bvh
+bvh
 aaa
 aaa
 aaa
@@ -200986,12 +200824,12 @@ aaa
 aaa
 aaa
 aaa
+aaa
 abj
 abj
 bvh
 abj
 abj
-aaa
 aaa
 aaa
 aaa

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -100011,31 +100011,28 @@
 "prh" = (
 /obj/structure/closet/secure_closet/guncabinet{
 	anchored = 1;
-	name = "Lethal Bullets"
+	name = "Tasers";
+	req_access = list(1)
 	},
-/obj/item/ammo_box/magazine/enforcer/lethal{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/ammo_box/magazine/enforcer/lethal,
-/obj/item/ammo_box/magazine/enforcer/lethal{
+/obj/item/gun/energy/gun/advtaser{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/ammo_box/magazine/enforcer/lethal{
-	pixel_x = -6;
-	pixel_y = 6
+/obj/item/gun/energy/gun/advtaser{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/gun/energy/gun/advtaser,
+/obj/machinery/camera{
+	c_tag = "Brig Local Armory";
+	dir = 1;
+	network = list("SS13","Security")
 	},
 /obj/machinery/power/apc{
 	name = "south bump";
 	pixel_y = -26
 	},
 /obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Brig Local Armory";
-	dir = 1;
-	network = list("SS13","Security")
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1
 	},
@@ -123487,20 +123484,24 @@
 	},
 /area/security/securearmory)
 "uqM" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+/obj/structure/closet/secure_closet/guncabinet{
+	anchored = 1;
+	name = "Lethal Bullets"
 	},
-/obj/effect/decal/warning_stripes/red/hollow,
-/obj/item/gun/energy/gun/advtaser{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/gun/advtaser,
-/obj/item/gun/energy/gun/advtaser{
+/obj/item/ammo_box/magazine/enforcer/lethal{
 	pixel_x = 3;
 	pixel_y = -3
 	},
+/obj/item/ammo_box/magazine/enforcer/lethal,
+/obj/item/ammo_box/magazine/enforcer/lethal{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/ammo_box/magazine/enforcer/lethal{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -19225,7 +19225,7 @@
 "aKY" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "aKZ" = (
 /obj/item/coin/gold,
 /obj/item/coin/iron,
@@ -19257,7 +19257,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "aLd" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/secondary/entry)
@@ -34654,7 +34654,7 @@
 /obj/effect/decal/cleanable/cobweb2,
 /obj/structure/bookcase,
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/library)
 "brt" = (
 /obj/machinery/hydroponics/constructable,
 /obj/item/radio/intercom{
@@ -35690,7 +35690,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken5"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "btT" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/structure/cable{
@@ -35703,7 +35703,7 @@
 "btU" = (
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/library)
 "btV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -61137,7 +61137,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "cpD" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -61873,7 +61873,7 @@
 	req_access_txt = "12"
 	},
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/library)
 "cqL" = (
 /obj/structure/closet{
 	icon_closed = "cabinet_closed";
@@ -72163,7 +72163,7 @@
 /obj/item/holosign_creator/atmos,
 /obj/item/toy/figure/atmos,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "cJJ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door_control{
@@ -74255,7 +74255,7 @@
 "cNU" = (
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall/r_wall,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "cNW" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/structure/cable/yellow{
@@ -75685,7 +75685,7 @@
 "cQP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "cQR" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -76934,7 +76934,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "cTf" = (
 /obj/machinery/newscaster{
 	name = "north newscaster";
@@ -80218,7 +80218,7 @@
 	name = "2maintenance loot spawner"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "cZG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -80554,7 +80554,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "daw" = (
 /obj/structure/lattice,
 /turf/simulated/wall/r_wall,
@@ -80711,7 +80711,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "daM" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
@@ -80940,7 +80940,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dbr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -80999,7 +80999,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dbz" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81344,7 +81344,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dco" = (
 /obj/structure/sign/directions/security{
 	dir = 1;
@@ -81371,7 +81371,7 @@
 /area/maintenance/asmaint)
 "dcq" = (
 /turf/simulated/wall/r_wall,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dcr" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
@@ -81789,7 +81789,7 @@
 /area/maintenance/turbine)
 "ddr" = (
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dds" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/warning_stripes/white/hollow,
@@ -82316,7 +82316,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dey" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -82421,7 +82421,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "deM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -82459,7 +82459,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "deQ" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -82529,7 +82529,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "deX" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
@@ -82667,7 +82667,7 @@
 	req_access_txt = "13"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dfn" = (
 /obj/machinery/power/solar_control{
 	id = "starboardsolar";
@@ -82724,7 +82724,7 @@
 	dir = 9;
 	icon_state = "blue"
 	},
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dfv" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -82772,7 +82772,7 @@
 "dfx" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall/r_wall,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dfy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable{
@@ -82803,7 +82803,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dfB" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
@@ -82821,12 +82821,12 @@
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dfD" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/transit_tube,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dfE" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -82839,7 +82839,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dfF" = (
 /obj/structure/closet/wardrobe/atmospherics_yellow,
 /obj/machinery/power/apc{
@@ -82941,7 +82941,7 @@
 	dir = 10;
 	icon_state = "blue"
 	},
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dfR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -82949,7 +82949,7 @@
 	req_access_txt = "75"
 	},
 /turf/simulated/floor/plasteel,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dfS" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -82970,7 +82970,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "blue"
 	},
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dfU" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/tinted{
@@ -82998,17 +82998,17 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "blue"
 	},
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dgc" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dgd" = (
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "blue"
 	},
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dge" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Biohazard Disposals";
@@ -83043,7 +83043,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dgj" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
@@ -83095,11 +83095,11 @@
 	name = "Escape Pod"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dgq" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dgr" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plasteel,
@@ -83156,7 +83156,7 @@
 	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall/r_wall,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dgH" = (
 /obj/machinery/newscaster{
 	name = "south newscaster";
@@ -83179,7 +83179,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dgJ" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -86871,7 +86871,7 @@
 	tag_interior_door = "atmospherics_south_inner"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dol" = (
 /obj/machinery/atmospherics/unary/outlet_injector/on{
 	dir = 8;
@@ -86905,7 +86905,7 @@
 	req_access_txt = "13"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "doo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/access_button/airlock_interior{
@@ -86915,11 +86915,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dop" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "doq" = (
 /obj/structure/table,
 /obj/machinery/kitchen_machine/microwave{
@@ -86940,13 +86940,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dos" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/storage)
+/area/maintenance/atmospherics)
 "dou" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "swall12";
@@ -88263,7 +88263,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "dAN" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
@@ -88336,7 +88336,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "dHG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -88565,7 +88565,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken7"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "epx" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -88659,7 +88659,7 @@
 "eCS" = (
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall,
-/area/library/abandoned)
+/area/maintenance/library)
 "eDI" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	name = "standard air scrubber";
@@ -88725,7 +88725,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "eIE" = (
 /obj/structure/chair/stool,
 /obj/effect/decal/warning_stripes/red/hollow,
@@ -88963,7 +88963,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "carpet"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "fdS" = (
 /obj/effect/decal/warning_stripes/southwest,
 /obj/effect/decal/cleanable/dirt,
@@ -89136,7 +89136,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "fDj" = (
 /obj/structure/closet/crate,
 /obj/item/target/alien,
@@ -89208,7 +89208,7 @@
 "fNV" = (
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "fOI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -89275,7 +89275,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "fTl" = (
 /obj/machinery/chem_master,
 /turf/simulated/shuttle/floor{
@@ -89332,7 +89332,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "fYw" = (
 /obj/structure/mirror{
 	pixel_y = -30
@@ -89344,7 +89344,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "fZO" = (
 /obj/machinery/computer/mech_bay_power_console,
 /obj/machinery/light/spot,
@@ -89369,7 +89369,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "gdm" = (
 /obj/machinery/clonepod/upgraded,
 /obj/machinery/light/spot{
@@ -89868,7 +89868,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "hsy" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
@@ -89903,7 +89903,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/library)
 "hwV" = (
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plating,
@@ -89936,7 +89936,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "hzr" = (
 /obj/effect/decal/warning_stripes/northeast,
 /obj/effect/decal/cleanable/dirt,
@@ -90050,7 +90050,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "hNC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -90061,7 +90061,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "hNI" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
@@ -90130,7 +90130,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "hTU" = (
 /obj/machinery/light/spot,
 /turf/simulated/floor/mech_bay_recharge_floor,
@@ -90349,7 +90349,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "iGx" = (
 /obj/effect/turf_decal/stripes{
 	dir = 8
@@ -90493,7 +90493,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "iUc" = (
 /turf/simulated/wall/r_wall,
 /area/tcommsat/chamber)
@@ -90635,7 +90635,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "jzp" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -90781,7 +90781,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "carpet"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "jXu" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -91095,7 +91095,7 @@
 /area/shuttle/escape)
 "kIF" = (
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/library)
 "kIR" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
@@ -91184,7 +91184,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "kUs" = (
 /obj/machinery/computer/atmos_alert,
 /turf/simulated/floor/plasteel{
@@ -91200,7 +91200,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "kUH" = (
 /turf/simulated/floor/greengrid,
 /area/toxins/xenobiology)
@@ -91359,7 +91359,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "lop" = (
 /obj/structure/chair{
 	dir = 8
@@ -91456,7 +91456,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "lGT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -91570,7 +91570,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken5"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "lQS" = (
 /obj/structure/shuttle/engine/propulsion/burst{
 	dir = 8
@@ -91655,7 +91655,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "lWN" = (
 /obj/structure/table/wood,
 /obj/item/stack/packageWrap,
@@ -91690,7 +91690,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "mcq" = (
 /obj/item/radio/intercom{
 	name = "east station intercom (General)";
@@ -91749,7 +91749,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "carpet"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "mmN" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -91991,7 +91991,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "mOm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -92080,7 +92080,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "nel" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -92152,7 +92152,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "njA" = (
 /obj/effect/decal/cleanable/ash,
 /obj/item/extinguisher,
@@ -92354,7 +92354,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "nHW" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -92381,7 +92381,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "nOf" = (
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 1
@@ -92399,7 +92399,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "nRi" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -92431,7 +92431,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "nVw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -92712,7 +92712,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "carpet"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "oHF" = (
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -92851,7 +92851,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "oXI" = (
 /obj/machinery/light{
 	dir = 4
@@ -93020,7 +93020,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "pBY" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/west,
@@ -93075,7 +93075,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "pGH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -93119,7 +93119,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "pIm" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
@@ -93140,7 +93140,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "pOu" = (
 /obj/machinery/computer/communications,
 /turf/simulated/shuttle/floor,
@@ -93200,7 +93200,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "pUD" = (
 /obj/structure/bed,
 /obj/item/bedsheet/blue,
@@ -93217,7 +93217,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "pWb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
@@ -93244,7 +93244,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "pZO" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
@@ -93412,7 +93412,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "quo" = (
 /obj/effect/decal/cleanable/dust,
 /obj/structure/chair/sofa/corp/left,
@@ -93461,7 +93461,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "qzo" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -93477,7 +93477,7 @@
 "qAF" = (
 /obj/structure/barricade/wooden,
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/library)
 "qAG" = (
 /obj/structure/sign/directions/security{
 	dir = 4;
@@ -93525,7 +93525,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken5"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "qDI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -93537,7 +93537,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "qEN" = (
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
@@ -93674,7 +93674,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "qPO" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
@@ -94152,7 +94152,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/library)
 "rIF" = (
 /obj/item/radio/intercom{
 	name = "east station intercom (General)";
@@ -94178,7 +94178,7 @@
 /obj/effect/decal/cleanable/dust,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "rNC" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -94312,7 +94312,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "carpet"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "skM" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -94520,7 +94520,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "sPV" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -94736,7 +94736,7 @@
 	req_access_txt = "12"
 	},
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "tku" = (
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel{
@@ -94891,7 +94891,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "tCK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -94952,7 +94952,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "tMX" = (
 /obj/machinery/biogenerator,
 /obj/effect/decal/cleanable/dirt,
@@ -95039,7 +95039,7 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "ugD" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -95119,7 +95119,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "uAy" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/tank/internals/emergency_oxygen/engi/empty,
@@ -95258,7 +95258,7 @@
 "uOR" = (
 /obj/effect/spawner/window,
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "uOX" = (
 /obj/structure/target_stake,
 /obj/effect/decal/warning_stripes/northwest,
@@ -95345,7 +95345,7 @@
 /area/toxins/xenobiology)
 "uXb" = (
 /turf/simulated/wall/rust,
-/area/library/abandoned)
+/area/maintenance/library)
 "uXj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -95451,7 +95451,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "vpO" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/slime/random,
@@ -95515,7 +95515,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "vAX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/computerframe,
@@ -95761,7 +95761,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "vZA" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -95902,7 +95902,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "wpV" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -95925,7 +95925,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/library)
 "wrE" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
@@ -95974,7 +95974,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/library/abandoned)
+/area/maintenance/library)
 "wwy" = (
 /obj/machinery/light_switch{
 	name = "custom light switch";
@@ -95992,7 +95992,7 @@
 /area/security/range)
 "wxz" = (
 /turf/simulated/wall,
-/area/library/abandoned)
+/area/maintenance/library)
 "wxQ" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -96049,7 +96049,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "wCS" = (
 /obj/structure/extinguisher_cabinet{
 	name = "east extinguisher cabinet";
@@ -96060,7 +96060,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "wCY" = (
 /obj/structure/rack{
 	dir = 8;
@@ -96160,7 +96160,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/library)
 "wOS" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass{
@@ -96221,7 +96221,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "wQN" = (
 /obj/machinery/washing_machine,
 /turf/simulated/floor/plasteel{
@@ -96420,7 +96420,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "xlo" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -96473,7 +96473,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "xsM" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
@@ -96631,7 +96631,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "carpet"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "xKt" = (
 /obj/effect/landmark{
 	name = "blobstart"
@@ -96660,7 +96660,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/wood,
-/area/library/abandoned)
+/area/maintenance/library)
 "xRa" = (
 /obj/machinery/light_construct{
 	dir = 4
@@ -96681,7 +96681,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "xTp" = (
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/dropper,
@@ -96823,7 +96823,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/library/abandoned)
+/area/maintenance/library)
 "ylx" = (
 /obj/machinery/door/airlock/centcom{
 	id_tag = "adminshuttle";

--- a/code/game/area/ss13_areas.dm
+++ b/code/game/area/ss13_areas.dm
@@ -662,6 +662,10 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	valid_territory = FALSE
 	sound_environment = SOUND_AREA_TUNNEL_ENCLOSED
 
+/area/maintenance/ai
+	name = "AI Maintenance"
+	icon_state = "green"
+
 /area/maintenance/fore
 	name = "Fore Maintenance"
 	icon_state = "fmaint"
@@ -702,11 +706,15 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "Locker Room Maintenance"
 	icon_state = "pmaint"
 
+/area/maintenance/perma
+	name = "Prison Maintenance"
+	icon_state = "green"
+
 /area/maintenance/aft
 	name = "Engineering Maintenance"
 	icon_state = "amaint"
 
-/area/maintenance/storage
+/area/maintenance/atmospherics
 	name = "Atmospherics Maintenance"
 	icon_state = "green"
 
@@ -726,10 +734,13 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "Genetics Maintenance"
 	icon_state = "asmaint"
 
-
 /area/maintenance/electrical
 	name = "Electrical Maintenance"
 	icon_state = "yellow"
+
+/area/maintenance/engineering
+	name = "Engineering Maintenance"
+	icon_state = "green"
 
 /area/maintenance/bar
 	name = "Abandoned Bar"
@@ -762,6 +773,11 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/maintenance/engrooms
 	name = "Abandoned Engineers Rooms"
 	icon_state = "yellow"
+
+/area/maintenance/library
+	name = "\improper Abandoned Library"
+	icon_state = "library"
+	sound_environment = SOUND_AREA_LARGE_ENCLOSED
 
 /area/maintenance/xenozoo
 	name = "Maintenance Xeno Zoo"
@@ -826,6 +842,10 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 
 /area/hallway/secondary/exit
 	name = "\improper Escape Shuttle Hallway"
+	icon_state = "escape"
+
+/area/hallway/secondary/exit/maint
+	name = "\improper Abandoned Escape Shuttle Hallway"
 	icon_state = "escape"
 
 /area/hallway/secondary/construction
@@ -1065,11 +1085,6 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "\improper Library"
 	icon_state = "library"
 	sound_environment = SOUND_AREA_LARGE_SOFTFLOOR
-
-/area/library/abandoned
-	name = "\improper Abandoned Library"
-	icon_state = "library"
-	sound_environment = SOUND_AREA_LARGE_ENCLOSED
 
 /area/chapel
 	icon_state = "chapel"


### PR DESCRIPTION
## What Does This PR Do
Исправляет проблемы области Medbay Maintenance (Delta/Kerberos): названия зон, возврат тазеров на место, нерф элементов влияющих на баланс по запросам игроков и администрации.

## Changelog
:cl:
add: AI Maintenance area
add: Prison Maintenance area
add: Abandoned Escape Shuttle Hallway area
del: all suragi jacket's from map (its loadout item)
del: gibber now is machine frame
del: chicken in maintence
del: maint airlock in Locker Room
tweak: chemical dispenser (machine frame) now have normal icon
tweak: detective clotches now is have more black colors and don't have armor
tweak: change normal walls in Virology on armored
fix: double apc in one Medbay Maintenance area
fix: #962 is back
/:cl: