### PR TITLE
Fix: Necropolis loot speedrun

### DIFF
--- a/_maps/map_files/Delta/Lavaland.dmm
+++ b/_maps/map_files/Delta/Lavaland.dmm
@@ -13,7 +13,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "ad" = (
 /turf/simulated/mineral/random/high_chance/volcanic,
 /area/lavaland/surface/outdoors)
@@ -23,13 +23,13 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "af" = (
 /obj/structure/necropolis_gate/legion_gate,
 /obj/structure/necropolis_arch,
 /obj/structure/stone_tile/slab,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "ag" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -42,7 +42,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "ah" = (
 /obj/structure/stone_tile/cracked{
 	dir = 1
@@ -55,7 +55,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "ai" = (
 /turf/simulated/mineral/random/volcanic,
 /area/lavaland/surface/outdoors)
@@ -275,7 +275,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "aP" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/ancient,
@@ -805,6 +805,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine/laborcamp)
+"cf" = (
+/obj/structure/clockwork/wall_gear,
+/turf/unsimulated/wall/lavaland/boss,
+/area/lavaland/surface/outdoors/necropolis)
 "cg" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1156,7 +1160,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "dk" = (
 /obj/item/stack/ore/silver,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
@@ -1188,7 +1192,7 @@
 	move_resist = 45000
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "dq" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -1214,7 +1218,7 @@
 	},
 /obj/structure/stone_tile/center/cracked,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "dv" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -1298,7 +1302,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "dG" = (
 /obj/structure/railing,
 /obj/structure/railing,
@@ -1368,7 +1372,7 @@
 	move_resist = 40000
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "dW" = (
 /obj/machinery/meter,
 /obj/structure/disposalpipe/segment,
@@ -1531,7 +1535,7 @@
 	},
 /obj/structure/stone_tile,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "ew" = (
 /obj/machinery/door_control{
 	id = "miningdorm1";
@@ -1580,6 +1584,10 @@
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/mine/production)
+"fa" = (
+/obj/structure/stone_tile/cracked,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/necropolis)
 "fb" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -1774,7 +1782,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
+"fB" = (
+/obj/structure/stone_tile/block{
+	dir = 8
+	},
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/necropolis)
 "fE" = (
 /obj/machinery/light{
 	dir = 8
@@ -1857,7 +1871,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "fU" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -1867,13 +1881,14 @@
 	},
 /area/mine/living_quarters)
 "fV" = (
-/turf/simulated/wall/indestructible/boss/see_through,
-/area/lavaland/surface/outdoors)
+/obj/structure/stone_tile/surrounding_tile,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/necropolis)
 "fW" = (
 /obj/structure/necropolis_gate/locked,
 /obj/structure/stone_tile/slab,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "fX" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1908,7 +1923,7 @@
 	},
 /obj/structure/stone_tile/center,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "gh" = (
 /obj/machinery/door/airlock{
 	id_tag = "toiletmining1";
@@ -1938,7 +1953,7 @@
 /obj/structure/stone_tile/surrounding_tile,
 /obj/structure/stone_tile/center,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "gk" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -1951,7 +1966,7 @@
 	},
 /obj/structure/stone_tile/center,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "gn" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -1963,11 +1978,11 @@
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "clockwork_floor"
 	},
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "go" = (
 /obj/structure/stone_tile/block,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "gp" = (
 /obj/machinery/cryopod/right,
 /obj/structure/sign/poster/random{
@@ -1996,7 +2011,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "gs" = (
 /obj/structure/stone_tile/cracked{
 	dir = 8
@@ -2009,7 +2024,7 @@
 	},
 /obj/structure/stone_tile,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "gt" = (
 /obj/machinery/light,
 /obj/machinery/computer/cryopod{
@@ -2061,7 +2076,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "gB" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -2073,7 +2088,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "gC" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -2086,7 +2101,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "gF" = (
 /obj/structure/fans/tiny,
 /obj/effect/decal/cleanable/dirt,
@@ -2110,7 +2125,7 @@
 	},
 /obj/structure/stone_tile/cracked,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "gH" = (
 /obj/machinery/cryopod,
 /obj/structure/closet/walllocker/emerglocker/east,
@@ -2164,13 +2179,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "gO" = (
 /obj/structure/stone_tile/block{
 	dir = 8
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "gP" = (
 /obj/structure/stone_tile/slab,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
@@ -2181,12 +2196,18 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "gT" = (
 /obj/structure/stone_tile/slab/cracked,
 /mob/living/simple_animal/hostile/asteroid/goliath/beast/ancient,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
+"gU" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 8
+	},
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/necropolis)
 "gW" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -2196,14 +2217,14 @@
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "clockwork_floor"
 	},
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "hd" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 1
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "he" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -2224,7 +2245,7 @@
 /obj/structure/stone_tile/center/cracked,
 /mob/living/simple_animal/hostile/megafauna/legion,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "hh" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile{
@@ -2234,7 +2255,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "hi" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 4
@@ -2245,7 +2266,7 @@
 	},
 /obj/structure/stone_tile/center/burnt,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "hm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -2257,7 +2278,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "hv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
@@ -2286,7 +2307,7 @@
 	},
 /obj/structure/stone_tile/slab,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "hD" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -2300,7 +2321,7 @@
 	},
 /obj/structure/bookcase,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "hE" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -2311,7 +2332,7 @@
 /obj/structure/stone_tile,
 /mob/living/simple_animal/hostile/asteroid/basilisk/watcher/magmawing,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "hF" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -2323,7 +2344,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "hG" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
@@ -2334,7 +2355,7 @@
 /obj/structure/table/reinforced/brass,
 /obj/item/weldingtool/experimental/brass,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "hH" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -2344,7 +2365,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "hI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -2363,7 +2384,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "hM" = (
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -2417,7 +2438,7 @@
 /obj/structure/stone_tile/cracked,
 /mob/living/simple_animal/hostile/big_legion,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "ic" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt,
@@ -2439,7 +2460,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "ij" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -2451,7 +2472,7 @@
 /obj/structure/table/reinforced/brass,
 /obj/item/twohanded/ratvarian_spear,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "ir" = (
 /obj/structure/stone_tile/slab/cracked{
 	dir = 5
@@ -2494,7 +2515,7 @@
 	},
 /obj/structure/stone_tile/block/cracked,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "iE" = (
 /obj/structure/mirror{
 	pixel_y = -30
@@ -2529,7 +2550,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "iM" = (
 /obj/item/stack/ore/glass/basalt,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
@@ -2547,7 +2568,7 @@
 	},
 /obj/structure/table/reinforced/brass,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "iP" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -2557,7 +2578,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "iU" = (
 /obj/structure/stone_tile{
 	dir = 8
@@ -2570,7 +2591,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "iX" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -2593,7 +2614,7 @@
 /obj/structure/stone_tile/center/cracked,
 /obj/structure/table/reinforced/brass,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "ja" = (
 /obj/structure/stone_tile{
 	dir = 8
@@ -2628,7 +2649,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "jk" = (
 /obj/structure/stone_tile/center,
 /obj/structure/stone_tile/surrounding_tile,
@@ -2639,7 +2660,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "jl" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -2652,7 +2673,7 @@
 	},
 /obj/structure/stone_tile/center/cracked,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "jm" = (
 /obj/structure/stone_tile/cracked,
 /obj/structure/stone_tile{
@@ -2665,7 +2686,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "jp" = (
 /obj/machinery/camera{
 	c_tag = "Labor Camp Breakroom";
@@ -2706,7 +2727,10 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
+"jG" = (
+/turf/unsimulated/wall/lavaland/boss,
+/area/lavaland/surface/outdoors/necropolis)
 "jH" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
@@ -2717,7 +2741,10 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
+"jK" = (
+/turf/simulated/mineral/random/volcanic,
+/area/lavaland/surface/outdoors/necropolis)
 "jL" = (
 /obj/structure/stone_tile/surrounding_tile,
 /obj/structure/stone_tile/surrounding_tile{
@@ -2728,7 +2755,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "jN" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
@@ -2739,7 +2766,7 @@
 /obj/structure/stone_tile/surrounding_tile,
 /obj/structure/stone_tile/center/cracked,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "jQ" = (
 /obj/structure/stone_tile{
 	dir = 1
@@ -2768,7 +2795,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "ka" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2783,7 +2810,7 @@
 "kg" = (
 /obj/structure/fluff/drake_statue,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "kj" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -2792,7 +2819,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "kk" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -2806,11 +2833,11 @@
 	},
 /obj/item/clockwork/clockgolem_remains,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "kl" = (
 /obj/structure/fluff/drake_statue/falling,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "km" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -2825,7 +2852,7 @@
 /obj/structure/table/reinforced/brass,
 /obj/item/storage/toolbox/brass,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "ko" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -2835,7 +2862,7 @@
 	},
 /obj/structure/stone_tile,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "kp" = (
 /turf/simulated/floor/plasteel,
 /area/mine/eva)
@@ -2850,7 +2877,7 @@
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "clockwork_floor"
 	},
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "ky" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -2859,7 +2886,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "kA" = (
 /obj/structure/stone_tile/cracked{
 	dir = 1
@@ -2872,7 +2899,7 @@
 	},
 /obj/structure/stone_tile,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "kB" = (
 /obj/structure/stone_tile/surrounding_tile,
 /obj/structure/stone_tile/surrounding_tile{
@@ -2883,7 +2910,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "kD" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -2896,7 +2923,7 @@
 	},
 /obj/structure/stone_tile/center,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "kE" = (
 /obj/machinery/light{
 	dir = 8
@@ -2910,7 +2937,7 @@
 /obj/structure/closet/crate/necropolis/tendril,
 /obj/structure/stone_tile/slab,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "kG" = (
 /turf/simulated/wall,
 /area/mine/eva)
@@ -2924,7 +2951,7 @@
 	},
 /obj/structure/stone_tile/center/cracked,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "kI" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -2934,7 +2961,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "kJ" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -2947,7 +2974,7 @@
 	},
 /obj/structure/stone_tile/center,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "kM" = (
 /obj/structure/stone_tile{
 	dir = 1
@@ -2960,7 +2987,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "kN" = (
 /obj/structure/stone_tile/cracked{
 	dir = 1
@@ -3006,7 +3033,16 @@
 /obj/structure/stone_tile/surrounding_tile,
 /obj/structure/stone_tile/center,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
+"kX" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 4
+	},
+/obj/structure/stone_tile/block/cracked{
+	dir = 8
+	},
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/necropolis)
 "kY" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
@@ -3019,7 +3055,7 @@
 	},
 /obj/item/clockwork/clockgolem_remains,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "lb" = (
 /obj/structure/stone_tile/cracked,
 /obj/structure/stone_tile{
@@ -3032,7 +3068,13 @@
 	dir = 1
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
+"ld" = (
+/obj/structure/stone_tile{
+	dir = 1
+	},
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/necropolis)
 "le" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -3042,7 +3084,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "lg" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -3051,7 +3093,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "lh" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/poddoor{
@@ -3070,7 +3112,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "ll" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -3079,7 +3121,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "lm" = (
 /obj/structure/railing{
 	dir = 9
@@ -3122,7 +3164,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "ls" = (
 /obj/structure/stone_tile/cracked{
 	dir = 8
@@ -3166,7 +3208,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "lB" = (
 /obj/structure/stone_tile/cracked{
 	dir = 8
@@ -3179,7 +3221,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "lC" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -3192,7 +3234,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "lE" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -3328,7 +3370,7 @@
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "clockwork_floor"
 	},
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "mj" = (
 /obj/item/clothing/under/color/orange,
 /obj/effect/decal/cleanable/ash,
@@ -3368,7 +3410,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "mr" = (
 /obj/structure/stone_tile{
 	dir = 4
@@ -3381,7 +3423,7 @@
 	},
 /obj/structure/stone_tile,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "ms" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -3391,14 +3433,14 @@
 	dir = 1
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "mt" = (
 /obj/structure/stone_tile{
 	dir = 1
 	},
 /obj/structure/stone_tile/cracked,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "mu" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -3448,7 +3490,7 @@
 	},
 /mob/living/simple_animal/hostile/asteroid/goliath/beast/ancient,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "mA" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -3592,7 +3634,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "mS" = (
 /obj/structure/stone_tile/cracked{
 	dir = 1
@@ -3605,7 +3647,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "mT" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -3624,7 +3666,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "mW" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
@@ -3633,7 +3675,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "mX" = (
 /obj/structure/stone_tile/cracked,
 /obj/structure/stone_tile{
@@ -3646,7 +3688,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "mY" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -3656,7 +3698,7 @@
 	},
 /obj/structure/stone_tile,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "mZ" = (
 /obj/structure/stone_tile{
 	dir = 1
@@ -3669,7 +3711,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "na" = (
 /obj/structure/chair{
 	dir = 8
@@ -3693,7 +3735,7 @@
 	},
 /obj/structure/stone_tile,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "nc" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -3706,7 +3748,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "ne" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -3716,11 +3758,11 @@
 	dir = 8
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "nf" = (
 /obj/structure/stone_tile/slab/cracked,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "ng" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -3730,7 +3772,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "nn" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -3740,12 +3782,12 @@
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "clockwork_floor"
 	},
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "no" = (
 /obj/structure/stone_tile/slab/cracked,
 /mob/living/simple_animal/hostile/asteroid/basilisk/watcher/magmawing,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "nr" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/warning_stripes/yellow/partial,
@@ -3777,7 +3819,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "nV" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -3835,7 +3877,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "ol" = (
 /obj/machinery/mineral/unloading_machine{
 	dir = 1;
@@ -3861,7 +3903,7 @@
 	},
 /obj/structure/stone_tile,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "oz" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -3875,7 +3917,7 @@
 	},
 /obj/structure/chair/brass,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "oA" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/machinery/atmospherics/unary/tank/air{
@@ -3919,7 +3961,7 @@
 	},
 /obj/structure/stone_tile/center,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "pt" = (
 /obj/structure/closet/crate/necropolis/tendril,
 /obj/structure/stone_tile/slab,
@@ -3927,7 +3969,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "pz" = (
 /obj/structure/stone_tile{
 	dir = 1
@@ -3940,7 +3982,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "pI" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 4
@@ -3953,7 +3995,7 @@
 	},
 /obj/structure/stone_tile/center/cracked,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "pK" = (
 /obj/structure/ore_box,
 /obj/machinery/firealarm{
@@ -3994,7 +4036,7 @@
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "clockwork_floor"
 	},
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "pT" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
@@ -4007,7 +4049,7 @@
 	},
 /obj/structure/stone_tile/center,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "pV" = (
 /obj/structure/stone_tile{
 	dir = 8
@@ -4020,7 +4062,19 @@
 	},
 /obj/structure/stone_tile/cracked,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
+"pW" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 4
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 4
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 8
+	},
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/necropolis)
 "pZ" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile{
@@ -4030,7 +4084,7 @@
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "clockwork_floor"
 	},
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "qa" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -4041,7 +4095,7 @@
 /obj/structure/stone_tile,
 /obj/structure/chair/brass,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "qb" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -4111,7 +4165,7 @@
 	},
 /obj/structure/bookcase,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "qC" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -4125,7 +4179,7 @@
 	},
 /obj/item/clockwork/clockgolem_remains,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "qD" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/light/small{
@@ -4159,11 +4213,11 @@
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "clockwork_floor"
 	},
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "qS" = (
 /obj/structure/clockwork/wall_gear,
 /turf/simulated/wall/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "qT" = (
 /turf/simulated/wall/rust,
 /area/mine/laborcamp)
@@ -4191,7 +4245,7 @@
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "clockwork_floor"
 	},
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "rc" = (
 /obj/structure/stone_tile{
 	dir = 1
@@ -4204,7 +4258,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "rd" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -4215,7 +4269,7 @@
 /obj/structure/stone_tile/surrounding_tile/cracked,
 /obj/structure/stone_tile/center,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "rf" = (
 /obj/machinery/door/airlock/external{
 	glass = 1;
@@ -4267,7 +4321,7 @@
 	},
 /obj/structure/stone_tile/slab,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "ry" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4327,7 +4381,7 @@
 	},
 /obj/structure/window/reinforced/clockwork,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "sq" = (
 /turf/simulated/wall,
 /area/mine/laborcamp/security)
@@ -4354,7 +4408,7 @@
 	},
 /obj/structure/stone_tile/center/cracked,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "sx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4364,6 +4418,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/eva)
+"sB" = (
+/obj/structure/stone_tile/cracked{
+	dir = 4
+	},
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/necropolis)
 "sC" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile{
@@ -4373,7 +4433,7 @@
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "clockwork_floor"
 	},
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "sF" = (
 /obj/machinery/door/airlock,
 /turf/simulated/floor/plasteel/white,
@@ -4453,7 +4513,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "sW" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
@@ -4513,7 +4573,7 @@
 /obj/structure/stone_tile,
 /obj/structure/table/reinforced/brass,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "ty" = (
 /obj/structure/lattice/catwalk,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
@@ -4522,7 +4582,7 @@
 /obj/structure/stone_tile/surrounding/cracked,
 /obj/structure/stone_tile/center/burnt,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "tC" = (
 /obj/machinery/camera{
 	c_tag = "Labor Camp Airlock";
@@ -4540,7 +4600,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "tJ" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
@@ -4551,7 +4611,7 @@
 /obj/structure/stone_tile/slab,
 /mob/living/simple_animal/hostile/asteroid/goliath/beast/ancient,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "tT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
@@ -4609,7 +4669,7 @@
 	move_resist = 40000
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "uw" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1;
@@ -4668,7 +4728,7 @@
 	},
 /mob/living/simple_animal/hostile/asteroid/goliath/beast/ancient,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "uS" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/suit_storage_unit/lavaland,
@@ -4692,7 +4752,7 @@
 	},
 /obj/structure/stone_tile/cracked,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "ve" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/mineral/equipment_vendor,
@@ -4764,7 +4824,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "vI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -4857,7 +4917,7 @@
 	},
 /obj/item/clockwork/clockgolem_remains,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "wA" = (
 /obj/structure/sign/restroom,
 /turf/simulated/wall,
@@ -4869,6 +4929,10 @@
 "wR" = (
 /turf/simulated/floor/bluegrid,
 /area/mine/maintenance)
+"wS" = (
+/obj/structure/stone_tile,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/necropolis)
 "wX" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall,
@@ -4883,7 +4947,7 @@
 	},
 /obj/structure/stone_tile/slab/burnt,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "xh" = (
 /obj/structure/window/reinforced/clockwork{
 	dir = 4;
@@ -4894,7 +4958,7 @@
 	},
 /obj/structure/stone_tile/slab,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "xl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -4913,7 +4977,7 @@
 /obj/structure/stone_tile,
 /obj/structure/bookcase,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "xt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -4983,14 +5047,14 @@
 	},
 /obj/structure/stone_tile/block,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "xO" = (
 /obj/structure/stone_tile/block{
 	dir = 1
 	},
 /obj/structure/stone_tile/surrounding_tile,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "xR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -4998,6 +5062,12 @@
 	icon_state = "browncorner"
 	},
 /area/mine/laborcamp)
+"xS" = (
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/necropolis)
 "xU" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
@@ -5012,7 +5082,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "yd" = (
 /obj/vehicle/lavaboat,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
@@ -5026,7 +5096,7 @@
 	},
 /obj/structure/stone_tile,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "ym" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5051,7 +5121,7 @@
 	},
 /obj/structure/closet/crate/necropolis,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "yq" = (
 /obj/structure/safe/floor,
 /obj/item/whetstone/cult{
@@ -5106,7 +5176,7 @@
 /obj/structure/table/reinforced/brass,
 /obj/item/wirecutters/brass,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "yJ" = (
 /obj/structure/stone_tile/center/cracked,
 /obj/structure/stone_tile/surrounding/cracked{
@@ -5117,7 +5187,7 @@
 	},
 /obj/structure/stone_tile/surrounding/cracked,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "yK" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -5168,6 +5238,10 @@
 	icon_state = "brown"
 	},
 /area/mine/maintenance)
+"zi" = (
+/obj/structure/stone_tile/slab,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/necropolis)
 "zk" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 1
@@ -5176,7 +5250,7 @@
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "clockwork_floor"
 	},
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "zl" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 8
@@ -5187,7 +5261,7 @@
 /obj/structure/stone_tile/surrounding_tile,
 /obj/structure/stone_tile/center,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "zo" = (
 /obj/structure/table,
 /obj/item/kitchen/utensil/fork,
@@ -5220,7 +5294,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "zB" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
@@ -5235,7 +5309,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "zI" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/suit_storage_unit/lavaland,
@@ -5255,7 +5329,7 @@
 /obj/structure/table/reinforced/brass,
 /obj/item/storage/toolbox/brass,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "zP" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 8
@@ -5268,7 +5342,10 @@
 	dir = 4
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
+"zW" = (
+/turf/simulated/floor/plating/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors/necropolis)
 "Ad" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
@@ -5283,7 +5360,7 @@
 	},
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion/tendril,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Ak" = (
 /obj/structure/chair{
 	dir = 4
@@ -5311,7 +5388,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "AB" = (
 /obj/machinery/light/small,
 /obj/structure/disposalpipe/segment{
@@ -5370,7 +5447,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "AU" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -5381,14 +5458,14 @@
 /obj/structure/stone_tile,
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Bh" = (
 /obj/structure/fluff/drake_statue{
 	move_resist = 40000
 	},
 /obj/structure/stone_tile/slab,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Bi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5419,7 +5496,7 @@
 	},
 /obj/structure/table/reinforced/brass,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Bm" = (
 /obj/structure/toilet{
 	dir = 4
@@ -5450,7 +5527,7 @@
 	},
 /obj/structure/stone_tile/center,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Bu" = (
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -5501,7 +5578,7 @@
 	move_resist = 45000
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "BR" = (
 /obj/structure/dispenser/oxygen,
 /obj/machinery/light,
@@ -5517,7 +5594,7 @@
 	},
 /obj/structure/closet/crate/necropolis/tendril,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "BX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -5538,7 +5615,10 @@
 	},
 /obj/structure/stone_tile,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
+"Ct" = (
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/necropolis)
 "Cy" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -5556,7 +5636,7 @@
 	},
 /obj/structure/stone_tile/center/cracked,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "CD" = (
 /obj/structure/window/reinforced/clockwork{
 	dir = 8;
@@ -5567,7 +5647,7 @@
 	},
 /obj/structure/stone_tile/slab,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "CE" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -5581,13 +5661,13 @@
 	},
 /mob/living/simple_animal/hostile/asteroid/basilisk/watcher/magmawing,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "CH" = (
 /obj/structure/stone_tile/surrounding,
 /obj/structure/stone_tile/center/cracked,
 /mob/living/simple_animal/hostile/asteroid/basilisk/watcher/magmawing,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "CL" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile{
@@ -5601,7 +5681,7 @@
 	move_resist = 45000
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "CM" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -5610,7 +5690,7 @@
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "clockwork_floor"
 	},
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "CS" = (
 /obj/machinery/camera{
 	c_tag = "Mining Coin Press";
@@ -5675,7 +5755,7 @@
 /obj/structure/table/reinforced/brass,
 /obj/item/weldingtool/experimental/brass,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Dl" = (
 /obj/structure/stone_tile/cracked{
 	dir = 1
@@ -5689,7 +5769,7 @@
 	},
 /obj/structure/bookcase,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Dm" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -5705,7 +5785,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Dv" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -5717,18 +5797,18 @@
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "clockwork_floor"
 	},
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Dw" = (
 /obj/structure/stone_tile/slab/cracked,
 /obj/structure/table/reinforced/brass,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Dx" = (
 /obj/structure/stone_tile/block/burnt{
 	dir = 1
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "DL" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -5743,13 +5823,17 @@
 /obj/structure/table/reinforced/brass,
 /obj/item/wrench/brass,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "DM" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
+"DN" = (
+/obj/structure/stone_tile/block/cracked,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/necropolis)
 "DP" = (
 /obj/structure/chair{
 	dir = 8
@@ -5769,7 +5853,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "DU" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/secure_closet/personal/mining,
@@ -5797,7 +5881,7 @@
 	},
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "El" = (
 /obj/structure/ore_box,
 /turf/simulated/floor/plasteel{
@@ -5816,7 +5900,7 @@
 /obj/item/clockwork/clockgolem_remains,
 /obj/structure/table/reinforced/brass,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "EF" = (
 /obj/structure/stone_tile/block/burnt{
 	dir = 8
@@ -5825,7 +5909,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "EJ" = (
 /obj/machinery/light{
 	dir = 4
@@ -5872,14 +5956,14 @@
 	move_resist = 45000
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "EQ" = (
 /obj/structure/stone_tile/block/burnt,
 /obj/structure/stone_tile/block{
 	dir = 1
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "EU" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -5899,7 +5983,7 @@
 	},
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion/tendril,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Fa" = (
 /obj/structure/stone_tile/block/burnt{
 	dir = 4
@@ -5908,7 +5992,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Fc" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -5918,7 +6002,7 @@
 	},
 /obj/structure/stone_tile/cracked,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Fe" = (
 /turf/simulated/wall,
 /area/mine/living_quarters)
@@ -5934,7 +6018,7 @@
 "Fy" = (
 /obj/structure/stone_tile/slab,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "FC" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "brown"
@@ -5962,7 +6046,7 @@
 	},
 /obj/structure/stone_tile/surrounding_tile,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "FK" = (
 /obj/structure/chair/stool/holostool,
 /turf/simulated/floor/plasteel,
@@ -6044,29 +6128,29 @@
 "Gg" = (
 /obj/effect/rune{
 	color = "#DAA520";
+	desc = "An odd collection of symbols.";
 	name = "brass rune";
-	rune_blood_color = "#DAA520";
-	desc = "An odd collection of symbols."
+	rune_blood_color = "#DAA520"
 	},
 /mob/living/simple_animal/hostile/megafauna/dragon{
+	color = "#C2B015";
+	health = 5000;
+	maxHealth = 5000;
 	melee_damage_lower = 60;
 	melee_damage_upper = 65;
-	name = "ancient drake";
-	health = 5000;
-	color = "#C2B015";
-	maxHealth = 5000
+	name = "ancient drake"
 	},
 /turf/simulated/floor/indestructible/boss{
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "clockwork_floor"
 	},
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Gi" = (
 /obj/structure/stone_tile/surrounding,
 /obj/structure/stone_tile/center/cracked,
 /obj/structure/bookcase,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Gj" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/door/airlock/external{
@@ -6105,7 +6189,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
+"Gs" = (
+/obj/structure/stone_tile/cracked{
+	dir = 8
+	},
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/necropolis)
 "Gt" = (
 /obj/machinery/door/airlock/external{
 	glass = 1;
@@ -6134,7 +6224,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "GA" = (
 /obj/effect/baseturf_helper/lava_land/surface,
 /obj/structure/disposalpipe/segment{
@@ -6167,7 +6257,7 @@
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "clockwork_floor"
 	},
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "GD" = (
 /obj/structure/sign/poster/contraband/lusty_xenomorph,
 /turf/simulated/wall,
@@ -6214,7 +6304,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "GV" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -6223,7 +6313,7 @@
 /obj/structure/stone_tile/center,
 /obj/structure/stone_tile/surrounding,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "GZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6256,7 +6346,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Hi" = (
 /obj/structure/bedsheetbin,
 /obj/structure/table,
@@ -6275,7 +6365,7 @@
 	},
 /obj/structure/bookcase,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Ht" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -6306,7 +6396,7 @@
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "clockwork_floor"
 	},
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "HA" = (
 /obj/machinery/atmospherics/binary/pump/on,
 /turf/simulated/floor/plasteel{
@@ -6319,7 +6409,7 @@
 	move_resist = 40000
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "HF" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/turf_decal/bot,
@@ -6380,7 +6470,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Ih" = (
 /obj/structure/stone_tile/cracked{
 	dir = 8
@@ -6393,7 +6483,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Il" = (
 /obj/machinery/vending/cola/free,
 /turf/simulated/floor/plasteel/dark,
@@ -6411,7 +6501,7 @@
 	},
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Iz" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -6436,7 +6526,7 @@
 	},
 /mob/living/simple_animal/hostile/asteroid/goliath/beast/ancient,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "IK" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -6461,7 +6551,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Jb" = (
 /obj/structure/stone_tile{
 	dir = 1
@@ -6471,7 +6561,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Je" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -6483,7 +6573,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Jg" = (
 /obj/structure/stone_tile{
 	dir = 8
@@ -6496,7 +6586,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Jk" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -6531,7 +6621,7 @@
 	},
 /mob/living/simple_animal/hostile/big_legion,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "JG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -6621,6 +6711,13 @@
 	icon_state = "brown"
 	},
 /area/mine/living_quarters)
+"Kp" = (
+/obj/structure/stone_tile/block/cracked,
+/obj/structure/stone_tile/block/cracked{
+	dir = 1
+	},
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/necropolis)
 "Ks" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 1
@@ -6628,7 +6725,7 @@
 /obj/structure/stone_tile/surrounding_tile/cracked,
 /obj/structure/stone_tile/center/cracked,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Ky" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Garbage Lavaland Collector";
@@ -6644,7 +6741,7 @@
 "KO" = (
 /obj/structure/stone_tile/surrounding_tile/cracked,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "KV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6712,7 +6809,7 @@
 /obj/item/wrench/brass,
 /obj/structure/table/reinforced/brass,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "LF" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -6725,7 +6822,7 @@
 /obj/structure/stone_tile/surrounding/burnt,
 /obj/structure/stone_tile/center/burnt,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "LL" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 1
@@ -6736,12 +6833,12 @@
 /obj/structure/stone_tile/surrounding_tile,
 /obj/structure/stone_tile/center/cracked,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "LN" = (
 /obj/structure/stone_tile/slab/cracked,
 /obj/structure/bookcase,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "LO" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/turf_decal/bot,
@@ -6794,7 +6891,7 @@
 /obj/item/clockwork/fallen_armor,
 /obj/structure/table/reinforced/brass,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Mj" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -6809,7 +6906,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Ml" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -6822,6 +6919,16 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/mine/eva)
+"MC" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/cracked,
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
+/turf/simulated/floor/plating/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors/necropolis)
 "ME" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6842,7 +6949,7 @@
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "clockwork_floor"
 	},
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "MJ" = (
 /obj/item/stack/ore/titanium,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
@@ -6866,11 +6973,15 @@
 	dir = 1
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
+"MP" = (
+/obj/structure/stone_tile/block,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/necropolis)
 "MU" = (
 /obj/structure/stone_tile/block/burnt,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "MV" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6928,7 +7039,7 @@
 	move_resist = 45000
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Np" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -6937,12 +7048,12 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Nw" = (
 /obj/structure/stone_tile/surrounding/cracked,
 /obj/structure/stone_tile/center/cracked,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "ND" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6965,6 +7076,12 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/mine/laborcamp)
+"NJ" = (
+/obj/structure/stone_tile/block{
+	dir = 4
+	},
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/necropolis)
 "NM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6979,7 +7096,7 @@
 	move_resist = 45000
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "NV" = (
 /obj/item/stack/ore/plasma,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
@@ -7018,7 +7135,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Ov" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -7057,14 +7174,18 @@
 /obj/structure/stone_tile/surrounding,
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion/tendril,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "OX" = (
 /obj/structure/stone_tile/surrounding_tile,
 /turf/simulated/floor/indestructible/boss{
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "clockwork_floor"
 	},
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
+"Pn" = (
+/obj/structure/stone_tile/slab/cracked,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/necropolis)
 "PF" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -7098,7 +7219,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "PM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -7151,11 +7272,11 @@
 	dir = 1
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Qi" = (
 /obj/structure/stone_tile/block/cracked,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Qn" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
@@ -7166,7 +7287,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Qo" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/extinguisher_cabinet{
@@ -7188,7 +7309,7 @@
 	},
 /obj/structure/bookcase,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Qw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -7201,7 +7322,7 @@
 /obj/structure/stone_tile/slab/cracked,
 /obj/item/clockwork/clockgolem_remains,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "QD" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7241,7 +7362,7 @@
 	},
 /obj/structure/stone_tile/block/cracked,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "QR" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -7257,7 +7378,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "QT" = (
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -7300,6 +7421,9 @@
 	icon_state = "browncorner"
 	},
 /area/mine/living_quarters)
+"RD" = (
+/turf/simulated/wall/indestructible/boss,
+/area/lavaland/surface/outdoors/necropolis)
 "RM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -7320,7 +7444,7 @@
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "clockwork_floor"
 	},
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Sb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7340,7 +7464,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Sd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7370,7 +7494,7 @@
 /obj/structure/stone_tile/surrounding,
 /obj/structure/stone_tile/center/cracked,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Sm" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
@@ -7380,7 +7504,7 @@
 	},
 /obj/structure/table/reinforced/brass,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Sn" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -7391,7 +7515,7 @@
 	},
 /obj/structure/table/reinforced/brass,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Ss" = (
 /obj/structure/rack,
 /obj/item/storage/bag/ore,
@@ -7439,14 +7563,14 @@
 /obj/structure/stone_tile{
 	dir = 8
 	},
-/turf/simulated/wall/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/turf/unsimulated/wall/lavaland/boss,
+/area/lavaland/surface/outdoors/necropolis)
 "Sy" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Sz" = (
 /obj/structure/chair{
 	dir = 8
@@ -7470,7 +7594,7 @@
 	move_resist = 45000
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "SD" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -7483,7 +7607,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "SF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -7494,7 +7618,7 @@
 /obj/structure/stone_tile/surrounding,
 /obj/structure/closet/crate/necropolis/tendril,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "SK" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -7523,7 +7647,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Td" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile/cracked{
@@ -7533,7 +7657,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Tj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
@@ -7567,7 +7691,7 @@
 	},
 /obj/structure/bookcase,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Tn" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -7668,7 +7792,7 @@
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "clockwork_floor"
 	},
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Ub" = (
 /obj/machinery/computer/shuttle/mining{
 	req_access = null
@@ -7689,7 +7813,7 @@
 	},
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion/tendril,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Uh" = (
 /obj/structure/lattice/catwalk,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
@@ -7700,7 +7824,7 @@
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "clockwork_floor"
 	},
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Ut" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 30
@@ -7723,7 +7847,7 @@
 	move_resist = 45000
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Uz" = (
 /turf/simulated/floor/mech_bay_recharge_floor,
 /area/mine/production)
@@ -7749,13 +7873,13 @@
 	},
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "UI" = (
 /obj/structure/stone_tile/block/burnt{
 	dir = 4
 	},
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "UJ" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -7766,7 +7890,7 @@
 /obj/structure/stone_tile,
 /obj/item/clockwork/clockgolem_remains,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "UK" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
@@ -7823,7 +7947,7 @@
 	},
 /obj/structure/stone_tile/block,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Vt" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -7855,7 +7979,7 @@
 /obj/structure/sacrificealtar,
 /obj/item/spellbook/oneuse/random,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "VJ" = (
 /obj/machinery/computer/secure_data{
 	dir = 8
@@ -7877,7 +8001,7 @@
 	move_resist = 45000
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "VN" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -7911,13 +8035,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "We" = (
 /obj/structure/stone_tile/slab,
 /obj/item/storage/toolbox/brass,
 /obj/structure/table/reinforced/brass,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Wf" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -7952,7 +8076,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Wt" = (
 /obj/structure/chair{
 	dir = 8
@@ -7974,6 +8098,9 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/production)
+"WC" = (
+/turf/simulated/mineral/random/high_chance/volcanic,
+/area/lavaland/surface/outdoors/necropolis)
 "WE" = (
 /obj/structure/sign/poster/random{
 	pixel_x = -32;
@@ -7990,6 +8117,15 @@
 	icon_state = "bar"
 	},
 /area/mine/living_quarters)
+"WI" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
+/turf/simulated/floor/plating/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors/necropolis)
 "WJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -8035,8 +8171,8 @@
 	dir = 8
 	},
 /obj/item/clockwork/clockgolem_remains,
-/turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/turf/unsimulated/wall/lavaland/boss,
+/area/lavaland/surface/outdoors/necropolis)
 "XW" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -8050,7 +8186,7 @@
 	},
 /obj/structure/table/reinforced/brass,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "XY" = (
 /obj/structure/stone_tile{
 	dir = 8
@@ -8063,7 +8199,7 @@
 	},
 /obj/structure/stone_tile/surrounding_tile/cracked,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Ym" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -8085,7 +8221,7 @@
 	},
 /obj/structure/stone_tile/center/cracked,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "YF" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -8098,7 +8234,7 @@
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "clockwork_floor"
 	},
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "YI" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -8113,7 +8249,7 @@
 /obj/structure/table/reinforced/brass,
 /obj/structure/table/reinforced/brass,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "YJ" = (
 /obj/machinery/door/airlock{
 	name = "Labor Camp Storage"
@@ -8137,7 +8273,7 @@
 	},
 /obj/structure/stone_tile,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "YQ" = (
 /obj/structure/closet/secure_closet/personal/mining,
 /obj/effect/turf_decal/bot,
@@ -8188,7 +8324,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Zf" = (
 /turf/simulated/wall/r_wall,
 /area/mine/living_quarters)
@@ -8218,7 +8354,7 @@
 	},
 /obj/structure/table/reinforced/brass,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "Zs" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/cans/beer{
@@ -8243,7 +8379,7 @@
 	},
 /obj/item/clockwork/clockgolem_remains,
 /turf/simulated/floor/indestructible/boss,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/necropolis)
 "ZA" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -30116,22 +30252,22 @@ aj
 aj
 "}
 (86,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+Ct
+Ct
+Ct
+Ct
+Ct
 ab
 ab
 aj
@@ -30373,23 +30509,23 @@ aj
 aj
 "}
 (87,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ix
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+DN
+Ct
+Ct
+Ct
+Ct
+Ct
 ab
 ab
 aj
@@ -30630,24 +30766,24 @@ aj
 aj
 "}
 (88,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ad
-jb
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+WC
+fB
+Ct
+Ct
+Ct
+Ct
+Ct
 ab
 ab
 aj
@@ -30887,24 +31023,24 @@ aj
 aj
 "}
 (89,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+Ct
+Ct
+Ct
+Ct
+Ct
 ab
 aj
 aj
@@ -31144,25 +31280,25 @@ aj
 aj
 "}
 (90,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ad
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+WC
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -31401,25 +31537,25 @@ aj
 aj
 "}
 (91,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ad
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+WC
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -31658,25 +31794,25 @@ aj
 aj
 "}
 (92,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-iy
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+fa
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -31915,25 +32051,25 @@ ab
 ab
 "}
 (93,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -32172,25 +32308,25 @@ ab
 ab
 "}
 (94,1,1) = {"
-aa
-aa
-aa
-aa
+jG
+jG
+jG
+jG
 Sx
-aa
-aa
-aa
-aa
-aa
-aa
-ad
-ad
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+jG
+WC
+WC
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -32429,25 +32565,25 @@ aj
 aj
 "}
 (95,1,1) = {"
-aa
-aa
-aa
+jG
+jG
+jG
 qB
 Hm
 Dl
-aa
-aa
-aa
-aa
-aa
-ad
-ix
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+WC
+DN
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -32686,26 +32822,26 @@ aj
 aj
 "}
 (96,1,1) = {"
-aa
-aa
-qS
+jG
+jG
+cf
 CE
 Sk
 mY
-aa
-aa
-aa
-aa
-aa
-ad
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+WC
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -32943,27 +33079,27 @@ ab
 ab
 "}
 (97,1,1) = {"
-aa
-aa
+jG
+jG
 xo
 ng
 Qy
 gC
 mq
-qS
-aa
-aa
-aa
-iy
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+cf
+jG
+jG
+jG
+fa
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -33200,29 +33336,29 @@ aj
 aj
 "}
 (98,1,1) = {"
-aa
-aa
+jG
+jG
 Hm
 nc
 qB
 Qr
 nc
 mW
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ai
-ai
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+Ct
+Ct
+Ct
+Ct
+jK
+jK
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -33457,8 +33593,8 @@ aj
 aj
 "}
 (99,1,1) = {"
-aa
-aa
+jG
+jG
 iO
 kY
 ng
@@ -33466,19 +33602,19 @@ nc
 gT
 qC
 xo
-aa
-aa
-ab
-ab
-ab
-ab
-ai
-ai
-ad
-ab
-ab
-ab
-ab
+jG
+jG
+Ct
+Ct
+Ct
+Ct
+jK
+jK
+WC
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -33714,8 +33850,8 @@ aj
 aj
 "}
 (100,1,1) = {"
-aa
-aa
+jG
+jG
 XW
 gC
 mW
@@ -33723,18 +33859,18 @@ gC
 nc
 Sk
 hD
-aa
-aa
-ab
-ab
-ab
-ad
-ai
-ai
-ad
-ab
-ab
-ab
+jG
+jG
+Ct
+Ct
+Ct
+WC
+jK
+jK
+WC
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -33971,26 +34107,26 @@ aj
 aj
 "}
 (101,1,1) = {"
-aa
-aa
+jG
+jG
 LN
 mW
 Gi
 nc
 mS
 Tl
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ad
-ad
-ab
-ab
-ab
+jG
+jG
+jG
+Ct
+Ct
+Ct
+Ct
+WC
+WC
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -34228,26 +34364,26 @@ aj
 aj
 "}
 (102,1,1) = {"
-aa
-aa
+jG
+jG
 hD
 mq
 Tl
 UH
 Qy
 hD
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -34485,26 +34621,26 @@ aj
 aj
 "}
 (103,1,1) = {"
-aa
-aa
-aa
+jG
+jG
+jG
 nc
 mY
 nc
 mW
-aa
-aa
-aa
-aa
-ad
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+WC
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -34742,26 +34878,26 @@ aj
 aj
 "}
 (104,1,1) = {"
-aa
-aa
-aa
+jG
+jG
+jG
 qS
-aa
+jG
 nf
-aa
-aa
-aa
-aa
-aa
-ad
-ad
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+WC
+WC
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -34999,26 +35135,26 @@ aj
 aj
 "}
 (105,1,1) = {"
-aa
-aa
-aa
-aa
-aa
+jG
+jG
+jG
+jG
+jG
 nc
-aa
-aa
-aa
-aa
-aa
-ad
-ad
-ad
-jb
-jb
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+jG
+WC
+WC
+fB
+fB
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -35256,26 +35392,26 @@ aj
 aj
 "}
 (106,1,1) = {"
-aa
-aa
-aa
+jG
+jG
+jG
 qS
 ng
 qC
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -35513,26 +35649,26 @@ aj
 aj
 "}
 (107,1,1) = {"
-aa
-aa
-aa
+jG
+jG
+jG
 mW
 nc
 mW
 Dw
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ad
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+WC
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -35770,26 +35906,26 @@ aj
 aj
 "}
 (108,1,1) = {"
-aa
-aa
+jG
+jG
 Sn
 mq
 mz
 nc
 xU
 XW
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ad
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+WC
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -36027,26 +36163,26 @@ aj
 aj
 "}
 (109,1,1) = {"
-aa
-aa
+jG
+jG
 yp
 CH
 ng
 gC
 Sk
 Sm
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ix
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+DN
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -36284,26 +36420,26 @@ aj
 aj
 "}
 (110,1,1) = {"
-aa
-aa
+jG
+jG
 Dw
 Zx
 nc
 mY
 qC
-qS
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
+cf
+jG
+jG
+RD
+jG
+jG
+jG
+jG
+jG
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -36541,26 +36677,26 @@ aj
 aj
 "}
 (111,1,1) = {"
-aa
-aa
-aa
+jG
+jG
+jG
 gC
 AU
 nf
-aa
-aa
-aa
+jG
+jG
+jG
 qS
 DL
 iO
-aa
-aa
-ad
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -36798,28 +36934,28 @@ aj
 aj
 "}
 (112,1,1) = {"
-aa
-aa
-aa
+jG
+jG
+jG
 qS
-aa
+jG
 nc
-aa
-aa
-aa
+jG
+jG
+RD
 Zx
 mq
 sS
 nf
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -37055,29 +37191,29 @@ ab
 ab
 "}
 (113,1,1) = {"
-aa
-aa
-aa
-aa
-aa
+jG
+jG
+jG
+jG
+jG
 mW
-aa
-aa
+jG
+jG
 km
 gC
 nc
 Sk
 ng
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -37312,28 +37448,28 @@ ab
 ab
 "}
 (114,1,1) = {"
-aa
-aa
-aa
-aa
-aa
+jG
+jG
+jG
+jG
+jG
 mq
-aa
-aa
+jG
+jG
 yH
 QR
 mW
 uM
 kk
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -37569,26 +37705,26 @@ aj
 aj
 "}
 (115,1,1) = {"
-aa
-aa
-aa
-aa
-aa
+jG
+jG
+jG
+jG
+jG
 nf
-aa
-aa
-aa
+jG
+jG
+jG
 Sk
 nc
 ng
 Zd
-aa
-ab
-ab
-ab
-ad
-ab
-ab
+jG
+jG
+Ct
+Ct
+WC
+Ct
+Ct
 aj
 aj
 aj
@@ -37826,26 +37962,26 @@ aj
 aj
 "}
 (116,1,1) = {"
-aa
-aa
-aa
-aa
+jG
+jG
+jG
+jG
 nc
 gC
 Qy
-qS
-aa
+cf
+jG
 mS
 no
 YI
 hG
-aa
-ab
-ab
-ad
-ai
-ai
-ab
+jG
+jG
+Ct
+WC
+jK
+jK
+Ct
 aj
 aj
 aj
@@ -38083,26 +38219,26 @@ aj
 aj
 "}
 (117,1,1) = {"
-aa
-aa
-aa
+jG
+jG
+jG
 BW
 mW
 ng
 nc
 gC
-aa
+jG
 mq
 gC
 qS
-aa
-aa
-ab
-ad
-ad
-ai
-ai
-ad
+jG
+jG
+jG
+WC
+WC
+jK
+jK
+WC
 aj
 aj
 aj
@@ -38340,9 +38476,9 @@ aj
 aj
 "}
 (118,1,1) = {"
-aa
-aa
-aa
+jG
+jG
+jG
 Dw
 Sk
 nc
@@ -38351,15 +38487,15 @@ mq
 mW
 nc
 wr
-aa
-aa
-aa
-it
+jG
+jG
+jG
+MP
 ky
-ad
-ai
-ai
-ad
+WC
+jK
+jK
+WC
 aj
 aj
 aj
@@ -38597,26 +38733,26 @@ aj
 aj
 "}
 (119,1,1) = {"
-aa
-aa
+jG
+jG
 qS
 Bj
 Dm
 UJ
 mS
 iZ
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ad
-ai
-ai
-jq
+jG
+jG
+jG
+jG
+jG
+jG
+Ct
+Ct
+WC
+jK
+jK
+wS
 aj
 aj
 aj
@@ -38854,26 +38990,26 @@ aj
 aj
 "}
 (120,1,1) = {"
-aa
-aa
-aa
+jG
+jG
+jG
 iO
 mq
 ng
 oz
 Bj
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+jG
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -39111,26 +39247,26 @@ aj
 aj
 "}
 (121,1,1) = {"
-aa
-aa
-aa
-aa
+jG
+jG
+jG
+jG
 hE
 nc
 nf
-qS
-aa
-aa
-aa
+cf
+jG
+jG
+jG
 ae
 jg
 gB
 gB
-js
-ab
-ab
-ab
-ab
+gU
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 mu
@@ -39368,27 +39504,27 @@ aj
 aj
 "}
 (122,1,1) = {"
-aa
-aa
-aa
-aa
-aa
+jG
+jG
+jG
+jG
+jG
 mW
-aa
-aa
-aa
-aa
-aa
+jG
+jG
+jG
+jG
+jG
 iC
 gr
 gs
 gr
 gr
-kR
-ab
-ab
-ab
-ab
+Pn
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -39625,26 +39761,26 @@ aj
 aj
 "}
 (123,1,1) = {"
-aa
-aa
-aa
-aa
-aa
+jG
+jG
+jG
+jG
+jG
 gC
-aa
-aa
-aa
-aa
-aa
+jG
+jG
+jG
+jG
+jG
 gR
 ag
 jF
 gM
 kB
 jm
-ix
-ab
-jS
+DN
+Ct
+Gs
 aj
 aj
 aj
@@ -39882,26 +40018,26 @@ aj
 aj
 "}
 (124,1,1) = {"
-aa
-aa
-aa
-aa
-aa
+jG
+jG
+jG
+jG
+jG
 mY
-aa
-aa
-aa
-aa
-aa
-aa
+jG
+jG
+jG
+jG
+jG
+jG
 gG
 go
 kg
 hs
 gr
 hH
-ab
-ab
+Ct
+Ct
 aj
 ly
 aj
@@ -40139,26 +40275,26 @@ aj
 aj
 "}
 (125,1,1) = {"
-aa
-aa
-aa
+jG
+jG
+jG
 mS
 mV
 mq
 mV
 nc
-aa
-aa
-fV
-fV
+jG
+jG
+jG
+jG
 gr
 jH
 gO
 kD
 ag
 le
-aa
-aa
+jG
+jG
 ls
 aj
 aj
@@ -40396,29 +40532,29 @@ aj
 aj
 "}
 (126,1,1) = {"
-aa
-aa
-fV
+jG
+jG
+jG
 gj
 gC
 mr
 nb
 ne
-aa
-aa
-fV
-fV
+jG
+jG
+jG
+jG
 jk
 gr
 gr
 gr
 gr
 gs
-aa
-lp
-lp
+jG
+pW
+pW
 lz
-lp
+pW
 lF
 lp
 lP
@@ -40671,10 +40807,10 @@ kj
 fT
 fT
 lg
-gP
-lq
-lu
-lq
+zi
+Kp
+kX
+Kp
 lD
 lG
 lu
@@ -40910,29 +41046,29 @@ aj
 aj
 "}
 (128,1,1) = {"
-aa
-aa
-fV
+jG
+jG
+jG
 gk
 mX
 mZ
 nc
 ng
-aa
-aa
-fV
-fV
+jG
+jG
+jG
+jG
 jl
 gr
 ah
 gG
 gs
 gy
-aa
+jG
 lr
-lv
-lv
-lE
+MC
+MC
+WI
 lv
 lE
 lR
@@ -41167,26 +41303,26 @@ aj
 aj
 "}
 (129,1,1) = {"
-aa
-aa
-aa
+jG
+jG
+jG
 mS
 mY
 ms
 hJ
 id
-aa
-aa
-fV
-fV
+jG
+jG
+jG
+jG
 jm
 jL
 gM
 kH
 gr
 hH
-aa
-aa
+jG
+jG
 lw
 aj
 aj
@@ -41424,26 +41560,26 @@ aj
 aj
 "}
 (130,1,1) = {"
-aa
-aa
-aa
-aa
-aa
+jG
+jG
+jG
+jG
+jG
 nf
-aa
-aa
-aa
-aa
-aa
-aa
+jG
+jG
+jG
+jG
+jG
+jG
 gr
 go
 kl
 hs
 gG
 lj
-ab
-ab
+Ct
+Ct
 aj
 aj
 mv
@@ -41681,26 +41817,26 @@ aj
 aj
 "}
 (131,1,1) = {"
-aa
-aa
-aa
-aa
-aa
+jG
+jG
+jG
+jG
+jG
 mY
-aa
-aa
-aa
-aa
-aa
+jG
+jG
+jG
+jG
+jG
 gR
 ah
 jN
 gO
 kJ
 gr
-it
-ab
-ab
+MP
+Ct
+Ct
 aj
 aj
 aj
@@ -41938,26 +42074,26 @@ aj
 aj
 "}
 (132,1,1) = {"
-aa
-aa
-aa
-aa
-aa
+jG
+jG
+jG
+jG
+jG
 mS
-aa
-aa
-aa
-aa
-aa
+jG
+jG
+jG
+jG
+jG
 gR
 gr
 gr
 gr
 jm
-gP
-ab
-ab
-ab
+zi
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -42195,26 +42331,26 @@ aj
 aj
 "}
 (133,1,1) = {"
-aa
-aa
-aa
+jG
+jG
+jG
 qS
 Sk
 ng
 mq
-qS
-aa
-aa
-aa
+cf
+jG
+jG
+jG
 ae
 gr
 jm
 ko
-iu
-ab
-ab
-ab
-ab
+NJ
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -42452,27 +42588,27 @@ aj
 aj
 "}
 (134,1,1) = {"
-aa
-aa
-aa
+jG
+jG
+jG
 tu
 nf
 mq
 qa
 Dw
-aa
-aa
-aa
-aa
-aa
-aa
-jq
-ab
-ab
-ab
-ab
-ab
-kN
+jG
+jG
+jG
+jG
+jG
+jG
+wS
+Ct
+Ct
+Ct
+Ct
+Ct
+xS
 aj
 aj
 aj
@@ -42709,26 +42845,26 @@ aj
 aj
 "}
 (135,1,1) = {"
-aa
-aa
-aa
+jG
+jG
+jG
 Zq
 Hg
 ng
 kY
 iZ
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-jR
+jG
+jG
+jG
+jG
+jG
+jG
+Ct
+Ct
+Ct
+sB
 mt
-ab
+Ct
 aj
 aj
 aj
@@ -42966,26 +43102,26 @@ aj
 aj
 "}
 (136,1,1) = {"
-aa
-aa
-aa
+jG
+jG
+jG
 qS
 mq
 hE
 ng
-qS
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-jq
-ab
+cf
+jG
+jG
+jG
+jG
+jG
+jG
+Ct
+Ct
+Ct
+Ct
+wS
+Ct
 aj
 aj
 aj
@@ -43223,26 +43359,26 @@ aj
 aj
 "}
 (137,1,1) = {"
-aa
-aa
-aa
-aa
+jG
+jG
+jG
+jG
 mY
 nf
 mq
-aa
-aa
-aa
-aa
+jG
+jG
+jG
+jG
 iK
-ab
-jQ
-jq
-ab
-ab
-ab
-ab
-ab
+Ct
+ld
+wS
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -43480,26 +43616,26 @@ aj
 aj
 "}
 (138,1,1) = {"
-aa
-aa
-aa
+jG
+jG
+jG
 wr
 Sk
 IH
 Sk
 Ir
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -43737,8 +43873,8 @@ aj
 aj
 "}
 (139,1,1) = {"
-aa
-aa
+jG
+jG
 ij
 mS
 Eh
@@ -43746,17 +43882,17 @@ mZ
 mZ
 nf
 Dh
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -43994,7 +44130,7 @@ aj
 aj
 "}
 (140,1,1) = {"
-aa
+jG
 qS
 Dw
 Sk
@@ -44003,17 +44139,17 @@ SJ
 mZ
 Sk
 Zq
-qS
-aa
-ad
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+cf
+jG
+WC
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 lI
@@ -44251,8 +44387,8 @@ aj
 aj
 "}
 (141,1,1) = {"
-aa
-aa
+jG
+jG
 zM
 mq
 Jy
@@ -44260,17 +44396,17 @@ mZ
 Eh
 mY
 iO
-aa
-aa
-aa
-ad
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+WC
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -44508,26 +44644,26 @@ aj
 aj
 "}
 (142,1,1) = {"
-aa
-aa
-aa
+jG
+jG
+jG
 ng
 Sk
 nf
 Sk
 Xl
-aa
-aa
-aa
-aa
-ad
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+WC
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -44765,26 +44901,26 @@ aj
 aj
 "}
 (143,1,1) = {"
-aa
-aa
-aa
-aa
+jG
+jG
+jG
+jG
 Je
 mY
 iP
-aa
-aa
-aa
-aa
-aa
-ad
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+WC
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -45022,26 +45158,26 @@ aj
 aj
 "}
 (144,1,1) = {"
-aa
-aa
-aa
-aa
+jG
+jG
+jG
+jG
 xO
 xM
 hd
-aa
-aa
-aa
-aa
-ad
-jq
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+WC
+wS
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 mw
@@ -45279,26 +45415,26 @@ aj
 aj
 "}
 (145,1,1) = {"
-aa
-aa
-aa
-aa
-aj
+jG
+jG
+jG
+jG
+zW
 zP
 FH
-aa
-aa
-aa
-aa
-iy
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+fa
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 mx
@@ -45536,26 +45672,26 @@ aj
 aj
 "}
 (146,1,1) = {"
-aa
-aa
-aa
-aa
+jG
+jG
+jG
+jG
 hs
 QO
 If
-aj
+zW
 aO
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -45793,26 +45929,26 @@ aj
 aj
 "}
 (147,1,1) = {"
-aa
-aa
-aa
-aa
+jG
+jG
+jG
+jG
 hs
 GW
 vF
 yJ
 go
-aa
-aa
-ad
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+WC
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -46050,26 +46186,26 @@ aj
 aj
 "}
 (148,1,1) = {"
-aa
-aa
-aa
-aa
-aj
+jG
+jG
+jG
+jG
+zW
 UI
 oh
 Sc
 go
-aa
-aa
-ad
-ad
-jR
-ad
-ab
-ab
+jG
+jG
+WC
+WC
+sB
+WC
+Ct
+Ct
 ll
-ab
-ab
+Ct
+Ct
 aj
 aj
 aj
@@ -46307,26 +46443,26 @@ aj
 aj
 "}
 (149,1,1) = {"
-aa
-aa
-aa
-aa
-fV
-fV
+jG
+jG
+jG
+jG
+jG
+jG
 jY
 fA
 go
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ad
-ab
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+WC
+Ct
 aj
 aj
 aj
@@ -46564,26 +46700,26 @@ aj
 aj
 "}
 (150,1,1) = {"
-aa
-aa
-aa
+jG
+jG
+jG
 qS
 Fy
-fV
+jG
 hs
 GS
 MU
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ad
-ab
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+WC
+Ct
 aj
 aj
 aj
@@ -46821,27 +46957,27 @@ aj
 aj
 "}
 (151,1,1) = {"
-aa
-aa
+jG
+jG
 pp
 gM
 gg
-fV
+jG
 hs
 yh
-aj
-aa
-aa
-ix
-ab
-ab
-ab
-ad
-ad
-ad
-ab
-ab
-ab
+zW
+jG
+jG
+DN
+Ct
+Ct
+Ct
+WC
+WC
+WC
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -47078,30 +47214,30 @@ aj
 aj
 "}
 (152,1,1) = {"
-aa
+jG
 qS
 go
 xd
 hs
-fV
+jG
 Dx
 Ih
 MU
-aa
-aa
-ab
-ab
-ab
-ad
-ad
-ad
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+Ct
+Ct
+Ct
+WC
+WC
+WC
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -47335,29 +47471,29 @@ aj
 aj
 "}
 (153,1,1) = {"
-aa
-aa
+jG
+jG
 kW
 gO
 pT
-fV
+jG
 hs
 dj
 MU
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -47592,33 +47728,33 @@ aj
 aj
 "}
 (154,1,1) = {"
-aa
-aa
-aa
+jG
+jG
+jG
 qS
 Fy
-fV
+jG
 Np
 Gq
 dF
-aa
-aa
-ad
-ad
-jS
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+WC
+WC
+Gs
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 ab
@@ -47849,31 +47985,31 @@ aj
 aj
 "}
 (155,1,1) = {"
-aa
-aa
-aa
-aa
-aa
+jG
+jG
+jG
+jG
+jG
 qS
 SD
 ox
 Jb
-aa
-aa
-aa
-aa
-ad
-ad
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+WC
+WC
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -48106,29 +48242,29 @@ aj
 aj
 "}
 (156,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
+jG
+jG
+jG
+jG
+jG
+jG
 zC
 LJ
 YA
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -48363,29 +48499,29 @@ aj
 aj
 "}
 (157,1,1) = {"
-aa
-aa
-aa
-qS
-aa
+jG
+jG
+jG
+cf
+jG
 Mj
 Ck
 ib
 PI
 sb
-aa
-qS
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+cf
+jG
+jG
+jG
+jG
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -48620,8 +48756,8 @@ aj
 aj
 "}
 (158,1,1) = {"
-aa
-aa
+jG
+jG
 Wr
 mV
 VQ
@@ -48633,16 +48769,16 @@ PI
 hF
 VQ
 Tb
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -48877,7 +49013,7 @@ aj
 aj
 "}
 (159,1,1) = {"
-aa
+jG
 qS
 hh
 iU
@@ -48890,16 +49026,16 @@ pV
 PI
 lB
 yh
-qS
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+cf
+jG
+jG
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -49134,7 +49270,7 @@ aj
 aj
 "}
 (160,1,1) = {"
-aa
+jG
 CD
 hh
 DR
@@ -49148,15 +49284,15 @@ YO
 XY
 yh
 hA
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -49391,7 +49527,7 @@ aj
 aj
 "}
 (161,1,1) = {"
-aa
+jG
 xh
 zw
 KO
@@ -49405,16 +49541,16 @@ gM
 rd
 Fc
 xh
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -49648,7 +49784,7 @@ aj
 aj
 "}
 (162,1,1) = {"
-aa
+jG
 Mg
 CL
 go
@@ -49662,17 +49798,17 @@ Bh
 hs
 Nj
 Lx
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -49905,7 +50041,7 @@ aj
 aj
 "}
 (163,1,1) = {"
-aa
+jG
 hA
 EX
 Ja
@@ -49919,14 +50055,14 @@ gO
 Bn
 Fc
 hA
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -50162,7 +50298,7 @@ aj
 aj
 "}
 (164,1,1) = {"
-aa
+jG
 xh
 MM
 Vk
@@ -50176,13 +50312,13 @@ qP
 EQ
 kI
 xh
-aa
-aa
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -50433,13 +50569,13 @@ Up
 OU
 QO
 Fy
-qS
-aa
-ab
-ab
-ab
-ab
-ab
+cf
+jG
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -50676,7 +50812,7 @@ aj
 aj
 "}
 (166,1,1) = {"
-aa
+jG
 hA
 hh
 Vk
@@ -50690,13 +50826,13 @@ OX
 EQ
 yh
 CD
-aa
-aa
-jS
-ad
-ad
-ab
-ab
+jG
+jG
+Gs
+WC
+WC
+Ct
+Ct
 aj
 aj
 aj
@@ -50933,7 +51069,7 @@ aj
 aj
 "}
 (167,1,1) = {"
-aa
+jG
 xh
 MM
 tE
@@ -50947,13 +51083,13 @@ UI
 LL
 kI
 xh
-aa
-aa
-ai
-ai
-ai
-ai
-ab
+jG
+jG
+jK
+jK
+jK
+jK
+Ct
 aj
 aj
 aj
@@ -51190,7 +51326,7 @@ aj
 aj
 "}
 (168,1,1) = {"
-aa
+jG
 We
 EP
 Qi
@@ -51204,13 +51340,13 @@ us
 jY
 VL
 Er
-aa
-aa
-ai
-ai
-ai
-ai
-ab
+jG
+jG
+jK
+jK
+jK
+jK
+Ct
 aj
 aj
 aj
@@ -51447,7 +51583,7 @@ aj
 aj
 "}
 (169,1,1) = {"
-aa
+jG
 hA
 Ai
 hi
@@ -51461,16 +51597,16 @@ Sy
 pI
 yh
 hA
-aa
-aa
-ai
-ai
-ai
-ai
-ab
-ab
-ab
-ab
+jG
+jG
+jK
+jK
+jK
+jK
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -51704,7 +51840,7 @@ aj
 aj
 "}
 (170,1,1) = {"
-aa
+jG
 rs
 Td
 kM
@@ -51718,16 +51854,16 @@ Ot
 uZ
 yh
 xh
-aa
-aa
-ai
-ai
-ai
-ai
-ad
-ab
-ab
-ab
+jG
+jG
+jK
+jK
+jK
+jK
+WC
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -51961,8 +52097,8 @@ aj
 aj
 "}
 (171,1,1) = {"
-aa
-qS
+jG
+cf
 Qb
 ms
 hJ
@@ -51974,17 +52110,17 @@ hJ
 hJ
 Uf
 ev
-qS
-aa
-aa
-ai
-ai
-ai
-ai
-ad
-ad
-ab
-ab
+cf
+jG
+jG
+jK
+jK
+jK
+jK
+WC
+WC
+Ct
+Ct
 aj
 aj
 aj
@@ -52218,30 +52354,30 @@ aj
 aj
 "}
 (172,1,1) = {"
-aa
-aa
-aa
-aa
-qS
+jG
+jG
+jG
+jG
+cf
 dp
 kF
 VE
 pt
 NS
-qS
-aa
-aa
-aa
-aa
-aa
-ai
-ai
-ai
-ai
-ad
-ad
-ab
-ab
+cf
+jG
+jG
+jG
+jG
+jG
+jK
+jK
+jK
+jK
+WC
+WC
+Ct
+Ct
 aj
 aj
 aj
@@ -52475,30 +52611,30 @@ aj
 aj
 "}
 (173,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-qS
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ai
-ai
-ai
-ai
-ai
-ad
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+cf
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jK
+jK
+jK
+jK
+jK
+WC
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -52732,30 +52868,30 @@ aj
 aj
 "}
 (174,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ad
-ai
-ai
-ai
-ai
-ad
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+Ct
+WC
+jK
+jK
+jK
+jK
+WC
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -52989,30 +53125,30 @@ aj
 aj
 "}
 (175,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ad
-ab
-ab
-kN
-ai
-ai
-ai
-ai
-jq
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+Ct
+xS
+jK
+jK
+jK
+jK
+wS
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -53246,29 +53382,29 @@ aj
 aj
 "}
 (176,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-it
-ab
-ai
-ai
-ai
-ai
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+MP
+Ct
+jK
+jK
+jK
+jK
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -53503,29 +53639,29 @@ aj
 aj
 "}
 (177,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ad
-ad
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+Ct
+Ct
+Ct
+WC
+WC
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -53760,29 +53896,29 @@ aj
 aj
 "}
 (178,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 aj
 aj
 aj
@@ -54017,28 +54153,28 @@ aj
 aj
 "}
 (179,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ad
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+WC
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 ab
 ab
 aj
@@ -54274,28 +54410,28 @@ aj
 aj
 "}
 (180,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-iy
-ab
-ad
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+fV
+WC
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 ab
 ab
 ab
@@ -54531,28 +54667,28 @@ aj
 aj
 "}
 (181,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+fa
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 ab
 ab
 ab
@@ -54788,27 +54924,27 @@ aj
 aj
 "}
 (182,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 ab
 ab
 ab
@@ -55045,27 +55181,27 @@ aj
 aj
 "}
 (183,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 ab
 ab
 aj
@@ -55302,26 +55438,26 @@ aj
 aj
 "}
 (184,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-ad
-ai
-ab
-ab
-ab
-ab
-ab
-ab
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+Ct
+WC
+jK
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 ab
 ab
 ab
@@ -55559,26 +55695,26 @@ aj
 aj
 "}
 (185,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ad
-ad
-ai
-jS
-ab
-ab
-ab
-ab
-ab
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+WC
+WC
+jK
+Gs
+Ct
+Ct
+Ct
+Ct
+Ct
 ab
 ab
 ab
@@ -55816,25 +55952,25 @@ aj
 aj
 "}
 (186,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ad
-ad
-ai
-ad
-ab
-ab
-ab
-ab
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+WC
+WC
+jK
+WC
+Ct
+Ct
+Ct
+Ct
 ab
 ab
 ab

--- a/code/game/area/areas/mining.dm
+++ b/code/game/area/areas/mining.dm
@@ -129,3 +129,8 @@
 
 /area/lavaland/surface/outdoors/explored
 	name = "Lavaland Labor Camp"
+
+/area/lavaland/surface/outdoors/necropolis
+	name = "Necropolis"
+	icon_state = "unexplored"
+	tele_proof = TRUE

--- a/code/game/turfs/unsimulated/walls.dm
+++ b/code/game/turfs/unsimulated/walls.dm
@@ -33,3 +33,24 @@
 /turf/unsimulated/wall/abductor
 	icon_state = "alien1"
 	explosion_block = 50
+
+/turf/unsimulated/wall/lavaland
+
+/turf/unsimulated/wall/lavaland/necropolis
+	name = "necropolis wall"
+	desc = "A seemingly impenetrable wall."
+	icon = 'icons/turf/walls.dmi'
+	icon_state = "necro"
+	baseturf = /turf/unsimulated/wall/lavaland/necropolis
+
+/turf/unsimulated/wall/lavaland/boss
+	name = "necropolis wall"
+	desc = "A thick, seemingly indestructible stone wall."
+	icon = 'icons/turf/walls/boss_wall.dmi'
+	icon_state = "wall"
+	canSmoothWith = list(/turf/unsimulated/wall/lavaland/boss, /turf/unsimulated/wall/lavaland/boss/see_through)
+	baseturf = /turf/simulated/floor/plating/asteroid/basalt
+	smooth = SMOOTH_TRUE
+
+/turf/unsimulated/wall/lavaland/boss/see_through
+	opacity = FALSE

--- a/code/modules/mining/shelters.dm
+++ b/code/modules/mining/shelters.dm
@@ -7,7 +7,7 @@
 
 /datum/map_template/shelter/New()
 	. = ..()
-	blacklisted_turfs = typecacheof(list(/turf/simulated/wall, /turf/simulated/mineral, /turf/simulated/shuttle/wall))
+	blacklisted_turfs = typecacheof(list(/turf/simulated/wall, /turf/simulated/mineral, /turf/simulated/shuttle/wall, /turf/unsimulated/wall))
 	whitelisted_turfs = list()
 	banned_areas = typecacheof(/area/shuttle)
 


### PR DESCRIPTION
* Добавляет в черный список проверки для капсул шахтеров на свободное место unsimulated стены
* Заменяет стены в зоне "Necropolis" на unsimulated аналог, что исправляет абуз РЦД на стены некрополя для получения лута
* Добавляет зону "Necropolis", которая запрещает использование блюспейс кристаллов для обхода мобов и получения лута
![F1](https://user-images.githubusercontent.com/91949115/200186605-405a8f03-1c9e-47d1-bbdf-0906db1e42f5.png)