### PR TITLE
FIX: Фиксы деления слаймов при достижении результатов и при смерти

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/death.dm
+++ b/code/modules/mob/living/simple_animal/slime/death.dm
@@ -3,20 +3,9 @@
 		return
 	if(!gibbed)
 		if(age_state.age != SLIME_BABY)
-			var/mob/living/simple_animal/slime/M = new(loc, colour)
-			M.rabid = TRUE
-			M.regenerate_icons()
-
-			age_state = new /datum/slime_age/baby
-			maxHealth = age_state.health
-			for(var/datum/action/innate/slime/reproduce/R in actions)
-				R.Remove(src)
-			var/datum/action/innate/slime/evolve/E = new
-			E.Grant(src)
-			revive()
-			regenerate_icons()
-			update_name()
-			return
+			if (nutrition >= get_hunger_nutrition())
+				force_split(FALSE)
+				return
 
 	if(buckled)
 		Feedstop(silent = TRUE) //releases ourselves from the mob we fed on.

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -240,13 +240,12 @@
 		amount_grown++
 		update_action_buttons_icon()
 
+		if(!ckey && amount_grown == age_state.amount_grown_for_split)
+			if(age_state.age != SLIME_BABY && prob(chance_reproduce) || age_state.age == SLIME_ELDER)
+				Reproduce()
+
 	if (buckled || Target || ckey)
 		return FALSE
-
-	var/chance_reproduce = 80
-	if(amount_grown == age_state.amount_grown_for_split)
-		if(age_state.age != SLIME_BABY && prob(chance_reproduce) || age_state.age == SLIME_ELDER)
-			Reproduce()
 
 	if(amount_grown >= age_state.amount_grown)
 		if(age_state.age != SLIME_ELDER)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -38,6 +38,7 @@
 
 	var/cores = 1 // the number of /obj/item/slime_extract's the slime has left inside
 	var/mutation_chance = 30 // Chance of mutating, should be between 25 and 35
+	var/chance_reproduce = 80
 
 	var/powerlevel = 0 // 1-10 controls how much electricity they are generating
 	var/amount_grown = 0 // controls how long the slime has been overfed, if 10, grows or reproduces

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -99,7 +99,7 @@
 
 /datum/reagent/aslimetoxin/reaction_mob(mob/living/M, method=REAGENT_TOUCH, volume)
 	if(method != REAGENT_TOUCH)
-		M.ForceContractDisease(new /datum/disease/transformation/slime(0))
+		M.ForceContractDisease(new /datum/disease/transformation/slime)
 
 
 /datum/reagent/mercury


### PR DESCRIPTION
## What Does This PR Do
- Теперь слаймы делятся как нормальные мальчики. И после смерти нету багов. Если слайм нормально успел наесть, то он отпочковывает пару ребятишек. Если слайм голодный - то он просто умирает самостоятельно.
- Добавлен модификатор "нажратости". В зависимости от "нажратости слайма" меняется число детей при которых он делится, даже после смерти. В основном дебафы, но если достиг максимального числа нутриентов, то сверху накидывается пару детей. 
- Небольшой рефактор смерти и делений
- А да, я похоже починил тот самый вирус слаймотоксина дающийся от черного экстракта...