### PR TITLE
Fix: slime age_state runtime fix

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -6,7 +6,7 @@
 	pass_flags = PASSTABLE | PASSGRILLE
 	ventcrawler = VENTCRAWLER_ALWAYS
 	gender = NEUTER
-	var/datum/slime_age/age_state = /datum/slime_age/baby
+	var/datum/slime_age/age_state = new /datum/slime_age/baby
 	var/docile = 0
 	faction = list("slime", "neutral")
 


### PR DESCRIPTION
## What Does This PR Do
Фикс нулевого age_state при инициализации, вызывающий рантайм