### PR TITLE
Фиксы багов целей ниндзя

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1799,6 +1799,12 @@
 					return
 				var/list/objective_types = list("stealthy", "generic", "aggressive")
 				var/objective_type = input("Select type of objectives to generate", "Objective type selection") as null|anything in objective_types
+				if(objective_type == "stealthy" || objective_type == "aggressive")
+					if(alert(usr, "Данный вид целей генерирует дополнительных антагонистов в раунд. Продолжить?","ВАЖНО!","Да","Нет") == "Нет")
+						return
+				if(!objective_type)
+					if(alert(usr, "Рандомный выбор типа целей имеет шанс сгенерировать дополнительных антагонистов в раунд. Продолжить генерацию?","ВАЖНО!","Да","Нет") == "Нет")
+						return
 				SSticker.mode.forge_ninja_objectives(src, objective_type)
 				SSticker.mode.basic_ninja_needs_check(src)
 				to_chat(usr, "<span class='notice'>Цели для ниндзя: [key] были сгенерированы. Вы можете их отредактировать и оповестить игрока о целях вручную.</span>")

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1038,7 +1038,12 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 	return
 
 /datum/objective/find_and_scan/find_target()
-	var/list/roles = list("Clown", "Mime", "Cargo Technician", "Shaft Miner", "Scientist", "Roboticist", "Medical Doctor", "Geneticist", "Security Officer", "Chemist", "Station Engineer", "Civilian")
+	var/list/roles = list("Clown", "Mime", "Cargo Technician",
+	"Shaft Miner", "Scientist", "Roboticist",
+	"Medical Doctor", "Geneticist", "Security Officer",
+	"Chemist", "Station Engineer", "Civilian",
+	"Botanist", "Chemist", "Virologist",
+	"Life Support Specialist")
 	var/list/possible_targets = list()
 	var/list/priority_targets = list()
 	log_debug("Ninja_Objectives_Log: Генерация цели на Похищения")
@@ -1070,7 +1075,8 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 		if(!(target.assigned_role in possible_roles))
 			log_debug("Ninja_Objectives_Log: Подмена одной из ролей под роль цели!")
 			possible_roles[pick(1,2,3)] = target.assigned_role
-
+	scans_to_win = clamp(round(possible_targets.len/10),initial(scans_to_win), 6)
+	log_debug("Ninja_Objectives_Log: scans_to_win: [scans_to_win]")
 	//Даже если мы не нашли цель. Эту задачу всё ещё можно будет выполнить похитив достаточно разных человек с ролями
 	explanation_text = "Найдите обладающего важной информацией человека среди следующих профессий: [possible_roles[1]], [possible_roles[2]], [possible_roles[3]]. \
 		Для проверки и анализа памяти человека, вам придётся похитить его и просканировать в специальном устройстве на вашей базе."
@@ -1109,10 +1115,6 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 			new_changeling_mind.make_Changeling()
 			possible_changelings.Remove(new_changeling_mind)
 			changelings += new_changeling_mind
-	else//Если не кого защищать, просто не даём цель
-		owner?.objectives -= src
-		log_debug("Ninja_Objectives_Log: Удаляем цель охоты на генок у ниндзя ибо нет генокрадов")
-		qdel(src)
 
 /datum/objective/vermit_hunt/check_completion()
 	var/killed_vermits = 0

--- a/code/game/gamemodes/spaceninja/ninja/machinery/ninja_mindscan_machine.dm
+++ b/code/game/gamemodes/spaceninja/ninja/machinery/ninja_mindscan_machine.dm
@@ -48,8 +48,6 @@
 			return
 		objective = temp_objective
 		ninja = user
-		// Лучше это высчитывать при записи цели в память. Дабы соответствовать реалиям на момент этой записи
-		objective.scans_to_win = max(initial(objective.scans_to_win), round(GLOB.human_list.len/12))
 		to_chat(user, span_boldwarning("User: [user] registered. Ready to scan."))
 	add_fingerprint(user)
 	ui_interact(user)
@@ -67,8 +65,6 @@
 			return
 		objective = temp_objective
 		ninja = user
-		// Лучше это высчитывать при записи цели в память. Дабы соответствовать реалиям на момент этой записи
-		objective.scans_to_win = max(initial(objective.scans_to_win), round(GLOB.human_list.len/15))
 		to_chat(user, span_boldwarning("User: [user.real_name] registered. Ready to scan."))
 
 	if(dropped == user) //No. Only other living. Not you

--- a/code/game/gamemodes/spaceninja/space_ninja.dm
+++ b/code/game/gamemodes/spaceninja/space_ninja.dm
@@ -373,7 +373,7 @@
 		ninja_bomb.detonation_objective = bomb_objective
 	ninja_mind.objectives += bomb_objective
 
-	//Похищать людей пока не найдёшь нужного//
+	//Похищать людей пока не найдёшь нужного
 	var/datum/objective/find_and_scan/find_objective = new
 	find_objective.owner = ninja_mind
 	find_objective.find_target()
@@ -384,6 +384,11 @@
 	hunt_changelings.owner = ninja_mind
 	hunt_changelings.find_target()
 	ninja_mind.objectives += hunt_changelings
+	if(!length(hunt_changelings.changelings))//Если нет генокрадов, просто не даём цель
+		GLOB.all_objectives -= hunt_changelings
+		ninja_mind.objectives -= hunt_changelings
+		log_debug("Ninja_Objectives_Log: Удаляем цель охоты на генок у ниндзя ибо нет генокрадов")
+		qdel(hunt_changelings)
 
 	//Выжить
 	if(!(locate(/datum/objective/survive) in ninja_mind.objectives))


### PR DESCRIPTION
## What Does This PR Do
* Цель на похищение и скан разума теперь выполнима(Раньше баговалась) и теперь количество необходимых сканирований варьируется от 3-ёх до 6-ти.
* У этой цели так же был расширен список возможных профессий которые надо похищать
* Теперь цель охоты на генокрадов правильно удаляется в случае если не удалось набрать ни одного генокрада.
* Теперь админам пишутся предупреждения при попытке сгенерировать цели которые могут вместе с собой сгенерировать новых антагов.