### PR TITLE
FIX: Расширения черного списка консоли ГП на ЦКшные должности.

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -29,6 +29,8 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 	// Jobs that do not appear in the list at all.
 	var/list/blacklisted_full = list(
 		/datum/job/ntnavyofficer,
+		/datum/job/ntnavyofficer/field,
+		/datum/job/ntspecops/supreme,
 		/datum/job/ntspecops,
 		/datum/job/ntspecops/solgovspecops,
 		/datum/job/civilian,

--- a/code/modules/newscaster/obj/newscaster.dm
+++ b/code/modules/newscaster/obj/newscaster.dm
@@ -79,6 +79,8 @@
 			/datum/job/barber,
 			/datum/job/chaplain,
 			/datum/job/ntnavyofficer,
+			/datum/job/ntnavyofficer/field,
+			/datum/job/ntspecops/supreme,
 			/datum/job/ntspecops,
 			/datum/job/ntspecops/solgovspecops,
 			/datum/job/civilian,


### PR DESCRIPTION
## What Does This PR Do
Внесение полевого ЦК офицера и Суприм Коммандера в черный список на приоритезацию
Центкомовская консоль по прежнему может всё это толкать.

## Why It's Good For The Game
Теперь нельзя послать запрос с ЦК, что станции необходим полевой ЦК офицер и Суприм Коммандер

