### PR TITLE
Благословение Капр-Си нуллродом

### DIFF
--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -381,16 +381,15 @@
 	force = 13
 	attack_verb = list("bitten", "eaten", "fin slapped")
 	hitsound = 'sound/weapons/bite.ogg'
-	var/used_blessing = FALSE
 
 /obj/item/nullrod/carp/attack_self(mob/living/user)
-	if(used_blessing)
+	if(user.mind && !(user.mind.isholy || user.mind.isblessed))
 		return
-	if(user.mind && !user.mind.isholy)
+	if ("carp" in user.faction)
+		to_chat(user, "You are already blessed by Carp-Sie.")
 		return
 	to_chat(user, "You are blessed by Carp-Sie. Wild space carp will no longer attack you.")
 	user.faction |= "carp"
-	used_blessing = TRUE
 
 /obj/item/nullrod/claymore/bostaff //May as well make it a "claymore" and inherit the blocking
 	name = "monk's staff"


### PR DESCRIPTION
Авоут
https://discord.com/channels/617003227182792704/755125334097133628/1040724510246182952

## What Does This PR Do
- добавляет carp-sie plushie возможность благословлять тех, кто благословлен священником
- добавлена возможность carp-sie plushie быть использованной множество раз.
- добавлен вывод в чат в случае если благословение получено

## Why It's Good For The Game
Логично что последователи священника с carp-sie plushie могут получить благословение самого бога через этот нуллрод.