### PR TITLE
Fix: PIMC points per minute fix 

### DIFF
--- a/code/game/machinery/computer/prisoner.dm
+++ b/code/game/machinery/computer/prisoner.dm
@@ -41,7 +41,7 @@
 			dat += text("<A href='?src=[UID()];id=1'>[inserted_id]</A><br>")
 			dat += text("Collected points: [p]. <A href='?src=[UID()];id=2'>Reset.</A><br>")
 			dat += text("Card goal: [g].  <A href='?src=[UID()];id=3'>Set </A><br>")
-			dat += text("Space Law recommends sentences of 150 points per minute they would normally serve in the brig.<BR>")
+			dat += text("Space Law recommends sentences of 100 points per minute they would normally serve in the brig.<BR>")
 		else
 			dat += text("<A href='?src=[UID()];id=0'>Insert Prisoner ID</A><br>")
 		var/turf/Tr = null


### PR DESCRIPTION
## What Does This PR Do
Корректирует значение указанное в консоли под нашу версию КЗ.
Вместо 150 очков за минуту до 100

По багрепорту : https://discord.com/channels/617003227182792704/617004034405957642/1036290194296557598
## Changelog
:cl:

fix: Корректировка значения очков добычи за минуту наказания

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
