### PR TITLE
fix: bayonet/seclite icon overlay

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -74,6 +74,7 @@
 
 /obj/item/gun/New()
 	..()
+	appearance_flags |= KEEP_TOGETHER
 	if(gun_light)
 		verbs += /obj/item/gun/proc/toggle_gunlight
 	build_zooming()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Исправляет летающие отдельно от оружия оверлеи. (Проявляется при повороте спрайта оружия.)
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Images of changes
![gun2](https://user-images.githubusercontent.com/79848183/196416371-9134c201-7f32-43c9-9295-45478da5a8bb.jpg)

В чём была проблема:
![gun3](https://user-images.githubusercontent.com/79848183/196419365-b2733edb-f9d2-4428-9935-a4cf661dc256.jpg)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
fix: gun accessories icon overlay
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
