### PR TITLE
FIX: RC detective (Detective/Delta/Kerberos)

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -127510,6 +127510,7 @@
 /area/medical/psych)
 "vlU" = (
 /obj/machinery/requests_console{
+	department = "Detective";
 	name = "Detective Requests Console";
 	pixel_x = -32
 	},


### PR DESCRIPTION
Фикс по репорту.
Исправлено значение у RC в офисе детектива:
department = "Detective"
Было:
https://cdn.discordapp.com/attachments/904864726973046834/1027679947919208549/unknown.png
Стало:
https://cdn.discordapp.com/attachments/972470941290471444/1032957569888702464/unknown.png