### PR TITLE
Fix: onhalf space ruin area name

### DIFF
--- a/code/modules/ruins/ruin_areas.dm
+++ b/code/modules/ruins/ruin_areas.dm
@@ -43,7 +43,7 @@
 	icon_state = "Sleep"
 
 /area/ruin/onehalf/bridge
-	name = "Bridge"
+	name = "Old Mining Bay Bridge"
 	icon_state = "bridge"
 
 // Old tcommsat


### PR DESCRIPTION
Название зоны инстанса космоса совпадает полностью с названием непосредственно мостика, что несет в себе проблемы при грифозных и щитспавновых настроениях администрации, а также вносит другие неудобства, связанные с наименованием зоны.
🆑 "Bridge" зона мостика инстанса onehalf стала называться более душным "Old Mining Bay Bridge"