### PR TITLE
Tweak: unathi diet

### DIFF
--- a/code/modules/mob/living/carbon/human/species/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/unathi.dm
@@ -72,8 +72,8 @@
 		"сворачивает себе шею!",
 		"задерживает дыхание!")
 
-	disliked_food = VEGETABLES | FRUIT | GRAIN
-	liked_food = MEAT | RAW | EGG
+	disliked_food = VEGETABLES | FRUIT | GRAIN | SUGAR | JUNKFOOD
+	liked_food = MEAT | RAW | EGG | GROSS
 
 /datum/action/innate/tail_lash
 	name = "Взмах хвостом"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Обновил диету унатхов в связи  с новым лором. Унатхи питаются исключительно пищей животного происхождения, никакого сахара и джанкфуда. Только животные, яйца, и насекомые.

## Why It's Good For The Game
Теперь диета унатхов соответствует лору.

## Changelog
:cl:
tweak: tweaked unathi diet so it fits to new lore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
