### PR TITLE
fix: убирание ненужного layer у стен на синди ЦК

### DIFF
--- a/_maps/map_files/cyberiad/z2.dmm
+++ b/_maps/map_files/cyberiad/z2.dmm
@@ -25882,7 +25882,6 @@
 "rkr" = (
 /turf/unsimulated/wall{
 	icon_state = "iron12";
-	layer = 10
 	},
 /area/syndicate_mothership)
 "rlj" = (

--- a/_maps/map_files/cyberiad/z2.dmm
+++ b/_maps/map_files/cyberiad/z2.dmm
@@ -23166,7 +23166,6 @@
 "pBn" = (
 /turf/unsimulated/wall{
 	icon_state = "iron14";
-	layer = 10
 	},
 /area/syndicate_mothership)
 "pBo" = (


### PR DESCRIPTION

## Why It's Good For The Game
госты теперь будут видны на фоне стенок

## Changelog
:cl:
fix: убраны ненужные layer у стен на синди ЦК
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
