### PR TITLE
Feat: GPS shutdown now works from neighboring tiles

### DIFF
--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -55,11 +55,13 @@ GLOBAL_LIST_EMPTY(GPS_list)
 	addtimer(CALLBACK(src, .proc/reboot), EMP_DISABLE_TIME)
 
 /obj/item/gps/AltClick(mob/living/user)
+	if(!Adjacent(user))
+		return
+	if(!iscarbon(usr) && !isrobot(usr))
+		return
 	if(!istype(user) || user.incapacitated())
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
-	if(ui_status(user, GLOB.inventory_state) != STATUS_INTERACTIVE)
-		return //user not valid to use gps
 	if(emped)
 		to_chat(user, "<span class='warning'>It's busted!</span>")
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Альтклик ЖПС(также известный как кнопка выключения в UI ЖПС) теперь работает в радиусе 1 тайла.
## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Это фиксит баг с невозможностью отключить "стационарный" ЖПС в убежищах шахтеров(https://discord.com/channels/617003227182792704/617004034405957642/1035675103020728390 по факту главная цель - фикс этого). Также добавляет удобства при работе с ЖПС. 
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: GPS shutdown now works from neighboring tiles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
