### PR TITLE
Fix: runtime in simulated turfs

### DIFF
--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -472,7 +472,7 @@
 			if(conductivity_directions&direction)
 				var/turf/neighbor = get_step(src,direction)
 
-				if(!neighbor.thermal_conductivity)
+				if(!neighbor?.thermal_conductivity)
 					continue
 
 				if(istype(neighbor, /turf/simulated)) //anything under this subtype will share in the exchange


### PR DESCRIPTION
Если на соседних клетках находится симулированный и не симулированный тайл то возникает рантайм. Без понятия почему этого не происходило раньше