### PR TITLE
fix: camera consoles

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -9,7 +9,7 @@
 
 	var/mapping = 0 // For the overview file (overview.dm), not used on this page
 
-	var/list/network = list()
+	var/list/network = list("SS13","Mining Outpost")
 	var/obj/machinery/camera/active_camera
 	var/list/watchers = list()
 

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -80,6 +80,10 @@
 		ui = new(user, src, ui_key, "CameraConsole", name, 1200, 600, master_ui, state)
 		ui.open()
 
+/obj/machinery/computer/security/ui_close(mob/user)
+	..()
+	watchers -= user.UID()
+
 /obj/machinery/computer/security/ui_data()
 	var/list/data = list()
 	data["network"] = network


### PR DESCRIPTION
[фикс с оффов 1](https://github.com/ParadiseSS13/Paradise/pull/18742)
[фикс с оффов 2](https://github.com/ParadiseSS13/Paradise/pull/16581)
Пересобранные/построенные security camera console теперь всегда подключается к нетворку станции.
Watchers list теперь обновляется.
Грубый фикс проблемы с камерами