### PR TITLE
fix: invisible meaty ores

### DIFF
--- a/code/modules/events/dust.dm
+++ b/code/modules/events/dust.dm
@@ -18,6 +18,7 @@
 	var/strength = 2 //ex_act severity number
 	var/life = 2 //how many things we hit before qdel(src)
 	var/atom/goal = null
+	var/shake_chance = 50
 
 /obj/effect/space_dust/weak
 	strength = 3
@@ -64,30 +65,33 @@
 	src.x = startx
 	src.y = starty
 	src.z = level_name_to_num(MAIN_STATION)
-	spawn(0)
-		walk_towards(src, goal, 1)
-	return
+	walk_towards(src, goal, 1)
 
 /obj/effect/space_dust/Bump(atom/A)
-	spawn(0)
-		if(prob(50))
-			for(var/mob/M in range(10, src))
-				if(!M.stat && !istype(M, /mob/living/silicon/ai))
-					shake_camera(M, 3, 1)
-		if(A)
-			playsound(src.loc, 'sound/effects/meteorimpact.ogg', 40, 1)
+	if(QDELETED(src))
+		return
+	if(prob(shake_chance))
+		for(var/mob/M in range(10, src))
+			if(!M.stat && !istype(M, /mob/living/silicon/ai))
+				shake_camera(M, 3, 1)
+	playsound(loc, 'sound/effects/meteorimpact.ogg', 40, 1)
 
-			if(ismob(A))
-				A.ex_act(strength)//This should work for now I guess
-			else if(!istype(A,/obj/machinery/power/emitter) && !istype(A,/obj/machinery/field/generator)) //Protect the singularity from getting released every round!
-				A.ex_act(strength) //Changing emitter/field gen ex_act would make it immune to bombs and C4
+	INVOKE_ASYNC(src, .proc/impact_meteor, A) // ex_act can have some sleeps in it
 
-			life--
-			if(life <= 0)
-				walk(src,0)
-				spawn(1)
-					qdel(src)
-				return
+/obj/effect/space_dust/proc/impact_meteor(atom/A)
+	var/turf/where = get_turf(A)
+	if(ismob(A))
+		A.ex_act(strength)//This should work for now I guess
+	else if(!istype(A, /obj/machinery/power/emitter) && !istype(A, /obj/machinery/field/generator)) //Protect the singularity from getting released every round!
+		A.ex_act(strength) //Changing emitter/field gen ex_act would make it immune to bombs and C4
+
+	life--
+	if(life <= 0)
+		walk(src, 0)
+		on_shatter(where)
+		qdel(src)
+
+/obj/effect/space_dust/proc/on_shatter(turf/where)
 	return
 
 /obj/effect/space_dust/Bumped(atom/A)

--- a/code/modules/events/meaty_ores.dm
+++ b/code/modules/events/meaty_ores.dm
@@ -29,7 +29,6 @@
 	if(A)
 		playsound(src.loc, 'sound/effects/meteorimpact.ogg', 40, 1)
 		walk(src,0)
-		invisibility = 101
 		new /obj/effect/decal/cleanable/blood(get_turf(A))
 		if(ismob(A))
 			A.ex_act(strength)
@@ -37,8 +36,8 @@
 			spawn(0)
 				if(A)
 					A.ex_act(strength)
-				if(src)
-					walk_towards(src,goal,1)
+		if(src)
+			walk_towards(src,goal,1)
 		life--
 		if(!life)
 			if(prob(80))

--- a/code/modules/events/meaty_ores.dm
+++ b/code/modules/events/meaty_ores.dm
@@ -19,34 +19,18 @@
 
 	strength = 1
 	life = 3
+	shake_chance = 20
 
-/obj/effect/space_dust/meaty/Bump(atom/A)
-	if(prob(20))
-		spawn(1)
-			for(var/mob/M in range(10, src))
-				if(!M.stat && !istype(M, /mob/living/silicon/ai))
-					shake_camera(M, 3, 1)
-	if(A)
-		playsound(src.loc, 'sound/effects/meteorimpact.ogg', 40, 1)
-		walk(src,0)
-		new /obj/effect/decal/cleanable/blood(get_turf(A))
-		if(ismob(A))
-			A.ex_act(strength)
-		else
-			spawn(0)
-				if(A)
-					A.ex_act(strength)
-		if(src)
-			walk_towards(src,goal,1)
-		life--
-		if(!life)
-			if(prob(80))
-				gibs(loc)
-				if(prob(45))
-					new /obj/item/reagent_containers/food/snacks/meat(loc)
-				else if(prob(10))
-					explosion(get_turf(loc), 0, pick(0,1), pick(2,3), 0, cause = src)
-			else
-				new /mob/living/simple_animal/cow(loc)
+/obj/effect/space_dust/meaty/impact_meteor(atom/A)
+	new /obj/effect/decal/cleanable/blood(get_turf(A))
+	..()
 
-			qdel(src)
+/obj/effect/space_dust/meaty/on_shatter(turf/where)
+	if(prob(80))
+		gibs(where)
+		if(prob(45))
+			new /obj/item/reagent_containers/food/snacks/meat(where)
+		else if(prob(10))
+			explosion(where, 0, pick(0,1), pick(2,3), 0, cause = src)
+	else
+		new /mob/living/simple_animal/cow(where)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Фиксит висящие на месте невидимые метеоры.
Перенесена часть рефактора с оффов, которая как раз фиксит эти метеоры. Код стал чуть получше.
https://github.com/ParadiseSS13/Paradise/pull/15203

Репорты
https://discord.com/channels/617003227182792704/617004034405957642/1040976700877586452
https://discord.com/channels/617003227182792704/617004034405957642/1037023351421546596
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Changelog
:cl:
tweak: Meaty ores will now not turn invisible once they hit their first target
tweak: Meaty ores will now not stop moving when they hit a mob
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
