### PR TITLE
fix: Stealth NanoMed Plus

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -57624,6 +57624,12 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft{
 	name = "Medbay Maintenance"
@@ -64755,6 +64761,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -68462,6 +68469,12 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance";
 	req_one_access_txt = "5;12"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft{
@@ -82439,17 +82452,18 @@
 /turf/simulated/wall/r_wall,
 /area/civilian/barber)
 "lEG" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/pipe/cap/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/cap/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft{
 	name = "Medbay Maintenance"
@@ -85884,6 +85898,22 @@
 	icon_state = "dark"
 	},
 /area/library)
+"mpf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "mpg" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -86369,10 +86399,7 @@
 /turf/simulated/floor/plating,
 /area/atmos)
 "muK" = (
-/obj/structure/grille{
-	density = 0;
-	icon_state = "brokengrille"
-	},
+/obj/structure/grille/broken,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
@@ -105259,6 +105286,19 @@
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
 	})
+"qti" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitegreen";
+	tag = "icon-whitegreen (EAST)"
+	},
+/area/medical/medbay)
 "qtk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -108956,11 +108996,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4;
-	initialize_directions = 13
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -110001,6 +110040,18 @@
 	icon_state = "dark"
 	},
 /area/bridge)
+"rua" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "rum" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -115059,6 +115110,17 @@
 	icon_state = "grimy"
 	},
 /area/crew_quarters/captain)
+"sye" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "syf" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -117067,7 +117129,7 @@
 /obj/item/storage/belt/holster,
 /obj/item/clothing/suit/jacket/leather/overcoat,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey,
-/obj/item/nullrod/fedora,
+/obj/item/clothing/head/fedora,
 /turf/simulated/floor/plating,
 /area/maintenance/detectives_office)
 "sWN" = (
@@ -121573,6 +121635,18 @@
 "tWn" = (
 /turf/simulated/wall,
 /area/security/execution)
+"tWK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "tWL" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -136649,6 +136723,17 @@
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall,
 /area/chapel/office)
+"xjT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/medbay)
 "xjZ" = (
 /obj/structure/chair{
 	dir = 8
@@ -141332,7 +141417,6 @@
 /area/bridge)
 "ydi" = (
 /obj/machinery/vending/medical,
-/obj/structure/falsewall,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
 	},
@@ -187195,7 +187279,7 @@ pxm
 gnK
 wDC
 sQt
-nSp
+xjT
 hVE
 rqY
 syk
@@ -187452,7 +187536,7 @@ xYg
 sno
 wDC
 xHj
-rqY
+qti
 iQw
 naz
 bzb
@@ -187966,7 +188050,7 @@ jJn
 eMN
 lvv
 gpT
-wGm
+tWK
 xFw
 xxH
 bLY
@@ -188223,7 +188307,7 @@ kEp
 hPb
 lvv
 oVf
-fdc
+rua
 xFw
 xcN
 vfC
@@ -188480,7 +188564,7 @@ feD
 xYy
 lvv
 fSZ
-wEP
+sye
 xFw
 aAh
 mBu
@@ -188736,7 +188820,7 @@ elW
 eUt
 xYM
 lvv
-wGm
+mpf
 tiG
 xFw
 xFw

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -57624,6 +57624,12 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft{
 	name = "Medbay Maintenance"
@@ -64755,6 +64761,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -68462,6 +68469,12 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance";
 	req_one_access_txt = "5;12"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft{
@@ -82439,17 +82452,18 @@
 /turf/simulated/wall/r_wall,
 /area/civilian/barber)
 "lEG" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/pipe/cap/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/cap/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft{
 	name = "Medbay Maintenance"
@@ -85884,6 +85898,22 @@
 	icon_state = "dark"
 	},
 /area/library)
+"mpf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "mpg" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -86369,10 +86399,7 @@
 /turf/simulated/floor/plating,
 /area/atmos)
 "muK" = (
-/obj/structure/grille{
-	density = 0;
-	icon_state = "brokengrille"
-	},
+/obj/structure/grille/broken,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
@@ -105259,6 +105286,19 @@
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
 	})
+"qti" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitegreen";
+	tag = "icon-whitegreen (EAST)"
+	},
+/area/medical/medbay)
 "qtk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -108956,11 +108996,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4;
-	initialize_directions = 13
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -110001,6 +110040,18 @@
 	icon_state = "dark"
 	},
 /area/bridge)
+"rua" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "rum" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -115059,6 +115110,17 @@
 	icon_state = "grimy"
 	},
 /area/crew_quarters/captain)
+"sye" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "syf" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -121573,6 +121635,18 @@
 "tWn" = (
 /turf/simulated/wall,
 /area/security/execution)
+"tWK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft{
+	name = "Medbay Maintenance"
+	})
 "tWL" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -136649,6 +136723,17 @@
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall,
 /area/chapel/office)
+"xjT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/medbay)
 "xjZ" = (
 /obj/structure/chair{
 	dir = 8
@@ -141332,7 +141417,6 @@
 /area/bridge)
 "ydi" = (
 /obj/machinery/vending/medical,
-/obj/structure/falsewall,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
 	},
@@ -187195,7 +187279,7 @@ pxm
 gnK
 wDC
 sQt
-nSp
+xjT
 hVE
 rqY
 syk
@@ -187452,7 +187536,7 @@ xYg
 sno
 wDC
 xHj
-rqY
+qti
 iQw
 naz
 bzb
@@ -187966,7 +188050,7 @@ jJn
 eMN
 lvv
 gpT
-wGm
+tWK
 xFw
 xxH
 bLY
@@ -188223,7 +188307,7 @@ kEp
 hPb
 lvv
 oVf
-fdc
+rua
 xFw
 xcN
 vfC
@@ -188480,7 +188564,7 @@ feD
 xYy
 lvv
 fSZ
-wEP
+sye
 xFw
 aAh
 mBu
@@ -188736,7 +188820,7 @@ elW
 eUt
 xYM
 lvv
-wGm
+mpf
 tiG
 xFw
 xFw


### PR DESCRIPTION
## What Does This PR Do
Исправляет мелкие ошибки за последние несколько дней

## Changelog
:cl:
add: Восстановлено пару труб
del: фальшстена на NanoMed Plus, который оказывается там был
fix: гриль со спрайтом поломанного стал нормальным сломанным
/:cl:
