### PR TITLE
fix: Отображение зоны danger в СДММ

### DIFF
--- a/code/game/area/areas/mining.dm
+++ b/code/game/area/areas/mining.dm
@@ -125,7 +125,7 @@
 	icon_state = "unexplored"
 
 /area/lavaland/surface/outdoors/unexplored/danger //megafauna will also spawn here
-	icon_state = "danger"
+	icon_state = "cave"
 
 /area/lavaland/surface/outdoors/explored
 	name = "Lavaland Labor Camp"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
ссылает на существующий скин зоны

## Why It's Good For The Game
Теперь зона /area/lavaland/surface/outdoors/unexplored/danger  будет корректно отображатся в СДММ, и работать с картой лаваленда будет более удобнее
## Images of changes
![image](https://user-images.githubusercontent.com/97447484/201105715-283e91a7-80c0-4f6b-9df7-0f1003e51223.png)



<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
