### PR TITLE
fix: Добавление гейту moonoutpost19 своих зон

### DIFF
--- a/_maps/map_files/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/map_files/RandomZLevels/moonoutpost19.dmm
@@ -4,56 +4,22 @@
 	icon_state = "rock";
 	name = "rock"
 	},
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "ab" = (
 /turf/simulated/mineral/random/labormineral,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "ac" = (
 /obj/structure/alien/weeds,
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "ad" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
 	},
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "ae" = (
 /obj/structure/alien/weeds,
 /obj/structure/alien/weeds{
@@ -62,30 +28,14 @@
 	name = "egg"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "af" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
 	},
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "ag" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
@@ -96,55 +46,23 @@
 	name = "egg"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "ah" = (
 /obj/structure/alien/weeds,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "ai" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
 	},
 /mob/living/simple_animal/hostile/alien,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "aj" = (
 /obj/structure/alien/weeds,
 /obj/structure/bed/nest,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "ak" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
@@ -155,71 +73,31 @@
 	name = "egg"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "al" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
 	},
 /obj/structure/bed/nest,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "am" = (
 /obj/structure/alien/weeds/node,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "an" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
 	},
 /obj/structure/bed/nest,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "ao" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "ap" = (
 /obj/structure/alien/weeds,
 /obj/structure/bed/nest,
@@ -234,29 +112,13 @@
 	icon_state = "gib1_flesh"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "aq" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "ar" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
@@ -264,21 +126,10 @@
 /obj/structure/alien/resin/wall,
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "as" = (
 /turf/simulated/wall/r_wall,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "at" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
@@ -288,30 +139,14 @@
 	icon_state = "gib1_flesh"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "au" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
 	},
 /mob/living/simple_animal/hostile/alien/sentinel,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "av" = (
 /obj/structure/alien/weeds,
 /obj/effect/decal/cleanable/blood/gibs{
@@ -319,58 +154,33 @@
 	icon_state = "gib2_flesh"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "aw" = (
 /obj/structure/alien/weeds/node,
 /obj/effect/decal/cleanable/blood{
 	color = "red"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "ax" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "darkred";
 	tag = "icon-darkred (NORTHWEST)"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "ay" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "az" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkredcorners";
 	tag = "icon-darkredcorners (NORTH)"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "aA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -378,33 +188,19 @@
 	icon_state = "darkred";
 	tag = "icon-darkred (NORTHEAST)"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "aB" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkredcorners";
 	tag = "icon-darkredcorners (EAST)"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "aC" = (
 /obj/structure/alien/weeds/node,
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "aD" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
@@ -424,15 +220,7 @@
 	icon_state = "gibdown1_flesh"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "aE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -440,10 +228,7 @@
 	icon_state = "darkredcorners";
 	tag = "icon-darkredcorners (NORTH)"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "aF" = (
 /obj/machinery/gateway{
 	dir = 1
@@ -452,10 +237,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "aG" = (
 /obj/machinery/gateway{
 	dir = 9
@@ -464,10 +246,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "aH" = (
 /obj/machinery/gateway{
 	dir = 5
@@ -476,10 +255,7 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "aI" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
@@ -494,15 +270,7 @@
 	icon_state = "gib1_flesh"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "aJ" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
@@ -512,15 +280,7 @@
 	icon_state = "gib2_flesh"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "aK" = (
 /obj/structure/alien/weeds,
 /obj/structure/alien/weeds{
@@ -532,30 +292,14 @@
 	color = "red"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "aL" = (
 /obj/structure/alien/weeds,
 /mob/living/simple_animal/hostile/alien/drone{
 	plants_off = 1
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "aM" = (
 /obj/machinery/light{
 	dir = 8
@@ -563,10 +307,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "aN" = (
 /obj/machinery/gateway/centeraway{
 	calibrated = 0
@@ -574,10 +315,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "aO" = (
 /obj/machinery/gateway{
 	dir = 8
@@ -586,22 +324,16 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "aP" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "aQ" = (
 /obj/machinery/gateway{
 	dir = 4
@@ -610,26 +342,14 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "aR" = (
 /obj/item/stack/ore/iron{
 	pixel_x = 7;
 	pixel_y = -6
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "aS" = (
 /obj/structure/alien/weeds,
 /mob/living/simple_animal/hostile/alien/queen/large{
@@ -639,45 +359,28 @@
 	plants_off = 1
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "aT" = (
 /turf/simulated/wall,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "aU" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkredcorners";
 	tag = "icon-darkredcorners (WEST)"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "aV" = (
 /obj/machinery/gateway,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "aW" = (
 /obj/machinery/gateway{
 	dir = 10
@@ -686,20 +389,14 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "aX" = (
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "darkredcorners";
 	tag = "icon-darkredcorners"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "aY" = (
 /obj/machinery/gateway{
 	dir = 6
@@ -709,22 +406,10 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "aZ" = (
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "ba" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
@@ -733,39 +418,20 @@
 	plants_off = 1
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "bb" = (
 /obj/structure/alien/weeds,
 /obj/effect/decal/cleanable/blood{
 	color = "red"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "bc" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bd" = (
 /obj/machinery/vending/cigarette,
 /obj/structure/sign/poster/contraband/smoke{
@@ -774,10 +440,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "be" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -785,10 +448,7 @@
 	icon_state = "darkred";
 	tag = "icon-darkred (SOUTHWEST)"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bf" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -800,20 +460,14 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bg" = (
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "darkred";
 	tag = "icon-darkred (SOUTHEAST)"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -821,10 +475,7 @@
 	icon_state = "darkredcorners";
 	tag = "icon-darkredcorners"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bi" = (
 /obj/structure/alien/weeds,
 /obj/structure/bed/nest,
@@ -839,28 +490,12 @@
 	color = "red"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "bj" = (
 /obj/structure/alien/weeds,
 /mob/living/simple_animal/hostile/alien/sentinel,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "bk" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
@@ -870,35 +505,16 @@
 	icon_state = "gib2_flesh"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "bl" = (
 /turf/simulated/mineral/random/high_chance,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "bm" = (
 /obj/item/cigbutt,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bn" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -910,10 +526,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bo" = (
 /obj/structure/table,
 /obj/machinery/kitchen_machine/microwave{
@@ -926,10 +539,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bp" = (
 /obj/machinery/alarm/monitor{
 	frequency = 1439;
@@ -940,10 +550,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bq" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -958,10 +565,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "br" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -978,10 +582,7 @@
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bs" = (
 /obj/machinery/door/window{
 	dir = 1;
@@ -997,10 +598,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bt" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -1010,10 +608,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bu" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -1025,10 +620,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bv" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms";
@@ -1037,10 +629,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bw" = (
 /obj/structure/sink{
 	pixel_y = 28
@@ -1052,18 +641,12 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bx" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "by" = (
 /obj/structure/table,
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -1075,30 +658,21 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bz" = (
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bA" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bB" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1109,21 +683,15 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bD" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/alarm/monitor{
 	dir = 8;
@@ -1135,16 +703,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bE" = (
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bF" = (
 /obj/structure/toilet{
 	dir = 1
@@ -1152,19 +714,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bH" = (
 /obj/structure/closet/crate/can,
 /obj/item/trash/syndi_cakes,
@@ -1172,55 +728,37 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bI" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bJ" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bK" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bM" = (
 /obj/structure/closet/l3closet/general,
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bN" = (
 /obj/structure/closet/emcloset,
 /obj/structure/window/reinforced{
@@ -1229,27 +767,18 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bO" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Break Room"
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bP" = (
 /obj/structure/grille,
 /obj/structure/window/full/basic,
 /turf/simulated/floor/plating,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1259,16 +788,12 @@
 	tag = ""
 	},
 /obj/machinery/door/airlock/highsecurity{
-	icon_state = "door_locked";
 	locked = 1;
 	name = "Gateway";
 	req_access_txt = "150"
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bR" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -1285,10 +810,7 @@
 /obj/item/multitool,
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plating,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bS" = (
 /obj/machinery/power/smes{
 	charge = 0;
@@ -1302,14 +824,11 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bT" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/computer/monitor,
 /obj/structure/cable{
@@ -1321,10 +840,7 @@
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plating,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bU" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/alarm/monitor{
@@ -1335,31 +851,17 @@
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plating,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bV" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plating,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bW" = (
 /obj/structure/alien/weeds/node,
 /mob/living/simple_animal/hostile/alien,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "bX" = (
 /obj/machinery/mineral/unloading_machine{
 	dir = 1;
@@ -1373,10 +875,7 @@
 /turf/simulated/floor/plating/airless{
 	name = "plating"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bY" = (
 /obj/machinery/conveyor{
 	dir = 2;
@@ -1384,10 +883,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "bZ" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
@@ -1404,19 +900,13 @@
 /turf/simulated/floor/plasteel/airless{
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "ca" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/airless{
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/alien/weeds{
@@ -1427,10 +917,7 @@
 	icon_state = "red";
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cc" = (
 /obj/machinery/alarm/monitor{
 	frequency = 1439;
@@ -1442,10 +929,7 @@
 	icon_state = "floorscorched2";
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/airless{
@@ -1453,10 +937,7 @@
 	icon_state = "red";
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "ce" = (
 /obj/structure/sign/biohazard{
 	pixel_y = 32
@@ -1466,10 +947,7 @@
 /turf/simulated/floor/plasteel/airless{
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cf" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1483,10 +961,7 @@
 /turf/simulated/floor/plasteel/airless{
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cg" = (
 /obj/machinery/light/small{
 	active_power_usage = 0;
@@ -1500,10 +975,7 @@
 	icon_state = "red";
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "ch" = (
 /obj/structure/sign/securearea{
 	pixel_x = 0;
@@ -1513,10 +985,7 @@
 /turf/simulated/floor/plasteel/airless{
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "ci" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1537,41 +1006,29 @@
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cj" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "ck" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plating,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cm" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -1581,40 +1038,28 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cn" = (
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "co" = (
 /turf/simulated/floor/plasteel/airless{
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cp" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel/airless{
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cq" = (
 /obj/machinery/door/airlock/public/glass{
 	density = 0;
 	emagged = 1;
-	icon_state = "door_open";
+	icon_state = "open";
 	locked = 1;
 	name = "Dormitories"
 	},
@@ -1628,30 +1073,21 @@
 	oxygen = 0;
 	temperature = 2.7
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cr" = (
 /turf/simulated/floor/plasteel/airless{
 	dir = 4;
 	icon_state = "red";
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cs" = (
 /turf/simulated/floor/plasteel/airless{
 	dir = 8;
 	icon_state = "red";
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "ct" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -1669,10 +1105,7 @@
 /turf/simulated/floor/plasteel/airless{
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cu" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -1686,10 +1119,7 @@
 	icon_state = "red";
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cv" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -1702,10 +1132,7 @@
 /turf/simulated/floor/plasteel/airless{
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1714,10 +1141,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cx" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -1731,10 +1155,7 @@
 	req_access_txt = "150"
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cy" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1757,10 +1178,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cz" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -1769,19 +1187,13 @@
 	tag = ""
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cA" = (
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cB" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -1791,40 +1203,32 @@
 	},
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cC" = (
 /obj/machinery/mineral/processing_unit{
 	dir = 1;
 	output_dir = 2
 	},
 /obj/effect/decal/warning_stripes/east,
+/obj/machinery/conveyor{
+	dir = 2;
+	id = "awaysyndie"
+	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cD" = (
 /obj/machinery/mineral/processing_unit_console{
 	machinedir = 8
 	},
 /turf/simulated/wall,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel/airless{
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cF" = (
 /obj/structure/grille/broken,
 /obj/item/stack/rods,
@@ -1836,10 +1240,7 @@
 /turf/simulated/floor/plating/airless{
 	name = "plating"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/airless{
@@ -1847,10 +1248,7 @@
 	icon_state = "red";
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/airless{
@@ -1858,20 +1256,14 @@
 	icon_state = "red";
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cI" = (
 /turf/simulated/floor/plasteel/airless{
 	dir = 10;
 	icon_state = "red";
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cJ" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/noalarm{
@@ -1889,20 +1281,14 @@
 	icon_state = "red";
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cK" = (
 /turf/simulated/floor/plasteel/airless{
 	dir = 2;
 	icon_state = "red";
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cL" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
@@ -1912,19 +1298,13 @@
 	icon_state = "red";
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cM" = (
 /obj/item/storage/box/lights/mixed,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plating,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cN" = (
 /obj/structure/cable,
 /obj/machinery/power/port_gen/pacman{
@@ -1933,10 +1313,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cO" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -1946,18 +1323,12 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cP" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plating,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cQ" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "awaysyndie";
@@ -1968,20 +1339,14 @@
 /turf/simulated/floor/plasteel/airless{
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cR" = (
 /obj/effect/landmark/damageturf,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/airless{
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cS" = (
 /obj/machinery/alarm/monitor{
 	dir = 8;
@@ -2002,15 +1367,12 @@
 	icon_state = "red";
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cT" = (
 /obj/machinery/door/airlock{
 	density = 0;
 	emagged = 1;
-	icon_state = "door_open";
+	icon_state = "open";
 	id_tag = "awaydorm4";
 	locked = 1;
 	name = "Dorm 1";
@@ -2023,20 +1385,14 @@
 	name = "floor";
 	tag = "icon-warningcorner (NORTH)"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cU" = (
 /obj/machinery/door/airlock{
 	id_tag = "awaydorm5";
 	name = "Dorm 2"
 	},
 /turf/simulated/floor/wood,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cV" = (
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plasteel/airless{
@@ -2044,20 +1400,14 @@
 	icon_state = "red";
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cW" = (
 /obj/structure/alien/weeds/node,
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel/airless{
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cX" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/metal{
@@ -2071,10 +1421,7 @@
 /turf/simulated/floor/plasteel/airless{
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cY" = (
 /obj/structure/closet/crate,
 /obj/item/storage/bag/ore,
@@ -2084,10 +1431,7 @@
 /obj/item/pickaxe,
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "cZ" = (
 /obj/machinery/door_control{
 	id = "awaydorm4";
@@ -2106,10 +1450,7 @@
 	name = "floor";
 	tag = "icon-warningcorner (NORTH)"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "da" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/airless{
@@ -2118,10 +1459,7 @@
 	name = "floor";
 	tag = "icon-warningcorner (NORTH)"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "db" = (
 /obj/machinery/door_control{
 	id = "awaydorm5";
@@ -2135,31 +1473,17 @@
 /obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "dc" = (
 /turf/simulated/floor/wood,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "dd" = (
 /obj/structure/alien/weeds/node,
 /mob/living/simple_animal/hostile/alien/drone{
 	plants_off = 1
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "de" = (
 /obj/machinery/mineral/stacking_machine{
 	dir = 1;
@@ -2167,20 +1491,18 @@
 	output_dir = 2
 	},
 /obj/effect/decal/warning_stripes/east,
+/obj/machinery/conveyor{
+	dir = 2;
+	id = "awaysyndie"
+	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "df" = (
 /obj/machinery/mineral/stacking_unit_console{
 	machinedir = 8
 	},
 /turf/simulated/wall,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "dg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -2190,10 +1512,7 @@
 /turf/simulated/floor/plasteel/airless{
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "dh" = (
 /obj/structure/chair/wood,
 /obj/machinery/alarm/monitor{
@@ -2211,10 +1530,7 @@
 	name = "floor";
 	tag = "icon-warningcorner (NORTH)"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "di" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -2225,10 +1541,7 @@
 	name = "floor";
 	tag = "icon-warningcorner (NORTH)"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "dj" = (
 /obj/machinery/alarm/monitor{
 	dir = 8;
@@ -2239,19 +1552,13 @@
 	req_access = "150"
 	},
 /turf/simulated/floor/wood,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "dk" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/wood,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "dl" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/glass{
@@ -2262,10 +1569,7 @@
 /turf/simulated/floor/plasteel/airless{
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "dm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/alien/weeds{
@@ -2277,41 +1581,32 @@
 /turf/simulated/floor/plasteel/airless{
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "dn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel/airless{
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "do" = (
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating/airless{
 	name = "plating"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "dp" = (
 /obj/machinery/power/port_gen/pacman/super{
 	desc = "A portable generator for emergency backup power.";
 	name = "S.U.P.E.R.P.A.C.M.A.N.-type portable generator"
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "dq" = (
 /obj/structure/table/wood,
 /obj/structure/sign/poster/contraband/c20r{
@@ -2328,10 +1623,7 @@
 	name = "floor";
 	tag = "icon-warningcorner (NORTH)"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "dr" = (
 /obj/structure/closet/secure_closet{
 	desc = "It's a secure locker for personnel. The first card swiped gains control.";
@@ -2354,10 +1646,7 @@
 	name = "floor";
 	tag = "icon-warningcorner (NORTH)"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "ds" = (
 /obj/structure/closet/secure_closet{
 	desc = "It's a secure locker for personnel. The first card swiped gains control.";
@@ -2373,28 +1662,19 @@
 	},
 /obj/item/stack/spacecash/c50,
 /turf/simulated/floor/wood,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "dt" = (
 /obj/structure/bed,
 /obj/item/bedsheet/syndie,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "du" = (
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating/airless{
 	name = "plating"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "dv" = (
 /obj/item/stack/ore/iron,
 /obj/item/stack/ore/iron{
@@ -2402,34 +1682,19 @@
 	pixel_y = -4
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "dw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/airless{
 	name = "plating"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "dx" = (
 /obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plasteel/airless{
 	name = "floor"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "dy" = (
 /obj/structure/dispenser/oxygen{
 	starting_oxygen_tanks = 9
@@ -2444,38 +1709,17 @@
 /turf/simulated/floor/plating/airless{
 	name = "plating"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "dz" = (
 /obj/item/stack/ore/iron{
 	pixel_x = -3;
 	pixel_y = 9
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "dA" = (
 /turf/simulated/mineral,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "dB" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -2486,7 +1730,7 @@
 	},
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "dC" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/space/syndicate/orange,
@@ -2497,10 +1741,7 @@
 /turf/simulated/floor/plating/airless{
 	name = "plating"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "dD" = (
 /obj/structure/sign/vacuum{
 	desc = "A warning sign which reads 'HOSTILE ATMOSPHERE AHEAD'";
@@ -2513,10 +1754,7 @@
 /turf/simulated/floor/plating/airless{
 	name = "plating"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "dE" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -2526,16 +1764,7 @@
 	icon_state = "tracks"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "dF" = (
 /obj/item/flashlight/lantern{
 	icon_state = "lantern-on";
@@ -2543,16 +1772,7 @@
 	},
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "dG" = (
 /obj/item/mining_scanner,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -2563,16 +1783,7 @@
 	icon_state = "tracks"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "dH" = (
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/plasteel/airless{
@@ -2580,52 +1791,22 @@
 	icon_state = "asteroidplating";
 	name = "plating"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "dI" = (
 /obj/item/storage/bag/ore,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "dJ" = (
 /obj/item/pickaxe/drill,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "dK" = (
 /turf/simulated/floor/plasteel/airless{
 	icon_plating = "asteroidplating";
 	icon_state = "asteroidplating";
 	name = "plating"
 	},
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "dL" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2635,26 +1816,14 @@
 	icon_state = "asteroidplating";
 	name = "plating"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "dM" = (
 /obj/item/stack/ore/iron{
 	pixel_x = -7;
 	pixel_y = -4
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "dN" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
@@ -2677,15 +1846,7 @@
 	icon_state = "tracks"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "dO" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
@@ -2698,58 +1859,23 @@
 	icon_state = "tracks"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "dP" = (
 /obj/structure/alien/weeds/node,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "dQ" = (
 /obj/structure/alien/weeds,
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "dR" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
 	},
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "dS" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
@@ -2761,107 +1887,45 @@
 	plants_off = 1
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a5{
-	always_unpowered = 1;
-	has_gravity = 1;
-	name = "The Hive";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/hive)
 "dT" = (
 /obj/structure/alien/weeds,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "dU" = (
 /obj/structure/alien/weeds/node,
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "dV" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "dW" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
 	},
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "dX" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "dY" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "dZ" = (
 /turf/simulated/wall/r_wall/rust,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ea" = (
 /turf/simulated/wall/r_wall,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eb" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -2869,42 +1933,27 @@
 /turf/simulated/floor/plating/airless{
 	name = "plating"
 	},
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "ec" = (
 /obj/structure/sign/biohazard,
 /turf/simulated/wall/r_wall,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ed" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ee" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ef" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eg" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
@@ -2913,10 +1962,7 @@
 	dir = 4;
 	icon_state = "whitehall"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eh" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -2924,10 +1970,7 @@
 /obj/machinery/portable_atmospherics/canister,
 /obj/structure/alien/weeds,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ei" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -2944,10 +1987,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ej" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -2963,10 +2003,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ek" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -2977,14 +2014,11 @@
 	req_access = null
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "el" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
@@ -2998,10 +2032,7 @@
 	icon_state = "tracks"
 	},
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "em" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
@@ -3014,17 +2045,11 @@
 	icon_state = "tracks"
 	},
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "en" = (
 /obj/structure/alien/weeds,
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eo" = (
 /obj/machinery/light{
 	active_power_usage = 0;
@@ -3043,10 +2068,7 @@
 	network = list("MO19X")
 	},
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ep" = (
 /obj/machinery/sparker{
 	desc = "A wall-mounted ignition device. This one has been applied with an acid-proof coating.";
@@ -3060,18 +2082,12 @@
 	},
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eq" = (
 /obj/structure/alien/weeds,
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "er" = (
 /obj/structure/alien/weeds,
 /obj/structure/bed/nest,
@@ -3081,10 +2097,7 @@
 	stat = 2
 	},
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "es" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
@@ -3098,25 +2111,16 @@
 	icon_state = "tracks"
 	},
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "et" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eu" = (
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ev" = (
 /obj/machinery/light/small{
 	active_power_usage = 0;
@@ -3126,10 +2130,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ew" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -3139,10 +2140,7 @@
 	icon_state = "weeds1"
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ex" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3159,10 +2157,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ey" = (
 /obj/structure/table/reinforced,
 /obj/structure/alien/weeds,
@@ -3176,14 +2171,11 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ez" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor/preopen{
 	desc = "A heavy duty blast door that opens mechanically. This one has been applied with an acid-proof coating.";
@@ -3194,10 +2186,7 @@
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eA" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -3205,10 +2194,7 @@
 	name = "HIGH VOLTAGE"
 	},
 /turf/simulated/wall/r_wall,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eB" = (
 /obj/structure/alien/weeds,
 /obj/structure/bed/nest,
@@ -3222,54 +2208,36 @@
 	icon_state = "gib2_flesh"
 	},
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eC" = (
 /obj/structure/alien/weeds/node,
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eD" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
 	},
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eE" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
 	},
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eF" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
 	},
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eG" = (
 /obj/structure/alien/weeds,
 /obj/structure/bed/nest,
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eH" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
@@ -3281,10 +2249,7 @@
 	icon_state = "tracks"
 	},
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eI" = (
 /obj/structure/alien/weeds,
 /obj/structure/alien/weeds{
@@ -3293,31 +2258,19 @@
 	name = "egg"
 	},
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eJ" = (
 /turf/simulated/wall,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eK" = (
 /turf/simulated/wall/rust,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eL" = (
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "whitehall"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eM" = (
 /obj/structure/grille,
 /obj/machinery/door/poddoor{
@@ -3327,10 +2280,7 @@
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eN" = (
 /obj/machinery/light/small{
 	active_power_usage = 0;
@@ -3347,10 +2297,7 @@
 	dir = 6;
 	icon_state = "whitehall"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eO" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3366,10 +2313,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eP" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door_control{
@@ -3391,10 +2335,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eQ" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
@@ -3405,10 +2346,7 @@
 	name = "egg"
 	},
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eR" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
@@ -3417,28 +2355,22 @@
 	color = "red"
 	},
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eS" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
 	},
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eT" = (
 /turf/simulated/wall,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "eU" = (
 /turf/simulated/wall/rust,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "eV" = (
 /turf/simulated/wall/r_wall,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "eW" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
@@ -3449,10 +2381,7 @@
 	dir = 2;
 	icon_state = "whitehall"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eX" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
@@ -3464,21 +2393,18 @@
 	dir = 2;
 	icon_state = "whitehall"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "eY" = (
 /obj/machinery/power/port_gen/pacman{
 	desc = "A portable generator for emergency backup power.";
 	name = "P.A.C.M.A.N.-type portable generator"
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "eZ" = (
 /obj/machinery/space_heater,
 /obj/machinery/light/small{
@@ -3488,7 +2414,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "fa" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3499,11 +2425,11 @@
 	},
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "fb" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/smes{
 	charge = 1.5e+006;
@@ -3513,14 +2439,14 @@
 	outputting = 0
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "fc" = (
 /obj/machinery/power/terminal{
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/alarm/monitor{
 	frequency = 1439;
@@ -3529,7 +2455,7 @@
 	req_access = null
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "fd" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3539,18 +2465,24 @@
 	tag = ""
 	},
 /obj/effect/decal/cleanable/blood/tracks{
+	color = "red";
 	desc = "Your instincts say you shouldn't be following these.";
 	dir = 5;
-	icon_state = "ltrails_1"
+	icon = 'icons/effects/blood.dmi';
+	icon_state = "tracks"
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	color = "red";
+	desc = "Your instincts say you shouldn't be following these.";
+	dir = 5;
+	icon = 'icons/effects/blood.dmi';
+	icon_state = "tracks"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurplecorner"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fe" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -3559,11 +2491,11 @@
 	tag = ""
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "ff" = (
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "fg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3574,7 +2506,7 @@
 	},
 /obj/item/newspaper,
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "fh" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -3583,10 +2515,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fi" = (
 /obj/structure/closet/crate/freezer,
 /obj/structure/alien/weeds{
@@ -3600,10 +2529,7 @@
 /obj/item/xenos_claw,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fj" = (
 /obj/machinery/firealarm/no_alarm{
 	dir = 2;
@@ -3617,27 +2543,18 @@
 /obj/item/storage/box/syringes,
 /obj/structure/alien/weeds,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fk" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fl" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fm" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3650,10 +2567,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fn" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/structure/window/reinforced,
@@ -3664,15 +2578,12 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fo" = (
 /obj/structure/cable,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor/preopen{
 	desc = "A heavy duty blast door that opens mechanically. This one has been applied with an acid-proof coating.";
@@ -3682,10 +2593,7 @@
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fp" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
@@ -3696,10 +2604,7 @@
 	name = "egg"
 	},
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fq" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
@@ -3711,10 +2616,7 @@
 	stat = 2
 	},
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fr" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3724,15 +2626,18 @@
 	tag = ""
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "fs" = (
 /obj/effect/decal/cleanable/blood/tracks{
+	color = "red";
 	desc = "Your instincts say you shouldn't be following these.";
 	dir = 8;
-	icon_state = "ltrails_1"
+	icon = 'icons/effects/blood.dmi';
+	icon_state = "tracks";
+	pixel_y = 9
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "ft" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3741,17 +2646,19 @@
 	pixel_x = 0;
 	tag = ""
 	},
+/obj/effect/decal/cleanable/blood/tracks{
+	color = "red";
+	desc = "Your instincts say you shouldn't be following these.";
+	dir = 8;
+	icon = 'icons/effects/blood.dmi';
+	icon_state = "tracks"
+	},
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "271";
 	req_one_access_txt = "0"
 	},
-/obj/effect/decal/cleanable/blood/tracks{
-	desc = "Your instincts say you shouldn't be following these.";
-	dir = 8;
-	icon_state = "ltrails_1"
-	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "fu" = (
 /obj/structure/sign/securearea{
 	pixel_x = 32
@@ -3770,10 +2677,7 @@
 	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fv" = (
 /obj/structure/table,
 /obj/item/stack/sheet/mineral/plasma{
@@ -3796,29 +2700,28 @@
 	icon_state = "weeds2"
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fw" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/obj/effect/decal/cleanable/blood/tracks{
-	desc = "Your instincts say you shouldn't be following these.";
-	icon_state = "ltrails_2"
-	},
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
+	},
+/obj/effect/decal/cleanable/blood/splatter{
+	color = "red"
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	color = "red";
+	desc = "Your instincts say you shouldn't be following these.";
+	icon = 'icons/effects/blood.dmi';
+	icon_state = "tracks"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurplecorner"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fx" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3827,7 +2730,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "fy" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3845,7 +2748,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "fz" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3856,10 +2759,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fA" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3869,10 +2769,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fB" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3884,10 +2781,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fC" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3900,10 +2794,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fD" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3917,10 +2808,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fE" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "A one meter section of pipe. This one has been applied with an acid-proof coating.";
@@ -3938,10 +2826,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fF" = (
 /obj/machinery/door/poddoor/preopen{
 	desc = "A heavy duty blast door that opens mechanically. This one has been applied with an acid-proof coating.";
@@ -3968,10 +2853,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fG" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "A one meter section of pipe. This one has been applied with an acid-proof coating.";
@@ -3982,10 +2864,7 @@
 	icon_state = "weeds1"
 	},
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fH" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "A one meter section of pipe. This one has been applied with an acid-proof coating.";
@@ -3999,10 +2878,7 @@
 	color = "red"
 	},
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fI" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "A one meter section of pipe. This one has been applied with an acid-proof coating.";
@@ -4014,10 +2890,7 @@
 	},
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "A one meter section of pipe. This one has been applied with an acid-proof coating.";
@@ -4027,10 +2900,7 @@
 /obj/structure/alien/weeds,
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fK" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	desc = "Has a valve and pump attached to it. This one has been applied with an acid-proof coating.";
@@ -4041,10 +2911,7 @@
 	},
 /obj/structure/alien/weeds,
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fL" = (
 /obj/machinery/light{
 	active_power_usage = 0;
@@ -4061,10 +2928,7 @@
 	network = list("MO19X")
 	},
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fM" = (
 /obj/structure/table,
 /obj/item/paper{
@@ -4074,7 +2938,7 @@
 /obj/item/pickaxe,
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "fN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4083,7 +2947,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "fO" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4093,10 +2957,10 @@
 	tag = ""
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "fP" = (
 /turf/simulated/wall/r_wall/rust,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "fQ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -4109,17 +2973,14 @@
 /obj/machinery/door/airlock/research{
 	density = 0;
 	emagged = 1;
-	icon_state = "door_open";
+	icon_state = "open";
 	locked = 1;
 	name = "Xenobiology Lab";
 	opacity = 0;
 	req_access_txt = "271"
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fR" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4140,15 +3001,12 @@
 	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fS" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/yellow,
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "fT" = (
 /obj/structure/filingcabinet,
 /obj/item/paper{
@@ -4159,10 +3017,7 @@
 	dir = 9;
 	icon_state = "red"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fU" = (
 /obj/structure/sign/poster/official/safety_report{
 	pixel_y = 32
@@ -4175,14 +3030,11 @@
 	dir = 5;
 	icon_state = "red"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "fW" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
@@ -4191,22 +3043,16 @@
 	dir = 8;
 	icon_state = "whitepurplecorner"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fX" = (
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "fY" = (
 /obj/item/cigbutt,
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "fZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4222,10 +3068,10 @@
 	tag = ""
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "ga" = (
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "gb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4;
@@ -4233,14 +3079,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gc" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/grille,
 /obj/machinery/door/poddoor/preopen{
@@ -4254,10 +3097,7 @@
 	item_state = "coil_red1"
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gd" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
@@ -4270,10 +3110,7 @@
 	icon_state = "small"
 	},
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ge" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
@@ -4286,10 +3123,7 @@
 	icon_state = "tracks"
 	},
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gf" = (
 /obj/structure/alien/weeds,
 /obj/structure/bed/nest,
@@ -4301,10 +3135,7 @@
 	icon_state = "tracks"
 	},
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gg" = (
 /obj/structure/alien/weeds,
 /obj/structure/bed/nest,
@@ -4318,10 +3149,7 @@
 	icon_state = "gibdown1_flesh"
 	},
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gh" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4340,7 +3168,7 @@
 	color = "black"
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "gi" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "0";
@@ -4354,7 +3182,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "gj" = (
 /obj/structure/closet/secure_closet{
 	icon_broken = "secbroken";
@@ -4385,10 +3213,7 @@
 	dir = 1;
 	icon_state = "red"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gk" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -30;
@@ -4398,19 +3223,13 @@
 	dir = 8;
 	icon_state = "red"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gl" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "red"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gm" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -4422,20 +3241,14 @@
 	dir = 8;
 	icon_state = "whitepurplecorner"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4;
 	level = 1
 	},
 /turf/simulated/wall/r_wall/rust,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "go" = (
 /obj/structure/sign/biohazard{
 	pixel_x = 32
@@ -4459,10 +3272,7 @@
 	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gp" = (
 /obj/machinery/door/firedoor,
 /obj/structure/extinguisher_cabinet{
@@ -4475,10 +3285,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gq" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -4489,10 +3296,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gr" = (
 /obj/structure/table,
 /obj/item/scalpel{
@@ -4509,20 +3313,14 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gs" = (
 /obj/structure/alien/weeds/node,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gt" = (
 /obj/structure/sink{
 	dir = 8;
@@ -4533,23 +3331,17 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gu" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gv" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/disposalpipe/segment{
 	desc = "An underfloor disposal pipe. This one has been applied with an acid-proof coating.";
@@ -4565,10 +3357,7 @@
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gw" = (
 /obj/structure/disposalpipe/segment{
 	desc = "An underfloor disposal pipe. This one has been applied with an acid-proof coating.";
@@ -4578,10 +3367,7 @@
 /obj/structure/alien/weeds,
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gx" = (
 /obj/structure/disposalpipe/segment{
 	desc = "An underfloor disposal pipe. This one has been applied with an acid-proof coating.";
@@ -4593,26 +3379,17 @@
 	icon_state = "weeds2"
 	},
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4;
 	level = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gz" = (
 /turf/simulated/mineral/random/labormineral,
-/area/awaycontent/a4{
-	has_gravity = 1;
-	name = "Syndicate Outpost"
-	})
+/area/moonoutpost19/syndicateoutpost)
 "gA" = (
 /obj/structure/table,
 /obj/item/mmi,
@@ -4623,10 +3400,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4634,10 +3408,7 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4;
@@ -4646,10 +3417,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gD" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -4662,10 +3430,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gE" = (
 /obj/structure/chair{
 	dir = 4
@@ -4678,10 +3443,7 @@
 	dir = 8;
 	icon_state = "red"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gF" = (
 /obj/item/stack/rods,
 /obj/item/shard{
@@ -4696,29 +3458,20 @@
 	dir = 4;
 	icon_state = "red"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gG" = (
 /obj/effect/decal/cleanable/blood/splatter{
 	color = "red"
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gH" = (
 /obj/structure/grille/broken,
 /obj/item/stack/rods,
 /obj/item/stack/rods,
 /obj/item/shard,
 /turf/simulated/floor/plating,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gI" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
@@ -4727,10 +3480,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gJ" = (
 /obj/structure/table,
 /obj/machinery/light/small{
@@ -4745,10 +3495,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gK" = (
 /obj/structure/filingcabinet/filingcabinet,
 /obj/machinery/light/small{
@@ -4783,14 +3530,11 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gL" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "gM" = (
 /obj/structure/table/reinforced,
 /obj/structure/alien/weeds{
@@ -4806,10 +3550,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gN" = (
 /obj/structure/disposalpipe/segment{
 	desc = "An underfloor disposal pipe. This one has been applied with an acid-proof coating.";
@@ -4819,10 +3560,7 @@
 	icon_state = "weeds1"
 	},
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gO" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
@@ -4831,16 +3569,13 @@
 	name = "Acid-Proof containment chamber blast door"
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gP" = (
 /obj/effect/decal/cleanable/blood/oil{
 	color = "black"
@@ -4863,7 +3598,7 @@
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "gQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4875,7 +3610,7 @@
 /obj/item/stack/rods,
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "gR" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -4885,26 +3620,17 @@
 	dir = 4;
 	icon_state = "red"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gS" = (
 /obj/structure/chair/office/dark,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gT" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurplecorner"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gU" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Post";
@@ -4913,10 +3639,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gV" = (
 /obj/machinery/optable,
 /obj/structure/alien/weeds{
@@ -4926,10 +3649,7 @@
 	dir = 1;
 	icon_state = "whitehall"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gW" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/latex,
@@ -4941,10 +3661,7 @@
 	dir = 1;
 	icon_state = "whitehall"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gX" = (
 /obj/structure/filingcabinet/filingcabinet,
 /obj/item/paper{
@@ -4967,10 +3684,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gY" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
@@ -4978,10 +3692,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "gZ" = (
 /obj/machinery/computer/operating,
 /obj/structure/alien/weeds,
@@ -4989,10 +3700,7 @@
 	dir = 1;
 	icon_state = "whitehall"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ha" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/alien/weeds{
@@ -5002,10 +3710,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hb" = (
 /obj/structure/disposaloutlet{
 	desc = "An outlet for the pneumatic disposal system. This one has been applied with an acid-proof coating.";
@@ -5021,10 +3726,7 @@
 	icon_state = "weeds1"
 	},
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hc" = (
 /obj/machinery/light{
 	active_power_usage = 0;
@@ -5041,10 +3743,7 @@
 	network = list("MO19X")
 	},
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hd" = (
 /obj/machinery/sparker{
 	desc = "A wall-mounted ignition device. This one has been applied with an acid-proof coating.";
@@ -5058,10 +3757,7 @@
 	},
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/engine,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "he" = (
 /obj/machinery/shieldwallgen{
 	locked = 0;
@@ -5069,10 +3765,7 @@
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plating,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hf" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5091,10 +3784,7 @@
 	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hg" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -5102,12 +3792,12 @@
 /obj/item/stock_parts/cell/high,
 /obj/item/radio/off,
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "hh" = (
 /obj/machinery/light/small,
 /obj/structure/closet/toolcloset,
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "hi" = (
 /obj/structure/table,
 /obj/item/book/manual/security_space_law,
@@ -5119,10 +3809,7 @@
 	dir = 10;
 	icon_state = "red"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hj" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -5134,20 +3821,14 @@
 	dir = 6;
 	icon_state = "red"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hk" = (
 /obj/structure/table,
 /obj/item/folder/red,
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hl" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5161,16 +3842,16 @@
 	},
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "hm" = (
 /obj/machinery/computer/monitor,
 /obj/structure/cable,
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "hn" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "ho" = (
 /obj/structure/closet/crate/can,
 /obj/item/clothing/gloves/color/latex,
@@ -5186,10 +3867,7 @@
 	dir = 2;
 	icon_state = "whitehall"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hp" = (
 /obj/structure/table,
 /obj/item/storage/box/gloves{
@@ -5200,10 +3878,7 @@
 	dir = 8;
 	icon_state = "whitecorner"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hq" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/noalarm{
@@ -5220,10 +3895,7 @@
 	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hr" = (
 /obj/structure/table,
 /obj/item/retractor,
@@ -5233,10 +3905,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hs" = (
 /obj/structure/table,
 /obj/item/cartridge/signal/toxins,
@@ -5249,14 +3918,11 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ht" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/light/small{
@@ -5276,21 +3942,18 @@
 	name = "Personal Log &mdash; Gerald Rosswell"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hu" = (
 /obj/structure/closet/crate,
 /obj/item/storage/box/lights/mixed,
 /obj/item/poster/random_contraband,
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "hv" = (
 /obj/machinery/door_control{
 	id = "Awaybiohazard";
@@ -5310,19 +3973,13 @@
 	dir = 8;
 	icon_state = "red"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hw" = (
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hx" = (
 /obj/structure/grille,
 /obj/machinery/door/poddoor{
@@ -5331,10 +3988,7 @@
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hy" = (
 /obj/item/stack/rods,
 /obj/item/shard{
@@ -5343,10 +3997,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hz" = (
 /obj/effect/decal/cleanable/blood/gibs/robot,
 /obj/effect/decal/cleanable/blood/oil{
@@ -5368,10 +4019,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hA" = (
 /obj/structure/grille/broken,
 /obj/item/stack/rods,
@@ -5380,10 +4028,7 @@
 	icon_state = "medium"
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hB" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/fire{
@@ -5398,31 +4043,22 @@
 	dir = 8;
 	icon_state = "whitehall"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hC" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hE" = (
 /obj/machinery/light{
 	active_power_usage = 0;
@@ -5443,10 +4079,7 @@
 	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hF" = (
 /obj/structure/noticeboard{
 	dir = 1;
@@ -5471,19 +4104,13 @@
 	dir = 8;
 	icon_state = "whitepurplecorner"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hH" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -5493,7 +4120,7 @@
 	},
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "hI" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular{
@@ -5513,22 +4140,13 @@
 	dir = 8;
 	icon_state = "whitehall"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hJ" = (
 /turf/simulated/wall/rust,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "hK" = (
 /turf/simulated/wall,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "hL" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -5539,7 +4157,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "hM" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5549,18 +4167,15 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "hN" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -5573,20 +4188,14 @@
 	dir = 8;
 	icon_state = "whitepurplecorner"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hP" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitehall"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hQ" = (
 /obj/structure/toilet{
 	dir = 4
@@ -5598,10 +4207,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "hR" = (
 /obj/structure/urinal{
 	pixel_y = 29
@@ -5609,10 +4215,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "hS" = (
 /obj/machinery/door/airlock{
 	name = "Unit 2"
@@ -5620,10 +4223,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "hT" = (
 /obj/structure/sink{
 	dir = 4;
@@ -5641,10 +4241,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "hU" = (
 /obj/machinery/shower{
 	pixel_y = 16
@@ -5653,10 +4250,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "hV" = (
 /obj/machinery/shower{
 	pixel_y = 16
@@ -5664,17 +4258,11 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "hW" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "hX" = (
 /obj/structure/closet/secure_closet{
 	icon_broken = "secureresbroken";
@@ -5689,10 +4277,7 @@
 	},
 /obj/item/clothing/suit/storage/labcoat,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hY" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -5707,14 +4292,11 @@
 	pixel_y = -2
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "hZ" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -5722,14 +4304,11 @@
 	pixel_y = 9
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ia" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -5741,28 +4320,22 @@
 	network = list("MO19X","MO19R")
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ib" = (
 /obj/machinery/computer/aifixer,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ic" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -5775,10 +4348,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "id" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -5791,10 +4361,7 @@
 	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ie" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced{
@@ -5805,19 +4372,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "if" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ig" = (
 /obj/structure/closet/l3closet/general,
 /obj/effect/decal/cleanable/dirt,
@@ -5825,10 +4386,7 @@
 	dir = 1;
 	icon_state = "whitehall"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ih" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/hud/health,
@@ -5841,10 +4399,7 @@
 	dir = 1;
 	icon_state = "whitehall"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ii" = (
 /obj/structure/closet/l3closet/general,
 /obj/machinery/light/small{
@@ -5857,20 +4412,14 @@
 	dir = 1;
 	icon_state = "whitehall"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ij" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitecorner"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ik" = (
 /obj/machinery/alarm/monitor{
 	dir = 4;
@@ -5886,10 +4435,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "il" = (
 /obj/structure/sink{
 	dir = 4;
@@ -5898,26 +4444,20 @@
 	pixel_y = 0
 	},
 /obj/structure/mirror{
+	broken = 1;
 	desc = "Oh no, seven years of bad luck!";
 	icon_state = "mirror_broke";
-	pixel_x = 28;
-	broken = 1
+	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "im" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "in" = (
 /obj/item/soap/nanotrasen,
 /obj/machinery/light/small{
@@ -5926,10 +4466,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "io" = (
 /obj/machinery/shower{
 	dir = 8
@@ -5937,10 +4474,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "ip" = (
 /obj/structure/rack,
 /obj/item/paicard{
@@ -5950,10 +4484,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "iq" = (
 /obj/structure/window/reinforced,
 /obj/structure/closet/secure_closet{
@@ -5972,42 +4503,30 @@
 /obj/item/clothing/mask/gas,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ir" = (
 /obj/structure/chair/office/light{
 	dir = 1;
 	pixel_y = 3
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "is" = (
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "it" = (
 /obj/structure/rack,
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "iu" = (
 /obj/effect/decal/cleanable/blood/splatter{
 	color = "red"
@@ -6015,19 +4534,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "iv" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "iw" = (
 /obj/item/storage/secure/safe{
 	pixel_x = 32;
@@ -6043,10 +4556,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ix" = (
 /obj/structure/toilet{
 	dir = 4
@@ -6057,10 +4567,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "iy" = (
 /obj/machinery/door/airlock{
 	name = "Unit 1"
@@ -6068,10 +4575,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "iz" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Showers"
@@ -6079,19 +4583,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "iA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "iB" = (
 /obj/machinery/shower{
 	dir = 8
@@ -6100,40 +4598,28 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "iC" = (
 /obj/structure/table,
 /obj/item/cigbutt,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "iD" = (
 /obj/structure/table,
 /obj/item/trash/plate,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "iE" = (
 /obj/structure/table,
 /obj/item/trash/raisins,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "iF" = (
 /obj/machinery/door/airlock{
 	name = "Private Restroom"
@@ -6141,10 +4627,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "iG" = (
 /obj/machinery/vending/medical{
 	req_access_txt = "271"
@@ -6153,10 +4636,7 @@
 	dir = 2;
 	icon_state = "whitehall"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "iH" = (
 /obj/structure/sink{
 	pixel_y = 28
@@ -6167,10 +4647,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "iI" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = 0;
@@ -6188,41 +4665,32 @@
 	network = list("MO19","MO19R")
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "iJ" = (
 /obj/machinery/newscaster{
 	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "iK" = (
 /obj/structure/table,
 /obj/item/radio/off,
 /obj/item/laser_pointer,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "iL" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -6233,7 +4701,7 @@
 	},
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "iM" = (
 /obj/structure/sign/securearea{
 	pixel_y = 32
@@ -6248,20 +4716,14 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "iN" = (
 /obj/structure/closet/firecloset,
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "iO" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -6272,20 +4734,14 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "iP" = (
 /obj/machinery/light/small,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "iQ" = (
 /obj/machinery/shower{
 	dir = 1;
@@ -6294,10 +4750,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "iR" = (
 /obj/structure/chair{
 	dir = 1
@@ -6306,10 +4759,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "iS" = (
 /obj/structure/chair{
 	dir = 1
@@ -6317,10 +4767,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "iT" = (
 /obj/structure/chair{
 	dir = 1
@@ -6331,33 +4778,24 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "iU" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = 0;
 	pixel_y = 0
 	},
 /turf/simulated/wall/rust,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "iV" = (
 /obj/machinery/vending/boozeomat{
 	req_access_txt = "0"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "iW" = (
 /obj/structure/table,
 /obj/machinery/kitchen_machine/microwave{
@@ -6365,10 +4803,7 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor/plating/airless,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "iX" = (
 /obj/structure/table,
 /obj/machinery/kitchen_machine/microwave{
@@ -6377,32 +4812,23 @@
 	},
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plating/airless,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "iY" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "iZ" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "ja" = (
 /obj/structure/toilet{
 	dir = 1
@@ -6410,24 +4836,12 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "jb" = (
 /obj/item/stack/rods,
 /obj/item/shard,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "jc" = (
 /obj/structure/table,
 /obj/item/storage/secure/briefcase,
@@ -6438,10 +4852,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "jd" = (
 /obj/structure/sink{
 	dir = 8;
@@ -6454,20 +4865,14 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "je" = (
 /obj/machinery/vending/snack,
 /obj/structure/sign/poster/official/ue_no{
 	pixel_y = 32
 	},
 /turf/simulated/floor/plating/airless,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jf" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms";
@@ -6476,37 +4881,25 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jg" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jh" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "ji" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jj" = (
 /obj/structure/closet/crate/can,
 /obj/machinery/light/small{
@@ -6517,34 +4910,22 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jk" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jl" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jm" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/carpet,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jn" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small,
@@ -6552,21 +4933,15 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "jo" = (
 /obj/effect/decal/cleanable/flour,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jp" = (
 /obj/machinery/firealarm/no_alarm{
 	dir = 4;
@@ -6575,14 +4950,11 @@
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jq" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -6599,10 +4971,7 @@
 	name = "Serving Hatch"
 	},
 /turf/simulated/floor/carpet,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jr" = (
 /obj/structure/closet/secure_closet{
 	icon_broken = "rdsecurebroken";
@@ -6618,38 +4987,29 @@
 /obj/item/storage/backpack/satchel_tox,
 /obj/item/clothing/gloves/color/latex,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "js" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jt" = (
 /obj/structure/closet/crate/can,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ju" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -6663,34 +5023,22 @@
 	level = 1
 	},
 /turf/simulated/floor/plating/airless,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jv" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jw" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jx" = (
 /obj/structure/table,
 /obj/item/book/manual/detective,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jy" = (
 /obj/structure/sign/science{
 	pixel_x = 0;
@@ -6702,20 +5050,14 @@
 	icon_state = "purple";
 	tag = "icon-purple (NORTHWEST)"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jz" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "purple";
 	tag = "icon-purple (NORTHEAST)"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4;
@@ -6725,10 +5067,7 @@
 	dir = 1;
 	icon_state = "whitepurplecorner"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "jB" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
@@ -6737,48 +5076,21 @@
 	icon_state = "weeds2"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "jC" = (
 /obj/structure/alien/weeds,
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "jD" = (
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
 	},
 /obj/structure/alien/weeds/node,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "jE" = (
 /obj/item/twohanded/required/kirbyplants{
 	desc = "A plastic potted plant.";
@@ -6788,40 +5100,25 @@
 /obj/effect/landmark/burnturf,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jG" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jH" = (
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jI" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jJ" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
@@ -6831,10 +5128,7 @@
 	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "jK" = (
 /obj/structure/noticeboard{
 	pixel_y = 32
@@ -6845,10 +5139,7 @@
 	},
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jL" = (
 /obj/machinery/alarm/monitor{
 	frequency = 1439;
@@ -6857,10 +5148,7 @@
 	req_access = null
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jM" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -6870,36 +5158,24 @@
 /obj/item/newspaper,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jN" = (
 /obj/item/cigbutt,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jO" = (
 /obj/structure/grille,
 /obj/structure/window/full/basic,
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jP" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "jQ" = (
 /obj/structure/table,
 /obj/item/book/manual/barman_recipes{
@@ -6907,14 +5183,11 @@
 	},
 /obj/item/reagent_containers/food/drinks/shaker,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jR" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets{
@@ -6922,25 +5195,19 @@
 	pixel_y = 3
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jS" = (
 /obj/machinery/vending/dinnerware,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jT" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -6950,10 +5217,7 @@
 	name = "Serving Hatch"
 	},
 /turf/simulated/floor/carpet,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jU" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 0;
@@ -6962,10 +5226,7 @@
 /obj/effect/landmark/burnturf,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jV" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 0;
@@ -6973,10 +5234,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jW" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -6986,22 +5244,16 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "jX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "jY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -7015,24 +5267,18 @@
 	req_one_access_txt = "0"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "jZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "ka" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Research Storage";
@@ -7041,14 +5287,11 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "kb" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "kc" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -7058,26 +5301,20 @@
 	},
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "kd" = (
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating/airless{
 	name = "plating"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "ke" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating/airless{
 	name = "plating"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kf" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
@@ -7085,24 +5322,18 @@
 	pressure_checks = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "kg" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kh" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -7116,10 +5347,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "ki" = (
 /obj/machinery/door/airlock/research{
 	id_tag = "";
@@ -7131,10 +5359,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "kj" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -7155,14 +5380,11 @@
 	req_access_txt = "271"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a2{
-	has_gravity = 1;
-	name = "MO19 Research"
-	})
+/area/moonoutpost19/mo19research)
 "kk" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -7173,7 +5395,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "kl" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -7184,10 +5406,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "km" = (
 /obj/structure/closet/crate/can,
 /obj/item/trash/candy,
@@ -7196,10 +5415,7 @@
 	dir = 2;
 	icon_state = "arrival"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kn" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -7212,41 +5428,32 @@
 	color = "black"
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a7)
+/area/moonoutpost19/mo19utilityroom)
 "ko" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Diner"
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kq" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
 /obj/item/kitchen/knife,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kr" = (
 /obj/structure/table,
 /obj/item/book/manual/chef_recipes{
@@ -7255,29 +5462,23 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "ks" = (
 /obj/effect/decal/cleanable/plant_smudge,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kt" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/processor,
 /obj/machinery/alarm/monitor{
@@ -7289,14 +5490,11 @@
 	req_access = null
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "ku" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -7312,29 +5510,20 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "arrival"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kw" = (
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "arrival"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kx" = (
 /obj/machinery/light/small,
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -7350,19 +5539,13 @@
 	dir = 2;
 	icon_state = "arrival"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "ky" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitecorner"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kz" = (
 /obj/structure/sign/poster/official/nanotrasen_logo{
 	pixel_y = -32
@@ -7371,10 +5554,7 @@
 	dir = 2;
 	icon_state = "arrival"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kA" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -7389,10 +5569,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kB" = (
 /obj/machinery/door/firedoor{
 	density = 1;
@@ -7401,10 +5578,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7413,14 +5587,11 @@
 	icon_state = "purple";
 	tag = "icon-purple (NORTH)"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kD" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/noalarm{
 	cell_type = 15000;
@@ -7433,18 +5604,12 @@
 	start_charge = 100
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kE" = (
 /turf/simulated/floor/plating/airless{
 	name = "plating"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kF" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -7460,10 +5625,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kG" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -7479,10 +5641,7 @@
 /obj/effect/landmark/damageturf,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kH" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -7499,10 +5658,7 @@
 /turf/simulated/floor/plating/airless{
 	name = "plating"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -7518,10 +5674,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kJ" = (
 /obj/machinery/door/firedoor{
 	density = 1;
@@ -7529,10 +5682,7 @@
 	opacity = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kK" = (
 /obj/machinery/firealarm/no_alarm{
 	dir = 1;
@@ -7540,10 +5690,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kL" = (
 /obj/effect/decal/cleanable/blood/xeno{
 	color = "green"
@@ -7552,10 +5699,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kM" = (
 /obj/effect/decal/cleanable/blood/xeno{
 	color = "green"
@@ -7566,32 +5710,23 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kN" = (
 /obj/structure/closet/crate/can,
 /obj/item/trash/plate,
 /obj/item/reagent_containers/food/snacks/badrecipe,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kO" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "arrival"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kP" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -7609,10 +5744,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kQ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -7628,10 +5760,7 @@
 /obj/effect/landmark/burnturf,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kR" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -7652,10 +5781,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kS" = (
 /obj/machinery/door/firedoor{
 	density = 1;
@@ -7666,10 +5792,7 @@
 	dir = 2;
 	icon_state = "neutralcorner"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kT" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/remains/human{
@@ -7679,10 +5802,7 @@
 /turf/simulated/floor/plating/airless{
 	name = "plating"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kU" = (
 /obj/machinery/light/small,
 /obj/structure/cable{
@@ -7698,10 +5818,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kV" = (
 /obj/machinery/door_control{
 	id = "awaydorm1";
@@ -7713,10 +5830,7 @@
 	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kW" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -7731,40 +5845,28 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kX" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "0";
 	req_one_access_txt = "0"
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kY" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel{
 	dir = 0;
 	icon_state = "blue"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "kZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 0;
 	icon_state = "blue"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "la" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -7776,20 +5878,14 @@
 	dir = 0;
 	icon_state = "blue"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lb" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lc" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 26;
@@ -7801,34 +5897,25 @@
 	network = list("MO19")
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "ld" = (
 /turf/simulated/floor/plating/asteroid/airless,
 /turf/simulated/shuttle/wall{
-	tag = "icon-swall_f6";
+	dir = 2;
 	icon_state = "swall_f6";
-	dir = 2
+	tag = "icon-swall_f6"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "le" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall12";
-	dir = 2
+	dir = 2;
+	icon_state = "swall12"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lf" = (
 /turf/simulated/floor/plating/asteroid/airless,
 /turf/simulated/shuttle/wall{
@@ -7836,20 +5923,14 @@
 	icon_state = "swall_f10";
 	layer = 2
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lg" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "arrival"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4;
@@ -7857,10 +5938,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "li" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -7874,35 +5952,20 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lj" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lk" = (
 /obj/item/stack/rods,
 /obj/item/shard{
 	icon_state = "small"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "ll" = (
 /obj/item/stack/rods,
 /obj/structure/grille/broken,
@@ -7913,10 +5976,7 @@
 /turf/simulated/floor/plating/airless{
 	name = "plating"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lm" = (
 /obj/structure/grille/broken,
 /obj/item/stack/rods,
@@ -7924,33 +5984,21 @@
 /turf/simulated/floor/plating/airless{
 	name = "plating"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "ln" = (
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lo" = (
 /turf/simulated/floor/carpet,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lp" = (
 /obj/machinery/door/airlock{
 	id_tag = "awaydorm1";
 	name = "Dorm 1"
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lq" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -7965,10 +6013,7 @@
 	req_access = null
 	},
 /turf/simulated/floor/carpet,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lr" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -7986,10 +6031,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "ls" = (
 /obj/structure/chair{
 	dir = 8
@@ -7997,10 +6039,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lt" = (
 /obj/machinery/firealarm/no_alarm{
 	dir = 4;
@@ -8015,10 +6054,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lu" = (
 /obj/machinery/door_control{
 	id = "awaykitchen";
@@ -8029,22 +6065,16 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lv" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lw" = (
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
@@ -8055,19 +6085,13 @@
 	icon_state = "showroomfloor";
 	temperature = 273.15
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lx" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor";
 	temperature = 273.15
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "ly" = (
 /obj/structure/closet/crate{
 	desc = "It's a storage unit for kitchen clothes and equipment.";
@@ -8079,54 +6103,36 @@
 	icon_state = "showroomfloor";
 	temperature = 273.15
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lz" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall14";
-	dir = 2
+	dir = 2;
+	icon_state = "swall14"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lA" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall8";
-	dir = 2
+	dir = 2;
+	icon_state = "swall8"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lB" = (
 /obj/structure/grille,
-/obj/structure/window/full/reinforced,
+/obj/structure/window/full/shuttle,
 /turf/simulated/shuttle/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lC" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall4";
-	dir = 2
+	dir = 2;
+	icon_state = "swall4"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lD" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall1";
-	dir = 2
+	dir = 2;
+	icon_state = "swall1"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/airless{
@@ -8134,10 +6140,7 @@
 	icon_state = "neutral";
 	name = "floor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lF" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4;
@@ -8145,18 +6148,12 @@
 	tag = "icon-burst_r (WEST)"
 	},
 /turf/simulated/shuttle/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lG" = (
 /obj/effect/landmark/damageturf,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lH" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
@@ -8165,18 +6162,12 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lJ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -8194,42 +6185,31 @@
 	icon_state = "purplecorner";
 	tag = "icon-purplecorner (NORTH)"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lK" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (EAST)";
+	dir = 4;
 	icon_state = "heater";
-	dir = 4
+	tag = "icon-heater (EAST)"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/simulated/shuttle/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lL" = (
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plasteel/airless{
+	germ_level = 20;
 	icon_state = "neutralcorner";
 	name = "floor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lM" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
 /turf/simulated/floor/carpet,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lN" = (
 /obj/structure/table/wood,
 /obj/item/lighter/zippo,
@@ -8238,32 +6218,20 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/carpet,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lO" = (
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lQ" = (
 /obj/effect/decal/cleanable/blood/oil{
 	color = "black"
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lR" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -8289,27 +6257,18 @@
 	dir = 4;
 	icon_state = "purplecorner"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lS" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lU" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -8317,10 +6276,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lV" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -8333,47 +6289,32 @@
 	icon_state = "showroomfloor";
 	temperature = 273.15
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lW" = (
 /turf/simulated/shuttle/floor,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f9";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f9"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lX" = (
 /obj/structure/table,
 /obj/item/storage/lockbox,
 /turf/simulated/shuttle/floor,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lY" = (
 /obj/structure/table,
 /obj/item/radio/off,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor2"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "lZ" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall3";
-	dir = 2
+	dir = 2;
+	icon_state = "swall3"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "ma" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = -32;
@@ -8382,10 +6323,7 @@
 /turf/simulated/shuttle/floor{
 	icon_state = "floor2"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mb" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -8394,25 +6332,16 @@
 	dir = 8
 	},
 /turf/simulated/shuttle/floor,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mc" = (
 /turf/simulated/shuttle/floor,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "md" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
 /turf/simulated/shuttle/floor,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "me" = (
 /obj/machinery/newscaster{
 	pixel_x = 0;
@@ -8422,17 +6351,11 @@
 	dir = 1
 	},
 /turf/simulated/shuttle/floor,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mf" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/shuttle/floor,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mg" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4;
@@ -8440,36 +6363,25 @@
 	tag = "icon-burst_l (WEST)"
 	},
 /turf/simulated/shuttle/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mi" = (
 /turf/simulated/floor/plasteel/airless{
+	germ_level = 20;
 	icon_state = "neutralcorner";
 	name = "floor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mj" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mk" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/cleanable/dirt,
@@ -8477,29 +6389,20 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "ml" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mm" = (
 /obj/structure/table,
 /obj/item/storage/backpack/satchel/withwallet,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mn" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -8517,10 +6420,7 @@
 	dir = 4;
 	icon_state = "purplecorner"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mo" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -8531,10 +6431,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mp" = (
 /obj/machinery/door/firedoor{
 	density = 1;
@@ -8553,18 +6450,12 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mq" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
 /turf/simulated/shuttle/floor,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mr" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -8575,27 +6466,18 @@
 /turf/simulated/shuttle/floor{
 	icon_state = "floor2"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "ms" = (
 /turf/simulated/shuttle/floor{
 	icon_state = "floor2"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mt" = (
 /obj/effect/landmark{
 	name = "awaystart"
 	},
 /turf/simulated/shuttle/floor,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mu" = (
 /obj/effect/landmark{
 	name = "awaystart"
@@ -8604,10 +6486,7 @@
 	dir = 8
 	},
 /turf/simulated/shuttle/floor,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mv" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -8618,10 +6497,7 @@
 /turf/simulated/shuttle/floor{
 	icon_state = "floor2"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mw" = (
 /obj/machinery/firealarm/no_alarm{
 	dir = 4;
@@ -8629,13 +6505,11 @@
 	},
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plasteel/airless{
+	germ_level = 20;
 	icon_state = "neutralcorner";
 	name = "floor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mx" = (
 /obj/structure/grille,
 /obj/structure/sign/vacuum{
@@ -8645,10 +6519,7 @@
 	},
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "my" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -8658,18 +6529,12 @@
 	icon_state = "tracks"
 	},
 /turf/simulated/floor/plating/airless,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mz" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mA" = (
 /obj/structure/table/wood,
 /obj/machinery/door_control{
@@ -8686,28 +6551,19 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/carpet,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mB" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/simulated/floor/carpet,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mC" = (
 /obj/machinery/computer/arcade,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mD" = (
 /obj/machinery/vending/cigarette,
 /obj/structure/sign/poster/contraband/smoke{
@@ -8716,10 +6572,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mE" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -8728,10 +6581,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mF" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey{
@@ -8749,26 +6599,17 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mG" = (
 /obj/structure/chair/comfy/beige,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mH" = (
 /obj/machinery/computer/shuttle,
 /turf/simulated/shuttle/floor,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mI" = (
 /obj/machinery/door/airlock/shuttle{
 	name = "Shuttle Cockpit"
@@ -8776,10 +6617,7 @@
 /turf/simulated/shuttle/floor{
 	icon_state = "floor2"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mJ" = (
 /obj/effect/landmark{
 	name = "awaystart"
@@ -8787,10 +6625,7 @@
 /turf/simulated/shuttle/floor{
 	icon_state = "floor2"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mK" = (
 /obj/structure/sign/vacuum{
 	desc = "A beacon used by a teleporter.";
@@ -8804,61 +6639,41 @@
 /turf/simulated/shuttle/floor{
 	icon_state = "floor2"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mL" = (
 /obj/machinery/door/airlock/shuttle{
 	name = "Shuttle Airlock"
 	},
 /turf/simulated/shuttle/floor,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mM" = (
 /obj/structure/closet/emcloset,
 /obj/structure/window/basic,
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mN" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mO" = (
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mP" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/airless{
+	germ_level = 20;
 	icon_state = "neutralcorner";
 	name = "floor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/camera{
@@ -8867,10 +6682,7 @@
 	network = list("MO19")
 	},
 /turf/simulated/floor/plating/airless,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mS" = (
 /obj/machinery/firealarm/no_alarm{
 	dir = 4;
@@ -8878,10 +6690,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mT" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -8891,10 +6700,7 @@
 	icon_state = "tracks"
 	},
 /turf/simulated/floor/carpet,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mU" = (
 /obj/machinery/door/airlock{
 	id_tag = "awaydorm2";
@@ -8908,10 +6714,7 @@
 	icon_state = "tracks"
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mV" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -8925,19 +6728,13 @@
 	req_access = null
 	},
 /turf/simulated/floor/carpet,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mW" = (
 /obj/structure/table,
 /obj/item/clipboard,
 /obj/item/pen,
 /turf/simulated/shuttle/floor,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mX" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -8946,19 +6743,13 @@
 /turf/simulated/shuttle/floor{
 	icon_state = "floor2"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mY" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall2";
-	dir = 2
+	dir = 2;
+	icon_state = "swall2"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "mZ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -8967,26 +6758,17 @@
 /turf/simulated/shuttle/floor{
 	icon_state = "floor2"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "na" = (
 /obj/item/cigbutt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nb" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nc" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -8994,10 +6776,7 @@
 	color = "red"
 	},
 /turf/simulated/floor/carpet,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nd" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -9012,47 +6791,32 @@
 	icon_state = "neutralcorner";
 	name = "floor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "ne" = (
 /turf/simulated/floor/plating/asteroid/airless,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f5";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f5"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nf" = (
 /turf/simulated/shuttle/floor,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f10";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f10"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "ng" = (
 /obj/structure/filingcabinet,
 /turf/simulated/shuttle/floor,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nh" = (
 /obj/machinery/light/small,
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
 /turf/simulated/shuttle/floor,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "ni" = (
 /obj/machinery/newscaster{
 	pixel_x = 0;
@@ -9060,10 +6824,7 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/shuttle/floor,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nj" = (
 /obj/structure/grille/broken,
 /obj/item/stack/rods,
@@ -9079,10 +6840,7 @@
 /turf/simulated/floor/plating/airless{
 	name = "plating"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nk" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -9095,43 +6853,28 @@
 /turf/simulated/floor/plating/airless{
 	name = "plating"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nl" = (
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/generic,
 /obj/structure/window/basic,
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nm" = (
 /obj/item/cigbutt,
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/candy,
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "no" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall13";
-	dir = 2
+	dir = 2;
+	icon_state = "swall13"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "np" = (
 /obj/structure/sign/vacuum{
 	desc = "A warning sign which reads 'HOSTILE ATMOSPHERE AHEAD'";
@@ -9140,73 +6883,47 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nq" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nr" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "ns" = (
 /obj/structure/table,
 /obj/item/deck/cards,
 /obj/effect/landmark/damageturf,
-/turf/simulated/floor/plasteel/airless{
-	dir = 8;
-	icon_state = "neutralcorner";
-	name = "floor"
+/turf/simulated/floor/plasteel{
+	germ_level = 20
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nt" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nu" = (
 /obj/structure/grille/broken,
 /obj/item/stack/rods,
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nv" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nw" = (
 /turf/simulated/floor/plating/asteroid/airless,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f9";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f9"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nx" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -9216,10 +6933,7 @@
 	icon_state = "asteroidplating";
 	name = "plating"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "ny" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -9236,20 +6950,14 @@
 	icon_state = "barber";
 	name = "floor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nz" = (
 /obj/machinery/washing_machine,
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "barber";
 	name = "floor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nA" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -9263,26 +6971,17 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nB" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nC" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nD" = (
 /obj/item/stack/rods,
 /obj/item/shard{
@@ -9296,16 +6995,7 @@
 	icon_state = "tracks"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "nE" = (
 /obj/machinery/alarm/monitor{
 	dir = 8;
@@ -9316,38 +7006,27 @@
 	req_access = null
 	},
 /turf/simulated/floor/plasteel/airless{
+	germ_level = 20;
 	icon_state = "neutralcorner";
 	name = "floor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nG" = (
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes/dromedaryco,
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nI" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -9364,31 +7043,26 @@
 	desc = "They look like human remains. The skeleton is laid out on its side and there seems to have been no sign of struggle.";
 	layer = 4.1
 	},
-/turf/simulated/floor/carpet,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/turf/simulated/floor/carpet{
+	germ_level = 20
+	},
+/area/moonoutpost19/mo19arrivals)
 "nJ" = (
 /obj/structure/dresser,
 /obj/item/paper{
 	info = "<i>Bugs break out. I run to here and lock door. I hear door next to me break open and screams. All nice people here dead now. I no want to be eaten, and bottle always said to be coward way out, but person who say that is stupid. Mira, there is no escape for me, tell Alexis and Elena that father will never come home, and that I love you all.</i>";
 	name = "Note"
 	},
-/turf/simulated/floor/carpet,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/turf/simulated/floor/carpet{
+	germ_level = 20
+	},
+/area/moonoutpost19/mo19arrivals)
 "nK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nL" = (
 /obj/structure/sign/vacuum{
 	desc = "A warning sign which reads 'HOSTILE ATMOSPHERE AHEAD'";
@@ -9396,89 +7070,66 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nM" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4;
 	level = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nO" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel/airless{
-	dir = 8;
-	icon_state = "neutralcorner";
-	name = "floor"
+/turf/simulated/floor/plasteel{
+	germ_level = 20
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nP" = (
 /obj/item/pen,
 /obj/item/storage/pill_bottle{
 	pixel_y = 6
 	},
-/turf/simulated/floor/carpet,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/turf/simulated/floor/carpet{
+	germ_level = 20
+	},
+/area/moonoutpost19/mo19arrivals)
 "nQ" = (
 /obj/machinery/door/airlock{
-	icon_state = "door_locked";
+	density = 0;
+	icon_state = "open";
 	id_tag = "awaydorm3";
 	locked = 1;
-	name = "Dorm 3"
+	name = "Dorm 3";
+	opacity = 0
 	},
-/turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/turf/simulated/floor/plasteel{
+	germ_level = 20
+	},
+/area/moonoutpost19/mo19arrivals)
 "nR" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nS" = (
 /obj/structure/closet,
 /obj/item/storage/box/lights/mixed,
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nT" = (
 /turf/simulated/floor/plasteel/airless{
 	dir = 4;
 	icon_state = "neutral";
 	name = "floor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -9492,29 +7143,22 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nV" = (
 /obj/machinery/newscaster{
 	pixel_x = 30;
 	pixel_y = 0
 	},
-/turf/simulated/floor/carpet,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/turf/simulated/floor/carpet{
+	germ_level = 20
+	},
+/area/moonoutpost19/mo19arrivals)
 "nW" = (
 /obj/structure/grille,
 /obj/structure/disposalpipe/segment,
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nX" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -9537,20 +7181,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nY" = (
 /turf/simulated/floor/plasteel/airless{
 	dir = 4;
+	germ_level = 20;
 	icon_state = "neutralcorner";
 	name = "floor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "nZ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -9560,38 +7199,27 @@
 	icon_state = "asteroidplating";
 	name = "plating"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "oa" = (
 /turf/simulated/floor/plating/airless,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "ob" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
 /turf/simulated/floor/plating/airless,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "oc" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plasteel/airless{
+	germ_level = 20;
 	icon_state = "neutralcorner";
 	name = "floor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "od" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/airless{
@@ -9599,44 +7227,17 @@
 	icon_state = "asteroidplating";
 	name = "plating"
 	},
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "oe" = (
 /obj/item/shard{
 	icon_state = "small"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "of" = (
 /obj/item/trash/candy,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "og" = (
 /obj/item/twohanded/required/kirbyplants{
 	desc = "A plastic potted plant.";
@@ -9647,30 +7248,15 @@
 	icon_state = "neutral";
 	name = "floor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "oh" = (
 /obj/item/pickaxe,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "oi" = (
 /obj/structure/chair/comfy/black,
 /turf/simulated/floor/plating/airless,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "oj" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -9681,62 +7267,29 @@
 	icon_state = "asteroidplating";
 	name = "plating"
 	},
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "ok" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
 	level = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "ol" = (
 /turf/simulated/mineral,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "om" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "on" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/awaycontent/a3{
-	always_unpowered = 1;
-	ambientsounds = list('sound/ambience/ambimine.ogg');
-	has_gravity = 1;
-	name = "Khonsu 19";
-	power_environ = 0;
-	power_equip = 0;
-	power_light = 0;
-	poweralm = 0
-	})
+/area/moonoutpost19/khonsu19)
 "oo" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
@@ -9745,10 +7298,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "op" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4;
@@ -9757,10 +7307,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "oq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -9771,10 +7318,7 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "or" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -9782,10 +7326,7 @@
 	level = 1
 	},
 /turf/simulated/floor/carpet,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "os" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -9793,14 +7334,11 @@
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cafeteria (NORTHEAST)";
+	dir = 5;
 	icon_state = "cafeteria";
-	dir = 5
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "ot" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -9817,33 +7355,21 @@
 	level = 1
 	},
 /turf/simulated/floor/carpet,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "ou" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "ov" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "ow" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "ox" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
@@ -9851,17 +7377,11 @@
 	pressure_checks = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "oy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "oz" = (
 /obj/machinery/door/firedoor{
 	density = 1;
@@ -9873,10 +7393,7 @@
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "oA" = (
 /obj/structure/closet/secure_closet{
 	desc = "It's a secure locker for personnel. The first card swiped gains control.";
@@ -9892,10 +7409,7 @@
 	},
 /obj/item/clothing/under/suit_jacket/navy,
 /turf/simulated/floor/carpet,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "oB" = (
 /obj/structure/table,
 /obj/item/multitool,
@@ -9903,19 +7417,15 @@
 	dir = 0;
 	icon_state = "blue"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "oC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/turf/simulated/floor/plasteel{
+	germ_level = 20
+	},
+/area/moonoutpost19/mo19arrivals)
 "oD" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -9926,10 +7436,7 @@
 	icon_state = "neutralcorner";
 	name = "floor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "oE" = (
 /obj/machinery/door/airlock{
 	name = "Kitchen Cold Room";
@@ -9938,10 +7445,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "oF" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -9951,11 +7455,10 @@
 	icon_state = "tracks"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/turf/simulated/floor/plasteel{
+	germ_level = 20
+	},
+/area/moonoutpost19/mo19arrivals)
 "oG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/airless{
@@ -9963,10 +7466,7 @@
 	icon_state = "neutralcorner";
 	name = "floor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "oH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -9976,10 +7476,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "oI" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -9990,11 +7487,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/turf/simulated/floor/plasteel{
+	germ_level = 20
+	},
+/area/moonoutpost19/mo19arrivals)
 "oJ" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "0";
@@ -10008,10 +7504,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "oK" = (
 /obj/structure/closet/secure_closet{
 	icon_broken = "fridgebroken";
@@ -10032,10 +7525,7 @@
 	icon_state = "showroomfloor";
 	temperature = 273.15
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "oL" = (
 /obj/structure/closet/secure_closet{
 	icon_state = "secure";
@@ -10051,10 +7541,7 @@
 	icon_state = "showroomfloor";
 	temperature = 273.15
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "oM" = (
 /obj/structure/closet/secure_closet{
 	icon_broken = "fridgebroken";
@@ -10075,10 +7562,7 @@
 	icon_state = "showroomfloor";
 	temperature = 273.15
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "oO" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6;
@@ -10086,28 +7570,19 @@
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "oP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/wall,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "oQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "oR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
@@ -10119,17 +7594,11 @@
 	icon_state = "neutralcorner";
 	name = "floor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "oT" = (
 /obj/machinery/atmospherics/binary/valve,
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "oU" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -10147,10 +7616,7 @@
 	icon_state = "neutralcorner";
 	name = "floor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "oW" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
@@ -10159,19 +7625,13 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "oX" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "oY" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -10185,10 +7645,7 @@
 	icon_state = "neutralcorner";
 	name = "floor"
 	},
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "oZ" = (
 /obj/structure/closet/secure_closet{
 	desc = "It's a secure locker for personnel. The first card swiped gains control.";
@@ -10204,29 +7661,20 @@
 	},
 /obj/item/clothing/under/assistantformal,
 /turf/simulated/floor/carpet,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "pa" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "pe" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "271";
 	req_one_access_txt = "0"
 	},
 /turf/simulated/floor/plating,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/area/moonoutpost19/mo19arrivals)
 "pg" = (
 /obj/structure/closet/secure_closet{
 	desc = "It's a secure locker for personnel. The first card swiped gains control.";
@@ -10241,11 +7689,39 @@
 	req_access_txt = "271"
 	},
 /obj/item/clothing/under/suit_jacket/burgundy,
-/turf/simulated/floor/carpet,
-/area/awaycontent/a1{
-	has_gravity = 1;
-	name = "MO19 Arrivals"
-	})
+/turf/simulated/floor/carpet{
+	germ_level = 20
+	},
+/area/moonoutpost19/mo19arrivals)
+"vO" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 1;
+	on = 1;
+	pressure_checks = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	germ_level = 20
+	},
+/area/moonoutpost19/mo19arrivals)
+"Jr" = (
+/obj/effect/landmark/damageturf,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	germ_level = 20
+	},
+/area/moonoutpost19/mo19arrivals)
+"Me" = (
+/turf/simulated/floor/carpet{
+	germ_level = 20
+	},
+/area/moonoutpost19/mo19arrivals)
+"Ob" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	germ_level = 20
+	},
+/area/moonoutpost19/mo19arrivals)
 
 (1,1,1) = {"
 aa
@@ -16940,8 +14416,8 @@ hK
 hK
 ny
 oF
-jF
-lG
+Ob
+Jr
 oa
 kd
 kd
@@ -17054,9 +14530,9 @@ mR
 nd
 oC
 oI
-lH
-jF
-jF
+vO
+Ob
+Ob
 oi
 kd
 aZ
@@ -17510,7 +14986,7 @@ hK
 ln
 hJ
 nJ
-lo
+Me
 nV
 hK
 ab

--- a/code/game/area/ss13_areas.dm
+++ b/code/game/area/ss13_areas.dm
@@ -2336,6 +2336,48 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "undersea"
 
 
+// Это зоны для гейта "moonoutpost19"
+/area/moonoutpost19
+	name = "moonoutpost"
+	has_gravity = TRUE
+	report_alerts = FALSE
+
+/area/moonoutpost19/mo19arrivals
+	name = "MO19 Arrivals"
+	icon_state = "awaycontent1"
+
+/area/moonoutpost19/mo19research
+	name = "MO19 Research"
+	icon_state = "awaycontent2"
+
+/area/moonoutpost19/khonsu19
+	name = "Khonsu 19"
+	icon_state = "awaycontent3"
+	always_unpowered = TRUE
+	ambientsounds = list('sound/ambience/ambimine.ogg')
+	power_environ = FALSE
+	power_equip = FALSE
+	power_light = FALSE
+	poweralm = FALSE
+
+/area/moonoutpost19/syndicateoutpost
+	name = "Syndicate Outpost"
+	icon_state = "awaycontent4"
+
+/area/moonoutpost19/hive
+	name = "The Hive"
+	icon_state = "awaycontent5"
+	always_unpowered = TRUE
+	power_environ = FALSE
+	power_equip = FALSE
+	power_light = FALSE
+	poweralm = FALSE
+
+/area/moonoutpost19/mo19utilityroom
+	name = "MO19 Utility Room"
+	icon_state = "awaycontent6"
+
+
 ////////////////////////AWAY AREAS///////////////////////////////////
 
 /area/awaycontent


### PR DESCRIPTION
## Why It's Good For The Game
Теперь у moonoutpost19 есть собственные зоны, а не измененные зоны для авейных построек через сдмм, и теперь надо менять 1 строку что бы исправить всю зону, а не у каждого тайла отдельно

## Changelog
:cl:
add: добавлены зоны для гейта и установлены на место старых
fix: исправлены эмо текстуры в СДММ, исправлено отображение дверей в гейте, исправлена зона без названия

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
