### PR TITLE
Fix: Deathsquad Equipment: replace termal glasses with sechudglasses 

### DIFF
--- a/code/modules/admin/verbs/striketeam.dm
+++ b/code/modules/admin/verbs/striketeam.dm
@@ -173,7 +173,7 @@ GLOBAL_VAR_INIT(sent_strike_team, 0)
 	equip_to_slot_or_del(new /obj/item/clothing/suit/space/hardsuit/deathsquad(src), slot_wear_suit)
 	equip_to_slot_or_del(new /obj/item/clothing/gloves/combat(src), slot_gloves)
 	equip_to_slot_or_del(new /obj/item/clothing/mask/gas/sechailer/swat(src), slot_wear_mask)
-	equip_to_slot_or_del(new /obj/item/clothing/glasses/thermal(src), slot_glasses)
+	equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/security/sunglasses(src), slot_glasses)
 
 	equip_to_slot_or_del(new /obj/item/storage/backpack/ert/security(src), slot_back)
 	equip_to_slot_or_del(new /obj/item/storage/box/responseteam(src), slot_in_backpack)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Заменяет в лодауте дедов термальные очки на  очки службы безопасности.
- Надетый шлем Deathsquad рига и так дает термальное зрение, зачем его дублировать.
- Добавляется возможность офицерам отряда смерти определять через секхуд своих, а так же важных лиц на станции в случае если дана миссия на спасение. 

PR сделан по просьбе СА epik1l. 

## Changelog
fix: correcting deathsquad equipment.


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
