### PR TITLE
FIX: VEIL/EMP отключают HARDHAT

### DIFF
--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -21,15 +21,15 @@
 		"Stok" = 'icons/mob/species/monkey/head.dmi'
 	)
 
-/obj/item/clothing/head/hardhat/attack_self(mob/living/user)
-	toggle_helmet_light(user)
+/obj/item/clothing/head/hardhat/attack_self()
+	toggle_helmet_light()
 
-/obj/item/clothing/head/hardhat/proc/toggle_helmet_light(mob/living/user)
+/obj/item/clothing/head/hardhat/proc/toggle_helmet_light()
 	on = !on
 	if(on)
-		turn_on(user)
+		turn_on()
 	else
-		turn_off(user)
+		turn_off()
 	update_icon()
 
 /obj/item/clothing/head/hardhat/update_icon()
@@ -43,16 +43,20 @@
 		A.UpdateButtonIcon()
 	..()
 
-/obj/item/clothing/head/hardhat/proc/turn_on(mob/user)
+/obj/item/clothing/head/hardhat/proc/turn_on()
 	set_light(brightness_on)
 
-/obj/item/clothing/head/hardhat/proc/turn_off(mob/user)
+/obj/item/clothing/head/hardhat/proc/turn_off()
 	set_light(0)
 
-/obj/item/clothing/head/hardhat/extinguish_light(mob/living/user)
+/obj/item/clothing/head/hardhat/emp_act(severity)
+	. = ..()
+	extinguish_light()
+
+/obj/item/clothing/head/hardhat/extinguish_light()
 	if(on)
 		on = FALSE
-		turn_off(user)
+		turn_off()
 		update_icon()
 		visible_message("<span class='danger'>[src]'s light fades and turns off.</span>")
 


### PR DESCRIPTION
## What Does This PR Do
Теперь абилки и ЕМП отключают HardHat'ы как это и должно быть.
Можно сказать баф тенелингов которые всегда получали пизды от шапок.

## Images of changes
![image](https://user-images.githubusercontent.com/41479614/200258070-4135b73d-613f-4083-b971-7a20dbd9509d.png)
