### PR TITLE
Генерация химикатов в шейкере сервисному юниту

### DIFF
--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -381,16 +381,15 @@
 	force = 13
 	attack_verb = list("bitten", "eaten", "fin slapped")
 	hitsound = 'sound/weapons/bite.ogg'
-	var/used_blessing = FALSE
 
 /obj/item/nullrod/carp/attack_self(mob/living/user)
-	if(used_blessing)
+	if(user.mind && !(user.mind.isholy || user.mind.isblessed))
 		return
-	if(user.mind && !user.mind.isholy)
+	if ("carp" in user.faction)
+		to_chat(user, "You are already blessed by Carp-Sie.")
 		return
 	to_chat(user, "You are blessed by Carp-Sie. Wild space carp will no longer attack you.")
 	user.faction |= "carp"
-	used_blessing = TRUE
 
 /obj/item/nullrod/claymore/bostaff //May as well make it a "claymore" and inherit the blocking
 	name = "monk's staff"

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -381,15 +381,16 @@
 	force = 13
 	attack_verb = list("bitten", "eaten", "fin slapped")
 	hitsound = 'sound/weapons/bite.ogg'
+	var/used_blessing = FALSE
 
 /obj/item/nullrod/carp/attack_self(mob/living/user)
-	if(user.mind && !(user.mind.isholy || user.mind.isblessed))
+	if(used_blessing)
 		return
-	if ("carp" in user.faction)
-		to_chat(user, "You are already blessed by Carp-Sie.")
+	if(user.mind && !user.mind.isholy)
 		return
 	to_chat(user, "You are blessed by Carp-Sie. Wild space carp will no longer attack you.")
 	user.faction |= "carp"
+	used_blessing = TRUE
 
 /obj/item/nullrod/claymore/bostaff //May as well make it a "claymore" and inherit the blocking
 	name = "monk's staff"


### PR DESCRIPTION
Предложка
https://discord.com/channels/617003227182792704/618952559607939072/1032836536699453512

## What Does This PR Do
- емагнутые сервисные юниты смогут востанавливать химикаты (раньше могли только напитки)  налитые в шейкер. Методом наливания из шейкера в другую емкость (например стакан) при этом тратится энергия.
- фикс бага при наливании из шейкера в человека, последние юниты жидкости не перегенерировались.
- При генерации химикатов сообщения в чат красного цвета.
- одинаковое время генерации жидкости при наливании в человека и в стакан
- добавление вывода в чат при наливании в человека  аналогично выводам при наливании в стакан
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Повысить полезность сервисного юнита для антагонистов. А так же даст смысл сейфти оверрайд апгрейду для мирных целей, например для помощи химикам.

## Video of changes
https://www.youtube.com/watch?v=vRZU8yfQqMw


