### PR TITLE
Fix: equipment in an exosuit becomes ghostly

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -678,14 +678,13 @@
 
 	if(istype(W, /obj/item/mecha_parts/mecha_equipment))
 		var/obj/item/mecha_parts/mecha_equipment/E = W
-		spawn()
-			if(E.can_attach(src))
-				if(!user.drop_item())
-					return
-				E.attach(src)
-				user.visible_message("[user] attaches [W] to [src].", "<span class='notice'>You attach [W] to [src].</span>")
-			else
-				to_chat(user, "<span class='warning'>You were unable to attach [W] to [src]!</span>")
+		if(E.can_attach(src))
+			if(!user.drop_item())
+				return
+			E.attach(src)
+			user.visible_message("[user] attaches [W] to [src].", "<span class='notice'>You attach [W] to [src].</span>")
+		else
+			to_chat(user, "<span class='warning'>You were unable to attach [W] to [src]!</span>")
 		return
 
 	if(W.GetID())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

Фиксит создание теневой и неактивной копии навесного оборудования при нажатии по нему и манипуляции с руками.
(Оно срабатывает при быстрой смене активной руки при клике по меху снаряжением)
## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Меньше багов :Keklown:
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
Скрин бага от создавшего репорт:
![изображение](https://user-images.githubusercontent.com/77164962/199844105-6f9ae555-efec-4ce3-8b4e-fb06dcd9a106.png)
Успешное воспроизведение бага на локалке(были случаи и хуже, с тремя и больше дублированных теневых пушек, но я не найду от них скринов): 
![изображение](https://user-images.githubusercontent.com/77164962/199843990-524850df-838b-44b7-a61d-de7156360dfe.png)
![изображение](https://user-images.githubusercontent.com/77164962/199844062-2505ef91-2bab-4f1c-a8ed-0b4f71912cfc.png)

## Changelog
:cl:
fix: equipment in an exosuit becomes ghostly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
