### PR TITLE
fix: Cogscarab gets Respawnability on death and winds up timer near beacon

### DIFF
--- a/code/game/gamemodes/clockwork/clockwork_structures.dm
+++ b/code/game/gamemodes/clockwork/clockwork_structures.dm
@@ -128,6 +128,9 @@
 			if(L.reagents?.has_reagent("holywater"))
 				to_chat(L, "<span class='warning'>You feel a terrible liquid disappearing from your body.</span>")
 				L.reagents.del_reagent("holywater")
+			if(iscogscarab(L))
+				var/mob/living/silicon/robot/cogscarab/C = L
+				C.wind_up_timer = min(C.wind_up_timer + 25, CLOCK_MAX_WIND_UP_TIMER) //every 6 seconds gains 25 seconds. roughly, every second 5 to timer.
 			if(!(L.health < L.maxHealth))
 				continue
 			new /obj/effect/temp_visual/heal(get_turf(L), "#960000")
@@ -136,9 +139,6 @@
 				L.heal_overall_damage(10, 10, TRUE, FALSE, TRUE)
 			if(isrobot(L))
 				L.heal_overall_damage(5, 5, TRUE)
-				if(iscogscarab(L))
-					var/mob/living/silicon/robot/cogscarab/C = L
-					C.wind_up_timer = min(C.wind_up_timer + 25, CLOCK_MAX_WIND_UP_TIMER) //every 6 seconds gains 25 seconds. roughly, every second 5 to timer.
 
 			else if(isanimal(L))
 				var/mob/living/simple_animal/M = L

--- a/code/game/gamemodes/clockwork/cogscarab.dm
+++ b/code/game/gamemodes/clockwork/cogscarab.dm
@@ -170,7 +170,7 @@
 	if(status_flags & GODMODE)
 		return
 	if(health <= -maxHealth && stat != DEAD)
-		ghostize(FALSE)
+		ghostize(TRUE)
 		gib()
 		log_debug("died of damage, trigger reason: [reason]")
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
С недавним выходом, я сделал ошибку в коде.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Отдайте скарабеям возможность респавна и восстановление таймера

## Changelog
:cl:
fix: Cogscarab now gets Respawnability on death
fix: Cogscarab now winds up timer without need to get hurt near the beacon.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
