### PR TITLE
DRAFT RnD maintrance remap

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -75,6 +75,22 @@
 	icon_state = "diagonalWall3"
 	},
 /area/shuttle/syndicate_elite)
+"aap" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/east,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology)
 "aaq" = (
 /turf/space,
 /turf/space,
@@ -683,6 +699,15 @@
 	},
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
+"adc" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark";
+	temperature = 80
+	},
+/area/toxins/xenobiology)
 "add" = (
 /obj/machinery/optable,
 /turf/simulated/shuttle/floor{
@@ -872,10 +897,6 @@
 	},
 /obj/structure/table,
 /obj/item/pickaxe,
-/obj/item/storage/firstaid/brute{
-	pixel_x = 5;
-	pixel_y = 5
-	},
 /obj/item/storage/firstaid/toxin,
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
@@ -884,11 +905,8 @@
 	dir = 1
 	},
 /obj/structure/table,
+/obj/item/scalpel,
 /obj/item/stack/cable_coil,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 5;
-	pixel_y = 5
-	},
 /obj/item/storage/firstaid/regular,
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
@@ -897,7 +915,7 @@
 	dir = 1
 	},
 /obj/structure/table,
-/obj/item/storage/toolbox/surgery,
+/obj/item/circular_saw,
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
 "adZ" = (
@@ -1932,7 +1950,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/toxins/mixing)
+/area/toxins/launch)
 "aix" = (
 /obj/machinery/porta_turret/syndicate,
 /turf/simulated/shuttle/wall{
@@ -2101,12 +2119,6 @@
 	icon_state = "swall_f6"
 	},
 /area/shuttle/pod_1)
-"ajy" = (
-/mob/living/simple_animal/mouse/brown,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
 "ajz" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -2117,6 +2129,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/mechanic_workshop/expedition)
+"ajA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "ajG" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -2835,6 +2857,15 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/syndicate)
+"anf" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/crew_quarters/theatre)
 "ang" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2890,6 +2921,26 @@
 	icon_state = "wall3"
 	},
 /area/shuttle/syndicate)
+"anz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 0;
+	icon_state = "red"
+	},
+/area/security/processing)
 "anC" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "swall13"
@@ -2979,7 +3030,9 @@
 "aoc" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "purplefull"
+	},
 /area/toxins/storage)
 "aod" = (
 /obj/structure/sign/securearea{
@@ -3010,15 +3063,6 @@
 "aoo" = (
 /turf/simulated/wall,
 /area/civilian/vacantoffice)
-"aos" = (
-/obj/item/twohanded/required/kirbyplants{
-	layer = 3.1
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/maintenance/library)
 "aou" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger{
@@ -3085,6 +3129,12 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/administration)
+"aoQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "aoR" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "s_docking_airlock";
@@ -3635,21 +3685,26 @@
 	},
 /area/shuttle/administration)
 "ars" = (
-/obj/machinery/light{
-	dir = 8
+/obj/effect/landmark{
+	name = "carpspawn"
 	},
-/obj/structure/closet/emcloset,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -24
+/obj/structure/grille{
+	density = 0;
+	icon_state = "brokengrille"
 	},
+/turf/space,
+/area/space)
+"art" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "chapel"
 	},
-/area/medical/research/nhallway)
+/area/crew_quarters/theatre)
 "aru" = (
 /turf/simulated/wall/r_wall,
 /area/security/permabrig)
@@ -3709,24 +3764,6 @@
 	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/lounge)
-"arH" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/gambling_den)
 "arM" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -3934,6 +3971,14 @@
 "atd" = (
 /turf/simulated/wall/r_wall,
 /area/engine/controlroom)
+"ati" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "atl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3968,6 +4013,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/bridge/checkpoint/north)
+"aty" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
 "atF" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/lattice,
@@ -4387,18 +4442,21 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/engine/mechanic_workshop/expedition)
-"avL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "avS" = (
 /turf/simulated/shuttle/floor,
 /area/shuttle/administration)
 "avX" = (
-/obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall/rust,
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/blood/writing,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
 /area/maintenance/fsmaint2{
 	name = "Tourist Area Maintenance"
 	})
@@ -5407,20 +5465,6 @@
 "aBI" = (
 /turf/simulated/wall/rust,
 /area/maintenance/bar)
-"aBK" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_x = 1;
-	pixel_y = 3
-	},
-/obj/machinery/light_switch{
-	pixel_x = -24
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/security/processing)
 "aBS" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
@@ -7187,14 +7231,6 @@
 	icon_state = "dark"
 	},
 /area/engine/mechanic_workshop/hangar)
-"aKL" = (
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
 "aKM" = (
 /obj/structure/computerframe,
 /turf/simulated/shuttle/floor,
@@ -7354,6 +7390,12 @@
 	},
 /turf/unsimulated/floor,
 /area/shuttle/specops)
+"aLq" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/toxins/xenobiology)
 "aLr" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -7622,8 +7664,12 @@
 	},
 /area/hallway/secondary/entry/lounge)
 "aMW" = (
-/turf/simulated/wall,
-/area/maintenance/gambling_den)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "aMX" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -7927,7 +7973,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "purplefull"
+	icon_state = "white"
 	},
 /area/medical/research/nhallway)
 "aOg" = (
@@ -8195,6 +8241,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
+"aPc" = (
+/obj/structure/grille/broken,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "aPd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8271,6 +8323,20 @@
 	icon_state = "caution"
 	},
 /area/maintenance/bar)
+"aPz" = (
+/obj/structure/closet{
+	icon_closed = "cabinet_closed";
+	icon_opened = "cabinet_open";
+	icon_state = "cabinet_closed"
+	},
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "aPA" = (
 /obj/structure/closet/wardrobe/red,
 /obj/item/clothing/suit/tracksuit/red,
@@ -8576,15 +8642,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/shuttle/trade/sol)
-"aRl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	temperature = 80
-	},
-/area/toxins/xenobiology)
 "aRo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -8817,25 +8874,13 @@
 	},
 /area/medical/sleeper)
 "aSF" = (
-/obj/structure/table,
-/obj/item/flashlight/seclite,
-/obj/item/restraints/handcuffs{
-	pixel_y = -3
-	},
-/obj/item/restraints/handcuffs{
-	pixel_y = 3
-	},
-/obj/machinery/door_control{
-	id = "Evidence Storage";
-	name = "Evidence Storage Privacy Shutters Control";
-	pixel_x = -24;
+/obj/machinery/vending/medical{
 	req_access_txt = "63"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "red"
+	icon_state = "white"
 	},
-/area/security/processing)
+/area/security/medbay)
 "aSG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -9466,6 +9511,11 @@
 /area/maintenance/aft{
 	name = "Medbay Maintenance"
 	})
+"aVw" = (
+/obj/structure/curtain/black,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "aVz" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -9498,6 +9548,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
+"aVV" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;47"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "aVX" = (
 /obj/structure/chair/sofa/left,
 /obj/effect/landmark{
@@ -9677,9 +9740,21 @@
 	},
 /area/crew_quarters/fitness)
 "aWY" = (
-/obj/structure/cult/archives,
-/turf/simulated/floor/plating,
-/area/maintenance/library)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door_control{
+	id = "xeno2";
+	name = "Containment Control";
+	pixel_y = 35;
+	req_access_txt = "55"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
+	},
+/area/toxins/xenobiology)
 "aXc" = (
 /obj/machinery/light{
 	dir = 4
@@ -10329,14 +10404,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engrooms)
 "baI" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -26
+/obj/structure/table,
+/obj/item/paper/deltainfo,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/newscaster/security_unit{
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -10365,19 +10439,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
-"baS" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitehall"
-	},
-/area/toxins/xenobiology)
 "baY" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
@@ -10460,10 +10521,22 @@
 	},
 /area/hallway/secondary/entry/commercial)
 "bbA" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/area/maintenance/gambling_den)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10;
+	initialize_directions = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "bbC" = (
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
@@ -10748,6 +10821,13 @@
 	icon_state = "wood-broken3"
 	},
 /area/maintenance/kitchen)
+"bdf" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "chapel"
+	},
+/area/crew_quarters/theatre)
 "bdi" = (
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -11253,21 +11333,20 @@
 	},
 /area/crew_quarters/kitchen)
 "bgt" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	icon_state = "2-8"
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Brig_lockdown";
+	name = "Brig Lockdown";
+	opacity = 0
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 0;
-	icon_state = "red"
-	},
-/area/security/processing)
+/turf/simulated/floor/plating,
+/area/security/evidence)
 "bgw" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -12531,6 +12610,17 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry/commercial)
+"blQ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/xenozoo)
 "blZ" = (
 /obj/machinery/vending/security,
 /obj/effect/decal/warning_stripes/red/hollow,
@@ -12660,9 +12750,10 @@
 	},
 /area/hallway/secondary/entry)
 "bmJ" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/wood,
+/area/crew_quarters/theatre)
 "bmM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door_control{
@@ -12805,6 +12896,28 @@
 	icon_state = "swall_f5"
 	},
 /area/shuttle/arrival/station)
+"bnX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/barricade/wooden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "boc" = (
 /obj/effect/turf_decal/box,
 /obj/structure/cable{
@@ -13234,6 +13347,9 @@
 /turf/simulated/wall,
 /area/hallway/primary/central/nw)
 "bqv" = (
+/obj/item/storage/secure/safe{
+	pixel_x = 32
+	},
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
 /turf/simulated/floor/wood/fancy/cherry,
@@ -13688,6 +13804,18 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"bsR" = (
+/turf/simulated/floor/carpet/purple,
+/area/crew_quarters/hor)
+"bsU" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "purple"
+	},
+/area/maintenance/xenozoo)
 "bsW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14081,17 +14209,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/lounge)
-"bub" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
-/area/security/processing)
 "buf" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
@@ -14660,10 +14777,6 @@
 /obj/machinery/light/spot,
 /turf/simulated/shuttle/floor,
 /area/shuttle/supply)
-"bwy" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
 "bwC" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -15141,6 +15254,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
+"byq" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark";
+	temperature = 80
+	},
+/area/toxins/xenobiology)
 "bys" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -15321,6 +15443,16 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
+"byT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "byU" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -15495,35 +15627,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/shuttle/trade/sol)
-"bzw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 2;
-	name = "Visiting Room";
-	req_access_txt = "63"
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	name = "Visiting Room";
-	req_access_txt = "63"
-	},
-/obj/structure/table/reinforced,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/interrogation)
 "bzy" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/structure/cable{
@@ -15581,19 +15684,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
-"bzG" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12;47"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
 "bzI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -16398,6 +16488,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/turbine)
 "bCB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
 	name = "Prisoner Processing";
@@ -16434,8 +16531,10 @@
 	},
 /area/maintenance/garden/north)
 "bCK" = (
-/turf/simulated/wall/rust,
-/area/maintenance/gambling_den)
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/barricade/wooden,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "bCL" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -16637,6 +16736,20 @@
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/commercial)
+"bDz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "bDB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/alarm{
@@ -17583,23 +17696,11 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/mrchangs)
 "bHH" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = 30
-	},
-/obj/machinery/camera{
-	c_tag = "Brig Medical Bay";
-	dir = 8;
-	network = list("SS13","Security")
-	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "whitered"
+	dir = 4;
+	icon_state = "darkredcorners"
 	},
-/area/security/medbay)
+/area/security/processing)
 "bHI" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -17631,21 +17732,32 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/serviceyard)
 "bHO" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_switch{
-	pixel_x = 24
-	},
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "darkred"
-	},
-/area/security/processing)
-"bHQ" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull"
+	dir = 1;
+	icon_state = "darkred"
+	},
+/area/security/evidence)
+"bHQ" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 0;
+	icon_state = "red"
 	},
 /area/security/processing)
 "bHS" = (
@@ -17665,6 +17777,14 @@
 	icon_state = "brown"
 	},
 /area/quartermaster/storage)
+"bIb" = (
+/obj/structure/sign/vacuum{
+	pixel_y = -32
+	},
+/obj/machinery/light,
+/obj/effect/decal/warning_stripes/southeast,
+/turf/simulated/floor/plasteel,
+/area/toxins/launch)
 "bId" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
@@ -17769,15 +17889,6 @@
 	},
 /turf/simulated/floor/greengrid,
 /area/engine/controlroom)
-"bIK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
 "bIP" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -17936,20 +18047,47 @@
 	},
 /area/crew_quarters/fitness)
 "bJA" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 30
+	},
 /turf/space,
-/turf/simulated/wall/r_wall,
-/area/security/evidence)
-"bJF" = (
-/obj/machinery/light/small,
-/obj/machinery/camera{
-	c_tag = "Xeno Containment 2";
-	dir = 1;
-	network = list("Research","SS13")
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "whitered"
 	},
-/area/toxins/xenobiology)
+/area/security/medbay)
+"bJE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
+"bJF" = (
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "experimentor";
+	name = "Experimentor Blast Door";
+	opacity = 0
+	},
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/toxins/explab)
 "bJP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18097,6 +18235,11 @@
 	icon_state = "yellowcorner"
 	},
 /area/storage/primary)
+"bKC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "bKE" = (
 /obj/machinery/computer/account_database,
 /turf/simulated/floor/plasteel{
@@ -18187,16 +18330,15 @@
 	},
 /area/crew_quarters/kitchen)
 "bLm" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 26
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/crayon{
+	desc = "Crayon art.";
+	icon_state = "squish";
+	name = "Graffiti";
+	pixel_y = 32
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2{
 	name = "Tourist Area Maintenance"
@@ -18218,22 +18360,20 @@
 "bLu" = (
 /turf/space,
 /turf/simulated/floor/plasteel{
-	dir = 9;
+	dir = 4;
 	icon_state = "red"
 	},
 /area/security/processing)
 "bLv" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/item/radio/intercom{
-	pixel_y = -30
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
 /area/security/interrogation)
 "bLA" = (
@@ -18317,6 +18457,21 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/solar/auxport)
+"bLV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurple"
+	},
+/area/toxins/explab)
 "bLY" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -19610,11 +19765,6 @@
 	tag = "icon-asteroid (NORTH)"
 	},
 /area/hydroponics)
-"bRb" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6"
-	},
-/area/maintenance/library)
 "bRe" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -20515,21 +20665,16 @@
 	},
 /area/turret_protected/aisat)
 "bUG" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id_tag = "SecMedPrivOutside"
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "2"
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "BridgeLockdown";
-	name = "Bridge Lockdown"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/security/medbay)
+/area/maintenance/perma)
 "bUH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -20596,6 +20741,17 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"bUX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/launch)
 "bVd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20764,10 +20920,15 @@
 /turf/simulated/floor/plating,
 /area/engine/controlroom)
 "bVJ" = (
-/obj/machinery/monkey_recycler,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/obj/effect/decal/warning_stripes/north,
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/simulated/floor/engine,
+/area/toxins/misc_lab)
 "bVL" = (
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -21651,13 +21812,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
-"bZG" = (
-/obj/structure/table,
-/obj/item/storage/fancy/donut_box,
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
-/area/security/processing)
 "bZH" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8;
@@ -22239,6 +22393,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/bar)
+"cbw" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_spawners/oil_maybe,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/xenozoo)
 "cbx" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/warning_stripes/yellow,
@@ -22661,6 +22832,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/fpmaint)
+"ccT" = (
+/obj/item/twohanded/required/kirbyplants,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/maintenance/library)
 "ccW" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -23122,6 +23300,10 @@
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/miningdock)
+"ceE" = (
+/obj/item/clothing/mask/face/rat,
+/turf/simulated/floor/plating,
+/area/maintenance/library)
 "ceI" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
@@ -23261,20 +23443,33 @@
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry)
+"cfp" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1
+	},
+/area/maintenance/asmaint2)
 "cfr" = (
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
 "cfs" = (
-/obj/machinery/camera{
-	c_tag = "Interrogation Room";
-	dir = 8;
-	network = list("SS13","Security","Interrogation")
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkred"
-	},
-/area/security/evidence)
+/obj/item/wirecutters,
+/turf/simulated/floor/plating,
+/area/maintenance/perma)
 "cft" = (
 /obj/machinery/camera{
 	c_tag = "Supermatter Pump Airlock";
@@ -23790,6 +23985,20 @@
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/mining)
+"chN" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "whitered"
+	},
+/area/security/medbay)
 "chP" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -24084,7 +24293,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cjs" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/southwestcorner,
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
 	name = "standard air scrubber";
@@ -24333,6 +24542,27 @@
 	icon_state = "dark"
 	},
 /area/crew_quarters/courtroom)
+"ckD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/grille/broken,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "ckE" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
@@ -24377,7 +24607,8 @@
 	dir = 8
 	},
 /obj/machinery/light_switch{
-	pixel_x = -24
+	pixel_x = -24;
+	pixel_y = -8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1
@@ -24438,8 +24669,9 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/item/clothing/glasses/welding/superior,
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
+	icon_state = "dark"
 	},
 /area/crew_quarters/hor)
 "clr" = (
@@ -24836,6 +25068,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
+"cmT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "cmV" = (
 /obj/machinery/light{
 	dir = 4
@@ -24850,20 +25090,19 @@
 /area/storage/secure)
 "cmX" = (
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xeno6";
+	name = "Creature Cell #6";
+	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
+/area/toxins/xenobiology)
 "cmZ" = (
 /obj/structure/bed,
 /turf/simulated/floor/plating,
@@ -25500,13 +25739,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "cpP" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "cpQ" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -25584,6 +25826,26 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
+"cqt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/security/medbay)
 "cqw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -25596,32 +25858,6 @@
 "cqG" = (
 /turf/simulated/floor/plasteel,
 /area/maintenance/garden/north)
-"cqJ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
 "cqK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -26070,9 +26306,17 @@
 /turf/simulated/wall/r_wall,
 /area/ai_monitored/storage/eva)
 "csO" = (
-/obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall,
-/area/maintenance/gambling_den)
+/obj/machinery/vending/artvend,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/ripped{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/crew_quarters/theatre)
 "csS" = (
 /obj/structure/closet/crate,
 /obj/item/stack/rods{
@@ -26131,15 +26375,6 @@
 /area/maintenance/port{
 	name = "Brig Maintenance"
 	})
-"cto" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurplecorner"
-	},
-/area/toxins/explab)
 "ctp" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -26469,6 +26704,28 @@
 	dir = 1
 	},
 /area/security/customs)
+"cuD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "cuM" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -27357,12 +27614,19 @@
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "cxW" = (
-/obj/structure/rack,
-/obj/item/weldingtool,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/holostool,
+/obj/item/ammo_casing{
+	pixel_x = 3;
+	pixel_y = 9
+	},
+/obj/item/ammo_casing{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/effect/spawner/random_spawners/blood_often,
+/turf/simulated/floor/carpet/royalblack,
+/area/maintenance/asmaint2)
 "cxY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -28636,20 +28900,6 @@
 	icon_state = "wood-broken6"
 	},
 /area/maintenance/kitchen)
-"cCw" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurple"
-	},
-/area/toxins/xenobiology)
 "cCz" = (
 /obj/structure/table/reinforced,
 /obj/item/extinguisher/mini{
@@ -30093,11 +30343,8 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/engrooms)
 "cHe" = (
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purplecorner"
-	},
-/area/maintenance/xenozoo)
+/turf/simulated/wall/r_wall,
+/area/toxins/xenobiology)
 "cHh" = (
 /obj/machinery/camera{
 	c_tag = "Service Hall South";
@@ -30423,20 +30670,6 @@
 	icon_state = "dark"
 	},
 /area/library)
-"cIx" = (
-/obj/item/shard{
-	icon_state = "small"
-	},
-/obj/item/shard{
-	icon_state = "medium";
-	pixel_x = -7;
-	pixel_y = -10
-	},
-/obj/item/airlock_electronics,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
 "cIz" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -30558,6 +30791,20 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
+"cIH" = (
+/obj/effect/decal/warning_stripes/west,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine,
+/area/maintenance/xenozoo)
 "cII" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/machinery/status_display,
@@ -30577,11 +30824,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/port/west)
-"cIM" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/toxins/xenobiology)
 "cIN" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -30870,23 +31112,15 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
-"cJK" = (
-/obj/effect/decal/remains/xeno,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
 "cJL" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
 "cJM" = (
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "darkred"
-	},
-/area/security/evidence)
+/obj/item/stack/cable_coil,
+/turf/simulated/floor/plating,
+/area/maintenance/perma)
 "cJN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -30896,11 +31130,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
-"cJO" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "cJS" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder{
@@ -30940,14 +31169,6 @@
 	icon_state = "brown"
 	},
 /area/quartermaster/delivery)
-"cKc" = (
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/structure/closet/l3closet/scientist,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "cKd" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -31208,7 +31429,8 @@
 /area/quartermaster/storage)
 "cLj" = (
 /obj/machinery/light_switch{
-	pixel_x = 24
+	pixel_x = 24;
+	pixel_y = 40
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/cabin3)
@@ -31217,7 +31439,8 @@
 /obj/item/folder/red,
 /obj/item/pen,
 /obj/machinery/light_switch{
-	pixel_x = -24
+	pixel_x = -24;
+	pixel_y = -8
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/cabin4)
@@ -31244,15 +31467,19 @@
 	},
 /area/engine/gravitygenerator)
 "cLz" = (
-/obj/machinery/smartfridge/secure/extract,
-/obj/machinery/light/small{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/structure/closet/walllocker/emerglocker{
-	pixel_x = -32
+/obj/machinery/power/apc{
+	name = "north bump";
+	pixel_y = 26
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "cLA" = (
 /obj/machinery/status_display{
 	pixel_y = -32
@@ -31303,18 +31530,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
-"cLL" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "sw_maint_outer";
-	locked = 1;
-	name = "West Maintenance External Access"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
 "cLU" = (
 /obj/machinery/light{
 	dir = 4
@@ -31396,9 +31611,6 @@
 	},
 /area/storage/tech)
 "cMl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/plasteel,
@@ -31582,14 +31794,6 @@
 	icon_state = "yellowfull"
 	},
 /area/engine/controlroom)
-"cNl" = (
-/obj/effect/decal/warning_stripes/west,
-/obj/structure/chair/office/light{
-	dir = 4;
-	pixel_y = 3
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "cNn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random_spawners/blood_maybe,
@@ -31606,6 +31810,23 @@
 /obj/structure/table,
 /turf/simulated/floor/plating,
 /area/maintenance/engrooms)
+"cNx" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "cNA" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
@@ -31645,6 +31866,24 @@
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/office)
+"cNL" = (
+/obj/machinery/atmospherics/unary/cold_sink/freezer{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -28
+	},
+/obj/item/paper{
+	name = "Записка";
+	desc = "Paper attached to freezer";
+	info = "<h1>Моему сменщику</h1><hr>Одна из камер содержания снабжена теплопроводящим контуром. Чтобы контур работал эффективно, пусти в него плазму из хранилища токсинов и настрой охладитель на желаемую температуру.<br><br><br><br>-Пит."
+	},
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (SOUTHWEST)"
+	},
+/area/toxins/xenobiology)
 "cNT" = (
 /obj/structure/sign/electricshock,
 /turf/simulated/wall/r_wall,
@@ -31905,12 +32144,35 @@
 /turf/space,
 /area/solar/starboard)
 "cOC" = (
-/obj/machinery/light/small{
+/obj/machinery/door/airlock/research/glass{
+	heat_proof = 1;
+	name = "Chemical Testing Room";
+	req_access_txt = "47"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "RnDChem";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/sign/fire{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "cOF" = (
 /obj/structure/closet/crate/internals,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -31926,49 +32188,47 @@
 	},
 /area/quartermaster/storage)
 "cOI" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/crayon/rainbow,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "cOL" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Chemical Toxins Lab";
+	network = list("Research","SS13");
+	dir = 8
 	},
-/obj/machinery/door_control{
-	id = "xeno6";
-	name = "Containment Control";
-	pixel_y = 35;
-	req_access_txt = "55"
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 28
 	},
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/dropper/precision,
+/obj/item/reagent_containers/dropper/precision,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper,
+/obj/item/storage/box/pillbottles,
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/gloves,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall"
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
 	},
-/area/toxins/xenobiology)
+/area/toxins/misc_lab)
 "cOM" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/toxins/xenobiology)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "cOO" = (
 /obj/structure/closet/secure_closet/injection,
 /obj/effect/decal/warning_stripes/red,
@@ -31984,33 +32244,16 @@
 /area/security/execution)
 "cOP" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/effect/landmark{
-	name = "lightsout"
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	icon_state = "purplefull"
-	},
-/area/toxins/xenobiology)
+/turf/simulated/floor/plasteel,
+/area/maintenance/asmaint2)
 "cOR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -32037,21 +32280,6 @@
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/storage)
-"cOT" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/slime_scanner,
-/obj/item/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 28
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "cOU" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
@@ -32132,22 +32360,15 @@
 	},
 /area/storage/primary)
 "cPk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/recharge_station,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/newscaster{
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
 	},
 /area/medical/research/nhallway)
 "cPl" = (
@@ -32167,6 +32388,17 @@
 	},
 /turf/simulated/floor/engine,
 /area/maintenance/turbine)
+"cPp" = (
+/obj/structure/table/wood,
+/obj/machinery/newscaster{
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/theatre)
 "cPq" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/structure/cable/yellow{
@@ -32260,13 +32492,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/chemistry)
-"cPG" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
 "cPI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -32447,11 +32672,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/casino)
-"cQt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/head/beret,
-/turf/simulated/floor/plating,
-/area/maintenance/library)
 "cQu" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/navbeacon{
@@ -32468,16 +32688,24 @@
 /area/clownoffice)
 "cQv" = (
 /obj/structure/table/reinforced,
-/obj/structure/window/reinforced,
-/obj/machinery/door_control{
-	id = "xenosecure";
-	name = "Containment Control";
-	pixel_y = 2;
-	req_access_txt = "55"
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the horrors within the test chamber.";
+	name = "Research Monitor";
+	network = list("TestChamber")
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
+	},
+/area/toxins/test_chamber)
+"cQx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/holosign/barrier,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "cQB" = (
 /obj/machinery/status_display{
 	pixel_y = 32
@@ -32494,20 +32722,17 @@
 	},
 /area/clownoffice)
 "cQH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9;
+	level = 2
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/sign/poster/contraband/revolver{
+	pixel_x = 32
 	},
-/obj/machinery/shower{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitehall"
-	},
-/area/toxins/xenobiology)
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel,
+/area/maintenance/asmaint2)
 "cQK" = (
 /obj/item/flag/clown,
 /obj/machinery/power/apc{
@@ -32521,13 +32746,6 @@
 	icon_state = "bar"
 	},
 /area/clownoffice)
-"cQN" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology)
 "cQP" = (
 /obj/machinery/suit_storage_unit/clown,
 /obj/machinery/door_control{
@@ -32859,12 +33077,11 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
 "cRC" = (
-/obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
+	dir = 9;
+	icon_state = "darkred"
 	},
-/area/security/processing)
+/area/security/interrogation)
 "cRE" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -32893,51 +33110,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
-"cRU" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"cRY" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitehall"
-	},
-/area/toxins/xenobiology)
-"cRW" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26;
+/obj/structure/closet/walllocker/emerglocker/north{
 	pixel_y = -32
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
-"cRX" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "purplefull"
 	},
-/area/toxins/xenobiology)
-"cRY" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/west,
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/area/toxins/test_chamber)
 "cSa" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/effect/decal/warning_stripes/north,
@@ -33104,6 +33288,14 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
+"cSH" = (
+/turf/simulated/floor/wood{
+	broken = 1;
+	icon_state = "wood-broken"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "cSI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -33187,8 +33379,11 @@
 /turf/simulated/wall,
 /area/maintenance/electrical)
 "cTi" = (
-/turf/simulated/wall,
-/area/maintenance/xenozoo)
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurplecorner"
+	},
+/area/medical/research/nhallway)
 "cTj" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 28
@@ -33216,16 +33411,10 @@
 /area/crew_quarters/chief)
 "cTr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 9
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/east,
-/obj/effect/decal/warning_stripes/west,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/turf/simulated/floor/engine,
+/area/toxins/explab)
 "cTu" = (
 /obj/structure/table/glass,
 /obj/machinery/camera{
@@ -33245,39 +33434,6 @@
 	icon_state = "whitepurple"
 	},
 /area/medical/genetics)
-"cTz" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "xeno2";
-	name = "Creature Cell #4";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology)
-"cTA" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurple"
-	},
-/area/toxins/xenobiology)
 "cTB" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -33295,14 +33451,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/maintenance/turbine)
-"cTG" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/ai_status_display{
-	pixel_y = -32
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "cTH" = (
 /obj/structure/sign/fire,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -33310,12 +33458,6 @@
 	},
 /turf/simulated/wall/r_wall/coated,
 /area/maintenance/turbine)
-"cTL" = (
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
 "cTM" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/drone_fabricator,
@@ -33336,19 +33478,12 @@
 	},
 /area/engine/break_room)
 "cTP" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/decal/warning_stripes/southwest,
+/obj/machinery/doppler_array{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/mixing)
+/turf/simulated/floor/plasteel,
+/area/toxins/launch)
 "cTQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -33446,6 +33581,30 @@
 	icon_state = "whiteyellow"
 	},
 /area/medical/chemistry)
+"cUc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/westright{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/nanotrasen_logo{
+	pixel_y = 32
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "ramptop"
+	},
+/area/crew_quarters/theatre)
 "cUe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -33652,21 +33811,13 @@
 "cUS" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/xenozoo)
-"cUU" = (
-/obj/structure/sign/electricshock,
-/turf/simulated/wall,
-/area/toxins/xenobiology)
 "cUW" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/east,
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "cUY" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -33698,32 +33849,18 @@
 	},
 /area/toxins/lab)
 "cVb" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/barricade/wooden,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "xeno3";
-	name = "Creature Cell #3";
-	opacity = 0
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 2;
-	name = "Creature Pen";
-	req_access_txt = "47"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/toxins/xenobiology)
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "cVc" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -33817,6 +33954,13 @@
 	icon_state = "white"
 	},
 /area/medical/sleeper)
+"cVC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_spawners/grille_often,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "cVD" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -33838,14 +33982,29 @@
 	},
 /area/bridge/meeting_room)
 "cVG" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/item/storage/bag/chemistry,
+/obj/item/storage/bag/chemistry,
+/obj/item/storage/bag/chemistry,
+/obj/item/storage/bag/chemistry,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 26;
+	pixel_y = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (SOUTHEAST)"
+	},
+/area/toxins/misc_lab)
 "cVH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -33953,27 +34112,14 @@
 	},
 /area/crew_quarters/bar)
 "cVU" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id_tag = "SecMedPrivOutside"
+/obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "BridgeLockdown";
-	name = "Bridge Lockdown"
-	},
-/turf/simulated/floor/plating,
-/area/security/medbay)
+/area/security/evidence)
 "cVX" = (
 /obj/machinery/door/airlock/glass{
 	name = "Cabin"
@@ -33988,7 +34134,8 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurplecorner"
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
 	},
 /area/medical/research/shallway)
 "cWa" = (
@@ -34005,18 +34152,6 @@
 	icon_state = "dark"
 	},
 /area/turret_protected/ai_upload)
-"cWb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
 "cWd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt{
@@ -34065,6 +34200,23 @@
 	icon_state = "caution"
 	},
 /area/atmos)
+"cWg" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/girder,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "cWi" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -34073,6 +34225,23 @@
 	icon_state = "grimy"
 	},
 /area/crew_quarters/captain)
+"cWk" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 26;
+	pixel_y = 4
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
+	},
+/area/toxins/explab)
 "cWn" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -34133,22 +34302,6 @@
 /obj/item/toy/cards/deck/syndicate,
 /turf/simulated/floor/plating,
 /area/maintenance/casino)
-"cWA" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "xeno3";
-	name = "Creature Cell #3";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology)
 "cWC" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -34252,13 +34405,13 @@
 	},
 /area/medical/reception)
 "cWV" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
 /area/toxins/xenobiology)
 "cWY" = (
@@ -34497,16 +34650,29 @@
 	icon_state = "brown"
 	},
 /area/quartermaster/sorting)
-"cXZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/table/wood/poker,
+"cXX" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "0-4"
 	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xeno7";
+	name = "Creature Cell #7";
+	opacity = 0
+	},
+/obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/toxins/xenobiology)
+"cXZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/theatre)
 "cYa" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -34581,21 +34747,14 @@
 /turf/simulated/floor/plating,
 /area/toxins/lab)
 "cYk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door_control{
-	id = "xeno2";
-	name = "Containment Control";
-	pixel_y = -28;
-	req_access_txt = "55"
-	},
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitehall"
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
 /area/toxins/xenobiology)
 "cYn" = (
@@ -35099,9 +35258,6 @@
 	icon_state = "grimy"
 	},
 /area/bridge/meeting_room)
-"dah" = (
-/turf/simulated/floor/engine,
-/area/toxins/test_chamber)
 "dai" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -35125,11 +35281,28 @@
 /turf/space,
 /area/space/nearstation)
 "dam" = (
-/obj/effect/decal/remains/human,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/area/maintenance/gambling_den)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10;
+	initialize_directions = 10
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
+	},
+/area/toxins/explab)
 "dan" = (
 /obj/machinery/newscaster{
 	pixel_x = 32;
@@ -35178,6 +35351,24 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
+"daA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/misc_lab)
 "daC" = (
 /obj/machinery/r_n_d/protolathe{
 	pixel_x = 1
@@ -35368,10 +35559,6 @@
 	name = "Brig Lockdown";
 	opacity = 0
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "SecPilotPriv"
-	},
 /turf/simulated/floor/plating,
 /area/security/podbay)
 "dbu" = (
@@ -35403,9 +35590,30 @@
 	},
 /area/crew_quarters/bar)
 "dbz" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "dbC" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -35516,6 +35724,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/fitness)
+"dcl" = (
+/turf/simulated/floor/engine,
+/area/toxins/explab)
 "dcm" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -35734,50 +35945,13 @@
 /area/aisat/maintenance{
 	name = "\improper AI Satellite Service"
 	})
-"dcU" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurplecorner"
-	},
-/area/toxins/misc_lab)
-"dcV" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
-	},
-/area/toxins/misc_lab)
-"dcW" = (
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
-	},
-/area/toxins/misc_lab)
-"dcX" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
-	},
-/area/toxins/misc_lab)
 "ddb" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/structure/closet/bombcloset,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurplecorner"
+	dir = 8;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
 	},
 /area/medical/research/nhallway)
 "ddc" = (
@@ -35843,8 +36017,16 @@
 	},
 /area/quartermaster/storage)
 "ddi" = (
-/turf/simulated/wall/r_wall,
-/area/toxins/explab)
+/obj/machinery/camera{
+	c_tag = "Xeno Containment 5";
+	network = list("Research","SS13");
+	dir = 1
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/toxins/xenobiology)
 "ddk" = (
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar/atrium)
@@ -35877,13 +36059,8 @@
 	},
 /area/crew_quarters/chief)
 "ddp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/structure/table/glass,
+/obj/item/storage/fancy/donut_box,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -36136,106 +36313,9 @@
 	name = "Comemmorative Plaque"
 	},
 /area/hallway/primary/fore)
-"deE" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
-	},
-/area/toxins/misc_lab)
-"deF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 10
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurple"
-	},
-/area/toxins/misc_lab)
 "deG" = (
 /turf/simulated/wall,
 /area/quartermaster/delivery)
-"deH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/explab)
-"deK" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurplecorner"
-	},
-/area/medical/research/nhallway)
-"deL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	tag = "icon-pipe-j1 (EAST)"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurplecorner"
-	},
-/area/toxins/explab)
 "deM" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced{
@@ -36262,35 +36342,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/kitchen)
 "deR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research/glass{
-	name = "Experimentor";
-	req_access_txt = "47"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/plasteel,
-/area/toxins/explab)
+/turf/space,
+/area/space/nearstation)
 "deS" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -36301,8 +36361,19 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-y"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "purplefull"
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
 	},
 /area/medical/research/nhallway)
 "deU" = (
@@ -36317,8 +36388,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "purplefull"
+	icon_state = "white"
 	},
 /area/medical/research/nhallway)
 "deW" = (
@@ -36328,11 +36402,14 @@
 	},
 /area/construction/hallway)
 "deX" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology)
 "dfa" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/structure/cable{
@@ -36349,11 +36426,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/red,
 /obj/item/radio/intercom{
-	pixel_y = -42
-	},
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_y = -28
+	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redcorner"
@@ -36375,6 +36448,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "dfh" = (
@@ -36384,19 +36460,6 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
 /area/assembly/chargebay)
-"dfj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/obj/machinery/door_control{
-	id = "xeno4";
-	name = "Containment Control";
-	pixel_y = 35;
-	req_access_txt = "55"
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "dfk" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -36503,83 +36566,40 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/delivery)
 "dfO" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/closet/crate{
+	icon_state = "crateopen";
+	opened = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurplecorner"
-	},
-/area/toxins/misc_lab)
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
 "dfP" = (
-/obj/machinery/atmospherics/binary/pump{
+/obj/machinery/camera{
+	c_tag = "Xeno Containment 2";
+	network = list("Research","SS13")
+	},
+/obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	icon_state = "dark"
 	},
-/area/toxins/misc_lab)
+/area/toxins/xenobiology)
 "dfQ" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
-"dfR" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/machinery/monkey_recycler,
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 28
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/explab)
-"dfS" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
-/area/toxins/explab)
+/area/toxins/xenobiology)
 "dfT" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/engine,
-/area/toxins/test_chamber)
+/area/toxins/explab)
 "dfU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -36595,17 +36615,13 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "dfV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -36618,19 +36634,6 @@
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
-"dfY" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel,
-/area/toxins/explab)
-"dfZ" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/structure/closet/radiation,
-/turf/simulated/floor/plasteel,
-/area/toxins/explab)
 "dga" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
@@ -36640,15 +36643,6 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/electrical)
 "dgb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple";
 	tag = "icon-whitepurple (WEST)"
@@ -36656,43 +36650,28 @@
 /area/medical/research/nhallway)
 "dgc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	tag = "icon-pipe-j1 (EAST)"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
-	},
-/area/medical/research/nhallway)
-"dgd" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurplecorner"
 	},
 /area/medical/research/nhallway)
 "dge" = (
 /obj/structure/table,
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/recharger{
 	pixel_x = 1;
 	pixel_y = 3
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
 	},
 /area/medical/research/nhallway)
 "dgi" = (
@@ -36705,20 +36684,20 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "dgk" = (
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner"
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
 	},
 /area/medical/research/nhallway)
 "dgo" = (
-/obj/effect/decal/cleanable/cobweb2,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "darkred"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/security/evidence)
+/turf/simulated/floor/plating,
+/area/maintenance/perma)
 "dgv" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -37053,21 +37032,6 @@
 	icon_state = "dark"
 	},
 /area/construction/hallway)
-"dhw" = (
-/obj/structure/table/wood,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/gambling_den)
-"dhx" = (
-/obj/machinery/atmospherics/binary/valve,
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
-	},
-/area/toxins/misc_lab)
 "dhA" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/camera{
@@ -37127,6 +37091,16 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -37190,21 +37164,15 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "dhX" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
+/obj/machinery/firealarm{
 	dir = 1;
-	id_tag = "SecMedPrivOutside"
+	pixel_y = -24
 	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "darkred"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "BridgeLockdown";
-	name = "Bridge Lockdown"
-	},
-/turf/simulated/floor/plating,
-/area/security/medbay)
+/area/security/evidence)
 "die" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -37453,40 +37421,19 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
-"dja" = (
-/obj/effect/decal/warning_stripes/yellow,
-/obj/machinery/atmospherics/unary/portables_connector{
+"djb" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurple"
-	},
-/area/toxins/misc_lab)
-"djb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/research{
-	name = "Chemical Toxins";
-	req_access_txt = "47"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/toxins/misc_lab)
+/area/toxins/xenobiology)
 "djc" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 25
@@ -37566,10 +37513,6 @@
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Toxin Mixing";
-	network = list("Research","SS13")
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
 	},
@@ -37581,6 +37524,10 @@
 	},
 /obj/machinery/firealarm{
 	pixel_y = 26
+	},
+/obj/machinery/camera{
+	c_tag = "Toxin Mixing";
+	network = list("Research","SS13")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -37806,65 +37753,11 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
-"dkp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
 "dks" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/oil/streak,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
-"dkt" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/tape/random{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/taperecorder,
-/obj/item/clothing/glasses/science,
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -26
-	},
-/obj/structure/cable,
-/obj/item/storage/bag/chemistry,
-/obj/item/storage/bag/chemistry,
-/obj/item/storage/bag/chemistry,
-/obj/item/storage/bag/chemistry,
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurple"
-	},
-/area/toxins/misc_lab)
-"dku" = (
-/obj/effect/decal/warning_stripes/yellow,
-/obj/machinery/smartfridge/medbay,
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "whitepurple"
-	},
-/area/toxins/misc_lab)
-"dkv" = (
-/obj/effect/decal/warning_stripes/south,
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/machinery/light,
-/turf/simulated/floor/engine,
-/area/toxins/misc_lab)
 "dkw" = (
 /obj/structure/plasticflaps/mining,
 /obj/machinery/conveyor/east{
@@ -37886,12 +37779,11 @@
 /turf/space,
 /area/space/nearstation)
 "dkz" = (
-/obj/structure/table,
-/obj/item/stack/medical/bruise_pack,
-/obj/item/stack/medical/ointment,
+/obj/effect/decal/warning_stripes/northwest,
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/toxins/explab)
+/obj/machinery/chem_dispenser,
+/turf/simulated/floor/engine,
+/area/toxins/misc_lab)
 "dkF" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
@@ -38080,9 +37972,11 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/mrchangs)
 "dlz" = (
-/mob/living/carbon/human/lesser/monkey,
-/turf/simulated/floor/engine,
-/area/toxins/test_chamber)
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/toxins/explab)
 "dlA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -38129,20 +38023,6 @@
 	icon_state = "dark"
 	},
 /area/construction/hallway)
-"dlL" = (
-/obj/machinery/reagentgrinder,
-/obj/structure/table/reinforced,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 28
-	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "whitepurple"
-	},
-/area/toxins/misc_lab)
 "dlM" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -38495,32 +38375,32 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/auxsolarport)
 "dmM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/remains/xeno,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/gambling_den)
-"dmN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Gambling Den"
-	},
-/obj/structure/barricade/wooden,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
+"dmO" = (
+/obj/structure/closet/radiation,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
+	},
+/area/toxins/explab)
 "dmP" = (
 /obj/effect/landmark/start{
 	name = "Quartermaster"
@@ -38620,9 +38500,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
 "dnf" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/ignition_switch{
@@ -38653,6 +38530,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/assembly/chargebay)
+"dnp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_x = -2;
+	pixel_y = 7
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
 "dns" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -39282,15 +39173,6 @@
 	icon_state = "white"
 	},
 /area/medical/medbay)
-"dpk" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/security/evidence)
 "dpn" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -39386,12 +39268,18 @@
 	},
 /area/crew_quarters/bar)
 "dpP" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
 "dpQ" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -39438,29 +39326,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
-"dpZ" = (
-/obj/structure/chair{
-	dir = 4
+"dqb" = (
+/obj/machinery/light{
+	dir = 1;
+	on = 1
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurplecorner"
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
 /area/medical/research/nhallway)
-"dqb" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "purplefull"
-	},
-/area/medical/research/shallway)
 "dqd" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
@@ -39501,11 +39377,6 @@
 	icon_state = "darkblue"
 	},
 /area/medical/morgue)
-"dqk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/remains/human,
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
 "dqq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -39574,17 +39445,6 @@
 	icon_state = "darkblue"
 	},
 /area/turret_protected/ai)
-"dqH" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/security/processing)
 "dqO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39682,7 +39542,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurple";
@@ -39696,6 +39556,21 @@
 	icon_state = "neutralfull"
 	},
 /area/assembly/robotics)
+"drA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/girder,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "drC" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
@@ -39902,17 +39777,6 @@
 	},
 /turf/simulated/floor/carpet/cyan,
 /area/medical/cmo)
-"dsj" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Security Officer"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
-/area/security/processing)
 "dsk" = (
 /obj/effect/decal/warning_stripes/southeastcorner,
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -40524,7 +40388,8 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurplecorner"
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
 	},
 /area/medical/research/shallway)
 "dvd" = (
@@ -40546,7 +40411,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "purplefull"
 	},
 /area/medical/research/shallway)
 "dvf" = (
@@ -41040,28 +40905,40 @@
 	},
 /area/crew_quarters/kitchen)
 "dxc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutral"
 	},
-/area/toxins/mixing)
+/area/toxins/launch)
 "dxd" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "swall7";
 	tag = "icon-swall7"
 	},
 /area/shuttle/supply)
+"dxe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "dxf" = (
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hop)
@@ -41324,17 +41201,17 @@
 	},
 /area/bridge/checkpoint/north)
 "dyp" = (
-/obj/structure/rack,
-/obj/item/extinguisher,
-/obj/item/clothing/mask/gas,
-/obj/item/grenade/chem_grenade/firefighting,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/light/small,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -26
+	},
+/obj/structure/cable,
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	dir = 4;
 	icon_state = "neutral"
 	},
-/area/toxins/mixing)
+/area/toxins/launch)
 "dyq" = (
 /obj/machinery/camera{
 	c_tag = "Research Toxins Storage Room";
@@ -41347,35 +41224,20 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
 "dyr" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/structure/closet/bombcloset,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/area/toxins/mixing)
+/turf/simulated/floor/plasteel,
+/area/toxins/launch)
 "dys" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/structure/closet/firecloset,
-/obj/machinery/camera{
-	c_tag = "Toxin Equipment Storage";
-	dir = 1;
-	network = list("Research","SS13")
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/toxins/mixing)
+/turf/simulated/floor/plasteel,
+/area/toxins/launch)
 "dyu" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/structure/reagent_dispensers/watertank,
-/obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	dir = 9;
+	dir = 8;
 	icon_state = "neutral"
 	},
-/area/toxins/mixing)
+/area/toxins/launch)
 "dyv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
@@ -41431,7 +41293,8 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurplecorner"
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
 	},
 /area/medical/research/shallway)
 "dyG" = (
@@ -41451,6 +41314,12 @@
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/bluegrid,
 /area/assembly/chargebay)
+"dyM" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitehall"
+	},
+/area/maintenance/asmaint2)
 "dza" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -41575,16 +41444,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
+/obj/structure/table/reinforced,
+/obj/item/radio/electropack,
+/obj/item/assembly/signaler,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "darkred"
 	},
-/area/security/medbay)
+/area/security/processing)
 "dzv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -41639,7 +41506,11 @@
 "dzA" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "caution"
+	},
 /area/toxins/storage)
 "dzC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -41651,7 +41522,11 @@
 "dzD" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "escape"
+	},
 /area/toxins/storage)
 "dzE" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -41669,7 +41544,8 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurplecorner"
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
 	},
 /area/medical/research/shallway)
 "dzI" = (
@@ -41677,14 +41553,16 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurplecorner"
+	dir = 10;
+	icon_state = "whitepurple"
 	},
 /area/medical/research/shallway)
 "dzJ" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
+	dir = 6;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (SOUTHEAST)"
 	},
 /area/medical/research/shallway)
 "dzL" = (
@@ -41708,49 +41586,39 @@
 	},
 /area/assembly/robotics)
 "dzY" = (
+/obj/structure/table,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/processing)
-"dAb" = (
-/obj/structure/bookcase{
-	name = "Forbidden Knowledge"
-	},
-/obj/item/book/manual/security_space_law,
-/obj/item/book/manual/sop_command,
-/obj/item/book/manual/sop_engineering,
-/obj/item/book/manual/sop_general,
-/obj/item/book/manual/sop_legal,
-/obj/item/book/manual/sop_medical,
-/obj/item/book/manual/sop_science,
-/obj/item/book/manual/sop_security,
-/obj/item/book/manual/sop_service,
-/obj/item/book/manual/sop_supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/permabrig)
+/area/security/evidence)
 "dAc" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 25
+/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
+/obj/item/radio/intercom{
+	pixel_y = 22
 	},
-/obj/item/reagent_containers/glass/bucket,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkred"
+	icon_state = "dark"
 	},
-/area/security/processing)
+/area/security/evidence)
 "dAf" = (
 /obj/structure/sign/chemistry,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall/r_wall,
 /area/medical/chemistry)
+"dAg" = (
+/obj/structure/sign/securearea,
+/turf/simulated/wall/r_wall/coated,
+/area/maintenance/xenozoo)
 "dAl" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -41800,9 +41668,7 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutral"
@@ -42137,8 +42003,10 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/toxins/mixing)
+/area/toxins/launch)
 "dBB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -42365,6 +42233,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/permabrig)
+"dCt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposaloutlet,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "dCv" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/engineering_guide{
@@ -42729,25 +42614,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
 "dDE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/door_control{
-	id = "temporary holding cell";
-	name = "Temporary Holding Cell Privacy Shutters Control";
-	pixel_x = -24;
-	req_access_txt = "63"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "red"
+	dir = 5;
+	icon_state = "darkred"
 	},
-/area/security/processing)
+/area/security/evidence)
 "dDH" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
@@ -42756,18 +42632,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/atmos)
-"dDI" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
 "dDK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -42820,22 +42684,14 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
+	icon_state = "white"
 	},
 /area/medical/research/restroom)
 "dDW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkblue"
-	},
-/area/chapel/main)
+/obj/structure/barricade/wooden,
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/library)
 "dEa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -42951,7 +42807,9 @@
 "dEH" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "bluefull"
+	},
 /area/toxins/storage)
 "dEO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -43100,8 +42958,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurplecorner"
+	icon_state = "white"
 	},
 /area/medical/research/restroom)
 "dFp" = (
@@ -43238,12 +43095,24 @@
 	name = "Medbay Maintenance"
 	})
 "dFK" = (
-/obj/structure/table/wood,
-/obj/item/paper/deltainfo,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/area/maintenance/library)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "dFM" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -43354,6 +43223,15 @@
 	icon_state = "dark"
 	},
 /area/library)
+"dGq" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 10
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology)
 "dGw" = (
 /obj/machinery/camera{
 	c_tag = "Fore Starboard Solars";
@@ -43373,9 +43251,7 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "dGB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/falsewall,
 /turf/simulated/floor/plating,
 /area/maintenance/library)
 "dGD" = (
@@ -43949,10 +43825,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurplecorner"
-	},
+/turf/simulated/floor/carpet/purple,
 /area/crew_quarters/hor)
 "dIi" = (
 /obj/machinery/light{
@@ -44023,9 +43896,19 @@
 	name = "\improper Virology Lobby"
 	})
 "dIo" = (
-/obj/effect/decal/warning_stripes/red,
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/item/reagent_containers/glass/bucket,
+/obj/structure/bookcase{
+	name = "Forbidden Knowledge"
+	},
+/obj/item/book/manual/security_space_law,
+/obj/item/book/manual/sop_command,
+/obj/item/book/manual/sop_engineering,
+/obj/item/book/manual/sop_general,
+/obj/item/book/manual/sop_legal,
+/obj/item/book/manual/sop_medical,
+/obj/item/book/manual/sop_science,
+/obj/item/book/manual/sop_security,
+/obj/item/book/manual/sop_service,
+/obj/item/book/manual/sop_supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -44423,6 +44306,12 @@
 	icon_state = "dark"
 	},
 /area/atmos)
+"dJP" = (
+/obj/machinery/bodyscanner,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/security/medbay)
 "dJS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -44702,13 +44591,20 @@
 	},
 /area/hydroponics)
 "dKY" = (
-/obj/item/radio/intercom{
-	pixel_y = -28
+/obj/effect/decal/warning_stripes/yellow,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "purplefull"
 	},
-/area/toxins/explab)
+/area/toxins/xenobiology)
 "dLb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -45175,16 +45071,9 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "dMK" = (
-/obj/structure/safe/floor,
-/obj/item/melee/cultblade,
-/obj/item/restraints/legcuffs/bola/cult,
-/obj/item/whetstone/cult,
-/obj/item/stack/sheet/runed_metal{
-	amount = 50
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/head/beret,
+/turf/simulated/floor/plating,
 /area/maintenance/library)
 "dML" = (
 /obj/structure/disposalpipe/segment{
@@ -45281,22 +45170,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "dNo" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 26
+/obj/item/radio/intercom{
+	pixel_x = 30
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
 /area/security/interrogation)
 "dNr" = (
@@ -45402,6 +45281,10 @@
 "dNB" = (
 /obj/effect/spawner/random_spawners/cobweb_right_frequent,
 /obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "dNC" = (
@@ -45417,9 +45300,8 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hop)
 "dNE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -45427,19 +45309,15 @@
 	},
 /turf/space,
 /turf/simulated/floor/plasteel{
-	dir = 1
+	icon_state = "dark"
 	},
 /area/security/processing)
 "dNG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+/obj/structure/closet/secure_closet/brig/evidence,
 /turf/simulated/floor/plasteel{
-	dir = 1
+	icon_state = "dark"
 	},
-/area/security/processing)
+/area/security/evidence)
 "dNO" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/firealarm{
@@ -45550,10 +45428,16 @@
 	name = "\improper Virology Lobby"
 	})
 "dOd" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
+	dir = 1;
 	icon_state = "darkred"
 	},
-/area/security/processing)
+/area/security/evidence)
 "dOf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45635,6 +45519,12 @@
 	icon_state = "dark"
 	},
 /area/atmos)
+"dOI" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/toxins/explab)
 "dOJ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -45784,6 +45674,12 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/serviceyard)
+"dPm" = (
+/obj/structure/sign/science{
+	icon_state = "xenobio2"
+	},
+/turf/simulated/wall,
+/area/toxins/xenobiology)
 "dPp" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
@@ -45959,15 +45855,6 @@
 	icon_state = "grimy"
 	},
 /area/chapel/main)
-"dQk" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
-/area/security/processing)
 "dQl" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -46407,9 +46294,6 @@
 	},
 /area/security/permabrig)
 "dRK" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = 6
@@ -46471,6 +46355,19 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/west)
+"dRU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/analyzer,
+/obj/item/multitool{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "purple"
+	},
+/area/maintenance/xenozoo)
 "dRW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -46518,13 +46415,11 @@
 	name = "\improper AI Satellite Hallway"
 	})
 "dSc" = (
-/obj/structure/window/reinforced,
 /obj/structure/closet/coffin,
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/chapel/main)
 "dSf" = (
@@ -46720,12 +46615,6 @@
 	icon_state = "dark"
 	},
 /area/chapel/office)
-"dSB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/turf/simulated/floor/plating,
-/area/maintenance/library)
 "dSC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -46739,7 +46628,9 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "dSD" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -46752,9 +46643,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (EAST)"
+	icon_state = "purplefull"
 	},
 /area/medical/research/nhallway)
 "dSF" = (
@@ -46881,6 +46770,17 @@
 	icon_state = "white"
 	},
 /area/crew_quarters/kitchen)
+"dTe" = (
+/obj/structure/bed,
+/obj/item/bedsheet/clown,
+/obj/effect/mob_spawn/human,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "dTf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47398,34 +47298,20 @@
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "dUG" = (
-/obj/structure/rack{
-	dir = 1
+/obj/structure/table/glass,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/item/storage/box/bodybags{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/evidence,
-/obj/item/storage/box/evidence{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/hand_labeler,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26;
-	pixel_y = 30
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "darkred"
+	icon_state = "whitered"
 	},
-/area/security/evidence)
+/area/security/medbay)
 "dUH" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -47462,12 +47348,7 @@
 	})
 "dUK" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box{
-	pixel_x = -13;
-	pixel_y = 3
-	},
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/storage/fancy/donut_box,
 /turf/simulated/floor/carpet,
 /area/chapel/office)
 "dUN" = (
@@ -47704,13 +47585,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2";
+	tag = "icon-pipe-j2 (EAST)"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard{
 	name = "Engineering Maintenance"
@@ -47941,13 +47823,20 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/serviceyard)
 "dWg" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/item/radio/intercom{
+	pixel_x = 30
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
+/obj/effect/decal/warning_stripes/northeast,
+/obj/machinery/door/window/brigdoor/northleft{
+	armor = list("melee"=85,"bullet"=20,"laser"=0,"energy"=0,"bomb"=60,"bio"=100,"rad"=100,"fire"=99,"acid"=100);
+	damage_deflection = 21
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/toxins/test_chamber)
 "dWh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -48027,17 +47916,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
-"dWs" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "dWv" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -48308,7 +48186,8 @@
 /obj/item/clothing/gloves/color/fyellow,
 /obj/item/multitool,
 /obj/machinery/light_switch{
-	pixel_x = -24
+	pixel_x = -24;
+	pixel_y = -8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1
@@ -48474,6 +48353,29 @@
 	icon_state = "neutralfull"
 	},
 /area/engine/engineering)
+"dXF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
 "dXG" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/cleaner,
@@ -48834,10 +48736,18 @@
 	},
 /area/quartermaster/qm)
 "dYs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "dYt" = (
 /obj/structure/disposalpipe/segment{
 	name = "Sorting Office"
@@ -48845,11 +48755,15 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/mrchangs)
 "dYv" = (
-/obj/effect/decal/cleanable/blood/xeno,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/tomato_smudge,
+/obj/structure/railing{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "dYy" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -49143,6 +49057,11 @@
 	maxcharge = 15000
 	},
 /obj/item/clothing/glasses/welding,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -49209,9 +49128,6 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
-"dZF" = (
-/turf/simulated/wall/r_wall,
-/area/maintenance/perma)
 "dZH" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
@@ -49378,7 +49294,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/toxins/mixing)
+/area/toxins/launch)
 "eaq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -49425,6 +49341,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/library)
+"eaV" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "purplefull"
+	},
+/area/toxins/xenobiology)
 "eaZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -49636,15 +49565,24 @@
 /turf/simulated/wall/r_wall,
 /area/atmos)
 "ecW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
-/area/toxins/explab)
+/area/toxins/misc_lab)
 "edb" = (
 /obj/structure/bed,
 /obj/item/bedsheet/red,
@@ -49702,19 +49640,33 @@
 /turf/simulated/floor/engine/air,
 /area/atmos)
 "edF" = (
-/obj/structure/closet/emcloset,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/barricade/wooden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/research{
+	name = "Research Division Access";
+	req_access_txt = "47"
+	},
+/turf/simulated/floor/plating,
 /area/maintenance/xenozoo)
 "edJ" = (
-/mob/living/simple_animal/mouse/brown,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
-/area/maintenance/gambling_den)
+/obj/structure/bed,
+/obj/item/bedsheet/orange,
+/turf/simulated/floor/carpet,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "edM" = (
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
@@ -49731,6 +49683,11 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
+"edN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bookcase,
+/turf/simulated/floor/plating,
+/area/maintenance/library)
 "eef" = (
 /obj/structure/sink{
 	dir = 8;
@@ -49808,12 +49765,6 @@
 	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay)
-"efg" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plasteel{
-	icon_state = "redfull"
-	},
-/area/security/processing)
 "efA" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -49829,28 +49780,12 @@
 	},
 /area/shuttle/siberia)
 "egh" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+/obj/item/clothing/mask/gas,
 /turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/maintenance/xenozoo)
 "egk" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -49960,15 +49895,6 @@
 	icon_state = "yellow"
 	},
 /area/engine/engineering)
-"egO" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
-	},
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
 "egU" = (
 /obj/structure/closet/l3closet/virology,
 /obj/item/storage/box/masks,
@@ -49981,6 +49907,14 @@
 /turf/simulated/floor/plasteel,
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
+	})
+"egZ" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
 	})
 "ehi" = (
 /obj/effect/spawner/random_spawners/fungus_maybe,
@@ -50155,20 +50089,13 @@
 	name = "Engineering Maintenance"
 	})
 "eiw" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/landmark/start{
-	name = "Scientist"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
-/area/toxins/xenobiology)
+/area/toxins/explab)
 "eix" = (
 /obj/machinery/light{
 	dir = 1
@@ -50216,10 +50143,6 @@
 	pixel_x = 5;
 	pixel_y = -5
 	},
-/obj/item/storage/secure/safe{
-	pixel_x = 4;
-	pixel_y = 32
-	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/lawoffice)
 "ejm" = (
@@ -50256,6 +50179,27 @@
 	icon_state = "neutralfull"
 	},
 /area/engine/engineering)
+"ejz" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/girder,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
 "ejB" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -50270,18 +50214,6 @@
 	},
 /turf/space,
 /area/maintenance/ai)
-"ejM" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
-/area/maintenance/library)
 "ejN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -50299,22 +50231,31 @@
 	},
 /area/security/armory)
 "ejU" = (
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -26
+/obj/structure/sign/poster/official/build{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
+"ekb" = (
+/obj/machinery/status_display{
+	pixel_x = -32
 	},
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/structure/cable,
-/turf/simulated/floor/engine,
-/area/toxins/test_chamber)
-"ekb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/xeno,
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/obj/machinery/reagentgrinder,
+/obj/machinery/button/windowtint{
+	anchored = 1;
+	id = "chem";
+	pixel_x = -24;
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
+	},
+/area/toxins/misc_lab)
 "ekj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -50373,31 +50314,29 @@
 /area/quartermaster/office)
 "ekt" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "xenosecure";
-	name = "Secure Creature Cell";
+	icon_state = "open";
+	id_tag = "RnDChem";
+	name = "Biohazard Shutter";
 	opacity = 0
 	},
-/obj/machinery/door/window/brigdoor{
-	dir = 8;
-	name = "Creature Pen";
-	req_access_txt = "47"
+/obj/effect/spawner/window/reinforced/plasma,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/area/toxins/xenobiology)
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "ekI" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -50595,7 +50534,7 @@
 	})
 "enm" = (
 /obj/structure/chair/sofa/corner{
-	dir = 4
+	dir = 1
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar/atrium)
@@ -50631,18 +50570,11 @@
 /area/atmos)
 "enV" = (
 /obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/security/glass{
 	name = "Prisoner Processing";
 	req_access_txt = "63"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "red"
@@ -50656,28 +50588,6 @@
 	icon_state = "darkblue"
 	},
 /area/turret_protected/ai)
-"eoF" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id_tag = "SecMedPrivOutside"
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "BridgeLockdown";
-	name = "Bridge Lockdown"
-	},
-/turf/simulated/floor/plating,
-/area/security/medbay)
 "eoM" = (
 /obj/structure/chair/sofa/corner,
 /turf/simulated/floor/carpet,
@@ -50693,9 +50603,7 @@
 	pixel_y = -30
 	},
 /obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
-	},
+/turf/simulated/floor/carpet/purple,
 /area/crew_quarters/hor)
 "epg" = (
 /obj/structure/closet/cardboard,
@@ -50716,17 +50624,13 @@
 	},
 /area/library)
 "epA" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/constructable_frame/machine_frame,
+/obj/machinery/light/small,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "purple"
 	},
-/obj/effect/decal/warning_stripes/northwest,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/area/maintenance/xenozoo)
 "epC" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -50780,9 +50684,19 @@
 	},
 /area/crew_quarters/courtroom)
 "epM" = (
-/obj/structure/chair/wood,
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/snacks/grown/tomato{
+	pixel_x = -10;
+	pixel_y = -12
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/black,
+/area/crew_quarters/theatre)
 "epY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -50860,6 +50774,24 @@
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
+"erd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "eri" = (
 /obj/structure/sink{
 	dir = 8;
@@ -50903,6 +50835,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/library)
+"erE" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE"
+	},
+/turf/simulated/wall,
+/area/maintenance/xenozoo)
 "erJ" = (
 /obj/machinery/ai_status_display{
 	pixel_y = 32
@@ -51083,8 +51023,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurplecorner"
+	icon_state = "white"
 	},
 /area/medical/research/nhallway)
 "esS" = (
@@ -51124,9 +51063,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -51147,10 +51083,13 @@
 	name = "Virology Maintenance"
 	})
 "ete" = (
-/turf/simulated/floor/wood,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 10
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology)
 "eto" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -51226,6 +51165,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
+"etW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "eue" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/botanic_leather,
@@ -51295,11 +51246,21 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/starboard)
 "evo" = (
-/obj/structure/chair/wood{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
+	},
+/area/toxins/xenobiology)
 "evI" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -51344,28 +51305,39 @@
 	icon_state = "neutralfull"
 	},
 /area/crew_quarters/locker)
+"ewa" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -25
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
+	},
+/area/toxins/xenobiology)
 "ewm" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "swall_f9"
 	},
 /area/shuttle/mining)
 "ewt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutral"
 	},
-/area/toxins/mixing)
+/area/toxins/launch)
 "ewx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -51423,6 +51395,24 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
+"exd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "chapel"
+	},
+/area/crew_quarters/theatre)
 "exh" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -51453,16 +51443,16 @@
 	},
 /area/medical/surgery/south)
 "exv" = (
-/obj/effect/decal/cleanable/cobweb2,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/alarm{
-	pixel_y = 23
+/obj/structure/table/reinforced,
+/obj/random/plushie,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -29
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "darkred"
+	dir = 1
 	},
-/area/security/interrogation)
+/area/security/processing)
 "exw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -51496,12 +51486,6 @@
 	icon_state = "red"
 	},
 /area/security/armory)
-"exN" = (
-/obj/structure/chair/stool/bar,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/maintenance/gambling_den)
 "exV" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/blue,
@@ -51511,6 +51495,22 @@
 	icon_state = "dark"
 	},
 /area/turret_protected/ai)
+"eyb" = (
+/obj/structure/sign/nosmoking_1{
+	pixel_y = 32
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purple"
+	},
+/area/maintenance/xenozoo)
 "eye" = (
 /obj/structure/chair/office/dark,
 /turf/simulated/floor/plasteel{
@@ -51590,22 +51590,20 @@
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "eyR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 0;
-	icon_state = "whitered"
+	icon_state = "dark"
 	},
-/area/security/medbay)
+/area/security/processing)
 "eyU" = (
 /obj/machinery/light{
 	dir = 4
@@ -51650,6 +51648,16 @@
 	icon_state = "dark"
 	},
 /area/gateway)
+"ezx" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "ezN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -51694,12 +51702,6 @@
 	icon_state = "yellow"
 	},
 /area/engine/engineering)
-"eAg" = (
-/obj/effect/decal/remains/human,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
 "eAm" = (
 /obj/machinery/camera/motion{
 	c_tag = "Minisat AI Core North";
@@ -51716,6 +51718,15 @@
 	icon_state = "darkblue"
 	},
 /area/turret_protected/ai)
+"eAn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine,
+/area/maintenance/xenozoo)
 "eAt" = (
 /obj/structure/closet/redcorp,
 /obj/item/clothing/suit/tracksuit/red,
@@ -51749,6 +51760,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "eAS" = (
@@ -51764,6 +51778,25 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
+"eBb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
+"eBj" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology)
 "eBn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -51773,6 +51806,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
+"eBr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder,
+/turf/simulated/floor/plasteel{
+	dir = 1
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "eBv" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -51869,6 +51911,11 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
+"eCh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/chair/wood/wings,
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "eCs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -51876,6 +51923,21 @@
 	icon_state = "neutral"
 	},
 /area/crew_quarters/sleep)
+"eCH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/effect/landmark{
+	name = "blobstart"
+	},
+/turf/simulated/floor/carpet,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "eCO" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -51889,14 +51951,15 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
 	},
 /area/medical/research/shallway)
 "eCP" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2{
 	name = "Tourist Area Maintenance"
@@ -51926,6 +51989,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/cabin3)
+"eDl" = (
+/obj/effect/spawner/random_spawners/blood_often,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "eDm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -52189,11 +52256,19 @@
 	},
 /area/atmos)
 "eFS" = (
-/obj/structure/sign/science{
-	icon_state = "xenobio2"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/obj/structure/table/wood,
+/obj/item/storage/briefcase{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/turf/simulated/wall/r_wall,
-/area/medical/research/nhallway)
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/crew_quarters/theatre)
 "eGb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -52211,6 +52286,47 @@
 /obj/effect/decal/cleanable/blood/oil/streak,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
+"eGd" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
+"eGh" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/test_chamber)
 "eGn" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -52240,21 +52356,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/hallway/secondary/exit)
-"eGA" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Xenobiology Lab";
-	req_access_txt = "47"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "eGC" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Service Bay";
@@ -52279,22 +52380,6 @@
 	},
 /turf/space,
 /area/security/podbay)
-"eGT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12;47"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
 "eHp" = (
 /obj/structure/chair/comfy/teal,
 /turf/simulated/floor/plasteel{
@@ -52333,17 +52418,6 @@
 	icon_state = "darkred"
 	},
 /area/security/permabrig)
-"eIb" = (
-/obj/structure/table,
-/obj/effect/decal/warning_stripes/yellow,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/paper/deltainfo,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurplecorner"
-	},
-/area/medical/research/nhallway)
 "eIk" = (
 /obj/machinery/atmospherics/unary/outlet_injector/on{
 	dir = 4;
@@ -52391,14 +52465,30 @@
 	},
 /area/turret_protected/ai)
 "eIQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/writing{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "eIV" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/spray/cleaner{
@@ -52522,6 +52612,14 @@
 /area/maintenance/port{
 	name = "Brig Maintenance"
 	})
+"eJG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/gloves/color/fyellow,
+/obj/item/storage/toolbox/electrical,
+/turf/simulated/floor/plating,
+/area/maintenance/xenozoo)
 "eJH" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/clothing/glasses/meson{
@@ -52567,6 +52665,12 @@
 	icon_state = "darkred"
 	},
 /area/security/execution)
+"eJP" = (
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/xenozoo)
 "eJR" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -52633,6 +52737,13 @@
 	icon_state = "dark"
 	},
 /area/library)
+"eKz" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/closet/radiation,
+/turf/simulated/floor/engine,
+/area/maintenance/xenozoo)
 "eKX" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -52648,6 +52759,20 @@
 	icon_state = "darkblue"
 	},
 /area/medical/surgery/south)
+"eLy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "eLE" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -52854,7 +52979,6 @@
 /area/crew_quarters/sleep)
 "eMZ" = (
 /obj/structure/bed/dogbed,
-/mob/living/simple_animal/pet/dog/security/detective,
 /turf/simulated/floor/wood,
 /area/security/detectives_office)
 "eNh" = (
@@ -52887,9 +53011,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/chair/office/dark{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -52973,6 +53094,17 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/central/sw)
+"eOk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/landmark{
+	name = "xeno_spawn";
+	pixel_x = -1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
 "eOr" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -53003,6 +53135,12 @@
 	icon_state = "dark"
 	},
 /area/toxins/lab)
+"eOK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/toxins/explab)
 "eON" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -53092,6 +53230,8 @@
 	name = "Virology Maintenance"
 	})
 "ePB" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -53102,14 +53242,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redfull";
@@ -53207,14 +53346,6 @@
 /obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel,
 /area/bridge/vip)
-"eRa" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/engine,
-/area/toxins/test_chamber)
 "eRk" = (
 /obj/machinery/sleeper/syndie{
 	dir = 4
@@ -53356,29 +53487,19 @@
 /area/crew_quarters/locker)
 "eTl" = (
 /obj/structure/cable{
-	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xeno1";
+	name = "Creature Cell #1";
+	opacity = 0
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
+/area/toxins/xenobiology)
 "eTs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -53502,20 +53623,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/kitchen)
-"eUm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
 "eUo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -53585,15 +53692,6 @@
 	icon_state = "grimy"
 	},
 /area/chapel/main)
-"eVu" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/turf/simulated/floor/plasteel{
-	dir = 0;
-	icon_state = "whitered"
-	},
-/area/security/medbay)
 "eVy" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -53710,17 +53808,15 @@
 	},
 /area/crew_quarters/bar/atrium)
 "eXc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door_control{
-	id = "xeno5";
-	name = "Containment Control";
-	pixel_y = 35;
-	req_access_txt = "55"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall"
+	icon_state = "white"
 	},
 /area/toxins/xenobiology)
 "eXe" = (
@@ -53738,13 +53834,16 @@
 	},
 /area/medical/morgue)
 "eXf" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/camera{
+	c_tag = "Xeno Containment 7";
+	dir = 1;
+	network = list("Research","SS13")
 	},
-/turf/simulated/floor/plating,
-/area/medical/research/nhallway)
+/obj/machinery/light/small,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/toxins/xenobiology)
 "eXm" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -53864,10 +53963,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
-"eYo" = (
-/obj/structure/table/wood/poker,
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
 "eYB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed,
@@ -53898,11 +53993,11 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar/atrium)
 "eYK" = (
-/obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/toxins/xenobiology)
+/turf/simulated/wall/r_wall/coated,
+/area/toxins/test_chamber)
 "eYO" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -53937,13 +54032,11 @@
 	},
 /area/quartermaster/office)
 "eYR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/effect/spawner/window/reinforced/plasma,
-/turf/simulated/floor/plating,
-/area/toxins/mixing)
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/plasteel,
+/area/toxins/launch)
 "eYT" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -54057,13 +54150,17 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/kitchen)
 "far" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/table/reinforced,
+/obj/item/storage/bag/bio,
+/obj/item/storage/bag/bio,
+/obj/item/storage/bag/bio,
+/obj/item/storage/bag/bio,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/area/toxins/xenobiology)
 "fat" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -54106,6 +54203,12 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
 /area/gateway)
+"faB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/item/trash/popcorn,
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "faG" = (
 /obj/effect/decal/warning_stripes/southeast,
 /obj/structure/morgue{
@@ -54195,19 +54298,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
-"fbz" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
 "fbF" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -54281,6 +54371,22 @@
 	icon_state = "neutralfull"
 	},
 /area/crew_quarters/locker)
+"fcS" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xeno2";
+	name = "Creature Cell #2";
+	opacity = 0
+	},
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology)
 "fcZ" = (
 /obj/machinery/door/airlock/hatch/gamma{
 	locked = 1;
@@ -54348,6 +54454,7 @@
 	},
 /area/quartermaster/qm)
 "fdX" = (
+/obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -54368,7 +54475,6 @@
 	id_tag = "PermaLockdown";
 	name = "Perma Lockdown"
 	},
-/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "feb" = (
@@ -54400,12 +54506,13 @@
 	icon_state = "neutralfull"
 	},
 /area/crew_quarters/locker)
-"feg" = (
-/obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+"feo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/area/toxins/explab)
+/turf/simulated/wall/r_wall,
+/area/toxins/xenobiology)
 "feu" = (
 /obj/structure/table/wood,
 /obj/item/storage/photo_album,
@@ -54460,6 +54567,33 @@
 	icon_state = "dark"
 	},
 /area/engine/hardsuitstorage)
+"feI" = (
+/obj/structure/window/reinforced/polarized{
+	dir = 8;
+	id = "pokerclub";
+	opacity = 1;
+	color = "#222222"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 1;
+	id = "pokerclub";
+	color = "#222222";
+	opacity = 1
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "pokerclub";
+	opacity = 1;
+	color = "#222222"
+	},
+/obj/structure/window/reinforced/polarized{
+	id = "pokerclub";
+	color = "#222222";
+	opacity = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "ffi" = (
 /obj/structure/table,
 /obj/item/folder,
@@ -54517,6 +54651,19 @@
 	icon_state = "dark"
 	},
 /area/security/permabrig)
+"ffM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1
+	},
+/area/maintenance/asmaint2)
 "ffP" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
@@ -54583,7 +54730,8 @@
 /obj/structure/bed,
 /obj/item/bedsheet/blue,
 /obj/machinery/light_switch{
-	pixel_x = 24
+	pixel_x = 24;
+	pixel_y = 40
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -54651,6 +54799,21 @@
 	icon_state = "darkred"
 	},
 /area/security/permabrig)
+"fgY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "whitehall"
+	},
+/area/maintenance/asmaint2)
 "fhd" = (
 /obj/structure/bed,
 /obj/item/bedsheet/syndie,
@@ -54659,6 +54822,10 @@
 	icon_state = "dark"
 	},
 /area/security/permabrig)
+"fhQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/royalblack,
+/area/maintenance/asmaint2)
 "fhY" = (
 /obj/structure/chair{
 	dir = 4
@@ -54671,12 +54838,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/fitness)
-"fib" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/security/evidence)
 "fif" = (
 /obj/structure/dresser,
 /obj/item/radio/intercom{
@@ -54685,22 +54846,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/cabin3)
-"fiH" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/engine,
-/area/toxins/test_chamber)
 "fiP" = (
 /obj/item/grenade/chem_grenade/metalfoam{
 	layer = 2.5;
@@ -54842,13 +54987,15 @@
 	},
 /area/security/permabrig)
 "fjQ" = (
-/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/coatrack,
 /obj/structure/sign/poster/contraband/random{
-	pixel_y = -32
+	pixel_x = -32
 	},
-/obj/machinery/vending/boozeomat,
 /turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "fjW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -54862,6 +55009,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft{
 	name = "Medbay Maintenance"
+	})
+"fjX" = (
+/obj/structure/rack,
+/obj/random/tool,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
 	})
 "fjY" = (
 /obj/machinery/door/firedoor,
@@ -54916,11 +55070,6 @@
 	icon_state = "red"
 	},
 /area/security/brig)
-"fku" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/closet,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
 "fkB" = (
 /obj/machinery/hydroponics/constructable{
 	desc = "These are connected with an irrigation tube. You see a little pipe connecting the trays.";
@@ -54999,13 +55148,21 @@
 	name = "Medbay Maintenance"
 	})
 "flH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/comfy/beige{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/area/maintenance/gambling_den)
+/turf/simulated/floor/carpet/royalblue,
+/area/crew_quarters/theatre)
+"flK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/turf/simulated/floor/engine,
+/area/maintenance/xenozoo)
 "flW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -55035,6 +55192,20 @@
 	icon_state = "grimy"
 	},
 /area/hallway/secondary/entry/lounge)
+"fmq" = (
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/item/radio/intercom{
+	pixel_x = 30
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/toxins/test_chamber)
 "fmw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -55219,30 +55390,6 @@
 	icon_state = "purplefull"
 	},
 /area/medical/research/nhallway)
-"fnM" = (
-/obj/machinery/door/airlock/security/glass{
-	id = "Interrogation";
-	id_tag = "Interrogation";
-	name = "Private Room";
-	req_access_txt = "63"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "darkredfull"
-	},
-/area/security/evidence)
 "foa" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/arcade,
@@ -55284,19 +55431,6 @@
 	tag = "icon-swall12"
 	},
 /area/shuttle/pod_4)
-"foU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/mob/living/simple_animal/mouse/brown,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/library)
 "foZ" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/condiment/peppermill{
@@ -55339,6 +55473,21 @@
 	icon_state = "dark"
 	},
 /area/library)
+"fpR" = (
+/obj/machinery/disposal,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/toxins/explab)
 "fqa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -55409,6 +55558,22 @@
 	icon_state = "arrival"
 	},
 /area/atmos)
+"fra" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "fre" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -55470,17 +55635,17 @@
 /turf/simulated/floor/engine/air,
 /area/atmos)
 "frM" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/sign/poster/contraband/random{
+/obj/machinery/newscaster{
 	pixel_x = -32
 	},
-/obj/structure/chair/stool/bar,
+/obj/structure/closet/bombcloset,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	dir = 8;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
 	},
-/area/maintenance/gambling_den)
+/area/toxins/explab)
 "frN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -55527,21 +55692,14 @@
 	},
 /area/crew_quarters/bar/atrium)
 "fsp" = (
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
-"fsq" = (
-/obj/machinery/button/windowtint{
-	anchored = 1;
-	id = "Interrogation";
-	pixel_y = 24;
-	req_access_txt = "63"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "darkred"
+	dir = 1;
+	icon_state = "purple"
 	},
-/area/security/evidence)
+/area/maintenance/xenozoo)
 "fsu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -55629,6 +55787,16 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
+"fsO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/comfy/beige{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/royalblue,
+/area/crew_quarters/theatre)
 "fsZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -55642,6 +55810,9 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/central/west)
+"ftc" = (
+/turf/simulated/wall/r_wall,
+/area/maintenance/perma)
 "ftj" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/door/firedoor,
@@ -55670,15 +55841,31 @@
 	tag = "icon-redfull (NORTHWEST)"
 	},
 /area/security/lobby)
-"ftu" = (
-/obj/structure/grille{
-	density = 0;
-	icon_state = "brokengrille"
+"ftD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
+	},
+/area/medical/research/nhallway)
 "ftG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/girder,
@@ -55745,15 +55932,27 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/west)
+"ful" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
+	},
+/area/medical/research/nhallway)
 "fuF" = (
-/obj/machinery/door/window/brigdoor/southleft{
-	dir = 1;
-	req_access_txt = "63"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "white"
 	},
-/area/security/evidence)
+/area/security/medbay)
 "fuR" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -55786,9 +55985,18 @@
 /turf/simulated/floor/wood,
 /area/security/detectives_office)
 "fvo" = (
-/obj/effect/decal/warning_stripes/yellow/partial,
+/obj/machinery/door/window/southright{
+	dir = 1;
+	name = "Toxins Launcher";
+	req_access_txt = "7"
+	},
+/obj/machinery/door/window/southright{
+	name = "Toxins Launcher";
+	req_access_txt = "7"
+	},
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plating,
-/area/toxins/mixing)
+/area/toxins/launch)
 "fvs" = (
 /obj/structure/table/wood,
 /obj/item/clothing/mask/cigarette/cigar{
@@ -55824,13 +56032,6 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
-"fvu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/engine,
-/area/toxins/test_chamber)
 "fvy" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -55916,6 +56117,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
+"fvZ" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xeno2";
+	name = "Creature Cell #2";
+	opacity = 0
+	},
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology)
 "fwe" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "laborcamp_home";
@@ -55933,27 +56149,34 @@
 /turf/simulated/floor/plating,
 /area/security/prisonershuttle)
 "fwf" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
 /area/maintenance/library)
 "fwt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
 "fwA" = (
+/obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/plasteel{
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Brig_lockdown";
+	name = "Brig Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
 	dir = 1;
-	icon_state = "whitered"
+	id_tag = "GYM";
+	locked = 1;
+	name = "Dungeon Privacy Shutters"
 	},
-/area/security/medbay)
+/turf/simulated/floor/plating,
+/area/security/processing)
 "fwR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -55989,13 +56212,6 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
-"fxy" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
-/area/maintenance/library)
 "fxz" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/electrical,
@@ -56030,16 +56246,11 @@
 	},
 /area/maintenance/starboard)
 "fye" = (
-/obj/structure/sign/goldenplaque{
-	desc = "ЦК награждает клоуна Шляпку как первого заключённого брига после перестройки. Он был задержан по статьям 100 104 и 309. Так держать.";
-	name = "Награда за первое нарушение в новом бриге";
-	pixel_y = 32
-	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	dir = 4;
+	icon_state = "darkred"
 	},
-/area/security/processing)
+/area/security/evidence)
 "fyj" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -56091,25 +56302,45 @@
 	},
 /area/security/customs)
 "fyJ" = (
-/obj/machinery/light/small,
-/obj/effect/decal/warning_stripes/south,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/barricade/wooden,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "fzv" = (
+/obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Brig_lockdown";
+	name = "Brig Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "GYM";
+	locked = 1;
+	name = "Dungeon Privacy Shutters"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitered"
-	},
-/area/security/medbay)
+/turf/simulated/floor/plating,
+/area/security/processing)
 "fzL" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -56117,22 +56348,22 @@
 	},
 /area/security/permabrig)
 "fzQ" = (
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_x = -30
-	},
-/obj/structure/table/glass,
-/obj/item/storage/toolbox/surgery{
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 4
-	},
+/obj/structure/bookcase,
+/obj/item/book/manual/security_space_law,
+/obj/item/book/manual/sop_command,
+/obj/item/book/manual/sop_engineering,
+/obj/item/book/manual/sop_general,
+/obj/item/book/manual/sop_legal,
+/obj/item/book/manual/sop_medical,
+/obj/item/book/manual/sop_science,
+/obj/item/book/manual/sop_security,
+/obj/item/book/manual/sop_service,
+/obj/item/book/manual/sop_supply,
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "whitered"
+	dir = 5;
+	icon_state = "darkred"
 	},
-/area/security/medbay)
+/area/security/processing)
 "fAl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -56143,29 +56374,41 @@
 	},
 /area/crew_quarters/locker)
 "fAq" = (
-/obj/machinery/power/apc{
-	cell_type = 5000;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 26
-	},
+/obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "whitered"
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Brig_lockdown";
+	name = "Brig Lockdown";
+	opacity = 0
 	},
-/area/security/medbay)
-"fAx" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "GYM";
+	locked = 1;
+	name = "Dungeon Privacy Shutters"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/plating,
 /area/security/processing)
+"fAx" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Brig_lockdown";
+	name = "Brig Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/security/evidence)
 "fAB" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -56214,6 +56457,14 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/west)
+"fAT" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
 "fBl" = (
 /obj/machinery/blackbox_recorder,
 /obj/machinery/alarm{
@@ -56299,16 +56550,19 @@
 	},
 /area/hallway/primary/fore)
 "fCp" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
-/area/toxins/mixing)
+/area/toxins/launch)
 "fCs" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -56337,8 +56591,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "fCJ" = (
-/obj/structure/table,
-/obj/item/taperecorder,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1
 	},
@@ -56377,6 +56643,10 @@
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/aft)
+"fDA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "fDB" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -56389,20 +56659,6 @@
 	tag = "icon-redfull (NORTHWEST)"
 	},
 /area/security/main)
-"fDW" = (
-/obj/machinery/door/window/westright{
-	name = "Front Desk"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/library)
 "fEc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -56411,14 +56667,6 @@
 	dir = 1
 	},
 /area/security/range)
-"fEg" = (
-/obj/machinery/recharge_station,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurplecorner"
-	},
-/area/medical/research/nhallway)
 "fEr" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -56662,7 +56910,7 @@
 	dir = 1;
 	icon_state = "neutral"
 	},
-/area/toxins/mixing)
+/area/toxins/launch)
 "fFR" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/secure_closet/engineering_electrical,
@@ -56678,6 +56926,15 @@
 	icon_state = "dark"
 	},
 /area/security/podbay)
+"fGc" = (
+/obj/structure/grille{
+	density = 0;
+	icon_state = "brokengrille"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
 "fGj" = (
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
@@ -56692,7 +56949,7 @@
 /area/turret_protected/ai)
 "fGz" = (
 /obj/structure/chair/sofa/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 1
@@ -56737,6 +56994,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/reception)
+"fHh" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/barricade/wooden,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "fHi" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -56900,20 +57175,37 @@
 /turf/simulated/floor/engine/co2,
 /area/atmos)
 "fJh" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = -32
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/newscaster{
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	dir = 1;
+	icon_state = "darkblue"
 	},
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "fJp" = (
 /obj/machinery/teleport/hub,
 /turf/simulated/floor/plating,
 /area/teleporter/abandoned)
+"fJN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
+	},
+/area/medical/research/nhallway)
 "fKf" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide{
 	anchored = 1
@@ -56921,16 +57213,10 @@
 /turf/simulated/floor/engine/co2,
 /area/atmos)
 "fKi" = (
-/obj/structure/rack,
-/obj/item/book/manual/engineering_guide,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
+/obj/structure/table/reinforced,
+/obj/item/book/manual/experimentor,
+/turf/simulated/floor/plasteel,
+/area/toxins/explab)
 "fKj" = (
 /obj/structure/chair{
 	dir = 1
@@ -57100,6 +57386,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/atmos)
+"fLR" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/xenozoo)
 "fMg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -57145,6 +57438,11 @@
 	dir = 6
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -57173,6 +57471,18 @@
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/port)
+"fMW" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel,
+/area/maintenance/asmaint2)
 "fNx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -57264,6 +57574,38 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
+"fOb" = (
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1379;
+	master_tag = "sw_maint_airlock";
+	name = "exterior access button";
+	pixel_x = 24;
+	pixel_y = 24
+	},
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/turf/space,
+/area/space/nearstation)
+"fOf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/confetti,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken7";
+	tag = "icon-wood-broken7"
+	},
+/area/crew_quarters/theatre)
+"fOi" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
+	},
+/area/toxins/test_chamber)
 "fOk" = (
 /obj/structure/grille,
 /obj/structure/window/full/shuttle,
@@ -57309,19 +57651,18 @@
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/fitness)
 "fOK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/door/airlock/research{
+	name = "Xenobiology Lab";
+	req_access_txt = "47"
 	},
-/obj/effect/decal/warning_stripes/yellow,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/door_control{
-	id = "xeno3";
-	name = "Containment Control";
-	pixel_y = -28;
-	req_access_txt = "55"
-	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "fON" = (
@@ -57339,20 +57680,13 @@
 	},
 /area/security/prison/cell_block/A)
 "fPi" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken";
+	tag = "icon-wood-broken"
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "xeno6";
-	name = "Creature Cell #6";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "fPA" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -57385,7 +57719,6 @@
 /obj/item/spacepod_equipment/weaponry/laser,
 /obj/item/clothing/suit/jacket/pilot,
 /obj/item/clothing/head/beret/sec,
-/obj/item/spacepod_equipment/weaponry/burst_taser,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -57510,24 +57843,20 @@
 	},
 /area/maintenance/kitchen)
 "fRj" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Temporary Holding Cell";
-	req_access_txt = "63"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 26
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull"
+	dir = 6;
+	icon_state = "darkred"
 	},
-/area/security/processing)
+/area/security/evidence)
 "fRt" = (
 /obj/structure/sign/directions/engineering{
 	dir = 8;
@@ -57595,10 +57924,14 @@
 	},
 /area/crew_quarters/sleep)
 "fRS" = (
-/obj/item/twohanded/required/kirbyplants,
+/obj/effect/decal/warning_stripes/northeast,
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/toxins/explab)
+/obj/machinery/chem_heater,
+/obj/structure/window/plasmareinforced{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/toxins/misc_lab)
 "fRW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -57661,12 +57994,6 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft{
 	name = "Medbay Maintenance"
@@ -57695,17 +58022,15 @@
 	},
 /area/hallway/primary/central/west)
 "fTu" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	external_pressure_bound = 140;
-	external_pressure_bound_default = 140;
-	on = 1;
-	pressure_checks = 0;
-	pressure_checks_default = 0
+/obj/structure/chair/office/light{
+	dir = 1;
+	pixel_y = 3
 	},
-/turf/simulated/floor/greengrid{
-	temperature = 80
+/obj/effect/landmark/start{
+	name = "Scientist"
 	},
-/area/toxins/xenobiology)
+/turf/simulated/floor/plasteel,
+/area/toxins/explab)
 "fTC" = (
 /obj/structure/table,
 /obj/machinery/vending/wallmed{
@@ -57867,6 +58192,14 @@
 	icon_state = "tranquillite"
 	},
 /area/maintenance/kitchen)
+"fUV" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitehall"
+	},
+/area/crew_quarters/theatre)
 "fVc" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -57895,18 +58228,13 @@
 	},
 /area/crew_quarters/kitchen)
 "fVn" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Xeno Kill Room";
-	network = list("Research","SS13")
-	},
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	temperature = 80
+	icon_state = "purple"
 	},
-/area/toxins/xenobiology)
+/area/maintenance/xenozoo)
 "fVv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -57958,19 +58286,10 @@
 	},
 /area/crew_quarters/locker)
 "fVN" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/turf/simulated/floor/greengrid{
+	temperature = 80
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
+/area/toxins/xenobiology)
 "fVO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -58050,18 +58369,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
-"fWk" = (
-/obj/machinery/atmospherics/unary/portables_connector,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 25
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/effect/decal/warning_stripes/southeast,
-/turf/simulated/floor/plasteel,
-/area/toxins/mixing)
 "fWl" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/window/reinforced,
@@ -58176,18 +58483,14 @@
 	icon_state = "dark"
 	},
 /area/security/podbay)
-"fXj" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
+"fXa" = (
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 1
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26;
-	pixel_y = 32
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/light,
 /turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/area/toxins/test_chamber)
 "fXm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -58281,15 +58584,6 @@
 	tag = "icon-whitepurple (WEST)"
 	},
 /area/assembly/robotics)
-"fXD" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/maintenance/xenozoo)
 "fXK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light,
@@ -58308,31 +58602,12 @@
 	},
 /turf/space,
 /area/space/nearstation)
-"fXQ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurple"
-	},
-/area/toxins/xenobiology)
 "fXV" = (
-/obj/structure/table,
-/obj/item/folder{
-	pixel_x = -3
-	},
-/obj/item/folder{
-	pixel_y = 3
-	},
-/obj/item/folder{
-	pixel_x = 3
-	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "red"
+	dir = 10;
+	icon_state = "darkred"
 	},
-/area/security/processing)
+/area/security/interrogation)
 "fXZ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
@@ -58354,14 +58629,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/assembly/showroom)
-"fYu" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology)
 "fYB" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
@@ -58444,6 +58711,21 @@
 	icon_state = "grimy"
 	},
 /area/assembly/showroom)
+"fZv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "fZE" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light,
@@ -58495,6 +58777,11 @@
 	icon_state = "green"
 	},
 /area/hallway/secondary/exit)
+"gam" = (
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken6"
+	},
+/area/maintenance/library)
 "gao" = (
 /turf/simulated/wall,
 /area/security/checkpoint/south)
@@ -58530,14 +58817,16 @@
 	},
 /area/maintenance/electrical)
 "gaJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "white"
 	},
-/area/maintenance/gambling_den)
+/area/toxins/xenobiology)
 "gbp" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -58807,6 +59096,12 @@
 	icon_state = "fancy-wood-birch-broken6"
 	},
 /area/maintenance/fsmaint)
+"geI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "geP" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -58965,18 +59260,26 @@
 	},
 /area/security/customs)
 "ghg" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/door_control{
+	id = "engsm1";
+	name = "Supermatter Blast Doors";
+	pixel_x = 26;
+	pixel_y = 6
 	},
-/obj/item/radio/intercom{
-	dir = 1;
-	pixel_x = -32
+/obj/structure/computerframe,
+/obj/machinery/door_control{
+	id = "smbolts1";
+	name = "Supermatter Bolt Control";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	pixel_x = 26;
+	pixel_y = -6
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 4;
+	icon_state = "purple"
 	},
-/area/maintenance/gambling_den)
+/area/maintenance/xenozoo)
 "ghj" = (
 /obj/machinery/atmospherics/trinary/mixer,
 /turf/simulated/floor/engine,
@@ -59019,20 +59322,17 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/cabin2)
 "gig" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "xeno1";
-	name = "Creature Cell #1";
-	opacity = 0
+/obj/machinery/door/firedoor,
+/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
-/turf/simulated/floor/plating,
 /area/toxins/xenobiology)
 "gih" = (
 /obj/structure/chair/office/light{
@@ -59063,6 +59363,22 @@
 /area/medical/research{
 	name = "Research Division"
 	})
+"gim" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "gio" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -59070,6 +59386,21 @@
 	icon_state = "neutralcorner"
 	},
 /area/maintenance/starboard)
+"giw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "gjf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
@@ -59150,22 +59481,6 @@
 	icon_state = "brown"
 	},
 /area/quartermaster/qm)
-"gkD" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
-/turf/simulated/floor/engine,
-/area/toxins/test_chamber)
 "gkQ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -59202,20 +59517,24 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "purplefull"
 	},
 /area/medical/research/shallway)
 "glb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/structure/table/reinforced,
+/obj/item/storage/bible,
+/obj/item/reagent_containers/food/drinks/bottle/holywater,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 9;
+	icon_state = "darkred"
 	},
-/area/security/medbay)
+/area/security/processing)
+"gld" = (
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkredcorners"
+	},
+/area/security/processing)
 "glp" = (
 /obj/machinery/light{
 	dir = 8
@@ -59315,11 +59634,21 @@
 	name = "Brig Maintenance"
 	})
 "glQ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_x = 1;
+	pixel_y = 3
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull"
+	icon_state = "redfull";
+	tag = "icon-redfull (NORTHWEST)"
 	},
 /area/security/processing)
 "glR" = (
@@ -59355,6 +59684,20 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
+"gmA" = (
+/obj/structure/table,
+/obj/item/storage/box/evidence,
+/obj/item/storage/box/evidence,
+/obj/item/hand_labeler,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/evidence)
 "gmI" = (
 /obj/machinery/camera{
 	c_tag = "Engine Room South";
@@ -59370,11 +59713,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"gmO" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "redfull"
+"gmU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/area/security/processing)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "gnf" = (
 /turf/simulated/wall,
 /area/crew_quarters/cabin2)
@@ -59393,23 +59746,17 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/cabin3)
 "gnv" = (
-/obj/machinery/optable,
-/obj/machinery/shower{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/tank/internals/anesthetic,
-/obj/item/clothing/mask/breath/medical,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/structure/closet,
+/obj/item/storage/box/handcuffs,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/stack/tape_roll,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitered"
+	dir = 6;
+	icon_state = "darkred"
 	},
-/area/security/medbay)
+/area/security/processing)
 "gnI" = (
 /obj/structure/table,
 /obj/item/storage/fancy/crayons,
@@ -59523,26 +59870,6 @@
 /area/maintenance/fsmaint2{
 	name = "Tourist Area Maintenance"
 	})
-"goC" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "xenosecure";
-	name = "Secure Creature Cell";
-	opacity = 0
-	},
-/obj/effect/spawner/window/reinforced/plasma,
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology)
 "goI" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -59588,6 +59915,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/podbay)
+"gpo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/theatre)
 "gps" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -59619,6 +59956,9 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -59776,9 +60116,11 @@
 	},
 /area/medical/sleeper)
 "gre" = (
-/obj/structure/bookcase,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken5"
+/obj/structure/table/wood,
+/obj/item/folder,
+/obj/item/pen,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
 /area/maintenance/library)
 "grm" = (
@@ -59793,6 +60135,17 @@
 "grq" = (
 /turf/simulated/wall,
 /area/quartermaster/office)
+"grC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
+	},
+/area/crew_quarters/theatre)
 "grN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
@@ -59812,22 +60165,16 @@
 	name = "Engineering Maintenance"
 	})
 "grU" = (
-/obj/structure/chair{
-	dir = 4
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/machinery/camera{
-	c_tag = "Prisoner Processing West";
-	dir = 4;
-	network = list("SS13","Security")
+/obj/machinery/door/poddoor/shutters/preopen{
+	id_tag = "SecMedPriv"
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/security/processing)
+/turf/simulated/floor/plating,
+/area/security/medbay)
 "grW" = (
 /obj/item/radio/intercom{
 	dir = 1;
@@ -59838,14 +60185,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/south)
-"gsc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/toxins/explab)
 "gss" = (
 /obj/item/flag/nt,
 /obj/machinery/status_display{
@@ -59884,7 +60223,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	dir = 4;
 	icon_state = "red"
 	},
 /area/security/processing)
@@ -59945,19 +60284,6 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
-"gue" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/landmark{
-	color = "#00ae00";
-	icon_state = "x_white";
-	name = "ninja_teleport"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/perma)
 "gui" = (
 /obj/structure/rack,
 /obj/item/target/syndicate,
@@ -60047,6 +60373,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/flasher{
+	id = "Cell 1";
+	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bcarpet05"
@@ -60226,6 +60556,23 @@
 	icon_state = "green"
 	},
 /area/hallway/secondary/exit)
+"gwQ" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/grille,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "gwY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -60251,6 +60598,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/ai)
+"gxh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_spawners/grille_often,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "gxj" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
@@ -60282,21 +60639,33 @@
 /turf/simulated/floor/plating,
 /area/maintenance/library)
 "gxI" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/item/flashlight/lamp,
+/obj/item/taperecorder,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/item/folder{
-	pixel_x = -3
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/item/folder{
-	pixel_y = 3
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "red"
+	icon_state = "dark"
 	},
 /area/security/interrogation)
+"gxL" = (
+/obj/item/twohanded/required/kirbyplants{
+	layer = 3.1
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/maintenance/library)
 "gxS" = (
 /obj/structure/dispenser,
 /obj/item/radio/intercom{
@@ -60396,16 +60765,10 @@
 	},
 /area/medical/genetics)
 "gze" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/writing,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2{
 	name = "Tourist Area Maintenance"
@@ -60428,6 +60791,13 @@
 	icon_state = "darkred"
 	},
 /area/security/podbay)
+"gzt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/comfy/beige{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "gzz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
@@ -60455,6 +60825,20 @@
 	icon_state = "grimy"
 	},
 /area/chapel/office)
+"gzC" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/syringes,
+/obj/item/extinguisher/mini,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology)
 "gzR" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -60494,17 +60878,29 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/miningdock)
 "gAD" = (
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/maintenance/gambling_den)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/curtain/open/shower/security{
+	name = "backstage";
+	alpha = 255;
+	icon_state = "closed";
+	opacity = 1
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "gAF" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whitepurplecorner"
 	},
 /area/medical/research/restroom)
 "gAS" = (
@@ -60605,6 +61001,19 @@
 	dir = 1
 	},
 /area/security/permahallway)
+"gBL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "gBU" = (
 /obj/structure/chair{
 	dir = 4
@@ -61103,26 +61512,31 @@
 	icon_state = "escape"
 	},
 /area/crew_quarters/locker)
-"gGZ" = (
-/obj/machinery/door_control{
-	id = "SecMedPrivOutside";
-	name = "Brig Medbay Privacy Shutters Control";
-	pixel_x = -8;
-	pixel_y = -28;
-	req_access_txt = "63"
-	},
-/obj/machinery/door_control{
-	id = "SecMedPrivInside";
-	name = "Brig Medbay Privacy Shutters Control";
-	pixel_x = 8;
-	pixel_y = -28;
-	req_access_txt = "63"
-	},
+"gGO" = (
 /turf/simulated/floor/plasteel{
-	dir = 0;
-	icon_state = "whitered"
+	icon_state = "purplefull"
 	},
-/area/security/medbay)
+/area/toxins/misc_lab)
+"gGZ" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Brig_lockdown";
+	name = "Brig Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id_tag = "GYM";
+	name = "Dungeon Privacy Shutters"
+	},
+/turf/simulated/floor/plating,
+/area/security/processing)
 "gHb" = (
 /obj/structure/window/reinforced,
 /obj/structure/table,
@@ -61167,6 +61581,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
+"gHo" = (
+/obj/machinery/camera{
+	c_tag = "Research Test Chamber room";
+	network = list("SS13","Research");
+	dir = 9
+	},
+/obj/machinery/atmospherics/binary/pump{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
+	},
+/area/toxins/test_chamber)
 "gHp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61199,12 +61629,44 @@
 	},
 /area/engine/engineering)
 "gHB" = (
-/obj/structure/curtain/open,
-/turf/simulated/floor/plasteel{
-	dir = 0;
-	icon_state = "whitered"
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/syringe{
+	pixel_x = -1;
+	pixel_y = -11
 	},
-/area/security/medbay)
+/obj/item/reagent_containers/syringe/calomel{
+	pixel_x = -1;
+	pixel_y = -6
+	},
+/obj/item/reagent_containers/syringe/heparin{
+	pixel_x = -1;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/glass/bottle/reagent/hairgrownium{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/glass/bottle/frostoil{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/glass/bottle/mutagen{
+	pixel_y = 6
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -6;
+	pixel_y = 30
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "darkred"
+	},
+/area/security/processing)
 "gHM" = (
 /obj/machinery/door_control{
 	id = "stationawaygate";
@@ -61247,11 +61709,23 @@
 /turf/simulated/floor/plating,
 /area/atmos)
 "gHY" = (
-/turf/simulated/floor/plasteel{
-	dir = 0;
-	icon_state = "whitered"
+/obj/machinery/door_control{
+	id = "GYM";
+	name = "Dungeon Privacy Shutters Control";
+	pixel_x = -24;
+	pixel_y = 23;
+	req_access_txt = "63"
 	},
-/area/security/medbay)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkredcorners"
+	},
+/area/security/processing)
 "gIa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -61354,6 +61828,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/surgery/south)
+"gJg" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/explab)
 "gJh" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/fire/firefighter,
@@ -61437,17 +61924,19 @@
 	},
 /area/security/permabrig)
 "gJO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/camera{
+	c_tag = "Evidence Storage";
+	dir = 6;
+	network = list("SS13","Security")
+	},
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 9;
+	icon_state = "darkred"
 	},
-/area/security/processing)
+/area/security/evidence)
 "gJQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -61504,6 +61993,11 @@
 	},
 /obj/structure/cable{
 	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
@@ -61545,11 +62039,6 @@
 	icon_state = "dark"
 	},
 /area/library)
-"gKK" = (
-/obj/machinery/atmospherics/unary/portables_connector,
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/mixing)
 "gKP" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood/fancy/cherry,
@@ -61568,6 +62057,21 @@
 	tag = "icon-vault (NORTHEAST)"
 	},
 /area/crew_quarters/bar)
+"gLl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "gLn" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "redcorner"
@@ -61579,6 +62083,19 @@
 	icon_state = "red"
 	},
 /area/security/prisonershuttle)
+"gLu" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 4;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurplecorner"
+	},
+/area/toxins/misc_lab)
 "gLx" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -61598,24 +62115,9 @@
 	name = "\improper Virology Lobby"
 	})
 "gLz" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/item/book/manual/security_space_law,
 /turf/simulated/floor/plasteel{
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/processing)
 "gLB" = (
@@ -61753,9 +62255,16 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/west)
+"gMs" = (
+/obj/structure/sign/securearea,
+/turf/simulated/wall/r_wall,
+/area/toxins/launch)
 "gMv" = (
-/obj/effect/landmark/damageturf,
-/turf/simulated/floor/plating/airless,
+/obj/effect/landmark/burnturf,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "darkred"
+	},
 /area/space)
 "gMw" = (
 /obj/effect/landmark{
@@ -61772,23 +62281,6 @@
 	icon_state = "dark"
 	},
 /area/library)
-"gMy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
 "gMS" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/vodka{
@@ -61893,13 +62385,6 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/solar/port)
-"gNL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/processing)
 "gNM" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/machinery/door/poddoor{
@@ -61965,19 +62450,30 @@
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "gNY" = (
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "purple"
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
 	},
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
 /area/maintenance/xenozoo)
 "gNZ" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/monkeycubes,
-/obj/item/storage/box/monkeycubes,
-/obj/effect/decal/warning_stripes/west,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/turf/simulated/floor/plasteel,
+/obj/effect/decal/warning_stripes/south,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (SOUTHWEST)"
+	},
 /area/toxins/xenobiology)
 "gOb" = (
 /obj/effect/spawner/window/reinforced,
@@ -62084,6 +62580,33 @@
 /area/shuttle/escape{
 	parallax_movedir = 2
 	})
+"gOG" = (
+/obj/machinery/door/window/brigdoor{
+	dir = 2;
+	name = "Creature Pen";
+	req_access_txt = "47"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xeno4";
+	name = "Creature Cell #4";
+	opacity = 0
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/toxins/xenobiology)
 "gOL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/table/wood,
@@ -62141,21 +62664,32 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "gPw" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "purple"
-	},
-/area/maintenance/xenozoo)
-"gPK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/writing{
+	dir = 8
+	},
+/obj/item/trash/spentcasing,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
+"gPK" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/area/maintenance/gambling_den)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "gPL" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -62241,11 +62775,6 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -62263,18 +62792,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/ntrep)
-"gQH" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
-	},
-/area/toxins/xenobiology)
 "gQN" = (
 /obj/machinery/hydroponics/constructable{
 	desc = "These are connected with an irrigation tube. You see a little pipe connecting the trays.";
@@ -62308,6 +62825,26 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"gQZ" = (
+/obj/machinery/door/airlock/research/glass{
+	name = "Experimentor";
+	req_access_txt = "47";
+	id = "EXP";
+	id_tag = "EXP"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/explab)
 "gRa" = (
 /obj/machinery/light,
 /obj/structure/closet/emcloset,
@@ -62554,38 +63091,18 @@
 	},
 /turf/simulated/floor/engine,
 /area/medical/chemistry)
-"gTG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/explab)
 "gTH" = (
 /turf/simulated/floor/plasteel,
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
 	})
 "gTK" = (
-/obj/machinery/computer/operating{
-	dir = 4
-	},
+/obj/machinery/vending/security,
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "whitered"
+	dir = 9;
+	icon_state = "red"
 	},
-/area/security/medbay)
+/area/security/processing)
 "gUa" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -62620,7 +63137,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
 	},
-/area/toxins/mixing)
+/area/toxins/launch)
 "gVd" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -62678,6 +63195,9 @@
 	dir = 5;
 	network = list("Research","SS13")
 	},
+/obj/machinery/status_display{
+	pixel_x = -32
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurple"
@@ -62703,6 +63223,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
+"gVJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/broken_bottle,
+/obj/item/chair/stool,
+/obj/effect/spawner/random_spawners/blood_often,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "gVK" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -62717,6 +63244,10 @@
 /turf/simulated/floor/plating,
 /area/security/checkpoint/south)
 "gVL" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
@@ -62728,10 +63259,6 @@
 	},
 /obj/structure/window/reinforced/polarized{
 	id = "execution"
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/security/execution)
@@ -62786,6 +63313,23 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/assembly/robotics)
+"gVZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1
+	},
+/area/maintenance/asmaint2)
 "gWh" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
@@ -62852,14 +63396,6 @@
 	icon_state = "neutralfull"
 	},
 /area/crew_quarters/courtroom)
-"gXb" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/status_display{
-	pixel_y = 32
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/toxins/explab)
 "gXc" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -62915,11 +63451,7 @@
 	},
 /area/quartermaster/office)
 "gXK" = (
-/obj/effect/decal/cleanable/blood,
-/obj/item/clothing/mask/cigarette/syndicate{
-	pixel_x = -7;
-	pixel_y = -1
-	},
+/obj/structure/chair/office/dark,
 /turf/simulated/floor/plating,
 /area/maintenance/library)
 "gXM" = (
@@ -62992,15 +63524,6 @@
 	tag = "icon-redfull (NORTHWEST)"
 	},
 /area/crew_quarters/kitchen)
-"gYN" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurplecorner"
-	},
-/area/toxins/explab)
 "gYX" = (
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -63148,6 +63671,17 @@
 /area/shuttle/escape{
 	parallax_movedir = 2
 	})
+"hbk" = (
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/hologram/holopad{
+	pixel_x = 16
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
+	},
+/area/toxins/explab)
 "hbA" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/extinguisher_cabinet{
@@ -63224,6 +63758,17 @@
 	icon_state = "red"
 	},
 /area/security/armory)
+"hco" = (
+/obj/item/radio/intercom{
+	pixel_x = 30
+	},
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
+	},
+/area/toxins/misc_lab)
 "hcu" = (
 /obj/structure/chair{
 	dir = 1
@@ -63429,17 +63974,6 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
-"heE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = 24
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitehall"
-	},
-/area/toxins/xenobiology)
 "heF" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -63469,12 +64003,19 @@
 /turf/simulated/floor/plating,
 /area/engine/controlroom)
 "hfq" = (
-/obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/area/maintenance/gambling_den)
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/turf/simulated/floor/carpet/black,
+/area/crew_quarters/theatre)
 "hfx" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -63751,13 +64292,18 @@
 	name = "Toxin Mixing";
 	req_access_txt = "47"
 	},
-/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/toxins/mixing)
+/area/toxins/launch)
+"hjo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/random/tool,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "hjp" = (
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken"
@@ -63892,22 +64438,12 @@
 	name = "Brig Lockdown";
 	opacity = 0
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "SecPilotPriv"
-	},
 /turf/simulated/floor/plating,
 /area/security/podbay)
 "hkF" = (
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
 /area/gateway)
-"hlh" = (
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
 "hlj" = (
 /obj/machinery/computer/crew{
 	dir = 4
@@ -63981,17 +64517,23 @@
 /turf/simulated/floor/plating,
 /area/security/podbay)
 "hmq" = (
-/obj/structure/closet/secure_closet/brigdoc{
-	req_access = list(2,5,)
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/item/handheld_defibrillator,
-/obj/item/storage/belt/medical,
-/obj/item/storage/pill_bottle,
-/obj/item/storage/pill_bottle/patch_pack,
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "whitered"
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Brig_lockdown";
+	name = "Brig Lockdown";
+	opacity = 0
 	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "SecMedPriv"
+	},
+/turf/simulated/floor/plating,
 /area/security/medbay)
 "hmB" = (
 /turf/simulated/floor/plasteel{
@@ -64062,27 +64604,33 @@
 	},
 /area/crew_quarters/fitness)
 "hnB" = (
-/obj/structure/table/glass,
-/obj/item/paper_bin{
-	pixel_y = 7
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/item/flashlight/lamp{
-	layer = 3.1;
-	pixel_x = -3;
-	pixel_y = 11
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/item/pen,
-/obj/item/folder/white{
-	pixel_x = 6;
-	pixel_y = 3
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/item/radio/intercom{
-	pixel_y = 32
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Brig_lockdown";
+	name = "Brig Lockdown";
+	opacity = 0
 	},
-/turf/simulated/floor/plasteel{
+/obj/machinery/door/poddoor/shutters/preopen{
 	dir = 1;
-	icon_state = "whitered"
+	id_tag = "SecMedPriv"
 	},
+/turf/simulated/floor/plating,
 /area/security/medbay)
 "hnE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -64144,6 +64692,21 @@
 /obj/machinery/computer/card,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
+"hof" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purple"
+	},
+/area/maintenance/xenozoo)
 "hog" = (
 /obj/machinery/sleeper{
 	pixel_x = 3
@@ -64171,6 +64734,25 @@
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
+"hoq" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/research/glass{
+	name = "Xenobiology Lab";
+	req_access_txt = "47";
+	id = "xeno";
+	id_tag = "xeno"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology)
 "hox" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -64232,12 +64814,13 @@
 	c_tag = "Research Hallway";
 	network = list("Research","SS13")
 	},
-/obj/item/radio/intercom{
-	pixel_y = 24
+/obj/machinery/firealarm{
+	pixel_y = 26
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurplecorner"
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
 /area/medical/research/nhallway)
 "hoT" = (
@@ -64273,19 +64856,6 @@
 	icon_state = "darkredfull"
 	},
 /area/security/warden)
-"hoX" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
 "hpc" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -64308,27 +64878,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "hpg" = (
-/obj/structure/table/glass,
-/obj/structure/sign/nosmoking_1{
-	pixel_x = 32
-	},
-/obj/item/storage/fancy/donut_box{
-	pixel_y = -4
-	},
-/obj/item/reagent_containers/food/drinks/mug/sec,
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "whitered"
-	},
-/area/security/medbay)
-"hph" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -64339,11 +64892,31 @@
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 1;
-	id_tag = "GYM";
-	locked = 1;
-	name = "Dungeon Privacy Shutters"
+	id_tag = "SecMedPriv"
 	},
 /turf/simulated/floor/plating,
+/area/security/medbay)
+"hph" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/obj/item/flash{
+	pixel_x = 1;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka{
+	pixel_x = 5;
+	pixel_y = -3
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkred"
+	},
 /area/security/processing)
 "hpE" = (
 /obj/machinery/newscaster{
@@ -64354,6 +64927,18 @@
 	icon_state = "neutralcorner"
 	},
 /area/bridge/vip)
+"hpN" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitehall"
+	},
+/area/maintenance/asmaint2)
 "hpO" = (
 /obj/structure/table/glass,
 /obj/item/flashlight/lamp,
@@ -64366,23 +64951,31 @@
 	},
 /area/medical/virology)
 "hpZ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/security/evidence)
+"hqa" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/morgue{
-	name = "Dungeon";
-	req_access_txt = "63"
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_spawners/oil_maybe,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "whitehall"
 	},
-/area/security/processing)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "hqh" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -64583,22 +65176,41 @@
 /area/maintenance/fsmaint2{
 	name = "Tourist Area Maintenance"
 	})
-"hsI" = (
-/obj/effect/decal/cleanable/cobweb2,
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 3.25;
-	pixel_x = 24
-	},
-/obj/item/radio/intercom{
-	pixel_y = 30
+"hsv" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "darkred"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/security/evidence)
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
+"hsI" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/perma)
+"hsK" = (
+/obj/structure/barricade/wooden,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/library)
 "hsQ" = (
 /obj/machinery/light{
 	dir = 8
@@ -64632,10 +65244,25 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/security/execution)
+"hsV" = (
+/obj/structure/sign/poster/official/nanotrasen_logo{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
+	},
+/area/medical/research/nhallway)
 "htb" = (
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
@@ -64644,6 +65271,19 @@
 /area/maintenance/fore{
 	name = "Hangar Maintenance"
 	})
+"htc" = (
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/light/small,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/floor/engine,
+/area/maintenance/xenozoo)
 "htt" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/manifold4w/visible/purple,
@@ -64654,16 +65294,17 @@
 	},
 /area/atmos)
 "htC" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "experimentor";
-	name = "Experimentor Blast Door";
-	opacity = 0
+/obj/machinery/shieldwallgen{
+	req_access = list(47)
 	},
-/turf/simulated/floor/plating,
-/area/toxins/explab)
+/obj/structure/sign/electricshock{
+	pixel_y = -32
+	},
+/obj/structure/cable,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology)
 "htF" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/structure/chair/comfy/brown{
@@ -64748,7 +65389,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -64816,6 +65456,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "hvI" = (
@@ -64872,25 +65515,12 @@
 	},
 /area/hallway/primary/central/sw)
 "hwj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurplecorner"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
+/area/toxins/misc_lab)
 "hwq" = (
 /obj/effect/spawner/random_spawners/fungus_probably,
 /turf/simulated/wall,
@@ -64919,25 +65549,6 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/central/south)
-"hwC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
 "hwE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille{
@@ -65116,6 +65727,13 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/central/south)
+"hzo" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 6
+	},
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology)
 "hzp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -65197,6 +65815,22 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/south)
+"hzY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "hAu" = (
 /obj/item/radio/intercom{
 	pixel_x = -28
@@ -65220,7 +65854,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "hAQ" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -65263,6 +65897,10 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
+"hBv" = (
+/obj/structure/lattice,
+/turf/simulated/wall/r_wall/coated,
+/area/maintenance/xenozoo)
 "hBD" = (
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall,
@@ -65338,6 +65976,23 @@
 	icon_state = "neutral"
 	},
 /area/toxins/mixing)
+"hCb" = (
+/obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door_control{
+	id = "xeno3";
+	name = "Containment Control";
+	pixel_y = 35;
+	req_access_txt = "55"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
+	},
+/area/toxins/xenobiology)
 "hCc" = (
 /obj/machinery/light/spot{
 	dir = 4;
@@ -65411,7 +66066,7 @@
 	tag = "icon-pipe-j1s (EAST)"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "purplefull"
 	},
 /area/medical/research/nhallway)
 "hCx" = (
@@ -65492,12 +66147,27 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
 "hDv" = (
-/obj/structure/table/wood/poker,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/area/maintenance/gambling_den)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology)
 "hDH" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -65550,6 +66220,22 @@
 	tag = "icon-asteroid (NORTH)"
 	},
 /area/hydroponics)
+"hEg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
+	},
+/area/toxins/xenobiology)
 "hEh" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "swall14"
@@ -65575,19 +66261,21 @@
 	},
 /area/library)
 "hEB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/door/window/brigdoor{
-	dir = 2;
-	name = "Creature Pen";
-	req_access_txt = "47"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
 	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/area/toxins/test_chamber)
 "hED" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -65601,7 +66289,35 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/prison/cell_block/A)
+"hEI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/warning_stripes/yellow,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/test_chamber)
 "hEK" = (
+/obj/machinery/door_control{
+	id = "brig_detprivacy";
+	name = "Detective Privacy Shutters Control";
+	pixel_x = null;
+	pixel_y = 22
+	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
@@ -65717,6 +66433,14 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"hFQ" = (
+/obj/effect/decal/cleanable/blood,
+/obj/item/clothing/mask/cigarette/syndicate{
+	pixel_x = -7;
+	pixel_y = -1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
 "hFX" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
@@ -65740,20 +66464,21 @@
 	},
 /turf/simulated/floor/carpet,
 /area/medical/psych)
-"hGI" = (
+"hGZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/gambling_den)
-"hGZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2{
@@ -65803,6 +66528,21 @@
 	icon_state = "whitepurple"
 	},
 /area/toxins/mixing)
+"hHq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/grille/broken,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "hHs" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -65925,23 +66665,16 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
-"hIS" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/security/prison/cell_block/A)
 "hIZ" = (
 /obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
+"hJo" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "hJA" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -65977,23 +66710,9 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/serviceyard)
 "hJG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurplecorner"
-	},
-/area/toxins/explab)
+/obj/machinery/light,
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "hJO" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -66008,6 +66727,9 @@
 	},
 /obj/item/assembly/signaler{
 	pixel_y = 13
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -66057,13 +66779,20 @@
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
 "hKl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/barricade/wooden,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xeno5";
+	name = "Creature Cell #5";
+	opacity = 0
+	},
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
+/area/toxins/xenobiology)
 "hKm" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -66080,15 +66809,36 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/central/ne)
+"hKo" = (
+/obj/structure/rack,
+/obj/random/tool,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
+"hKs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "hKt" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/closet/bombcloset,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkblue"
+	dir = 1;
+	icon_state = "neutral"
 	},
-/area/chapel/main)
+/area/toxins/launch)
 "hKB" = (
 /turf/simulated/floor/plating,
 /area/maintenance/casino)
@@ -66185,17 +66935,19 @@
 	},
 /area/blueshield)
 "hLD" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 4
 	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard{
@@ -66232,21 +66984,6 @@
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"hLZ" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 26
-	},
-/obj/structure/table/wood,
-/obj/item/clothing/gloves/color/fyellow,
-/obj/item/storage/toolbox/electrical,
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
 "hMh" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/south,
@@ -66401,6 +67138,18 @@
 	icon_state = "neutralfull"
 	},
 /area/crew_quarters/sleep)
+"hNY" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/toxins/test_chamber)
 "hOi" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -66456,6 +67205,12 @@
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/storage)
+"hOE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/security/processing)
 "hOJ" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -66463,11 +67218,12 @@
 	},
 /area/crew_quarters/courtroom)
 "hOT" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 4;
+	on = 1
+	},
+/turf/simulated/floor/engine,
+/area/maintenance/xenozoo)
 "hOZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -66500,16 +67256,10 @@
 /obj/item/folder/blue,
 /obj/item/pen/multi/fountain,
 /obj/item/paper/safe_code{
-	owner = "captain";
-	pixel_x = -6;
-	pixel_y = -6
+	owner = "captain"
 	},
 /obj/item/paper/monitorkey,
 /obj/item/lighter/zippo/cap,
-/obj/item/paper/rnd_logs_key{
-	pixel_x = 6;
-	pixel_y = 6
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -66533,6 +67283,21 @@
 	icon_state = "purple"
 	},
 /area/quartermaster/miningdock)
+"hPO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/misc_lab)
 "hPQ" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -66566,6 +67331,12 @@
 	icon_state = "dark"
 	},
 /area/crew_quarters/courtroom)
+"hQe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/machinery/recharger,
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "hQg" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -66610,6 +67381,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
+"hQs" = (
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "hQz" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -66680,35 +67457,21 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/hor)
 "hQX" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Brig_lockdown";
-	name = "Brig Lockdown";
-	opacity = 0
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id_tag = "GYM";
-	locked = 1;
-	name = "Dungeon Privacy Shutters"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull";
+	tag = "icon-redfull (NORTHWEST)"
+	},
 /area/security/processing)
 "hRd" = (
 /obj/structure/table,
@@ -66767,11 +67530,7 @@
 /area/civilian/vacantoffice)
 "hRD" = (
 /obj/structure/bed,
-/obj/item/radio/intercom{
-	pixel_y = -42
-	},
-/obj/machinery/flasher{
-	id = "Cell 5";
+/obj/machinery/newscaster{
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -66779,11 +67538,6 @@
 	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
-"hRI" = (
-/obj/item/stack/cable_coil,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/perma)
 "hRL" = (
 /obj/structure/holosign/barrier/atmos,
 /turf/simulated/floor/plating,
@@ -66856,19 +67610,33 @@
 /turf/simulated/wall,
 /area/quartermaster/storage)
 "hSO" = (
-/obj/effect/decal/cleanable/blood/tracks,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/trash/semki{
+	pixel_x = 2;
+	pixel_y = -12
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/barricade/wooden,
-/obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/library)
+/area/crew_quarters/theatre)
+"hTr" = (
+/obj/structure/table/wood,
+/obj/item/soap,
+/obj/machinery/light,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken";
+	tag = "icon-wood-broken"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "hTs" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -32
@@ -66903,11 +67671,6 @@
 	icon_state = "dark"
 	},
 /area/security/warden)
-"hTO" = (
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
-/area/security/brig)
 "hTS" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -67017,38 +67780,6 @@
 /obj/structure/sign/securearea,
 /turf/simulated/wall,
 /area/engine/engineering)
-"hUH" = (
-/obj/structure/sign/biohazard,
-/turf/simulated/wall,
-/area/toxins/xenobiology)
-"hUJ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/landmark/start{
-	name = "Scientist"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology)
-"hUL" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
 "hUP" = (
 /obj/effect/landmark/burnturf,
 /obj/machinery/light/small{
@@ -67226,13 +67957,9 @@
 	},
 /area/medical/virology)
 "hWA" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
-	},
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
+/obj/structure/lattice,
+/turf/simulated/wall,
+/area/maintenance/asmaint2)
 "hWL" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -67248,17 +67975,13 @@
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "hWX" = (
-/obj/structure/closet/secure_closet/brig/evidence,
-/obj/machinery/light{
-	dir = 1;
-	in_use = 1
+/obj/machinery/sleeper{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "darkred"
+	icon_state = "white"
 	},
-/area/security/evidence)
+/area/security/medbay)
 "hXd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastleft{
@@ -67308,14 +68031,19 @@
 	},
 /area/quartermaster/storage)
 "hXy" = (
-/obj/structure/closet/secure_closet/brig/evidence,
-/obj/effect/decal/cleanable/cobweb2,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "darkred"
+/obj/structure/bed/roller,
+/obj/machinery/light{
+	dir = 1
 	},
-/area/security/evidence)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/security/medbay)
 "hXD" = (
 /obj/machinery/power/smes,
 /obj/structure/cable{
@@ -67345,7 +68073,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "purplefull"
 	},
 /area/medical/research/shallway)
 "hYl" = (
@@ -67402,19 +68130,17 @@
 	},
 /area/chapel/office)
 "hYQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	dir = 8;
+	icon_state = "darkred"
 	},
-/area/security/processing)
+/area/security/evidence)
 "hZa" = (
 /obj/structure/table/reinforced,
 /obj/item/paicard,
@@ -67423,6 +68149,19 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
+"hZD" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
+	},
+/area/toxins/xenobiology)
 "hZV" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -67434,15 +68173,17 @@
 	name = "Virology Maintenance"
 	})
 "hZW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkredcorners"
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -26
 	},
-/area/security/evidence)
+/turf/simulated/floor/plating,
+/area/maintenance/perma)
 "iaa" = (
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -67473,31 +68214,6 @@
 	dir = 1
 	},
 /area/security/armory)
-"iah" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/disposal,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/ignition_switch{
-	id = "testigniter";
-	pixel_x = -24;
-	pixel_y = 6
-	},
-/obj/machinery/door_control{
-	id = "RnDChem";
-	name = "Chamber Blast Doors";
-	pixel_x = -24;
-	pixel_y = -5
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurple"
-	},
-/area/toxins/misc_lab)
 "iau" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -67514,42 +68230,43 @@
 	})
 "ibj" = (
 /obj/structure/cable{
+	d1 = 1;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "1-8"
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Brig_lockdown";
-	name = "Brig Lockdown";
-	opacity = 0
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id_tag = "GYM";
-	locked = 1;
-	name = "Dungeon Privacy Shutters"
-	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/security/processing)
-"ibu" = (
+/area/security/permabrig)
+"ibp" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/mob/living/simple_animal/mouse/brown,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
-"ibA" = (
-/obj/structure/grille{
-	density = 0;
-	icon_state = "brokengrille"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/item/shard,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/area/maintenance/asmaint2)
+"ibu" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology)
 "ibF" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "Perma2";
@@ -67649,12 +68366,13 @@
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "icl" = (
-/obj/effect/landmark/burnturf,
+/obj/effect/decal/warning_stripes/red,
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "darkred"
+	icon_state = "dark"
 	},
-/area/space)
+/area/security/permabrig)
 "icp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -67687,9 +68405,18 @@
 	parallax_movedir = 2
 	})
 "icz" = (
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/obj/effect/landmark{
+	name = "xeno_spawn";
+	pixel_x = -1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/turf/simulated/floor/engine,
+/area/toxins/explab)
 "icF" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -67709,10 +68436,6 @@
 /obj/item/storage/box/zipties,
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
-"ido" = (
-/obj/effect/decal/cleanable/crayon,
-/turf/simulated/floor/plating,
-/area/maintenance/library)
 "idt" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
@@ -67720,11 +68443,13 @@
 /area/space/nearstation)
 "idu" = (
 /obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/structure/closet/coffin,
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/door/window/eastleft{
+	dir = 8;
+	name = "Coffin Storage";
+	req_access_txt = "22"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "vault"
@@ -67755,11 +68480,22 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
-"idZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/maintenance/library)
+"iec" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "purplefull"
+	},
+/area/toxins/xenobiology)
 "ief" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -67786,15 +68522,16 @@
 	},
 /area/crew_quarters/sleep)
 "ies" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/closet/secure_closet/personal/cabinet{
+	opened = 1
 	},
-/obj/structure/chair/stool,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/item/clothing/shoes/clown_shoes,
+/obj/item/clothing/gloves/color/rainbow/clown,
+/obj/item/reagent_containers/spray/waterflower,
 /turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "ieY" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -67808,16 +68545,14 @@
 	},
 /area/turret_protected/ai)
 "ifq" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/structure/bed,
+/obj/item/bedsheet/patriot,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/obj/effect/decal/warning_stripes/southeast,
-/obj/machinery/shieldwallgen{
-	req_access = list(47)
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "ifw" = (
 /obj/item/radio/intercom{
 	pixel_x = 26;
@@ -67986,18 +68721,6 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
-"igZ" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/structure/sign/poster/official/obey{
-	pixel_x = 32
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/security/processing)
 "ihl" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -68066,9 +68789,22 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "ihw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1
 	},
 /area/security/processing)
 "ihB" = (
@@ -68121,6 +68857,21 @@
 	icon_state = "neutralfull"
 	},
 /area/atmos)
+"iiw" = (
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken"
+	},
+/area/maintenance/library)
+"iiB" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/structure/window/plasmareinforced{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/xenozoo)
 "iiP" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -68202,6 +68953,10 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/maintenance/maintcentral)
+"ijs" = (
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plating,
+/area/toxins/launch)
 "ijv" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -68232,19 +68987,22 @@
 	parallax_movedir = 2
 	})
 "ijD" = (
-/obj/machinery/suit_storage_unit/security/warden,
+/obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkred"
 	},
 /area/security/warden)
 "ijH" = (
-/obj/structure/rack,
-/obj/item/paper,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
+/obj/machinery/door/airlock/bananium,
+/obj/item/grown/bananapeel{
+	layer = 1.9
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
 	})
 "ijJ" = (
 /obj/machinery/portable_atmospherics/canister/toxins{
@@ -68265,6 +69023,13 @@
 	icon_state = "tranquillite"
 	},
 /area/maintenance/kitchen)
+"ijY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/clothing,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/theatre)
 "ikc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -68280,9 +69045,16 @@
 	},
 /area/crew_quarters/courtroom)
 "ikg" = (
+/obj/machinery/camera{
+	c_tag = "Xeno High Security Containment";
+	dir = 1;
+	network = list("Research","SS13")
+	},
+/obj/item/radio/intercom{
+	pixel_y = -32
+	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "whitepurple"
+	icon_state = "dark"
 	},
 /area/toxins/xenobiology)
 "ikr" = (
@@ -68312,11 +69084,6 @@
 	icon_state = "purple"
 	},
 /area/atmos)
-"ikA" = (
-/turf/simulated/wall/r_wall,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
 "ikJ" = (
 /obj/structure/closet/secure_closet/hop,
 /obj/machinery/camera{
@@ -68391,6 +69158,12 @@
 	icon_state = "freezerfloor"
 	},
 /area/crew_quarters/kitchen)
+"ilC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/maintenance/xenozoo)
 "ilF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -68401,16 +69174,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
-"ilJ" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/storage/bag/bio,
-/obj/item/storage/bag/bio,
-/obj/item/storage/bag/bio,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "ilL" = (
 /obj/structure/sign/engineering{
 	pixel_x = -32
@@ -68494,12 +69257,6 @@
 	name = "Medbay Maintenance";
 	req_one_access_txt = "5;12"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft{
 	name = "Medbay Maintenance"
@@ -68565,14 +69322,6 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
-"imT" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
 "ind" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/landmark{
@@ -68608,6 +69357,19 @@
 	icon_state = "dark"
 	},
 /area/chapel/main)
+"inz" = (
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/obj/structure/table,
+/obj/item/wrench,
+/obj/item/crowbar,
+/obj/item/clothing/mask/gas,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology)
 "inF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -68729,6 +69491,29 @@
 	icon_state = "vault"
 	},
 /area/tcommsat/chamber)
+"ioF" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "ioU" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -68741,9 +69526,21 @@
 	},
 /area/security/permahallway)
 "ipb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/maintenance/xenozoo)
 "ipi" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/item/clothing/glasses/hud/hydroponic,
@@ -68880,11 +69677,8 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/mixing)
 "iqN" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/obj/effect/spawner/window/reinforced/plasma,
+/turf/simulated/floor/plating,
 /area/maintenance/xenozoo)
 "iqP" = (
 /obj/effect/spawner/window/reinforced,
@@ -69029,6 +69823,10 @@
 "irJ" = (
 /turf/simulated/wall/r_wall,
 /area/engine/mechanic_workshop/expedition)
+"irK" = (
+/obj/effect/spawner/random_spawners/wall_rusted_probably,
+/turf/simulated/wall,
+/area/maintenance/asmaint2)
 "irV" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -69112,15 +69910,6 @@
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
 	})
-"isM" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research/nhallway)
 "itk" = (
 /obj/structure/sink{
 	dir = 8;
@@ -69178,6 +69967,24 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/bridge/vip)
+"iuk" = (
+/obj/item/radio/intercom{
+	pixel_x = 28
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "iul" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/light/small{
@@ -69262,35 +70069,20 @@
 /area/maintenance/starboard{
 	name = "Engineering Maintenance"
 	})
-"ive" = (
-/obj/structure/bed,
-/obj/item/bedsheet/patriot,
+"ivv" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/monkeycubes,
+/obj/item/storage/box/monkeycubes,
+/obj/item/storage/box/monkeycubes,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
-"ivi" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
+/area/toxins/test_chamber)
 "ivw" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -69421,13 +70213,26 @@
 /turf/simulated/floor/wood,
 /area/assembly/showroom)
 "iwC" = (
-/obj/structure/closet/secure_closet/brig/evidence,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/glass,
+/obj/machinery/computer/med_data/laptop{
+	pixel_x = 1;
+	pixel_y = 2
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/obj/item/radio/intercom{
+	pixel_x = -30
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24;
+	pixel_y = 28
+	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "darkred"
+	icon_state = "whitered"
 	},
-/area/security/evidence)
+/area/security/medbay)
 "iwI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -69449,15 +70254,11 @@
 	},
 /area/security/prison/cell_block/A)
 "iwS" = (
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 24
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "darkredcorners"
+	icon_state = "whitered"
 	},
-/area/security/evidence)
+/area/security/medbay)
 "ixc" = (
 /obj/machinery/door_timer/cell_2,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -69495,19 +70296,20 @@
 	},
 /area/gateway)
 "ixk" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/item/radio/intercom{
-	pixel_x = 30;
-	pixel_y = 30
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = 60;
+	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkred"
+	dir = 1;
+	icon_state = "whitered"
 	},
-/area/security/evidence)
+/area/security/medbay)
 "ixm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/camera{
@@ -69536,17 +70338,14 @@
 /turf/simulated/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "ixu" = (
-/obj/machinery/bodyscanner{
-	dir = 4
-	},
-/obj/structure/sign/poster/official/cleanliness{
-	pixel_x = -32
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -25
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "whitered"
+	icon_state = "dark"
 	},
-/area/security/medbay)
+/area/security/processing)
 "ixy" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -69665,7 +70464,6 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "iAf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
@@ -69673,9 +70471,10 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1
+	dir = 10;
+	icon_state = "darkred"
 	},
-/area/security/processing)
+/area/security/evidence)
 "iAj" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -69717,25 +70516,12 @@
 	name = "Brig Maintenance"
 	})
 "iAK" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized{
-	dir = 8;
-	id = "Interrogation"
+/obj/structure/disposaloutlet{
+	dir = 1
 	},
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "Interrogation"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 1;
-	id = "Interrogation"
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
+/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plating,
-/area/security/evidence)
+/area/space/nearstation)
 "iAS" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -69775,21 +70561,9 @@
 	},
 /area/crew_quarters/sleep)
 "iBE" = (
-/obj/item/flashlight/lamp{
-	layer = 4;
-	pixel_x = 7;
-	pixel_y = 14
-	},
-/obj/item/radio/intercom/locked/confessional{
-	frequency = 1470;
-	pixel_y = -4;
-	req_access_txt = "63"
-	},
-/obj/structure/table/reinforced,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/evidence)
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/plating,
+/area/maintenance/perma)
 "iBT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -69824,11 +70598,8 @@
 	},
 /area/chapel/main)
 "iCk" = (
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkred"
-	},
-/area/security/evidence)
+/turf/simulated/floor/plating,
+/area/maintenance/perma)
 "iCu" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -70026,40 +70797,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "iFi" = (
-/obj/item/shard{
-	icon_state = "medium";
-	pixel_x = 9;
-	pixel_y = -9
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/obj/effect/spawner/random_spawners/wall_rusted_maybe,
+/turf/simulated/wall,
 /area/maintenance/library)
-"iFq" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research/glass{
-	name = "Xenobiology Lab";
-	req_access_txt = "47"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "iFu" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -70117,15 +70857,22 @@
 	icon_state = "darkblue"
 	},
 /area/turret_protected/ai)
+"iFB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/east,
+/obj/machinery/door/window/brigdoor,
+/turf/simulated/floor/plating,
+/area/maintenance/xenozoo)
 "iFD" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
-/area/maintenance/gambling_den)
+/turf/simulated/floor/wood,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "iFG" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/table,
@@ -70154,6 +70901,14 @@
 	icon_state = "neutralfull"
 	},
 /area/engine/engineering)
+"iFI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "iFO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -70223,9 +70978,19 @@
 	},
 /area/turret_protected/ai)
 "iGn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
-	icon_state = "red"
+	dir = 1
 	},
 /area/security/processing)
 "iGo" = (
@@ -70245,24 +71010,6 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
-"iGx" = (
-/obj/structure/bookcase,
-/obj/item/book/manual/security_space_law,
-/obj/item/book/manual/sop_command,
-/obj/item/book/manual/sop_engineering,
-/obj/item/book/manual/sop_general,
-/obj/item/book/manual/sop_legal,
-/obj/item/book/manual/sop_medical,
-/obj/item/book/manual/sop_science,
-/obj/item/book/manual/sop_security,
-/obj/item/book/manual/sop_service,
-/obj/item/book/manual/sop_supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "darkred"
-	},
-/area/security/processing)
 "iGE" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -70396,19 +71143,25 @@
 /turf/simulated/floor/carpet,
 /area/ntrep)
 "iHF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc{
+	cell_type = 25000;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24;
+	shock_proof = 1
+	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/structure/cable,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkblue"
 	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "iHJ" = (
 /obj/machinery/atmospherics/trinary/filter{
 	desc = "Отфильтровывает токсины из трубы и отправляет их в камеру хранения";
@@ -70490,19 +71243,18 @@
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "iIq" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple";
 	tag = "icon-whitepurple (NORTH)"
 	},
-/area/toxins/explab)
+/area/toxins/xenobiology)
 "iIN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -70549,14 +71301,15 @@
 	icon_state = "dark"
 	},
 /area/chapel/main)
-"iJJ" = (
-/obj/structure/table,
-/obj/item/folder/red,
-/obj/item/pen,
+"iJF" = (
+/obj/structure/bed,
+/obj/item/bedsheet/rainbow,
 /turf/simulated/floor/plasteel{
-	dir = 1
+	icon_state = "grimy"
 	},
-/area/security/processing)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "iJL" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -70580,6 +71333,11 @@
 /obj/structure/table/reinforced,
 /obj/item/taperecorder,
 /obj/item/clothing/glasses/sunglasses/blindfold,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/engine,
 /area/security/execution)
 "iJV" = (
@@ -70601,15 +71359,6 @@
 	icon_state = "neutralfull"
 	},
 /area/engine/hardsuitstorage)
-"iJW" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/east,
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "iJZ" = (
 /obj/structure/window/reinforced,
 /obj/machinery/door/window{
@@ -70650,19 +71399,11 @@
 	},
 /area/library)
 "iKW" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door_control{
-	id = "xeno1";
-	name = "Containment Control";
-	pixel_y = -28;
-	req_access_txt = "55"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitehall"
+	icon_state = "white"
 	},
 /area/toxins/xenobiology)
 "iLb" = (
@@ -70748,6 +71489,22 @@
 	icon_state = "neutralfull"
 	},
 /area/atmos)
+"iLE" = (
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/engine,
+/area/toxins/misc_lab)
+"iLG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/clipboard,
+/obj/item/folder,
+/turf/simulated/floor/plasteel{
+	icon_state = "purple"
+	},
+/area/maintenance/xenozoo)
 "iLK" = (
 /obj/machinery/portable_atmospherics/scrubber/huge/stationary,
 /obj/effect/decal/warning_stripes/red/hollow,
@@ -70779,20 +71536,6 @@
 /area/shuttle/escape{
 	parallax_movedir = 2
 	})
-"iLT" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 25
-	},
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "red"
-	},
-/area/security/processing)
 "iLV" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
@@ -70867,6 +71610,13 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/sleep)
+"iMM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/black,
+/area/crew_quarters/theatre)
 "iNf" = (
 /obj/machinery/requests_console{
 	department = "Engineering";
@@ -70956,11 +71706,6 @@
 /obj/item/camera,
 /turf/simulated/floor/plasteel/grimy,
 /area/civilian/vacantoffice)
-"iNR" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
 "iNS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
@@ -70992,19 +71737,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/security/lobby)
-"iOx" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/security/medbay)
 "iOz" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -71085,8 +71817,7 @@
 /area/atmos)
 "iPx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/bookcase,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plating,
 /area/maintenance/library)
 "iPD" = (
 /obj/structure/cable{
@@ -71103,19 +71834,6 @@
 /obj/effect/decal/warning_stripes/northeastsouth,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
-"iPH" = (
-/obj/item/radio/intercom/locked/confessional{
-	frequency = 1470;
-	pixel_y = 4;
-	req_access_txt = "63"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/security/processing)
 "iQf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -71128,20 +71846,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
-"iQu" = (
-/obj/machinery/atmospherics/unary/cold_sink/freezer{
-	current_temperature = 80;
-	dir = 1;
-	min_temperature = 80;
-	on = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26;
-	pixel_y = 32
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "iQw" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -71328,11 +72032,18 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "iTQ" = (
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whiteredcorner"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/area/security/medbay)
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding8"
+	},
+/obj/structure/closet/secure_closet/brig/evidence,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/evidence)
 "iTZ" = (
 /turf/simulated/wall,
 /area/crew_quarters/serviceyard)
@@ -71434,12 +72145,15 @@
 	},
 /area/chapel/main)
 "iVo" = (
-/obj/effect/decal/remains/xeno,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/confetti,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "purple"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/area/maintenance/xenozoo)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "iVt" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -71456,6 +72170,29 @@
 	},
 /turf/simulated/floor/plating,
 /area/toxins/lab)
+"iVv" = (
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	dir = 1;
+	id = "chem"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 8;
+	id = "chem"
+	},
+/obj/structure/window/reinforced/polarized{
+	id = "chem"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "chem"
+	},
+/turf/simulated/floor/plating,
+/area/toxins/misc_lab)
 "iVE" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -71537,12 +72274,20 @@
 	},
 /area/crew_quarters/hor)
 "iWq" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Gambling Den"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/barricade/wooden,
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/crew_quarters/theatre)
 "iWB" = (
 /obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/autolathe,
@@ -71652,10 +72397,14 @@
 	},
 /area/shuttle/syndicate_sit)
 "iXv" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
 	},
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
 /area/maintenance/xenozoo)
 "iXx" = (
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -71667,13 +72416,20 @@
 	icon_state = "escape"
 	},
 /area/hallway/primary/port/west)
-"iXI" = (
-/obj/effect/decal/remains/xeno,
+"iXM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
+"iXO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/wood{
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "iXX" = (
 /obj/machinery/computer/security,
 /turf/simulated/floor/bluegrid,
@@ -71691,39 +72447,6 @@
 	icon_state = "neutralfull"
 	},
 /area/storage/secure)
-"iYl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
-"iYq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/west,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/research{
-	name = "Chemical Toxins";
-	req_access_txt = "47"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/toxins/explab)
 "iYw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -71753,15 +72476,12 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
-"iYC" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+"iYB" = (
+/obj/structure/sign/science{
+	icon_state = "doors"
 	},
-/obj/machinery/disposal,
-/obj/machinery/light,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/toxins/explab)
+/turf/simulated/wall,
+/area/toxins/xenobiology)
 "iYE" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/extinguisher_cabinet{
@@ -71805,6 +72525,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/bridge/checkpoint/south)
+"iZe" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/gloves/color/white,
+/obj/item/clothing/gloves/color/white,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/turf/simulated/floor/plasteel,
+/area/toxins/explab)
 "iZf" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -71883,30 +72611,11 @@
 	},
 /area/maintenance/kitchen)
 "iZG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
+/obj/effect/decal/cleanable/blood/xeno,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "dark"
 	},
-/area/medical/research/nhallway)
+/area/toxins/xenobiology)
 "iZQ" = (
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall,
@@ -72056,15 +72765,6 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay2)
-"jch" = (
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkred"
-	},
-/area/security/evidence)
 "jcq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -72155,32 +72855,22 @@
 	},
 /area/engine/engineering)
 "jdU" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Interrogation Room";
+	dir = 8;
+	network = list("SS13","Security")
+	},
 /obj/machinery/button/windowtint{
 	anchored = 1;
-	id = "visiting room";
+	id = "Interrogation";
 	pixel_x = 24
 	},
-/obj/structure/table,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
-/obj/item/paper_bin{
-	pixel_x = -4;
-	pixel_y = 3
-	},
-/obj/item/pen,
-/obj/item/flashlight/lamp{
-	layer = 4;
-	pixel_x = 7;
-	pixel_y = 14
-	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "red"
+	dir = 4;
+	icon_state = "darkred"
 	},
 /area/security/interrogation)
 "jeg" = (
@@ -72217,6 +72907,9 @@
 	icon_state = "red"
 	},
 /area/security/customs)
+"jel" = (
+/turf/simulated/floor/engine,
+/area/maintenance/xenozoo)
 "jem" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -72309,11 +73002,6 @@
 	icon_state = "darkblue"
 	},
 /area/tcommsat/chamber)
-"jfk" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/toxins/explab)
 "jfp" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -72330,6 +73018,17 @@
 	},
 /turf/simulated/floor/wood,
 /area/security/hos)
+"jfv" = (
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "purple"
+	},
+/area/maintenance/xenozoo)
 "jfE" = (
 /obj/item/stack/rods{
 	amount = 3
@@ -72411,6 +73110,24 @@
 /obj/structure/grille,
 /turf/space,
 /area/space/nearstation)
+"jgD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "jgZ" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
@@ -72433,17 +73150,21 @@
 	},
 /area/toxins/lab)
 "jhm" = (
-/obj/effect/landmark{
-	name = "xeno_spawn";
-	pixel_x = -1
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "sw_maint_inner";
+	locked = 1;
+	name = "West Maintenance External Access";
+	req_access_txt = "10;13"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/toxins/explab)
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "jhv" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -72459,6 +73180,19 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating/airless,
 /area/toxins/test_area)
+"jhO" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "purplefull"
+	},
+/area/maintenance/xenozoo)
 "jhQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -72590,27 +73324,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/grille{
+	density = 0;
+	icon_state = "brokengrille"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard{
 	name = "Engineering Maintenance"
 	})
-"jiX" = (
-/obj/structure/closet,
-/obj/item/storage/box/handcuffs,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/stack/tape_roll,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "darkred"
-	},
-/area/security/processing)
 "jjb" = (
 /obj/machinery/washing_machine,
 /turf/simulated/floor/plasteel{
@@ -72661,16 +73382,26 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "jjC" = (
-/obj/machinery/status_display,
-/turf/simulated/wall/r_wall,
-/area/toxins/explab)
-"jjD" = (
-/obj/machinery/sparker{
-	id = "testigniter";
-	name = "Test Igniter";
-	pixel_x = -25
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/turf/simulated/floor/engine,
+/area/crew_quarters/theatre)
+"jjD" = (
+/obj/machinery/light_switch{
+	pixel_x = 26;
+	pixel_y = 26;
+	on = 0
+	},
+/obj/machinery/atmospherics/binary/valve,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/status_display{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (SOUTHEAST)"
+	},
 /area/toxins/test_chamber)
 "jjT" = (
 /obj/machinery/dna_scannernew,
@@ -72679,30 +73410,44 @@
 	icon_state = "whitepurple"
 	},
 /area/medical/genetics)
-"jjV" = (
-/obj/structure/chair/office/dark,
-/turf/simulated/floor/plating,
-/area/maintenance/library)
 "jjY" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
-"jkc" = (
-/obj/effect/decal/warning_stripes/northeast,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 9;
-	level = 2
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = 11;
+	pixel_y = -4
 	},
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/obj/effect/decal/cleanable/blood/writing{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/spentcasing,
+/turf/simulated/floor/lubed,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "jkl" = (
-/obj/structure/closet/secure_closet/brig/evidence,
+/obj/machinery/computer/crew,
+/obj/machinery/camera{
+	c_tag = "Brig Medbay";
+	dir = 4;
+	network = list("SS13","Security")
+	},
+/obj/machinery/door_control{
+	id = "SecMedPriv";
+	name = "Brig Medbay Privacy Shutters Control";
+	pixel_x = -24;
+	req_access_txt = "63"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "darkred"
+	icon_state = "whitered"
 	},
-/area/security/evidence)
+/area/security/medbay)
 "jku" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/greengrid,
@@ -72733,23 +73478,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "jkT" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Brig Physician"
+	},
+/turf/simulated/floor/plasteel{
 	dir = 4;
-	on = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/evidence)
-"jlc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "whiteredfull"
 	},
 /area/security/medbay)
 "jlj" = (
@@ -72780,33 +73517,47 @@
 	icon_state = "darkblue"
 	},
 /area/turret_protected/ai)
+"jll" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall/r_wall,
+/area/security/processing)
 "jlz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/door/morgue{
+	name = "Dungeon"
+	},
+/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "red"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/turf/simulated/floor/plasteel,
 /area/security/processing)
 "jlH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/security{
+	name = "Evidence Storage";
+	req_access_txt = "63"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 0;
-	icon_state = "red"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/security/processing)
+/turf/simulated/floor/plasteel,
+/area/security/evidence)
 "jlK" = (
 /turf/space,
 /area/space/nearstation)
@@ -72832,6 +73583,12 @@
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"jmi" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/engine,
+/area/toxins/explab)
 "jmj" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -72874,7 +73631,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "purplefull"
 	},
 /area/medical/research/shallway)
 "jmN" = (
@@ -72891,6 +73648,19 @@
 	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
+"jmO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "jmR" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -72910,27 +73680,24 @@
 /turf/simulated/floor/plating,
 /area/security/checkpoint/south)
 "jnn" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized{
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 8;
-	id = "Interrogation"
+	icon_state = "pipe-c"
 	},
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "Interrogation"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Brig_lockdown";
+	name = "Brig Lockdown";
+	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/security/evidence)
+/area/security/processing)
 "jnr" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light_switch{
@@ -73000,13 +73767,12 @@
 /turf/simulated/floor/plasteel,
 /area/medical/research/nhallway)
 "joq" = (
-/obj/item/taperecorder,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/evidence)
+/obj/structure/table,
+/obj/item/clothing/under/color/orange/prison,
+/obj/item/clothing/shoes/orange,
+/obj/item/wrench,
+/turf/simulated/floor/plating,
+/area/maintenance/perma)
 "jot" = (
 /obj/item/stack/medical/bruise_pack,
 /obj/item/stack/medical/bruise_pack/advanced,
@@ -73047,6 +73813,21 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/controlroom)
+"joz" = (
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xeno4";
+	name = "Creature Cell #4";
+	opacity = 0
+	},
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology)
 "joA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -73148,6 +73929,10 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
+"jpB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "jpK" = (
 /obj/effect/decal/warning_stripes/arrow{
 	dir = 4
@@ -73159,31 +73944,12 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/fore)
-"jpT" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/tank/internals/emergency_oxygen/engi/empty,
-/obj/item/tank/internals/emergency_oxygen/engi/empty,
-/obj/item/reagent_containers/iv_bag/blood/AMinus,
-/obj/item/reagent_containers/iv_bag/blood/APlus,
-/obj/item/reagent_containers/iv_bag/blood/BMinus,
-/obj/item/reagent_containers/iv_bag/blood/BPlus,
-/obj/item/reagent_containers/iv_bag/blood/OMinus,
-/obj/item/reagent_containers/iv_bag/blood/OPlus,
-/obj/item/reagent_containers/iv_bag/blood/random,
-/obj/item/reagent_containers/iv_bag/blood/random,
-/obj/item/reagent_containers/iv_bag/blood/random,
-/obj/item/reagent_containers/iv_bag/salglu,
-/obj/machinery/iv_drip,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+"jpY" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitered"
+	icon_state = "chapel"
 	},
-/area/security/medbay)
+/area/crew_quarters/theatre)
 "jqb" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -73290,13 +74056,15 @@
 	},
 /area/turret_protected/ai)
 "jrc" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/area/toxins/explab)
+/turf/simulated/floor/carpet/black,
+/area/crew_quarters/theatre)
 "jrh" = (
 /obj/machinery/vending/shoedispenser,
 /turf/simulated/floor/plasteel{
@@ -73469,16 +74237,6 @@
 	icon_state = "arrival"
 	},
 /area/atmos)
-"jsw" = (
-/obj/effect/landmark{
-	name = "blobstart"
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
 "jsz" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating/airless,
@@ -73510,6 +74268,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"jtf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/crew_quarters/theatre)
 "jtg" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -73534,14 +74302,6 @@
 	icon_state = "caution"
 	},
 /area/atmos)
-"jtl" = (
-/obj/structure/table/wood,
-/obj/item/folder,
-/obj/item/pen,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/maintenance/library)
 "jtr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -73645,38 +74405,21 @@
 	icon_state = "caution"
 	},
 /area/atmos)
-"juf" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26;
-	pixel_y = -32
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "jun" = (
 /turf/simulated/floor/wood/fancy/cherry,
 /area/lawoffice)
+"juu" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/toxins/xenobiology)
 "juy" = (
 /obj/structure/falsewall,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
-"juL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/mineral_door/wood,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/maintenance/library)
 "juR" = (
 /obj/structure/table/wood,
 /obj/item/storage/bible,
@@ -73706,37 +74449,10 @@
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/storage)
-"jvy" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "xeno5";
-	name = "Creature Cell #5";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology)
 "jvC" = (
-/obj/structure/table/wood/poker,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/effect/spawner/random_spawners/oil_maybe,
 /turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/maintenance/asmaint2)
 "jvK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -73750,6 +74466,13 @@
 	dir = 1
 	},
 /area/security/securehallway)
+"jvU" = (
+/obj/machinery/computer/camera_advanced/xenobio,
+/obj/machinery/status_display{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology)
 "jwd" = (
 /obj/structure/table,
 /obj/item/assembly/igniter,
@@ -73764,6 +74487,9 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/portable_atmospherics/pump,
+/obj/item/radio/intercom{
+	pixel_y = 21
+	},
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
 "jwn" = (
@@ -73836,9 +74562,6 @@
 /obj/effect/decal/warning_stripes/west,
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/light,
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
 	name = "standard air scrubber";
@@ -73864,6 +74587,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/security/checkpoint/south)
+"jxa" = (
+/obj/structure/sign/xenobio{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/medical/research/nhallway)
 "jxh" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -73880,21 +74611,17 @@
 	},
 /area/security/hos)
 "jxo" = (
-/obj/structure/table/wood,
-/obj/item/stack/rods{
-	amount = 10
+/obj/machinery/disposal/deliveryChute{
+	name = "Stage enterance"
 	},
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/machinery/light{
-	dir = 1;
-	on = 1
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/sign/barsign{
-	pixel_y = 32
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "jxu" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/manifold4w/visible/cyan{
@@ -74076,6 +74803,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
+"jyD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/theatre)
 "jyF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -74114,15 +74849,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/atmos/control)
-"jyU" = (
-/obj/effect/decal/warning_stripes/southwest,
-/obj/machinery/chem_heater,
-/obj/structure/window/plasmareinforced{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/engine,
-/area/toxins/misc_lab)
 "jzn" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -74270,7 +74996,9 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "bluefull"
+	},
 /area/toxins/storage)
 "jBI" = (
 /obj/machinery/smartfridge,
@@ -74435,6 +75163,13 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/nw)
+"jCZ" = (
+/obj/item/healthanalyzer,
+/obj/structure/table,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/toxins/explab)
 "jDk" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -74452,12 +75187,12 @@
 	},
 /area/security/securearmory)
 "jDz" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/barricade/wooden,
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
+/area/maintenance/xenozoo)
 "jDQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -74512,6 +75247,30 @@
 	icon_state = "dark"
 	},
 /area/security/permabrig)
+"jED" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
+"jEI" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/item/storage/fancy/crayons{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/lipstick/random{
+	step_x = -5
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "jEJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -74543,10 +75302,10 @@
 	name = "Engineering Maintenance"
 	})
 "jFg" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/barricade/wooden,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/confetti,
 /turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/area/crew_quarters/theatre)
 "jFn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -74556,15 +75315,25 @@
 	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
-"jFA" = (
-/obj/machinery/atmospherics/trinary/filter{
-	dir = 8
+"jFs" = (
+/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurplecorner"
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/toxins/explab)
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/engine,
+/area/maintenance/xenozoo)
 "jFH" = (
 /obj/structure/chair/comfy/lime,
 /obj/effect/landmark/start{
@@ -74683,56 +75452,6 @@
 	icon_state = "darkblue"
 	},
 /area/bridge)
-"jHw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/gambling_den)
-"jHx" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
-"jHC" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4
-	},
-/turf/simulated/floor/engine,
-/area/toxins/test_chamber)
 "jHF" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -74752,14 +75471,20 @@
 	},
 /area/quartermaster/office)
 "jHH" = (
-/obj/effect/decal/warning_stripes/northeast,
-/obj/machinery/chem_dispenser,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/structure/sign/nosmoking_2{
-	pixel_y = 32
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/engine,
-/area/toxins/misc_lab)
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenosecure";
+	name = "Secure Creature Cell";
+	opacity = 0
+	},
+/obj/effect/spawner/window/reinforced/plasma,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology)
 "jHJ" = (
 /obj/machinery/computer/prisoner{
 	req_access = null;
@@ -74841,6 +75566,15 @@
 /area/maintenance/aft{
 	name = "Medbay Maintenance"
 	})
+"jIu" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
 "jIv" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -74857,11 +75591,6 @@
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -24
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
@@ -74923,11 +75652,19 @@
 	},
 /area/security/prisonershuttle)
 "jIV" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
-/turf/simulated/wall,
-/area/maintenance/gambling_den)
+/turf/simulated/floor/plasteel,
+/area/maintenance/xenozoo)
 "jJj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -74960,25 +75697,18 @@
 	name = "\improper Medical Suit Storage"
 	})
 "jJq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/structure/disposalpipe/junction,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurplecorner"
+	icon_state = "purplefull"
 	},
-/area/toxins/explab)
+/area/toxins/misc_lab)
 "jJr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -75119,17 +75849,13 @@
 	name = "Virology Maintenance"
 	})
 "jKV" = (
-/obj/effect/decal/warning_stripes/arrow,
-/obj/structure/disposaloutlet,
-/obj/structure/window/plasmareinforced{
-	dir = 1
-	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/driver_button{
+	id_tag = "toxinsdriver";
+	pixel_x = 26
 	},
-/turf/simulated/floor/plating,
-/area/toxins/mixing)
+/turf/simulated/floor/plasteel,
+/area/toxins/launch)
 "jKW" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -75179,6 +75905,19 @@
 	icon_state = "arrival"
 	},
 /area/crew_quarters/locker)
+"jLq" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research/nhallway)
 "jLs" = (
 /obj/machinery/status_display{
 	pixel_y = -32
@@ -75196,12 +75935,10 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/security/checkpoint/south)
-"jMf" = (
-/obj/structure/table,
-/obj/item/multitool,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/perma)
+"jLI" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "jMi" = (
 /obj/structure/table/wood,
 /obj/item/folder,
@@ -75251,14 +75988,26 @@
 	parallax_movedir = 2
 	})
 "jMH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/effect/decal/cleanable/blood/xeno,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/maintenance/gambling_den)
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenosecure";
+	name = "Secure Creature Cell";
+	opacity = 0
+	},
+/obj/effect/spawner/window/reinforced/plasma,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology)
 "jMT" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet,
@@ -75274,6 +76023,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/teleporter)
+"jNB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research/nhallway)
 "jNE" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -75441,10 +76205,8 @@
 	},
 /area/bridge/vip)
 "jPC" = (
-/obj/effect/landmark/burnturf,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkred"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plating/airless,
 /area/space)
 "jPK" = (
 /obj/structure/window/reinforced{
@@ -75467,6 +76229,16 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/light,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /obj/item/radio/intercom{
 	pixel_y = -30
 	},
@@ -75489,7 +76261,8 @@
 /obj/item/folder,
 /obj/item/razor,
 /obj/machinery/light_switch{
-	pixel_x = -24
+	pixel_x = -24;
+	pixel_y = -8
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/cabin2)
@@ -75530,32 +76303,17 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/sorting)
 "jRg" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 4;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "white"
 	},
-/area/security/evidence)
-"jRh" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump Engineering";
-	pixel_y = 24;
-	shock_proof = 1
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkred"
-	},
-/area/security/evidence)
+/area/security/medbay)
 "jRl" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -75656,8 +76414,10 @@
 	},
 /area/medical/medbay2)
 "jSk" = (
-/obj/structure/closet/firecloset,
-/turf/simulated/floor/plating/airless,
+/obj/effect/landmark/burnturf,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkred"
+	},
 /area/space)
 "jSs" = (
 /obj/machinery/camera{
@@ -75761,9 +76521,23 @@
 	name = "Engineering Maintenance"
 	})
 "jTz" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/grille,
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/obj/structure/window/plasmareinforced{
+	dir = 8
+	},
+/obj/structure/window/plasmareinforced,
+/obj/structure/window/plasmareinforced{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/toxins/mixing)
+/area/toxins/launch)
 "jTD" = (
 /obj/machinery/atmospherics/binary/volume_pump/on{
 	desc = "Выкачивает углекислый газ и токсины со станции и отправляет на фильтрацию";
@@ -75812,33 +76586,6 @@
 	icon_state = "white"
 	},
 /area/toxins/mixing)
-"jUs" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
-"jUu" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
 "jUE" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -75856,23 +76603,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
 "jUM" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "red"
+	dir = 1
 	},
 /area/security/processing)
 "jUO" = (
@@ -75929,21 +76663,13 @@
 /area/maintenance/asmaint2)
 "jVg" = (
 /obj/structure/chair{
-	dir = 4
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	dir = 1;
 	icon_state = "red"
 	},
 /area/security/processing)
@@ -75973,15 +76699,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain/bedroom)
-"jVL" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
-	},
-/area/toxins/misc_lab)
 "jWl" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
@@ -76048,6 +76765,14 @@
 /area/maintenance/fore{
 	name = "Hangar Maintenance"
 	})
+"jWI" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/security/processing)
 "jXb" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -76060,17 +76785,15 @@
 	name = "Virology Maintenance"
 	})
 "jXd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/chair,
+/obj/structure/sign/goldenplaque{
+	desc = "ЦК награждает клоуна Шляпку как первого заключённого брига после перестройки. Он был задержан по статьям 100 104 и 309. Так держать.";
+	name = "Награда за первое нарушение в новом бриге";
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	dir = 9;
+	icon_state = "red"
 	},
 /area/security/processing)
 "jXe" = (
@@ -76103,11 +76826,12 @@
 /turf/simulated/floor/plasteel,
 /area/bridge/checkpoint/south)
 "jXk" = (
-/obj/structure/chair{
-	dir = 4
+/obj/structure/chair,
+/obj/machinery/newscaster{
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
+	dir = 1;
 	icon_state = "red"
 	},
 /area/security/processing)
@@ -76123,6 +76847,16 @@
 	},
 /turf/space,
 /area/space)
+"jXC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/tomato_smudge,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/crew_quarters/theatre)
 "jXD" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/structure/closet/crate,
@@ -76177,6 +76911,15 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/crew_quarters/serviceyard)
+"jYw" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken3";
+	tag = "icon-wood-broken3"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "jYE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/camera_assembly,
@@ -76185,23 +76928,6 @@
 	icon_state = "caution"
 	},
 /area/maintenance/bar)
-"jYQ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/camera{
-	c_tag = "Xenobio East";
-	dir = 8;
-	network = list("Research","SS13")
-	},
-/obj/machinery/requests_console{
-	department = "Xenobiology";
-	departmentType = 2;
-	name = "Xenobiology Requests Console";
-	pixel_x = 30
-	},
-/obj/machinery/reagentgrinder,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "jYS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -76213,22 +76939,36 @@
 /turf/simulated/floor/plating,
 /area/maintenance/kitchen)
 "jZb" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/item/clothing/head/kitty,
-/turf/simulated/floor/plating,
-/area/maintenance/library)
-"jZj" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutral"
+	dir = 8;
+	icon_state = "darkblue"
 	},
-/area/toxins/mixing)
+/area/crew_quarters/theatre)
+"jZj" = (
+/obj/machinery/camera{
+	c_tag = "Cosmination Room";
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/chapel/main)
+"jZw" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen";
+	opened = 1
+	},
+/obj/random/tool,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "jZz" = (
 /obj/machinery/camera{
 	c_tag = "Library South";
@@ -76237,18 +76977,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/library)
-"jZA" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
 "jZI" = (
 /obj/structure/lattice,
 /turf/space,
@@ -76269,18 +76997,12 @@
 	},
 /area/turret_protected/aisat_interior)
 "jZY" = (
-/obj/structure/table,
-/obj/item/storage/fancy/cigarettes/cigpack_robust,
-/obj/item/lighter,
-/obj/item/ashtray/glass{
-	pixel_x = 6;
-	pixel_y = 7
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_y = -28
+/obj/structure/chair,
+/obj/item/radio/intercom{
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
+	dir = 1;
 	icon_state = "red"
 	},
 /area/security/processing)
@@ -76291,11 +77013,12 @@
 	},
 /area/security/brigstaff)
 "kay" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/rods,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "kaB" = (
 /obj/structure/rack{
 	dir = 8;
@@ -76359,21 +77082,17 @@
 /turf/simulated/floor/mech_bay_recharge_floor,
 /area/assembly/chargebay)
 "kbT" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized{
-	id = "Interrogation"
+/obj/structure/chair,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/window/reinforced/polarized{
-	dir = 8;
-	id = "Interrogation"
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "red"
 	},
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "Interrogation"
-	},
-/obj/structure/cable,
-/turf/simulated/floor/plating,
-/area/security/evidence)
+/area/security/processing)
 "kbW" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -76447,11 +77166,13 @@
 	},
 /area/toxins/lab)
 "kdd" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "darkred"
+	dir = 1
 	},
-/area/security/evidence)
+/area/security/processing)
 "kdl" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1;
@@ -76490,12 +77211,6 @@
 	icon_state = "darkred"
 	},
 /area/security/permabrig)
-"kdP" = (
-/obj/item/radio/intercom{
-	pixel_y = 23
-	},
-/turf/simulated/floor/engine,
-/area/toxins/test_chamber)
 "keb" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -76556,11 +77271,10 @@
 	},
 /area/security/securehallway)
 "keE" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkred"
-	},
-/area/security/evidence)
+/obj/structure/table,
+/obj/item/multitool,
+/turf/simulated/floor/plating,
+/area/maintenance/perma)
 "keL" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
@@ -76577,10 +77291,9 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "kfc" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "darkred"
-	},
-/area/security/evidence)
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/perma)
 "kff" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
@@ -76658,6 +77371,18 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
+"kfG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/writing,
+/obj/structure/grille/broken,
+/turf/simulated/floor/plasteel{
+	dir = 1
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "kfS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -76685,14 +77410,12 @@
 	},
 /area/security/reception)
 "kfT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/comfy/brown{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/blood/xeno,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/gambling_den)
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "kfX" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -76708,11 +77431,6 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/maintenance/ai)
-"kgB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
 "khe" = (
 /obj/machinery/computer/operating{
 	dir = 8
@@ -76757,21 +77475,13 @@
 /area/turret_protected/ai)
 "khz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/railing/corner{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "khM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/curtain/black,
@@ -76804,18 +77514,6 @@
 	icon_state = "dark"
 	},
 /area/turret_protected/ai)
-"kim" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10;
-	initialize_directions = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken5"
-	},
-/area/maintenance/library)
 "kiG" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -76899,13 +77597,6 @@
 	icon_state = "grimy"
 	},
 /area/security/hos)
-"kjF" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/obj/effect/decal/warning_stripes/northeastcorner,
-/turf/simulated/floor/plasteel,
-/area/toxins/explab)
 "kjS" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical{
@@ -76920,15 +77611,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/ai)
 "kjT" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
+/turf/space,
+/area/space/nearstation)
 "kkd" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -76961,17 +77651,15 @@
 	},
 /area/medical/surgery/south)
 "kko" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/reagent_containers/glass/beaker,
+/obj/item/reagent_containers/dropper,
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "kku" = (
 /obj/structure/cable{
@@ -76996,10 +77684,14 @@
 /turf/simulated/floor/greengrid,
 /area/security/nuke_storage)
 "kkV" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/confetti,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "klb" = (
 /obj/structure/grille,
 /obj/effect/decal/warning_stripes/south,
@@ -77015,11 +77707,6 @@
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/mining)
-"klo" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/explab)
 "klr" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -77063,18 +77750,6 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"klB" = (
-/obj/structure/curtain/open,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/security/medbay)
 "klC" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics N2O Tank";
@@ -77115,13 +77790,6 @@
 	icon_state = "white"
 	},
 /area/crew_quarters/captain/bedroom)
-"klN" = (
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plasteel{
-	dir = 0;
-	icon_state = "whitered"
-	},
-/area/security/medbay)
 "klO" = (
 /obj/machinery/atmospherics/binary/pump{
 	desc = "Подаёт оксид азота для смешивания с другими газами";
@@ -77229,9 +77897,11 @@
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "kmL" = (
-/obj/machinery/atmospherics/unary/tank/air,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
+/obj/effect/spawner/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/toxins/xenobiology)
 "kmU" = (
 /obj/structure/transit_tube/station{
@@ -77257,9 +77927,20 @@
 	},
 /area/construction/hallway)
 "kna" = (
-/turf/simulated/floor/greengrid{
-	temperature = 80
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xeno5";
+	name = "Creature Cell #5";
+	opacity = 0
+	},
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
 /area/toxins/xenobiology)
 "knb" = (
 /obj/structure/disposalpipe/segment,
@@ -77321,22 +78002,30 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "knU" = (
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/turf/simulated/floor/engine,
+/area/toxins/misc_lab)
+"kof" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10;
-	initialize_directions = 10
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
+/area/maintenance/asmaint2)
 "kov" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "swall_f10"
@@ -77361,15 +78050,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "koy" = (
-/obj/machinery/light/small{
+/obj/structure/disposaloutlet{
 	dir = 1
 	},
-/obj/structure/closet/firecloset,
+/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "whitepurple"
+	icon_state = "dark"
 	},
-/area/toxins/explab)
+/area/toxins/xenobiology)
 "koA" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -77397,6 +78085,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "koK" = (
@@ -77412,6 +78103,22 @@
 	icon_state = "browncorner"
 	},
 /area/quartermaster/delivery)
+"kpl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "kpn" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -77446,17 +78153,6 @@
 	icon_state = "blue"
 	},
 /area/bridge/checkpoint/south)
-"kps" = (
-/obj/effect/decal/warning_stripes/southwest,
-/obj/structure/window/plasmareinforced{
-	dir = 8
-	},
-/obj/structure/window/plasmareinforced,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal,
-/turf/simulated/floor/engine,
-/area/toxins/misc_lab)
 "kpF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -77533,6 +78229,12 @@
 	icon_state = "blue"
 	},
 /area/bridge/checkpoint/north)
+"kpZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/crew_quarters/theatre)
 "kqm" = (
 /obj/structure/grille,
 /obj/structure/window/full/shuttle,
@@ -77540,6 +78242,31 @@
 /turf/simulated/floor/plating,
 /area/shuttle/escape{
 	parallax_movedir = 2
+	})
+"kqu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/crayon{
+	desc = "Crayon art.";
+	icon_state = "skrek";
+	name = "Graffiti";
+	pixel_y = -32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
 	})
 "kqJ" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -77558,6 +78285,10 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
+"kqO" = (
+/obj/effect/decal/cleanable/crayon,
+/turf/simulated/floor/plating,
+/area/maintenance/library)
 "krc" = (
 /obj/machinery/vending/autodrobe,
 /obj/machinery/firealarm{
@@ -77655,15 +78386,33 @@
 	icon_state = "white"
 	},
 /area/medical/chemistry)
-"krM" = (
-/obj/machinery/light/small{
-	dir = 1
+"krK" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkred"
+	icon_state = "redfull";
+	tag = "icon-redfull (NORTHWEST)"
 	},
-/area/security/interrogation)
+/area/security/processing)
+"krM" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "red"
+	},
+/area/security/processing)
 "krN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -77675,6 +78424,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
+"krO" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "krY" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
@@ -77701,18 +78467,23 @@
 /area/maintenance/consarea{
 	name = "Virology Maintenance Construction Area"
 	})
-"ksN" = (
-/obj/machinery/light/small{
+"ksJ" = (
+/obj/item/clothing/head/fluff/lfbowler,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken"
+	},
+/area/maintenance/library)
+"ksY" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Xeno Containment 4";
-	network = list("Research","SS13")
+/obj/structure/chair/office/light{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "whitepurple"
 	},
-/area/toxins/xenobiology)
+/area/toxins/test_chamber)
 "ktf" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	name = "standard air scrubber";
@@ -77831,13 +78602,12 @@
 	},
 /area/crew_quarters/fitness)
 "kul" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -28
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
-	},
-/obj/machinery/camera{
-	c_tag = "Cosmination Room";
-	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -77886,11 +78656,19 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/central/west)
-"kvB" = (
-/obj/machinery/atmospherics/unary/portables_connector,
-/obj/effect/decal/warning_stripes/southwest,
+"kvk" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/west,
+/obj/effect/landmark/start{
+	name = "Scientist"
+	},
 /turf/simulated/floor/plasteel,
-/area/toxins/explab)
+/area/toxins/xenobiology)
+"kvB" = (
+/turf/simulated/floor/greengrid,
+/area/toxins/xenobiology)
 "kvH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -77945,12 +78723,6 @@
 /obj/structure/chair/stool/bar,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"kwN" = (
-/obj/structure/computerframe,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
 "kxq" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/flashbangs{
@@ -77972,6 +78744,17 @@
 	icon_state = "dark"
 	},
 /area/toxins/lab)
+"kxz" = (
+/obj/structure/grille,
+/obj/structure/window/plasmareinforced{
+	dir = 8
+	},
+/obj/structure/window/plasmareinforced,
+/obj/structure/window/plasmareinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/toxins/launch)
 "kxD" = (
 /obj/machinery/status_display,
 /turf/simulated/wall,
@@ -77988,44 +78771,16 @@
 /turf/simulated/floor/plasteel,
 /area/teleporter)
 "kxN" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/remains/human,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
-"kxQ" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "xeno5";
-	name = "Creature Cell #5";
-	opacity = 0
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	name = "Creature Pen";
-	req_access_txt = "47"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/toxins/xenobiology)
+/area/crew_quarters/theatre)
 "kxT" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -78040,6 +78795,16 @@
 	icon_state = "dark"
 	},
 /area/engine/aienter)
+"kyd" = (
+/obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurplecorner"
+	},
+/area/toxins/xenobiology)
 "kyv" = (
 /obj/machinery/light{
 	dir = 8
@@ -78050,6 +78815,17 @@
 	icon_state = "blue"
 	},
 /area/bridge/checkpoint/south)
+"kyw" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkred"
+	},
+/area/security/interrogation)
 "kyC" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -78142,22 +78918,29 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/cabin4)
 "kzx" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/multitool,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/radio/intercom{
-	pixel_y = 21
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/decal/warning_stripes/east,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "whitepurple"
+	icon_state = "white"
 	},
-/area/toxins/misc_lab)
+/area/toxins/xenobiology)
 "kzy" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -78194,13 +78977,13 @@
 	},
 /area/security/main)
 "kzU" = (
-/obj/machinery/recharge_station,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "red"
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id_tag = "SecMedPriv"
 	},
-/area/security/processing)
+/turf/simulated/floor/plating,
+/area/security/medbay)
 "kzV" = (
 /obj/structure/table,
 /obj/machinery/kitchen_machine/microwave{
@@ -78226,18 +79009,39 @@
 	},
 /area/engine/hardsuitstorage)
 "kAm" = (
-/obj/structure/chair{
+/obj/machinery/door/airlock/medical/glass{
+	name = "Brig Medical Bay";
+	req_one_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -30
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "red"
+	icon_state = "white"
 	},
-/area/security/processing)
+/area/security/medbay)
 "kAp" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -78363,13 +79167,6 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/atmos/control)
-"kBv" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = 32
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
 "kBJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shard,
@@ -78386,16 +79183,28 @@
 /obj/item/cane,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/cabin4)
+"kCa" = (
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plating,
+/area/maintenance/xenozoo)
 "kCn" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the horrors within the test chamber.";
-	name = "Research Monitor";
-	network = list("TestChamber")
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurple"
+	icon_state = "white"
 	},
 /area/toxins/misc_lab)
 "kCr" = (
@@ -78449,33 +79258,6 @@
 	icon_state = "darkredcorners"
 	},
 /area/security/podbay)
-"kCE" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26;
-	pixel_y = 32
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
-"kCF" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/syringes,
-/obj/item/extinguisher/mini,
-/obj/effect/decal/warning_stripes/yellow,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 28
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "kCV" = (
 /obj/machinery/light_switch{
 	pixel_x = 24;
@@ -78500,19 +79282,7 @@
 	},
 /area/assembly/chargebay)
 "kCW" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "RnDChem";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/obj/effect/spawner/window/reinforced/plasma,
-/turf/simulated/floor/engine,
+/turf/simulated/wall/r_wall,
 /area/toxins/test_chamber)
 "kDa" = (
 /obj/structure/sign/poster/contraband/random{
@@ -78523,23 +79293,14 @@
 	name = "Engineering Maintenance"
 	})
 "kDr" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
-"kDH" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	temperature = 80
+	icon_state = "bar"
 	},
-/area/toxins/xenobiology)
+/area/crew_quarters/theatre)
 "kDP" = (
 /obj/machinery/firealarm{
 	pixel_y = -26
@@ -78556,19 +79317,16 @@
 /obj/effect/decal/cleanable/crayon,
 /turf/simulated/floor/wood,
 /area/maintenance/library)
+"kDT" = (
+/obj/effect/decal/warning_stripes/northwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology)
 "kEg" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
 	},
 /area/medical/research/nhallway)
 "kEj" = (
@@ -78603,24 +79361,16 @@
 	},
 /area/medical/virology)
 "kEH" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/cable{
+	d1 = 1;
 	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkred"
+	icon_state = "white"
 	},
-/area/security/evidence)
+/area/security/medbay)
 "kEM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -78785,8 +79535,8 @@
 	},
 /area/crew_quarters/kitchen)
 "kGY" = (
-/obj/structure/lattice,
-/turf/simulated/wall/rust,
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/plating/airless,
 /area/space)
 "kHa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -78801,6 +79551,26 @@
 	icon_state = "white"
 	},
 /area/crew_quarters/kitchen)
+"kHj" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 28
+	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
+	},
+/area/toxins/misc_lab)
+"kHm" = (
+/obj/machinery/sparker{
+	id = "testigniter";
+	name = "Test Igniter";
+	pixel_x = -25
+	},
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "kHo" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
@@ -78836,18 +79606,9 @@
 	},
 /area/security/securehallway)
 "kHF" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/misc_lab)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/crew_quarters/theatre)
 "kHS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -78895,6 +79656,11 @@
 	icon_state = "blue"
 	},
 /area/bridge/checkpoint/south)
+"kIw" = (
+/obj/machinery/atmospherics/unary/tank/air,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel,
+/area/maintenance/asmaint2)
 "kIA" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/effect/landmark/start{
@@ -78908,6 +79674,18 @@
 	tag = "icon-redfull (NORTHWEST)"
 	},
 /area/crew_quarters/kitchen)
+"kJc" = (
+/obj/machinery/camera{
+	c_tag = "Research West Hallway";
+	network = list("Research","SS13")
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
+	},
+/area/medical/research/nhallway)
 "kJi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -78929,12 +79707,6 @@
 /area/maintenance/consarea{
 	name = "Virology Maintenance Construction Area"
 	})
-"kJj" = (
-/obj/structure/table,
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
-/area/security/processing)
 "kJm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -78944,12 +79716,6 @@
 	icon_state = "white"
 	},
 /area/crew_quarters/kitchen)
-"kJr" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
 "kJs" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/window/reinforced,
@@ -79101,6 +79867,19 @@
 	icon_state = "grimy"
 	},
 /area/library)
+"kLm" = (
+/obj/structure/closet/secure_closet/research_reagents,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = -28
+	},
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTHWEST)"
+	},
+/area/toxins/misc_lab)
 "kLx" = (
 /obj/machinery/field/generator{
 	anchored = 1;
@@ -79120,22 +79899,31 @@
 /area/maintenance/consarea{
 	name = "Virology Maintenance Construction Area"
 	})
+"kLO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "kLP" = (
 /turf/simulated/wall,
 /area/atmos)
 "kLY" = (
-/obj/machinery/door/window/southright{
-	dir = 1;
-	name = "Toxins Launcher";
-	req_access_txt = "7"
-	},
-/obj/machinery/door/window/southright{
-	name = "Toxins Launcher";
-	req_access_txt = "7"
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plating,
-/area/toxins/mixing)
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel,
+/area/toxins/launch)
 "kLZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -79235,21 +80023,6 @@
 /obj/item/clothing/suit/browntrenchcoat,
 /turf/simulated/floor/wood,
 /area/crew_quarters/cabin3)
-"kMD" = (
-/obj/structure/table/glass,
-/obj/item/storage/firstaid/adv{
-	pixel_x = 1;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bottle/charcoal,
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_y = 2
-	},
-/turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "whitered"
-	},
-/area/security/medbay)
 "kMK" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/storage/box/bodybags,
@@ -79277,19 +80050,9 @@
 	},
 /area/security/permabrig)
 "kNj" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/gambling_den)
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "kNl" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/security_space_law,
@@ -79340,26 +80103,43 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
-"kNI" = (
+"kNH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/door_control{
+	id = "xeno7";
+	name = "Containment Control";
+	pixel_y = 35;
+	req_access_txt = "55"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
+	},
+/area/toxins/xenobiology)
+"kNK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 4;
-	frequency = 1443;
-	icon_state = "on";
-	id = "air_in";
-	on = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/engine,
-/area/toxins/test_chamber)
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "kNO" = (
 /obj/structure/lattice,
 /obj/machinery/camera{
@@ -79368,33 +80148,12 @@
 	},
 /turf/space,
 /area/maintenance/ai)
-"kNU" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
-	},
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
-"kOj" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
-/area/maintenance/library)
 "kOu" = (
 /obj/structure/window/reinforced,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
 	},
 /area/shuttle/syndicate_sit)
-"kOD" = (
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
-/turf/simulated/floor/carpet,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
 "kOP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -79436,29 +80195,23 @@
 	},
 /area/turret_protected/ai)
 "kPC" = (
-/obj/item/shard{
-	icon_state = "medium";
-	pixel_x = 9;
-	pixel_y = -9
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "kPH" = (
 /obj/structure/rack,
 /obj/item/extinguisher,
 /obj/item/clothing/mask/gas,
 /obj/item/grenade/chem_grenade/firefighting,
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
 	},
-/area/toxins/mixing)
+/area/toxins/launch)
 "kQx" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -79541,6 +80294,13 @@
 	icon_state = "freezerfloor"
 	},
 /area/crew_quarters/locker/locker_toilet)
+"kRp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/theatre)
 "kRz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -79575,17 +80335,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/cabin4)
-"kRM" = (
-/obj/effect/decal/warning_stripes/north,
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1;
-	on = 1
-	},
-/turf/simulated/floor/engine,
-/area/toxins/misc_lab)
 "kRP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -79645,12 +80394,6 @@
 	tag = "icon-whitebluecorner"
 	},
 /area/medical/paramedic)
-"kSW" = (
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purple"
-	},
-/area/maintenance/xenozoo)
 "kTg" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -79708,12 +80451,25 @@
 /area/medical/morgue)
 "kTD" = (
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "kTT" = (
 /obj/effect/landmark/burnturf,
 /turf/simulated/wall/rust,
@@ -79733,6 +80489,13 @@
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/mining)
+"kUp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "kUr" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/structure/disposalpipe/segment{
@@ -79759,12 +80522,20 @@
 	parallax_movedir = 2
 	})
 "kUR" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/item/flag/clown,
 /turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
+"kUX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/airlock/highsecurity{
+	heat_proof = 1;
+	id_tag = "smbolts1";
+	locked = 1;
+	name = "Supermatter Chamber"
+	},
+/turf/simulated/floor/engine,
 /area/maintenance/xenozoo)
 "kVo" = (
 /turf/simulated/wall,
@@ -79772,6 +80543,25 @@
 "kVs" = (
 /turf/simulated/wall,
 /area/medical/medbay2)
+"kVu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/test_chamber)
 "kVz" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -79784,8 +80574,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "purplefull"
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
 /area/medical/research/nhallway)
 "kVH" = (
@@ -79846,13 +80641,6 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
-"kWn" = (
-/obj/effect/decal/warning_stripes/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
 "kWt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -79860,6 +80648,22 @@
 	icon_state = "dark"
 	},
 /area/chapel/office)
+"kWG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/effect/landmark{
+	name = "xeno_spawn";
+	pixel_x = -1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "kWH" = (
 /obj/structure/sign/nosmoking_1,
 /turf/simulated/wall,
@@ -79872,9 +80676,23 @@
 /turf/simulated/shuttle/floor,
 /area/shuttle/mining)
 "kWY" = (
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/obj/effect/decal/cleanable/blood/writing{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/bananium,
+/obj/item/soap/nanotrasen,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "kXF" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "redcorner"
@@ -79910,6 +80728,13 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"kYb" = (
+/obj/machinery/camera{
+	c_tag = "Experimentation Lab";
+	network = list("Research","SS13")
+	},
+/turf/simulated/floor/engine,
+/area/toxins/explab)
 "kYe" = (
 /obj/item/chair/wood/wings{
 	dir = 1
@@ -79922,6 +80747,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/kitchen)
+"kYg" = (
+/obj/effect/decal/warning_stripes/west,
+/obj/structure/chair/office/light{
+	dir = 4;
+	pixel_y = 3
+	},
+/obj/effect/landmark/start{
+	name = "Scientist"
+	},
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology)
 "kYh" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -79929,6 +80765,10 @@
 /area/shuttle/escape{
 	parallax_movedir = 2
 	})
+"kYm" = (
+/obj/structure/sign/biohazard,
+/turf/simulated/wall,
+/area/toxins/xenobiology)
 "kYq" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -79950,35 +80790,37 @@
 	icon_state = "redcorner"
 	},
 /area/hallway/primary/starboard/east)
-"kYM" = (
+"kYD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/item/radio/beacon,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTHWEST)"
 	},
-/turf/simulated/floor/engine,
-/area/toxins/test_chamber)
+/area/toxins/misc_lab)
 "kYQ" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/sleep)
-"kZh" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
+"kZm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
 	},
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/turf/simulated/floor/plating,
+/area/maintenance/xenozoo)
 "kZo" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
@@ -79989,8 +80831,10 @@
 	},
 /area/maintenance/kitchen)
 "kZr" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/structure/bookcase,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken5"
+	},
 /area/maintenance/library)
 "kZv" = (
 /obj/effect/spawner/window/reinforced,
@@ -80038,13 +80882,12 @@
 	},
 /area/medical/virology)
 "kZD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitehall"
-	},
-/area/toxins/xenobiology)
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "kZJ" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
@@ -80080,30 +80923,6 @@
 	icon_state = "blue"
 	},
 /area/bridge/checkpoint/south)
-"kZU" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "lap" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -80113,6 +80932,24 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/exit)
+"lax" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Gambling Den"
+	},
+/obj/structure/barricade/wooden,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "lay" = (
 /obj/effect/landmark/burnturf,
 /obj/structure/holosign/barrier/engineering,
@@ -80123,39 +80960,35 @@
 	name = "Virology Maintenance Construction Area"
 	})
 "laz" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Brig_lockdown";
+	name = "Brig Lockdown";
+	opacity = 0
+	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 8;
-	id_tag = "Evidence Storage"
-	},
-/obj/structure/cable,
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "BridgeLockdown";
-	name = "Bridge Lockdown"
+	id_tag = "SecMedPriv"
 	},
 /turf/simulated/floor/plating,
-/area/security/evidence)
-"laB" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/area/security/medbay)
 "laF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister,
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "whitepurple"
+	dir = 8;
+	icon_state = "purple"
 	},
-/area/toxins/xenobiology)
+/area/maintenance/xenozoo)
 "lbj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -80173,36 +81006,15 @@
 	},
 /area/security/range)
 "lbp" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp{
-	layer = 4;
-	pixel_x = -2;
-	pixel_y = 9
-	},
-/obj/item/folder{
-	pixel_x = 3
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/brigdoc,
+/obj/item/storage/belt/medical,
+/obj/item/storage/pill_bottle,
+/obj/item/storage/pill_bottle/patch_pack,
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "darkred"
+	dir = 8;
+	icon_state = "whitered"
 	},
-/area/security/evidence)
-"lbz" = (
-/obj/structure/table/reinforced,
-/obj/item/crowbar,
-/obj/item/wrench,
-/obj/item/clothing/mask/gas,
-/obj/machinery/camera{
-	c_tag = "Research Outpost Temporary Storage";
-	network = list("Research Outpost")
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 28
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/mixing)
+/area/security/medbay)
 "lbE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/warning_stripes/south,
@@ -80305,11 +81117,47 @@
 	name = "Virology Maintenance Construction Area"
 	})
 "lcG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random_spawners/grille_maybe,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xeno7";
+	name = "Creature Cell #7";
+	opacity = 0
+	},
+/obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
+/area/toxins/xenobiology)
+"lcK" = (
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	name = "Creature Pen";
+	req_access_txt = "47"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xeno3";
+	name = "Creature Cell #3";
+	opacity = 0
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/toxins/xenobiology)
 "lde" = (
 /obj/structure/table,
 /obj/item/radio{
@@ -80380,13 +81228,12 @@
 /turf/simulated/floor/plating,
 /area/security/prison/cell_block/A)
 "ldS" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	icon_state = "darkred"
+	dir = 4;
+	icon_state = "whiteredfull"
 	},
-/area/security/evidence)
+/area/security/medbay)
 "ldV" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/plasteel{
@@ -80422,32 +81269,31 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint2)
 "lev" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light{
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/toxins/test_chamber)
+"leX" = (
+/obj/machinery/atmospherics/trinary/mixer{
 	dir = 4
 	},
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/reagent_containers/glass/beaker,
-/obj/item/reagent_containers/dropper,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
-"lfc" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/window/plasmareinforced{
+	dir = 1
 	},
-/obj/effect/landmark/start{
-	name = "Brig Physician"
+/turf/simulated/floor/plasteel,
+/area/toxins/test_chamber)
+"lfc" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26;
+	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "redcorner"
 	},
-/area/security/medbay)
+/area/security/processing)
 "lfd" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -80501,6 +81347,17 @@
 /obj/effect/decal/cleanable/blood/oil/streak,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
+"lfs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
+	},
+/area/toxins/xenobiology)
 "lfv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -80517,25 +81374,6 @@
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
 	})
-"lfw" = (
-/obj/machinery/camera{
-	c_tag = "Visiting Room";
-	dir = 8;
-	network = list("SS13","Security")
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "darkred"
-	},
-/area/security/interrogation)
 "lfA" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -80553,7 +81391,10 @@
 "lfG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "lfQ" = (
@@ -80673,23 +81514,48 @@
 /turf/simulated/floor/plating,
 /area/maintenance/detectives_office)
 "lgN" = (
-/obj/machinery/light{
-	dir = 4
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitered"
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/area/security/medbay)
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Brig_lockdown";
+	name = "Brig Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "SecPilotPriv"
+	},
+/turf/simulated/floor/plating,
+/area/security/podbay)
 "lgS" = (
-/obj/machinery/light{
-	dir = 8
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitered"
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Brig_lockdown";
+	name = "Brig Lockdown";
+	opacity = 0
 	},
-/area/security/medbay)
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "SecPilotPriv"
+	},
+/turf/simulated/floor/plating,
+/area/security/podbay)
 "lhe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger{
@@ -80782,6 +81648,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/podbay)
+"lhL" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	id_tag = "toxinsdriver";
+	name = "disposal bay door";
+	protected = 0
+	},
+/turf/simulated/floor/plating,
+/area/toxins/launch)
 "lhQ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -80856,6 +81731,14 @@
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/central/south)
+"liX" = (
+/obj/machinery/hologram/holopad{
+	pixel_y = 16
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/toxins/misc_lab)
 "liZ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -80874,6 +81757,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/ai)
+"lja" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/multitool,
+/obj/item/multitool,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
+	},
+/area/toxins/misc_lab)
 "ljm" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -80949,6 +81849,22 @@
 	icon_state = "yellow"
 	},
 /area/maintenance/electrical)
+"lka" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "lke" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
@@ -81029,6 +81945,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/ai)
+"lld" = (
+/obj/machinery/camera{
+	c_tag = "Xeno Containment 6";
+	network = list("Research","SS13");
+	dir = 1
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/toxins/xenobiology)
 "llt" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/security_space_law,
@@ -81105,6 +82032,14 @@
 	tag = "icon-redfull (NORTHWEST)"
 	},
 /area/security/lobby)
+"llS" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (SOUTHWEST)"
+	},
+/area/toxins/misc_lab)
 "lmd" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -81124,18 +82059,6 @@
 	icon_state = "dark"
 	},
 /area/security/permabrig)
-"lmf" = (
-/obj/effect/landmark{
-	color = "#00ae00";
-	icon_state = "x_white";
-	name = "ninja_teleport"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
 "lmj" = (
 /obj/structure/table/reinforced,
 /obj/item/mmi/robotic_brain,
@@ -81174,17 +82097,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/ai)
-"lmR" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	dir = 0;
-	icon_state = "whitered"
-	},
-/area/security/medbay)
 "lmV" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -81221,6 +82133,11 @@
 "lnB" = (
 /turf/simulated/wall,
 /area/crew_quarters/mrchangs)
+"lnE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/head/griffin,
+/turf/simulated/floor/plating,
+/area/maintenance/library)
 "lnH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -81238,14 +82155,20 @@
 	},
 /area/crew_quarters/locker)
 "lnW" = (
-/obj/machinery/vending/cigarette,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/official/safety_report{
-	pixel_y = 32
+/obj/structure/table/reinforced,
+/obj/item/flashlight{
+	pixel_y = 4
+	},
+/obj/item/wirecutters{
+	pixel_y = 18
+	},
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	dir = 4;
+	icon_state = "darkred"
 	},
 /area/security/processing)
 "lof" = (
@@ -81292,20 +82215,20 @@
 	},
 /area/medical/chemistry)
 "lot" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/item/wrench,
+/obj/item/crowbar,
+/obj/item/clothing/mask/gas,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "xeno3";
-	name = "Creature Cell #3";
-	opacity = 0
+/obj/structure/table,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
 	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology)
+/area/toxins/explab)
 "lov" = (
 /turf/simulated/wall,
 /area/crew_quarters/cabin4)
@@ -81435,8 +82358,15 @@
 /turf/simulated/floor/plating,
 /area/security/checkpoint/south)
 "lpm" = (
-/turf/simulated/wall/r_wall/coated,
-/area/toxins/test_chamber)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
+	},
+/area/toxins/misc_lab)
 "lpp" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -81493,17 +82423,9 @@
 /turf/simulated/floor/plasteel,
 /area/bridge/checkpoint/south)
 "lpC" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Xeno Containment 5";
-	network = list("Research","SS13")
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/toxins/xenobiology)
+/obj/structure/closet/l3closet/scientist,
+/turf/simulated/floor/engine,
+/area/maintenance/xenozoo)
 "lpH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -81545,6 +82467,11 @@
 	icon_state = "green"
 	},
 /area/maintenance/garden)
+"lqc" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "lqe" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -81565,6 +82492,9 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
+"lqo" = (
+/turf/simulated/floor/carpet/royalblack,
+/area/maintenance/asmaint2)
 "lqA" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/binary/valve/digital{
@@ -81843,31 +82773,20 @@
 	},
 /area/medical/medbay2)
 "luw" = (
-/obj/structure/closet,
-/obj/item/roller,
-/obj/item/roller{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/effect/decal/cleanable/cobweb2,
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/surgery{
+	pixel_y = -6
 	},
-/obj/item/storage/box/masks{
-	pixel_x = 2
-	},
-/obj/item/storage/box/gloves{
-	pixel_y = 2
-	},
-/obj/item/storage/box/bodybags{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 27
+/obj/item/implanter/mindshield{
+	pixel_x = 4;
+	pixel_y = 12
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitered"
+	dir = 5;
+	icon_state = "darkred"
 	},
-/area/security/medbay)
+/area/security/processing)
 "luy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -81919,12 +82838,6 @@
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/storage)
-"luL" = (
-/obj/structure/closet/firecloset,
-/obj/effect/decal/cleanable/cobweb2,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/perma)
 "luQ" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -81937,6 +82850,11 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/siberia)
+"lvc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_spawners/wall_rusted_probably,
+/turf/simulated/wall,
+/area/maintenance/asmaint2)
 "lvh" = (
 /obj/machinery/power/tesla_coil{
 	anchored = 1
@@ -81949,27 +82867,15 @@
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "lvo" = (
-/obj/structure/chair/wood/wings{
-	dir = 8;
-	tag = "icon-wooden_chair_wings (WEST)"
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
-	},
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
-"lvs" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "purple"
+	icon_state = "dark"
 	},
-/area/maintenance/xenozoo)
+/area/toxins/xenobiology)
+"lvs" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "purplefull"
+	},
+/area/toxins/xenobiology)
 "lvv" = (
 /turf/simulated/wall/r_wall,
 /area/medical/cmostore{
@@ -82082,6 +82988,21 @@
 	icon_state = "green"
 	},
 /area/hydroponics)
+"lwB" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/plasteel{
+	dir = 1
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "lwC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/camera_film,
@@ -82102,22 +83023,30 @@
 	},
 /turf/space,
 /area/space/nearstation)
-"lxh" = (
-/obj/machinery/light/small,
-/obj/structure/closet/bombcloset,
+"lwW" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/obj/structure/sign/poster/random{
+	pixel_y = -32
+	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
 	icon_state = "whitepurple"
 	},
-/area/toxins/explab)
+/area/medical/research/nhallway)
 "lxD" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/area/maintenance/xenozoo)
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/space/nearstation)
 "lxQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/table/reinforced,
@@ -82148,17 +83077,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/crew_quarters/sleep)
-"lyg" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/iv_bag/blood/OMinus,
-/obj/item/reagent_containers/iv_bag/blood/OMinus,
-/obj/item/reagent_containers/iv_bag/blood/OMinus,
-/obj/item/reagent_containers/iv_bag/blood/OMinus,
-/obj/item/reagent_containers/iv_bag/salglu,
-/obj/item/reagent_containers/iv_bag/salglu,
-/turf/space,
-/turf/simulated/shuttle/floor4/vox,
-/area/shuttle/vox)
 "lyi" = (
 /obj/structure/table,
 /obj/item/stack/packageWrap,
@@ -82317,6 +83235,21 @@
 /obj/item/lighter/zippo/rd,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
+"lzk" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "whitehall"
+	},
+/area/maintenance/asmaint2)
 "lzm" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -82457,11 +83390,23 @@
 	},
 /area/medical/ward)
 "lAU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/simulated/wall/r_wall,
-/area/security/processing)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkred"
+	},
+/area/security/evidence)
 "lAV" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
@@ -82471,11 +83416,15 @@
 	},
 /area/atmos)
 "lAZ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkred"
+/obj/structure/closet/secure_closet/brig/evidence,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
 	},
-/area/security/processing)
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/security/evidence)
 "lBh" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -82490,28 +83439,13 @@
 	},
 /area/medical/research/shallway)
 "lBo" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/landmark/start{
-	name = "Scientist"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
-"lBw" = (
-/obj/machinery/flasher/portable,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/item/wrench,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/security/processing)
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/obj/machinery/light,
+/turf/simulated/floor/wood,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "lBD" = (
 /obj/structure/table/wood,
 /obj/item/folder,
@@ -82545,27 +83479,22 @@
 	},
 /turf/simulated/floor/carpet,
 /area/chapel/office)
+"lCb" = (
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/folder/white,
+/obj/item/pen,
+/turf/simulated/floor/plasteel,
+/area/toxins/explab)
 "lCu" = (
 /obj/structure/cable{
-	icon_state = "1-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/turf/simulated/floor/plasteel{
+	icon_state = "darkred"
 	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized{
-	id = "visiting room"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 8;
-	id = "visiting room"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "visiting room"
-	},
-/turf/simulated/floor/plating,
 /area/security/interrogation)
 "lCK" = (
 /obj/machinery/light,
@@ -82605,17 +83534,6 @@
 /obj/structure/bookcase,
 /turf/simulated/floor/wood,
 /area/library)
-"lDu" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/west,
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "lDx" = (
 /obj/machinery/computer/merch{
 	dir = 1
@@ -82664,18 +83582,17 @@
 /turf/simulated/wall/r_wall,
 /area/civilian/barber)
 "lEG" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
+/obj/machinery/atmospherics/pipe/cap/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/cap/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/aft{
 	name = "Medbay Maintenance"
@@ -82697,6 +83614,10 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard/east)
+"lEW" = (
+/obj/structure/curtain/black,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "lFf" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -82713,25 +83634,31 @@
 	icon_state = "brown"
 	},
 /area/quartermaster/miningdock)
-"lFu" = (
+"lFm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_spawners/blood_maybe,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "redcorner"
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/crew_quarters/theatre)
+"lFu" = (
+/obj/structure/chair,
+/obj/effect/landmark/start{
+	name = "Security Officer"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1
 	},
 /area/security/processing)
 "lFw" = (
-/obj/machinery/door/window/brigdoor{
-	dir = 2;
-	name = "Creature Pen"
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	name = "Creature Pen"
-	},
+/obj/structure/table/reinforced,
+/obj/item/wrench,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "white"
 	},
-/area/maintenance/xenozoo)
+/area/toxins/xenobiology)
 "lFG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -82752,31 +83679,18 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/exit)
-"lFP" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "xenosecure";
-	name = "Secure Creature Cell";
-	opacity = 0
-	},
-/obj/effect/spawner/window/reinforced/plasma,
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology)
 "lGo" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "purplefull"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/area/toxins/xenobiology)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "lGv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -82842,16 +83756,15 @@
 	name = "Research Division"
 	})
 "lGO" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/clothing/mask/gas/clown_hat/pennywise,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "bar"
 	},
-/area/toxins/xenobiology)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "lGR" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -82974,6 +83887,23 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/simulated/floor/engine/insulated/vacuum,
 /area/toxins/mixing)
+"lHO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = 24
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobio Central";
+	network = list("Research","SS13")
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
+	},
+/area/toxins/xenobiology)
 "lHR" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -83298,6 +84228,30 @@
 	icon_state = "neutralfull"
 	},
 /area/crew_quarters/locker)
+"lLU" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Brig_lockdown";
+	name = "Brig Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id_tag = "SecMedPriv"
+	},
+/turf/simulated/floor/plating,
+/area/security/medbay)
 "lLV" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -83351,20 +84305,30 @@
 	name = "\improper Virology Lobby"
 	})
 "lMd" = (
-/obj/structure/closet/secure_closet/brig/evidence,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
+/obj/structure/closet/crate/freezer,
+/obj/item/tank/internals/emergency_oxygen/engi/empty,
+/obj/item/tank/internals/emergency_oxygen/engi/empty,
+/obj/item/reagent_containers/iv_bag/blood/AMinus,
+/obj/item/reagent_containers/iv_bag/blood/APlus,
+/obj/item/reagent_containers/iv_bag/blood/BMinus,
+/obj/item/reagent_containers/iv_bag/blood/BPlus,
+/obj/item/reagent_containers/iv_bag/blood/OMinus,
+/obj/item/reagent_containers/iv_bag/blood/OPlus,
+/obj/item/reagent_containers/iv_bag/blood/random,
+/obj/item/reagent_containers/iv_bag/blood/random,
+/obj/item/reagent_containers/iv_bag/blood/random,
+/obj/machinery/iv_drip,
+/obj/item/reagent_containers/iv_bag/salglu,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/cobweb{
-	layer = 4
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault"
+	icon_state = "whitered"
 	},
-/area/security/evidence)
+/area/security/medbay)
 "lMi" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -83383,6 +84347,40 @@
 	icon_state = "redcorner"
 	},
 /area/security/lobby)
+"lMn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/chair,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 0;
+	icon_state = "red"
+	},
+/area/security/processing)
+"lMr" = (
+/obj/machinery/flasher/portable,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/item/wrench,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "red"
+	},
+/area/security/processing)
 "lMu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -83452,11 +84450,6 @@
 	icon_state = "redcorner"
 	},
 /area/security/armory)
-"lNh" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/wood,
-/area/maintenance/library)
 "lNp" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger{
@@ -83499,6 +84492,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
 	},
@@ -83539,6 +84533,16 @@
 	icon_state = "yellowfull"
 	},
 /area/maintenance/electrical)
+"lOn" = (
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/toxins/explab)
 "lOt" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -83570,11 +84574,17 @@
 	},
 /area/bridge)
 "lOu" = (
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "darkred"
+/obj/machinery/light,
+/obj/machinery/camera{
+	c_tag = "Temporal Cell";
+	dir = 1;
+	network = list("SS13","Security")
 	},
-/area/security/interrogation)
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "red"
+	},
+/area/security/processing)
 "lOz" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -83682,10 +84692,32 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/permabrig)
+"lPR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
+	},
+/area/toxins/explab)
 "lPW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random_spawners/fungus_maybe,
-/turf/simulated/wall,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken6"
+	},
 /area/maintenance/library)
 "lQa" = (
 /obj/effect/decal/cleanable/dirt,
@@ -83748,11 +84780,8 @@
 	},
 /area/bridge)
 "lQT" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "lQU" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -83822,13 +84851,6 @@
 	},
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
-"lRT" = (
-/obj/effect/decal/warning_stripes/southeast,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
 "lSr" = (
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -83893,6 +84915,22 @@
 	},
 /turf/simulated/floor/carpet,
 /area/assembly/showroom)
+"lTd" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xeno6";
+	name = "Creature Cell #6";
+	opacity = 0
+	},
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology)
 "lTm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -83978,6 +85016,16 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/cryo)
+"lTN" = (
+/obj/effect/spawner/window/reinforced/plasma,
+/obj/machinery/door/poddoor{
+	name = "Supermatter Blast Doors";
+	density = 0;
+	opacity = 0;
+	id_tag = "engsm1"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/xenozoo)
 "lTQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -84046,15 +85094,12 @@
 	},
 /area/bridge)
 "lUS" = (
-/obj/effect/decal/warning_stripes/yellow,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "lUZ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
@@ -84091,18 +85136,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
-"lVe" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/west,
-/obj/effect/decal/warning_stripes/east,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "lVo" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -84141,12 +85174,36 @@
 	},
 /area/turret_protected/aisat)
 "lVP" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/item/radio/beacon,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 4;
+	frequency = 1443;
+	icon_state = "on";
+	id = "air_in";
+	on = 1
+	},
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
+"lVZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/maintenance/library)
 "lWa" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -84197,19 +85254,27 @@
 /area/gateway)
 "lWl" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	dir = 1;
+	id = "chem"
 	},
-/obj/effect/decal/warning_stripes/west,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/window/reinforced/polarized{
+	dir = 8;
+	id = "chem"
 	},
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/obj/structure/window/reinforced/polarized{
+	id = "chem"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "chem"
+	},
+/turf/simulated/floor/plating,
+/area/toxins/misc_lab)
 "lWu" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
@@ -84250,6 +85315,20 @@
 /area/maintenance/consarea{
 	name = "Virology Maintenance Construction Area"
 	})
+"lWI" = (
+/obj/effect/decal/warning_stripes/yellow,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "purplefull"
+	},
+/area/toxins/xenobiology)
 "lWM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -84272,20 +85351,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/kitchen)
-"lXa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/item/twohanded/required/kirbyplants,
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitehall"
-	},
-/area/toxins/xenobiology)
 "lXr" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
@@ -84327,6 +85392,25 @@
 	icon_state = "vault"
 	},
 /area/bridge)
+"lXJ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "lXQ" = (
 /obj/machinery/door/airlock/external{
 	name = "Toxins Test Chamber"
@@ -84515,13 +85599,6 @@
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
 	})
-"mad" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/flashlight,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/toxins/explab)
 "mak" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	name = "standard air scrubber";
@@ -84541,6 +85618,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/ntrep)
+"mar" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/ants,
+/obj/item/chair/wood/wings{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/black,
+/area/crew_quarters/theatre)
 "mav" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -84661,21 +85746,30 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/cigarettes/cigpack_robust,
 /obj/item/lighter,
-/turf/simulated/floor/engine,
-/area/security/execution)
-"mbR" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "purple"
+/turf/simulated/floor/engine,
+/area/security/execution)
+"mbR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/area/maintenance/xenozoo)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
+	},
+/area/toxins/explab)
 "mbT" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -84775,26 +85869,6 @@
 "mcI" = (
 /turf/simulated/shuttle/floor,
 /area/shuttle/transport)
-"mcQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
 "mcY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -84823,12 +85897,11 @@
 /turf/simulated/floor/carpet/black,
 /area/bridge/vip)
 "mdb" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkblue"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "mdc" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -84960,7 +86033,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
+	icon_state = "white"
 	},
 /area/medical/research/shallway)
 "mfd" = (
@@ -84974,17 +86047,17 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "mfo" = (
-/obj/structure/chair/office/light{
-	dir = 4;
-	pixel_y = 3
-	},
-/obj/effect/landmark/start{
-	name = "Brig Physician"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 1
 	},
-/area/security/medbay)
+/area/security/processing)
 "mft" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -85206,33 +86279,6 @@
 	icon_state = "escape"
 	},
 /area/bridge/checkpoint/south)
-"mhC" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "xeno6";
-	name = "Creature Cell #6";
-	opacity = 0
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	name = "Creature Pen";
-	req_access_txt = "47"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/toxins/xenobiology)
 "mhL" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/warning_stripes/yellow,
@@ -85291,16 +86337,27 @@
 	},
 /area/shuttle/syndicate_sit)
 "miq" = (
-/obj/structure/closet/secure_closet/brig/evidence,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+	dir = 4;
+	icon_state = "whiteredfull"
 	},
-/area/security/evidence)
+/area/security/medbay)
 "miw" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/warning_stripes/west,
@@ -85441,10 +86498,27 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/medical/research/nhallway)
+"mkf" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/masks{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/storage/box/gloves,
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = -8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "whitered"
+	},
+/area/security/medbay)
 "mkg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -85495,31 +86569,54 @@
 	},
 /area/medical/virology/lab)
 "mkm" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/shieldwallgen{
-	req_access = list(47)
-	},
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology)
-"mkF" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 28
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/toxins/explab)
-"mkL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurple"
+	},
+/area/toxins/explab)
+"mkD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
+	},
+/area/toxins/xenobiology)
+"mkI" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
+"mkL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/engine,
 /area/toxins/explab)
 "mkM" = (
 /obj/structure/cable{
@@ -85537,9 +86634,13 @@
 /turf/simulated/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "mkS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall,
-/area/maintenance/asmaint2)
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/closet/l3closet/scientist,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/toxins/launch)
 "mla" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -85575,8 +86676,9 @@
 /turf/simulated/floor/plasteel,
 /area/security/checkpoint/south)
 "mlh" = (
-/turf/simulated/wall/r_wall/rust,
-/area/toxins/mixing)
+/obj/effect/decal/warning_stripes/yellow/partial,
+/turf/simulated/floor/plating,
+/area/toxins/launch)
 "mll" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -85612,6 +86714,17 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/west)
+"mlJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/writing,
+/obj/structure/curtain/open/shower/security{
+	name = "backstage";
+	alpha = 255
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "tranquillite"
+	},
+/area/crew_quarters/theatre)
 "mlL" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Shuttle Airlock";
@@ -85624,13 +86737,11 @@
 /area/shuttle/siberia)
 "mlM" = (
 /obj/structure/table,
-/obj/item/flashlight/lamp{
-	layer = 4;
-	pixel_x = 7;
-	pixel_y = 14
-	},
+/obj/item/flashlight/seclite,
+/obj/item/restraints/handcuffs,
 /turf/simulated/floor/plasteel{
-	dir = 1
+	icon_state = "redfull";
+	tag = "icon-redfull (NORTHWEST)"
 	},
 /area/security/processing)
 "mlW" = (
@@ -85649,15 +86760,26 @@
 	},
 /area/chapel/office)
 "mlX" = (
-/obj/machinery/computer/crew,
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 30
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 26
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitered"
+	icon_state = "red"
 	},
-/area/security/medbay)
+/area/security/processing)
 "mml" = (
 /turf/simulated/floor/plasteel{
 	dir = 0;
@@ -85755,18 +86877,6 @@
 /area/maintenance/aft{
 	name = "Medbay Maintenance"
 	})
-"mnf" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whiteredfull"
-	},
-/area/security/medbay)
 "mnh" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
@@ -85919,20 +87029,9 @@
 	},
 /area/security/podbay)
 "mov" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10;
-	initialize_directions = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "purplefull"
-	},
-/area/toxins/xenobiology)
+/obj/structure/sign/securearea,
+/turf/simulated/wall/r_wall,
+/area/toxins/explab)
 "moE" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
@@ -85983,22 +87082,11 @@
 	icon_state = "dark"
 	},
 /area/library)
-"mpf" = (
+"mpd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
+/obj/structure/table_frame/wood,
 /turf/simulated/floor/plating,
-/area/maintenance/aft{
-	name = "Medbay Maintenance"
-	})
+/area/crew_quarters/theatre)
 "mpg" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -86043,7 +87131,7 @@
 "mpI" = (
 /turf/space,
 /turf/simulated/wall/r_wall,
-/area/security/prison/cell_block/A)
+/area/security/medbay)
 "mpW" = (
 /obj/machinery/light{
 	dir = 1;
@@ -86055,20 +87143,30 @@
 	},
 /area/security/brig)
 "mqj" = (
-/obj/structure/table/reinforced,
-/obj/item/mmi{
-	pixel_x = 1;
-	pixel_y = -9
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 4;
-	pixel_y = 7
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "darkred"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/processing)
 "mqp" = (
@@ -86151,6 +87249,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hop)
+"mqJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "mqV" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -86263,6 +87367,11 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "mrN" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "darkred"
@@ -86297,6 +87406,11 @@
 	icon_state = "dark"
 	},
 /area/construction/hallway)
+"msb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/coatrack,
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "mss" = (
 /obj/item/chair/wood/wings{
 	dir = 1
@@ -86305,6 +87419,10 @@
 	icon_state = "wood-broken3"
 	},
 /area/maintenance/kitchen)
+"msA" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall,
+/area/toxins/test_chamber)
 "msG" = (
 /obj/structure/window/reinforced,
 /obj/structure/chair/comfy/black{
@@ -86321,21 +87439,6 @@
 	icon_state = "dark"
 	},
 /area/crew_quarters/courtroom)
-"msW" = (
-/obj/machinery/power/apc{
-	cell_type = 25000;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24;
-	shock_proof = 1
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/perma)
 "mth" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -86361,6 +87464,57 @@
 	icon_state = "neutralfull"
 	},
 /area/engine/break_room)
+"mtp" = (
+/obj/structure/window/reinforced/polarized{
+	id = "pokerclub";
+	color = "#222222";
+	opacity = 1
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "pokerclub";
+	opacity = 1;
+	color = "#222222"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	dir = 1;
+	id = "pokerclub";
+	color = "#222222";
+	opacity = 1
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 8;
+	id = "pokerclub";
+	opacity = 1;
+	color = "#222222"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
+"mtr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "mtz" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder{
@@ -86426,16 +87580,6 @@
 	icon_state = "red"
 	},
 /area/security/range)
-"muf" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/barricade/wooden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
 "muo" = (
 /obj/structure/table/reinforced,
 /obj/item/analyzer,
@@ -86453,6 +87597,16 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
+"mur" = (
+/obj/structure/window/plasmareinforced{
+	dir = 4
+	},
+/obj/structure/window/plasmareinforced{
+	dir = 8
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/toxins/launch)
 "muD" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -86482,7 +87636,10 @@
 /turf/simulated/floor/plating,
 /area/atmos)
 "muK" = (
-/obj/structure/grille/broken,
+/obj/structure/grille{
+	density = 0;
+	icon_state = "brokengrille"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
@@ -86511,15 +87668,17 @@
 	icon_state = "darkblue"
 	},
 /area/construction/hallway)
-"muV" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+"mvk" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall,
+/area/chapel/main)
+"mvo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/confetti,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "mvI" = (
 /obj/machinery/door_timer/cell_1{
 	dir = 1;
@@ -86569,17 +87728,21 @@
 	name = "\improper AI Satellite Service"
 	})
 "mwg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/wall/r_wall,
-/area/security/processing)
-"mwh" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkred"
+	},
+/area/security/evidence)
+"mwi" = (
+/turf/simulated/wall/r_wall/coated,
+/area/toxins/test_chamber)
 "mwu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
@@ -86621,25 +87784,6 @@
 /area/aisat{
 	name = "\improper AI Satellite Hallway"
 	})
-"mwW" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/landmark{
-	name = "blobstart"
-	},
-/obj/effect/decal/warning_stripes/north,
-/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "mxb" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -86707,14 +87851,12 @@
 	},
 /area/security/prisonershuttle)
 "mxT" = (
-/obj/machinery/smartfridge/secure/extract,
-/obj/machinery/light_switch{
-	pixel_x = -26
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -25
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/turf/simulated/floor/engine,
+/area/toxins/explab)
 "mxV" = (
 /obj/machinery/camera{
 	c_tag = "Central Ring Hallway North 3"
@@ -86725,19 +87867,14 @@
 	},
 /area/hallway/primary/central/north)
 "mxZ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/chem_heater,
+/obj/structure/window/plasmareinforced{
+	dir = 4
 	},
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	name = "Creature Pen";
-	req_access_txt = "47"
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/turf/simulated/floor/engine,
+/area/toxins/misc_lab)
 "mya" = (
 /obj/structure/sign/greencross,
 /turf/simulated/wall,
@@ -86757,17 +87894,32 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/north)
-"myH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -26
-	},
-/obj/structure/cable,
+"myF" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	icon_state = "purplefull"
 	},
-/area/maintenance/library)
+/area/toxins/xenobiology)
+"myH" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/girder,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
 "myO" = (
 /obj/item/radio/intercom{
 	pixel_y = 22
@@ -86896,18 +88048,16 @@
 	},
 /area/construction/hallway)
 "mzZ" = (
-/obj/structure/sign/science{
-	icon_state = "doors"
+/obj/effect/decal/warning_stripes/south,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/wall,
-/area/toxins/xenobiology)
-"mAa" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "mAd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -86927,13 +88077,6 @@
 	icon_state = "neutralfull"
 	},
 /area/engine/hardsuitstorage)
-"mAn" = (
-/obj/machinery/computer/camera_advanced/xenobio,
-/obj/machinery/status_display{
-	pixel_x = 32
-	},
-/turf/simulated/floor/greengrid,
-/area/toxins/xenobiology)
 "mAq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -87001,6 +88144,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/north)
 "mAN" = (
+/obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "open";
@@ -87012,7 +88156,6 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/prison/cell_block/A)
 "mAO" = (
@@ -87161,15 +88304,27 @@
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "mBF" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/item/pen,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
+	icon_state = "dark"
+	},
+/area/security/interrogation)
+"mBL" = (
+/obj/structure/table,
+/obj/item/flashlight/lamp,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull";
+	tag = "icon-redfull (NORTHWEST)"
 	},
 /area/security/processing)
 "mBR" = (
@@ -87180,16 +88335,12 @@
 	},
 /area/security/warden)
 "mBV" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/ash,
+/obj/structure/railing{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurple"
-	},
-/area/toxins/explab)
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "mCe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -87208,6 +88359,23 @@
 	icon_state = "dark"
 	},
 /area/crew_quarters/courtroom)
+"mCj" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/start{
+	name = "Security Officer"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/security/processing)
 "mCD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -87410,12 +88578,19 @@
 	},
 /area/hallway/primary/starboard/east)
 "mDL" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
+/obj/machinery/newscaster/security_unit{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkred"
+	},
 /area/security/interrogation)
 "mDN" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -87510,12 +88685,14 @@
 	},
 /area/medical/medbay2)
 "mEu" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "darkred"
+	},
 /area/security/interrogation)
 "mEA" = (
 /obj/effect/landmark/burnturf,
@@ -87538,7 +88715,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
 	},
 /area/medical/research/shallway)
 "mEG" = (
@@ -87610,6 +88789,11 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -87629,14 +88813,10 @@
 	},
 /area/security/podbay)
 "mFH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	temperature = 80
+	icon_state = "white"
 	},
-/area/toxins/xenobiology)
+/area/medical/research/shallway)
 "mGd" = (
 /obj/effect/decal/cleanable/blood/drip{
 	pixel_x = -4;
@@ -87701,9 +88881,23 @@
 	},
 /area/turret_protected/aisat_interior)
 "mGL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
 	},
 /area/medical/research/nhallway)
 "mHa" = (
@@ -87719,6 +88913,16 @@
 "mHd" = (
 /turf/simulated/floor/engine/insulated/vacuum,
 /area/atmos)
+"mHi" = (
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_x = 9;
+	pixel_y = -9
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/maintenance/library)
 "mHl" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -87752,21 +88956,12 @@
 	},
 /area/medical/research/nhallway)
 "mIg" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id_tag = "rdprivacy";
-	name = "Research Director Office Shutters";
-	opacity = 0
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/hor)
+/area/medical/research/nhallway)
 "mIh" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Gas Mix Tank";
@@ -87781,11 +88976,22 @@
 	dir = 1
 	},
 /area/security/main)
-"mIv" = (
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/perma)
+"mIE" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/south,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/item/pen{
+	pixel_x = 8
+	},
+/obj/item/folder/white,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology)
 "mIO" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -87915,15 +89121,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/cloning)
-"mJT" = (
-/obj/machinery/light_switch{
-	pixel_x = -24
-	},
-/turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "whitered"
-	},
-/area/security/medbay)
 "mJU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
@@ -88035,6 +89232,27 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
+"mKG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkbluecorners"
+	},
+/area/crew_quarters/theatre)
 "mKN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -88069,28 +89287,21 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "purplefull"
+	icon_state = "white"
 	},
 /area/medical/research/nhallway)
 "mLo" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/bible,
-/obj/item/reagent_containers/food/drinks/bottle/holywater,
-/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/glass/bucket,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = -6
+	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 10;
 	icon_state = "darkred"
 	},
 /area/security/processing)
-"mLx" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/gambling_den)
 "mLE" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -88130,29 +89341,25 @@
 	},
 /area/hallway/secondary/exit)
 "mLS" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken3";
+	tag = "icon-wood-broken3"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
+/area/crew_quarters/theatre)
 "mMd" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/nw)
 "mMf" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "whitepurple"
 	},
-/area/medical/research/nhallway)
+/area/toxins/explab)
 "mMg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -88213,18 +89420,6 @@
 	icon_state = "vault"
 	},
 /area/bridge)
-"mMr" = (
-/obj/structure/table,
-/obj/machinery/light,
-/obj/item/crowbar,
-/obj/item/wrench,
-/obj/item/clothing/mask/gas,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "mMw" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -88323,20 +89518,24 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
-"mNV" = (
-/obj/machinery/door_control{
-	id = "GYM";
-	name = "Dungeon Privacy Shutters Control";
-	pixel_x = 24;
-	pixel_y = 23;
-	req_access_txt = "63"
-	},
+"mNS" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkredcorners"
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/security/processing)
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
+"mNW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "mNY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -88356,7 +89555,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "purplefull"
+	icon_state = "white"
 	},
 /area/medical/research/nhallway)
 "mOb" = (
@@ -88476,6 +89675,13 @@
 /area/maintenance/aft{
 	name = "Medbay Maintenance"
 	})
+"mPB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "mPC" = (
 /obj/machinery/light{
 	dir = 4
@@ -88519,19 +89725,22 @@
 /area/hallway/primary/port/west)
 "mPL" = (
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/structure/table/reinforced,
-/obj/item/radio/electropack,
-/obj/item/assembly/signaler,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkred"
+	icon_state = "darkredcorners"
 	},
-/area/security/processing)
+/area/security/evidence)
 "mQn" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -88580,17 +89789,11 @@
 	name = "\improper Virology Lobby"
 	})
 "mQI" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/closet/bombcloset,
+/turf/simulated/floor/plasteel{
+	icon_state = "purplefull"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/area/toxins/test_chamber)
 "mQL" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -88602,21 +89805,6 @@
 	},
 /turf/space,
 /area/space)
-"mQO" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "xeno1";
-	name = "Creature Cell #1";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology)
 "mRc" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 4
@@ -88672,11 +89860,42 @@
 /obj/item/paper/deltainfo,
 /turf/simulated/floor/carpet/black,
 /area/bridge/vip)
+"mRA" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology)
 "mRE" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/structure/sign/poster/contraband/clown{
+	pixel_y = 32
+	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "mRF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -88714,6 +89933,18 @@
 	icon_state = "blue"
 	},
 /area/bridge/checkpoint/south)
+"mRK" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 4;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken3"
+	},
+/area/maintenance/library)
 "mRM" = (
 /obj/effect/landmark/start{
 	name = "Shaft Miner"
@@ -88744,7 +89975,9 @@
 	pixel_x = 26
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
 	},
 /area/medical/research/shallway)
 "mSn" = (
@@ -88917,20 +90150,10 @@
 	},
 /area/maintenance/starboard)
 "mUg" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "xeno2";
-	name = "Creature Cell #4";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology)
+/area/toxins/misc_lab)
 "mUi" = (
 /obj/machinery/photocopier,
 /obj/machinery/newscaster{
@@ -88965,10 +90188,6 @@
 	icon_state = "grimy"
 	},
 /area/bridge)
-"mUF" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall/r_wall,
-/area/toxins/explab)
 "mUQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
@@ -88998,21 +90217,22 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "mUY" = (
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel,
-/area/toxins/mixing)
-"mVH" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;47"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
+"mVD" = (
 /turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/area/toxins/explab)
 "mVO" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -89036,21 +90256,22 @@
 	parallax_movedir = 2
 	})
 "mWo" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/engine,
+/area/toxins/misc_lab)
 "mWC" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
+/obj/machinery/camera{
+	c_tag = "Research Outpost Temporary Storage";
+	network = list("Research Outpost")
 	},
-/area/toxins/mixing)
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 28
+	},
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/launch)
 "mWP" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -89115,10 +90336,32 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/detectives_office)
+"mXq" = (
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
+	},
+/area/toxins/explab)
 "mXt" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/maintenance/ai)
+"mXB" = (
+/obj/machinery/constructable_frame/machine_frame,
+/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purple"
+	},
+/area/maintenance/xenozoo)
 "mXF" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -89186,13 +90429,9 @@
 	},
 /area/bridge)
 "mYk" = (
-/obj/effect/landmark{
-	name = "revenantspawn"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/gambling_den)
+/mob/living/simple_animal/mouse,
+/turf/simulated/floor/wood,
+/area/crew_quarters/theatre)
 "mYl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6;
@@ -89270,6 +90509,14 @@
 /area/maintenance/aft{
 	name = "Medbay Maintenance"
 	})
+"mZd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "mZk" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -89280,12 +90527,6 @@
 	icon_state = "neutralfull"
 	},
 /area/bridge/checkpoint/south)
-"mZA" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/toxins/explab)
 "mZC" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -89302,18 +90543,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
-"mZI" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "xenosecure";
-	name = "Secure Creature Cell";
-	opacity = 0
-	},
-/obj/effect/spawner/window/reinforced/plasma,
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology)
 "mZK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	name = "standard air scrubber";
@@ -89456,32 +90685,6 @@
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
 	})
-"naC" = (
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	id_tag = "sw_maint_airlock";
-	pixel_y = 25;
-	tag_airpump = "sw_maint_pump";
-	tag_chamber_sensor = "sw_maint_sensor";
-	tag_exterior_door = "sw_maint_outer";
-	tag_interior_door = "sw_maint_inner"
-	},
-/obj/machinery/airlock_sensor{
-	id_tag = "sw_maint_sensor";
-	pixel_y = 33
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
-	frequency = 1379;
-	id_tag = "sw_maint_pump"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
 "naD" = (
 /obj/item/target,
 /turf/simulated/floor/plasteel/airless,
@@ -89581,7 +90784,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
@@ -89593,8 +90795,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2";
+	tag = "icon-pipe-j2"
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "purplefull"
 	},
 /area/medical/research/shallway)
 "nbA" = (
@@ -89604,6 +90811,31 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
+"nbK" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
 "nbP" = (
 /obj/structure/urinal{
 	pixel_y = 28
@@ -89709,8 +90941,16 @@
 	},
 /area/medical/reception)
 "ndo" = (
-/obj/item/clothing/mask/face/rat,
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/mineral_door/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
 /area/maintenance/library)
 "ndp" = (
 /obj/effect/decal/cleanable/dirt,
@@ -89797,23 +91037,6 @@
 	tag = "icon-vault (NORTHEAST)"
 	},
 /area/security/detectives_office)
-"ndY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
 "nee" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -89918,13 +91141,25 @@
 	icon_state = "grimy"
 	},
 /area/chapel/main)
-"nfm" = (
-/obj/machinery/light/small,
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = -32
+"nfj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/maintenance/asmaint2)
+"nfm" = (
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/engine,
+/area/maintenance/xenozoo)
 "nft" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -89953,18 +91188,20 @@
 /turf/simulated/floor/plating,
 /area/security/customs)
 "nfO" = (
-/obj/machinery/ai_status_display{
-	pixel_y = 32
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	name = "standard air scrubber";
 	on = 1;
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
+/obj/machinery/light{
+	dir = 1;
+	on = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple"
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
 /area/medical/research/nhallway)
 "nfX" = (
@@ -90024,6 +91261,23 @@
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
 	})
+"nhj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "nhs" = (
 /obj/structure/table,
 /obj/machinery/kitchen_machine/microwave{
@@ -90082,23 +91336,6 @@
 	icon_state = "darkredcorners"
 	},
 /area/security/securearmory)
-"nig" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Break Room Maintenance";
-	req_access_txt = "47"
-	},
-/turf/simulated/floor/plasteel,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
 "nim" = (
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/transparent/glass,
@@ -90139,17 +91376,7 @@
 /turf/simulated/floor/plating,
 /area/bridge/checkpoint/south)
 "niI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "redcorner"
@@ -90345,34 +91572,20 @@
 	icon_state = "red"
 	},
 /area/security/checkpoint/south)
-"nkH" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/engine,
-/area/toxins/test_chamber)
 "nkJ" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/item/pen{
+	pixel_x = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
 	},
-/area/toxins/mixing)
+/area/toxins/launch)
 "nkN" = (
 /obj/structure/chair/comfy/teal{
 	dir = 8
@@ -90549,7 +91762,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "purplefull"
 	},
 /area/medical/research/shallway)
 "nmy" = (
@@ -90571,12 +91784,10 @@
 /turf/simulated/floor/wood,
 /area/security/hos)
 "nnt" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2{
 	name = "Tourist Area Maintenance"
@@ -90611,15 +91822,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
-"nnG" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/evidence)
 "nnI" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -90650,6 +91852,19 @@
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
 /area/engine/engineering)
+"nnU" = (
+/obj/structure/window/plasmareinforced{
+	dir = 4
+	},
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/obj/structure/window/plasmareinforced{
+	dir = 8
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/toxins/launch)
 "noj" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -90730,16 +91945,23 @@
 	icon_state = "dark"
 	},
 /area/library)
+"noK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/grille/broken,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
 "npg" = (
-/obj/structure/table/reinforced,
-/obj/item/folder,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "nph" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/door_control{
@@ -90848,6 +92070,25 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar/atrium)
+"nqz" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "purplefull"
+	},
+/area/toxins/xenobiology)
 "nqB" = (
 /obj/structure/table/reinforced,
 /obj/item/folder,
@@ -90980,20 +92221,19 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar/atrium)
 "nrd" = (
-/obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "xeno4";
-	name = "Creature Cell #4";
-	opacity = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology)
+/area/toxins/test_chamber)
 "nrg" = (
 /obj/machinery/flasher_button{
 	id = "gulagshuttleflasher";
@@ -91039,7 +92279,8 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurplecorner"
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
 /area/medical/research/nhallway)
 "nrF" = (
@@ -91218,11 +92459,45 @@
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "nsU" = (
-/obj/structure/closet/emcloset,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2{
 	name = "Tourist Area Maintenance"
 	})
+"nsW" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/radio/beacon,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
+	},
+/area/medical/research/nhallway)
 "nte" = (
 /turf/simulated/wall,
 /area/maintenance/asmaint2)
@@ -91351,6 +92626,31 @@
 	icon_state = "darkblue"
 	},
 /area/turret_protected/aisat_interior)
+"nul" = (
+/obj/machinery/door/window/brigdoor{
+	dir = 2;
+	name = "Creature Pen";
+	req_access_txt = "47"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenosecure";
+	name = "Secure Creature Cell";
+	opacity = 0
+	},
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology)
 "nuE" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -91451,6 +92751,18 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/central/north)
+"nvu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate{
+	icon_state = "crateopen";
+	opened = 1
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitehall"
+	},
+/area/maintenance/asmaint2)
 "nvA" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -91484,6 +92796,20 @@
 	icon_state = "red"
 	},
 /area/security/brig)
+"nvX" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "nwf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -91600,26 +92926,35 @@
 /obj/structure/bed,
 /obj/item/bedsheet/red,
 /obj/item/radio/intercom{
-	pixel_y = 36
-	},
-/obj/machinery/flasher{
-	id = "Cell 1";
-	pixel_y = 28
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
+"nyg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "nyi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -91692,6 +93027,11 @@
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "nzk" = (
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
 	id = "execution"
@@ -91703,10 +93043,13 @@
 /obj/structure/window/reinforced/polarized{
 	id = "execution"
 	},
-/obj/structure/cable,
-/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/security/execution)
+"nzC" = (
+/obj/item/twohanded/required/kirbyplants,
+/obj/item/clothing/head/kitty,
+/turf/simulated/floor/plating,
+/area/maintenance/library)
 "nzN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -91797,8 +93140,14 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/newscaster{
-	pixel_y = 33
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/flasher{
+	id = "Cell 3";
+	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -91852,15 +93201,6 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
-"nBl" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/structure/disposaloutlet,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/toxins/xenobiology)
 "nBn" = (
 /obj/structure/lattice,
 /turf/simulated/wall,
@@ -91877,13 +93217,43 @@
 	name = "Research Division"
 	})
 "nBy" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 32
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/blood/writing,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "bar"
 	},
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
+"nBB" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/grille/broken,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
 "nBI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -91927,6 +93297,12 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
+"nCg" = (
+/obj/item/radio/intercom{
+	pixel_y = 24
+	},
+/turf/simulated/floor/engine,
+/area/toxins/explab)
 "nCm" = (
 /obj/structure/rack,
 /obj/item/tank/internals/oxygen,
@@ -91960,11 +93336,11 @@
 "nCX" = (
 /obj/structure/bed,
 /obj/item/radio/intercom{
-	pixel_y = 36
+	pixel_y = 24
 	},
-/obj/machinery/flasher{
-	id = "Cell 1";
-	pixel_y = 28
+/obj/machinery/newscaster{
+	pixel_x = 27;
+	pixel_y = 33
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -92017,8 +93393,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/newscaster{
-	pixel_y = 33
+/obj/item/radio/intercom{
+	pixel_y = 36
+	},
+/obj/machinery/flasher{
+	id = "Cell 5";
+	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1
@@ -92089,6 +93469,19 @@
 	icon_state = "vault"
 	},
 /area/engine/gravitygenerator)
+"nDX" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
+	},
+/area/toxins/test_chamber)
 "nEb" = (
 /obj/machinery/chem_heater,
 /obj/effect/decal/warning_stripes/southwest,
@@ -92116,6 +93509,25 @@
 	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
+"nEm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "nEB" = (
 /obj/machinery/disposal,
 /obj/effect/decal/warning_stripes/red/hollow,
@@ -92198,27 +93610,9 @@
 	icon_state = "grimy"
 	},
 /area/crew_quarters/captain/bedroom)
-"nFK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/item/stack/sheet/wood,
-/turf/simulated/floor/plating,
-/area/maintenance/library)
 "nFL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed,
-/obj/machinery/flasher{
-	id = "Cell 5";
-	pixel_y = 28
-	},
-/obj/item/radio/intercom{
-	pixel_y = 36
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1
 	},
@@ -92232,7 +93626,10 @@
 	},
 /area/medical/virology/lab)
 "nGa" = (
-/obj/structure/rack/gunrack,
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -92241,12 +93638,16 @@
 	},
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/item/gun/projectile/shotgun/riot{
-	pixel_x = -7
+	pixel_x = -1;
+	pixel_y = -6
 	},
 /obj/item/gun/projectile/shotgun/riot{
-	pixel_x = 7
+	pixel_x = -1;
+	pixel_y = -3
 	},
-/obj/item/gun/projectile/shotgun/riot,
+/obj/item/gun/projectile/shotgun/riot{
+	pixel_x = -1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -92271,21 +93672,20 @@
 	name = "Medbay Maintenance"
 	})
 "nGj" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "sw_maint_inner";
-	locked = 1;
-	name = "West Maintenance External Access";
-	req_access_txt = "10;13"
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenosecure";
+	name = "Secure Creature Cell";
+	opacity = 0
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
+/obj/effect/spawner/window/reinforced/plasma,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology)
 "nGl" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -92306,9 +93706,12 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/cabin2)
 "nGq" = (
-/obj/structure/chair,
+/obj/structure/table,
+/obj/item/storage/fancy/donut_box,
 /obj/structure/cable{
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -92398,22 +93801,6 @@
 /area/maintenance/aft{
 	name = "Medbay Maintenance"
 	})
-"nHt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/item/stack/sheet/wood,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/library)
 "nHu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -92441,20 +93828,27 @@
 /area/security/main)
 "nHQ" = (
 /obj/effect/decal/warning_stripes/southeast,
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
 /area/toxins/mixing)
+"nHY" = (
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_x = 9;
+	pixel_y = -9
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "nIa" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/metal{
@@ -92466,6 +93860,18 @@
 /obj/item/storage/belt/utility,
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
+"nIg" = (
+/obj/machinery/camera{
+	c_tag = "Xeno Containment 4";
+	network = list("Research","SS13")
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/toxins/xenobiology)
 "nIm" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -92527,6 +93933,15 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"nIQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "nIS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
@@ -92566,39 +93981,35 @@
 	name = "Virology Maintenance"
 	})
 "nJm" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/surgery{
-	pixel_y = -6
-	},
-/obj/item/implanter/mindshield{
-	pixel_x = 4;
-	pixel_y = 12
-	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "darkred"
-	},
-/area/security/processing)
-"nJr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkred"
+	dir = 1
 	},
-/area/security/evidence)
+/area/security/processing)
+"nJr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whiteredfull"
+	},
+/area/security/medbay)
 "nJv" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt,
@@ -92629,10 +94040,18 @@
 	name = "Virology Maintenance"
 	})
 "nJx" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 28
+/obj/structure/chair{
+	dir = 1
 	},
-/turf/simulated/wall/r_wall,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "red"
+	},
 /area/security/processing)
 "nJD" = (
 /obj/structure/disposalpipe/segment,
@@ -92648,23 +94067,37 @@
 /turf/simulated/floor/plasteel,
 /area/bridge/checkpoint/south)
 "nJR" = (
-/obj/effect/spawner/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id_tag = "temporary holding cell";
-	locked = 1;
-	name = "Temporary Holding Cell Privacy Shutters"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "BridgeLockdown";
-	name = "Bridge Lockdown"
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating,
-/area/security/processing)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	id = "Interrogation";
+	name = "Private Room";
+	req_access_txt = "63"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/interrogation)
 "nJZ" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light{
@@ -92680,24 +94113,33 @@
 	name = "Research Division"
 	})
 "nKc" = (
-/obj/structure/window/reinforced/polarized{
-	dir = 1;
-	id = "visiting room"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/window/reinforced/polarized{
-	dir = 8;
-	id = "visiting room"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "visiting room"
+/obj/structure/chair{
+	dir = 4
 	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/grille,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/security/interrogation)
 "nKe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -92747,16 +94189,18 @@
 	})
 "nKG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/chair/comfy/purp{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "purplefull"
+	icon_state = "white"
 	},
 /area/medical/research/nhallway)
 "nKJ" = (
@@ -92787,12 +94231,32 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "nLj" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
 	},
-/area/maintenance/gambling_den)
+/turf/simulated/floor/carpet/royalblack,
+/area/maintenance/asmaint2)
+"nLC" = (
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xenosecure";
+	name = "Secure Creature Cell";
+	opacity = 0
+	},
+/obj/effect/spawner/window/reinforced/plasma,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology)
 "nLE" = (
 /obj/structure/table,
 /obj/machinery/camera{
@@ -92864,6 +94328,21 @@
 /area/medical/research{
 	name = "Research Division"
 	})
+"nMk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/crayon{
+	desc = "Crayon art.";
+	icon_state = "brokenheart";
+	name = "Graffiti";
+	pixel_x = -32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "nMs" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -92892,15 +94371,6 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay2)
-"nMC" = (
-/obj/machinery/light{
-	dir = 1;
-	on = 1
-	},
-/obj/structure/closet/bombcloset,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/toxins/explab)
 "nMD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
@@ -92920,6 +94390,21 @@
 	icon_state = "dark"
 	},
 /area/security/permahallway)
+"nMR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/girder,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "nNc" = (
 /obj/machinery/conveyor/north{
 	id = "QMLoad"
@@ -92970,6 +94455,21 @@
 /turf/space,
 /turf/simulated/wall/r_wall,
 /area/security/processing)
+"nNw" = (
+/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/obj/structure/window/plasmareinforced{
+	dir = 4
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/toxins/misc_lab)
 "nNy" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -93063,6 +94563,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/electrical)
+"nOy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/writing{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "nOK" = (
 /obj/machinery/power/solar{
 	name = "Aft Starboard Solar Panel"
@@ -93075,8 +94587,19 @@
 	icon_state = "solarpanel"
 	},
 /area/solar/port)
+"nOO" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse/gray,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "nOR" = (
-/obj/structure/table/wood,
+/obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -93089,6 +94612,13 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/cabin4)
+"nPj" = (
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
+	},
+/area/toxins/misc_lab)
 "nPr" = (
 /obj/machinery/photocopier,
 /obj/structure/cable{
@@ -93243,9 +94773,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurplecorner"
+	icon_state = "white"
 	},
 /area/medical/research/shallway)
 "nQZ" = (
@@ -93313,6 +94845,16 @@
 	icon_state = "green"
 	},
 /area/atmos)
+"nRR" = (
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/medical/research/nhallway)
 "nRT" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -93325,6 +94867,13 @@
 	icon_state = "red"
 	},
 /area/security/customs)
+"nSb" = (
+/obj/effect/decal/cleanable/tomato_smudge,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "nSd" = (
 /obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -93348,6 +94897,19 @@
 	icon_state = "vault"
 	},
 /area/storage/tech)
+"nSg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1
+	},
+/area/maintenance/asmaint2)
 "nSl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -93374,18 +94936,20 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/fitness)
 "nSs" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xeno3";
+	name = "Creature Cell #3";
+	opacity = 0
 	},
-/area/toxins/explab)
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology)
 "nSt" = (
 /obj/structure/table/reinforced,
 /obj/item/weldingtool,
@@ -93433,39 +94997,17 @@
 	name = "Virology Maintenance"
 	})
 "nSW" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/poddoor{
-	id_tag = "toxinsdriver";
-	name = "disposal bay door";
-	protected = 0
-	},
-/turf/simulated/floor/plating,
-/area/toxins/mixing)
-"nSZ" = (
-/obj/structure/chair{
-	desc = "Этот красивый стул был отлит из двух трофейных боргов синдиката.";
-	name = "Дизайнерский стул"
-	},
-/obj/machinery/shower{
-	pixel_y = 5
-	},
-/obj/effect/decal/cleanable/blood/old,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+	dir = 9;
+	icon_state = "neutral"
 	},
-/area/security/processing)
+/area/toxins/launch)
+"nSZ" = (
+/turf/simulated/wall/r_wall,
+/area/security/evidence)
 "nTe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -93549,14 +95091,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"nTV" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/item/radio/intercom{
-	pixel_y = 24
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/explab)
 "nTY" = (
 /obj/machinery/chem_master{
 	pixel_x = -1
@@ -93600,12 +95134,15 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/bar)
 "nUy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
+	},
+/area/toxins/misc_lab)
 "nUI" = (
 /obj/docking_port/mobile/supply,
 /obj/docking_port/stationary{
@@ -93647,6 +95184,14 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
+"nVa" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA"
+	},
+/turf/simulated/wall/r_wall/rust,
+/area/maintenance/xenozoo)
 "nVA" = (
 /obj/machinery/computer/HolodeckControl,
 /turf/simulated/floor/plasteel,
@@ -93689,11 +95234,15 @@
 /obj/item/lighter/zippo/nt_rep,
 /turf/simulated/floor/carpet,
 /area/ntrep)
-"nWr" = (
+"nWt" = (
+/obj/machinery/light/small,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
+	},
+/obj/machinery/vending/boozeomat,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall,
-/area/maintenance/library)
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "nWB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -93729,10 +95278,20 @@
 	icon_state = "darkblue"
 	},
 /area/construction/hallway)
-"nWY" = (
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+"nWM" = (
+/obj/machinery/processor{
+	desc = "A machine used to process slimes and retrieve their extract.";
+	name = "Slime Processor"
+	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/light_switch{
+	pixel_x = 40;
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology)
 "nXe" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced{
@@ -93811,22 +95370,10 @@
 /turf/simulated/floor/carpet,
 /area/bridge)
 "nXK" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/mob/living/simple_animal/pet/dog/security,
+/obj/structure/bed/dogbed,
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	dir = 1;
 	icon_state = "red"
 	},
 /area/security/processing)
@@ -93900,8 +95447,6 @@
 	},
 /area/hallway/primary/central/north)
 "nZi" = (
-/obj/structure/closet/emcloset,
-/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurple";
@@ -93954,29 +95499,11 @@
 	pixel_x = 58;
 	pixel_y = 30
 	},
-/obj/structure/bed/dogbed,
-/mob/living/simple_animal/pet/dog/security/warden,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkredcorners"
 	},
 /area/security/warden)
-"oar" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used to monitor interrogations.";
-	dir = 4;
-	layer = 4;
-	name = "Interrogation Monitor";
-	network = list("Interrogation");
-	req_access_txt = "63"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/security/processing)
 "oau" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -94163,6 +95690,13 @@
 	icon_state = "vault"
 	},
 /area/security/nuke_storage)
+"ocj" = (
+/obj/effect/landmark{
+	name = "revenantspawn"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/engine,
+/area/toxins/explab)
 "ocu" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -94226,18 +95760,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/barricade/wooden,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1
+	},
+/area/maintenance/asmaint2)
 "ocE" = (
 /turf/simulated/floor/plasteel{
 	dir = 7;
@@ -94280,12 +95813,21 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
-"odT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+"odp" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xeno3";
+	name = "Creature Cell #3";
+	opacity = 0
+	},
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
 /area/toxins/xenobiology)
 "odX" = (
 /turf/simulated/wall/rust,
@@ -94508,6 +96050,12 @@
 /obj/item/chair/stool,
 /turf/simulated/floor/carpet/arcade,
 /area/maintenance/starboard)
+"ogo" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/maintenance/xenozoo)
 "ogy" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -94550,33 +96098,22 @@
 	},
 /area/security/prison/cell_block/A)
 "ogO" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/window/brigdoor{
-	name = "Creature Pen";
-	req_access_txt = "47"
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
-"ogP" = (
 /obj/structure/table/reinforced,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/item/storage/box/monkeycubes,
-/obj/item/storage/box/monkeycubes,
-/obj/item/storage/box/monkeycubes,
-/obj/item/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the 'Space' from Space Cleaner and written in Chemistry. Scrawled on the back is, 'Okay, whoever filled this with polytrinic acid, it was only funny the first time. It was hard enough replacing the CMO's first cat!'";
-	name = "Chemistry Cleaner"
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/tape/random{
+	pixel_x = 3;
+	pixel_y = -3
 	},
+/obj/item/taperecorder,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whitepurple"
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (SOUTHWEST)"
 	},
-/area/toxins/misc_lab)
+/area/toxins/test_chamber)
 "ogV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -94719,6 +96256,16 @@
 	tag = "icon-whitepurple (EAST)"
 	},
 /area/toxins/lab)
+"ohC" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 28
+	},
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = 40
+	},
+/turf/simulated/floor/plasteel,
+/area/toxins/explab)
 "ohL" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -94730,14 +96277,8 @@
 	},
 /area/engine/hardsuitstorage)
 "ohN" = (
-/obj/structure/table,
-/obj/machinery/light,
-/obj/item/reagent_containers/food/drinks/mug/sec,
-/obj/item/storage/fancy/donut_box,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/chair{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
@@ -94899,6 +96440,12 @@
 	icon_state = "dark"
 	},
 /area/security/permabrig)
+"ojW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/library)
 "okc" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -94974,13 +96521,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/reception)
-"okD" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+"okC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/area/maintenance/xenozoo)
+/mob/living/simple_animal/mouse/brown,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
+"okD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/toy/figure/clown,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "okH" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -95237,9 +96798,11 @@
 	},
 /area/security/permahallway)
 "onr" = (
-/obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/suit_storage_unit/rd/secure,
-/turf/simulated/floor/plasteel,
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/crew_quarters/hor)
 "onT" = (
 /turf/simulated/wall,
@@ -95348,28 +96911,35 @@
 	},
 /area/storage/primary)
 "opE" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id_tag = "temporary holding cell";
-	locked = 1;
-	name = "Temporary Holding Cell Privacy Shutters"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Temporal Prisoner Cell";
+	req_access_txt = "63"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "BridgeLockdown";
-	name = "Bridge Lockdown"
+/turf/simulated/floor/plasteel{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
 /area/security/processing)
 "opF" = (
 /obj/effect/spawner/window/reinforced,
@@ -95641,19 +97211,6 @@
 	icon_state = "dark"
 	},
 /area/bridge)
-"osq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
 "oss" = (
 /obj/structure/table/wood,
 /obj/item/lighter/zippo/engraved{
@@ -95665,10 +97222,6 @@
 /area/maintenance/fsmaint2{
 	name = "Tourist Area Maintenance"
 	})
-"osx" = (
-/obj/structure/sign/securearea,
-/turf/simulated/wall/r_wall,
-/area/toxins/explab)
 "osE" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced{
@@ -95715,19 +97268,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/bridge)
-"otn" = (
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 29;
-	pixel_y = 22
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/obj/structure/sink{
-	pixel_y = 30
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "otC" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -95739,6 +97279,16 @@
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/magistrateoffice)
+"otK" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "otM" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/effect/decal/warning_stripes/red/hollow,
@@ -95762,19 +97312,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/blueshield)
-"otP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/gambling_den)
 "oud" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/binary/volume_pump{
@@ -95842,10 +97379,13 @@
 	name = "Research Division"
 	})
 "ouO" = (
-/obj/structure/table/wood,
-/obj/machinery/cell_charger,
+/obj/machinery/vending/autodrobe,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "ovf" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
@@ -95857,6 +97397,22 @@
 	icon_state = "neutralfull"
 	},
 /area/atmos)
+"ovj" = (
+/obj/machinery/telepad_cargo,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/camera{
+	c_tag = "Experimention Lab Office";
+	dir = 1;
+	network = list("Research","SS13")
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/toxins/explab)
 "ovk" = (
 /obj/machinery/shieldgen,
 /turf/simulated/floor/plating,
@@ -96082,7 +97638,9 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
 	},
 /area/medical/research/shallway)
 "oxF" = (
@@ -96197,22 +97755,11 @@
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/storage)
-"oyP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/grille{
-	density = 0;
-	icon_state = "brokengrille"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
 "oyT" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -25
+/obj/machinery/vending/coffee,
+/obj/machinery/light,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
@@ -96318,12 +97865,25 @@
 	name = "Virology Maintenance"
 	})
 "ozX" = (
-/obj/structure/disposaloutlet{
-	dir = 1
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/plating,
-/area/space/nearstation)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26;
+	pixel_y = 30
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkred"
+	},
+/area/security/evidence)
 "oAa" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -96454,11 +98014,6 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/solar/port)
-"oAO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/head/griffin,
-/turf/simulated/floor/plating,
-/area/maintenance/library)
 "oAW" = (
 /obj/machinery/light,
 /obj/effect/decal/warning_stripes/south,
@@ -96493,9 +98048,15 @@
 	},
 /area/hallway/primary/central/north)
 "oBj" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/closet/emcloset,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurplecorner"
+	dir = 8;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
 	},
 /area/medical/research/nhallway)
 "oBA" = (
@@ -96541,12 +98102,13 @@
 /area/maintenance/fpmaint)
 "oBM" = (
 /obj/machinery/camera{
-	c_tag = "Research West Hallway";
+	c_tag = "Research Central Hallway";
 	network = list("Research","SS13")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurplecorner"
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
 /area/medical/research/nhallway)
 "oCc" = (
@@ -96565,6 +98127,14 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/surgery/north)
+"oCh" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/turf/simulated/floor/plasteel,
+/area/toxins/explab)
 "oCk" = (
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs{
@@ -96660,33 +98230,6 @@
 	icon_state = "white"
 	},
 /area/toxins/mixing)
-"oDN" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/security/evidence)
-"oDO" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/security/brig)
 "oEg" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "Труба служит для подачу горючей смеси в турбину для её работы";
@@ -96741,11 +98284,16 @@
 	},
 /area/security/range)
 "oEJ" = (
-/obj/item/shard,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/maintenance/library)
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "oET" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=A31";
@@ -96867,6 +98415,12 @@
 /area/shuttle/escape{
 	parallax_movedir = 2
 	})
+"oGQ" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "oGV" = (
 /obj/machinery/camera{
 	c_tag = "Central Ring Hallway East 3";
@@ -96949,31 +98503,6 @@
 	icon_state = "red"
 	},
 /area/security/main)
-"oHK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/gambling_den)
-"oHS" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
 "oHY" = (
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/vending/cigarette,
@@ -97175,10 +98704,27 @@
 /area/medical/sleeper)
 "oJS" = (
 /obj/structure/table/reinforced,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/item/wrench,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/obj/item/radio/electropack,
+/obj/item/assembly/signaler,
+/obj/item/healthanalyzer,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
+	},
+/area/toxins/test_chamber)
 "oJX" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -97236,18 +98782,31 @@
 /turf/space,
 /area/space/nearstation)
 "oKx" = (
-/obj/machinery/vending/plasmaresearch,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "whitepurple"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/area/toxins/misc_lab)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "oKD" = (
 /obj/effect/decal/warning_stripes/eastnorthwest,
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/light_switch{
+	pixel_x = -4;
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel,
 /area/toxins/mixing)
@@ -97313,6 +98872,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior)
+"oLA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/stack/sheet/wood,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
 "oLC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
@@ -97509,15 +99084,14 @@
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/port/west)
+"oMS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/maintenance/library)
 "oNa" = (
-/obj/structure/sign/vacuum{
-	pixel_y = -32
-	},
-/obj/machinery/light,
-/obj/effect/decal/warning_stripes/southeast,
-/obj/structure/closet/bombcloset,
-/turf/simulated/floor/plasteel,
-/area/toxins/mixing)
+/turf/simulated/wall/r_wall/rust,
+/area/toxins/launch)
 "oNr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -97545,7 +99119,6 @@
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
 /obj/item/folder,
-/obj/item/toy/figure/scientist,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -6;
 	pixel_y = -30
@@ -97577,7 +99150,19 @@
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "oOo" = (
-/turf/simulated/wall/r_wall,
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door_control{
+	id = "xenosecure";
+	name = "Containment Control";
+	pixel_y = 2;
+	req_access_txt = "55"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/toxins/xenobiology)
 "oOq" = (
 /obj/structure/table/reinforced,
@@ -97687,11 +99272,6 @@
 	icon_state = "blue"
 	},
 /area/hydroponics)
-"oPF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bookcase,
-/turf/simulated/floor/plating,
-/area/maintenance/library)
 "oPG" = (
 /mob/living/simple_animal/mouse/white,
 /obj/structure/cable{
@@ -97739,16 +99319,19 @@
 	},
 /area/crew_quarters/sleep)
 "oPR" = (
-/obj/structure/rack/gunrack,
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/item/gun/energy/laser{
-	pixel_x = -8
+	pixel_x = -2;
+	pixel_y = 3
 	},
+/obj/item/gun/energy/laser,
 /obj/item/gun/energy/laser{
-	pixel_x = 10
-	},
-/obj/item/gun/energy/laser{
-	pixel_x = 1
+	pixel_x = 3;
+	pixel_y = -3
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -97768,6 +99351,13 @@
 	icon_state = "swall_f9"
 	},
 /area/shuttle/pod_3)
+"oQj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/autodrobe,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "oQk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -97890,6 +99480,20 @@
 	icon_state = "neutralfull"
 	},
 /area/atmos)
+"oRo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/girder,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
 "oRr" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -97902,8 +99506,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "purplefull"
+	icon_state = "white"
 	},
 /area/medical/research/nhallway)
 "oRC" = (
@@ -98138,25 +99745,11 @@
 	},
 /area/security/nuke_storage)
 "oUh" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/structure/chair/comfy/purp,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/medical/research/nhallway)
-"oUj" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
 "oUs" = (
 /obj/item/bedsheet/mime,
 /obj/structure/bed,
@@ -98230,7 +99823,9 @@
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
 	},
 /area/medical/research/shallway)
 "oVs" = (
@@ -98305,11 +99900,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "purplefull"
 	},
 /area/medical/research/nhallway)
 "oWp" = (
@@ -98373,9 +99971,8 @@
 	parallax_movedir = 2
 	})
 "oWK" = (
-/obj/structure/sign/securearea,
 /turf/simulated/wall/r_wall,
-/area/toxins/mixing)
+/area/toxins/launch)
 "oWL" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor/plating,
@@ -98391,14 +99988,13 @@
 	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
-"oWU" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+"oWX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/maintenance/perma)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "oXa" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -98511,6 +100107,11 @@
 	icon_state = "white"
 	},
 /area/toxins/lab)
+"oYg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "oYj" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -98533,19 +100134,33 @@
 /obj/machinery/status_display{
 	pixel_x = 32
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (EAST)"
-	},
+/turf/simulated/floor/carpet/purple,
 /area/crew_quarters/hor)
 "oYl" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/hand_labeler,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/machinery/power/apc{
+	name = "north bump";
+	pixel_y = 26
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/item/pen{
+	pixel_x = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTHWEST)"
+	},
+/area/toxins/test_chamber)
 "oYp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -98563,30 +100178,63 @@
 	},
 /area/toxins/lab)
 "oYL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	name = "Creature Pen";
+	req_access_txt = "47"
+	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xeno1";
+	name = "Creature Cell #1";
+	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/maintenance/gambling_den)
+/area/toxins/xenobiology)
 "oYO" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "swall_f9"
 	},
 /area/shuttle/supply)
+"oZa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "oZd" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "redcorner"
@@ -98600,6 +100248,24 @@
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/storage)
+"oZv" = (
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "RnDChem";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/obj/effect/spawner/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "oZz" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -98655,23 +100321,37 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/kitchen)
 "paa" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
+/obj/machinery/light{
 	dir = 1;
-	id_tag = "temporary holding cell";
-	locked = 1;
-	name = "Temporary Holding Cell Privacy Shutters"
+	on = 1
 	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "BridgeLockdown";
-	name = "Bridge Lockdown"
+/obj/machinery/newscaster/security_unit{
+	pixel_y = 32
 	},
-/turf/simulated/floor/plating,
-/area/security/processing)
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/security/brig)
+"pal" = (
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "RnDChem";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/obj/effect/spawner/window/reinforced/plasma,
+/obj/structure/cable,
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
+"pax" = (
+/obj/item/stack/sheet/mineral/plasma,
+/obj/structure/table,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/toxins/explab)
 "paK" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -98679,12 +100359,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
-"paO" = (
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "red"
-	},
-/area/security/processing)
 "pbg" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -98768,11 +100442,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/bridge/vip)
-"pbV" = (
-/obj/structure/closet/emcloset,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/perma)
 "pbX" = (
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -98872,14 +100541,12 @@
 "pda" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/simulated/floor/plasteel,
-/area/toxins/storage)
-"pdi" = (
-/obj/item/clothing/head/fluff/lfbowler,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull";
+	tag = "icon-redfull (NORTHWEST)"
 	},
-/area/maintenance/library)
+/area/toxins/storage)
 "pdt" = (
 /obj/item/radio/intercom{
 	pixel_y = 24
@@ -98899,6 +100566,12 @@
 	icon_state = "red"
 	},
 /area/security/permahallway)
+"pdZ" = (
+/obj/item/radio/intercom{
+	pixel_y = 24
+	},
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "pee" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -98968,24 +100641,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
-"pfa" = (
-/obj/structure/cable,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
 "pfs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -98999,13 +100654,12 @@
 	},
 /area/medical/medbay2)
 "pfA" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/north,
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/area/toxins/mixing)
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "pfD" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/window/eastright{
@@ -99077,12 +100731,27 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurplecorner"
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
 /area/medical/research/nhallway)
 "pgt" = (
 /obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard{
 	name = "Engineering Maintenance"
@@ -99110,6 +100779,20 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay)
+"pgE" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/security/processing)
 "pgF" = (
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
@@ -99170,6 +100853,14 @@
 	icon_state = "dark"
 	},
 /area/security/warden)
+"pgQ" = (
+/obj/machinery/camera{
+	c_tag = "Research Test Chamber";
+	network = list("TestChamber","SS13","Research");
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "pgR" = (
 /obj/machinery/door/window/brigdoor/southleft{
 	dir = 4;
@@ -99180,17 +100871,18 @@
 	},
 /area/security/prisonershuttle)
 "phd" = (
-/obj/machinery/light/small{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
+/area/maintenance/xenozoo)
 "phf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -99220,12 +100912,19 @@
 	icon_state = "white"
 	},
 /area/medical/medbay2)
-"phh" = (
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurplecorner"
+"phx" = (
+/obj/machinery/light_switch{
+	pixel_x = 8;
+	pixel_y = 26
 	},
-/area/toxins/explab)
+/obj/structure/closet/l3closet/scientist,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTHWEST)"
+	},
+/area/toxins/xenobiology)
 "phz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -99249,6 +100948,19 @@
 	icon_state = "dark"
 	},
 /area/medical/morgue)
+"phD" = (
+/obj/machinery/power/apc/worn_out{
+	cell_type = 0;
+	dir = 1;
+	pixel_y = 26
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/xenozoo)
 "phO" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -99288,6 +101000,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "pif" = (
+/obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
@@ -99314,6 +101027,13 @@
 	icon_state = "grimy"
 	},
 /area/library)
+"piU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/red,
+/area/maintenance/library)
 "piW" = (
 /obj/machinery/vending/artvend,
 /turf/simulated/floor/plasteel{
@@ -99371,11 +101091,19 @@
 	},
 /area/hallway/primary/port/west)
 "pjT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/table,
+/obj/item/folder/red,
+/obj/item/pen/multi,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1
+	icon_state = "redfull";
+	tag = "icon-redfull (NORTHWEST)"
 	},
 /area/security/processing)
 "pkc" = (
@@ -99420,11 +101148,15 @@
 	},
 /area/crew_quarters/bar/atrium)
 "pkp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/dresser,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/theatre)
 "pkr" = (
 /obj/item/trash/plate{
 	pixel_x = -5;
@@ -99519,17 +101251,30 @@
 	})
 "pln" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 9
 	},
-/obj/structure/chair/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_spawners/blood_often,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/maintenance/gambling_den)
+/turf/simulated/floor/plasteel{
+	icon_state = "whitehall"
+	},
+/area/maintenance/asmaint2)
 "plt" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -99575,20 +101320,35 @@
 	icon_state = "brown"
 	},
 /area/crew_quarters/chief)
+"plQ" = (
+/obj/machinery/door/airlock/highsecurity{
+	heat_proof = 1;
+	name = "Supermatter Chamber"
+	},
+/obj/machinery/door/poddoor{
+	name = "Supermatter Blast Doors";
+	density = 0;
+	opacity = 0;
+	id_tag = "engsm1"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/maintenance/xenozoo)
 "pmd" = (
 /obj/structure/sign/greencross,
 /turf/simulated/wall,
 /area/medical/medbay)
-"pmu" = (
-/obj/structure/chair/wood,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+"pmm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/hatdispenser,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "pmx" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -99597,6 +101357,35 @@
 /area/shuttle/escape{
 	parallax_movedir = 2
 	})
+"pmY" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "pnb" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -99698,15 +101487,11 @@
 	},
 /area/chapel/main)
 "pnM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/chair/wood,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/fancy/black,
+/obj/item/toy/cards/deck,
+/turf/simulated/floor/carpet/royalblack,
+/area/maintenance/asmaint2)
 "pnT" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -99718,15 +101503,12 @@
 	},
 /area/hallway/primary/central/sw)
 "poa" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/obj/effect/landmark{
-	name = "xeno_spawn";
-	pixel_x = -1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "pob" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -99799,6 +101581,10 @@
 	icon_state = "neutralfull"
 	},
 /area/crew_quarters/sleep)
+"pop" = (
+/obj/machinery/computer/rdconsole/experiment,
+/turf/simulated/floor/plasteel,
+/area/toxins/explab)
 "poq" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -99875,6 +101661,32 @@
 	icon_state = "darkblue"
 	},
 /area/maintenance/detectives_office)
+"poG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "poO" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -99983,23 +101795,22 @@
 	},
 /area/engine/break_room)
 "pqz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/status_display{
+	pixel_y = 32
 	},
-/turf/simulated/floor/plasteel,
-/area/toxins/explab)
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
+	},
+/area/toxins/xenobiology)
 "pqC" = (
 /obj/effect/turf_decal/box,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -100091,14 +101902,6 @@
 	icon_state = "vault"
 	},
 /area/assembly/showroom)
-"prm" = (
-/obj/effect/landmark{
-	name = "revenantspawn"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/toxins/explab)
 "prr" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -100130,24 +101933,12 @@
 	},
 /area/maintenance/library)
 "prC" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
+/area/maintenance/asmaint2)
 "prI" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -100310,18 +102101,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
-"psB" = (
-/obj/structure/barricade/wooden,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/library)
 "psE" = (
 /obj/structure/sink{
 	dir = 1
@@ -100346,17 +102125,37 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay)
+"ptg" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/bananalamp{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "pth" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 1;
+/obj/structure/cable/yellow{
 	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/maintenance/xenozoo)
+"ptk" = (
+/obj/structure/holosign/barrier,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "pts" = (
 /turf/simulated/wall,
 /area/crew_quarters/cabin3)
@@ -100372,6 +102171,10 @@
 /obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
+"ptX" = (
+/mob/living/simple_animal/slime,
+/turf/simulated/floor/greengrid,
+/area/toxins/xenobiology)
 "pua" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -100505,6 +102308,12 @@
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
 	})
+"pvf" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
+/turf/simulated/floor/plasteel,
+/area/toxins/explab)
 "pvm" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/chair{
@@ -100589,6 +102398,13 @@
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
 	})
+"pwi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "chapel"
+	},
+/area/crew_quarters/theatre)
 "pwt" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -100609,13 +102425,12 @@
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/fitness)
 "pwH" = (
-/obj/machinery/light/small,
 /obj/effect/decal/warning_stripes/southeast,
 /obj/structure/closet/walllocker/emerglocker/north{
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel,
-/area/toxins/mixing)
+/area/toxins/launch)
 "pwN" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
@@ -100633,6 +102448,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/courtroom)
+"pwV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "pxm" = (
 /obj/effect/landmark/start{
 	name = "Medical Doctor"
@@ -100718,6 +102551,12 @@
 	icon_state = "dark"
 	},
 /area/security/securearmory)
+"pys" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/theatre)
 "pyN" = (
 /obj/machinery/power/emitter{
 	anchored = 1;
@@ -100739,25 +102578,10 @@
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"pzh" = (
-/obj/machinery/vending/medical{
-	req_access_txt = "63"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitered"
-	},
-/area/security/medbay)
 "pzi" = (
 /obj/structure/chair/comfy/brown,
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
-"pzu" = (
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/gambling_den)
 "pzE" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
@@ -100769,7 +102593,6 @@
 	},
 /area/maintenance/electrical)
 "pzG" = (
-/obj/effect/decal/warning_stripes/southwestcorner,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -100818,57 +102641,23 @@
 	tag = "icon-whiteblue (NORTH)"
 	},
 /area/medical/sleeper)
-"pzS" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "xeno1";
-	name = "Creature Cell #1";
-	opacity = 0
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 2;
-	name = "Creature Pen";
-	req_access_txt = "47"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/toxins/xenobiology)
 "pzW" = (
 /obj/machinery/computer/guestpass{
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurplecorner"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
-"pzY" = (
-/turf/simulated/floor/plating,
-/area/maintenance/perma)
 "pAa" = (
+/obj/effect/decal/warning_stripes/northwest,
 /obj/structure/table/reinforced,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the test chamber.";
-	dir = 4;
-	layer = 4;
-	name = "Test Chamber Telescreen";
-	network = list("Toxins")
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/item/assembly/signaler,
 /turf/simulated/floor/plasteel,
-/area/toxins/mixing)
+/area/toxins/launch)
 "pAg" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -100882,16 +102671,12 @@
 /turf/simulated/floor/plating,
 /area/bridge)
 "pAh" = (
-/obj/structure/chair/office/dark{
-	dir = 8
+/obj/item/stack/cable_coil,
+/obj/structure/table,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
 	},
-/obj/item/radio/intercom{
-	pixel_x = -26;
-	pixel_y = 26
-	},
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/mixing)
+/area/toxins/explab)
 "pAi" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -100942,18 +102727,6 @@
 	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
-"pAC" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whiteredcorner"
-	},
-/area/security/medbay)
 "pAL" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -100964,6 +102737,14 @@
 /obj/structure/chair/comfy/brown,
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
+"pAS" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
+	},
+/area/medical/research/nhallway)
 "pAT" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -101000,27 +102781,16 @@
 	icon_state = "white"
 	},
 /area/medical/genetics)
-"pBc" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
 "pBd" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Security Officer"
+	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	dir = 4;
+	icon_state = "red"
 	},
 /area/security/processing)
 "pBi" = (
@@ -101139,19 +102909,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/bridge)
-"pBU" = (
+"pBT" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xeno4";
+	name = "Creature Cell #4";
+	opacity = 0
 	},
-/area/security/brig)
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/toxins/xenobiology)
 "pCa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/burnturf,
@@ -101234,20 +103007,8 @@
 	},
 /area/toxins/lab)
 "pCz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
-/area/maintenance/gambling_den)
+/turf/simulated/wall,
+/area/toxins/xenobiology)
 "pCB" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
@@ -101260,6 +103021,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	name = "RD Junction";
+	sortType = 13
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
@@ -101323,12 +103089,12 @@
 	name = "Dominator's";
 	req_access = list(1)
 	},
-/obj/item/gun/energy/dominator/sibyl,
-/obj/item/gun/energy/dominator/sibyl,
-/obj/item/gun/energy/dominator/sibyl,
-/obj/item/gun/energy/dominator/sibyl,
-/obj/item/gun/energy/dominator/sibyl,
-/obj/item/gun/energy/dominator/sibyl,
+/obj/item/gun/energy/dominator,
+/obj/item/gun/energy/dominator,
+/obj/item/gun/energy/dominator,
+/obj/item/gun/energy/dominator,
+/obj/item/gun/energy/dominator,
+/obj/item/gun/energy/dominator,
 /obj/machinery/light,
 /obj/machinery/firealarm{
 	pixel_y = -26
@@ -101422,11 +103188,17 @@
 	icon_state = "diagonalWall3"
 	},
 /area/shuttle/syndicate)
+"pDX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "pEd" = (
 /obj/structure/closet/walllocker/emerglocker/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurplecorner"
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
 /area/medical/research/nhallway)
 "pEi" = (
@@ -101480,6 +103252,26 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
+"pEO" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "purplefull"
+	},
+/area/medical/research/nhallway)
 "pET" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -101504,22 +103296,6 @@
 	icon_state = "yellow"
 	},
 /area/engine/mechanic_workshop)
-"pFk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/maintenance/library)
 "pFn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -101554,12 +103330,11 @@
 /area/bridge)
 "pFA" = (
 /obj/structure/table,
-/obj/item/paper/deltainfo,
+/obj/item/restraints/handcuffs,
 /obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -101765,34 +103540,30 @@
 	},
 /area/security/prison/cell_block/A)
 "pHK" = (
-/obj/machinery/camera{
-	c_tag = "Xeno High Security Containment";
-	dir = 4;
-	network = list("Research","SS13");
-	pixel_y = -22
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/toxins/xenobiology)
-"pHL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
+	},
+/area/medical/research/nhallway)
+"pHL" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple";
 	tag = "icon-whitepurple (WEST)"
 	},
 /area/medical/research/nhallway)
+"pHO" = (
+/turf/simulated/wall,
+/area/maintenance/xenozoo)
 "pHP" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/secure_data/laptop,
@@ -101812,6 +103583,20 @@
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/storage)
+"pHX" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "purplefull"
+	},
+/area/toxins/xenobiology)
 "pIb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -101884,6 +103669,14 @@
 	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
+"pIz" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "pID" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -102029,7 +103822,9 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "purplefull"
+	},
 /area/toxins/storage)
 "pJx" = (
 /turf/simulated/floor/plasteel{
@@ -102079,7 +103874,6 @@
 /obj/machinery/ai_status_display{
 	pixel_x = -32
 	},
-/obj/effect/decal/warning_stripes/east,
 /obj/machinery/camera{
 	c_tag = "Research Director's Bedroom";
 	dir = 4;
@@ -102087,14 +103881,11 @@
 	pixel_y = -22
 	},
 /obj/item/flag/rnd,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/hor)
-"pKg" = (
-/obj/structure/disposalpipe/segment,
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "dark"
 	},
-/area/medical/research/nhallway)
+/area/crew_quarters/hor)
 "pKh" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance";
@@ -102112,16 +103903,6 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
-"pKk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
-	},
-/area/toxins/xenobiology)
 "pKm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -102178,25 +103959,15 @@
 	},
 /area/security/prison/cell_block/A)
 "pKP" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/piano,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
 	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "pKY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -102222,7 +103993,22 @@
 	tag = "icon-whitebluefull"
 	},
 /area/medical/sleeper)
+"pLa" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/monkeycubes,
+/obj/item/storage/box/monkeycubes,
+/obj/effect/decal/warning_stripes/west,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology)
 "pLb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -102233,19 +104019,22 @@
 	name = "Brig Physician";
 	sortType = 24
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
+"pLk" = (
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "pLm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -102255,11 +104044,6 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 1
 	},
@@ -102334,11 +104118,20 @@
 	icon_state = "darkblue"
 	},
 /area/medical/surgery/south)
-"pLR" = (
-/turf/simulated/floor/carpet,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
+"pLY" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/barricade/wooden,
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/library)
 "pMb" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
@@ -102378,22 +104171,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/garden/north)
 "pMH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "pMQ" = (
 /obj/effect/decal/warning_stripes/southeastcorner,
 /obj/effect/decal/cleanable/dirt,
@@ -102402,22 +104191,32 @@
 	name = "Virology Maintenance"
 	})
 "pMV" = (
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	name = "Creature Pen";
+	req_access_txt = "47"
+	},
 /obj/structure/cable{
-	d1 = 4;
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xeno7";
+	name = "Creature Cell #7";
+	opacity = 0
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
+/area/toxins/xenobiology)
 "pNi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall,
@@ -102513,9 +104312,19 @@
 	},
 /area/security/securehallway)
 "pNO" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
+/obj/structure/chair/comfy/purp{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/medical/research/nhallway)
+"pNV" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull";
+	tag = "icon-redfull (NORTHWEST)"
+	},
+/area/security/processing)
 "pNW" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 1;
@@ -102541,6 +104350,20 @@
 /area/medical/research{
 	name = "Research Division"
 	})
+"pOf" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/west,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology)
 "pOg" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -102601,6 +104424,26 @@
 	icon_state = "red"
 	},
 /area/security/checkpoint/south)
+"pPk" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1
+	},
+/area/maintenance/asmaint2)
 "pPo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -102718,14 +104561,17 @@
 	},
 /area/security/securehallway)
 "pQd" = (
-/obj/item/radio/beacon,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/effect/decal/warning_stripes/yellow,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/medical/research/nhallway)
+/area/toxins/xenobiology)
 "pQe" = (
 /obj/structure/table,
 /obj/item/seeds/harebell{
@@ -102795,28 +104641,19 @@
 /area/security/lobby)
 "pQP" = (
 /obj/structure/chair{
-	dir = 8
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Prisoner Processing";
+	dir = 6;
+	network = list("SS13","Security")
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	dir = 1;
 	icon_state = "red"
 	},
 /area/security/processing)
@@ -102913,16 +104750,29 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar/atrium)
 "pSd" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/confetti,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/structure/closet/coffin,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/curtain/open/shower/security{
+	name = "backstage";
+	alpha = 255;
+	icon_state = "closed";
+	opacity = 1
+	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "vault"
+	icon_state = "tranquillite"
 	},
-/area/chapel/main)
+/area/crew_quarters/theatre)
 "pSp" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -103031,6 +104881,10 @@
 /area/maintenance/aft{
 	name = "Medbay Maintenance"
 	})
+"pUr" = (
+/obj/machinery/atmospherics/binary/pump,
+/turf/simulated/floor/engine,
+/area/maintenance/xenozoo)
 "pUz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -103106,10 +104960,13 @@
 /area/toxins/mixing)
 "pVo" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/chair/wood{
+	dir = 1
 	},
-/area/maintenance/xenozoo)
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "pVu" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
@@ -103144,22 +105001,25 @@
 	},
 /area/crew_quarters/sleep)
 "pVL" = (
-/obj/machinery/disposal,
-/obj/effect/decal/warning_stripes/red,
-/obj/structure/disposalpipe/trunk{
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/sign/deathsposal{
-	pixel_y = 32
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding1"
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/brig/evidence,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull"
+	icon_state = "dark"
 	},
-/area/security/processing)
+/area/security/evidence)
 "pVM" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -103465,22 +105325,6 @@
 	icon_state = "whitepurple"
 	},
 /area/toxins/lab)
-"pYL" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/misc_lab)
 "pYR" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -103558,21 +105402,11 @@
 	})
 "pZR" = (
 /obj/effect/decal/warning_stripes/northwest,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/item/radio/intercom{
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
-/area/toxins/mixing)
-"qac" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
+/area/toxins/launch)
 "qak" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel,
@@ -103582,9 +105416,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
@@ -103631,9 +105462,21 @@
 	},
 /area/shuttle/siberia)
 "qbq" = (
-/obj/structure/table/wood,
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/picket_sign,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/crew_quarters/theatre)
 "qbt" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -103737,6 +105580,11 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"qcc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "qcd" = (
 /obj/machinery/ai_slipper,
 /obj/structure/cable{
@@ -103856,6 +105704,22 @@
 	icon_state = "dark"
 	},
 /area/security/securearmory)
+"qdv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "qdz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -103896,6 +105760,44 @@
 	icon_state = "caution"
 	},
 /area/atmos)
+"qed" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "whitehall"
+	},
+/area/maintenance/asmaint2)
+"qee" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "purplefull"
+	},
+/area/medical/research/nhallway)
 "qef" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -104005,17 +105907,6 @@
 	icon_state = "white"
 	},
 /area/medical/sleeper)
-"qfc" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/evidence)
 "qfe" = (
 /obj/machinery/newscaster{
 	pixel_x = -28;
@@ -104071,33 +105962,9 @@
 	icon_state = "grimy"
 	},
 /area/crew_quarters/bar/atrium)
-"qfD" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/door_control{
-	id = "xenokill";
-	name = "Xenobio Kill Room Bolts";
-	normaldoorcontrol = 1;
-	pixel_x = 30;
-	specialfunctions = 4
-	},
-/obj/machinery/door/airlock/research/glass{
-	id_tag = "xenokill";
-	locked = 1;
-	name = "Xenobio Kill Room"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/toxins/xenobiology)
+"qfF" = (
+/turf/simulated/wall,
+/area/crew_quarters/theatre)
 "qfI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -104209,7 +106076,8 @@
 	},
 /area/security/brig)
 "qgX" = (
-/turf/simulated/floor/plating/airless,
+/obj/structure/lattice,
+/turf/simulated/wall/rust,
 /area/space)
 "qgZ" = (
 /obj/machinery/iv_drip,
@@ -104225,15 +106093,20 @@
 	})
 "qhf" = (
 /obj/structure/table/reinforced,
-/obj/item/stamp/rd,
-/obj/item/paper_bin,
-/obj/item/pen,
 /obj/machinery/door_control{
 	id = "rdprivacy";
 	name = "Privacy Shutters";
 	pixel_x = -6;
 	pixel_y = 6
 	},
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/item/pen{
+	pixel_x = 8
+	},
+/obj/item/stamp/rd,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurple";
@@ -104251,17 +106124,20 @@
 	},
 /area/security/brig)
 "qhH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitehall"
+	dir = 6;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (SOUTHEAST)"
 	},
-/area/toxins/xenobiology)
+/area/toxins/misc_lab)
 "qhS" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/machinery/vending/wallmed{
@@ -104292,17 +106168,15 @@
 	name = "Research Division"
 	})
 "qhW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "dark"
 	},
 /area/security/processing)
 "qic" = (
@@ -104329,24 +106203,24 @@
 /area/security/permabrig)
 "qie" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
-	id = "visiting room"
-	},
-/obj/structure/window/reinforced/polarized{
 	dir = 1;
-	id = "visiting room"
+	id = "Interrogation"
 	},
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
-	id = "visiting room"
+	id = "Interrogation"
+	},
+/obj/structure/window/reinforced/polarized{
+	id = "Interrogation"
 	},
 /obj/structure/window/reinforced/polarized{
 	dir = 4;
-	id = "visiting room"
+	id = "Interrogation"
 	},
 /turf/simulated/floor/plating,
 /area/security/interrogation)
@@ -104407,26 +106281,6 @@
 	icon_state = "red"
 	},
 /area/security/securehallway)
-"qiR" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10;
-	initialize_directions = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
 "qiU" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -104504,6 +106358,29 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
+"qjv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/chair/stool{
+	dir = 1
+	},
+/obj/item/ammo_casing{
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/obj/item/ammo_casing{
+	pixel_x = -12;
+	pixel_y = -2
+	},
+/obj/effect/spawner/random_spawners/blood_often,
+/obj/machinery/button/windowtint{
+	anchored = 1;
+	id = "pokerclub";
+	pixel_x = -24;
+	active = 1;
+	icon_state = "light1"
+	},
+/turf/simulated/floor/carpet/royalblack,
+/area/maintenance/asmaint2)
 "qjy" = (
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating,
@@ -104559,13 +106436,21 @@
 	},
 /area/crew_quarters/locker)
 "qjU" = (
-/obj/structure/closet/secure_closet/brig/evidence,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+/obj/structure/table/glass,
+/obj/item/storage/firstaid/adv{
+	pixel_x = 1;
+	pixel_y = 2
 	},
-/area/security/evidence)
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bottle/charcoal,
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	dir = 0;
+	icon_state = "whitered"
+	},
+/area/security/medbay)
 "qjY" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -104638,6 +106523,15 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
+"qkU" = (
+/obj/machinery/door/poddoor{
+	name = "Supermatter Venting";
+	opacity = 0;
+	density = 0;
+	id_tag = "SupermatterVenting"
+	},
+/turf/simulated/floor/engine/insulated/vacuum,
+/area/maintenance/xenozoo)
 "qla" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/extinguisher_cabinet{
@@ -104660,20 +106554,24 @@
 	icon_state = "yellowfull"
 	},
 /area/engine/engineering)
-"qlw" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
+"qlJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
-"qlJ" = (
-/obj/structure/sign/science{
-	icon_state = "xenobio2"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/wall,
-/area/toxins/xenobiology)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
+	},
+/area/toxins/test_chamber)
 "qlK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -104707,13 +106605,6 @@
 	icon_state = "bcarpet05"
 	},
 /area/blueshield)
-"qlS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/red,
-/area/maintenance/library)
 "qlT" = (
 /obj/machinery/light,
 /obj/machinery/firealarm{
@@ -104724,26 +106615,6 @@
 	icon_state = "dark"
 	},
 /area/turret_protected/ai_upload)
-"qlW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/security/evidence)
 "qlZ" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -104783,14 +106654,13 @@
 	icon_state = "redyellowfull"
 	},
 /area/engine/break_room)
-"qmv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
+"qmw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
+/area/crew_quarters/theatre)
 "qmz" = (
 /obj/structure/window/reinforced/polarized{
 	id = "vir_work_zone1"
@@ -104907,16 +106777,6 @@
 /area/shuttle/escape{
 	parallax_movedir = 2
 	})
-"qnQ" = (
-/obj/structure/table/wood/poker,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
 "qoa" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
@@ -104927,28 +106787,17 @@
 	name = "Virology Maintenance"
 	})
 "qol" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 26
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "whitehall"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
-"qor" = (
-/obj/structure/table/wood,
-/obj/item/folder{
-	pixel_y = 3
-	},
-/obj/item/stack/tape_roll{
-	pixel_y = -5
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/library)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "qos" = (
 /obj/structure/table,
 /obj/item/wrench,
@@ -105010,23 +106859,18 @@
 	},
 /area/hallway/primary/central/sw)
 "qoN" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding1"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
+/obj/structure/closet/secure_closet/brig/evidence,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "dark"
 	},
-/area/security/processing)
+/area/security/evidence)
 "qoQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -105187,6 +107031,21 @@
 	dir = 1
 	},
 /area/security/reception)
+"qpV" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
+	},
+/area/toxins/xenobiology)
 "qpZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -105278,15 +107137,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/toxins/mixing)
+/area/toxins/launch)
 "qrz" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -105347,17 +107205,18 @@
 	},
 /area/turret_protected/aisat)
 "qrW" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurplecorner"
 	},
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/area/toxins/explab)
 "qsa" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -105494,19 +107353,6 @@
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
 	})
-"qti" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (EAST)"
-	},
-/area/medical/medbay)
 "qtk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -105541,9 +107387,32 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "qtq" = (
-/obj/structure/sign/securearea,
-/turf/simulated/wall,
-/area/toxins/explab)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 26
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
+	},
+/area/toxins/xenobiology)
 "qtv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -105587,16 +107456,38 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/nw)
-"qtZ" = (
+"qtX" = (
+/obj/machinery/door/window/westright{
+	name = "Front Desk"
+	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
+"qtZ" = (
+/obj/effect/mob_spawn/human,
+/turf/simulated/floor/engine,
+/area/maintenance/xenozoo)
+"quc" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 4;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
 	},
-/area/toxins/explab)
+/area/medical/research/nhallway)
 "qud" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -105691,6 +107582,15 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/central/west)
+"quB" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "quO" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/chair/sofa/pew/right,
@@ -105700,10 +107600,17 @@
 	},
 /area/chapel/main)
 "quV" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "purplefull"
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -26
 	},
-/area/toxins/explab)
+/obj/structure/table,
+/obj/item/flashlight/lamp,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
+	},
+/area/medical/research/nhallway)
 "quW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -105853,6 +107760,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/bridge)
+"qwu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 8
+	},
+/turf/simulated/floor/carpet/royalblack,
+/area/maintenance/asmaint2)
 "qwy" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/regular,
@@ -105889,6 +107805,11 @@
 "qwC" = (
 /turf/simulated/wall,
 /area/medical/surgery/south)
+"qwE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/writing,
+/turf/simulated/floor/wood,
+/area/crew_quarters/theatre)
 "qwG" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -105974,10 +107895,9 @@
 	name = "\improper Virology Lobby"
 	})
 "qxf" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/bookcase,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
+/turf/simulated/floor/wood,
 /area/maintenance/library)
 "qxo" = (
 /obj/structure/cable{
@@ -105998,13 +107918,24 @@
 	},
 /area/medical/medbay)
 "qxv" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (EAST)"
+/obj/structure/chair/wood/wings{
+	dir = 8;
+	tag = "icon-wooden_chair_wings (WEST)"
 	},
-/area/toxins/explab)
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken6";
+	tag = "icon-wood-broken6"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "qxE" = (
 /obj/machinery/power/solar{
 	name = "Aft Starboard Solar Panel"
@@ -106350,21 +108281,15 @@
 	},
 /area/hallway/primary/central/east)
 "qBV" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id_tag = "SecMedPrivOutside"
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "darkred"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "BridgeLockdown";
-	name = "Bridge Lockdown"
-	},
-/turf/simulated/floor/plating,
-/area/security/medbay)
+/area/security/permabrig)
 "qBZ" = (
 /obj/item/wrench,
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
@@ -106404,11 +108329,21 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurplecorner"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/area/crew_quarters/hor)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research/nhallway)
 "qCL" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -106451,17 +108386,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/bridge/vip)
-"qDn" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/security/processing)
 "qDz" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -106527,20 +108451,21 @@
 	},
 /area/security/customs)
 "qEo" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1379;
+	master_tag = "sw_maint_airlock";
+	name = "interior access button";
+	pixel_x = -24;
+	pixel_y = 24
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
 	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "whitepurple"
-	},
-/area/toxins/explab)
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "qEC" = (
 /turf/simulated/wall,
 /area/crew_quarters/fitness)
@@ -106604,6 +108529,12 @@
 /obj/machinery/floodlight,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
+"qFr" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "qFw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -106692,21 +108623,32 @@
 	},
 /area/crew_quarters/chief)
 "qFQ" = (
-/obj/structure/closet/bombcloset,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/bookcase,
+/obj/item/book/manual/sop_science,
+/obj/item/book/manual/research_and_development,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurplecorner"
+	dir = 10;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (SOUTHWEST)"
 	},
 /area/medical/research/nhallway)
 "qGf" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
@@ -106734,19 +108676,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/prison/cell_block/A)
-"qGp" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/machinery/light{
-	dir = 1;
-	on = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitehall"
-	},
-/area/toxins/xenobiology)
 "qGv" = (
 /obj/machinery/light,
 /obj/structure/table/reinforced,
@@ -106772,6 +108701,19 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
+"qGG" = (
+/obj/machinery/power/smes,
+/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purple"
+	},
+/area/maintenance/xenozoo)
 "qGO" = (
 /obj/machinery/door/airlock/medical/glass{
 	id = "cloninglab";
@@ -106791,14 +108733,6 @@
 	icon_state = "white"
 	},
 /area/medical/cloning)
-"qGP" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
 "qGR" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -106806,16 +108740,19 @@
 	name = "Tourist Area Maintenance"
 	})
 "qHb" = (
-/obj/machinery/vending/wallmed{
-	layer = 3.3;
-	name = "Emergency NanoMed";
-	pixel_y = 32
-	},
-/turf/simulated/floor/plasteel{
+/obj/machinery/door/window/brigdoor/southleft{
 	dir = 1;
-	icon_state = "red"
+	req_access_txt = "63"
 	},
-/area/security/processing)
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding1"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/evidence)
 "qHk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
@@ -106870,15 +108807,18 @@
 	name = "Engineering Maintenance"
 	})
 "qIk" = (
-/obj/structure/closet/coffin,
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/closet/firecloset,
+/obj/machinery/camera{
+	c_tag = "Toxin Equipment Storage";
+	dir = 1;
+	network = list("Research","SS13")
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "neutral"
 	},
-/area/chapel/main)
+/area/toxins/launch)
 "qIo" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -106930,6 +108870,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/warden)
+"qIE" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
+	},
+/area/toxins/misc_lab)
 "qIQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -107316,9 +109264,6 @@
 /obj/structure/window/reinforced/polarized{
 	id = "execution"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/plating,
 /area/security/execution)
 "qNd" = (
@@ -107579,8 +109524,13 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/starboard)
 "qQf" = (
-/obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall/r_wall,
+/obj/structure/window/plasmareinforced{
+	dir = 4
+	},
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
 /area/maintenance/xenozoo)
 "qQk" = (
 /obj/structure/closet/crate/freezer,
@@ -107605,17 +109555,10 @@
 	},
 /area/medical/surgery/south)
 "qQl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
-/area/maintenance/gambling_den)
+/mob/living/carbon/human/lesser/monkey,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "qQq" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -107667,13 +109610,11 @@
 	},
 /area/bridge/meeting_room)
 "qQQ" = (
-/obj/structure/table/reinforced,
-/obj/item/dice/d10,
-/obj/item/dice/d20,
+/obj/random/plushie,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "bar"
 	},
-/area/maintenance/xenozoo)
+/area/crew_quarters/theatre)
 "qQS" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -107738,9 +109679,16 @@
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/lawoffice)
+"qSr" = (
+/mob/living/simple_animal/mouse/gray,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "qSE" = (
-/turf/simulated/wall,
-/area/toxins/explab)
+/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/chem_dispenser,
+/turf/simulated/floor/engine,
+/area/toxins/misc_lab)
 "qSG" = (
 /obj/item/phone{
 	pixel_x = -3;
@@ -107759,25 +109707,14 @@
 	},
 /area/turret_protected/ai_upload)
 "qSI" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door_control{
-	id = "experimentor";
-	name = "Experimentor Control";
-	pixel_x = -26
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "experimentor";
-	name = "Experimentor Blast Door";
-	opacity = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/dresser,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "bar"
 	},
-/area/toxins/explab)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "qSJ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger{
@@ -107802,15 +109739,6 @@
 	},
 /area/maintenance/aft{
 	name = "Medbay Maintenance"
-	})
-"qTt" = (
-/obj/structure/girder,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
 	})
 "qTv" = (
 /obj/structure/sign/greencross,
@@ -108027,20 +109955,6 @@
 	icon_state = "swall_f6"
 	},
 /area/shuttle/supply)
-"qVB" = (
-/obj/structure/closet{
-	icon_closed = "cabinet_closed";
-	icon_opened = "cabinet_open";
-	icon_state = "cabinet_closed"
-	},
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
 "qVN" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -108058,10 +109972,6 @@
 /area/maintenance/consarea{
 	name = "Virology Maintenance Construction Area"
 	})
-"qVO" = (
-/obj/structure/sign/electricshock,
-/turf/simulated/wall/r_wall,
-/area/toxins/xenobiology)
 "qWf" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -108079,29 +109989,6 @@
 	tag = "icon-vault (NORTHEAST)"
 	},
 /area/crew_quarters/heads/hop)
-"qWg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/chair,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/flasher{
-	desc = "A floor-mounted flashbulb device.";
-	id = "visiting room flash";
-	layer = 5;
-	pixel_x = 56;
-	range = 3
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "darkred"
-	},
-/area/security/interrogation)
 "qWu" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -108126,11 +110013,17 @@
 	},
 /area/security/main)
 "qWC" = (
-/obj/structure/table/wood/poker,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "qWU" = (
 /turf/simulated/wall/r_wall,
 /area/teleporter/abandoned)
@@ -108195,9 +110088,15 @@
 	},
 /area/maintenance/starboard)
 "qXu" = (
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/twohanded/required/kirbyplants,
+/obj/machinery/light/small,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "qXv" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -108564,16 +110463,11 @@
 	},
 /area/medical/morgue)
 "rbA" = (
-/obj/structure/closet/secure_closet/research_reagents,
-/obj/effect/decal/warning_stripes/yellow,
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurple"
+	icon_state = "purplefull"
 	},
-/area/toxins/misc_lab)
+/area/maintenance/xenozoo)
 "rbD" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -108585,26 +110479,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
-"rbH" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	tag = "icon-pipe-j1 (EAST)"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurple"
-	},
-/area/toxins/misc_lab)
 "rbI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -108642,12 +110516,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
 "rbR" = (
-/obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed,
+/obj/item/bedsheet/blue,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 0;
+	icon_state = "whitered"
 	},
-/area/security/evidence)
+/area/security/medbay)
 "rbU" = (
 /obj/machinery/vending/cola,
 /obj/effect/decal/warning_stripes/red/hollow,
@@ -108655,6 +110530,21 @@
 	dir = 1
 	},
 /area/security/permabrig)
+"rbW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/ants,
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/item/reagent_containers/food/snacks/grown/tomato{
+	pixel_x = -10;
+	pixel_y = -12
+	},
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken5";
+	tag = "icon-wood-broken5"
+	},
+/area/crew_quarters/theatre)
 "rbY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -108806,24 +110696,6 @@
 /obj/structure/sign/securearea,
 /turf/simulated/wall,
 /area/engine/break_room)
-"rcX" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurplecorner"
-	},
-/area/toxins/misc_lab)
 "rdn" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=A24";
@@ -108854,25 +110726,6 @@
 	icon_state = "dark"
 	},
 /area/security/permahallway)
-"rdB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/misc_lab)
 "rdK" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -108893,6 +110746,16 @@
 /area/maintenance/fore{
 	name = "Hangar Maintenance"
 	})
+"rdQ" = (
+/obj/item/radio/intercom{
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
+	},
+/area/medical/research/nhallway)
 "rdT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -108900,24 +110763,6 @@
 	icon_state = "redcorner"
 	},
 /area/security/main)
-"rdX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "red"
-	},
-/area/security/interrogation)
 "ref" = (
 /obj/structure/table/reinforced,
 /obj/item/analyzer,
@@ -108930,40 +110775,6 @@
 /mob/living/simple_animal/mouse/brown,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"reH" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/syringe{
-	pixel_x = -1;
-	pixel_y = -11
-	},
-/obj/item/reagent_containers/syringe/calomel{
-	pixel_x = -1;
-	pixel_y = -6
-	},
-/obj/item/reagent_containers/syringe/heparin{
-	pixel_x = -1;
-	pixel_y = -1
-	},
-/obj/item/reagent_containers/syringe/calomel{
-	pixel_x = -1;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/glass/bottle/reagent/hairgrownium{
-	pixel_x = -6;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/glass/bottle/frostoil{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/glass/bottle/mutagen{
-	pixel_y = 6
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/security/processing)
 "reI" = (
 /obj/structure/chair{
 	dir = 8
@@ -109011,33 +110822,19 @@
 	},
 /area/crew_quarters/courtroom)
 "rfs" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/taperecorder,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/effect/decal/warning_stripes/northwest,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple"
+	dir = 8;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
 	},
-/area/toxins/explab)
+/area/toxins/xenobiology)
 "rfz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -109057,66 +110854,21 @@
 	},
 /obj/item/clipboard,
 /obj/item/toy/figure/scientist,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -25
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "neutral"
 	},
-/area/toxins/mixing)
-"rfB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/hologram/holopad,
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start{
-	name = "Scientist"
-	},
-/obj/effect/decal/warning_stripes/north,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
-	},
-/area/toxins/explab)
+/area/toxins/launch)
 "rfK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/folder/white,
-/obj/item/pen,
-/obj/effect/decal/warning_stripes/northeast,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "whitepurplecorner"
 	},
-/area/toxins/explab)
+/area/assembly/robotics)
 "rfQ" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/warning_stripes/yellow,
@@ -109133,39 +110885,6 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
-"rgj" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/camera{
-	c_tag = "Xenobio West";
-	network = list("Research","SS13")
-	},
-/obj/machinery/status_display{
-	pixel_y = 32
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
-"rgp" = (
-/obj/structure/curtain/open,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitered"
-	},
-/area/security/medbay)
 "rgy" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -109198,16 +110917,11 @@
 	},
 /area/medical/research/restroom)
 "rgF" = (
-/obj/machinery/driver_button{
-	id_tag = "toxinsdriver";
-	pixel_x = -26
-	},
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
 /obj/effect/decal/warning_stripes/west,
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom,
 /turf/simulated/floor/plasteel,
-/area/toxins/mixing)
+/area/toxins/launch)
 "rgY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -109225,9 +110939,11 @@
 	},
 /area/medical/medbay2)
 "rho" = (
-/obj/machinery/hologram/holopad,
+/obj/structure/chair/comfy/purp{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "purplefull"
+	icon_state = "white"
 	},
 /area/medical/research/nhallway)
 "rhx" = (
@@ -109250,40 +110966,15 @@
 	},
 /area/engine/hardsuitstorage)
 "rhD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research/nhallway)
-"rhG" = (
-/obj/machinery/camera{
-	c_tag = "Temporary Holding Cell";
-	dir = 8;
-	network = list("SS13","Security")
-	},
-/obj/structure/chair{
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "red"
+	dir = 8;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
 	},
-/area/security/processing)
+/area/medical/research/shallway)
 "rhQ" = (
 /obj/item/radio/intercom{
 	pixel_y = -30
@@ -109301,10 +110992,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -109491,6 +111182,19 @@
 	},
 /turf/simulated/floor/wood,
 /area/assembly/showroom)
+"rks" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology)
 "rkw" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining/glass{
@@ -109510,15 +111214,8 @@
 /turf/simulated/floor/carpet/black,
 /area/shuttle/trade/sol)
 "rkO" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "purplefull"
 	},
 /area/medical/research/nhallway)
 "rkP" = (
@@ -109530,11 +111227,6 @@
 	icon_state = "red"
 	},
 /area/security/securehallway)
-"rkV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
 "rle" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plasteel{
@@ -109625,6 +111317,17 @@
 /area/shuttle/escape{
 	parallax_movedir = 2
 	})
+"rlN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/shower{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology)
 "rma" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel{
@@ -109913,7 +111616,9 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
 	},
 /area/medical/research/shallway)
 "roC" = (
@@ -109973,9 +111678,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
+/turf/simulated/floor/carpet/purple,
 /area/crew_quarters/hor)
 "rpw" = (
 /turf/simulated/floor/plasteel{
@@ -110175,15 +111878,6 @@
 	icon_state = "neutralfull"
 	},
 /area/crew_quarters/courtroom)
-"rsh" = (
-/obj/structure/table/wood,
-/obj/item/folder,
-/obj/item/pen,
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/library)
 "rsy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -110203,6 +111897,23 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
+"rsA" = (
+/obj/structure/table/reinforced,
+/obj/machinery/camera{
+	c_tag = "Xenobio East";
+	dir = 8;
+	network = list("Research","SS13")
+	},
+/obj/machinery/requests_console{
+	department = "Xenobiology";
+	departmentType = 2;
+	name = "Xenobiology Requests Console";
+	pixel_x = 30
+	},
+/obj/machinery/reagentgrinder,
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology)
 "rsC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
@@ -110254,6 +111965,18 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/nw)
+"rsQ" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/slime_scanner,
+/obj/item/slime_scanner,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (SOUTHEAST)"
+	},
+/area/toxins/xenobiology)
 "rsV" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall/r_wall,
@@ -110294,10 +112017,11 @@
 "rtb" = (
 /obj/structure/closet/coffin,
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/door/window/eastleft{
-	dir = 8;
-	name = "Coffin Storage";
-	req_access_txt = "22"
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -110330,23 +112054,9 @@
 	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
-"rtu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/security/processing)
 "rtB" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/obj/structure/sign/biohazard,
+/turf/simulated/wall,
 /area/maintenance/xenozoo)
 "rtG" = (
 /turf/simulated/floor/plasteel{
@@ -110373,18 +112083,6 @@
 	icon_state = "dark"
 	},
 /area/bridge)
-"rua" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft{
-	name = "Medbay Maintenance"
-	})
 "rum" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -110716,15 +112414,6 @@
 	dir = 1
 	},
 /area/security/reception)
-"rxH" = (
-/obj/structure/disposalpipe/trunk,
-/obj/structure/disposaloutlet{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/toxins/xenobiology)
 "rxL" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -110885,12 +112574,8 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/cabin3)
 "rzA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/wall/r_wall,
-/area/security/evidence)
+/turf/simulated/floor/plating/airless,
+/area/space)
 "rzM" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -110898,8 +112583,18 @@
 /area/maintenance/asmaint2)
 "rzO" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/obj/item/ticket_machine_ticket{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "rzT" = (
 /turf/simulated/floor/mech_bay_recharge_floor,
 /area/assembly/robotics)
@@ -110966,8 +112661,11 @@
 	},
 /area/chapel/main)
 "rAM" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall,
-/area/toxins/xenobiology)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "rAN" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -110992,11 +112690,6 @@
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/central/ne)
-"rBh" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/obj/effect/decal/warning_stripes/southeast,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
 "rBk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -111011,6 +112704,16 @@
 /area/maintenance/fore{
 	name = "Hangar Maintenance"
 	})
+"rBm" = (
+/obj/machinery/light/small,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitehall"
+	},
+/area/crew_quarters/theatre)
 "rBx" = (
 /obj/machinery/computer/crew,
 /obj/machinery/door_control{
@@ -111059,27 +112762,21 @@
 	icon_state = "bcarpet05"
 	},
 /area/security/prison/cell_block/A)
+"rBI" = (
+/obj/machinery/light{
+	dir = 1;
+	on = 1
+	},
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "rCf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/effect/spawner/window/reinforced/plasma,
 /obj/structure/cable{
-	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "purplefull"
-	},
-/area/medical/research/nhallway)
+/turf/simulated/floor/plating,
+/area/toxins/mixing)
 "rCs" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
@@ -111089,6 +112786,10 @@
 	scrub_Toxins = 1
 	},
 /obj/machinery/light,
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_y = -24
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bcarpet05"
 	},
@@ -111200,6 +112901,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -111324,14 +113028,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/hallway/secondary/entry)
-"rEd" = (
-/obj/machinery/camera{
-	c_tag = "Research Test Chamber";
-	dir = 4;
-	network = list("TestChamber","SS13","Research")
-	},
-/turf/simulated/floor/engine,
-/area/toxins/test_chamber)
 "rEe" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -111354,15 +113050,12 @@
 	},
 /area/maintenance/bar)
 "rEx" = (
-/obj/structure/table/reinforced,
-/obj/item/radio/electropack,
-/obj/item/assembly/signaler,
-/obj/item/healthanalyzer,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurple"
+	dir = 4;
+	icon_state = "darkblue"
 	},
-/area/toxins/misc_lab)
+/area/crew_quarters/theatre)
 "rEC" = (
 /obj/machinery/newscaster{
 	pixel_x = 28
@@ -111430,6 +113123,17 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
+"rFo" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology)
 "rFw" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/structure/table/wood,
@@ -111473,11 +113177,26 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
 "rFG" = (
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurplecorner"
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/area/toxins/misc_lab)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/research{
+	name = "Chemical Testing Room";
+	req_access_txt = "47"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/test_chamber)
 "rFJ" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -111501,40 +113220,30 @@
 	name = "Virology Maintenance"
 	})
 "rGw" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/beakers,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/smartfridge/medbay,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/sign/poster/official/cleanliness{
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (SOUTHEAST)"
+	dir = 5;
+	icon_state = "whitepurple"
 	},
 /area/toxins/misc_lab)
 "rGx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/mug/sec,
+/obj/machinery/light{
 	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = 24
+	},
+/obj/item/lighter,
+/obj/item/storage/fancy/cigarettes/cigpack_robust,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/processing)
 "rGz" = (
@@ -111568,6 +113277,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
+"rGG" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -26
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "rGK" = (
 /obj/machinery/flasher/portable,
 /obj/effect/decal/warning_stripes/red/hollow,
@@ -111580,10 +113298,15 @@
 	},
 /area/security/securearmory)
 "rGM" = (
-/obj/machinery/computer/rdconsole/experiment,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/toxins/explab)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
+	},
+/area/toxins/xenobiology)
 "rGO" = (
 /obj/effect/decal/warning_stripes/red,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -111595,6 +113318,16 @@
 	icon_state = "vault"
 	},
 /area/security/securearmory)
+"rGY" = (
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "whitepurple"
+	},
+/area/toxins/launch)
 "rHl" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
@@ -111649,14 +113382,14 @@
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "rHD" = (
-/obj/machinery/atmospherics/unary/portables_connector,
-/obj/machinery/light{
-	dir = 1;
-	on = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
-/area/toxins/mixing)
+/obj/machinery/r_n_d/experimentor{
+	pixel_y = 16
+	},
+/turf/simulated/floor/engine,
+/area/toxins/explab)
 "rHM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -111688,21 +113421,33 @@
 	},
 /area/security/securearmory)
 "rIt" = (
-/obj/machinery/atmospherics/unary/portables_connector,
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/effect/decal/warning_stripes/southeast,
-/turf/simulated/floor/plasteel,
-/area/toxins/explab)
-"rIw" = (
-/obj/structure/chair{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "red"
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
 	},
-/area/security/processing)
+/area/crew_quarters/theatre)
+"rIw" = (
+/obj/structure/cable,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	dir = 1;
+	id = "Interrogation"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 8;
+	id = "Interrogation"
+	},
+/obj/structure/window/reinforced/polarized{
+	id = "Interrogation"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "Interrogation"
+	},
+/turf/simulated/floor/plating,
+/area/security/interrogation)
 "rIx" = (
 /turf/simulated/wall/r_wall,
 /area/teleporter)
@@ -111764,9 +113509,6 @@
 /turf/simulated/floor/plasteel,
 /area/teleporter)
 "rJr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/vending/cigarette,
 /obj/structure/cable{
 	d1 = 1;
@@ -111774,7 +113516,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
 	},
 /area/medical/research/nhallway)
 "rJw" = (
@@ -111804,17 +113547,10 @@
 /area/security/securearmory)
 "rJJ" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/closet/radiation,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
 	},
 /area/medical/research/nhallway)
 "rJL" = (
@@ -111842,8 +113578,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurplecorner"
+	icon_state = "white"
 	},
 /area/medical/research/nhallway)
 "rKg" = (
@@ -111893,12 +113628,10 @@
 	},
 /area/hallway/primary/central/south)
 "rKQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurplecorner"
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
 	},
 /area/medical/research/shallway)
 "rKX" = (
@@ -111912,11 +113645,6 @@
 	parallax_movedir = 2
 	})
 "rKZ" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -111924,8 +113652,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "purplefull"
+	icon_state = "white"
 	},
 /area/medical/research/shallway)
 "rLd" = (
@@ -111968,6 +113697,27 @@
 	icon_state = "dark"
 	},
 /area/security/securearmory)
+"rLm" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobio West";
+	network = list("Research","SS13");
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
+	},
+/area/toxins/xenobiology)
 "rLo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -112121,9 +113871,17 @@
 	},
 /area/library)
 "rMu" = (
-/obj/effect/spawner/random_spawners/wall_rusted_maybe,
-/turf/simulated/wall,
-/area/maintenance/library)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research/nhallway)
 "rMN" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -112148,9 +113906,15 @@
 	name = "Virology Maintenance"
 	})
 "rNg" = (
-/obj/effect/decal/remains/xeno,
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 28
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "rNh" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -112236,6 +114000,11 @@
 	name = "\improper AI Satellite Hallway"
 	})
 "rOY" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "darkred"
@@ -112301,7 +114070,7 @@
 /area/shuttle/syndicate_sit)
 "rPI" = (
 /turf/simulated/wall/rust,
-/area/toxins/mixing)
+/area/toxins/launch)
 "rPP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -112344,12 +114113,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/aienter)
-"rQm" = (
-/obj/effect/decal/warning_stripes/southeast,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
 "rQt" = (
 /obj/item/cigbutt{
 	pixel_x = -10;
@@ -112434,6 +114197,25 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
 /area/engine/engineering)
+"rQY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "purplefull"
+	},
+/area/medical/research/nhallway)
 "rRf" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	id_tag = "engineering_east_airlock";
@@ -112485,11 +114267,20 @@
 /area/crew_quarters/locker/locker_toilet)
 "rRM" = (
 /obj/structure/rack,
-/obj/item/wrench,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
+/obj/item/extinguisher,
+/obj/item/clothing/mask/gas,
+/obj/item/grenade/chem_grenade/firefighting,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/light/small,
+/obj/machinery/light_switch{
+	pixel_x = -26;
+	pixel_y = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "neutral"
+	},
+/area/toxins/launch)
 "rRO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -112582,7 +114373,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "purplefull"
+	icon_state = "white"
 	},
 /area/medical/research/shallway)
 "rSr" = (
@@ -112727,20 +114518,10 @@
 	},
 /area/turret_protected/aisat)
 "rUu" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/turf/simulated/floor/plating,
 /area/maintenance/library)
 "rUC" = (
 /obj/effect/spawner/window/reinforced,
@@ -112766,11 +114547,12 @@
 	},
 /area/medical/virology)
 "rUS" = (
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/area/maintenance/gambling_den)
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "rVb" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/rods{
@@ -112908,10 +114690,7 @@
 /area/crew_quarters/captain/bedroom)
 "rWt" = (
 /obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Security Officer"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -112991,6 +114770,12 @@
 	icon_state = "caution"
 	},
 /area/engine/break_room)
+"rXw" = (
+/obj/machinery/smartfridge/secure/extract,
+/turf/simulated/floor/plasteel{
+	icon_state = "purplefull"
+	},
+/area/toxins/xenobiology)
 "rXz" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -113005,15 +114790,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
-"rYz" = (
-/obj/structure/chair/wood/wings{
-	dir = 8;
-	tag = "icon-wooden_chair_wings (WEST)"
-	},
-/turf/simulated/floor/wood,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
 "rYG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -113129,32 +114905,22 @@
 /turf/simulated/floor/plating,
 /area/chapel/main)
 "san" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "xeno4";
-	name = "Creature Cell #4";
-	opacity = 0
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	name = "Creature Pen";
-	req_access_txt = "47"
+/obj/item/radio/intercom{
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "purplefull"
 	},
-/area/toxins/xenobiology)
+/area/toxins/test_chamber)
 "say" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -113259,15 +115025,15 @@
 	},
 /area/crew_quarters/hor)
 "sbj" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/item/storage/toolbox/mechanical,
+/obj/item/flashlight,
+/obj/structure/table,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTHWEST)"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
+/area/toxins/explab)
 "sbn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -113313,14 +115079,6 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
-"sbF" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
 "sbR" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -113363,7 +115121,7 @@
 /area/library)
 "scn" = (
 /turf/simulated/floor/plasteel{
-	dir = 9;
+	dir = 8;
 	icon_state = "red"
 	},
 /area/security/processing)
@@ -113380,6 +115138,24 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
+"scv" = (
+/obj/effect/landmark{
+	color = "#00ae00";
+	icon_state = "x_white";
+	name = "ninja_teleport"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "scx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -113388,12 +115164,25 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
+"scB" = (
+/obj/structure/bookcase,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken"
+	},
+/area/maintenance/library)
 "scD" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/item/clothing/shoes/clown_shoes,
+/obj/structure/curtain/open/shower/security{
+	name = "backstage";
+	alpha = 255;
+	icon_state = "closed";
+	opacity = 1
 	},
-/area/maintenance/gambling_den)
+/turf/simulated/floor/plasteel{
+	icon_state = "tranquillite"
+	},
+/area/crew_quarters/theatre)
 "scE" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "barber"
@@ -113436,16 +115225,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "scZ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/turf/simulated/floor/engine,
-/area/toxins/test_chamber)
+/area/toxins/xenobiology)
 "sdb" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -113504,6 +115293,14 @@
 	icon_state = "white"
 	},
 /area/medical/reception)
+"sdL" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "sdY" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -113588,23 +115385,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
-"seF" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/misc_lab)
 "seH" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -113636,13 +115416,6 @@
 	tag = "icon-redfull (NORTHWEST)"
 	},
 /area/crew_quarters/kitchen)
-"sfq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
 "sfC" = (
 /obj/machinery/vending/tool,
 /obj/item/radio/intercom{
@@ -113653,21 +115426,20 @@
 	},
 /area/maintenance/kitchen)
 "sfI" = (
-/obj/machinery/camera{
-	c_tag = "Experimention Lab";
-	dir = 1;
-	network = list("Research","SS13")
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/toxins/explab)
+/area/crew_quarters/theatre)
 "sfU" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurple"
-	},
-/area/toxins/misc_lab)
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
 "sfZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/burnturf,
@@ -113675,6 +115447,12 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
+"sgk" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken"
+	},
+/area/crew_quarters/theatre)
 "sgo" = (
 /obj/machinery/vending/wallmed{
 	pixel_y = 30
@@ -113685,16 +115463,14 @@
 	},
 /area/bridge/vip)
 "sgu" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 28
+/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/chem_master,
+/obj/structure/window/plasmareinforced,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (SOUTHEAST)"
-	},
+/turf/simulated/floor/engine,
 /area/toxins/misc_lab)
 "sgw" = (
 /obj/effect/spawner/window/reinforced,
@@ -113743,6 +115519,25 @@
 	icon_state = "neutralfull"
 	},
 /area/storage/primary)
+"sgN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/stack/sheet/wood,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
 "sgX" = (
 /obj/machinery/vending/cola,
 /obj/effect/decal/warning_stripes/yellow,
@@ -113805,8 +115600,11 @@
 /turf/space,
 /area/space/nearstation)
 "sic" = (
-/turf/simulated/floor/greengrid,
-/area/maintenance/xenozoo)
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/plasteel{
+	icon_state = "purplefull"
+	},
+/area/toxins/test_chamber)
 "sid" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -113826,7 +115624,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "purplefull"
 	},
 /area/medical/research/shallway)
 "sil" = (
@@ -113971,6 +115769,14 @@
 "sjs" = (
 /turf/simulated/floor/plasteel,
 /area/maintenance/bar)
+"sjF" = (
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken5";
+	tag = "icon-wood-broken5"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "sjO" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/tinted{
@@ -113984,10 +115790,12 @@
 	name = "Virology Maintenance"
 	})
 "sjQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/black,
+/area/crew_quarters/theatre)
 "sjW" = (
 /obj/structure/sign/science,
 /turf/simulated/wall/r_wall,
@@ -114041,22 +115849,10 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/central/nw)
-"skC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/evidence)
+"skJ" = (
+/obj/structure/cult/archives,
+/turf/simulated/floor/plating,
+/area/maintenance/library)
 "skZ" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -114072,6 +115868,22 @@
 /obj/machinery/door/airlock/public/glass,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
+"slh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "sll" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -114108,6 +115920,15 @@
 	tag = "icon-whitebluecorner"
 	},
 /area/medical/sleeper)
+"slp" = (
+/obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology)
 "slr" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -114171,6 +115992,18 @@
 /obj/machinery/light,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/magistrateoffice)
+"slI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "slQ" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -114210,17 +116043,15 @@
 	},
 /area/medical/cloning)
 "smw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 4;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
+	dir = 1
 	},
 /area/security/processing)
 "smD" = (
@@ -114459,22 +116290,6 @@
 	icon_state = "darkblue"
 	},
 /area/medical/surgery/north)
-"spe" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "xeno5";
-	name = "Creature Cell #5";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology)
 "sps" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -114506,9 +116321,11 @@
 /area/medical/cmo)
 "spH" = (
 /obj/structure/closet/secure_closet/RD,
-/obj/effect/decal/warning_stripes/northeast,
 /obj/item/megaphone,
-/turf/simulated/floor/plasteel,
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/crew_quarters/hor)
 "spK" = (
 /obj/structure/cable{
@@ -114573,6 +116390,14 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
+"sqn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitehall"
+	},
+/area/maintenance/asmaint2)
 "sqo" = (
 /mob/living/simple_animal/hostile/carp/megacarp{
 	desc = "Странная космическая акула, летающая неподалёку от станции. Многие поговаривают, что данное существо - аватар могущественного блю-спейс божества";
@@ -114689,6 +116514,16 @@
 /area/maintenance/starboard{
 	name = "Engineering Maintenance"
 	})
+"srl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/wallmed{
+	pixel_y = 30
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purple"
+	},
+/area/maintenance/xenozoo)
 "srp" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -114754,14 +116589,6 @@
 	icon_state = "vault"
 	},
 /area/bridge)
-"srM" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/permabrig)
 "srP" = (
 /obj/structure/chair/sofa{
 	dir = 1
@@ -114853,6 +116680,13 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
+"stb" = (
+/obj/item/twohanded/required/kirbyplants,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken"
+	},
+/area/maintenance/library)
 "stf" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -114915,17 +116749,32 @@
 	tag = "icon-whiteblue (EAST)"
 	},
 /area/medical/sleeper)
-"stT" = (
-/obj/effect/decal/warning_stripes/red/hollow,
-/obj/structure/rack/gunrack,
-/obj/item/gun/energy/gun{
-	pixel_x = -7
+"stE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1
 	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
+"stT" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/item/gun/energy/gun{
-	pixel_x = 9
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/gun,
+/obj/item/gun/energy/gun{
+	pixel_x = 3;
+	pixel_y = -3
 	},
 /obj/structure/window/reinforced,
-/obj/item/gun/energy/gun,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -114947,18 +116796,26 @@
 /turf/simulated/floor/plating,
 /area/lawoffice)
 "suf" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/window/westright{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes/arrow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
 	},
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "sui" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
@@ -114988,6 +116845,36 @@
 	icon_state = "dark"
 	},
 /area/crew_quarters/courtroom)
+"sus" = (
+/obj/machinery/door_control{
+	id = "RnDChem";
+	name = "Chamber Blast Doors";
+	pixel_x = -24;
+	pixel_y = -5
+	},
+/obj/machinery/ignition_switch{
+	id = "testigniter";
+	pixel_x = -24;
+	pixel_y = 6
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
+	},
+/area/toxins/test_chamber)
 "sut" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
@@ -115068,21 +116955,20 @@
 	icon_state = "red"
 	},
 /area/security/armory)
+"suX" = (
+/turf/simulated/wall/r_wall/rust,
+/area/maintenance/asmaint2)
 "svh" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	name = "RD Junction";
-	sortType = 13
-	},
 /obj/structure/table/reinforced,
 /obj/item/aicard,
 /obj/item/circuitboard/aicore,
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "svo" = (
@@ -115098,11 +116984,6 @@
 /obj/effect/spawner/random_spawners/blood_maybe,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
-"svD" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurple"
-	},
-/area/toxins/misc_lab)
 "svL" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -115180,6 +117061,13 @@
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/lawoffice)
+"swG" = (
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology)
 "swI" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -115304,7 +117192,6 @@
 	},
 /area/maintenance/electrical)
 "sxt" = (
-/obj/effect/decal/warning_stripes/southeastcorner,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -115379,21 +117266,16 @@
 	},
 /area/crew_quarters/captain)
 "sxS" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/westright,
+/obj/structure/sign/poster/official/nanotrasen_logo{
+	pixel_y = 32
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "ramptop"
 	},
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "sxW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -115435,17 +117317,6 @@
 	icon_state = "grimy"
 	},
 /area/crew_quarters/captain)
-"sye" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft{
-	name = "Medbay Maintenance"
-	})
 "syf" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -115486,17 +117357,24 @@
 	},
 /area/medical/medbay)
 "sys" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
+/area/maintenance/asmaint2)
 "syv" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/white{
@@ -115548,18 +117426,11 @@
 	},
 /area/security/permabrig)
 "szb" = (
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
+	dir = 1
 	},
 /area/security/processing)
-"szc" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
-	},
-/turf/simulated/floor/engine,
-/area/toxins/test_chamber)
 "szd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -115578,10 +117449,19 @@
 	icon_state = "darkred"
 	},
 /area/security/securearmory)
+"szN" = (
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/maintenance/xenozoo)
 "szQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/writing,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/theatre)
 "szR" = (
 /turf/simulated/wall/r_wall,
 /area/chapel/office)
@@ -115716,31 +117596,31 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
-"sBx" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/item/reagent_containers/dropper/precision,
-/obj/item/reagent_containers/dropper/precision,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/dropper,
-/obj/item/storage/box/pillbottles,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/syringes,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurple"
+"sBn" = (
+/obj/effect/spawner/window/reinforced/plasma,
+/obj/machinery/door/poddoor{
+	name = "Supermatter Blast Doors";
+	density = 0;
+	opacity = 0;
+	id_tag = "engsm1"
 	},
-/area/toxins/misc_lab)
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/xenozoo)
+"sBx" = (
+/obj/machinery/camera{
+	c_tag = "Xeno Containment 1";
+	network = list("Research","SS13")
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/toxins/xenobiology)
 "sBL" = (
 /turf/simulated/wall/r_wall,
 /area/security/main)
@@ -115755,41 +117635,39 @@
 	},
 /area/crew_quarters/chief)
 "sCb" = (
-/turf/simulated/wall/r_wall,
-/area/security/evidence)
-"sCf" = (
-/obj/effect/decal/warning_stripes/northwest,
-/obj/machinery/disposal,
-/obj/structure/window/plasmareinforced{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitered"
 	},
-/obj/structure/window/plasmareinforced{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/engine,
-/area/toxins/misc_lab)
+/area/security/medbay)
 "sCp" = (
 /obj/machinery/light,
 /obj/structure/filingcabinet,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/magistrateoffice)
 "sCt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/writing{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
 	dir = 4;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
 	},
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "sCy" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -115875,6 +117753,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "darkred"
@@ -115886,6 +117769,20 @@
 	icon_state = "darkred"
 	},
 /area/maintenance/fpmaint)
+"sDq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10;
+	initialize_directions = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "sDu" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -116009,29 +117906,23 @@
 	name = "Virology Maintenance"
 	})
 "sEz" = (
-/obj/machinery/light{
-	dir = 1;
-	on = 1
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/blood/xeno,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/area/toxins/xenobiology)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "sEG" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/ai)
-"sEK" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
-"sEO" = (
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/engine,
-/area/toxins/misc_lab)
 "sEV" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -116050,15 +117941,6 @@
 	icon_state = "neutral"
 	},
 /area/crew_quarters/sleep)
-"sEZ" = (
-/obj/effect/decal/warning_stripes/northeast,
-/obj/machinery/chem_master,
-/obj/structure/window/plasmareinforced{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/engine,
-/area/toxins/misc_lab)
 "sFa" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/bottle/ether,
@@ -116077,6 +117959,20 @@
 	icon_state = "red"
 	},
 /area/security/range)
+"sFn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_spawners/grille_maybe,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "sFF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -116137,6 +118033,17 @@
 	icon_state = "dark"
 	},
 /area/security/podbay)
+"sGq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/crew_quarters/theatre)
 "sGz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light{
@@ -116158,6 +118065,25 @@
 	icon_state = "darkbluefull"
 	},
 /area/turret_protected/aisat_interior)
+"sGN" = (
+/obj/effect/decal/warning_stripes/yellow,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "purplefull"
+	},
+/area/toxins/xenobiology)
 "sGS" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -116188,14 +118114,49 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/lawoffice)
 "sHq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/door/airlock/research/glass{
+	name = "Experimentor";
+	req_access_txt = "47"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "experimentor";
+	name = "Experimentor Blast Door";
+	opacity = 0
 	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door_control{
+	id = "experimentor";
+	name = "Experimentor Control";
+	pixel_x = 26
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/engine,
 /area/toxins/explab)
+"sHy" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/mob/living/simple_animal/mouse,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/blood/writing,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/crew_quarters/theatre)
 "sHA" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -116230,17 +118191,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/blueshield)
-"sHY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "sIo" = (
 /obj/item/radio/intercom{
 	pixel_y = 21
@@ -116295,32 +118245,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/aisat_interior)
-"sIV" = (
-/obj/machinery/door/airlock/research/glass{
-	heat_proof = 1;
-	name = "Chemical Testing Room";
-	req_access_txt = "47"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "RnDChem";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/engine,
-/area/toxins/test_chamber)
 "sIX" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
@@ -116408,12 +118332,6 @@
 	tag = "icon-redfull (NORTHWEST)"
 	},
 /area/crew_quarters/kitchen)
-"sKK" = (
-/obj/effect/decal/warning_stripes/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/toxins/explab)
 "sKP" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/highsecurity{
@@ -116472,6 +118390,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/security/hos)
+"sMa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
+	},
+/area/toxins/explab)
 "sMh" = (
 /obj/structure/table,
 /obj/item/clothing/ears/earmuffs,
@@ -116529,22 +118457,11 @@
 	name = "Virology Maintenance"
 	})
 "sMF" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken6"
 	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "sMH" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -116675,6 +118592,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
+"sNM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/explab)
 "sNQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -116845,16 +118774,8 @@
 	},
 /area/security/range)
 "sPF" = (
-/obj/machinery/light/small,
-/obj/machinery/camera{
-	c_tag = "Xeno Containment 1";
-	dir = 1;
-	network = list("Research","SS13")
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/toxins/xenobiology)
+/turf/simulated/wall/r_wall/rust,
+/area/maintenance/xenozoo)
 "sPG" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -116970,12 +118891,6 @@
 /area/medical/research{
 	name = "Research Division"
 	})
-"sRk" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/hand_labeler,
-/turf/simulated/floor/engine,
-/area/toxins/test_chamber)
 "sRo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -117003,14 +118918,25 @@
 	},
 /area/bridge)
 "sRy" = (
-/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/space,
-/area/space/nearstation)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "sRA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -117054,20 +118980,37 @@
 	icon_state = "vault"
 	},
 /area/bridge)
-"sRM" = (
+"sRL" = (
+/obj/machinery/door/window/brigdoor{
+	dir = 2;
+	name = "Creature Pen";
+	req_access_txt = "47"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xeno5";
+	name = "Creature Cell #5";
+	opacity = 0
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "purple"
+	icon_state = "dark"
 	},
-/area/maintenance/xenozoo)
-"sRN" = (
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
+/area/toxins/xenobiology)
+"sRM" = (
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/space/nearstation)
+/area/toxins/explab)
 "sRV" = (
 /obj/item/radio/intercom{
 	pixel_y = 22
@@ -117121,6 +119064,18 @@
 	icon_state = "neutralfull"
 	},
 /area/bridge/checkpoint/south)
+"sSx" = (
+/obj/structure/sign/nosmoking_2{
+	pixel_x = -32
+	},
+/obj/structure/closet/emcloset,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTHWEST)"
+	},
+/area/medical/research/nhallway)
 "sSC" = (
 /obj/item/reagent_containers/food/snacks/meat/human,
 /obj/item/reagent_containers/food/snacks/meat/human,
@@ -117142,15 +119097,16 @@
 	},
 /area/security/prisonershuttle)
 "sSH" = (
-/obj/machinery/light_switch{
-	pixel_x = 26
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 27
 	},
-/obj/effect/decal/warning_stripes/southeast,
-/obj/machinery/chem_dispenser,
-/obj/effect/decal/warning_stripes/yellow,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/engine,
-/area/toxins/misc_lab)
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
+	},
+/area/toxins/test_chamber)
 "sSQ" = (
 /obj/item/shard{
 	icon_state = "medium";
@@ -117164,6 +119120,22 @@
 	icon_state = "tranquillite"
 	},
 /area/maintenance/kitchen)
+"sTk" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull";
+	tag = "icon-redfull (NORTHWEST)"
+	},
+/area/security/processing)
 "sTA" = (
 /obj/item/flag/sec,
 /obj/machinery/alarm{
@@ -117208,28 +119180,19 @@
 	icon_state = "red"
 	},
 /area/security/range)
-"sTR" = (
-/obj/structure/table/reinforced,
-/obj/item/bikehorn{
-	pixel_x = -1;
-	pixel_y = 13
+"sTX" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/item/instrument/bikehorn{
-	pixel_y = -2
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/obj/item/kitchen/utensil/spoon{
-	pixel_x = -3;
-	pixel_y = 18
-	},
-/obj/item/kitchen/utensil/fork{
-	pixel_x = -4;
-	pixel_y = 18
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/security/processing)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/maintenance/xenozoo)
 "sUa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -117257,36 +119220,6 @@
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/central/ne)
-"sUj" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/explab)
 "sUp" = (
 /obj/structure/closet/lawcloset,
 /obj/item/clothing/under/rank/internalaffairs,
@@ -117303,6 +119236,9 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 27
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -117365,16 +119301,6 @@
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/storage)
-"sVm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/security/processing)
 "sVx" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -117440,6 +119366,21 @@
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
+"sWj" = (
+/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/chem_master{
+	pixel_x = -1;
+	layer = 3.3
+	},
+/turf/simulated/floor/engine,
+/area/toxins/misc_lab)
 "sWp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -117456,29 +119397,28 @@
 /obj/item/storage/belt/holster,
 /obj/item/clothing/suit/jacket/leather/overcoat,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey,
-/obj/item/clothing/head/fedora,
+/obj/item/nullrod/fedora,
 /turf/simulated/floor/plating,
 /area/maintenance/detectives_office)
+"sWN" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/processing)
 "sXk" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "redcorner"
 	},
 /area/security/prisonershuttle)
-"sXq" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+"sXF" = (
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "darkred"
+	icon_state = "whitepurple"
 	},
-/area/security/interrogation)
+/area/toxins/misc_lab)
 "sXQ" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bottle/morphine{
@@ -117520,18 +119460,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"sYB" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/toxins/explab)
 "sYS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -117571,10 +119499,21 @@
 /turf/simulated/floor/carpet/black,
 /area/bridge/vip)
 "sZg" = (
-/obj/effect/decal/remains/xeno,
-/obj/effect/decal/cleanable/blood/xeno,
-/turf/simulated/floor/greengrid,
-/area/toxins/xenobiology)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "sZj" = (
 /obj/structure/chair/office/dark,
 /obj/structure/cable{
@@ -117744,6 +119683,42 @@
 	icon_state = "carpet"
 	},
 /area/crew_quarters/courtroom)
+"taT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_x = -32;
+	pixel_y = 32
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/xenozoo)
+"taV" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/hologram/holopad,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/landmark{
+	name = "lightsout"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology)
 "tbb" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -117756,6 +119731,13 @@
 	icon_state = "brown"
 	},
 /area/quartermaster/sorting)
+"tby" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/donut_box,
+/turf/simulated/floor/plasteel{
+	dir = 1
+	},
+/area/security/processing)
 "tbM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -117849,16 +119831,6 @@
 /area/maintenance/portsolar)
 "tcH" = (
 /obj/machinery/computer/secure_data,
-/obj/machinery/door_control{
-	id = "brig_detprivacy";
-	name = "Detective Privacy Shutters Control";
-	pixel_x = -6;
-	pixel_y = 22
-	},
-/obj/machinery/light_switch{
-	pixel_x = 6;
-	pixel_y = 24
-	},
 /turf/simulated/floor/wood,
 /area/security/detectives_office)
 "tcK" = (
@@ -117921,17 +119893,21 @@
 /turf/simulated/floor/plating,
 /area/security/hos)
 "tda" = (
-/obj/machinery/r_n_d/experimentor,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4
 	},
-/area/toxins/explab)
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
+	},
+/area/toxins/xenobiology)
 "tdf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "whitepurplecorner"
 	},
 /area/medical/research/restroom)
 "tdh" = (
@@ -118193,13 +120169,10 @@
 /area/security/securearmory)
 "tfy" = (
 /obj/machinery/vending/snack,
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2 (EAST)"
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
+	dir = 6;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (SOUTHEAST)"
 	},
 /area/medical/research/nhallway)
 "tfB" = (
@@ -118214,22 +120187,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "tfI" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
+	icon_state = "white"
 	},
-/area/toxins/explab)
+/area/toxins/xenobiology)
 "tfK" = (
 /obj/machinery/sleeper{
 	pixel_x = 3
@@ -118307,8 +120272,12 @@
 	name = "\improper AI Satellite Hallway"
 	})
 "tgM" = (
-/obj/effect/decal/remains/human,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "purplefull"
+	},
 /area/maintenance/xenozoo)
 "tgP" = (
 /obj/item/radio/intercom{
@@ -118378,14 +120347,16 @@
 /turf/simulated/floor/engine,
 /area/engine/controlroom)
 "thA" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/ants,
+/obj/structure/chair/comfy/beige{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/engine,
-/area/toxins/test_chamber)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/royalblue,
+/area/crew_quarters/theatre)
 "thO" = (
 /turf/simulated/wall,
 /area/security/customs)
@@ -118495,6 +120466,16 @@
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
+"tiD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/random{
+	pixel_x = -32
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "tiG" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -118639,14 +120620,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai)
-"tko" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/processing)
 "tkr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -118681,13 +120654,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
-"tkE" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/perma)
 "tkW" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -118804,19 +120770,6 @@
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
 	})
-"tmw" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_switch{
-	pixel_x = 24
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/security/processing)
 "tmB" = (
 /obj/effect/decal/warning_stripes/blue,
 /obj/structure/rack{
@@ -118863,11 +120816,39 @@
 	},
 /turf/simulated/floor/carpet,
 /area/lawoffice)
+"tmO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/grown/tomato{
+	pixel_x = 10;
+	pixel_y = 12
+	},
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/black,
+/area/crew_quarters/theatre)
 "tmR" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/structure/holosign/barrier,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 1
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
+"tmU" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "purple"
 	},
 /area/maintenance/xenozoo)
 "tmW" = (
@@ -118926,16 +120907,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/surgery/south)
-"tns" = (
-/obj/structure/window/reinforced,
-/obj/machinery/computer/med_data{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "whitered"
-	},
-/area/security/medbay)
 "tnM" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/teargas,
@@ -118946,9 +120917,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -22;
 	pixel_y = -8
-	},
-/obj/item/key/security{
-	pixel_y = 13
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -119005,6 +120973,12 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"toy" = (
+/obj/structure/sign/nosmoking_1{
+	pixel_x = 32
+	},
+/turf/simulated/floor/engine,
+/area/toxins/explab)
 "toB" = (
 /obj/item/radio/intercom{
 	pixel_x = -27
@@ -119270,14 +121244,17 @@
 	name = "\improper AI Satellite Hallway"
 	})
 "tsu" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/gloves/color/white,
-/obj/item/clothing/gloves/color/white,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel,
-/area/toxins/explab)
+/obj/machinery/camera{
+	c_tag = "Xeno Containment 3";
+	network = list("Research","SS13")
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/toxins/xenobiology)
 "tsB" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluecorner";
@@ -119285,11 +121262,17 @@
 	},
 /area/medical/sleeper)
 "tsG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/vending/plasmaresearch,
+/obj/structure/sign/nosmoking_2{
+	pixel_y = 32
 	},
-/turf/simulated/wall/r_wall/coated,
-/area/toxins/test_chamber)
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTHWEST)"
+	},
+/area/toxins/misc_lab)
 "tsS" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light_switch{
@@ -119347,14 +121330,21 @@
 	},
 /area/medical/biostorage)
 "ttc" = (
-/obj/machinery/sleeper{
-	dir = 4
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitered"
+	icon_state = "redfull";
+	tag = "icon-redfull (NORTHWEST)"
 	},
-/area/security/medbay)
+/area/security/processing)
 "ttw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -119387,13 +121377,13 @@
 	},
 /area/crew_quarters/fitness)
 "tui" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
 /area/toxins/xenobiology)
 "tum" = (
 /obj/machinery/light{
@@ -119434,14 +121424,6 @@
 	},
 /turf/space,
 /area/space/nearstation)
-"tuS" = (
-/obj/machinery/vending/security,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "red"
-	},
-/area/security/processing)
 "tuT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -119465,12 +121447,9 @@
 	},
 /area/security/customs)
 "tuY" = (
-/obj/machinery/light,
-/obj/item/twohanded/required/kirbyplants,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
+/obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
+	dir = 6;
 	icon_state = "red"
 	},
 /area/security/processing)
@@ -119496,20 +121475,6 @@
 	icon_state = "solarpanel"
 	},
 /area/solar/port)
-"tvu" = (
-/obj/machinery/camera{
-	c_tag = "Prisoner Processing East";
-	dir = 8;
-	network = list("SS13","Security")
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/security/processing)
 "tvK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -119584,8 +121549,13 @@
 /area/security/hos)
 "twh" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/crew_quarters/theatre)
 "two" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -119596,11 +121566,6 @@
 	icon_state = "red"
 	},
 /area/security/securehallway)
-"twN" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/mask/gas,
-/turf/simulated/floor/engine,
-/area/toxins/test_chamber)
 "twP" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
@@ -119635,7 +121600,7 @@
 	dir = 8;
 	icon_state = "neutral"
 	},
-/area/toxins/mixing)
+/area/toxins/launch)
 "txk" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -119650,13 +121615,8 @@
 	},
 /area/turret_protected/aisat_interior)
 "txl" = (
-/obj/structure/table/wood,
-/obj/item/soap,
-/obj/machinery/light,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
-	},
+/mob/living/simple_animal/mouse,
+/turf/simulated/floor/plating,
 /area/maintenance/fsmaint2{
 	name = "Tourist Area Maintenance"
 	})
@@ -119689,6 +121649,10 @@
 	tag = "icon-redfull (NORTHWEST)"
 	},
 /area/security/permahallway)
+"txB" = (
+/obj/structure/sign/fire,
+/turf/simulated/wall/r_wall,
+/area/toxins/launch)
 "txD" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/effect/decal/cleanable/dirt,
@@ -119696,15 +121660,6 @@
 /area/maintenance/consarea{
 	name = "Virology Maintenance Construction Area"
 	})
-"txE" = (
-/obj/machinery/atmospherics/unary/portables_connector,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "txI" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -119718,6 +121673,14 @@
 	icon_state = "neutralfull"
 	},
 /area/engine/break_room)
+"tyd" = (
+/obj/machinery/constructable_frame/machine_frame,
+/obj/structure/cable,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "purple"
+	},
+/area/maintenance/xenozoo)
 "tyn" = (
 /obj/machinery/photocopier,
 /obj/structure/extinguisher_cabinet{
@@ -119897,25 +121860,6 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
-"tzZ" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 1;
-	on = 1
-	},
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/light_switch{
-	pixel_x = 4;
-	pixel_y = 26
-	},
-/obj/item/radio/intercom{
-	dir = 1;
-	pixel_x = 28
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "tAq" = (
 /obj/item/shard,
 /obj/effect/decal/cleanable/dirt,
@@ -119955,6 +121899,48 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/kitchen)
+"tAK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
+"tBj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/crew_quarters/theatre)
 "tBr" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -120015,6 +122001,22 @@
 /area/maintenance/port{
 	name = "Brig Maintenance"
 	})
+"tCg" = (
+/obj/structure/chair/wood/wings{
+	dir = 8;
+	tag = "icon-wooden_chair_wings (WEST)"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "tCj" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -120066,6 +122068,17 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/sw)
+"tCG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -26
+	},
+/obj/structure/cable,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/maintenance/library)
 "tCM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -120099,14 +122112,17 @@
 	},
 /area/security/execution)
 "tCR" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "darkred"
-	},
-/area/security/permabrig)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "tDc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -120126,6 +122142,18 @@
 	icon_state = "grimy"
 	},
 /area/chapel/main)
+"tDh" = (
+/obj/structure/safe/floor,
+/obj/item/melee/cultblade,
+/obj/item/restraints/legcuffs/bola/cult,
+/obj/item/whetstone/cult,
+/obj/item/stack/sheet/runed_metal{
+	amount = 50
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/maintenance/library)
 "tDB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -120146,9 +122174,11 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/south,
-/obj/item/twohanded/required/kirbyplants,
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -120168,6 +122198,16 @@
 	icon_state = "darkblue"
 	},
 /area/bridge)
+"tEe" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 4;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "tEg" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -120222,22 +122262,15 @@
 	},
 /area/bridge)
 "tEB" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/firealarm{
+	pixel_y = 26
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurplecorner"
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
-/area/medical/research/shallway)
+/area/medical/research/nhallway)
 "tED" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -120319,18 +122352,19 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
+"tEO" = (
+/obj/machinery/atmospherics/unary/portables_connector,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/maintenance/asmaint2)
 "tFd" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"tFf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/evidence)
 "tFj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -120358,16 +122392,15 @@
 	},
 /area/library)
 "tFv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/processing)
 "tFz" = (
@@ -120567,16 +122600,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
-"tHp" = (
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "red"
-	},
-/area/security/processing)
-"tHr" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "tHz" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -120633,7 +122656,8 @@
 	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_x = -24
+	pixel_x = -24;
+	pixel_y = -8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -120754,12 +122778,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker/locker_toilet)
-"tJh" = (
-/mob/living/simple_animal/pet/dog/pug,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/toxins/explab)
 "tJk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
@@ -120780,6 +122798,17 @@
 	icon_state = "grimy"
 	},
 /area/crew_quarters/bar/atrium)
+"tJL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/item/stack/sheet/wood,
+/turf/simulated/floor/plating,
+/area/maintenance/library)
 "tJM" = (
 /obj/machinery/light_switch{
 	pixel_x = 4;
@@ -120820,25 +122849,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
-"tJX" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id_tag = "Evidence Storage"
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "BridgeLockdown";
-	name = "Bridge Lockdown"
-	},
-/turf/simulated/floor/plating,
-/area/security/evidence)
 "tKa" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -120848,15 +122858,12 @@
 	},
 /area/hallway/primary/central/sw)
 "tKh" = (
-/obj/structure/chair,
-/obj/item/radio/intercom{
-	pixel_y = 30
-	},
+/obj/structure/closet/secure_closet/brig/evidence,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	dir = 8;
+	icon_state = "vault"
 	},
-/area/security/processing)
+/area/security/evidence)
 "tKj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/north,
@@ -120882,17 +122889,12 @@
 /turf/simulated/floor/wood,
 /area/security/detectives_office)
 "tKK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/table,
+/obj/item/book/manual/security_space_law,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "red"
+	icon_state = "redfull";
+	tag = "icon-redfull (NORTHWEST)"
 	},
 /area/security/processing)
 "tKL" = (
@@ -120929,20 +122931,20 @@
 /turf/space,
 /area/space/nearstation)
 "tLc" = (
-/obj/effect/spawner/window/reinforced,
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	name = "Creature Pen";
+	req_access_txt = "47"
+	},
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "xeno6";
-	name = "Creature Cell #6";
-	opacity = 0
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/turf/simulated/floor/plating,
 /area/toxins/xenobiology)
 "tLf" = (
 /obj/structure/cable{
@@ -121014,22 +123016,6 @@
 	icon_state = "darkblue"
 	},
 /area/bridge)
-"tLB" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "tLD" = (
 /turf/simulated/wall,
 /area/security/permabrig)
@@ -121434,16 +123420,48 @@
 	},
 /area/bridge)
 "tOD" = (
-/obj/machinery/light/small,
-/obj/machinery/camera{
-	c_tag = "Xeno Containment 3";
-	dir = 1;
-	network = list("Research","SS13")
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
+"tOE" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/door/airlock/research/glass{
+	name = "Chemical Toxins";
+	req_access_txt = "47";
+	id = "chem";
+	id_tag = "chem"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "white"
 	},
-/area/toxins/xenobiology)
+/area/toxins/misc_lab)
 "tON" = (
 /turf/simulated/floor/carpet,
 /area/crew_quarters/fitness)
@@ -121496,10 +123514,26 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar/atrium)
+"tPn" = (
+/obj/effect/spawner/window/reinforced/plasma,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/toxins/mixing)
 "tPv" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
+"tPC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitehall"
+	},
+/area/maintenance/asmaint2)
 "tPD" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 1;
@@ -121595,6 +123629,19 @@
 /area/maintenance/aft{
 	name = "Medbay Maintenance"
 	})
+"tQD" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology)
 "tQF" = (
 /obj/machinery/light{
 	dir = 4
@@ -121894,6 +123941,28 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/detectives_office)
+"tUn" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/item/pen{
+	pixel_x = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
+	},
+/area/toxins/misc_lab)
+"tUo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/xenozoo)
 "tUB" = (
 /obj/machinery/vending/snack,
 /obj/effect/decal/warning_stripes/red/hollow,
@@ -122004,6 +124073,11 @@
 	icon_state = "green"
 	},
 /area/hallway/secondary/exit)
+"tVD" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/wood,
+/area/maintenance/library)
 "tVP" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -122071,34 +124145,6 @@
 "tWn" = (
 /turf/simulated/wall,
 /area/security/execution)
-"tWK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft{
-	name = "Medbay Maintenance"
-	})
-"tWL" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "xeno4";
-	name = "Creature Cell #4";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology)
 "tWM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -122254,6 +124300,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/detectives_office)
+"tYh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/sosjerky,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken6"
+	},
+/area/crew_quarters/theatre)
 "tYi" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -122289,14 +124342,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/cabin2)
-"tYs" = (
-/obj/structure/table,
-/obj/item/clothing/under/color/orange/prison,
-/obj/item/clothing/shoes/orange,
-/obj/item/wrench,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/perma)
 "tYx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -122317,6 +124362,28 @@
 	icon_state = "darkblue"
 	},
 /area/chapel/main)
+"tYE" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/beakers,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
+	},
+/area/toxins/misc_lab)
 "tYG" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -122394,13 +124461,22 @@
 	},
 /area/medical/surgery/south)
 "tZs" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/obj/machinery/light,
-/turf/simulated/floor/wood,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;47"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "tZI" = (
 /obj/structure/disposalpipe/junction{
 	dir = 2;
@@ -122417,6 +124493,18 @@
 	icon_state = "brown"
 	},
 /area/quartermaster/sorting)
+"tZL" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology)
 "tZN" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -122435,30 +124523,14 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
-"tZU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/explab)
 "ual" = (
-/obj/item/radio/intercom{
-	pixel_y = 24
+/obj/machinery/alarm{
+	pixel_y = 22
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurplecorner"
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
 /area/medical/research/nhallway)
 "uaF" = (
@@ -122504,11 +124576,12 @@
 	},
 /area/security/processing)
 "ubu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/comfy/beige{
+	dir = 1
 	},
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/turf/simulated/floor/carpet/royalblue,
+/area/crew_quarters/theatre)
 "ubA" = (
 /obj/structure/table,
 /obj/item/clipboard,
@@ -122561,6 +124634,25 @@
 /area/maintenance/aft{
 	name = "Medbay Maintenance"
 	})
+"ucb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "ucf" = (
 /obj/machinery/disposal,
 /obj/machinery/alarm{
@@ -122572,6 +124664,33 @@
 	icon_state = "whitebluecorner"
 	},
 /area/medical/surgery/north)
+"uch" = (
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	name = "Creature Pen";
+	req_access_txt = "47"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xeno2";
+	name = "Creature Cell #2";
+	opacity = 0
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/toxins/xenobiology)
 "ucx" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -122579,14 +124698,13 @@
 	},
 /area/chapel/main)
 "ucB" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/effect/landmark{
+	color = "#00ae00";
+	icon_state = "x_white";
+	name = "ninja_teleport"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkredcorners"
-	},
-/area/security/evidence)
+/turf/simulated/floor/plating,
+/area/maintenance/perma)
 "ucJ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
@@ -122673,13 +124791,8 @@
 	},
 /area/crew_quarters/locker)
 "udm" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/medical/research/nhallway)
+/turf/simulated/wall/r_wall,
+/area/toxins/explab)
 "udw" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -122790,16 +124903,6 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
-"uex" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
 "uey" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -122843,6 +124946,10 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/bridge/vip)
+"ueV" = (
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "ufg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -123040,28 +125147,21 @@
 	},
 /area/hallway/primary/central/ne)
 "ugu" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
-	name = "Evidence Storage";
-	req_access_txt = "63"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/item/twohanded/required/kirbyplants,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 26
 	},
 /obj/structure/cable{
-	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "darkredfull"
+	dir = 4;
+	icon_state = "whitered"
 	},
-/area/security/evidence)
+/area/security/medbay)
 "ugy" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
@@ -123293,12 +125393,9 @@
 	},
 /obj/item/flashlight/lamp,
 /obj/item/paper/monitorkey,
-/obj/item/paper/rnd_logs_key{
-	pixel_x = 6;
-	pixel_y = 6
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
+	icon_state = "dark"
 	},
 /area/crew_quarters/hor)
 "ujm" = (
@@ -123467,20 +125564,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/permabrig)
-"ulN" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/processing)
 "umd" = (
 /obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
+"ump" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/grille/broken,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "umr" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -123531,6 +125633,16 @@
 	icon_state = "red"
 	},
 /area/security/securehallway)
+"umE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/fancy/black,
+/obj/item/flashlight/lamp/green{
+	on = 0;
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/turf/simulated/floor/carpet/royalblack,
+/area/maintenance/asmaint2)
 "umL" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
@@ -123675,6 +125787,26 @@
 /area/maintenance/aft{
 	name = "Medbay Maintenance"
 	})
+"unY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "uob" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -123774,11 +125906,28 @@
 /area/quartermaster/storage)
 "upr" = (
 /obj/effect/decal/warning_stripes/south,
+/obj/machinery/light_switch{
+	pixel_x = 6;
+	pixel_y = -26
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutral"
 	},
 /area/toxins/mixing)
+"upu" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/computerframe,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purple"
+	},
+/area/maintenance/xenozoo)
 "upx" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -123874,6 +126023,31 @@
 /obj/machinery/shieldgen,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
+"uqr" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
 "uqu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -123927,6 +126101,21 @@
 	icon_state = "tranquillite"
 	},
 /area/maintenance/kitchen)
+"ure" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/door_control{
+	id = "xeno4";
+	name = "Containment Control";
+	pixel_y = -28;
+	req_access_txt = "55"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology)
 "urn" = (
 /obj/structure/rack{
 	dir = 8;
@@ -123976,13 +126165,11 @@
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "usd" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/barricade/wooden,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology)
 "usx" = (
 /obj/machinery/light/small,
 /obj/item/radio/intercom{
@@ -124041,9 +126228,14 @@
 	},
 /area/crew_quarters/courtroom)
 "utb" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "utf" = (
 /obj/effect/landmark/burnturf,
 /obj/effect/landmark/damageturf,
@@ -124097,6 +126289,30 @@
 	},
 /turf/simulated/floor/plating,
 /area/assembly/robotics)
+"uub" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research/nhallway)
 "uue" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -124161,6 +126377,9 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
+"uuy" = (
+/turf/simulated/wall,
+/area/toxins/test_chamber)
 "uuA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -124263,16 +126482,26 @@
 	},
 /area/medical/genetics)
 "uve" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/machinery/door/airlock/research{
+	name = "Chemical Toxins";
+	req_access_txt = "47"
 	},
-/obj/machinery/disposal,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/misc_lab)
 "uvp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -124389,12 +126618,6 @@
 	tag = "icon-asteroid (NORTH)"
 	},
 /area/hydroponics)
-"uwp" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
 "uws" = (
 /obj/machinery/vending/cola,
 /obj/effect/decal/warning_stripes/yellow,
@@ -124406,6 +126629,24 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/fitness)
+"uwD" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "uwP" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
@@ -124439,15 +126680,32 @@
 /area/maintenance/starboard{
 	name = "Engineering Maintenance"
 	})
-"uxj" = (
+"uxh" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurple"
+	},
+/area/toxins/explab)
+"uxj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "purple"
+	},
+/area/maintenance/xenozoo)
 "uxy" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -124470,6 +126728,21 @@
 	icon_state = "dark"
 	},
 /area/chapel/main)
+"uxE" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Xeno Kill Room";
+	network = list("Research","SS13");
+	dir = 1
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark";
+	temperature = 80
+	},
+/area/toxins/xenobiology)
 "uxL" = (
 /obj/machinery/recharge_station,
 /obj/effect/decal/warning_stripes/red/hollow,
@@ -124525,6 +126798,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
 	id = "execution"
@@ -124537,10 +126811,6 @@
 	dir = 4;
 	id = "execution"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/security/execution)
 "uyr" = (
@@ -124559,27 +126829,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/security/execution)
-"uyw" = (
-/obj/structure/table/reinforced,
-/obj/item/flashlight{
-	pixel_y = 4
-	},
-/obj/item/wirecutters{
-	pixel_y = 18
-	},
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 25
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkred"
-	},
-/area/security/processing)
 "uyD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -124787,6 +127036,11 @@
 	},
 /obj/structure/cable{
 	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
@@ -124858,6 +127112,14 @@
 	icon_state = "dark"
 	},
 /area/security/hos)
+"uBL" = (
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
+	},
+/area/toxins/explab)
 "uBQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -124920,6 +127182,13 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
+"uCo" = (
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/test_chamber)
 "uCs" = (
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -124956,6 +127225,30 @@
 	icon_state = "caution"
 	},
 /area/maintenance/bar)
+"uCQ" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4
+	},
+/obj/structure/sign/vacuum{
+	pixel_y = -32
+	},
+/obj/machinery/door_control{
+	id = "smbolts1";
+	name = "Supermatter Bolt Control";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	pixel_x = -26;
+	pixel_y = -6
+	},
+/obj/machinery/door_control{
+	id = "engsm1";
+	name = "Supermatter Blast Doors";
+	pixel_x = -26;
+	pixel_y = 6
+	},
+/turf/simulated/floor/engine,
+/area/maintenance/xenozoo)
 "uCS" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "swall_f6"
@@ -125127,12 +127420,8 @@
 	name = "\improper Virology Lobby"
 	})
 "uFo" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
+/turf/simulated/wall/r_wall/coated,
+/area/maintenance/xenozoo)
 "uFp" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -125185,13 +127474,13 @@
 /turf/simulated/wall/r_wall,
 /area/space/nearstation)
 "uFM" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "SecMedPrivInside"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/security/medbay)
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/processing)
 "uFO" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -125305,17 +127594,32 @@
 	},
 /area/turret_protected/aisat_interior)
 "uHq" = (
-/obj/structure/bed,
-/obj/item/bedsheet/rainbow,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology)
 "uHt" = (
 /obj/structure/cable,
 /obj/effect/spawner/window/reinforced/plasma,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
 "uHu" = (
@@ -125500,20 +127804,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door_control{
+	id = "xeno5";
+	name = "Containment Control";
+	pixel_y = -28;
+	req_access_txt = "55"
 	},
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
-"uJd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/remains/human,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "whitepurple"
 	},
-/area/maintenance/gambling_den)
+/area/toxins/xenobiology)
 "uJi" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -125561,16 +127861,17 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "purplefull"
 	},
 /area/medical/research/nhallway)
 "uJw" = (
-/obj/structure/table/wood/poker,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/area/maintenance/gambling_den)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "uJx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -125596,6 +127897,15 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar/atrium)
+"uJH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurplecorner"
+	},
+/area/toxins/xenobiology)
 "uJJ" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -125632,12 +127942,29 @@
 	name = "Virology Maintenance"
 	})
 "uKk" = (
-/obj/structure/sign/redcross{
-	pixel_y = 32
+/obj/structure/table/reinforced,
+/obj/item/bikehorn{
+	pixel_x = -1;
+	pixel_y = 13
+	},
+/obj/item/instrument/bikehorn{
+	pixel_y = -2
+	},
+/obj/item/kitchen/utensil/spoon{
+	pixel_x = -3;
+	pixel_y = 18
+	},
+/obj/item/kitchen/utensil/fork{
+	pixel_x = -4;
+	pixel_y = 18
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	dir = 10;
+	icon_state = "darkred"
 	},
 /area/security/processing)
 "uKo" = (
@@ -125673,22 +128000,44 @@
 	icon_state = "darkblue"
 	},
 /area/medical/surgery/south)
-"uKN" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
+"uKM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 4;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
+"uKN" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6
+	},
+/obj/effect/decal/warning_stripes/northwest,
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/area/toxins/test_chamber)
 "uKQ" = (
-/obj/structure/table/wood/poker,
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/secure/briefcase{
+	pixel_x = 8;
+	pixel_y = 4
+	},
+/obj/structure/chair/comfy/beige{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "uKR" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -125771,19 +128120,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/south)
-"uLD" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "uLR" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -125819,10 +128155,23 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "uLY" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/area/security/medbay)
+/obj/structure/table/reinforced,
+/obj/item/mmi{
+	pixel_x = 1;
+	pixel_y = -9
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkred"
+	},
+/area/security/processing)
 "uMn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -125933,11 +128282,16 @@
 	},
 /area/security/brigstaff)
 "uNV" = (
-/obj/structure/chair/wood/wings{
-	dir = 8;
-	tag = "icon-wooden_chair_wings (WEST)"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1
+	},
 /area/maintenance/fsmaint2{
 	name = "Tourist Area Maintenance"
 	})
@@ -125987,11 +128341,11 @@
 	},
 /area/construction/hallway)
 "uOt" = (
-/turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "red"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/security/processing)
+/turf/simulated/wall/r_wall,
+/area/security/evidence)
 "uOu" = (
 /obj/structure/chair/comfy/red{
 	dir = 4
@@ -126049,28 +128403,6 @@
 	},
 /turf/space,
 /area/space/nearstation)
-"uOZ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -9;
-	pixel_y = 5
-	},
-/obj/item/flash{
-	pixel_x = 1;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka{
-	pixel_x = 5;
-	pixel_y = -3
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/security/processing)
 "uPa" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -126120,14 +128452,39 @@
 /obj/machinery/hydroponics/soil,
 /turf/simulated/floor/grass,
 /area/hydroponics)
+"uPx" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/pie{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/snacks/grown/banana{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/snacks/grown/banana{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/snacks/grown/banana,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/mirror{
+	icon_state = "mirror_broke";
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "uPB" = (
 /obj/structure/dresser,
 /obj/machinery/vending/wallmed{
 	pixel_x = 26
 	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurplecorner"
+	icon_state = "dark"
 	},
 /area/crew_quarters/hor)
 "uPF" = (
@@ -126160,19 +128517,10 @@
 	},
 /area/medical/medbay)
 "uPX" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "uQb" = (
 /obj/structure/disposalpipe/sortjunction{
 	name = "CE's Junction";
@@ -126215,11 +128563,13 @@
 	},
 /area/security/main)
 "uQr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology)
 "uQy" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
@@ -126320,19 +128670,6 @@
 	icon_state = "caution"
 	},
 /area/maintenance/bar)
-"uRn" = (
-/obj/effect/decal/warning_stripes/northwest,
-/obj/machinery/chem_heater,
-/obj/structure/window/plasmareinforced{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/camera{
-	c_tag = "Chemical Toxins Lab";
-	network = list("Research","SS13")
-	},
-/turf/simulated/floor/engine,
-/area/toxins/misc_lab)
 "uRr" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -126346,24 +128683,30 @@
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "uRG" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
+/obj/structure/chair{
+	desc = "Этот красивый стул был отлит из двух трофейных боргов синдиката.";
+	name = "Дизайнерский стул"
+	},
+/obj/machinery/shower{
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/medical{
-	name = "Brig Medical Bay";
-	req_access_txt = "63"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whiteredfull"
+	dir = 8;
+	icon_state = "vault"
 	},
-/area/security/medbay)
+/area/security/processing)
 "uRI" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -126400,33 +128743,25 @@
 	icon_state = "whitebluecorner"
 	},
 /area/medical/genetics)
-"uRW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+"uSt" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "red"
-	},
-/area/security/processing)
-"uSt" = (
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	tag = "icon-pipe-j2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "purplefull"
 	},
 /area/medical/research/nhallway)
 "uSv" = (
@@ -126446,6 +128781,10 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
+"uSK" = (
+/obj/effect/decal/cleanable/blood/xeno,
+/turf/simulated/floor/greengrid,
+/area/toxins/xenobiology)
 "uSR" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -126467,19 +128806,13 @@
 	},
 /area/medical/genetics)
 "uSY" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	id = "visiting room";
-	id_tag = "visiting room";
-	name = "Visiting Room";
-	req_access_txt = "63"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "darkredfull"
+	icon_state = "red"
 	},
-/area/security/interrogation)
+/area/security/processing)
 "uTb" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluefull"
@@ -126498,13 +128831,12 @@
 	},
 /area/medical/virology/lab)
 "uTm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/structure/table/wood,
+/obj/item/folder{
+	pixel_y = 3
 	},
-/obj/effect/landmark{
-	name = "xeno_spawn";
-	pixel_x = -1
+/obj/item/stack/tape_roll{
+	pixel_y = -5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/library)
@@ -126551,6 +128883,16 @@
 	icon_state = "darkred"
 	},
 /area/security/securearmory)
+"uTU" = (
+/obj/structure/sign/chemistry{
+	pixel_x = 32
+	},
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/medical/research/nhallway)
 "uUa" = (
 /obj/machinery/light{
 	dir = 4
@@ -126610,17 +128952,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior)
-"uUT" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "2"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/perma)
 "uUW" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -126663,6 +128994,23 @@
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
 	})
+"uVn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "purplefull"
+	},
+/area/medical/research/nhallway)
 "uVw" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -126824,23 +129172,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "uXc" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/structure/table,
+/obj/item/paper/deltainfo,
+/obj/machinery/status_display{
+	pixel_x = -32
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 26
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (SOUTHWEST)"
 	},
-/obj/machinery/camera{
-	c_tag = "Experimentation Lab Office";
-	network = list("Research","SS13")
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/obj/machinery/telepad_cargo,
-/turf/simulated/floor/plasteel,
-/area/toxins/explab)
+/area/medical/research/nhallway)
 "uXf" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -126923,10 +129265,15 @@
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "uXU" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/crew_quarters/theatre)
 "uXX" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -126974,6 +129321,22 @@
 /obj/structure/grille,
 /turf/simulated/wall/r_wall,
 /area/atmos)
+"uYv" = (
+/obj/machinery/door_control{
+	id = "xenokill";
+	name = "Xenobio Kill Room Bolts";
+	normaldoorcontrol = 1;
+	pixel_x = 30;
+	specialfunctions = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/machinery/door/airlock/research/glass{
+	id_tag = "xenokill";
+	locked = 1;
+	name = "Xenobio Kill Room"
+	},
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology)
 "uYw" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -126994,18 +129357,9 @@
 	},
 /area/hallway/secondary/exit)
 "uYP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_spawners/fungus_maybe,
+/turf/simulated/wall,
 /area/maintenance/library)
 "uYS" = (
 /obj/structure/window/reinforced{
@@ -127149,6 +129503,21 @@
 	dir = 1
 	},
 /area/security/main)
+"uZZ" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 26
+	},
+/obj/structure/filingcabinet/chestdrawer,
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (SOUTHEAST)"
+	},
+/area/toxins/explab)
 "vad" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -127202,12 +129571,14 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "vaH" = (
-/obj/structure/chair/office/light{
-	dir = 4
+/obj/structure/closet/l3closet/scientist,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (SOUTHWEST)"
 	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/area/toxins/explab)
 "vaS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/rods,
@@ -127254,8 +129625,12 @@
 	},
 /area/hallway/primary/port)
 "vbw" = (
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "vbJ" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -127309,15 +129684,29 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "vcj" = (
-/obj/effect/decal/cleanable/vomit,
-/obj/effect/landmark{
-	name = "blobstart"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/newscaster{
+	pixel_y = 32
 	},
-/obj/item/flag/syndi,
+/obj/item/trash/syndi_cakes{
+	pixel_y = 7
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "darkblue"
 	},
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "vct" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/power/port_gen/pacman,
@@ -127358,6 +129747,19 @@
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/lawoffice)
+"vcS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
 "vcX" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -127373,18 +129775,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/west)
-"vdu" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Xeno Containment 6";
-	network = list("Research","SS13")
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/toxins/xenobiology)
 "vdz" = (
 /obj/item/flag/nt,
 /turf/simulated/floor/plasteel{
@@ -127431,20 +129821,31 @@
 	},
 /area/medical/paramedic)
 "veO" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	id_tag = "sw_maint_airlock";
+	pixel_y = 25;
+	tag_airpump = "sw_maint_pump";
+	tag_chamber_sensor = "sw_maint_sensor";
+	tag_exterior_door = "sw_maint_outer";
+	tag_interior_door = "sw_maint_inner"
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "xenosecure";
-	name = "Secure Creature Cell";
-	opacity = 0
+/obj/machinery/airlock_sensor{
+	id_tag = "sw_maint_sensor";
+	pixel_y = 33
 	},
-/obj/effect/spawner/window/reinforced/plasma,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1379;
+	id_tag = "sw_maint_pump"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
-/area/toxins/xenobiology)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "vfa" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -127634,6 +130035,21 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
+"vhg" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/blood/writing{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/theatre)
 "vhp" = (
 /obj/structure/bed,
 /obj/item/radio/intercom{
@@ -127754,9 +130170,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "purplefull"
-	},
+/turf/simulated/floor/carpet/purple,
 /area/crew_quarters/hor)
 "vic" = (
 /turf/simulated/floor/plasteel{
@@ -127774,16 +130188,6 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
-"vik" = (
-/obj/structure/table/reinforced,
-/obj/item/camera,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
 "viq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -127911,9 +130315,14 @@
 	},
 /area/medical/genetics)
 "vkm" = (
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/obj/item/trash/spentcasing,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "vku" = (
 /turf/simulated/wall,
 /area/security/permahallway)
@@ -127937,22 +130346,32 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/prisonershuttle)
+"vkR" = (
+/obj/structure/chair/wood/wings{
+	dir = 8;
+	tag = "icon-wooden_chair_wings (WEST)"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "vkS" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/teleporter/abandoned)
 "vkV" = (
-/obj/effect/decal/warning_stripes/yellow,
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/structure/sign/deathsposal{
-	pixel_x = -32
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "vkX" = (
 /obj/effect/decal/ants,
 /turf/simulated/floor/plating,
@@ -127971,42 +130390,18 @@
 	icon_state = "whitepurple"
 	},
 /area/medical/genetics)
-"vlf" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "xeno2";
-	name = "Creature Cell #4";
-	opacity = 0
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 2;
-	name = "Creature Pen";
-	req_access_txt = "47"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/toxins/xenobiology)
 "vlh" = (
 /obj/machinery/bodyscanner,
 /obj/machinery/light/spot,
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
 "vli" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/decal/warning_stripes/northeast,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plasteel,
-/area/toxins/mixing)
+/area/toxins/launch)
 "vly" = (
 /obj/machinery/suit_storage_unit/engine,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -128027,7 +130422,7 @@
 /area/security/securehallway)
 "vlG" = (
 /turf/simulated/wall,
-/area/toxins/mixing)
+/area/toxins/launch)
 "vlH" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/unres{
@@ -128049,7 +130444,6 @@
 /area/medical/psych)
 "vlU" = (
 /obj/machinery/requests_console{
-	department = "Detective";
 	name = "Detective Requests Console";
 	pixel_x = -32
 	},
@@ -128072,9 +130466,9 @@
 /turf/simulated/floor/wood,
 /area/ntrep)
 "vmj" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	dir = 1
 	},
 /area/security/processing)
 "vmn" = (
@@ -128113,21 +130507,19 @@
 /area/medical/medbay)
 "vmL" = (
 /obj/effect/decal/warning_stripes/east,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/toxins/mixing)
-"vmP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10;
-	initialize_directions = 10
+/area/toxins/launch)
+"vmT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
 /area/maintenance/fsmaint2{
 	name = "Tourist Area Maintenance"
 	})
@@ -128163,9 +130555,7 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
+/turf/simulated/floor/carpet/purple,
 /area/crew_quarters/hor)
 "vns" = (
 /obj/structure/lattice,
@@ -128174,15 +130564,6 @@
 	},
 /turf/space,
 /area/space/nearstation)
-"vnu" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
-	},
-/area/medical/research/nhallway)
 "vnH" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -128215,6 +130596,19 @@
 	icon_state = "dark"
 	},
 /area/medical/genetics)
+"voe" = (
+/obj/machinery/power/emitter{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/maintenance/xenozoo)
 "vof" = (
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
@@ -128246,36 +130640,45 @@
 	},
 /area/medical/genetics)
 "vor" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/structure/girder,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
+/area/maintenance/xenozoo)
 "vos" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/experimentor,
-/obj/item/healthanalyzer,
-/obj/effect/decal/warning_stripes/northwestcorner,
-/turf/simulated/floor/plasteel,
-/area/toxins/explab)
+/obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurplecorner"
+	},
+/area/toxins/xenobiology)
 "vov" = (
 /obj/structure/grille/broken,
 /obj/structure/inflatable/door,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "voL" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/closet/secure_closet/research_reagents,
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = -8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "purplefull"
+	dir = 10;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (SOUTHWEST)"
 	},
-/area/toxins/xenobiology)
+/area/toxins/misc_lab)
 "voP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -128324,6 +130727,23 @@
 	icon_state = "darkblue"
 	},
 /area/medical/surgery/south)
+"vpe" = (
+/obj/structure/barricade/wooden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/research{
+	name = "Research Division Access";
+	req_access_txt = "47"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/xenozoo)
 "vpi" = (
 /obj/structure/rack{
 	dir = 8;
@@ -128372,19 +130792,15 @@
 	},
 /area/security/brig)
 "vpz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/mob/living/simple_animal/pet/dog/pug,
+/turf/simulated/floor/engine,
+/area/toxins/explab)
 "vpA" = (
 /obj/structure/window/reinforced,
 /obj/item/twohanded/required/kirbyplants,
@@ -128478,15 +130894,11 @@
 	icon_state = "tranquillite"
 	},
 /area/maintenance/kitchen)
-"vqp" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/security/processing)
+"vqm" = (
+/obj/structure/disposaloutlet,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "vqK" = (
 /obj/structure/bed,
 /obj/item/bedsheet/cmo,
@@ -128609,6 +131021,10 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/siberia)
+"vrY" = (
+/obj/effect/spawner/random_spawners/wall_rusted_probably,
+/turf/simulated/wall,
+/area/maintenance/xenozoo)
 "vsb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -128672,16 +131088,17 @@
 	},
 /area/toxins/mixing)
 "vsE" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -32;
-	pixel_y = -32
-	},
-/obj/effect/decal/warning_stripes/southwest,
-/obj/machinery/doppler_array{
-	dir = 8
+/obj/effect/decal/warning_stripes/west,
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the test chamber.";
+	dir = 4;
+	layer = 4;
+	name = "Test Chamber Telescreen";
+	network = list("Toxins")
 	},
 /turf/simulated/floor/plasteel,
-/area/toxins/mixing)
+/area/toxins/launch)
 "vsF" = (
 /turf/simulated/wall,
 /area/crew_quarters/sleep)
@@ -128746,6 +131163,21 @@
 	tag = "icon-whitebluefull"
 	},
 /area/medical/sleeper)
+"vtH" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel,
+/area/maintenance/asmaint2)
 "vtK" = (
 /obj/structure/lattice,
 /obj/machinery/camera{
@@ -128826,17 +131258,6 @@
 	icon_state = "dark"
 	},
 /area/security/hos)
-"vuq" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/security/processing)
 "vur" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -129033,6 +131454,14 @@
 /area/shuttle/escape{
 	parallax_movedir = 2
 	})
+"vwW" = (
+/obj/structure/table/glass,
+/obj/item/clipboard,
+/obj/item/toy/figure/scientist,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research/nhallway)
 "vwX" = (
 /obj/structure/table/wood,
 /obj/machinery/alarm{
@@ -129169,6 +131598,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/bed/dogbed,
+/mob/living/simple_animal/pet/dog/security/warden,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredcorners"
 	},
@@ -129224,8 +131655,23 @@
 	},
 /area/hallway/primary/central/west)
 "vyi" = (
-/turf/simulated/wall/r_wall,
-/area/security/interrogation)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/hologram/holopad,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull";
+	tag = "icon-redfull (NORTHWEST)"
+	},
+/area/security/processing)
 "vyk" = (
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit/maint)
@@ -129239,24 +131685,30 @@
 	},
 /area/security/customs)
 "vyB" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-y"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "purplefull"
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
 /area/medical/research/nhallway)
 "vyD" = (
@@ -129270,9 +131722,28 @@
 	},
 /area/chapel/main)
 "vyF" = (
-/mob/living/simple_animal/slime,
-/turf/simulated/floor/greengrid,
-/area/toxins/xenobiology)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;47"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
 "vyN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -129307,12 +131778,24 @@
 	},
 /area/hallway/primary/central/south)
 "vzx" = (
-/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 6
 	},
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "vzz" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -129346,11 +131829,18 @@
 /turf/simulated/wall,
 /area/maintenance/kitchen)
 "vzN" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display{
+	pixel_y = 32
 	},
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "vzV" = (
 /obj/machinery/door/window/brigdoor{
 	base_state = "rightsecure";
@@ -129496,15 +131986,6 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
-"vAN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
 "vAZ" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -129587,6 +132068,13 @@
 	icon_state = "dark"
 	},
 /area/medical/virology)
+"vBv" = (
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (SOUTHWEST)"
+	},
+/area/toxins/misc_lab)
 "vBE" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
@@ -129596,8 +132084,12 @@
 	scrub_Toxins = 1
 	},
 /obj/machinery/light,
-/obj/machinery/newscaster{
+/obj/machinery/flasher{
+	id = "Cell 5";
 	pixel_y = -28
+	},
+/obj/item/radio/intercom{
+	pixel_y = -42
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
@@ -129774,6 +132266,38 @@
 	},
 /turf/simulated/floor/wood,
 /area/maintenance/kitchen)
+"vCM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
+"vCS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "vCW" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/leafybush,
@@ -129837,15 +132361,6 @@
 	icon_state = "cmo"
 	},
 /area/medical/cmo)
-"vDf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/red,
-/area/maintenance/library)
 "vDi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/official/random{
@@ -129927,14 +132442,13 @@
 /turf/simulated/floor/plating,
 /area/security/prisonershuttle)
 "vEh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/item/reagent_containers/food/snacks/grown/tomato{
+	pixel_x = -10;
+	pixel_y = -12
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
+/obj/item/chair/wood/wings,
+/turf/simulated/floor/carpet/black,
+/area/crew_quarters/theatre)
 "vEo" = (
 /turf/simulated/wall,
 /area/assembly/chargebay)
@@ -130045,6 +132559,15 @@
 	},
 /turf/simulated/floor/carpet,
 /area/lawoffice)
+"vFO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken6";
+	tag = "icon-wood-broken6"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "vFU" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/wood,
@@ -130229,24 +132752,27 @@
 	},
 /area/security/permabrig)
 "vIt" = (
-/obj/machinery/camera{
-	c_tag = "Evidence Storage";
-	dir = 8;
-	network = list("SS13","Security")
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/effect/landmark/start{
+	name = "Brig Physician"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "darkred"
+	icon_state = "white"
 	},
-/area/security/evidence)
+/area/security/medbay)
+"vIz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/writing,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken"
+	},
+/area/crew_quarters/theatre)
 "vIC" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -130329,20 +132855,27 @@
 	name = "\improper Virology Lobby"
 	})
 "vJJ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4;
-	on = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteredfull"
+	icon_state = "red"
 	},
-/area/security/medbay)
+/area/security/processing)
 "vJQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -130397,6 +132930,22 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/lawoffice)
+"vKT" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse,
+/obj/effect/decal/cleanable/crayon{
+	desc = "Crayon art.";
+	icon_state = "shitcuritys";
+	name = "Graffiti";
+	pixel_x = 32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "vLh" = (
 /obj/structure/lattice,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -130485,9 +133034,46 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay)
+"vMn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain/open/shower/security{
+	name = "backstage";
+	alpha = 255
+	},
+/obj/effect/decal/cleanable/blood/writing,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/crew_quarters/theatre)
+"vMI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/crew_quarters/theatre)
 "vMK" = (
 /turf/simulated/wall/r_wall,
 /area/security/processing)
+"vMP" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "vMV" = (
 /obj/machinery/door_control{
 	id = "RoboPrivat";
@@ -130785,18 +133371,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/kitchen)
 "vPC" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitered"
+	dir = 1
 	},
-/area/security/medbay)
+/area/security/processing)
 "vPO" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -131087,7 +133674,6 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard{
 	name = "Engineering Maintenance"
@@ -131445,20 +134031,18 @@
 	},
 /area/hallway/primary/starboard/east)
 "vVL" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/obj/effect/spawner/random_spawners/wall_rusted_probably,
+/turf/simulated/wall,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "vVR" = (
-/obj/structure/closet/coffin,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/mass_driver{
+	dir = 8;
+	id_tag = "toxinsdriver"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
+/turf/simulated/floor/plating,
+/area/toxins/launch)
 "vWa" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -131575,15 +134159,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
-"vWQ" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+"vWO" = (
+/obj/machinery/disposal,
+/obj/structure/sign/deathsposal{
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plating,
-/area/toxins/xenobiology)
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "red"
+	},
+/area/security/processing)
 "vWS" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -131782,15 +134370,27 @@
 	dir = 4;
 	id = "execution"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/plating,
 /area/security/execution)
 "vZn" = (
-/obj/effect/spawner/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/library)
+/area/maintenance/asmaint2)
 "vZo" = (
 /obj/structure/ore_box,
 /obj/machinery/newscaster/security_unit{
@@ -131952,19 +134552,30 @@
 	icon_state = "wood-broken3"
 	},
 /area/maintenance/kitchen)
+"wbg" = (
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "wbi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
+/area/crew_quarters/theatre)
 "wbl" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
@@ -131997,10 +134608,6 @@
 	icon_state = "darkblue"
 	},
 /area/turret_protected/aisat)
-"wbO" = (
-/obj/item/wirecutters,
-/turf/simulated/floor/plating,
-/area/maintenance/perma)
 "wbP" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -132121,10 +134728,6 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
-"wcN" = (
-/obj/structure/table/wood,
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
 "wcO" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -132139,13 +134742,6 @@
 /area/shuttle/escape{
 	parallax_movedir = 2
 	})
-"wcS" = (
-/obj/structure/disposaloutlet,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/turf/simulated/floor/engine,
-/area/toxins/test_chamber)
 "wcV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/burnturf,
@@ -132194,18 +134790,18 @@
 	},
 /area/medical/reception)
 "wdx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/drip{
-	pixel_x = -2;
-	pixel_y = 7
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/turf/simulated/floor/plating,
 /area/maintenance/library)
 "wdz" = (
 /obj/structure/table/reinforced,
@@ -132239,11 +134835,8 @@
 	},
 /area/crew_quarters/fitness)
 "wdH" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
+/obj/machinery/status_display,
+/turf/simulated/wall/r_wall,
 /area/toxins/explab)
 "wdO" = (
 /obj/item/twohanded/required/kirbyplants,
@@ -132320,9 +134913,6 @@
 	},
 /area/engine/aienter)
 "weY" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	dir = 4;
 	pixel_x = 28
@@ -132516,16 +135106,48 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/crew_quarters/hor)
+"wiD" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
+	},
+/turf/simulated/floor/engine,
+/area/maintenance/xenozoo)
+"wiI" = (
+/obj/structure/grille/broken,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "wiM" = (
 /turf/simulated/floor/plasteel{
 	dir = 7;
 	icon_state = "yellow"
 	},
 /area/engine/break_room)
-"wiT" = (
-/obj/effect/decal/warning_stripes/west,
+"wiS" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen";
+	opened = 1
+	},
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/toxins/mixing)
+/area/maintenance/asmaint2)
+"wiT" = (
+/obj/structure/grille,
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/obj/structure/window/plasmareinforced{
+	dir = 8
+	},
+/obj/structure/window/plasmareinforced,
+/obj/structure/window/plasmareinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/toxins/launch)
 "wiW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -132623,19 +135245,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/construction/hallway)
-"wjG" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id_tag = "SecMedPrivOutside"
-	},
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "BridgeLockdown";
-	name = "Bridge Lockdown"
-	},
-/turf/simulated/floor/plating,
-/area/security/medbay)
 "wjI" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/asmaint2)
@@ -132751,23 +135360,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
-"wla" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/security/processing)
 "wlk" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
@@ -132784,6 +135376,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/ai)
+"wlt" = (
+/obj/structure/table/wood,
+/obj/item/paper/deltainfo,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/maintenance/library)
 "wlx" = (
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker/locker_toilet)
@@ -132813,31 +135412,29 @@
 	},
 /area/crew_quarters/sleep)
 "wlX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/chair/wood{
-	dir = 8
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 28
 	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
-"wmd" = (
-/obj/structure/grille,
-/obj/structure/window/plasmareinforced{
-	dir = 8
-	},
-/obj/structure/window/plasmareinforced,
-/obj/structure/window/plasmareinforced{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/window/plasmareinforced{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
+"wmd" = (
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
-/area/toxins/mixing)
+/area/toxins/launch)
 "wmm" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/decal/cleanable/dirt,
@@ -132890,16 +135487,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/ai)
 "wmL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/fungus,
+/turf/simulated/wall,
 /area/maintenance/library)
 "wmW" = (
 /obj/effect/spawner/window/reinforced,
@@ -133079,15 +135669,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
-"woM" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whiteredfull"
-	},
-/area/security/medbay)
 "wpk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
@@ -133399,6 +135980,27 @@
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/supply)
+"wsc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "wsf" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -133451,6 +136053,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/customs)
+"wsx" = (
+/obj/structure/computerframe,
+/obj/machinery/door_control{
+	id = "SupermatterVenting";
+	name = "Supermatter Venting Control";
+	pixel_x = 26
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purple"
+	},
+/area/maintenance/xenozoo)
 "wsA" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/electrical,
@@ -133591,9 +136205,20 @@
 	},
 /area/hallway/primary/port)
 "wtZ" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "wua" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -133613,16 +136238,10 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "wuf" = (
-/obj/structure/chair{
-	dir = 8
-	},
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
@@ -133636,6 +136255,20 @@
 	icon_state = "grimy"
 	},
 /area/security/hos)
+"wuG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door_control{
+	id = "xeno6";
+	name = "Containment Control";
+	pixel_y = -28;
+	req_access_txt = "55"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology)
 "wuP" = (
 /obj/machinery/access_button{
 	command = "cycle_exterior";
@@ -133701,19 +136334,11 @@
 	},
 /area/crew_quarters/captain)
 "wvQ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
+/turf/simulated/floor/engine,
+/area/toxins/explab)
 "wvS" = (
 /obj/machinery/requests_console{
 	department = "Morgue";
@@ -133824,6 +136449,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/library)
+"wwz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/confetti,
+/turf/simulated/floor/wood{
+	broken = 1;
+	icon_state = "wood-broken"
+	},
+/area/crew_quarters/theatre)
 "wwI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -133870,19 +136503,10 @@
 	},
 /area/security/customs)
 "wwO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
-	dir = 1
+	dir = 5;
+	icon_state = "red"
 	},
 /area/security/processing)
 "wwZ" = (
@@ -134129,6 +136753,10 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
+"wzZ" = (
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel,
+/area/toxins/xenobiology)
 "wAe" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -134163,24 +136791,18 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "wAv" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 26
+/area/medical/research/nhallway)
+"wAx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/ants,
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/folder/white,
-/obj/item/pen,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/turf/simulated/floor/carpet/black,
+/area/crew_quarters/theatre)
 "wAE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_construct/small{
@@ -134212,6 +136834,42 @@
 	icon_state = "darkredcorners"
 	},
 /area/security/warden)
+"wBa" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark";
+	temperature = 80
+	},
+/area/toxins/xenobiology)
+"wBd" = (
+/obj/machinery/door/window/brigdoor{
+	dir = 2;
+	name = "Creature Pen";
+	req_access_txt = "47"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xeno6";
+	name = "Creature Cell #6";
+	opacity = 0
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/toxins/xenobiology)
 "wBf" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -134220,10 +136878,19 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/syndicate_sit)
+"wBj" = (
+/obj/structure/grille/broken,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
 "wBo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/paper_bin,
+/obj/structure/table/wood,
+/obj/item/pen,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -134232,7 +136899,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/spirit_board,
 /turf/simulated/floor/carpet,
 /area/chapel/office)
 "wBq" = (
@@ -134242,23 +136908,14 @@
 	},
 /area/engine/mechanic_workshop/hangar)
 "wBr" = (
-/obj/structure/cable{
-	d1 = 4;
+/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/structure/cable/yellow{
+	d1 = 1;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
+/turf/simulated/floor/engine,
+/area/maintenance/xenozoo)
 "wBW" = (
 /obj/structure/chair/sofa/left,
 /obj/effect/landmark/start{
@@ -134316,6 +136973,12 @@
 	icon_state = "grimy"
 	},
 /area/crew_quarters/heads/hop)
+"wCu" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "wCy" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer{
 	dir = 1
@@ -134371,22 +137034,13 @@
 /area/maintenance/electrical)
 "wDg" = (
 /obj/structure/cable{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "RnDChem";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4
-	},
-/obj/effect/spawner/window/reinforced/plasma,
-/turf/simulated/floor/engine,
-/area/toxins/test_chamber)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/maintenance/xenozoo)
 "wDh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -134531,11 +137185,7 @@
 	icon_state = "dark"
 	},
 /area/engine/hardsuitstorage)
-"wEJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
+"wED" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -134547,26 +137197,26 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
 	},
 /area/medical/research/nhallway)
-"wEK" = (
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "sw_maint_airlock";
-	name = "interior access button";
-	pixel_x = -24;
-	pixel_y = 24
+"wEJ" = (
+/obj/structure/table/glass,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/obj/item/pen{
+	pixel_x = 8
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research/nhallway)
 "wEM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -134664,11 +137314,10 @@
 	},
 /area/medical/morgue)
 "wFY" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/turf/space,
+/area/space/nearstation)
 "wGd" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -134728,17 +137377,17 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
-"wGH" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"wGI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/item/reagent_containers/food/snacks/grown/tomato{
+	pixel_x = 10;
+	pixel_y = 12
 	},
-/area/maintenance/gambling_den)
+/turf/simulated/floor/carpet/black,
+/area/crew_quarters/theatre)
 "wGM" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -134754,11 +137403,40 @@
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/miningdock)
+"wGQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
+	},
+/area/toxins/misc_lab)
 "wGU" = (
 /obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
+"wGV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/xenozoo)
 "wGW" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -134802,18 +137480,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/maintenance/starboard)
-"wHu" = (
-/obj/structure/table,
-/obj/item/storage/fancy/donut_box,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom{
-	pixel_x = -32
-	},
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "red"
-	},
-/area/security/processing)
 "wHz" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -135023,6 +137689,13 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
+"wKk" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitehall"
+	},
+/area/maintenance/asmaint2)
 "wKp" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -135072,15 +137745,7 @@
 "wLd" = (
 /obj/effect/spawner/random_spawners/wall_rusted_probably,
 /turf/simulated/wall,
-/area/maintenance/gambling_den)
-"wLq" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/evidence)
+/area/crew_quarters/theatre)
 "wLu" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "BrigLeft";
@@ -135122,13 +137787,15 @@
 	},
 /area/security/hos)
 "wLC" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/structure/closet/l3closet/scientist,
-/turf/simulated/floor/plasteel{
+/obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
-	icon_state = "neutral"
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
-/area/toxins/mixing)
+/turf/simulated/floor/plasteel,
+/area/toxins/launch)
 "wLE" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	frequency = 1379;
@@ -135231,6 +137898,22 @@
 	icon_state = "dark"
 	},
 /area/turret_protected/ai_upload)
+"wMR" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "wMU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -135240,8 +137923,16 @@
 	},
 /area/hallway/primary/central/east)
 "wMW" = (
-/turf/simulated/floor/greengrid,
-/area/toxins/xenobiology)
+/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal,
+/obj/structure/window/plasmareinforced,
+/obj/structure/window/plasmareinforced{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/toxins/misc_lab)
 "wMY" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -135290,12 +137981,11 @@
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "wNN" = (
-/obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 10
 	},
-/area/toxins/explab)
+/turf/simulated/wall/r_wall,
+/area/toxins/xenobiology)
 "wNO" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/structure/window/reinforced{
@@ -135316,21 +138006,11 @@
 	},
 /area/hallway/primary/starboard/east)
 "wOc" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/item/flashlight/lamp{
-	layer = 4;
-	pixel_x = 7;
-	pixel_y = 14
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1
@@ -135357,16 +138037,24 @@
 	},
 /area/medical/research/restroom)
 "wOn" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
-/area/maintenance/gambling_den)
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "wOo" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
@@ -135386,6 +138074,10 @@
 "wOp" = (
 /turf/simulated/wall,
 /area/hallway/secondary/exit/maint)
+"wOE" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden,
+/turf/simulated/floor/engine,
+/area/maintenance/xenozoo)
 "wOF" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -135399,9 +138091,16 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
+	icon_state = "white"
 	},
 /area/medical/research/shallway)
+"wOK" = (
+/obj/structure/grille/broken,
+/obj/item/shard{
+	icon_state = "small"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "wPc" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -135422,6 +138121,22 @@
 	tag = "icon-vault (NORTHEAST)"
 	},
 /area/storage/tech)
+"wPs" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology)
 "wPv" = (
 /obj/structure/table/reinforced,
 /obj/item/assembly/timer,
@@ -135547,10 +138262,24 @@
 	},
 /area/medical/surgery/north)
 "wQA" = (
-/obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/hologram/holopad,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/toxins/xenobiology)
 "wQJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -135590,9 +138319,13 @@
 	},
 /area/security/checkpoint)
 "wQX" = (
-/obj/structure/barricade/wooden,
-/obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/red,
 /area/maintenance/library)
 "wRq" = (
 /obj/structure/sign/poster/official/fruit_bowl{
@@ -135612,16 +138345,13 @@
 	parallax_movedir = 2
 	})
 "wRw" = (
-/obj/machinery/light{
-	dir = 1;
-	on = 1
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurplecorner"
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
 /area/medical/research/nhallway)
 "wRz" = (
@@ -135688,12 +138418,6 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/surgery/south)
-"wSc" = (
-/obj/structure/table/wood/poker,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/maintenance/gambling_den)
 "wSh" = (
 /obj/structure/sign/poster/contraband/communist_state{
 	pixel_x = 33
@@ -135864,7 +138588,8 @@
 	pixel_y = -24
 	},
 /obj/machinery/light_switch{
-	pixel_x = 24
+	pixel_x = 24;
+	pixel_y = 40
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/stack/tape_roll,
@@ -135898,12 +138623,17 @@
 	},
 /area/security/permabrig)
 "wUX" = (
-/obj/machinery/status_display{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/sign/fire,
-/turf/simulated/wall/r_wall/coated,
-/area/toxins/test_chamber)
+/turf/simulated/floor/plasteel{
+	icon_state = "purplefull"
+	},
+/area/toxins/xenobiology)
 "wVc" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -135958,12 +138688,14 @@
 /turf/space,
 /area/space/nearstation)
 "wVP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/structure/disposaloutlet,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/toxins/xenobiology)
 "wVQ" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Toxin Mixing";
@@ -135979,15 +138711,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/toxins/mixing)
-"wVT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
 "wWb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
@@ -136170,40 +138893,34 @@
 	},
 /turf/space,
 /area/space/nearstation)
-"wYh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
+"wYa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 10
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "wYr" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "swall_f9"
 	},
 /area/shuttle/trade/sol)
 "wYL" = (
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1379;
-	master_tag = "sw_maint_airlock";
-	name = "exterior access button";
-	pixel_x = 24;
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/space/nearstation)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_spawners/grille_maybe,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "wYM" = (
 /obj/structure/closet/secure_closet/security,
 /obj/effect/decal/warning_stripes/red/hollow,
@@ -136221,6 +138938,11 @@
 	dir = 1
 	},
 /area/security/customs)
+"wYT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/simulated/floor/carpet/royalblack,
+/area/maintenance/asmaint2)
 "wYX" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -136279,9 +139001,21 @@
 /turf/simulated/floor/carpet/black,
 /area/bridge/vip)
 "wZL" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "xeno1";
+	name = "Creature Cell #1";
+	opacity = 0
+	},
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/toxins/explab)
+/area/toxins/xenobiology)
 "wZR" = (
 /obj/machinery/iv_drip,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -136297,6 +139031,25 @@
 	icon_state = "dark"
 	},
 /area/medical/surgery/south)
+"xad" = (
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/toxins/test_chamber)
 "xan" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -136364,10 +139117,17 @@
 	},
 /area/security/lobby)
 "xbh" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "xbk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
@@ -136408,6 +139168,17 @@
 	icon_state = "dark"
 	},
 /area/security/prison/cell_block/A)
+"xbE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
+/obj/item/shard{
+	icon_state = "small"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "xbJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -136427,30 +139198,23 @@
 /area/security/permabrig)
 "xbS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/table/wood,
+/obj/structure/sign/poster/random{
+	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkblue"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/area/crew_quarters/theatre)
+"xbU" = (
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
+/area/toxins/xenobiology)
 "xcb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -136654,15 +139418,6 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
-"xdB" = (
-/obj/machinery/processor{
-	desc = "A machine used to process slimes and retrieve their extract.";
-	name = "Slime Processor"
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "xdE" = (
 /obj/item/radio/intercom{
 	dir = 1;
@@ -136801,19 +139556,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/toxins/mixing)
-"xeP" = (
-/obj/machinery/door/window/brigdoor{
-	name = "Creature Pen"
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 8;
-	name = "Creature Pen"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
+/area/toxins/storage)
 "xeQ" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -136826,17 +139569,33 @@
 	},
 /area/assembly/robotics)
 "xfd" = (
-/obj/machinery/atmospherics/unary/portables_connector,
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door_control{
+	id = "xeno1";
+	name = "Containment Control";
+	pixel_y = -28;
+	req_access_txt = "55"
+	},
+/obj/machinery/door_control{
+	id = "xeno1";
+	name = "Containment Control";
+	pixel_y = -28;
+	req_access_txt = "55"
+	},
+/obj/machinery/door_control{
+	id = "xeno1";
+	name = "Containment Control";
+	pixel_y = 35;
+	req_access_txt = "55"
+	},
+/turf/simulated/floor/plasteel{
 	dir = 1;
-	on = 1
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
-/obj/structure/sign/nosmoking_2{
-	pixel_y = 32
-	},
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
-/area/toxins/explab)
+/area/toxins/xenobiology)
 "xfo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/walllocker/emerglocker{
@@ -137184,6 +139943,28 @@
 	},
 /turf/simulated/wall,
 /area/crew_quarters/fitness)
+"xiD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10;
+	initialize_directions = 10
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/toxins/misc_lab)
 "xiE" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -137219,8 +140000,29 @@
 /turf/simulated/floor/plasteel,
 /area/bridge/vip)
 "xji" = (
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "xjj" = (
 /obj/structure/table,
 /obj/item/paper/deltainfo,
@@ -137239,15 +140041,14 @@
 	},
 /area/chapel/office)
 "xjm" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/writing,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "xjr" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -137260,17 +140061,12 @@
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall,
 /area/chapel/office)
-"xjT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+"xjP" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "whitepurple"
 	},
-/area/medical/medbay)
+/area/toxins/xenobiology)
 "xjZ" = (
 /obj/structure/chair{
 	dir = 8
@@ -137312,6 +140108,30 @@
 	tag = "icon-swall_f5"
 	},
 /area/shuttle/pod_4)
+"xli" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/decal/warning_stripes/west,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology)
 "xlq" = (
 /obj/structure/filingcabinet/employment,
 /obj/machinery/camera{
@@ -137391,21 +140211,6 @@
 	icon_state = "darkblue"
 	},
 /area/medical/morgue)
-"xne" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/east,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
 "xnf" = (
 /turf/simulated/wall,
 /area/engine/engineering/monitor)
@@ -137537,24 +140342,6 @@
 /area/medical/research{
 	name = "Research Division"
 	})
-"xnO" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (EAST)"
-	},
-/area/toxins/misc_lab)
 "xnT" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -137579,9 +140366,6 @@
 	id_tag = "rdprivacy";
 	name = "Research Director Office Shutters";
 	opacity = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plating,
@@ -137684,10 +140468,9 @@
 	name = "Medbay Maintenance"
 	})
 "xpr" = (
-/obj/item/twohanded/required/kirbyplants,
+/obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "dark"
 	},
 /area/security/processing)
 "xpx" = (
@@ -137700,9 +140483,19 @@
 	},
 /area/security/warden)
 "xpz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "red"
+	dir = 1
 	},
 /area/security/processing)
 "xpD" = (
@@ -137861,13 +140654,6 @@
 /obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
-"xqE" = (
-/obj/vehicle/secway,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
-	},
-/area/security/securearmory)
 "xqJ" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/cleanable/blood,
@@ -137928,14 +140714,19 @@
 	name = "\improper Medical Suit Storage"
 	})
 "xrx" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6"
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
 /area/maintenance/library)
 "xrA" = (
@@ -137971,16 +140762,19 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "xsc" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/toxins/xenobiology)
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 28
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
+	},
+/area/toxins/test_chamber)
 "xsd" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -138110,6 +140904,13 @@
 /obj/structure/lattice,
 /turf/simulated/wall/r_wall,
 /area/construction/hallway)
+"xtp" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/space,
+/area/space/nearstation)
 "xts" = (
 /obj/effect/decal/warning_stripes/southeastcorner,
 /obj/machinery/atmospherics/unary/tank/air,
@@ -138118,14 +140919,14 @@
 	name = "\improper AI Satellite Service"
 	})
 "xtw" = (
-/obj/machinery/atmospherics/trinary/filter{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
+/obj/machinery/light{
 	dir = 1;
-	icon_state = "neutral"
+	on = 1
 	},
-/area/toxins/mixing)
+/obj/effect/decal/warning_stripes/south,
+/obj/structure/closet/bombcloset,
+/turf/simulated/floor/plasteel,
+/area/toxins/launch)
 "xtz" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/structure/table/reinforced,
@@ -138293,13 +141094,6 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
-"xuG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
 "xuK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -138490,35 +141284,28 @@
 	},
 /area/security/warden)
 "xwd" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/light_switch{
 	pixel_x = 26;
 	pixel_y = -4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/toxins/mixing)
+/obj/structure/table/reinforced,
+/obj/item/wrench,
+/obj/item/crowbar,
+/obj/item/clothing/mask/gas,
+/turf/simulated/floor/plasteel,
+/area/toxins/launch)
 "xwf" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/bombcloset,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "neutral"
 	},
-/area/toxins/mixing)
+/area/toxins/launch)
 "xwj" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/tower,
@@ -138529,13 +141316,6 @@
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
 /area/toxins/storage)
-"xwt" = (
-/obj/effect/decal/warning_stripes/southeast,
-/obj/machinery/chem_master,
-/obj/structure/window/plasmareinforced,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/engine,
-/area/toxins/misc_lab)
 "xwx" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -138594,8 +141374,10 @@
 /turf/simulated/floor/plating/airless,
 /area/toxins/test_area)
 "xwW" = (
-/obj/structure/falsewall,
-/turf/simulated/floor/plating,
+/obj/structure/table/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
 /area/maintenance/library)
 "xwX" = (
 /obj/machinery/suit_storage_unit/captain,
@@ -138613,6 +141395,14 @@
 /obj/item/reagent_containers/spray/cleaner,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
+"xxf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/crayon/random,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/theatre)
 "xxg" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -138684,24 +141474,28 @@
 	icon_state = "white"
 	},
 /area/toxins/mixing)
-"xxx" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+"xxw" = (
+/obj/structure/window/plasmareinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/turf/simulated/floor/plating,
+/area/maintenance/xenozoo)
+"xxx" = (
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "dark"
 	},
 /area/security/interrogation)
 "xxy" = (
@@ -138772,14 +141566,10 @@
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "xxJ" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/toxins/mixing)
+/obj/effect/decal/warning_stripes/southwest,
+/obj/structure/closet/l3closet/scientist,
+/turf/simulated/floor/plasteel,
+/area/toxins/launch)
 "xxK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -138818,6 +141608,12 @@
 	},
 /turf/simulated/wall,
 /area/crew_quarters/courtroom)
+"xyw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/fancy/black,
+/obj/item/cigbutt/cigarbutt,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "xyJ" = (
 /obj/machinery/teleport/hub,
 /obj/effect/decal/warning_stripes/southwest,
@@ -138833,12 +141629,17 @@
 /turf/simulated/floor/engine/insulated/vacuum,
 /area/toxins/mixing)
 "xyQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
-/turf/simulated/wall/r_wall,
-/area/security/evidence)
+/obj/item/wrench,
+/obj/effect/decal/warning_stripes/southeast,
+/turf/simulated/floor/plasteel,
+/area/toxins/test_chamber)
 "xyS" = (
 /obj/machinery/computer/teleporter,
 /obj/effect/decal/warning_stripes/southeast,
@@ -138961,7 +141762,16 @@
 /obj/machinery/computer/area_atmos,
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
+"xzO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "xAb" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
@@ -138974,15 +141784,25 @@
 /obj/structure/window/reinforced/polarized{
 	id = "execution"
 	},
-/obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/security/execution)
 "xAj" = (
-/turf/simulated/floor/plasteel{
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/disposal,
+/obj/machinery/firealarm{
 	dir = 8;
-	icon_state = "whitepurplecorner"
+	pixel_x = -26
 	},
-/area/medical/research/shallway)
+/obj/structure/disposalpipe/trunk,
+/obj/structure/sign/deathsposal{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTHWEST)"
+	},
+/area/toxins/xenobiology)
 "xAp" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/power/apc{
@@ -139084,6 +141904,21 @@
 	icon_state = "dark"
 	},
 /area/library)
+"xBu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/decal/warning_stripes/south,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology)
 "xBv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -139187,12 +142022,17 @@
 	},
 /area/security/execution)
 "xCD" = (
-/obj/machinery/mass_driver{
-	dir = 8;
-	id_tag = "toxinsdriver"
+/obj/effect/decal/warning_stripes/arrow,
+/obj/structure/disposaloutlet,
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/toxins/mixing)
+/area/toxins/launch)
 "xCH" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -139284,24 +142124,45 @@
 	},
 /area/medical/research/shallway)
 "xDB" = (
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/crew_quarters/theatre)
 "xDD" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner"
+	dir = 4;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (EAST)"
 	},
 /area/medical/research/shallway)
 "xDG" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/item/taperecorder,
+/turf/simulated/floor/plasteel,
+/area/toxins/explab)
+"xDK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "whitepurple"
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
 	},
-/area/toxins/explab)
+/area/crew_quarters/theatre)
 "xDL" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -139628,6 +142489,13 @@
 	icon_state = "dark"
 	},
 /area/engine/aienter)
+"xGn" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark";
+	temperature = 80
+	},
+/area/toxins/xenobiology)
 "xGB" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -139640,11 +142508,6 @@
 	icon_state = "darkblue"
 	},
 /area/medical/morgue)
-"xGN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/girder,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
 "xGX" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
@@ -139904,7 +142767,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "purplefull"
+	icon_state = "white"
 	},
 /area/medical/research/shallway)
 "xJj" = (
@@ -139915,8 +142778,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurplecorner"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "xJC" = (
@@ -139956,11 +142818,25 @@
 	name = "Engineering Maintenance"
 	})
 "xJW" = (
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/area/maintenance/library)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "xKd" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -139991,22 +142867,12 @@
 /turf/simulated/floor/plating,
 /area/security/podbay)
 "xKp" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
+/obj/structure/table,
+/obj/item/taperecorder,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
+	icon_state = "redfull";
+	tag = "icon-redfull (NORTHWEST)"
 	},
 /area/security/processing)
 "xKq" = (
@@ -140054,20 +142920,6 @@
 /area/medical/cmostore{
 	name = "\improper Medical Suit Storage"
 	})
-"xKF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/gambling_den)
 "xKH" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/machinery/camera{
@@ -140127,8 +142979,9 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurplecorner"
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
 /area/medical/research/nhallway)
 "xKT" = (
@@ -140165,6 +143018,11 @@
 /area/engine/engineering)
 "xLB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkred"
@@ -140234,14 +143092,14 @@
 /area/engine/engineering)
 "xLY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 6
 	},
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTHWEST)"
 	},
-/turf/simulated/floor/plasteel,
-/area/toxins/mixing)
+/area/toxins/launch)
 "xMc" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -140264,13 +143122,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
-/turf/simulated/floor/plasteel,
-/area/toxins/mixing)
+/area/toxins/launch)
 "xMh" = (
 /obj/effect/landmark{
 	name = "lightsout"
@@ -140315,22 +143172,19 @@
 	icon_state = "yellow"
 	},
 /area/engine/engineering/monitor)
-"xMC" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
 "xME" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (NORTH)"
 	},
-/turf/simulated/floor/plasteel,
-/area/toxins/mixing)
+/area/toxins/launch)
 "xMX" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -140376,8 +143230,8 @@
 /area/engine/engineering)
 "xNu" = (
 /obj/effect/decal/warning_stripes/northeast,
-/obj/machinery/atmospherics/unary/portables_connector{
-	layer = 2
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -140409,6 +143263,20 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
+"xNT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	dir = 1
+	},
+/area/maintenance/asmaint2)
 "xOk" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/cans/beer{
@@ -140547,19 +143415,21 @@
 	},
 /area/bridge/checkpoint/south)
 "xPe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/door/airlock/research{
 	name = "Toxin Test Firing Range";
 	req_access_txt = "47"
 	},
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/toxins/mixing)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/launch)
 "xPg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -140670,7 +143540,7 @@
 	dir = 4;
 	icon_state = "neutral"
 	},
-/area/toxins/mixing)
+/area/toxins/launch)
 "xQb" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -140887,6 +143757,15 @@
 	icon_state = "darkred"
 	},
 /area/security/podbay)
+"xRF" = (
+/obj/structure/table/wood,
+/obj/item/folder,
+/obj/item/pen,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/library)
 "xRL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
@@ -140903,6 +143782,10 @@
 	icon_state = "yellowfull"
 	},
 /area/maintenance/electrical)
+"xRP" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "xRU" = (
 /obj/item/shard{
 	icon_state = "small"
@@ -140964,12 +143847,26 @@
 	icon_state = "whitegreencorner"
 	},
 /area/medical/virology)
+"xSz" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall/r_wall/coated,
+/area/maintenance/xenozoo)
 "xSG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
+/obj/machinery/door/window/brigdoor{
+	dir = 2;
+	name = "Creature Pen";
+	req_access_txt = "47"
+	},
+/obj/effect/decal/warning_stripes/yellow,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology)
 "xSP" = (
 /obj/machinery/r_n_d/server/core,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -141187,14 +144084,16 @@
 	},
 /area/hallway/primary/aft)
 "xUX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 10;
+	initialize_directions = 10
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken5"
+	},
 /area/maintenance/library)
 "xVg" = (
 /obj/structure/chair/wood{
@@ -141243,21 +144142,6 @@
 /obj/effect/spawner/random_spawners/grille_maybe,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
-"xWg" = (
-/obj/structure/bed/dogbed,
-/mob/living/simple_animal/pet/dog/security,
-/obj/machinery/flasher_button{
-	id = "visiting room flash";
-	name = "visiting room flasher button";
-	pixel_x = 24;
-	pixel_y = -24
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/security/processing)
 "xWh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -141400,11 +144284,6 @@
 	icon_state = "brown"
 	},
 /area/quartermaster/miningdock)
-"xXu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
 "xXA" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -141547,11 +144426,16 @@
 /turf/simulated/floor/wood,
 /area/security/detectives_office)
 "xYp" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/engine,
-/area/toxins/test_chamber)
+/obj/machinery/door/firedoor,
+/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/toxins/xenobiology)
 "xYq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -141567,11 +144451,16 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain/bedroom)
 "xYt" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	temperature = 80
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/area/toxins/xenobiology)
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/xenozoo)
 "xYw" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -141609,23 +144498,20 @@
 /turf/simulated/floor/plating,
 /area/medical/reception)
 "xZc" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/item/stack/sheet/wood,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/turf/simulated/floor/plating,
 /area/maintenance/library)
 "xZk" = (
 /obj/structure/morgue,
@@ -141750,23 +144636,6 @@
 /area/shuttle/escape{
 	parallax_movedir = 2
 	})
-"yam" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/security/processing)
 "yap" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -141826,33 +144695,10 @@
 	icon_state = "darkblue"
 	},
 /area/construction/hallway)
-"ybL" = (
-/obj/structure/table/reinforced,
-/obj/item/wrench,
-/obj/item/crowbar,
-/obj/item/clothing/mask/gas,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/toxins/explab)
 "ybN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall,
+/area/crew_quarters/theatre)
 "ybR" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -141933,13 +144779,18 @@
 	icon_state = "dark"
 	},
 /area/chapel/main)
-"ycE" = (
+"ycy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2{
-	name = "Tourist Area Maintenance"
-	})
+/obj/item/reagent_containers/food/snacks/grown/tomato{
+	pixel_x = -10;
+	pixel_y = -12
+	},
+/obj/effect/decal/ants,
+/obj/item/chair/wood/wings{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/black,
+/area/crew_quarters/theatre)
 "ycJ" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -141953,10 +144804,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/security/detectives_office)
-"ycP" = (
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/engine,
-/area/toxins/misc_lab)
 "ycU" = (
 /obj/machinery/door_control{
 	desiredstate = 1;
@@ -141995,6 +144842,7 @@
 /area/bridge)
 "ydi" = (
 /obj/machinery/vending/medical,
+/obj/structure/falsewall,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
 	},
@@ -142017,11 +144865,6 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/central/se)
-"ydv" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/structure/closet/l3closet/scientist,
-/turf/simulated/floor/plasteel,
-/area/toxins/mixing)
 "ydy" = (
 /obj/structure/grille,
 /obj/structure/window/full/shuttle,
@@ -142045,24 +144888,12 @@
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/fitness)
 "ydO" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurple"
-	},
-/area/toxins/xenobiology)
+/obj/machinery/atmospherics/unary/portables_connector,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "ydQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -142128,6 +144959,12 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/central/south)
+"yew" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "yeA" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -142198,9 +145035,13 @@
 /turf/simulated/floor/plating,
 /area/chapel/main)
 "yeL" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/toxins/mixing)
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
+	},
+/area/toxins/launch)
 "yeN" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -142225,6 +145066,12 @@
 /area/maintenance/asmaint{
 	name = "Virology Maintenance"
 	})
+"yfe" = (
+/obj/item/shard,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/maintenance/library)
 "yff" = (
 /obj/machinery/bodyscanner,
 /obj/effect/decal/warning_stripes/blue/hollow,
@@ -142275,11 +145122,19 @@
 /turf/simulated/floor/plasteel,
 /area/bridge/vip)
 "yfG" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/plasteel,
-/area/toxins/mixing)
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple";
+	tag = "icon-whitepurple (WEST)"
+	},
+/area/toxins/launch)
 "yfK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -142320,13 +145175,16 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "ygf" = (
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 28
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/toxins/mixing)
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "whitepurple"
+	},
+/area/toxins/launch)
 "ygk" = (
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plating,
@@ -142334,20 +145192,16 @@
 	name = "Virology Maintenance"
 	})
 "ygy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/maintenance{
-	name = "Gambling Den"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/barricade/wooden,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table/wood,
+/obj/machinery/cell_charger,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "ygC" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/decal/warning_stripes/yellow,
@@ -142486,21 +145340,18 @@
 /turf/simulated/floor/wood,
 /area/security/hos)
 "yhO" = (
-/obj/machinery/light/small,
 /obj/effect/decal/warning_stripes/southwest,
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/machinery/light/small,
 /turf/simulated/floor/plasteel,
-/area/toxins/mixing)
+/area/toxins/launch)
 "yhS" = (
 /obj/structure/sign/securearea,
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall/r_wall,
-/area/toxins/mixing)
+/area/toxins/launch)
 "yhX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -142680,9 +145531,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/light_switch{
-	pixel_y = -24
-	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/lawoffice)
 "yjG" = (
@@ -142796,24 +145644,24 @@
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
 "ykI" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/cable,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "Interrogation"
 	},
-/obj/machinery/door/airlock/security/glass{
-	id = "visiting room";
-	id_tag = "visiting room";
-	name = "Visiting Room";
-	req_access_txt = "63"
+/obj/structure/window/reinforced/polarized{
+	dir = 1;
+	id = "Interrogation"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+/obj/structure/window/reinforced/polarized{
+	dir = 8;
+	id = "Interrogation"
 	},
+/obj/structure/window/reinforced/polarized{
+	id = "Interrogation"
+	},
+/turf/simulated/floor/plating,
 /area/security/interrogation)
 "ykR" = (
 /obj/structure/cable{
@@ -142953,8 +145801,13 @@
 	},
 /area/hallway/primary/aft)
 "ylW" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "sw_maint_outer";
+	locked = 1;
+	name = "West Maintenance External Access"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2{
 	name = "Tourist Area Maintenance"
@@ -153677,13 +156530,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abj
+abj
+abj
+abj
+abj
+abj
+abj
 aaa
 aaa
 aaa
@@ -153933,15 +156786,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abj
+abj
+fps
+fps
+fps
+fps
+fps
+abj
+abj
 aaa
 aaa
 aaa
@@ -154189,17 +157042,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abj
+abj
+fps
+fps
+gOO
+hRY
+gOO
+fps
+fps
+abj
+abj
 aaa
 aaa
 aaa
@@ -154445,19 +157298,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abj
+abj
+fps
+fps
+gOO
+gOO
+rFb
+gOO
+gOO
+fps
+fps
+abj
+abj
 aaa
 aaa
 aaa
@@ -154701,21 +157554,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abj
+abj
+fps
+fps
+naD
+gOO
+quy
+lqn
+vNE
+gOO
+naD
+fps
+fps
+abj
+abj
 aaa
 aaa
 aaa
@@ -154957,23 +157810,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abj
+abj
+fps
+fps
+quy
+lqn
+lqn
+mal
+gOO
+rDp
+lqn
+lqn
+vNE
+fps
+fps
+abj
+abj
 aaa
 aaa
 aaa
@@ -155213,25 +158066,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abj
+abj
+fps
+fps
+gOO
+oFX
+gOO
+gOO
+gOO
+gOO
+gOO
+gOO
+gOO
+tni
+gOO
+fps
+fps
+abj
+abj
 aaa
 aaa
 aaa
@@ -155470,25 +158323,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abj
+fps
+fps
+gOO
+gOO
+oFX
+gOO
+gOO
+njv
+nzh
+rvn
+gOO
+gOO
+tni
+gOO
+gOO
+fps
+fps
+abj
 aaa
 aaa
 aaa
@@ -155727,25 +158580,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 abj
+fps
+gOO
+gOO
+quy
+mal
+gOO
+gOO
+nlk
+hRY
+rSa
+gOO
+gOO
+rDp
+vNE
+gOO
+gOO
+fps
 abj
-abj
-abj
-abj
-abj
-abj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -155984,25 +158837,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-abj
 abj
 fps
-fps
-fps
-fps
+hRY
+jIc
+oFX
+gOO
+gOO
+gOO
+tni
+oFK
+oFX
+gOO
+gOO
+gOO
+tni
+vOV
+hRY
 fps
 abj
-abj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -156241,25 +159094,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 abj
-abj
-fps
 fps
 gOO
-hRY
+gOO
+lox
+rvn
+gOO
+gOO
+tni
+qNR
+oFX
+gOO
+gOO
+njv
+tja
+gOO
 gOO
 fps
-fps
 abj
-abj
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -156477,46 +159330,46 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bvh
+bvh
+abj
+bCI
+bCI
+abj
+bCI
+bCI
+bCI
+abj
+bCI
+bCI
+abj
+bCI
+bCI
+abj
+abj
+bvh
+bvh
 aaa
 aaa
 abj
+cNC
+fps
+gOO
+gOO
+oFX
+gOO
+gOO
+tni
+qNR
+oFX
+gOO
+gOO
+tni
+gOO
+gOO
+fps
+cNC
 abj
-fps
-fps
-gOO
-gOO
-rFb
-gOO
-gOO
-fps
-fps
-abj
-abj
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -156734,46 +159587,46 @@ aaa
 aaa
 aaa
 aaa
+bvh
+abj
 aaa
+abj
 aaa
+abj
 aaa
+abj
 aaa
+abj
 aaa
+abj
 aaa
+abj
 aaa
+abj
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abj
+bvh
 aaa
 aaa
 abj
-abj
+fps
 fps
 fps
 naD
+oFX
 gOO
-quy
-lqn
-vNE
 gOO
+tni
+qNR
+oFX
+gOO
+gOO
+tni
 naD
 fps
 fps
 abj
 abj
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -156991,45 +159844,45 @@ aaa
 aaa
 aaa
 aaa
+abj
 aaa
+bCI
+bCI
+abj
+bCI
+bCI
+bCI
+abj
+bCI
+abj
+bCI
+bCI
+abj
+abj
+bvh
+bqc
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abj
 aaa
 aaa
 abj
 abj
 fps
 fps
-quy
-lqn
-lqn
-mal
+fps
+fps
+mBE
 gOO
-rDp
-lqn
-lqn
-vNE
+tni
+qNR
+oFX
+gOO
+tcD
+fps
+fps
 fps
 fps
 abj
-abj
-aaa
 aaa
 aaa
 aaa
@@ -157248,44 +160101,44 @@ aaa
 aaa
 aaa
 aaa
+abj
+abj
 aaa
+abj
+abj
+abj
 aaa
+abj
+abj
+abj
 aaa
+abj
+abj
+abj
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abj
+abj
+abj
+bvh
 aaa
 aaa
 aaa
 abj
-abj
 fps
-fps
-gOO
-oFX
-gOO
-gOO
-gOO
-gOO
-gOO
+qNR
+qNR
+mka
 gOO
 gOO
 tni
+qNR
+oFX
 gOO
+gOO
+mka
+qNR
+wUq
 fps
-fps
-abj
 abj
 aaa
 aaa
@@ -157505,44 +160358,44 @@ aaa
 aaa
 aaa
 aaa
+bvh
 aaa
+hsp
+hsp
+qGR
+iSO
+hsp
+nTk
+qGR
+hsp
+hsp
+iSO
+qGR
+hsp
+hsp
 aaa
+bvh
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bvh
 aaa
 aaa
 aaa
 abj
+jhN
+qNR
+cLs
 fps
 fps
-gOO
-gOO
-oFX
-gOO
-gOO
-njv
-nzh
-rvn
-gOO
 gOO
 tni
-gOO
+qNR
+oFX
 gOO
 fps
 fps
+tGo
+qNR
+jhN
 abj
 aaa
 aaa
@@ -157754,53 +160607,53 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bvh
+bvh
+wFY
+bvh
+bCI
+bCI
+abj
+bvh
+bvh
+abj
+hsp
+aPz
+iFD
+cUW
+hsp
+aPz
+cSH
+lUS
+hsp
+aPz
+sjF
+lBo
+hsp
+abj
+abj
+abj
+abj
 aaa
 aaa
 aaa
 abj
 fps
-gOO
-gOO
-quy
-mal
-gOO
-gOO
-nlk
-hRY
-rSa
-gOO
-gOO
-rDp
-vNE
-gOO
-gOO
+kuG
+lyk
 fps
-abj
+fps
+fps
+tni
+qNR
+oFX
+fps
+fps
+fps
+qNR
+xwV
+fps
+gLS
 aaa
 aaa
 aaa
@@ -158011,51 +160864,51 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bvh
+abj
+wFY
+abj
 aaa
 abj
+aaa
+abj
+abj
+aaa
+hsp
+fPi
+jYw
+oss
+iSO
+pxR
+pxR
+hTr
+nTk
+qFr
+iFD
+goA
+hsp
+abj
+bvh
+aaa
+bvh
+aaa
+aaa
+aaa
+gLS
 fps
-hRY
-jIc
-oFX
-gOO
-gOO
-gOO
-tni
-oFK
-oFX
-gOO
-gOO
-gOO
-tni
-vOV
-hRY
+fps
+lXQ
+fps
+abj
+fps
+fps
+poh
+fps
+fps
+abj
+fps
+mka
+fps
 fps
 abj
 aaa
@@ -158268,52 +161121,52 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aae
-aaa
-aaa
-aaa
-aaa
-aaa
+abj
+abj
+wFY
+abj
+bvh
+bCI
+bvh
+abj
+abj
+abj
+hsp
+uJw
+scv
+qxv
+hsp
+hJo
+eCH
+vkR
+hsp
+uJw
+kWG
+tCg
+hsp
+abj
+bvh
+abj
+bvh
 aaa
 aaa
 aaa
 abj
-fps
-gOO
-gOO
-lox
-rvn
-gOO
-gOO
-tni
-qNR
-oFX
-gOO
-gOO
-njv
-tja
-gOO
-gOO
-fps
+abj
+abj
+xtp
+vOJ
+vOJ
+kjT
+abj
+jlK
+abj
+abj
+abj
+abj
+abj
+abj
+abj
 abj
 aaa
 aaa
@@ -158525,53 +161378,53 @@ aaa
 aaa
 aaa
 aaa
+bvh
+abj
+wFY
+abj
+abj
+abj
+abj
+abj
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+hsp
+iJF
+gPK
+pxR
+hsp
+edJ
+vmT
+vFO
+iSO
+ifq
+eLy
+oRQ
+hsp
+abj
+abj
 aaa
 abj
-cNC
-fps
-gOO
-gOO
-oFX
-gOO
-gOO
-tni
-qNR
-oFX
-gOO
-gOO
-tni
-gOO
-gOO
-fps
-cNC
-abj
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+tKX
+bvh
+jlK
+rTH
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -158782,53 +161635,53 @@ bCI
 abj
 abj
 abj
-aaa
-acF
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bvh
 abj
-fps
-fps
-fps
-naD
-oFX
-gOO
-gOO
-tni
-qNR
-oFX
-gOO
-gOO
-tni
-naD
-fps
-fps
+wFY
+cUS
+iqN
+iqN
+cUS
+hBv
+uFo
+qkU
+xSz
+uFo
+cVb
+hsp
+hsp
+hsp
+cVb
+iSO
+hsp
+iSO
+cVb
+hsp
+hsp
+aaa
+bvh
 abj
-abj
+bvh
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+tKX
+bvh
+jlK
+bvh
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -159040,51 +161893,51 @@ aaa
 aaa
 aaa
 abj
-acF
+abj
+fOb
+cUS
+lpC
+jel
+uCQ
+uFo
+jel
+jel
+jel
+uFo
+uNV
+wUr
+byT
+nMk
+gPK
+ajA
+wUr
+byT
+gPK
+eBb
+hsp
 abj
 abj
-bCI
-bCI
-bCI
 abj
-bCI
-bCI
-bCI
-abj
-bCI
-bCI
-abj
-bCI
-bCI
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bvh
 aaa
 abj
+bvh
+bvh
+aaa
+aaa
+aaa
+aaa
+aaa
+tKX
+bvh
+jlK
 abj
-fps
-fps
-fps
-fps
-mBE
-gOO
-tni
-qNR
-oFX
-gOO
-tcD
-fps
-fps
-fps
-fps
-abj
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -159296,52 +162149,52 @@ bCI
 bCI
 bCI
 abj
+abj
+ePn
+ylW
+cUS
+eKz
+flK
+wOE
+kUX
+ogo
+qtZ
+jel
+uFo
+lGo
+krO
+sFn
+slh
+cNx
+ckD
+slh
+wYL
+lwB
+otK
+hsp
+abj
+abj
+abj
+wFY
+lxD
+wFY
+abj
+bvh
 aaa
-acF
 aaa
+aaa
+aaa
+aaa
+tKX
+abj
+jlK
 abj
 aaa
-abj
-aaa
-abj
-aaa
-abj
-aaa
-abj
-aaa
-abj
-abj
-aaa
-bCI
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abj
-fps
-qNR
-qNR
-mka
-gOO
-gOO
-tni
-qNR
-oFX
-gOO
-gOO
-mka
-qNR
-wUq
-fps
-abj
 aaa
 aaa
 aaa
@@ -159554,51 +162407,51 @@ abj
 aaa
 abj
 abj
-acF
+ePn
+veO
+cUS
+nfm
+ilC
+wiD
+uFo
+jel
+jel
+hOT
+uFo
+eBr
+ucb
+qfF
+qfF
+qfF
+qfF
+qfF
+qfF
+fHh
+qfF
+qfF
+qfF
+xRP
+xRP
+qfF
+kpZ
+qfF
 abj
-bCI
-bCI
-bCI
-abj
-bCI
-bCI
-bCI
-abj
-bCI
-abj
-bCI
-bCI
-abj
 abj
 aaa
 aaa
 aaa
 aaa
 aaa
+tKX
+bvh
+jlK
+bvh
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-abj
-jhN
-qNR
-cLs
-fps
-fps
-gOO
-tni
-qNR
-oFX
-gOO
-fps
-fps
-tGo
-qNR
-jhN
-abj
 aaa
 aaa
 aaa
@@ -159810,52 +162663,52 @@ lnn
 lnn
 lnn
 bXU
-aaa
-acF
-aaa
+ePn
+ePn
+jhm
+cUS
+sPF
+plQ
+nVa
+dAg
+lTN
+lTN
+sBn
+uFo
+ump
+kqu
+qfF
+hQe
+cPp
+pmm
+ijY
+wLd
+exd
+jZb
+pDX
+xbS
+geI
+vbw
+tiD
+art
+ybN
 abj
-aaa
 abj
+bvh
+bvh
+aaa
+aaa
+aaa
+tKX
 abj
-abj
-aaa
-abj
-abj
-abj
-aaa
-abj
-abj
-abj
-bCI
+jlK
+bvh
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abj
-fps
-kuG
-lyk
-fps
-fps
-fps
-tni
-qNR
-oFX
-fps
-fps
-fps
-qNR
-xwV
-fps
-gLS
 aaa
 aaa
 aaa
@@ -160067,22 +162920,45 @@ bXU
 bXU
 bXU
 bXU
+ydO
+iXM
+qEo
+pHO
+jfv
+taT
+tmU
+szN
+kCa
+jel
+xYt
+pHO
+wUr
+nsU
+qfF
+kRp
+anf
+xxf
+aoQ
+wLd
+bbA
+mNS
+hSO
+dYs
+qbq
+oEJ
+wtZ
+qmw
+qfF
 abj
-wYL
-hsp
-hsp
-qGR
-iSO
-hsp
-nTk
-qGR
-hsp
-hsp
-iSO
-qGR
-hsp
-hsp
 abj
+abj
+bvh
+aaa
+aaa
+aaa
+tKX
+bCI
+jlK
 bCI
 aaa
 aaa
@@ -160090,29 +162966,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-gLS
-fps
-fps
-lXQ
-fps
-abj
-fps
-fps
-poh
-fps
-fps
-abj
-fps
-mka
-fps
-fps
-abj
 aaa
 aaa
 aaa
@@ -160324,52 +163177,52 @@ ldN
 fsc
 ldN
 bXU
-ePn
-cLL
-hsp
-qVB
-ete
-ylW
-hsp
-qVB
-aKL
-oYl
-hsp
-qVB
-cpP
-tZs
-hsp
-aaa
-bCI
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cDu
+pxR
+pxR
+pHO
+eyb
+kZm
+eJG
+eJP
+jDz
+voe
+htc
+vrY
+quB
+unY
+qfF
+uXU
+kNj
+rIt
+jyD
+qfF
+rNg
+wGI
+hfq
+kZD
+epM
+mar
+nyg
+nIQ
+qfF
+qfF
+qfF
 abj
 abj
-abj
+aaa
+aaa
+aaa
 tKX
-abj
-abj
-abj
-abj
+bCI
 jlK
 abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -160582,45 +163435,45 @@ abj
 cbb
 bXU
 ePn
-naC
-iSO
-hWA
-kNU
-oss
-iSO
 pxR
 pxR
-txl
-hsp
-deX
-ete
-goA
-qGR
+pHO
+wGV
+xrC
+fVn
+gNY
+jFs
+cIH
+wBr
+pHO
+etW
+kLO
+wLd
+ygy
+vkV
+kDr
+eFS
+qfF
+fJh
+kZD
+ycy
+sjQ
+kZD
+sjQ
+sDq
+fZv
+dbz
+bdf
+qfF
 abj
 abj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abj
+abj
+abj
 tKX
-aaa
-aaa
-aaa
-bvh
+abj
 jlK
-iGw
-aaa
+bqc
 aaa
 aaa
 aaa
@@ -160839,45 +163692,45 @@ hdZ
 cbb
 tzi
 bXU
-nGj
-avX
-uFo
-lmf
-lvo
-hsp
 pxR
-xMC
-uNV
-iSO
-uFo
+fIg
+pHO
+srl
+xrC
+iLG
+eJP
+eAn
+pUr
+egh
+pHO
 wUr
-rYz
-qGR
+nEm
+qfF
+csO
+kNj
+jtf
+jyD
+qfF
+vzN
+jXC
+kay
+sfI
+jXC
+vMI
+rEx
+rEx
+erd
+mdb
+xRP
+xRP
+abj
+abj
 abj
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 tKX
-aaa
-aaa
-aaa
 bvh
 jlK
 bvh
-aaa
 aaa
 aaa
 aaa
@@ -161096,45 +163949,45 @@ rfZ
 cbb
 tzi
 bXU
-wEK
-hsp
-uHq
-wUr
 pxR
-hsp
-kOD
-pLR
-egO
-nTk
-ive
-sbF
-oRQ
-hsp
+olA
+pHO
+phD
+rbA
+bsU
+qQf
+iFB
+xxw
+iiB
+pHO
+quB
+nsU
+qfF
+ouO
+rIt
+gpo
+msb
+qfF
+sxS
+mLS
+kHF
+jFg
+sMF
+twh
+flH
+thA
+oZa
+kNj
+mpd
+xRP
 abj
 aaa
-aaa
-bqc
-aaa
-bqc
-aaa
-aaa
-bqc
-bqc
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bvh
 aaa
 tKX
-aaa
-aaa
-aaa
 bvh
 jlK
 bvh
-aaa
 aaa
 aaa
 aaa
@@ -161353,45 +164206,45 @@ rfZ
 pyN
 kZJ
 bXU
-qmv
-hOT
-hsp
-jDz
-hsp
-iSO
-hsp
-jDz
-iSO
-hsp
-iSO
-jDz
-hsp
-hsp
+nlR
+ejU
+pHO
+hof
+xrC
+iXv
+fLR
+xrC
+laF
+epA
+pHO
+cLz
+cuD
+wLd
+jEI
+pys
+sGq
+szQ
+vMn
+mlJ
+qwE
+vIz
+iXO
+uPX
+twh
+ubu
+gzt
+wsc
+kNj
+rBm
+qfF
 abj
 aaa
-aaa
-abj
-aaa
-abj
-aaa
-abj
-abj
-abj
-abj
-aaa
-aaa
-aaa
-aaa
-aaa
+bvh
 aaa
 tKX
-aaa
-aaa
-aaa
 abj
 jlK
 abj
-aaa
 aaa
 aaa
 aaa
@@ -161610,45 +164463,45 @@ rfZ
 cbb
 cDv
 bXU
-vmP
-usd
-xSG
-xSG
-sfq
+wMR
+mkI
+edF
+cbw
+jhO
 phd
-fIg
-wUr
-olA
+blQ
+sTX
+tgM
 vor
-wUr
-wUr
-nsU
-nTk
+vpe
+hqa
+vMP
+qfF
+jxo
+suf
+vhg
+pKP
+dCt
+scD
+kHF
+mYk
+tYh
+kHF
+mBV
+kfT
+ubu
+tAK
+kNj
+fUV
+xRP
 abj
 abj
-aaa
-dbz
-dbz
-aMW
-dbz
-aMW
-dbz
-dbz
 abj
-aaa
-bCI
-bCI
-aaa
-aaa
-aaa
+abj
 tKX
-aaa
-aaa
-aaa
 bvh
 jlK
 bvh
-aaa
 aaa
 aaa
 aaa
@@ -161867,45 +164720,45 @@ rfZ
 pUS
 ufl
 bXU
-nlR
-ycE
-fIg
-olA
+gim
 pxR
-wUr
-wUr
-pxR
-pxR
-wUr
-pxR
-pxR
-pxR
-hsp
-abj
-abj
-sRN
-dbz
+rtB
+fsp
+tUo
+jIV
+wDg
+pth
+ipb
+uxj
+erE
+eCP
+nEm
+qfF
 xDB
-fJh
-wSc
-frM
-vbw
-dbz
-abj
-abj
-abj
-abj
+kNj
+sCt
+pMH
+gAD
+pSd
+wwz
+kHF
+bmJ
+fOf
+twh
+ubu
+ubu
+tAK
+kNj
+nWt
+qfF
 abj
 aaa
+bvh
 aaa
 tKX
-aaa
-aaa
-aaa
 bCI
 jlK
 bCI
-aaa
 aaa
 aaa
 aaa
@@ -162124,45 +164977,45 @@ cbb
 cDv
 bXU
 bXU
+cWg
 pxR
-cUS
-cUS
-cUS
-jFg
-cUS
-qQf
-cUS
-cUS
-cUS
-cUS
-qGR
-hKl
-aMW
-csO
-dbz
-jIV
-dbz
-vbw
-bbA
-hDv
-exN
+pHO
+dRU
+wsx
+ghg
+upu
+mXB
+qGG
+tyd
+pHO
+bLm
+kTD
+avX
+nBy
+sHy
+iuk
+xDK
+qfF
+cUc
+sMF
+kHF
+npg
+sgk
+twh
+fsO
+uKQ
 xji
-dbz
-aMW
-dbz
-csO
-aMW
+kNj
+oGQ
+xRP
 abj
-bCI
+aaa
+bvh
 aaa
 tKX
-aaa
-aaa
-aaa
 bvh
 jlK
 abj
-aaa
 aaa
 aaa
 aaa
@@ -162381,45 +165234,45 @@ cbb
 pBi
 bXU
 cDu
-wUr
-cUS
-iqN
-iXv
-lQT
-iXv
-bwy
-cTL
-nWY
-okD
-cUS
+hKs
 pxR
-pxR
-bCK
-uXU
+pHO
+vrY
+pHO
+pHO
+pHO
+pHO
+pHO
+vrY
+pHO
+nnt
+eIQ
+wLd
+qfF
+qfF
+qfF
+pys
+qfF
+mtr
+nSb
+dYv
+kay
+nSb
+khz
+faB
 vbw
-kDr
-pzu
-xji
-wSc
-hDv
-exN
-xji
-epM
-ghg
-evo
-xDB
-aMW
+mKG
+kNj
+xRP
+xRP
 abj
-bCI
-bCI
+abj
+abj
+aaa
 tKX
-aaa
-aaa
-aaa
 abj
 jlK
 abj
-aaa
 aaa
 aaa
 aaa
@@ -162638,45 +165491,45 @@ cbb
 cDv
 bXU
 bXU
+hzY
 pxR
-bwy
-edF
-fsp
-xrC
-cJK
-lFw
-xrC
-tgM
-fyJ
-cUS
-pxR
-olA
-wLd
-vbw
-gPK
-oHK
-ipb
-ekb
-szQ
-szQ
-szQ
-sjQ
-gaJ
-mLx
-dYs
-kay
-dbz
+vVL
+wUr
+byT
+utb
+mPB
+utb
+wUr
+utb
+cVC
+wUr
+eIQ
+qfF
+pkp
+qQQ
+poa
+rIt
+qfF
+vcj
+rbW
+iMM
+eCh
+vEh
+rUS
+vzx
+qWC
+poG
+jpY
+qfF
+abj
+abj
 abj
 abj
 abj
 tKX
-bCI
-aaa
-aaa
 bvh
 jlK
 bvh
-aaa
 aaa
 aaa
 aaa
@@ -162895,45 +165748,45 @@ rfZ
 oak
 xqC
 bXU
-pxR
-cUS
-rtB
-fsp
-sRM
+lXJ
+oWX
+fyJ
+stE
+cVC
 kPC
-ibA
-cPG
 tmR
-rBh
-cUS
-eCP
-nsU
-wLd
-hfq
-uQr
-sCt
-iXI
-vbw
-vzN
-iFD
-kay
-dqk
-wVP
-xXu
-kfT
-nLj
-bCK
+stE
+stE
+xjm
+kfG
+gze
+hsv
+qfF
+qfF
+qfF
+qfF
+cXZ
+qfF
+wlX
+eCh
+jrc
+tmO
+uKM
+wAx
+wbi
+mdb
+qfF
+qfF
+qfF
 abj
 aaa
-aaa
-tKX
 bCI
 aaa
 aaa
+tKX
 bvh
 jlK
 bvh
-aaa
 aaa
 aaa
 aaa
@@ -163152,45 +166005,45 @@ rfZ
 cbb
 cDv
 bXU
+hzY
 pxR
-qQf
-cUS
+hsp
 qol
-fsp
-pVo
-cTi
-bwy
-bwy
-bwy
-cUS
-bLm
+iVo
+cQx
+jjY
+ptk
 olA
+xbh
+gxh
+vKT
+ioF
+qfF
+pkp
+jjC
+poa
+lFm
 wLd
-ouO
-flH
-ies
-egh
-sxS
-sxS
-sxS
-sxS
-sxS
-sMF
-xji
-flH
-kJr
-dbz
-dbz
-dbz
-aaa
-tKX
+sZg
+dYs
+iWq
+tBj
+tOD
+kxN
+wOn
+mdb
+ybN
+abj
+abj
+abj
+abj
 bCI
 abj
 abj
+tKX
 abj
 jlK
 abj
-aaa
 aaa
 aaa
 aaa
@@ -163409,45 +166262,45 @@ rfZ
 pyN
 kHo
 bXU
-pxR
-cUS
-npg
-mbR
-fsp
-kgB
-cLz
+hzY
+aPc
+hsp
+hsp
+hsp
+hsp
+kWY
 vVL
-lxD
-qQQ
-cUS
-nnt
-fIg
-aMW
-hLZ
-kxN
-uIT
-hGI
-dYs
-dYv
-gAD
-gAD
-vbw
-uPX
-rUS
-ubu
-xji
-vbw
-vbw
-dbz
+hsp
+vVL
+hsp
+rAM
+bnX
+qfF
+qfF
+wLd
+qfF
+bCK
+qfF
+grC
+rzO
+pDX
+iHF
+iFI
+pIz
+jgD
+pwi
+qfF
+abj
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 tKX
-aaa
-aaa
-aaa
 bvh
 jlK
 bvh
-aaa
 aaa
 aaa
 aaa
@@ -163667,44 +166520,44 @@ cbb
 cDv
 bXU
 hGZ
-bwy
-kwN
-kTD
-cHe
-fsp
-kSW
-kSW
-xrC
-utb
-cUS
-mLS
-fIg
+hQs
+hsp
+ptg
+lGO
+mvo
+gPw
+hsp
+fjQ
+ies
+hsp
+hlJ
+pPk
+wKr
+xbE
+wKr
 aMW
-jxo
-suf
-uIT
-pKP
-dYs
-scD
-vbw
-mYk
-dYs
-uPX
-vbw
-vzx
-eYo
-rUS
-nfm
-aMW
-abj
+wKr
+qfF
+wLd
+qfF
+wLd
+qfF
+wLd
+qfF
+lax
+qfF
+wLd
+hWA
+nte
+nte
+aaa
+aaa
+aaa
+aaa
 tKX
-aaa
-aaa
-aaa
 bvh
 jlK
 bvh
-aaa
 aaa
 aaa
 aaa
@@ -163923,45 +166776,45 @@ tgf
 uJj
 gHc
 bXU
-pxR
-bwy
-kwN
-far
-kUR
-fXD
-ibu
-kUR
-lvs
-xjm
-muf
-gze
-wUr
-aMW
-xDB
-kNj
-pln
-pMH
-gAD
-dYs
-vcj
-gAD
-bmJ
-uPX
-twh
-vzx
-uJw
-vbw
-wcN
-dbz
-aaa
+hzY
+olA
+hsp
+uPx
+pVo
+vkm
+nOy
+hsp
+mZd
+okD
+vVL
+tPC
+gLL
+dyM
+lvc
+hKo
+sys
+slI
+slI
+slI
+slI
+slI
+slI
+kof
+slI
+ibp
+wKr
+nte
+wKr
+dFM
+nte
+abj
+abj
+abj
+abj
 tKX
-abj
-abj
-abj
 abj
 jlK
 abj
-aaa
 aaa
 aae
 aaa
@@ -164180,45 +167033,45 @@ bXU
 ePR
 bXU
 bXU
-pxR
-bwy
-kwN
-gPw
-iVo
-fsp
-gNY
-xrC
-oUj
-xbh
-cUS
-mLS
+hzY
+txl
+hsp
+mRE
+egZ
+kkV
 wUr
-aMW
-nBy
-suf
-pnM
-pMH
-gAD
-vbw
-gAD
-dYs
-dYs
-uPX
-wtZ
-vzx
-uKQ
-xji
-fjQ
-aMW
+ijH
+mvo
+qXu
+hsp
+wKr
+uwD
+dyM
+xzO
+fGj
+pwV
+fGj
+wiI
+fGj
+tzX
+jvC
+wiI
+fGj
+fGj
+dmM
+wKr
+ueV
+prC
+yew
+nte
 abj
+aaa
+aaa
+aaa
 tKX
-aaa
-aaa
-aaa
 bvh
 jlK
 bvh
-aaa
 aaa
 aaa
 aaa
@@ -164437,45 +167290,45 @@ bXU
 rRf
 pZM
 bXU
-wUr
-cUS
-vik
-fsp
-xrC
-pVo
-wFY
-eAg
-iNR
-xrC
-qQf
-mLS
-pxR
-csO
-vbw
-kNj
-pmu
-pMH
-vbw
-bmJ
-vbw
-dYv
-gAD
-uPX
-rzO
-wOn
-uJw
-vbw
-qbq
-dbz
-aaa
+hKs
+jZw
+hsp
+dTe
+mPB
+cOI
+kUR
+rAM
+oQj
+qSI
+hsp
+hpN
+cfp
+dyM
+irK
+tzX
+kNK
+nte
+mtp
+lEW
+nte
+lEW
+feI
+nte
+tzX
+dmM
+wKr
+nte
+bKC
+aSP
+nte
+abj
+abj
+abj
+abj
 tKX
-abj
-abj
-abj
 abj
 jlK
 abj
-aaa
 aaa
 aaa
 aaa
@@ -164694,41 +167547,42 @@ oGZ
 gFc
 wnb
 bXU
-pxR
-cUS
-cUS
-bwy
-cIx
-bwy
-cUS
-bwy
-xeP
-bwy
-cUS
-mLS
-pxR
-iWq
-vbw
-jHw
-qnQ
-dfQ
-jUs
-jUs
-jUs
-iHF
-wGH
-pfa
-edJ
+fHh
+hsp
+vVL
+hsp
+hsp
+vVL
+hsp
+hsp
+vVL
+hsp
+vVL
+wKr
+ocD
+wKr
+sqn
+nvu
+qed
+nte
+nLj
+fhQ
+qjv
+qcc
+cmT
+suX
+fGj
 dmM
-qWC
-dbz
-dbz
-dbz
+wKr
+nte
+nte
+nte
+nte
+vEZ
+vEZ
+aaa
 aaa
 tKX
-aaa
-aaa
-aaa
 bvh
 jlK
 bvh
@@ -164764,7 +167618,6 @@ abj
 abj
 bCI
 bCI
-aaa
 aaa
 aaa
 aaa
@@ -164951,41 +167804,42 @@ bXU
 sII
 oGZ
 bXU
-pxR
-nUy
-cUS
-cTL
-pVo
-vkm
-bwy
-kWY
-pVo
-okD
-cUS
-hoX
-xbS
-ygy
-xKF
-arH
-jvC
-cXZ
-pCz
-wlX
-cWb
-qQl
-vAN
-dDI
-kZh
-uJd
-mdb
-aMW
-abj
+nbK
+vcS
+vcS
+noK
+vcS
+vcS
+oRo
+vcS
+vcS
+tCR
+fgY
+xNT
+pmY
+ffM
+nSg
+cOM
+pln
+lEW
+lqo
+xyw
+pnM
+umE
+wYT
+aVw
+eDl
+gLl
+cpP
+jmO
+mKN
+mKN
+nvX
+nHY
+vEZ
 aaa
 aaa
 tKX
-bCI
-aaa
-aaa
 bvh
 jlK
 bvh
@@ -165025,7 +167879,6 @@ bCI
 abj
 bCI
 bCI
-aaa
 aaa
 aaa
 aaa
@@ -165208,41 +168061,42 @@ glp
 hSF
 wGU
 bXU
-hGZ
-olA
-bwy
-mRE
-fsp
-kkV
-bwy
-kWn
-sic
-qXu
-qQf
-olA
-ivi
-wLd
-pkp
-jMH
-poa
-dYs
-dam
-dYs
-dYs
-dYs
-vbw
-otP
-oYL
-khz
-dYv
-dbz
-abj
+dXF
+cbC
+dfO
+lGR
+cbC
+cbC
+jIu
+cbC
+cbC
+irK
+hjo
+wKk
+gVZ
+wKr
+wKr
+wKk
+lzk
+suX
+wKr
+cxW
+qwu
+gVJ
+fhQ
+suX
+pLk
+fGj
+wKr
+fGj
+wKr
+fGj
+nfj
+wiI
+vEZ
 abj
 abj
 tKX
-bCI
-abj
-abj
 abj
 jlK
 abj
@@ -165282,7 +168136,6 @@ abj
 aaa
 aaa
 bCI
-aaa
 aaa
 aaa
 aaa
@@ -165465,41 +168318,42 @@ jsU
 eMv
 rEO
 bXU
-pxR
-fIg
-cUS
-cPG
-cOC
-lRT
-bwy
-jjY
-cOC
-rQm
-cUS
-fIg
-prC
-wLd
-xDB
-kBv
-dYs
-dYs
-dYs
-rNg
-xDB
-dhw
-imT
-qbq
-pzu
-eUm
-xDB
-aMW
-abj
+hLD
+cbC
+mwi
+mwi
+mwi
+mwi
+mwi
+mwi
+mwi
+mwi
+mwi
+mwi
+fra
+irK
+nte
+nte
+mUY
+nte
+cHe
+cHe
+cHe
+cHe
+cHe
+cHe
+cHe
+cHe
+cHe
+cHe
+cHe
+cHe
+rNX
+tzX
+nte
 aaa
 aaa
 tKX
-bCI
-aaa
-aaa
 bvh
 jlK
 bvh
@@ -165539,7 +168393,6 @@ pIR
 tvi
 aaa
 abj
-aaa
 aaa
 aaa
 aaa
@@ -165722,41 +168575,42 @@ uyI
 fPD
 rfz
 bXU
-jDz
-cUS
-cUS
-cUS
-cUS
-qQf
-cUS
-cUS
-cUS
-cUS
-cUS
-cUS
-ocD
-iZQ
-iZQ
-lpm
-lpm
-lpm
-lpm
-lpm
-lpm
-lpm
-lpm
-lpm
-lpm
-dmN
+hLD
+qUe
+mwi
+lQT
+lQT
+lQT
+kHm
+pgQ
+lQT
+lQT
+lQT
+mwi
+giw
+wKr
+dFM
 nte
+cOP
+fMW
+cHe
+phx
+ewa
+rLm
+gNZ
+pQd
+htC
+cHe
+lvo
+xbU
+lvo
+cHe
+rNX
+fGj
 nte
-aaa
 aaa
 aaa
 tKX
-bCI
-aaa
-aaa
 bvh
 jlK
 bvh
@@ -165796,7 +168650,6 @@ dYL
 tvi
 aaa
 bCI
-aaa
 aaa
 aaa
 aaa
@@ -165980,40 +168833,41 @@ tzM
 wXm
 gVN
 pgt
-yhX
-yhX
-dWg
-cbC
-yhX
-cbC
-cbC
-fYZ
-dWg
-cbC
-yhX
-hwC
-cbC
-cbC
-lpm
-dah
-xYp
-jjD
-dlz
-rEd
-xYp
-szc
-twN
-lpm
-rNX
-aSP
-vEZ
-aaa
+wBj
+mwi
+rBI
+lQT
+lQT
+lQT
+lQT
+lQT
+lQT
+hJG
+mwi
+sRy
+nOO
+rGG
+nte
+tEO
+vtH
+fOK
+dfV
+pHX
+hDv
+usd
+swG
+jHH
+cHe
+lvo
+uSK
+lvo
+cHe
+nfj
+fGj
+nte
 aaa
 aaa
 tKX
-aaa
-aaa
-aaa
 bvh
 jlK
 bvh
@@ -166047,13 +168901,12 @@ abj
 nOK
 dYL
 tvi
-abj
+coE
 nOK
 dYL
 tvi
-abj
+coE
 bCI
-aaa
 aaa
 aaa
 aaa
@@ -166237,40 +169090,41 @@ fQv
 gmI
 bXU
 hLD
-jFc
-xiH
-ybN
-wbi
-wbi
-vpz
-wbi
-wbi
-wbi
-wbi
-wbi
-cqJ
-xiH
-wYh
-lpm
-wcS
-gkD
-kYM
-kNI
-nkH
-fiH
-nkH
-ejU
-lpm
-gMy
+cbC
+mwi
+lQT
+lQT
+tEe
+lQT
+lQT
+wCu
+lQT
+lQT
+mwi
+giw
 wKr
+wiS
+nte
+kIw
+cQH
+cHe
+inz
+uJH
+eaV
+usd
+oOo
+nLC
+lvo
+lvo
+uSK
+lvo
+cHe
+rNX
+fGj
 vEZ
 abj
-abj
-abj
+aaa
 tKX
-abj
-acF
-abj
 abj
 jlK
 abj
@@ -166310,7 +169164,6 @@ dYL
 tvi
 aaa
 abj
-aaa
 aaa
 aaa
 aaa
@@ -166494,40 +169347,41 @@ mGs
 eLU
 cCh
 dVy
-yhX
-ftu
-qTt
-ikA
-ikA
-ikA
-ikA
-ikA
-ikA
-ikA
-ikA
-ikA
 cbC
-oHS
-lpm
-kdP
-dfT
-fvu
-jHC
-thA
-scZ
-eRa
-sRk
-lpm
-rNX
+mwi
+lQT
+lQT
+wYa
+lVP
+qQl
+mNW
+lQT
+lQT
+mwi
+vCM
+wiI
+cHe
+cHe
+cHe
+cHe
+cHe
+pCz
+pqz
+wQA
+mzZ
+tLc
+nul
+lvo
+lvo
+uSK
+ikg
+cHe
+vZn
 wKr
 vEZ
-aaa
-aaa
-aaa
+abj
+abj
 tKX
-aaa
-acF
-aaa
 abj
 jlK
 abj
@@ -166570,7 +169424,6 @@ abj
 bCI
 bCI
 bCI
-aaa
 aaa
 aaa
 aaa
@@ -166750,41 +169603,42 @@ eXY
 jwN
 gpV
 bXU
-cDz
-yhX
+nBB
 cbC
-fbz
-ikA
-cOM
-cOM
-cIM
-pHK
-cIM
-cIM
-cIM
-ikA
-hUL
-pMV
-lpm
-wUX
-sIV
-tsG
-wDg
-kCW
-kCW
-kCW
-lpm
-lpm
-rAh
-tLI
-nte
-abj
+mwi
+vqm
+jLI
+dxe
+sEz
+lQT
+lQT
+lQT
+lQT
+mwi
+giw
+xzo
+cHe
+lvo
+lvo
+koy
+cXX
+djb
+lfs
+eaV
+usd
+scZ
+jMH
+wVP
+iZG
+kvB
+lvo
+cHe
+drA
+fGj
+vEZ
 abj
 abj
 tKX
-abj
-acF
-iGw
 abj
 jlK
 abj
@@ -166827,7 +169681,6 @@ aaa
 abj
 aaa
 bCI
-aaa
 aaa
 aaa
 aaa
@@ -167007,41 +169860,42 @@ tPv
 tPv
 vhV
 bXU
-cDz
-yhX
-yhX
-fKi
-ikA
-sEz
-sZg
-wMW
-wMW
-wMW
-wMW
-eYK
-ikA
+myH
 cbC
-oHS
-oOZ
-oKx
-pYL
-iah
-rbA
-rEx
-kCn
+mwi
+pdZ
+lQT
+kUp
+jED
+fDA
+ezx
+lQT
+lQT
+mwi
+giw
+lqc
+cHe
 sBx
-ogP
-oOZ
-rAh
-xzo
-ycn
+kvB
+lvo
+pMV
+xSG
+mkD
+mRA
+tui
+lFw
+nGj
+cHe
+lvo
+kvB
+lvo
+cHe
+hHq
+fGj
+vEZ
 aaa
-aaa
-aaa
+abj
 tKX
-aaa
-aaa
-aaa
 bvh
 jlK
 bvh
@@ -167084,7 +169938,6 @@ hkf
 cUB
 abj
 abj
-aaa
 aaa
 aaa
 aaa
@@ -167265,40 +170118,41 @@ dWi
 mDe
 mDe
 iRu
-yhX
-yhX
-vEh
-ikA
-cIM
-cOM
-cIM
-cIM
-cIM
-cIM
-cIM
-ikA
-lGR
-oHS
-oOZ
-kzx
-xnO
-dcU
-deE
-dfO
-seF
-kHF
-dkt
-oOZ
+cbC
+mwi
+rBI
+lQT
+mqJ
+sEz
+lQT
+lQT
+lQT
+hJG
+mwi
+giw
+wKr
+cHe
+lvo
+lvo
+lvo
+lcG
+deX
+kNH
+sGN
+xBu
+pQd
+htC
+feo
+lvo
+juu
+iZG
+cHe
 rNX
-xGN
+fGj
 nte
 aaa
 aaa
-aaa
 tKX
-bCI
-aaa
-aaa
 bvh
 jlK
 bvh
@@ -167341,7 +170195,6 @@ aaa
 abj
 aaa
 bCI
-aaa
 aaa
 aaa
 aaa
@@ -167522,40 +170375,41 @@ uTp
 ecF
 mDe
 dvC
-cbC
-cbC
-oyP
-ikA
-oOo
-qVO
-cIM
-cIM
-lGO
-qVO
-oOo
-ikA
-cbC
-oHS
-oOZ
-uRn
-kps
-dcV
-deF
-dfP
-dhx
-dja
-dku
-oOZ
-rNX
-uex
+wBj
+mwi
+wbg
+bDz
+gBL
+oKx
+ati
+lQT
+lQT
+lQT
+mwi
+giw
+wKr
+cHe
+pCz
+pCz
+pCz
+pCz
+iYB
+gig
+aap
+xYp
+dPm
+cHe
+cHe
+cHe
+cHe
+cHe
+cHe
+nfj
+fGj
 nte
-aaa
-aaa
-aaa
+abj
+abj
 tKX
-bCI
-aaa
-aaa
 abj
 jlK
 abj
@@ -167598,7 +170452,6 @@ abj
 bCI
 bCI
 bCI
-aaa
 aaa
 aaa
 aaa
@@ -167778,41 +170631,42 @@ xBS
 kAe
 cAD
 mDe
-eTl
-sbj
-jZA
-jUu
-ikA
-ifq
-veO
-lFP
-ekt
-goC
-mZI
-mkm
-ikA
+ufD
 qUe
-pMV
-oOZ
-kRM
-ycP
-dcW
-rbH
-jVL
-sfU
-sCf
-jyU
-oOZ
-rAh
-xzo
-vEZ
-aaa
+mwi
+mwi
+cOC
+eYK
+oZv
+ekt
+pal
+mwi
+mwi
+mwi
+oOX
+wKr
+cHe
+lvo
+lvo
+koy
+wZL
+djb
+cYk
+lWI
+ure
+tfI
+joz
+lvo
+lvo
+lvo
+cHe
+dFK
+wrP
+fGj
+nte
 aaa
 aaa
 tKX
-bCI
-aaa
-aaa
 abj
 jlK
 abj
@@ -167852,7 +170706,6 @@ oAM
 tvi
 aaa
 abj
-aaa
 aaa
 aaa
 aaa
@@ -168036,40 +170889,41 @@ ocE
 vct
 mDe
 dvC
-ikA
-ikA
-nig
-cXa
-muV
+qUe
+kCW
+oYl
+hEI
+sus
 oJS
 cQv
 ogO
 uKN
-wQA
-muV
-ikA
-ybR
-pMV
-oOZ
-jHH
-xwt
-dcX
-rcX
-rFG
-svD
-sEO
-dkv
-oOZ
+uCo
+kCW
+nMR
+wKr
+cHe
+dfP
+ptX
+lvo
+oYL
+xSG
+hEg
+xli
+pOf
+tLc
+gOG
+lvo
+kvB
+ddi
+cHe
 rNX
+fGj
 fGj
 vEZ
 aaa
 aaa
-aaa
 tKX
-bCI
-aaa
-aaa
 bvh
 jlK
 bvh
@@ -168109,7 +170963,6 @@ oAM
 tvi
 abj
 bCI
-aaa
 aaa
 aaa
 aaa
@@ -168293,40 +171146,41 @@ ocE
 nTz
 mDe
 dvC
-ikA
-cJO
-epA
-rAM
-rgj
-qrW
-uxj
-kZU
-uxj
-tLB
-uLD
-ikA
-ajy
-wBr
-oOZ
-oOZ
-oOZ
-dlL
-rdB
-rGw
-sgu
-sEZ
-sSH
-oOZ
+cbC
+kCW
+ivv
+lev
+nDX
+xad
+fOi
+ksY
+leX
+fXa
+kCW
+nMR
+oYg
+cHe
+lvo
+lvo
+lvo
+eTl
+deX
+xfd
+nqz
+xjP
+gaJ
+pBT
+wVP
+lvo
+lvo
+cHe
 rNX
-wKr
+qSr
+fGj
 vEZ
 aaa
 aaa
-aaa
 tKX
-aaa
-aaa
-aaa
 bvh
 jlK
 bvh
@@ -168366,7 +171220,6 @@ oAM
 tvi
 aaa
 bCI
-aaa
 aaa
 aaa
 aaa
@@ -168550,40 +171403,41 @@ kAe
 gqh
 mDe
 iRu
-ikA
-txE
-mwW
-eGA
+cbC
+kCW
+fmq
+sSH
 xsc
-lVP
-dpP
-lBo
-mVH
-avL
-cKc
-ikA
-cbC
-cmX
-cbC
-cbC
-oOZ
-oOZ
-djb
-oOZ
-oOZ
-oOZ
-oOZ
-oOZ
-dmN
-mkS
-nte
-abj
+kVu
+gHo
+jjD
+dWg
+xyQ
+kCW
+giw
+wKr
+cHe
+pCz
+pCz
+pCz
+pCz
+pCz
+lHO
+tQD
+eBj
+pCz
+pCz
+pCz
+pCz
+pCz
+cHe
+rNX
+wOK
+vEZ
+vEZ
 abj
 abj
 tKX
-abj
-abj
-abj
 abj
 jlK
 abj
@@ -168623,7 +171477,6 @@ srW
 tvi
 aaa
 bCI
-aaa
 aaa
 aaa
 aaa
@@ -168807,40 +171660,41 @@ kAe
 wEA
 mDe
 cDz
-ikA
-kmL
-jkc
-rAM
-tzZ
-mwh
-odT
-muV
-lUS
-mwh
-mMr
-ikA
-yhX
-knU
-sys
-ndY
-ddi
+cbC
+kCW
+kCW
+kCW
+kCW
+rFG
+kCW
+kCW
+kCW
+kCW
+kCW
+giw
+fGj
+cHe
+lvo
+lvo
 koy
-deH
-xDG
-ddi
-wVT
+fcS
+djb
+cWV
+eaV
+uIT
+tfI
+hKl
+lvo
+lvo
+lvo
+cHe
+bJE
 xzo
-tzX
-rNX
-qac
 nte
-nte
+abj
 aaa
 aaa
 tKX
-aaa
-aaa
-aaa
 bvh
 jlK
 bvh
@@ -168880,7 +171734,6 @@ abj
 aaa
 aaa
 bCI
-aaa
 aaa
 aaa
 aaa
@@ -169064,51 +171917,52 @@ ocE
 xJC
 mDe
 dvC
-ikA
-rAM
-rAM
-rAM
-rAM
+wBj
+xLM
+fAT
+uuy
+sic
 qlJ
 cRY
-lDu
-lVe
-qlJ
-rAM
-ikA
-ikA
-ikA
-ikA
-qiR
-eGT
-iIq
-sUj
-dfS
-bzG
-yjo
-pth
-yjo
-hwj
-wvQ
-fku
+uuy
+aSP
+hlJ
+fGj
+giw
+fGj
+cHe
+tsu
+kvB
+lvo
+uch
+xSG
+qpV
+taV
+rks
+tLc
+sRL
+lvo
+ptX
+lld
+cHe
+rNX
+fGj
 nte
-aaa
 abj
-sRy
-vOJ
-vOJ
-vOJ
+abj
+abj
+deR
 vOJ
 vOJ
 vOJ
 wuP
 dFg
 dFg
-vZn
-vZn
-vZn
-vZn
-vZn
+fwf
+fwf
+fwf
+fwf
+fwf
 nFe
 dFg
 dFg
@@ -169137,7 +171991,6 @@ bCI
 bCI
 abj
 bCI
-aaa
 aaa
 aaa
 aaa
@@ -169320,57 +172173,58 @@ mAl
 ocE
 aeY
 mDe
-dvC
-ikA
-cIM
-cIM
-cIM
+uqr
+eGd
+dpP
+dpP
+vyF
 nrd
-qlw
-dfj
-muV
-iYl
-cVG
-gig
-nBl
-cIM
-cIM
-ikA
-ijH
-mUF
-qEo
-tZU
-lxh
-ddi
-tpM
-wKr
-jsw
+eGh
+hNY
+aVV
+cOM
+cOM
+cOM
+gwQ
 fGj
-kVJ
-tzX
-nte
-abj
-dkI
-xpD
-xpD
-dkI
-wmd
-dkI
+cHe
+lvo
+lvo
+lvo
+fvZ
+deX
+aWY
+eaV
+uQr
+gaJ
+kna
+wVP
+lvo
+lvo
+cHe
+rNX
+fGj
+oWK
+oWK
+nnU
+mur
+kxz
+oWK
 jsz
-dkI
+oWK
 swI
 dFg
 nvU
-ndo
+ceE
 dHt
-kOj
+iiw
 dHt
-cQt
-oPF
-lPW
+dMK
+edN
+uYP
 pWR
-lNh
-dSB
+tVD
+rUu
 dFg
 abj
 txq
@@ -169390,7 +172244,6 @@ abj
 bCI
 bCI
 abj
-aaa
 aaa
 aaa
 aaa
@@ -169578,56 +172431,57 @@ kAe
 xHY
 mDe
 cDz
-ikA
-ksN
-vyF
-cIM
+yhX
+yhX
+ybR
+msA
 san
 hEB
 mQI
-cOI
-lWl
-mxZ
-pzS
-cIM
-wMW
-sPF
-ddi
-ddi
-ddi
-ddi
-iYq
-ddi
-ddi
-ddi
-ddi
-ddi
-ddi
-rtl
-eIQ
-vEZ
-aaa
-xpD
-pAh
+uuy
+pfA
+fGj
+fGj
+kpl
+fGj
+cHe
+pCz
+pCz
+pCz
+pCz
+dPm
+hZD
+tQD
+rlN
+iYB
+pCz
+pCz
+pCz
+pCz
+cHe
+rNX
+fGj
+oWK
 pAa
 rgF
 vsE
-xpD
+cTP
+wiT
 dHp
-mlh
+oNa
 obv
 dFg
 dHt
-kOj
-qxf
-kZr
+iiw
+scB
 iPx
-kZr
+qxf
+iPx
 nvU
 nFe
-oAO
-jjV
-dGB
+lnE
+gXK
+ojW
 yfs
 abj
 txq
@@ -169642,7 +172496,6 @@ aaa
 abj
 aaa
 abj
-aaa
 aaa
 aaa
 aaa
@@ -169835,55 +172688,56 @@ nTm
 obE
 mDe
 cDz
-ikA
-cIM
-cIM
-rxH
-tWL
+cbC
+oOZ
+oOZ
+oOZ
+oOZ
 uve
-kZD
-dfV
-iKW
-cRW
-mQO
-cIM
-cIM
-cIM
-ddi
-mad
-ybL
-fRS
-gTG
-dkz
-ddi
-jfk
-jrc
-jfk
-ddi
-dIy
+oOZ
+oOZ
+oOZ
+oOZ
+oOZ
+giw
 fGj
-vEZ
-abj
-xpD
-mUY
+cHe
+lvo
+lvo
+koy
+odp
+djb
+rGM
+iec
+wuG
+tfI
+cmX
+lvo
+lvo
+lvo
+cHe
+lka
+fGj
+oWK
 vli
 vmL
-oNa
+vmL
+bIb
 vlG
-nSW
-dkI
+lhL
+oWK
 ijv
 dFg
 xDk
 qsF
-kZr
-ejM
+iPx
+mRK
 mBc
-bRb
+gam
 opP
 dFg
 xex
-uTm
+eOk
 kDR
 dFg
 nte
@@ -169891,7 +172745,7 @@ txq
 txq
 qUc
 txq
-txq
+wjI
 cAr
 nte
 abj
@@ -169899,7 +172753,6 @@ bCI
 abj
 aaa
 bCI
-aaa
 aaa
 aaa
 aaa
@@ -170092,57 +172945,58 @@ cCd
 nqI
 mDe
 nso
-ikA
-rAM
-rAM
-rAM
-rAM
-rAM
-heE
+cbC
+oOZ
+dkz
+sgu
+kLm
+kCn
+ekb
 voL
-lXa
-mzZ
-rAM
-rAM
-rAM
-rAM
-ddi
+sWj
+qSE
+oOZ
+giw
+wKr
+cHe
+nIg
+ptX
+lvo
+lcK
+xSG
+evo
+kzx
+uHq
+tLc
+wBd
+lvo
 kvB
-cto
-nSs
-hJG
-sKK
-qSI
-ecW
-sYB
-wNN
-ddi
-rtl
+eXf
+cHe
+drA
 fGj
-ycn
-aaa
-dkI
-lbz
+oWK
 mWC
 xLY
-ydv
-xpD
+rGY
+kLY
 wiT
-dkI
+ijs
+oWK
 fjF
 dFg
 roX
 mbF
 nvU
-kim
+xUX
 nwf
-idZ
-nFK
+oMS
+tJL
 err
-wdx
+dnp
 cNA
-aWY
-rMu
+skJ
+iFi
 fGj
 mfv
 xfo
@@ -170156,7 +173010,6 @@ bCI
 bCI
 abj
 bCI
-aaa
 aaa
 aaa
 aaa
@@ -170349,57 +173202,58 @@ mDe
 mDe
 mDe
 cDz
-ikA
-cIM
-cIM
-cIM
-jvy
-qlw
-eXc
-cWV
-qhH
-juf
-cTz
-nBl
-cIM
-cIM
-ddi
-xfd
-jFA
-klo
-deL
-iYC
-osx
-mkL
-tJh
-dKY
-ddi
-pBc
-lcG
-vEZ
-abj
-xpD
-gKK
+cbC
+oOZ
+bVJ
+mWo
+mUg
+kYD
+vBv
+mUg
+iLE
+knU
+oOZ
+nhj
+gmU
+cHe
+lvo
+lvo
+lvo
+nSs
+deX
+hCb
+lWI
+slp
+gaJ
+lTd
+wVP
+lvo
+lvo
+cHe
+qdv
+fGj
+oWK
 xxJ
 xMf
 yeL
 kLY
 fvo
 mlh
+oNa
 aAG
 dFg
-rsh
+xRF
 qsF
 qsF
 ohs
-kZr
-kZr
+iPx
+iPx
 cSo
 dFg
 mJU
 wwu
-ido
-xwW
+kqO
+dGB
 iqs
 eOt
 mKN
@@ -170413,7 +173267,6 @@ abj
 abj
 aaa
 bCI
-aaa
 aaa
 aaa
 aaa
@@ -170606,54 +173459,55 @@ xiH
 xiH
 xiH
 ack
-ikA
-lpC
+cbC
+oOZ
+fRS
 wMW
-cIM
-kxQ
-hEB
-baS
-cOP
-cRU
+qIE
+wGQ
+liX
+sXF
+nNw
 mxZ
-vlf
-cIM
-vyF
-bJF
-ddi
-rIt
-gYN
-quV
-jJq
-tsu
-jjC
-mkL
-prm
-jfk
-ddi
-rtl
+oOZ
+uHA
+tZs
+cHe
+cHe
+cHe
+cHe
+pCz
+kYm
+iIq
+aap
+rFo
+kYm
+pCz
+cHe
+cHe
+cHe
+cHe
+rNX
 fGj
-vEZ
-aaa
-xpD
-rHD
+oWK
 xtw
 xME
 yfG
 eYR
 jTz
-dkI
+wmd
+oWK
 aAG
 dFg
-gre
-kOj
-oPF
+kZr
+iiw
+edN
 sQd
-kZr
+iPx
 opt
-xUX
+aty
 dFg
-kZr
+iPx
 mxx
 ydB
 dFg
@@ -170670,7 +173524,6 @@ aaa
 bCI
 abj
 abj
-aaa
 aaa
 aaa
 aaa
@@ -170863,56 +173716,57 @@ cbC
 cbC
 yhX
 jiV
-ikA
-cIM
-cIM
-rxH
-spe
-kCE
-kZD
-cWV
-cYk
-mAa
-mUg
-cIM
-cIM
-cIM
-ddi
+cbC
+oOZ
+tsG
+nPj
+hwj
+ecW
+sXF
+gLu
+nUy
+llS
+iVv
+sSx
+fJN
+oBj
+quV
 uXc
-mBV
-qtZ
+cHe
+xAj
 rfs
 vos
-htC
-mkL
+dKY
+kyd
 tda
-sfI
-ddi
-dIy
-wKr
-nte
-abj
-dkI
-fWk
+cNL
+hzo
+xGn
+adc
+cHe
+bJE
+fGj
+oWK
 xwd
-xME
+bUX
 ygf
 jKV
 xCD
-dkI
+vVR
+oWK
 cAA
 dFg
 uGt
-pdi
-gXK
+ksJ
+hFQ
 ibJ
 qsF
 qsF
-xrx
 lPW
-jZb
+uYP
+nzC
 eaP
-qor
+uTm
 nFe
 rNX
 gJr
@@ -170927,7 +173781,6 @@ abj
 bCI
 aaa
 abj
-aaa
 aaa
 aaa
 aaa
@@ -171119,59 +173972,60 @@ bYj
 bYj
 cbC
 yhX
-ugg
-ikA
-rAM
-rAM
-rAM
-rAM
-mzZ
-qGp
-voL
-cQH
-cUU
-rAM
-rAM
-rAM
-rAM
-ddi
-gXb
-phh
-quV
-rfB
-rGM
-htC
-sHq
-jfk
-jfk
-ddi
-rtl
-wKr
-nte
-ycn
-dkI
-dkI
-dkI
-xPe
-dkI
+ejz
+qUe
+oOZ
+kHj
+gGO
+mUg
+xiD
+qhH
+hPO
+jJq
+daA
+tOE
+jLq
+qGf
+jLq
+pEO
+wAv
+cHe
+qtq
+eXc
+wUX
+ibu
+myF
+dGq
+dfQ
+kmL
+fVN
+wBa
+cHe
+rNX
+fGj
 oWK
-dkI
-dkI
+oWK
+xPe
+oWK
+oWK
+gMs
+oWK
+oWK
 xTb
 dFg
 nFe
-nWr
-xwW
+wmL
+dGB
 tGd
 tGd
 wTW
-juL
+ndo
 jaN
-rMu
+iFi
 jaN
 jaN
 dFg
-mcQ
+xJW
 fGj
 nte
 qcX
@@ -171184,7 +174038,6 @@ aaa
 bCI
 aaa
 abj
-aaa
 aaa
 aaa
 aaa
@@ -171375,37 +174228,37 @@ aAB
 mVO
 bYj
 yfm
-qUe
+cbC
 cAT
-ikA
-cIM
-cIM
-cIM
-fPi
-fXj
+fjX
+oOZ
+rGw
+lpm
+hco
+tUn
 cOL
-kko
-qhH
+lja
+tYE
 cVG
-cWA
-nBl
-cIM
-cIM
-ddi
-nTV
-phh
-klo
-rfK
-kjF
-htC
-mkL
-jfk
-mZA
-ddi
-rtl
-fGj
-uwp
-fGj
+lWl
+uTU
+hsV
+cTi
+uub
+rMu
+hoq
+wPs
+lvs
+iKW
+rXw
+tZL
+lvs
+ete
+uYv
+fVN
+uxE
+cHe
+rNX
 wKr
 rPI
 pZR
@@ -171414,20 +174267,21 @@ yhO
 vlG
 rzM
 uLX
+jpB
 tqc
-psB
+hsK
 dXX
-wmL
 nyi
-wmL
-wmL
+wdx
+nyi
+nyi
+sgN
+oLA
 xZc
-nHt
-pFk
-uYP
-wmL
+lVZ
+nyi
 prs
-hSO
+pLY
 fNY
 fGj
 nte
@@ -171441,7 +174295,6 @@ aaa
 abj
 aaa
 bCI
-aaa
 aaa
 aaa
 aaa
@@ -171631,38 +174484,38 @@ iKD
 euu
 vwX
 bYj
-yhX
-rRM
+czD
+cbC
 ugg
-ikA
-vdu
-vyF
-cIM
-mhC
-hEB
-laB
-jHx
-xne
-mxZ
-cVb
-cIM
-wMW
-tOD
-ddi
-nMC
-phh
-qxv
-tfI
-dfY
-jjC
-gsc
-jhm
-feg
-ddi
+qUe
+oOZ
+oOZ
+oOZ
+oOZ
+oOZ
+oOZ
+oOZ
+oOZ
+oOZ
+oOZ
+udm
+udm
+kJc
+uVn
+lwW
+cHe
+far
+kDT
+kYg
+pLa
+kvk
+wzZ
+nWM
+aLq
 fVN
-bAE
-tHn
-yjo
+wBa
+cHe
+vCS
 tHn
 leo
 gVc
@@ -171671,16 +174524,17 @@ fFM
 leo
 yjo
 yjo
+vTC
 eOQ
-wQX
+dDW
 pWT
 pWT
 mJv
 pWT
 pWT
-rUu
+xrx
 pWT
-iFi
+mHi
 qqV
 pWT
 bTQ
@@ -171701,7 +174555,6 @@ bCI
 abj
 abj
 abj
-aaa
 aaa
 aaa
 aaa
@@ -171891,35 +174744,35 @@ bYj
 cbC
 cbC
 ugg
-ikA
-cIM
-cIM
-rxH
-tLc
-uve
-odT
-muV
-fOK
-mAa
+cbC
+udm
+dcl
+dcl
+jmi
+mxT
+mov
+sbj
 lot
-cIM
-cIM
-cIM
-ddi
-dfR
-wdH
-mkF
-pqz
-dfZ
-ddi
-jfk
-jfk
-jfk
-ddi
-sEK
-tzX
-bIK
-qGP
+dmO
+frM
+vaH
+udm
+tEB
+qCK
+jxa
+cHe
+gzC
+kko
+jvU
+rsA
+jvU
+mIE
+rsQ
+wNN
+xGn
+byq
+cHe
+hlJ
 aSP
 vlG
 eap
@@ -171928,22 +174781,23 @@ pwH
 vlG
 hlJ
 fGj
+fGj
 rNX
 dFg
 mDD
 pWT
 pWT
-xJW
-xcV
-fDW
-tXP
 nOR
+xcV
+qtX
+tXP
+xwW
 dFg
 dFg
 dFg
 dFg
 tBs
-rkV
+oYg
 nte
 dRc
 oOX
@@ -171958,7 +174812,6 @@ bCI
 aaa
 aaa
 bqc
-aaa
 aaa
 aaa
 aaa
@@ -172148,26 +175001,26 @@ bYj
 cbC
 hwE
 ugg
-ikA
-rAM
-rAM
-rAM
-rAM
-hUH
-iJW
-cUW
-cTr
-hUH
-rAM
-rAM
-oOo
-oOo
-ddi
-qSE
-wZL
-qSE
-deR
-qtq
+cbC
+udm
+dcl
+dcl
+mkL
+dfT
+sHq
+sNM
+mMf
+sMa
+mbR
+dlz
+udm
+nrB
+dSD
+nRR
+cHe
+cHe
+cHe
+cHe
 dkI
 dkI
 dkI
@@ -172179,25 +175032,26 @@ dkI
 dkI
 dkI
 dkI
-dkI
+oWK
 hiV
-dkI
-dkI
+oWK
+oWK
+oWK
 jVd
 fGj
 rNX
 wjj
 uMC
-kZr
+iPx
 pWT
 tbO
-jtl
-foU
-vDf
-myH
+gre
+okC
+wQX
+tCG
 dFg
 qPa
-dMK
+tDh
 nFe
 rNX
 fGj
@@ -172215,7 +175069,6 @@ abj
 abj
 aaa
 bvh
-aaa
 aaa
 aaa
 aaa
@@ -172402,31 +175255,31 @@ cva
 cAM
 cAP
 bYj
-npT
+cbC
 qUe
-ugg
-ikA
-xYt
-xYt
-xYt
-rAM
-bVJ
-odT
-muV
-sHY
-xdB
-mxT
-vkV
-eFS
-fEg
-ars
-eIb
-nZi
+ejz
+cbC
+udm
+dcl
+ocj
+vpz
+dcl
+udm
+fpR
+uBL
+qrW
+mkm
+pax
+sRM
+mIg
+qCK
+xQZ
+ful
 ddb
 cPk
 qFQ
 djf
-pfA
+vsA
 dAv
 tDD
 gVo
@@ -172439,7 +175292,8 @@ dkI
 rfA
 dxc
 dyp
-dkI
+rRM
+oWK
 tLI
 fGj
 rAh
@@ -172447,9 +175301,9 @@ dFg
 loV
 pWT
 pWT
-oEJ
-nOR
-qlS
+yfe
+xwW
+piU
 xua
 hfU
 gxv
@@ -172458,7 +175312,7 @@ tiU
 wjj
 rNX
 fGj
-nte
+dJx
 dJx
 dRs
 dJx
@@ -172472,7 +175326,6 @@ aaa
 bCI
 abj
 abj
-aaa
 aaa
 aaa
 aaa
@@ -172662,27 +175515,27 @@ bYj
 yhX
 qUe
 cAT
-ikA
-xYt
-fTu
-kDH
-vWQ
-iQu
-laF
-gQH
-pKk
-cRX
-ikg
-ilJ
+cbC
 udm
-oBj
-puv
-mHX
+nCg
+dcl
+rHD
+dcl
+wdH
+iZe
+mVD
+hbk
+lPR
+pAh
+sRM
+mIg
+rQY
+nZi
 rkO
-puv
-iZG
+quc
+rkO
 dgb
-uHt
+tPn
 xNu
 oSQ
 nHQ
@@ -172696,18 +175549,19 @@ xpD
 nkJ
 fCp
 dyr
-dkI
+hKt
+oWK
 tzX
 fGj
 yap
 dFg
-fxy
+stb
 pWT
 pWT
-aos
+gxL
 qks
-fwf
-dFK
+ccT
+wlt
 dKE
 dFg
 wxU
@@ -172715,11 +175569,11 @@ dMd
 dFg
 rAh
 wKr
-nte
+dJx
 xQE
 llF
-hKt
 kul
+jZj
 prI
 juR
 fvy
@@ -172729,7 +175583,6 @@ abj
 bCI
 abj
 bqc
-aaa
 aaa
 aaa
 aaa
@@ -172919,24 +175772,24 @@ bYj
 kDa
 hHE
 qpC
-ikA
-fVn
-kna
-aRl
-qfD
-tui
-cCw
-hUJ
-mov
+fGc
+udm
+kYb
+dcl
+eOK
+dcl
+bJF
+pvf
+xDG
 eiw
-ydO
-dWs
-iFq
-uSt
+bLV
+jCZ
+sRM
+mIg
 vyB
 mkc
 nKG
-ddp
+jNB
 deS
 dgc
 dhL
@@ -172945,26 +175798,27 @@ uBQ
 lHT
 wfs
 lNC
-cTP
+wfs
 cGa
 rMg
 wCE
 wVQ
-jZj
+gVc
 dBA
 dys
-dkI
+qIk
+oWK
 hur
 naf
 rNX
 dFg
 dFg
-wQX
-wQX
+dDW
+dDW
 dFg
 dFg
-lPW
-rMu
+uYP
+iFi
 dFg
 dFg
 dFg
@@ -172972,13 +175826,13 @@ dFg
 dFg
 rNX
 fGj
-nte
+dJx
 qeg
 ivT
-dDW
 kee
 sxt
 hAQ
+dio
 dio
 wsC
 yiZ
@@ -172986,7 +175840,6 @@ acF
 acF
 acF
 acF
-aaa
 aaa
 aaa
 aaa
@@ -173173,30 +176026,30 @@ enb
 eTP
 frp
 bYj
-cbC
+npT
 qUe
 cAT
-ikA
-xYt
+lGR
+udm
+dcl
+icz
+cTr
+dcl
+bJF
+pop
 fTu
-mFH
-fYu
-tHr
-fXQ
-lGo
-cQN
-lGo
-cTA
-mwh
-eXf
-oBj
+mXq
+dam
+gJg
+gQZ
+pHK
+uSt
 oUh
-vnu
-mMf
-dgd
-rhD
+vwW
+pNO
+rQY
 kEg
-uHt
+rCf
 dju
 jTZ
 oDB
@@ -173210,7 +176063,8 @@ xpD
 kPH
 qrj
 wLC
-dkI
+mkS
+oWK
 sRC
 fGj
 tvK
@@ -173222,24 +176076,23 @@ vTC
 mKN
 dIs
 cSp
-osq
+jmO
 tHn
 yjo
 yjo
 tHn
 wrP
 fGj
-nte
-pSd
+dJx
 rtb
 idu
 tYx
+lsV
 mrf
 uhI
 sag
 sag
 yeK
-aaa
 aaa
 aaa
 aaa
@@ -173431,27 +176284,27 @@ bYj
 dHk
 bYj
 yhX
-cxW
+cbC
 ugg
-ikA
-xYt
-xYt
-xYt
-rAM
-otn
-icz
-cNl
-gNZ
-vaH
-mWo
-cTG
-uHA
-oBj
-oRr
+qUe
+udm
+wvQ
+dcl
+dcl
+dcl
+bJF
+fKi
+lCb
+eiw
+uxh
+ovj
+udm
+dqb
+nsW
+oUh
+ddp
 pNO
-pNO
-pNO
-deU
+mGL
 dge
 dhR
 djt
@@ -173467,7 +176320,8 @@ dkI
 xwf
 ewt
 dyu
-dkI
+nSW
+oWK
 dQL
 naf
 fGj
@@ -173486,13 +176340,13 @@ gvH
 tzX
 wKr
 fGj
-nte
-qIk
+dJx
 fyt
 xLL
 dHi
 pzG
 cjs
+iJw
 iJw
 rFw
 yiZ
@@ -173500,7 +176354,6 @@ acF
 acF
 acF
 acF
-aaa
 aaa
 aaa
 aaa
@@ -173690,27 +176543,27 @@ fWc
 iHM
 iHM
 vSU
-ikA
-ikA
-ikA
-ikA
-ikA
-kCF
-lev
-mAn
-jYQ
-mAn
-wAv
-cOT
-uHA
+fjX
+udm
+dcl
+toy
+dOI
+dcl
+wdH
+oCh
+ohC
+lOn
+cWk
+uZZ
+udm
 oBM
+wED
 oUh
-dpZ
-isM
-deK
-rhD
+wEJ
+pNO
+rQY
 rJJ
-uHt
+tPn
 hxp
 dkF
 biW
@@ -173721,14 +176574,14 @@ vHs
 xbn
 xpD
 xbn
-djf
+txB
 xeK
 yhS
-dkI
-wjI
-wjI
-wjI
-wjI
+oWK
+oWK
+puB
+puB
+puB
 dWy
 woL
 kVJ
@@ -173743,17 +176596,17 @@ dIx
 dIx
 dNB
 lfG
-mkS
+sdL
+mvk
 iyh
-vVR
 dSc
 waL
 dRK
 sUw
 fqq
+fqq
 xuj
 dJx
-abj
 bvh
 abj
 bqc
@@ -173947,25 +176800,25 @@ yhX
 cbC
 yhX
 ugg
-dkp
-kjT
-ekk
-hlh
-ikA
-qWU
-qWU
-qWU
-qWU
-qWU
-qWU
-qWU
-uHA
+cbC
+udm
+udm
+udm
+udm
+udm
+udm
+udm
+udm
+udm
+udm
+udm
+udm
 wRw
 kVz
 puv
 rho
 puv
-rCf
+ftD
 rJr
 uHt
 djw
@@ -174010,7 +176863,7 @@ dIx
 pSp
 dIx
 dIx
-abj
+dJx
 bCI
 aaa
 abj
@@ -174204,10 +177057,10 @@ nhJ
 qUe
 cbC
 cDU
-xuG
-cbC
-cbC
 yhX
+dfO
+ekk
+sfU
 ybR
 sVN
 cNt
@@ -174219,12 +177072,12 @@ aEh
 uHA
 ual
 oWk
-mGL
-pQd
-puv
-rhD
+dgk
+rkO
+pAS
+qee
 pHL
-uHt
+rCf
 djx
 pCm
 biX
@@ -174474,12 +177327,12 @@ hbL
 uuo
 tjq
 uHA
-nrB
-wEJ
-pKg
+pgp
+oRr
+mHX
 drs
 dgk
-dSD
+deU
 tfy
 dkI
 djy
@@ -174737,7 +177590,7 @@ pzW
 vsH
 dds
 koA
-mIg
+xoj
 vsH
 vsH
 vsH
@@ -174988,9 +177841,9 @@ fYC
 izb
 fJp
 uHA
-pgp
-fnI
-xQZ
+nrB
+vye
+wAv
 vsH
 wAs
 pCB
@@ -175245,9 +178098,9 @@ cSd
 jcR
 sVN
 uHA
-puv
-vye
-xQZ
+rdQ
+fnI
+wAv
 pUL
 xdz
 rDf
@@ -175257,9 +178110,9 @@ jmo
 iWl
 uPh
 loO
-wir
+bsR
 rpv
-ena
+bsR
 vsH
 xSf
 xSf
@@ -175760,18 +178613,18 @@ cSc
 nDf
 uHA
 pEd
-vye
-xQZ
+fnI
+wAv
 loO
 ddx
 dff
-qCK
+wir
 biO
 qhf
 mTu
 ena
 wKB
-wir
+bsR
 vnq
 clq
 nYC
@@ -176017,8 +178870,8 @@ qWU
 qWU
 uHA
 hoS
-fnI
-xQZ
+vye
+wAv
 ets
 dkP
 hvE
@@ -176273,9 +179126,9 @@ hQl
 wiY
 nDj
 uHA
-oBj
-vye
-xQZ
+mIg
+fnI
+wAv
 wbP
 hQW
 gpA
@@ -176534,21 +179387,21 @@ esP
 mKZ
 xQZ
 cVZ
-xAj
+rKQ
 nQS
 rKQ
-dzI
-xAj
-xAj
-xAj
+rhD
+rKQ
+rKQ
+rKQ
 dzH
-xAj
-xAj
-xAj
+rKQ
+rKQ
+rKQ
 duY
-xAj
-tEB
-xAj
+rKQ
+wOF
+rKQ
 dyC
 dzI
 wEh
@@ -176789,23 +179642,23 @@ xKu
 sjW
 pAy
 hCs
-qGf
+jLq
 nmp
 xJf
 nbx
 rKZ
 sid
+lBh
 xDv
-lBh
-dqb
+rNO
 gkY
-dqb
+rNO
 jmL
-dqb
-lBh
+rNO
+xDv
 rSp
 dvd
-xDv
+lBh
 hYi
 rNO
 exh
@@ -177046,13 +179899,13 @@ job
 jJs
 rJZ
 mNY
-mHX
+dgk
 oVl
 rot
 xDD
 xDD
 wOF
-xDD
+mFH
 xDD
 oxm
 eCO
@@ -179115,7 +181968,7 @@ wTm
 xsv
 hGm
 vMV
-wjc
+rfK
 wJG
 xus
 gih
@@ -187860,7 +190713,7 @@ pxm
 gnK
 wDC
 sQt
-xjT
+nSp
 hVE
 rqY
 syk
@@ -188117,7 +190970,7 @@ xYg
 sno
 wDC
 xHj
-qti
+rqY
 iQw
 naz
 bzb
@@ -188631,7 +191484,7 @@ jJn
 eMN
 lvv
 gpT
-tWK
+wGm
 xFw
 xxH
 bLY
@@ -188888,7 +191741,7 @@ kEp
 hPb
 lvv
 oVf
-rua
+fdc
 xFw
 xcN
 vfC
@@ -189145,7 +191998,7 @@ feD
 xYy
 lvv
 fSZ
-sye
+wEP
 xFw
 aAh
 mBu
@@ -189401,7 +192254,7 @@ elW
 eUt
 xYM
 lvv
-mpf
+wGm
 tiG
 xFw
 xFw
@@ -189820,23 +192673,23 @@ aaa
 aaa
 aaa
 aaa
-bvh
-bvh
 aaa
 aaa
-bvh
-bvh
-bvh
+aaa
+aaa
+aaa
+aaa
+bCI
 abj
 abj
 abj
 acF
 jgl
 acF
-coE
-coE
-coE
-ykg
+aaa
+aaa
+aaa
+mAV
 nAA
 fMS
 xbB
@@ -189932,7 +192785,7 @@ ehY
 dLR
 aaa
 aaa
-aae
+ars
 aaa
 aaa
 bAP
@@ -190076,24 +192929,24 @@ aaa
 aaa
 aaa
 aaa
-bvh
-bvh
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bCI
 abj
 abj
-abj
-abj
-abj
-abj
-abj
-abj
-sCb
-sCb
-sCb
-tJX
+cri
+cri
+cri
+cri
 laz
-sCb
-sCb
-ykg
+lLU
+cri
+cri
 nCX
 jmN
 vfE
@@ -190189,7 +193042,7 @@ uTj
 ipw
 aaa
 aaa
-aaa
+yga
 aaa
 bAP
 bAP
@@ -190333,24 +193186,24 @@ aaa
 aaa
 aaa
 aaa
-dZq
+aaq
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bCI
 abj
-abj
 cri
 cri
-qBV
-eoF
-wjG
-cri
-cri
-sCb
 iwC
 jkl
 dUG
 lbp
 lMd
-qjU
-ykg
+mkf
+cri
 rVi
 ldR
 ykg
@@ -190591,15 +193444,15 @@ aaa
 aaa
 aaq
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 abj
-cri
-cri
-ixu
-ttc
-jpT
-pzh
-kMD
-cri
+hmq
 hWX
 iwS
 jkT
@@ -190607,7 +193460,7 @@ jRg
 ldS
 fuF
 rbR
-ykg
+cri
 nDc
 wDh
 vfE
@@ -190847,16 +193700,16 @@ aaa
 aaa
 aaa
 aaa
-bvh
+aaa
+aaa
+aaa
+aaa
+aaa
+bCI
+bCI
 abj
-bUG
-fzQ
-iTQ
-uLY
-mnf
-uLY
-eVu
-cri
+abj
+hnB
 hXy
 ixk
 kEH
@@ -190864,7 +193717,7 @@ nJr
 vIt
 miq
 qjU
-ykg
+cri
 nDm
 ogZ
 bNo
@@ -191104,23 +193957,23 @@ aaa
 aaa
 aaa
 aaa
-bvh
+aaa
+aaa
+aaa
+aaa
+bCI
+bCI
 abj
-cVU
-gnv
-lfc
-vJJ
-iOx
-woM
-lmR
-cri
-sCb
+abj
+abj
+hpg
+dJP
 bJA
 sCb
 ugu
 sCb
-sCb
-sCb
+cqt
+chN
 mpI
 nFL
 oAc
@@ -191361,26 +194214,26 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
 bvh
 abj
-dhX
-gTK
-lgN
-vPC
-pAC
-jlc
+abj
+vMK
 gGZ
 cri
-tuS
-aBK
+cri
+cri
 aSF
-yam
+cri
 grU
 kAm
 kzU
-vMK
+cri
 rVi
-hIS
+qGj
 ykg
 rpF
 pJi
@@ -191619,21 +194472,21 @@ aaa
 aaa
 aaq
 aaa
+aaa
+aaa
+aaa
+aaa
 abj
-cri
-cri
-cri
-cri
-rgp
-klB
+vMK
+vMK
 gHB
-cri
+hph
 uKk
-ubg
-ubg
-wwO
-ubg
-ubg
+vMK
+vMK
+vMK
+gTK
+ihw
 lFu
 baI
 nGq
@@ -191875,25 +194728,25 @@ aaa
 aaa
 aaa
 aaa
-dZq
+aaq
+aaa
+aaa
+aaa
+bvh
 abj
-cri
-hmq
-lgS
-mJT
 fwA
 glb
 gHY
 uFM
-vmj
-ubg
-szb
-wwO
-kXF
+gld
+mLo
+jll
+vWO
+lfc
 ihw
 ubg
-szb
 ubg
+nJm
 ohN
 nNu
 oWy
@@ -192132,12 +194985,12 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
 bvh
 abj
-cri
-hnB
-mfo
-klN
 fzv
 dzu
 eyR
@@ -192146,11 +194999,11 @@ qhW
 dNE
 jlz
 jUM
-rWt
-xpz
+jUM
+sTk
 gsY
 bLu
-ubg
+ttc
 wuf
 ojn
 gVB
@@ -192389,25 +195242,25 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
 bvh
 abj
-cri
-hpg
-mlX
-tns
 fAq
 luw
 bHH
-uFM
+sWN
 xpr
-ubg
-iGn
+ixu
+hOE
 gLz
-kJj
-fCJ
-mlM
-vmj
 ubg
+anz
+mlM
+mBL
+nJx
 jIx
 vMK
 oWT
@@ -192647,21 +195500,21 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
 abj
-cri
-cri
-cri
-cri
-cri
-cri
-cri
-cri
+vMK
+vMK
+fzQ
+uLY
 lnW
-ubg
-tHp
+gnv
+hOE
 pQP
 smw
-smw
+lMn
 xKp
 tKK
 tFv
@@ -192903,28 +195756,28 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
 bvh
 abj
 abj
 vMK
-mqj
-reH
-uOZ
-sTR
-jiX
 vMK
-dqH
-ubg
-efg
+vMK
+vMK
+vMK
+hOE
 rGx
-gmO
+iGn
 bHQ
 pjT
 glQ
-ubg
-ubg
+mqj
+mfo
 bCB
-hTO
+vsb
 ePB
 vsb
 qFz
@@ -193160,25 +196013,25 @@ aaa
 aaa
 aaa
 aaa
-bvh
+aaa
+aaa
+aaa
+aaa
 bvh
 abj
-hph
-mLo
-dzY
-tko
-gNL
+abj
+nSZ
 lAZ
-vMK
 tKh
-ubg
+tKh
+lAZ
 uOt
 jVg
 xpz
-xpz
+pNV
 rWt
 scn
-ubg
+hQX
 kXF
 mTP
 iyV
@@ -193418,13 +196271,13 @@ aaa
 aaa
 aaa
 aaa
-bvh
+aaa
+aaa
+aaa
+aaa
 abj
-hQX
-mPL
-ulN
 nSZ
-gJO
+nSZ
 gJO
 hpZ
 hYQ
@@ -193432,10 +196285,10 @@ iAf
 jlH
 wOc
 fCJ
-bZG
-iJJ
-vmj
 ubg
+ubg
+vmj
+vPC
 oyT
 rzh
 nRT
@@ -193675,24 +196528,24 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+bvh
 abj
-abj
-ibj
-nJm
-mNV
 fAx
 dzY
 dOd
-vMK
+mPL
 fye
-ubg
-tHp
+dhX
+uOt
 nXK
-szb
-vqp
-szb
-paO
+xpz
 ubg
+szb
+ubg
+xpz
 pif
 inl
 nRT
@@ -193932,27 +196785,27 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
 bvh
 abj
-vMK
-nJx
-iGx
-uyw
+nSZ
 dAc
 bHO
 mwg
 pVL
-ubg
-xpz
+iTQ
+uOt
 wwO
-lFu
-pBd
-ubg
 xpz
-ubg
+pBd
+mlX
+mCj
+vJJ
 tuY
 rzh
-mpW
+paa
 ija
 nvV
 hgM
@@ -194189,27 +197042,27 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
 bvh
 abj
-abj
-vMK
-vMK
-vMK
-vMK
-vMK
+fAx
+gmA
+ozX
 lAU
 qHb
-ubg
-ubg
-wwO
-ubg
-ubg
-ubg
-ubg
-ubg
+cVU
+uOt
+jWI
+opE
+ojn
+wMw
+qie
+nJR
 rIw
-inl
-nRT
+wMw
+wlk
 tLv
 nvV
 qFD
@@ -194446,27 +197299,27 @@ aaa
 aaa
 aaa
 aaa
-bCI
-bvh
+aaa
+aaa
+aaa
+aaa
 abj
-nJR
-wHu
-lBw
-rtu
+nSZ
+nSZ
 dDE
 fRj
 qoN
 dNG
-dNG
+uOt
 jXd
-tvu
-szb
-xWg
+xpz
+lMr
+wMw
 cRC
 mBF
 fXV
-rzh
-oDO
+wMw
+yhA
 tcP
 oau
 qIz
@@ -194704,26 +197557,26 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+bvh
 abj
 abj
-opE
-sVm
-bub
-dQk
+nSZ
 bgt
-qDn
-wla
-ubg
-dsj
+nSZ
+nSZ
+nSZ
+uOt
 jXk
 vyi
 uSY
 qie
-vyi
+kyw
 nKc
 lCu
-wMw
-pby
+rIw
+nRT
 tLv
 nvV
 tzh
@@ -194961,21 +197814,21 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+bvh
 bvh
 abj
-paa
-rhG
-igZ
-tmw
-iLT
-vuq
-uRW
-iPH
-oar
+abj
+abj
+abj
+abj
+acF
+hOE
 jZY
-vyi
+krK
 lOu
-sXq
+wMw
 mDL
 gxI
 bLv
@@ -195197,7 +198050,6 @@ aaa
 aaa
 aaa
 aaa
-coE
 aaa
 aaa
 aaa
@@ -195218,26 +198070,27 @@ aaa
 aaa
 aaa
 aaa
-bCI
-abj
-vMK
-vMK
-vMK
-vMK
-rzA
-xyQ
-fnM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 iAK
 jnn
 kbT
-vyi
+pgE
 krM
-qWg
-bzw
+qie
+kyw
 xxx
-rdX
+lCu
 ykI
-pBU
+nRT
 pLm
 qhn
 lhS
@@ -195450,11 +198303,16 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
 coE
-coE
-cCE
-coE
-kGY
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -195476,25 +198334,20 @@ aaa
 aaa
 aaa
 bvh
-abj
+bvh
 abj
 abj
 acF
-acF
-fib
-fsq
-qlW
-oDN
-dpk
+vMK
 kdd
-vyi
+tby
 exv
-lfw
+wMw
 mEu
 jdU
 dNo
 wMw
-nRT
+pby
 tLv
 nvV
 lhS
@@ -195708,11 +198561,10 @@ aaa
 aaa
 aaa
 coE
-cCE
-icl
-gMv
-qgX
 coE
+cCE
+coE
+qgX
 aaa
 aaa
 aaa
@@ -195734,23 +198586,24 @@ aaa
 aaa
 aaa
 aaa
+bCI
+bCI
+bCI
 aaa
-aaa
-aaa
-ozX
-xyQ
-jRh
-skC
-qfc
-wLq
-kfc
-vyi
-vyi
-vyi
-vyi
-vyi
-vyi
-vyi
+abj
+abj
+abj
+ftc
+ftc
+ftc
+ftc
+aru
+aru
+aru
+aru
+aru
+aru
+aru
 hdu
 pLB
 bzC
@@ -195964,11 +198817,11 @@ aaa
 aaa
 aaa
 aaa
+coE
 cCE
-gKd
 gMv
 jPC
-cCE
+rzA
 coE
 aaa
 aaa
@@ -195993,11 +198846,11 @@ abj
 abj
 abj
 abj
-acF
-acF
-sCb
-jch
-tFf
+abj
+abj
+ftc
+ftc
+ftc
 iBE
 joq
 keE
@@ -196221,12 +199074,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
 cCE
-cCE
+gKd
+jPC
 jSk
 cCE
-cCE
+coE
 aaa
 aaa
 aaa
@@ -196252,11 +199105,11 @@ mAr
 fdX
 fAB
 aru
-sCb
+aru
 hsI
 hZW
 ucB
-nnG
+iCk
 kfc
 aru
 lPJ
@@ -196479,12 +199332,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 cCE
-coE
 cCE
-coE
+kGY
+cCE
+cCE
+aaa
 aaa
 aaa
 aaa
@@ -196510,7 +199363,7 @@ ffs
 fAM
 gnI
 aru
-sCb
+aru
 dgo
 iCk
 cfs
@@ -196738,9 +199591,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+cCE
 coE
+cCE
 coE
 aaa
 aaa
@@ -196768,7 +199621,7 @@ jxB
 wTJ
 gKa
 aru
-aru
+bUG
 aru
 aru
 aru
@@ -196997,8 +199850,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+coE
+coE
 aaa
 aaa
 aaa
@@ -197025,7 +199878,7 @@ vIm
 qDW
 uPb
 wTJ
-dAb
+vIm
 qbt
 drU
 cfz
@@ -197045,7 +199898,7 @@ xmw
 tsW
 vuE
 urn
-xqE
+vuE
 vYt
 wCH
 myZ
@@ -197281,8 +200134,8 @@ tLD
 fBo
 val
 gKm
-xan
-xan
+val
+ibj
 nfZ
 joA
 kfn
@@ -198823,7 +201676,7 @@ fiU
 fCQ
 fCQ
 gOj
-tCR
+wxD
 aru
 xwO
 eHM
@@ -199337,8 +202190,8 @@ tLD
 cxr
 val
 gQC
-val
-srM
+xan
+xan
 iDp
 jqd
 sdz
@@ -199594,8 +202447,8 @@ ojw
 vIm
 cqf
 vGv
-kTh
-vIm
+qBV
+icl
 iCu
 jqn
 rEC
@@ -199851,11 +202704,11 @@ iZf
 fCT
 kTh
 gQN
-dZF
-uUT
-dZF
-dZF
-dZF
+aru
+aru
+aru
+aru
+aru
 wyD
 wyD
 wyD
@@ -200107,12 +202960,12 @@ eur
 fkB
 kti
 gof
-dZF
-dZF
-oWU
-pzY
-wbO
-hRI
+aru
+aru
+abj
+abj
+abj
+abj
 wyD
 lVa
 mop
@@ -200364,13 +203217,13 @@ mAr
 nos
 fEI
 aru
-dZF
-pbV
-gue
-pzY
-pzY
-mIv
-wyD
+aru
+abj
+abj
+bCI
+bCI
+abj
+lgN
 dZu
 mrN
 mFk
@@ -200621,13 +203474,13 @@ abj
 abj
 abj
 abj
-dZF
-luL
-msW
-tkE
-tYs
-jMf
-wyD
+abj
+abj
+aaa
+aaa
+bCI
+abj
+lgS
 lWf
 fEz
 xxF
@@ -200643,7 +203496,7 @@ vZl
 xAb
 tWn
 vZl
-nzk
+xAb
 tWn
 qKm
 qKm
@@ -200877,13 +203730,13 @@ bCI
 bCI
 bCI
 aaa
+bCI
+bCI
+bCI
+aaa
+aaa
+aaa
 abj
-dZF
-dZF
-dZF
-dZF
-dZF
-dZF
 wyD
 haO
 pku
@@ -201134,12 +203987,12 @@ aaa
 aaa
 aaa
 aaa
-abj
-abj
-abj
-abj
-abj
-abj
+aaa
+aaa
+aaa
+aaa
+aaa
+bCI
 abj
 lhC
 fHL
@@ -201391,11 +204244,11 @@ aaa
 aaa
 aaa
 aaa
-bvh
-bvh
-bvh
 aaa
-bCI
+aaa
+aaa
+aaa
+aaa
 bCI
 abj
 lhQ
@@ -202892,7 +205745,7 @@ aaf
 aer
 adZ
 abr
-lyg
+aec
 afi
 afZ
 aaa


### PR DESCRIPTION
драфт

## What Does This PR Do
Продолжение уродования расширения 1-тайловых техов и переработки заброшенных зон РнД.

Изменение и увеличение количества возможных маршрутов в техах, расширение коридоров до 2 тайлов, улучшенная детализация.
Бойцовский клуб заменён на театр с разделением на два помещения - сцены и кулис.
Старое ксено заменено на тестовою зону СМа(принадлежность-инженерия/РнД).
Старые комнатушки перемещены чуть ниже с добавлением коридора.
В дополнение к кулисам добавлена клоунская. 
