### PR TITLE
FEAT: Delta Abandoned RnD areas & maintrance update

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -3721,26 +3721,12 @@
 	},
 /area/hallway/secondary/entry/lounge)
 "arH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/structure/holosign/barrier,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/maintenance/asmaint3)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "arM" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -4400,9 +4386,21 @@
 /turf/simulated/shuttle/floor,
 /area/shuttle/administration)
 "avX" = (
-/obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall/rust,
-/area/maintenance/tourist)
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "sw_maint_inner";
+	locked = 1;
+	name = "West Maintenance External Access";
+	req_access_txt = "10;13"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "avZ" = (
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/bluegrid,
@@ -4741,6 +4739,10 @@
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
+"axV" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "aye" = (
 /obj/machinery/atmospherics/unary/outlet_injector/on{
 	dir = 8
@@ -4832,6 +4834,16 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/engine/mechanic_workshop)
+"ayN" = (
+/obj/machinery/light/small,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitehall"
+	},
+/area/crew_quarters/theatre)
 "ayQ" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 8;
@@ -6438,6 +6450,14 @@
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry)
+"aGP" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/obj/machinery/light,
+/turf/simulated/floor/wood,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "aGQ" = (
 /obj/machinery/light{
 	dir = 1
@@ -7169,11 +7189,11 @@
 	},
 /area/engine/mechanic_workshop/hangar)
 "aKL" = (
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/area/maintenance/tourist)
+/turf/simulated/floor/engine,
+/area/toxins/ab_sm)
 "aKM" = (
 /obj/structure/computerframe,
 /turf/simulated/shuttle/floor,
@@ -7601,8 +7621,13 @@
 	},
 /area/hallway/secondary/entry/lounge)
 "aMW" = (
-/turf/simulated/wall,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/crayon/random,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/theatre)
 "aMX" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -8851,13 +8876,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/barricade/wooden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1
+	},
+/area/maintenance/asmaint3)
 "aSQ" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -9624,6 +9650,22 @@
 /obj/structure/sign/directions/science,
 /turf/simulated/wall,
 /area/hallway/secondary/entry/lounge)
+"aWO" = (
+/obj/structure/sign/nosmoking_1{
+	pixel_y = 32
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purple"
+	},
+/area/toxins/ab_sm)
 "aWP" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
@@ -9852,6 +9894,25 @@
 /obj/machinery/status_display,
 /turf/simulated/wall,
 /area/quartermaster/qm)
+"aXW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint3)
 "aYd" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -10426,10 +10487,22 @@
 	},
 /area/hallway/secondary/entry/commercial)
 "bbA" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/area/maintenance/gambling_den)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10;
+	initialize_directions = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "bbC" = (
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
@@ -12632,9 +12705,29 @@
 	},
 /area/hallway/secondary/entry)
 "bmJ" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "bmM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door_control{
@@ -14618,9 +14711,18 @@
 /turf/simulated/shuttle/floor,
 /area/shuttle/supply)
 "bwy" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/bananalamp{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "bwC" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -16385,8 +16487,23 @@
 	},
 /area/maintenance/garden/north)
 "bCK" = (
-/turf/simulated/wall/rust,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "bCL" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -18143,18 +18260,19 @@
 	},
 /area/crew_quarters/kitchen)
 "bLm" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 26
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/crayon{
+	desc = "Crayon art.";
+	icon_state = "squish";
+	name = "Graffiti";
+	pixel_y = 32
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "bLo" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "construction access"
@@ -20680,15 +20798,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/area/maintenance/asmaint3)
 "bVL" = (
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -25372,11 +25490,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "cpP" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/area/maintenance/tourist)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "cpQ" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -25924,9 +26048,9 @@
 /turf/simulated/wall/r_wall,
 /area/ai_monitored/storage/eva)
 "csO" = (
-/obj/effect/decal/cleanable/fungus,
+/obj/effect/spawner/random_spawners/wall_rusted_probably,
 /turf/simulated/wall,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "csS" = (
 /obj/structure/closet/crate,
 /obj/item/stack/rods{
@@ -26749,6 +26873,20 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"cwi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "cwk" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -28374,6 +28512,10 @@
 	icon_state = "browncorner"
 	},
 /area/quartermaster/sorting)
+"cBQ" = (
+/obj/structure/sign/securearea,
+/turf/simulated/wall/r_wall/coated,
+/area/toxins/ab_sm)
 "cBY" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -28876,7 +29018,9 @@
 	name = "3maintenance loot spawner"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "cDv" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
@@ -29944,11 +30088,15 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/engrooms)
 "cHe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "purplecorner"
+	icon_state = "whitehall"
 	},
-/area/maintenance/xenozoo)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "cHh" = (
 /obj/machinery/camera{
 	c_tag = "Service Hall South";
@@ -30271,19 +30419,15 @@
 	},
 /area/library)
 "cIx" = (
-/obj/item/shard{
-	icon_state = "small"
-	},
-/obj/item/shard{
-	icon_state = "medium";
-	pixel_x = -7;
-	pixel_y = -10
-	},
-/obj/item/airlock_electronics,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/clothing/mask/gas/clown_hat/pennywise,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "bar"
 	},
-/area/maintenance/xenozoo)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "cIz" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -30718,11 +30862,18 @@
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
 "cJK" = (
-/obj/effect/decal/remains/xeno,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/maintenance/xenozoo)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/toxins/ab_sm)
 "cJL" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -30787,10 +30938,10 @@
 	},
 /area/quartermaster/delivery)
 "cKc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "cKd" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -31087,15 +31238,20 @@
 	},
 /area/engine/gravitygenerator)
 "cLz" = (
-/obj/machinery/smartfridge/secure/extract,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/closet/walllocker/emerglocker{
-	pixel_x = -32
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "whitehall"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/area/maintenance/asmaint3)
 "cLA" = (
 /obj/machinery/status_display{
 	pixel_y = -32
@@ -31145,15 +31301,14 @@
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
 "cLL" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "sw_maint_outer";
-	locked = 1;
-	name = "West Maintenance External Access"
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitehall"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "cLU" = (
 /obj/machinery/light{
 	dir = 4
@@ -31735,12 +31890,12 @@
 /turf/space,
 /area/solar/starboard)
 "cOC" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/autodrobe,
 /turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "cOF" = (
 /obj/structure/closet/crate/internals,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -32069,12 +32224,16 @@
 /turf/simulated/floor/plating,
 /area/medical/chemistry)
 "cPG" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/structure/bed,
+/obj/item/bedsheet/clown,
+/obj/effect/mob_spawn/human,
+/obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "bar"
 	},
-/area/maintenance/xenozoo)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "cPI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -33003,8 +33162,18 @@
 /turf/simulated/wall,
 /area/maintenance/electrical)
 "cTi" = (
-/turf/simulated/wall,
-/area/maintenance/xenozoo)
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/computerframe,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purple"
+	},
+/area/toxins/ab_sm)
 "cTj" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 28
@@ -33127,11 +33296,30 @@
 /turf/simulated/wall/r_wall/coated,
 /area/maintenance/turbine)
 "cTL" = (
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/pie{
+	pixel_y = 7
 	},
-/area/maintenance/xenozoo)
+/obj/item/reagent_containers/food/snacks/grown/banana{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/snacks/grown/banana{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/snacks/grown/banana,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/mirror{
+	icon_state = "mirror_broke";
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "cTM" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/drone_fabricator,
@@ -33457,8 +33645,16 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
 "cUS" = (
-/turf/simulated/wall/r_wall,
-/area/maintenance/xenozoo)
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/warning_stripes/east,
+/obj/machinery/door/window/brigdoor,
+/turf/simulated/floor/plating,
+/area/toxins/ab_sm)
 "cUU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -33829,17 +34025,10 @@
 	},
 /area/turret_protected/ai_upload)
 "cWb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/chair/wood/wings,
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "cWd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt{
@@ -34317,15 +34506,12 @@
 	},
 /area/quartermaster/sorting)
 "cXZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/table/wood/poker,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "cYa" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -35245,7 +35431,7 @@
 "dbz" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "dbC" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -36004,11 +36190,13 @@
 	},
 /area/hallway/primary/fore)
 "deE" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 4;
+	icon_state = "darkblue"
 	},
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "deF" = (
 /obj/effect/decal/warning_stripes/southeast,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -36046,20 +36234,22 @@
 	},
 /area/medical/research/nhallway)
 "deL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/maintenance{
-	name = "Gambling Den"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/structure/barricade/wooden,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/crew_quarters/theatre)
 "deM" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced{
@@ -36149,9 +36339,30 @@
 	},
 /area/construction/hallway)
 "deX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/maintenance/tourist)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "dfa" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/structure/cable{
@@ -36347,25 +36558,13 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "dfQ" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
 	},
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "dfR" = (
 /obj/structure/sign/xenobio{
 	pixel_y = -32
@@ -36403,8 +36602,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/maintenance/asmaint3)
 "dfU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -36857,14 +37059,10 @@
 	},
 /area/construction/hallway)
 "dhw" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/gambling_den)
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "dhx" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -38278,14 +38476,24 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/auxsolarport)
 "dmM" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 6
 	},
-/obj/effect/decal/remains/xeno,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/area/maintenance/gambling_den)
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "dmN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -38300,6 +38508,10 @@
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
 "dmP" = (
@@ -39277,9 +39489,13 @@
 /area/medical/morgue)
 "dqk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/remains/human,
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/crew_quarters/theatre)
 "dqq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -42513,17 +42729,19 @@
 /turf/simulated/wall/r_wall,
 /area/atmos)
 "dDI" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood{
 	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 4;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "dDK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -42676,6 +42894,13 @@
 /obj/item/clothing/glasses/sunglasses,
 /turf/simulated/floor/plating,
 /area/maintenance/casino)
+"dEw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/sosjerky,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken6"
+	},
+/area/crew_quarters/theatre)
 "dEA" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -45200,6 +45425,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hop)
+"dNP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "dNR" = (
 /obj/machinery/cooker/foodgrill,
 /turf/simulated/floor/wood,
@@ -48359,10 +48591,14 @@
 	},
 /area/quartermaster/qm)
 "dYs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_spawners/blood_maybe,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
 	},
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "dYt" = (
 /obj/structure/disposalpipe/segment{
 	name = "Sorting Office"
@@ -48370,11 +48606,16 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/mrchangs)
 "dYv" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/writing,
+/obj/structure/curtain/open/shower/security{
+	name = "backstage";
+	alpha = 255
 	},
-/area/maintenance/gambling_den)
+/turf/simulated/floor/plasteel{
+	icon_state = "tranquillite"
+	},
+/area/crew_quarters/theatre)
 "dYy" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -48416,6 +48657,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"dYH" = (
+/obj/structure/bed,
+/obj/item/bedsheet/orange,
+/turf/simulated/floor/carpet,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "dYJ" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
@@ -49238,17 +49486,34 @@
 /turf/simulated/floor/engine/air,
 /area/atmos)
 "edF" = (
-/obj/structure/closet/emcloset,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/barricade/wooden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/maintenance/xenozoo)
-"edJ" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/research{
+	name = "Research Division Access";
+	req_access_txt = "47"
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/asmaint3)
+/area/toxins/ab_sm)
+"edJ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "edM" = (
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
@@ -49354,6 +49619,23 @@
 	icon_state = "redfull"
 	},
 /area/security/processing)
+"efo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1
+	},
+/area/maintenance/asmaint3)
 "efA" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -49373,7 +49655,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "whitehall"
+	},
 /area/maintenance/asmaint3)
 "efR" = (
 /turf/simulated/shuttle/floor{
@@ -49381,28 +49666,10 @@
 	},
 /area/shuttle/siberia)
 "egh" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/coatrack,
 /turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "egl" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/simulated/floor/plasteel{
@@ -49503,12 +49770,21 @@
 	},
 /area/engine/engineering)
 "egO" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/maintenance/tourist)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "egU" = (
 /obj/structure/closet/l3closet/virology,
 /obj/item/storage/box/masks,
@@ -49758,6 +50034,10 @@
 	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
+"ejo" = (
+/obj/structure/falsewall,
+/turf/space,
+/area/crew_quarters/theatre)
 "ejp" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -50303,9 +50583,19 @@
 	},
 /area/crew_quarters/courtroom)
 "epM" = (
-/obj/structure/chair/wood,
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/snacks/grown/tomato{
+	pixel_x = -10;
+	pixel_y = -12
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/black,
+/area/crew_quarters/theatre)
 "epY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -50660,8 +50950,14 @@
 	},
 /area/maintenance/asmaint)
 "ete" = (
-/turf/simulated/floor/wood,
-/area/maintenance/tourist)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder,
+/turf/simulated/floor/plasteel{
+	dir = 1
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "eto" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -50806,11 +51102,20 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/starboard)
 "evo" = (
-/obj/structure/chair/wood{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "evI" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -50993,11 +51298,19 @@
 	},
 /area/security/armory)
 "exN" = (
-/obj/structure/chair/stool/bar,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/area/maintenance/gambling_den)
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/turf/simulated/floor/carpet/black,
+/area/crew_quarters/theatre)
 "exV" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/blue,
@@ -51189,11 +51502,11 @@
 	},
 /area/engine/engineering)
 "eAg" = (
-/obj/effect/decal/remains/human,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
+/obj/effect/spawner/random_spawners/wall_rusted_probably,
+/turf/simulated/wall,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "eAm" = (
 /obj/machinery/camera/motion{
 	c_tag = "Minisat AI Core North";
@@ -51402,12 +51715,13 @@
 	},
 /area/medical/research/shallway)
 "eCP" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder,
 /turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "eCU" = (
 /obj/structure/table,
 /obj/item/paper/deltainfo,
@@ -52575,8 +52889,31 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "ePn" = (
-/turf/simulated/wall/r_wall,
-/area/maintenance/tourist)
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	id_tag = "sw_maint_airlock";
+	pixel_y = 25;
+	tag_airpump = "sw_maint_pump";
+	tag_chamber_sensor = "sw_maint_sensor";
+	tag_exterior_door = "sw_maint_outer";
+	tag_interior_door = "sw_maint_inner"
+	},
+/obj/machinery/airlock_sensor{
+	id_tag = "sw_maint_sensor";
+	pixel_y = 33
+	},
+/obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1379;
+	id_tag = "sw_maint_pump"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "ePt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -52668,6 +53005,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
+"eQq" = (
+/turf/simulated/floor/plating,
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
 "eQA" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -53262,6 +53604,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
+"eXq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/obj/machinery/cell_charger,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/theatre)
 "eXx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/warning_stripes/east,
@@ -53390,9 +53743,16 @@
 	},
 /area/medical/research/nhallway)
 "eYo" = (
-/obj/structure/table/wood/poker,
+/obj/structure/table/wood,
+/obj/item/lighter/zippo/engraved{
+	pixel_x = 1;
+	pixel_y = 3
+	},
+/obj/machinery/light,
 /turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "eYB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed,
@@ -53575,13 +53935,11 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/kitchen)
 "far" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/area/crew_quarters/theatre)
 "fat" = (
 /obj/structure/closet/firecloset,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -53995,6 +54353,24 @@
 	icon_state = "dark"
 	},
 /area/engine/hardsuitstorage)
+"feG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint3)
 "ffi" = (
 /obj/structure/table,
 /obj/item/folder,
@@ -54368,13 +54744,14 @@
 	},
 /area/security/permabrig)
 "fjQ" = (
-/obj/machinery/light/small,
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = -32
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purple"
 	},
-/obj/machinery/vending/boozeomat,
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/toxins/ab_sm)
 "fjW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -54520,13 +54897,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "flH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/comfy/beige{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/area/maintenance/gambling_den)
+/turf/simulated/floor/carpet/royalblue,
+/area/crew_quarters/theatre)
 "flW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -54987,17 +55366,20 @@
 /turf/simulated/floor/engine/air,
 /area/atmos)
 "frM" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/sign/poster/contraband/random{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/crayon{
+	desc = "Crayon art.";
+	icon_state = "brokenheart";
+	name = "Graffiti";
 	pixel_x = -32
 	},
-/obj/structure/chair/stool/bar,
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	dir = 8;
+	icon_state = "whitehall"
 	},
-/area/maintenance/gambling_den)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "frN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -55042,8 +55424,18 @@
 	},
 /area/crew_quarters/bar/atrium)
 "fsp" = (
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/obj/structure/computerframe,
+/obj/machinery/door_control{
+	id = "SupermatterVenting";
+	name = "Supermatter Venting Control";
+	pixel_x = 26;
+	req_access_txt = "24,47"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purple"
+	},
+/area/toxins/ab_sm)
 "fsq" = (
 /obj/machinery/button/windowtint{
 	anchored = 1;
@@ -55616,13 +56008,16 @@
 	},
 /area/security/customs)
 "fyJ" = (
-/obj/machinery/light/small,
-/obj/effect/decal/warning_stripes/south,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/area/maintenance/xenozoo)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/toxins/ab_sm)
 "fzv" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -55837,27 +56232,27 @@
 /area/toxins/launch)
 "fCq" = (
 /obj/structure/window/reinforced/polarized{
-	color = "#222222";
 	dir = 8;
 	id = "pokerclub";
-	opacity = 1
+	opacity = 1;
+	color = "#222222"
 	},
 /obj/structure/window/reinforced/polarized{
-	color = "#222222";
 	dir = 1;
 	id = "pokerclub";
+	color = "#222222";
 	opacity = 1
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
-	color = "#222222";
 	dir = 4;
 	id = "pokerclub";
-	opacity = 1
+	opacity = 1;
+	color = "#222222"
 	},
 /obj/structure/window/reinforced/polarized{
-	color = "#222222";
 	id = "pokerclub";
+	color = "#222222";
 	opacity = 1
 	},
 /turf/simulated/floor/plating,
@@ -56221,29 +56616,21 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "fFT" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "fGa" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -56400,10 +56787,17 @@
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "fIg" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitehall"
+	},
+/area/maintenance/asmaint3)
 "fIi" = (
 /obj/machinery/computer/operating{
 	dir = 8
@@ -56472,16 +56866,23 @@
 /turf/simulated/floor/engine/co2,
 /area/atmos)
 "fJh" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = -32
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	dir = 1;
+	icon_state = "chapel"
 	},
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "fJp" = (
 /obj/machinery/teleport/hub,
 /turf/simulated/floor/plating,
@@ -57240,9 +57641,39 @@
 	},
 /area/hydroponics)
 "fSK" = (
-/obj/structure/closet/firecloset,
-/turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
+"fSL" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "fSZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/random{
@@ -57486,6 +57917,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
+"fVr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/theatre)
 "fVv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -57541,8 +57979,11 @@
 	dir = 4;
 	pixel_y = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/engineering)
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
 "fVO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -57593,6 +58034,12 @@
 	icon_state = "white"
 	},
 /area/toxins/lab)
+"fWb" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "fWc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -57859,14 +58306,13 @@
 	},
 /area/assembly/robotics)
 "fXD" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/maintenance/xenozoo)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "fXK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light,
@@ -58112,15 +58558,34 @@
 	},
 /area/maintenance/electrical)
 "gaJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc{
+	cell_type = 25000;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24;
+	shock_proof = 1
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 4;
+	icon_state = "darkblue"
 	},
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
+"gaS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/barricade/wooden,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "gbp" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -58309,6 +58774,28 @@
 	icon_state = "freezerfloor"
 	},
 /area/crew_quarters/sleep)
+"gdD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "gdQ" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/decal/warning_stripes/yellow,
@@ -58378,6 +58865,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar/atrium)
+"geu" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "purple"
+	},
+/area/toxins/ab_sm)
 "geA" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -58550,21 +59046,10 @@
 	},
 /area/security/customs)
 "ghg" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	dir = 1;
-	pixel_x = -32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/ants,
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "ghj" = (
 /obj/machinery/atmospherics/trinary/mixer,
 /turf/simulated/floor/engine,
@@ -58649,6 +59134,22 @@
 	icon_state = "neutralcorner"
 	},
 /area/maintenance/starboard)
+"giV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "gjf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/closet/walllocker/emerglocker/west,
@@ -58738,6 +59239,18 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint3)
+"gkG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "gkQ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -58907,6 +59420,13 @@
 	},
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
+"gmj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/plating,
+/area/toxins/ab_sm)
 "gmk" = (
 /obj/structure/cult/archives,
 /obj/machinery/newscaster{
@@ -59104,10 +59624,24 @@
 	},
 /area/medical/sleeper)
 "goA" = (
-/obj/structure/table/wood,
-/obj/item/camera,
-/turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "goC" = (
 /obj/structure/window/plasmareinforced{
 	dir = 4
@@ -59969,14 +60503,11 @@
 /area/medical/genetics)
 "gze" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/gambling_den)
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "gzr" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -60059,11 +60590,12 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/miningdock)
 "gAD" = (
-/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/rods,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "gAF" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -60438,16 +60970,12 @@
 /turf/simulated/floor/plasteel,
 /area/gateway)
 "gEJ" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
+/obj/effect/decal/cleanable/tomato_smudge,
+/obj/structure/railing{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/area/crew_quarters/theatre)
 "gEK" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -60787,6 +61315,13 @@
 	icon_state = "whitered"
 	},
 /area/security/medbay)
+"gHE" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/obj/item/clothing/mask/gas,
+/turf/simulated/floor/plating,
+/area/toxins/ab_sm)
 "gHM" = (
 /obj/machinery/door_control{
 	id = "stationawaygate";
@@ -61529,11 +62064,25 @@
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "gNY" = (
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "purple"
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = 11;
+	pixel_y = -4
 	},
-/area/maintenance/xenozoo)
+/obj/effect/decal/cleanable/blood/writing{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/spentcasing,
+/turf/simulated/floor/lubed,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "gNZ" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/monkeycubes,
@@ -61717,31 +62266,22 @@
 /area/maintenance/starboard)
 "gPw" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "purple"
+	icon_state = "whitehall"
 	},
-/area/maintenance/xenozoo)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "gPK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/random/plushie,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "bar"
 	},
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "gPL" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -61981,6 +62521,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/assembly/showroom)
+"gSo" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/toxins/ab_sm)
 "gSF" = (
 /obj/machinery/alarm{
 	pixel_y = 23
@@ -62148,6 +62695,24 @@
 	icon_state = "whitered"
 	},
 /area/security/medbay)
+"gTM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "gUa" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -62586,6 +63151,16 @@
 	icon_state = "dark"
 	},
 /area/toxins/xenobiology)
+"gYP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/wallmed{
+	pixel_y = 30
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purple"
+	},
+/area/toxins/ab_sm)
 "gYX" = (
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -62649,6 +63224,12 @@
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
+"gZP" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "hab" = (
 /obj/structure/cable,
 /obj/machinery/power/solar_control{
@@ -62821,6 +63402,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/shuttle/trade/sol)
+"hcC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "hcE" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -63043,12 +63634,17 @@
 /turf/simulated/floor/plating,
 /area/engine/controlroom)
 "hfq" = (
-/obj/item/twohanded/required/kirbyplants,
+/obj/machinery/vending/artvend,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/sign/poster/ripped{
+	pixel_y = 32
 	},
-/area/maintenance/gambling_den)
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/crew_quarters/theatre)
 "hfx" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -63574,6 +64170,30 @@
 	icon_state = "whitered"
 	},
 /area/security/medbay)
+"hmA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/confetti,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/curtain/open/shower/security{
+	name = "backstage";
+	alpha = 255;
+	icon_state = "closed";
+	opacity = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "tranquillite"
+	},
+/area/crew_quarters/theatre)
 "hmB" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -64160,8 +64780,25 @@
 	},
 /area/bridge/checkpoint/south)
 "hsp" = (
-/turf/simulated/wall,
-/area/maintenance/tourist)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "hsI" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/machinery/firealarm{
@@ -64800,6 +65437,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"hAI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/holosign/barrier,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "hAQ" = (
 /obj/effect/decal/warning_stripes/southeastcorner,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -65069,12 +65713,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
 "hDv" = (
-/obj/structure/table/wood/poker,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/area/maintenance/gambling_den)
+/obj/item/reagent_containers/food/snacks/grown/tomato{
+	pixel_x = 10;
+	pixel_y = 12
+	},
+/turf/simulated/floor/carpet/black,
+/area/crew_quarters/theatre)
 "hDH" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -65212,6 +65860,21 @@
 	icon_state = "dark"
 	},
 /area/library)
+"hFa" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purple"
+	},
+/area/toxins/ab_sm)
 "hFe" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -65316,15 +65979,12 @@
 /turf/simulated/floor/carpet,
 /area/medical/psych)
 "hGI" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/writing,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "bar"
 	},
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "hGZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -65341,8 +66001,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/engineering)
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
 "hHa" = (
 /turf/simulated/wall,
 /area/hallway/primary/central/north)
@@ -65636,11 +66301,22 @@
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
 "hKl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/barricade/wooden,
 /turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "hKm" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -65804,20 +66480,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "hLZ" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 26
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /obj/structure/table/wood,
-/obj/item/clothing/gloves/color/fyellow,
-/obj/item/storage/toolbox/electrical,
+/obj/item/storage/fancy/crayons{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/lipstick/random{
+	step_x = -5
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "hMh" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/south,
@@ -66030,8 +66705,11 @@
 /area/crew_quarters/courtroom)
 "hOT" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall,
-/area/maintenance/tourist)
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken3";
+	tag = "icon-wood-broken3"
+	},
+/area/crew_quarters/theatre)
 "hOZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -66619,6 +67297,24 @@
 	icon_state = "blue"
 	},
 /area/bridge/checkpoint/south)
+"hVq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/crew_quarters/theatre)
 "hVw" = (
 /obj/structure/closet/crate/medical,
 /obj/item/reagent_containers/spray/cleaner{
@@ -66761,11 +67457,16 @@
 	},
 /area/medical/virology)
 "hWA" = (
+/obj/structure/table/wood,
+/obj/item/soap,
+/obj/machinery/light,
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken";
 	tag = "icon-wood-broken"
 	},
-/area/maintenance/tourist)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "hWL" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -66952,6 +67653,30 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
+"hZy" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/mob/living/simple_animal/mouse,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/blood/writing,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/crew_quarters/theatre)
+"hZK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/confetti,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "hZV" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -67066,13 +67791,14 @@
 	},
 /area/toxins/launch)
 "ibA" = (
-/obj/structure/grille{
-	density = 0;
-	icon_state = "brokengrille"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/item/shard,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/toxins/ab_sm)
 "ibF" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "Perma2";
@@ -67255,6 +67981,12 @@
 	icon_state = "vault"
 	},
 /area/chapel/main)
+"idC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "idE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -67594,6 +68326,20 @@
 	icon_state = "redcorner"
 	},
 /area/security/processing)
+"ihy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "ihB" = (
 /obj/machinery/atmospherics/unary/outlet_injector/on{
 	dir = 1
@@ -68410,12 +69156,8 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/mixing)
 "iqN" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
+/turf/simulated/wall,
+/area/toxins/ab_sm)
 "iqP" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -68793,12 +69535,23 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "ive" = (
-/obj/structure/bed,
-/obj/item/bedsheet/patriot,
+/obj/effect/landmark{
+	color = "#00ae00";
+	icon_state = "x_white";
+	name = "ninja_teleport"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/maintenance/tourist)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "ivi" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -69100,6 +69853,13 @@
 	icon_state = "vault"
 	},
 /area/chapel/main)
+"iyj" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/closet/radiation,
+/turf/simulated/floor/engine,
+/area/toxins/ab_sm)
 "iyV" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -69552,24 +70312,26 @@
 	},
 /area/maintenance/library)
 "iFq" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/window/westright{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes/arrow{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
 	},
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "iFu" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -69628,14 +70390,22 @@
 	},
 /area/turret_protected/ai)
 "iFD" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/curtain/open/shower/security{
+	name = "backstage";
+	alpha = 255;
+	icon_state = "closed";
+	opacity = 1
 	},
-/area/maintenance/gambling_den)
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "iFG" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/table,
@@ -69900,19 +70670,12 @@
 /turf/simulated/floor/carpet,
 /area/ntrep)
 "iHF" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/obj/structure/cable,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/turf/simulated/floor/carpet/black,
+/area/crew_quarters/theatre)
 "iHJ" = (
 /obj/machinery/atmospherics/trinary/filter{
 	desc = "Отфильтровывает токсины из трубы и отправляет их в камеру хранения";
@@ -70481,10 +71244,15 @@
 /turf/simulated/floor/plasteel/grimy,
 /area/civilian/vacantoffice)
 "iNR" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/newscaster{
+	pixel_y = 32
 	},
-/area/maintenance/xenozoo)
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "iNS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
@@ -70517,19 +71285,30 @@
 	},
 /area/security/lobby)
 "iOv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/engineering)
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
 "iOx" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -70757,8 +71536,18 @@
 	},
 /area/maintenance/asmaint)
 "iSO" = (
-/turf/simulated/wall/rust,
-/area/maintenance/tourist)
+/obj/machinery/power/emitter{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/toxins/ab_sm)
 "iSS" = (
 /obj/machinery/power/grounding_rod{
 	anchored = 1
@@ -70863,6 +71652,27 @@
 "iTZ" = (
 /turf/simulated/wall,
 /area/crew_quarters/serviceyard)
+"iUq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "iUs" = (
 /obj/machinery/door_control{
 	desiredstate = 1;
@@ -70959,12 +71769,15 @@
 	},
 /area/chapel/main)
 "iVo" = (
-/obj/effect/decal/remains/xeno,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/confetti,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "purple"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/area/maintenance/xenozoo)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "iVt" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -71061,13 +71874,33 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/crew_quarters/hor)
-"iWq" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Gambling Den"
+"iWo" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/structure/barricade/wooden,
 /turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
+"iWq" = (
+/obj/structure/chair/wood/wings{
+	dir = 8;
+	tag = "icon-wooden_chair_wings (WEST)"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken6";
+	tag = "icon-wood-broken6"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "iWB" = (
 /obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/autolathe,
@@ -71175,11 +72008,15 @@
 	},
 /area/shuttle/syndicate_sit)
 "iXv" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
+/area/toxins/ab_sm)
 "iXx" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
@@ -71190,13 +72027,20 @@
 	icon_state = "escape"
 	},
 /area/hallway/primary/port/west)
+"iXy" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "iXI" = (
-/obj/effect/decal/remains/xeno,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "iXX" = (
 /obj/machinery/computer/security,
 /turf/simulated/floor/bluegrid,
@@ -71244,6 +72088,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
+"iYt" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitehall"
+	},
+/area/crew_quarters/theatre)
 "iYw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -71602,6 +72454,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/reception)
+"jcX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint3)
 "jdn" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/cleanable/dirt,
@@ -71723,6 +72580,12 @@
 	icon_state = "red"
 	},
 /area/security/customs)
+"jel" = (
+/obj/effect/decal/cleanable/fungus,
+/turf/simulated/wall,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "jem" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -71763,6 +72626,17 @@
 	icon_state = "red"
 	},
 /area/security/range)
+"jeR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "jeV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
@@ -71914,6 +72788,12 @@
 /obj/structure/grille,
 /turf/space,
 /area/space/nearstation)
+"jgq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/random/tool,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint3)
 "jgZ" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
@@ -72158,6 +73038,12 @@
 	},
 /turf/simulated/floor/engine,
 /area/toxins/test_chamber)
+"jjO" = (
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
 "jjT" = (
 /obj/machinery/dna_scannernew,
 /turf/simulated/floor/plasteel{
@@ -72170,10 +73056,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/library)
 "jjY" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "jkc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -72400,11 +73287,11 @@
 	},
 /area/maintenance/asmaint)
 "jnc" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitehall"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/maintenance/asmaint3)
 "jnn" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
@@ -72617,11 +73504,11 @@
 	},
 /obj/effect/spawner/random_spawners/blood_often,
 /obj/machinery/button/windowtint{
-	active = 1;
 	anchored = 1;
-	icon_state = "light1";
 	id = "pokerclub";
-	pixel_x = -24
+	pixel_x = -24;
+	active = 1;
+	icon_state = "light1"
 	},
 /turf/simulated/floor/carpet/royalblack,
 /area/maintenance/asmaint3)
@@ -73243,18 +74130,30 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "jvC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/effect/spawner/random_spawners/blood_often,
-/turf/simulated/floor/plating,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitehall"
+	},
 /area/maintenance/asmaint3)
 "jvK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -73394,21 +74293,17 @@
 	},
 /area/security/hos)
 "jxo" = (
-/obj/structure/table/wood,
-/obj/item/stack/rods{
-	amount = 10
+/obj/machinery/disposal/deliveryChute{
+	name = "Stage enterance"
 	},
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/machinery/light{
-	dir = 1;
-	on = 1
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/sign/barsign{
-	pixel_y = 32
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "jxu" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/manifold4w/visible/cyan{
@@ -73773,7 +74668,9 @@
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "jBm" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/item/radio/intercom{
@@ -73969,8 +74866,21 @@
 "jDz" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/barricade/wooden,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "jDQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -74052,10 +74962,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "jFg" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/barricade/wooden,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "purplefull"
+	},
+/area/toxins/ab_sm)
 "jFn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -74195,18 +75106,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
 "jHx" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/writing,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "jHC" = (
 /turf/simulated/wall/r_wall/rust,
 /area/toxins/launch)
@@ -74244,6 +75151,24 @@
 	icon_state = "dark"
 	},
 /area/security/prisonershuttle)
+"jHM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/writing{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "jHV" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
@@ -74393,11 +75318,16 @@
 	},
 /area/security/prisonershuttle)
 "jIV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/wall,
-/area/maintenance/gambling_den)
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "jJj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -74471,6 +75401,16 @@
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall,
 /area/atmos/control)
+"jJF" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
+	},
+/turf/simulated/floor/engine,
+/area/toxins/ab_sm)
 "jJM" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/plasteel{
@@ -74698,14 +75638,18 @@
 /turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 "jMH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/blood/xeno,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "bar"
 	},
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
+"jMJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/gloves/color/fyellow,
+/obj/item/storage/toolbox/electrical,
+/turf/simulated/floor/plating,
+/area/toxins/ab_sm)
 "jMT" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet,
@@ -74833,6 +75777,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/bridge/vip)
+"jOH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "jPa" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -75282,18 +76242,20 @@
 	},
 /area/toxins/mixing)
 "jUs" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/ants,
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/obj/structure/cable,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/item/reagent_containers/food/snacks/grown/tomato{
+	pixel_x = -10;
+	pixel_y = -12
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken5";
+	tag = "icon-wood-broken5"
+	},
+/area/crew_quarters/theatre)
 "jUt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -75701,6 +76663,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
+"jZo" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/crew_quarters/theatre)
 "jZz" = (
 /obj/machinery/camera{
 	c_tag = "Library South";
@@ -75718,8 +76689,11 @@
 	icon_state = "1-2"
 	},
 /obj/structure/girder,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/maintenance/engineering)
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
 "jZI" = (
 /obj/structure/lattice,
 /turf/space,
@@ -75762,11 +76736,20 @@
 	},
 /area/security/brigstaff)
 "kay" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "kaB" = (
 /obj/structure/rack{
 	dir = 8;
@@ -75904,6 +76887,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
+"kcA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/grille/broken,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "kcN" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -76142,6 +77140,13 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
+"kfz" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitehall"
+	},
+/area/maintenance/asmaint3)
 "kfS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -76169,14 +77174,18 @@
 	},
 /area/security/reception)
 "kfT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/blood/xeno,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "bar"
 	},
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "kfX" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -76193,9 +77202,17 @@
 /area/maintenance/ai)
 "kgB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "chapel"
+	},
+/area/crew_quarters/theatre)
+"kgW" = (
+/obj/effect/decal/cleanable/ash,
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/area/crew_quarters/theatre)
 "khe" = (
 /obj/machinery/computer/operating{
 	dir = 8
@@ -76239,22 +77256,24 @@
 	},
 /area/turret_protected/ai)
 "khz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/maintenance/gambling_den)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "khM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/curtain/black,
@@ -76482,10 +77501,15 @@
 /turf/simulated/floor/greengrid,
 /area/security/nuke_storage)
 "kkV" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/confetti,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "klb" = (
 /obj/structure/grille,
 /obj/effect/decal/warning_stripes/south,
@@ -77226,11 +78250,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/turf/simulated/floor/plasteel{
+	dir = 1
+	},
+/area/maintenance/asmaint3)
 "ktf" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	name = "standard air scrubber";
@@ -77328,6 +78355,22 @@
 	dir = 1
 	},
 /area/security/reception)
+"ktU" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse,
+/obj/effect/decal/cleanable/crayon{
+	desc = "Crayon art.";
+	icon_state = "shitcuritys";
+	name = "Graffiti";
+	pixel_x = 32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "ktZ" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -77469,16 +78512,23 @@
 	icon_state = "white"
 	},
 /area/medical/biostorage)
+"kwD" = (
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken5";
+	tag = "icon-wood-broken5"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "kwG" = (
 /obj/structure/chair/stool/bar,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
 "kwN" = (
-/obj/structure/computerframe,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
+/turf/simulated/wall,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "kxq" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/flashbangs{
@@ -77534,11 +78584,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/barricade/wooden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "kxQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
@@ -77596,6 +78651,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology/lab)
+"kyP" = (
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "kyT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -77985,10 +79049,38 @@
 	},
 /area/toxins/misc_lab)
 "kCF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/grown/tomato{
+	pixel_x = -10;
+	pixel_y = -12
+	},
+/obj/effect/decal/ants,
+/obj/item/chair/wood/wings{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/black,
+/area/crew_quarters/theatre)
+"kCH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "whitehall"
+	},
+/area/maintenance/asmaint3)
 "kCV" = (
 /obj/machinery/light_switch{
 	pixel_x = 24;
@@ -78026,9 +79118,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "kDr" = (
-/obj/structure/chair/wood,
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/obj/effect/spawner/window/reinforced/plasma,
+/turf/simulated/floor/plating,
+/area/toxins/ab_sm)
 "kDH" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -78162,6 +79254,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/maintcentral)
+"kFv" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "kFz" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/warning_stripes/southeast,
@@ -78348,18 +79457,10 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "kHJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/gambling_den)
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "kHS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -78460,11 +79561,16 @@
 	},
 /area/crew_quarters/kitchen)
 "kJr" = (
-/obj/structure/chair/wood{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/ants,
+/obj/structure/chair/comfy/beige{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/turf/simulated/floor/carpet/royalblue,
+/area/crew_quarters/theatre)
 "kJs" = (
 /obj/structure/window/reinforced,
 /obj/machinery/vending/cola,
@@ -78590,6 +79696,17 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/south)
+"kKW" = (
+/obj/structure/closet/secure_closet/personal/cabinet{
+	opened = 1
+	},
+/obj/item/clothing/shoes/clown_shoes,
+/obj/item/clothing/gloves/color/rainbow/clown,
+/obj/item/reagent_containers/spray/waterflower,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "kKZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -78783,18 +79900,8 @@
 	},
 /area/security/permabrig)
 "kNj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/random/tool,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
 "kNl" = (
@@ -78815,6 +79922,23 @@
 	icon_state = "red"
 	},
 /area/security/checkpoint)
+"kNr" = (
+/obj/structure/barricade/wooden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/research{
+	name = "Research Division Access";
+	req_access_txt = "47"
+	},
+/turf/simulated/floor/plating,
+/area/toxins/ab_sm)
 "kNt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -78864,12 +79988,9 @@
 /turf/space,
 /area/maintenance/ai)
 "kNU" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
-	},
-/area/maintenance/tourist)
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/engine,
+/area/toxins/ab_sm)
 "kOj" = (
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken"
@@ -78882,10 +80003,11 @@
 	},
 /area/shuttle/syndicate_sit)
 "kOD" = (
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
-/turf/simulated/floor/carpet,
-/area/maintenance/tourist)
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/toxins/ab_sm)
 "kOP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -78925,13 +80047,19 @@
 	},
 /area/turret_protected/ai)
 "kPC" = (
-/obj/item/shard{
-	icon_state = "medium";
-	pixel_x = 9;
-	pixel_y = -9
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/toxins/ab_sm)
 "kPH" = (
 /obj/structure/rack,
 /obj/item/extinguisher,
@@ -79123,11 +80251,12 @@
 	},
 /area/medical/paramedic)
 "kSW" = (
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purple"
-	},
-/area/maintenance/xenozoo)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "kTg" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -79184,13 +80313,22 @@
 	},
 /area/medical/morgue)
 "kTD" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposaloutlet,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/area/crew_quarters/theatre)
 "kTT" = (
 /turf/simulated/wall/rust,
 /area/maintenance/consarea_virology)
@@ -79229,13 +80367,20 @@
 /turf/simulated/wall/r_wall,
 /area/hallway/secondary/exit)
 "kUR" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/holosign/barrier,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "kVo" = (
 /turf/simulated/wall,
 /area/engine/engineering)
@@ -79320,12 +80465,17 @@
 /turf/space,
 /area/space/nearstation)
 "kWn" = (
-/obj/effect/decal/warning_stripes/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/item/grown/bananapeel{
+	layer = 1.9
 	},
-/area/maintenance/xenozoo)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/bananium/glass,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "kWt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -79345,9 +80495,12 @@
 /turf/simulated/shuttle/floor,
 /area/shuttle/mining)
 "kWY" = (
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/area/toxins/ab_sm)
 "kXF" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "redcorner"
@@ -79437,9 +80590,6 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 32
-	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint3)
 "kYQ" = (
@@ -79449,15 +80599,15 @@
 	},
 /area/crew_quarters/sleep)
 "kZh" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/crew_quarters/theatre)
 "kZo" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
@@ -79905,6 +81055,18 @@
 	icon_state = "white"
 	},
 /area/medical/research)
+"lff" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "lfh" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 28
@@ -80397,6 +81559,13 @@
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/aft)
+"lkh" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "lkn" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/carpet/arcade,
@@ -80560,15 +81729,8 @@
 	},
 /area/security/permabrig)
 "lmf" = (
-/obj/effect/landmark{
-	color = "#00ae00";
-	icon_state = "x_white";
-	name = "ninja_teleport"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/maintenance/tourist)
+/turf/simulated/wall/r_wall/rust,
+/area/toxins/ab_sm)
 "lmj" = (
 /obj/structure/table/reinforced,
 /obj/item/mmi/robotic_brain,
@@ -80670,6 +81832,10 @@
 	icon_state = "neutralfull"
 	},
 /area/crew_quarters/locker)
+"lnT" = (
+/obj/machinery/atmospherics/binary/pump,
+/turf/simulated/floor/engine,
+/area/toxins/ab_sm)
 "lnW" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/decal/cleanable/dirt,
@@ -80698,6 +81864,22 @@
 	},
 /turf/simulated/floor/engine/n20,
 /area/atmos)
+"lon" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/picket_sign,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/crew_quarters/theatre)
 "loq" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -80780,6 +81962,14 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
+"loN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "loO" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -81252,6 +82442,16 @@
 	icon_state = "vault"
 	},
 /area/atmos)
+"ltR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "ltW" = (
 /turf/simulated/wall/r_wall,
 /area/medical/virology)
@@ -81343,6 +82543,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/perma)
+"luN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	dir = 1
+	},
+/area/maintenance/asmaint3)
 "luQ" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -81367,25 +82581,31 @@
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "lvo" = (
-/obj/structure/chair/wood/wings{
-	dir = 8;
-	tag = "icon-wooden_chair_wings (WEST)"
+/obj/machinery/door/airlock/highsecurity{
+	heat_proof = 1;
+	name = "Supermatter Chamber"
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+/obj/machinery/door/poddoor{
+	name = "Supermatter Blast Doors";
+	density = 0;
+	opacity = 0;
+	id_tag = "engsm1"
 	},
-/area/maintenance/tourist)
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/toxins/ab_sm)
 "lvs" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "purple"
+	dir = 1
 	},
-/area/maintenance/xenozoo)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "lvv" = (
 /turf/simulated/wall/r_wall,
 /area/medical/cmostore)
@@ -81452,6 +82672,15 @@
 	icon_state = "chapel"
 	},
 /area/maintenance/asmaint)
+"lwf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "lwk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -81529,13 +82758,10 @@
 	},
 /area/toxins/xenobiology)
 "lxD" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
+/turf/simulated/floor/wood,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "lxQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/table/reinforced,
@@ -81948,6 +83174,14 @@
 	icon_state = "red"
 	},
 /area/security/processing)
+"lBB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/wood{
+	broken = 1;
+	icon_state = "wood-broken"
+	},
+/area/crew_quarters/theatre)
 "lBD" = (
 /obj/structure/table/wood,
 /obj/item/folder,
@@ -82149,18 +83383,16 @@
 	},
 /area/security/processing)
 "lFw" = (
-/obj/machinery/door/window/brigdoor{
-	dir = 2;
-	name = "Creature Pen"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	name = "Creature Pen"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/toxins/ab_sm)
 "lFG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -82417,6 +83649,17 @@
 	icon_state = "purplefull"
 	},
 /area/toxins/mixing)
+"lIb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/toxins/ab_sm)
 "lIo" = (
 /obj/item/radio/intercom{
 	pixel_y = -29
@@ -83153,11 +84396,9 @@
 	},
 /area/bridge)
 "lQT" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/toxins/ab_sm)
 "lQU" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -83228,12 +84469,12 @@
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
 "lRT" = (
-/obj/effect/decal/warning_stripes/southeast,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
+/obj/item/toy/crayon/rainbow,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "lSr" = (
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -84047,19 +85288,24 @@
 /obj/item/lighter,
 /turf/simulated/floor/engine,
 /area/security/execution)
-"mbR" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"mbO" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen";
+	opened = 1
 	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
+"mbR" = (
+/obj/machinery/constructable_frame/machine_frame,
+/obj/structure/cable,
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 6;
 	icon_state = "purple"
 	},
-/area/maintenance/xenozoo)
+/area/toxins/ab_sm)
 "mbT" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -84198,12 +85444,11 @@
 /turf/simulated/floor/carpet/black,
 /area/bridge/vip)
 "mdb" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkblue"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "mdc" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -84304,6 +85549,14 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"meM" = (
+/turf/simulated/floor/wood{
+	broken = 1;
+	icon_state = "wood-broken"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "meO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
@@ -85764,15 +87017,17 @@
 	},
 /area/security/range)
 "muf" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/barricade/wooden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/writing,
+/obj/structure/grille/broken,
+/turf/simulated/floor/plasteel{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "muo" = (
 /obj/structure/table/reinforced,
 /obj/item/analyzer,
@@ -85884,6 +87139,19 @@
 	tag = "icon-whitepurple (WEST)"
 	},
 /area/toxins/test_chamber)
+"mvv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/crew_quarters/theatre)
 "mvI" = (
 /obj/machinery/door_timer/cell_1{
 	dir = 1;
@@ -86556,14 +87824,22 @@
 /area/security/warden)
 "mBV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/girder,
 /turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "mCe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -87005,6 +88281,25 @@
 	icon_state = "darkredcorners"
 	},
 /area/security/podbay)
+"mFv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint3)
 "mFH" = (
 /obj/effect/landmark{
 	name = "xeno_spawn";
@@ -87192,6 +88487,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/podbay)
+"mIU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/crew_quarters/theatre)
 "mIV" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -87494,13 +88800,11 @@
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/hallway/secondary/exit)
 "mLS" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "mMd" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -87965,6 +89269,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
 "mRc" = (
@@ -88023,10 +89328,17 @@
 /turf/simulated/floor/carpet/black,
 /area/bridge/vip)
 "mRE" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/structure/sign/poster/contraband/clown{
+	pixel_y = 32
+	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "mRF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -88173,6 +89485,15 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
+"mTl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine,
+/area/toxins/ab_sm)
 "mTu" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -88372,6 +89693,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall,
 /area/chapel/main)
+"mVw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	name = "north bump";
+	pixel_y = 26
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "mVH" = (
 /obj/item/radio/intercom{
 	pixel_x = 30
@@ -88446,11 +89781,21 @@
 	},
 /area/toxins/explab)
 "mWw" = (
-/obj/effect/decal/remains/xeno,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/area/maintenance/gambling_den)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "mWC" = (
 /obj/machinery/camera{
 	c_tag = "Research Outpost Temporary Storage";
@@ -88599,13 +89944,9 @@
 	},
 /area/bridge)
 "mYk" = (
-/obj/effect/landmark{
-	name = "revenantspawn"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/gambling_den)
+/mob/living/simple_animal/mouse,
+/turf/simulated/floor/wood,
+/area/crew_quarters/theatre)
 "mYl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6;
@@ -88660,6 +90001,32 @@
 	icon_state = "dark"
 	},
 /area/ai_monitored/storage/eva)
+"mZb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "mZc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -88689,6 +90056,30 @@
 	icon_state = "neutralfull"
 	},
 /area/bridge/checkpoint/south)
+"mZq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "mZA" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 10
@@ -88860,29 +90251,10 @@
 /turf/simulated/wall/r_wall,
 /area/medical/virology/lab)
 "naC" = (
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	id_tag = "sw_maint_airlock";
-	pixel_y = 25;
-	tag_airpump = "sw_maint_pump";
-	tag_chamber_sensor = "sw_maint_sensor";
-	tag_exterior_door = "sw_maint_outer";
-	tag_interior_door = "sw_maint_inner"
-	},
-/obj/machinery/airlock_sensor{
-	id_tag = "sw_maint_sensor";
-	pixel_y = 33
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
-	frequency = 1379;
-	id_tag = "sw_maint_pump"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/turf/simulated/wall/r_wall,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "naD" = (
 /obj/item/target,
 /turf/simulated/floor/plasteel/airless,
@@ -88973,6 +90345,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/hos)
+"nbm" = (
+/obj/effect/spawner/window/reinforced/plasma,
+/obj/machinery/door/poddoor{
+	name = "Supermatter Blast Doors";
+	density = 0;
+	opacity = 0;
+	id_tag = "engsm1"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/toxins/ab_sm)
 "nbr" = (
 /obj/item/grenade/clusterbuster/honk,
 /turf/simulated/floor/plating,
@@ -89158,6 +90543,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker/locker_toilet)
+"ndz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "ndJ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -89321,12 +90713,9 @@
 	},
 /area/chapel/main)
 "nfm" = (
-/obj/machinery/light/small,
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = -32
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "nft" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -89875,12 +91264,23 @@
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/port/west)
-"nlR" = (
-/obj/machinery/light/small{
-	dir = 1
+"nlP" = (
+/obj/structure/bed,
+/obj/item/bedsheet/patriot,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
+"nlR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitehall"
+	},
+/area/maintenance/asmaint3)
 "nmd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -89948,14 +91348,14 @@
 /turf/simulated/floor/wood,
 /area/security/hos)
 "nnt" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "nnw" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
@@ -90090,15 +91490,28 @@
 	},
 /area/library)
 "npg" = (
-/obj/structure/table/reinforced,
-/obj/item/folder,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "whitehall"
 	},
-/area/maintenance/xenozoo)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "nph" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/door_control{
@@ -90569,9 +91982,23 @@
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "nsU" = (
-/obj/structure/closet/emcloset,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder,
 /turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "nte" = (
 /turf/simulated/wall,
 /area/maintenance/asmaint2)
@@ -90619,6 +92046,13 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/central/north)
+"ntI" = (
+/obj/structure/table/wood,
+/obj/item/camera,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "ntK" = (
 /obj/structure/sign/securearea{
 	pixel_x = -32
@@ -90701,6 +92135,14 @@
 	icon_state = "darkblue"
 	},
 /area/turret_protected/aisat_interior)
+"nuz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitehall"
+	},
+/area/maintenance/asmaint3)
 "nuE" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -91215,13 +92657,23 @@
 	},
 /area/medical/research)
 "nBy" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 32
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/blood/writing,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "bar"
 	},
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "nBI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -91597,19 +93049,22 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "nGj" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "sw_maint_inner";
-	locked = 1;
-	name = "West Maintenance External Access";
-	req_access_txt = "10;13"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_spawners/oil_maybe,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/area/toxins/ab_sm)
 "nGl" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -92087,6 +93542,13 @@
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/storage)
+"nKR" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "chapel"
+	},
+/area/crew_quarters/theatre)
 "nKW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -92109,12 +93571,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "nLj" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 4;
+	icon_state = "darkblue"
 	},
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "nLE" = (
 /obj/structure/table,
 /obj/machinery/camera{
@@ -92239,6 +93701,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"nMF" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "nMG" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
@@ -92350,6 +93819,15 @@
 	icon_state = "neutralfull"
 	},
 /area/engine/break_room)
+"nOl" = (
+/obj/structure/bed,
+/obj/item/bedsheet/rainbow,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "nOn" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/science{
@@ -92816,9 +94294,8 @@
 	},
 /area/maintenance/kitchen)
 "nTk" = (
-/obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall,
-/area/maintenance/tourist)
+/turf/simulated/wall/r_wall/coated,
+/area/toxins/ab_sm)
 "nTm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -92946,8 +94423,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/maintenance/engineering)
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
 "nUI" = (
 /obj/docking_port/mobile/supply,
 /obj/docking_port/stationary{
@@ -92987,6 +94467,21 @@
 	icon_state = "neutralcorner"
 	},
 /area/maintenance/asmaint)
+"nVz" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/plasteel{
+	dir = 1
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "nVA" = (
 /obj/machinery/computer/HolodeckControl,
 /turf/simulated/floor/plasteel,
@@ -93021,6 +94516,16 @@
 	icon_state = "darkblue"
 	},
 /area/bridge)
+"nWk" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/structure/window/plasmareinforced{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating,
+/area/toxins/ab_sm)
 "nWl" = (
 /obj/structure/table/wood,
 /obj/item/folder,
@@ -93075,9 +94580,16 @@
 	},
 /area/construction/hallway)
 "nWY" = (
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "purple"
+	},
+/area/toxins/ab_sm)
 "nXe" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced{
@@ -93173,6 +94685,18 @@
 	icon_state = "red"
 	},
 /area/security/processing)
+"nXQ" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "sw_maint_outer";
+	locked = 1;
+	name = "West Maintenance External Access"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "nYi" = (
 /obj/structure/table/reinforced,
 /obj/item/seeds/lime,
@@ -93643,6 +95167,21 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/exit)
+"oec" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/effect/landmark{
+	name = "blobstart"
+	},
+/turf/simulated/floor/carpet,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "oee" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -94315,12 +95854,13 @@
 /turf/simulated/floor/plating,
 /area/security/reception)
 "okD" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/machinery/constructable_frame/machine_frame,
+/obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 10;
+	icon_state = "purple"
 	},
-/area/maintenance/xenozoo)
+/area/toxins/ab_sm)
 "okH" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -94385,10 +95925,34 @@
 	icon_state = "dark"
 	},
 /area/security/permabrig)
-"olA" = (
-/obj/structure/girder,
+"olr" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/area/maintenance/asmaint3)
+"olA" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "olG" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -94656,6 +96220,21 @@
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/pod_4)
+"ope" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "opt" = (
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken7"
@@ -94873,6 +96452,9 @@
 	icon_state = "cmo"
 	},
 /area/medical/ward)
+"orr" = (
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "orw" = (
 /obj/machinery/atmospherics/binary/pump{
 	desc = "Переводит смесь из хранилища в трубы";
@@ -94988,14 +96570,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "oss" = (
-/obj/structure/table/wood,
-/obj/item/lighter/zippo/engraved{
-	pixel_x = 1;
-	pixel_y = 3
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
-/obj/machinery/light,
-/turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/turf/simulated/floor/engine,
+/area/toxins/ab_sm)
 "osx" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall/r_wall,
@@ -95092,18 +96671,17 @@
 /turf/simulated/floor/plating,
 /area/blueshield)
 "otP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
-/area/maintenance/gambling_den)
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "oud" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/binary/volume_pump{
@@ -95149,10 +96727,13 @@
 	},
 /area/medical/research)
 "ouO" = (
-/obj/structure/table/wood,
-/obj/machinery/cell_charger,
+/obj/machinery/vending/autodrobe,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "ovf" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
@@ -95185,6 +96766,17 @@
 	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/lounge)
+"ovB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "chapel"
+	},
+/area/crew_quarters/theatre)
 "ovH" = (
 /obj/item/trash/candy,
 /obj/item/trash/chips{
@@ -96283,6 +97875,21 @@
 	tag = "icon-whitepurple (WEST)"
 	},
 /area/medical/research/nhallway)
+"oHO" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/blood/writing,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "oHS" = (
 /obj/machinery/mass_driver{
 	dir = 8;
@@ -96853,6 +98460,11 @@
 /obj/structure/sign/electricshock,
 /turf/simulated/wall/r_wall,
 /area/storage/tech)
+"oNB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/confetti,
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "oNP" = (
 /obj/machinery/light{
 	dir = 1;
@@ -97161,6 +98773,16 @@
 	tag = "icon-whitebluefull"
 	},
 /area/medical/reception)
+"oRb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/comfy/beige{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/royalblue,
+/area/crew_quarters/theatre)
 "oRe" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -97234,11 +98856,14 @@
 /turf/simulated/floor/plating,
 /area/engine/break_room)
 "oRQ" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/area/maintenance/tourist)
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "oRS" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -97344,9 +98969,15 @@
 	},
 /area/medical/research)
 "oTb" = (
-/mob/living/simple_animal/mouse/brown,
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/tomato_smudge,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/crew_quarters/theatre)
 "oTc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -97470,9 +99101,11 @@
 	},
 /area/medical/research/nhallway)
 "oUj" = (
-/obj/effect/decal/cleanable/blood/xeno,
+/obj/structure/girder,
 /turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "oUs" = (
 /obj/item/bedsheet/mime,
 /obj/structure/bed,
@@ -97868,10 +99501,9 @@
 /turf/simulated/floor/carpet/purple,
 /area/crew_quarters/hor)
 "oYl" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/obj/effect/mob_spawn/human,
+/turf/simulated/floor/engine,
+/area/toxins/ab_sm)
 "oYp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -97889,16 +99521,16 @@
 	},
 /area/toxins/lab)
 "oYL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/gambling_den)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "oYO" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "swall_f9"
@@ -97996,6 +99628,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/processing)
+"paw" = (
+/obj/item/flag/clown,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "paK" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -98126,6 +99764,19 @@
 	icon_state = "red"
 	},
 /area/security/permahallway)
+"pcj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain/open/shower/security{
+	name = "backstage";
+	alpha = 255
+	},
+/obj/effect/decal/cleanable/blood/writing,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/crew_quarters/theatre)
 "pcp" = (
 /turf/simulated/floor/plasteel{
 	dir = 0;
@@ -98295,23 +99946,13 @@
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "pfa" = (
-/obj/structure/cable,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/item/reagent_containers/food/snacks/grown/tomato{
+	pixel_x = -10;
+	pixel_y = -12
 	},
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/item/chair/wood/wings,
+/turf/simulated/floor/carpet/black,
+/area/crew_quarters/theatre)
 "pfs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -98325,10 +99966,8 @@
 	},
 /area/medical/medbay2)
 "pfA" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -98336,10 +99975,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/area/maintenance/gambling_den)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "pfD" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/window/eastright{
@@ -98777,11 +100420,15 @@
 	},
 /area/crew_quarters/bar/atrium)
 "pkp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/dresser,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/theatre)
 "pkr" = (
 /obj/item/trash/plate{
 	pixel_x = -5;
@@ -99048,15 +100695,12 @@
 	},
 /area/chapel/main)
 "pnM" = (
-/obj/structure/lattice,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkblue"
 	},
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
-/turf/space,
-/area/space/nearstation)
+/area/crew_quarters/theatre)
 "pnT" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -99068,15 +100712,12 @@
 	},
 /area/hallway/primary/central/sw)
 "poa" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/obj/effect/landmark{
-	name = "xeno_spawn";
-	pixel_x = -1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "pob" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -99820,7 +101461,6 @@
 	},
 /area/hallway/primary/central/east)
 "puK" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -99832,11 +101472,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/area/maintenance/asmaint3)
 "puN" = (
 /turf/simulated/wall/rust,
 /area/maintenance/disposal)
@@ -100008,8 +101649,17 @@
 /turf/simulated/floor/wood,
 /area/security/hos)
 "pxR" = (
-/turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/spawner/random_spawners/oil_maybe,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "pyh" = (
 /obj/machinery/vending/wallmed{
 	pixel_x = 25
@@ -100096,11 +101746,19 @@
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
 "pzu" = (
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ticket_machine_ticket{
+	pixel_x = 6;
+	pixel_y = 12
 	},
-/area/maintenance/gambling_den)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "pzE" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
@@ -100319,6 +101977,16 @@
 	icon_state = "whitebluefull"
 	},
 /area/medical/medbay)
+"pAU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "pAV" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -100541,20 +102209,12 @@
 	},
 /area/toxins/lab)
 "pCz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_spawners/grille_often,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "pCB" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
@@ -100666,6 +102326,19 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/central/east)
+"pDf" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/barricade/wooden,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "pDh" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -100869,6 +102542,14 @@
 	icon_state = "red"
 	},
 /area/security/processing)
+"pFD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/effect/decal/ants,
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "pFE" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -101018,9 +102699,11 @@
 	},
 /area/hallway/primary/central/se)
 "pGX" = (
-/obj/structure/girder,
+/mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "pGY" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -101461,25 +103144,15 @@
 	},
 /area/security/prison/cell_block/A)
 "pKP" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/piano,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
 	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "pKY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -101618,8 +103291,13 @@
 	},
 /area/medical/surgery/south)
 "pLR" = (
-/turf/simulated/floor/carpet,
-/area/maintenance/tourist)
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plating,
+/area/toxins/ab_sm)
 "pMb" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
@@ -101660,22 +103338,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/garden/north)
 "pMH" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "pMQ" = (
 /obj/machinery/door/airlock/external{
 	hackProof = 1;
@@ -102385,11 +104052,26 @@
 	},
 /area/toxins/mixing)
 "pVo" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/door_control{
+	id = "engsm1";
+	name = "Supermatter Blast Doors";
+	pixel_x = 26;
+	pixel_y = 6
 	},
-/area/maintenance/xenozoo)
+/obj/structure/computerframe,
+/obj/machinery/door_control{
+	id = "smbolts1";
+	name = "Supermatter Bolt Control";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	pixel_x = 26;
+	pixel_y = -6
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purple"
+	},
+/area/toxins/ab_sm)
 "pVu" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
@@ -102423,6 +104105,18 @@
 	icon_state = "neutralfull"
 	},
 /area/crew_quarters/sleep)
+"pVC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "pVL" = (
 /obj/machinery/disposal,
 /obj/effect/decal/warning_stripes/red,
@@ -102888,10 +104582,26 @@
 	icon_state = "dark"
 	},
 /area/shuttle/siberia)
-"qbq" = (
+"qbg" = (
 /obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
+"qbq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
 "qbt" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -103102,6 +104812,11 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
+"qdn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table_frame/wood,
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "qdp" = (
 /obj/structure/rack{
 	dir = 8;
@@ -103181,6 +104896,17 @@
 	icon_state = "darkblue"
 	},
 /area/chapel/main)
+"qej" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
+	},
+/area/crew_quarters/theatre)
 "qek" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -103735,6 +105461,14 @@
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"qjB" = (
+/obj/structure/sign/poster/official/build{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "qjE" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -103804,6 +105538,11 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/fitness)
+"qkb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/writing,
+/turf/simulated/floor/wood,
+/area/crew_quarters/theatre)
 "qks" = (
 /obj/structure/table/wood,
 /obj/item/stack/tape_roll,
@@ -103913,6 +105652,12 @@
 	icon_state = "chapel"
 	},
 /area/maintenance/asmaint)
+"qlL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/machinery/recharger,
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "qlN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -104155,19 +105900,28 @@
 	icon_state = "neutralcorner"
 	},
 /area/maintenance/asmaint)
+"qog" = (
+/obj/machinery/door/poddoor{
+	name = "Supermatter Venting";
+	opacity = 0;
+	density = 0;
+	id_tag = "SupermatterVenting"
+	},
+/turf/simulated/floor/engine/insulated/vacuum,
+/area/toxins/ab_sm)
 "qol" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 26
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/analyzer,
+/obj/item/multitool{
+	pixel_x = 4;
+	pixel_y = -4
 	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "purple"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/area/toxins/ab_sm)
 "qor" = (
 /obj/structure/table/wood,
 /obj/item/folder{
@@ -104722,11 +106476,13 @@
 /turf/simulated/floor/plating,
 /area/medical/virology/lab)
 "qta" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "purple"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/area/toxins/ab_sm)
 "qti" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -104780,8 +106536,12 @@
 	icon_state = "1-2"
 	},
 /obj/structure/grille/broken,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/engineering)
+/area/maintenance/starboard{
+	name = "Engineering Maintenance"
+	})
 "qtv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -105116,6 +106876,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
+"qwg" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "qwo" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/medic,
@@ -105873,6 +107643,10 @@
 /obj/machinery/floodlight,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
+"qFt" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden,
+/turf/simulated/floor/engine,
+/area/toxins/ab_sm)
 "qFw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -105916,6 +107690,17 @@
 	icon_state = "neutralcorner"
 	},
 /area/bridge/vip)
+"qFy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "qFz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -106065,9 +107850,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
 "qGR" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/obj/structure/closet/l3closet/scientist,
+/turf/simulated/floor/engine,
+/area/toxins/ab_sm)
 "qHb" = (
 /obj/machinery/vending/wallmed{
 	layer = 3.3;
@@ -106441,6 +108226,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
+"qLb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
+/obj/item/shard{
+	icon_state = "small"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint3)
 "qLc" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
@@ -106535,6 +108331,23 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/nw)
+"qMK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "qMN" = (
 /obj/structure/table,
 /obj/item/book/manual/nuclear,
@@ -106615,12 +108428,30 @@
 	},
 /area/shuttle/syndicate_sit)
 "qNu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/xeno,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/blood/writing{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "qNA" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -106629,6 +108460,30 @@
 	icon_state = "vault"
 	},
 /area/shuttle/escape)
+"qNG" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4
+	},
+/obj/structure/sign/vacuum{
+	pixel_y = -32
+	},
+/obj/machinery/door_control{
+	id = "smbolts1";
+	name = "Supermatter Bolt Control";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	pixel_x = -26;
+	pixel_y = -6
+	},
+/obj/machinery/door_control{
+	id = "engsm1";
+	name = "Supermatter Blast Doors";
+	pixel_x = -26;
+	pixel_y = 6
+	},
+/turf/simulated/floor/engine,
+/area/toxins/ab_sm)
 "qNQ" = (
 /obj/item/bikehorn/rubberducky,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -106849,9 +108704,14 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/starboard)
 "qQf" = (
-/obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall/r_wall,
-/area/maintenance/xenozoo)
+/obj/structure/window/plasmareinforced{
+	dir = 4
+	},
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/toxins/ab_sm)
 "qQk" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/reagent_containers/iv_bag/blood/AMinus,
@@ -106875,17 +108735,15 @@
 	},
 /area/medical/surgery/south)
 "qQl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/area/maintenance/gambling_den)
+/turf/simulated/floor/carpet/black,
+/area/crew_quarters/theatre)
 "qQq" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -106935,13 +108793,9 @@
 	},
 /area/bridge/meeting_room)
 "qQQ" = (
-/obj/structure/table/reinforced,
-/obj/item/dice/d10,
-/obj/item/dice/d20,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
+/obj/effect/spawner/random_spawners/wall_rusted_probably,
+/turf/simulated/wall,
+/area/toxins/ab_sm)
 "qQS" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -107303,17 +109157,15 @@
 	},
 /area/shuttle/supply)
 "qVB" = (
-/obj/structure/closet{
-	icon_closed = "cabinet_closed";
-	icon_opened = "cabinet_open";
-	icon_state = "cabinet_closed"
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/airlock/highsecurity{
+	heat_proof = 1;
+	id_tag = "smbolts1";
+	locked = 1;
+	name = "Supermatter Chamber"
 	},
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/turf/simulated/floor/engine,
+/area/toxins/ab_sm)
 "qVN" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -107410,11 +109262,17 @@
 	},
 /area/security/main)
 "qWC" = (
-/obj/structure/table/wood/poker,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "qWU" = (
 /turf/simulated/wall/r_wall,
 /area/teleporter/abandoned)
@@ -107477,9 +109335,15 @@
 	},
 /area/maintenance/starboard)
 "qXu" = (
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/obj/structure/coatrack,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "qXv" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -108123,6 +109987,20 @@
 	icon_state = "white"
 	},
 /area/toxins/xenobiology)
+"rdF" = (
+/obj/effect/decal/warning_stripes/west,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine,
+/area/toxins/ab_sm)
 "rdK" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -109548,13 +111426,9 @@
 	},
 /area/security/processing)
 "rtB" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
+/obj/structure/sign/biohazard,
+/turf/simulated/wall,
+/area/toxins/ab_sm)
 "rtG" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "redfull";
@@ -110086,14 +111960,20 @@
 /area/maintenance/asmaint2)
 "rzO" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/crew_quarters/theatre)
 "rzQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/black,
+/area/crew_quarters/theatre)
 "rzT" = (
 /turf/simulated/floor/mech_bay_recharge_floor,
 /area/assembly/robotics)
@@ -110183,10 +112063,20 @@
 	},
 /area/hallway/primary/central/ne)
 "rBh" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/obj/effect/decal/warning_stripes/southeast,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "purple"
+	},
+/area/toxins/ab_sm)
 "rBk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -111541,11 +113431,14 @@
 /turf/simulated/floor/plating,
 /area/engine/aienter)
 "rQm" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/dresser,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "bar"
 	},
-/area/maintenance/xenozoo)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "rQt" = (
 /obj/item/cigbutt{
 	pixel_x = -10;
@@ -111681,22 +113574,24 @@
 /area/crew_quarters/locker/locker_toilet)
 "rRM" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/remains/human,
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1
+	},
+/area/maintenance/asmaint3)
 "rRO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -111956,11 +113851,37 @@
 	},
 /area/medical/virology)
 "rUS" = (
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/area/maintenance/gambling_den)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
+"rUW" = (
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken";
+	tag = "icon-wood-broken"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "rVb" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/rods{
@@ -112203,12 +114124,30 @@
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
 "rYz" = (
-/obj/structure/chair/wood/wings{
-	dir = 8;
-	tag = "icon-wooden_chair_wings (WEST)"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/maintenance/tourist)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/crayon{
+	desc = "Crayon art.";
+	icon_state = "skrek";
+	name = "Graffiti";
+	pixel_y = -32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "rYG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -112508,11 +114447,15 @@
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "sbF" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/area/maintenance/tourist)
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/toxins/ab_sm)
 "sbR" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -112582,10 +114525,17 @@
 /area/storage/primary)
 "scD" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/item/clothing/shoes/clown_shoes,
+/obj/structure/curtain/open/shower/security{
+	name = "backstage";
+	alpha = 255;
+	icon_state = "closed";
+	opacity = 1
 	},
-/area/maintenance/gambling_den)
+/turf/simulated/floor/plasteel{
+	icon_state = "tranquillite"
+	},
+/area/crew_quarters/theatre)
 "scE" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "barber"
@@ -112707,6 +114657,12 @@
 	icon_state = "white"
 	},
 /area/medical/reception)
+"sdH" = (
+/obj/structure/window/plasmareinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/toxins/ab_sm)
 "sdY" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -112830,9 +114786,15 @@
 	},
 /area/crew_quarters/kitchen)
 "sfq" = (
-/obj/structure/chair/stool,
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/theatre)
 "sfC" = (
 /obj/machinery/vending/tool,
 /obj/item/radio/intercom{
@@ -112877,6 +114839,20 @@
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint)
+"sgc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10;
+	initialize_directions = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "sgo" = (
 /obj/machinery/vending/wallmed{
 	pixel_y = 30
@@ -112930,6 +114906,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology/lab)
+"sgC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/crew_quarters/theatre)
 "sgK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -113010,8 +114997,15 @@
 /turf/space,
 /area/space/nearstation)
 "sic" = (
-/turf/simulated/floor/greengrid,
-/area/maintenance/xenozoo)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/confetti,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "sid" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -113668,8 +115662,8 @@
 	},
 /area/medical/surgery/north)
 "soZ" = (
-/obj/structure/closet/firecloset,
-/turf/simulated/floor/plating,
+/obj/effect/spawner/random_spawners/wall_rusted_probably,
+/turf/simulated/wall,
 /area/maintenance/asmaint3)
 "spe" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -113956,6 +115950,22 @@
 	icon_state = "dark"
 	},
 /area/security/permabrig)
+"srO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/effect/landmark{
+	name = "xeno_spawn";
+	pixel_x = -1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "srP" = (
 /obj/structure/chair/sofa{
 	dir = 1
@@ -114165,6 +116175,13 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
+"sul" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/clothing,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/theatre)
 "sum" = (
 /obj/structure/chair{
 	dir = 4
@@ -114331,6 +116348,23 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
+"swa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "sws" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -114552,21 +116586,9 @@
 	},
 /area/crew_quarters/captain)
 "sxS" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/crew_quarters/theatre)
 "sxW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -114608,6 +116630,14 @@
 	icon_state = "grimy"
 	},
 /area/crew_quarters/captain)
+"syd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/toy/figure/clown,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "sye" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -114931,15 +116961,18 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/magistrateoffice)
 "sCt" = (
-/obj/structure/table/wood/poker,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "purplefull"
+	},
+/area/toxins/ab_sm)
 "sCy" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -115272,6 +117305,21 @@
 	icon_state = "darkblue"
 	},
 /area/construction/hallway)
+"sFX" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/blood/writing{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/theatre)
 "sGl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -115653,6 +117701,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/security/hos)
+"sMd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/writing,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken"
+	},
+/area/crew_quarters/theatre)
 "sMh" = (
 /obj/structure/table,
 /obj/item/clothing/ears/earmuffs,
@@ -115708,22 +117763,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "sMF" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken6"
 	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "sMH" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -116131,28 +118175,28 @@
 /area/medical/research)
 "sRk" = (
 /obj/structure/window/reinforced/polarized{
-	color = "#222222";
 	id = "pokerclub";
+	color = "#222222";
 	opacity = 1
 	},
 /obj/structure/window/reinforced/polarized{
-	color = "#222222";
 	dir = 4;
 	id = "pokerclub";
-	opacity = 1
+	opacity = 1;
+	color = "#222222"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
-	color = "#222222";
 	dir = 1;
 	id = "pokerclub";
+	color = "#222222";
 	opacity = 1
 	},
 /obj/structure/window/reinforced/polarized{
-	color = "#222222";
 	dir = 8;
 	id = "pokerclub";
-	opacity = 1
+	opacity = 1;
+	color = "#222222"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
@@ -116209,6 +118253,14 @@
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
+"sRF" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen";
+	opened = 1
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint3)
 "sRG" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil/random,
@@ -116233,17 +118285,35 @@
 	},
 /area/bridge)
 "sRM" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "purple"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office/dark{
+	dir = 4
 	},
-/area/maintenance/xenozoo)
+/turf/simulated/floor/plating,
+/area/toxins/ab_sm)
 "sRN" = (
-/obj/structure/chair/wood,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
 	},
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/writing{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/crew_quarters/theatre)
 "sRV" = (
 /obj/item/radio/intercom{
 	pixel_y = 22
@@ -116532,6 +118602,15 @@
 	icon_state = "whitegreencorner"
 	},
 /area/medical/virology)
+"sVz" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "sVC" = (
 /obj/structure/chair/comfy/brown,
 /obj/structure/cable{
@@ -116603,6 +118682,15 @@
 "sWs" = (
 /turf/simulated/floor/carpet,
 /area/lawoffice)
+"sWt" = (
+/obj/machinery/light/small,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
+	},
+/obj/machinery/vending/boozeomat,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "sWE" = (
 /obj/structure/safe/floor,
 /obj/item/clothing/mask/cigarette/pipe,
@@ -117261,6 +119349,22 @@
 	icon_state = "neutralfull"
 	},
 /area/engine/engineering)
+"teC" = (
+/obj/structure/chair/wood/wings{
+	dir = 8;
+	tag = "icon-wooden_chair_wings (WEST)"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "teD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -117343,10 +119447,19 @@
 	},
 /area/security/securearmory)
 "tfr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/obj/structure/table/wood,
+/obj/item/storage/briefcase{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/crew_quarters/theatre)
 "tfy" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel{
@@ -117452,9 +119565,13 @@
 	},
 /area/aisat)
 "tgM" = (
-/obj/effect/decal/remains/human,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "purplefull"
+	},
+/area/toxins/ab_sm)
 "tgP" = (
 /obj/item/radio/intercom{
 	dir = 1;
@@ -117569,6 +119686,17 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/security/detectives_office)
+"tig" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/westright,
+/obj/structure/sign/poster/official/nanotrasen_logo{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "ramptop"
+	},
+/area/crew_quarters/theatre)
 "tii" = (
 /obj/structure/chair{
 	dir = 4
@@ -118006,12 +120134,21 @@
 /turf/simulated/floor/carpet,
 /area/lawoffice)
 "tmR" = (
-/obj/effect/decal/warning_stripes/east,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/power/terminal{
+	dir = 4
 	},
-/area/maintenance/xenozoo)
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/toxins/ab_sm)
 "tmW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -118507,6 +120644,13 @@
 	icon_state = "whitered"
 	},
 /area/security/medbay)
+"ttp" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 4;
+	on = 1
+	},
+/turf/simulated/floor/engine,
+/area/toxins/ab_sm)
 "ttw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -118731,9 +120875,12 @@
 /turf/simulated/floor/wood,
 /area/security/hos)
 "twh" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
 /turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "two" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -118796,14 +120943,8 @@
 	},
 /area/turret_protected/aisat_interior)
 "txl" = (
-/obj/structure/table/wood,
-/obj/item/soap,
-/obj/machinery/light,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
-	},
-/area/maintenance/tourist)
+/turf/simulated/floor/engine,
+/area/toxins/ab_sm)
 "txq" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/portsolar)
@@ -119968,6 +122109,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
+"tJV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/toxins/ab_sm)
 "tJX" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -120118,6 +122266,17 @@
 /obj/structure/lattice,
 /turf/simulated/wall,
 /area/maintenance/bar)
+"tLo" = (
+/obj/structure/table/wood,
+/obj/machinery/newscaster{
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/theatre)
 "tLr" = (
 /obj/structure/table,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -121012,6 +123171,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/detectives_office)
+"tUn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/hatdispenser,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/crew_quarters/theatre)
 "tUB" = (
 /obj/machinery/vending/snack,
 /obj/effect/decal/warning_stripes/red/hollow,
@@ -121501,11 +123669,22 @@
 	},
 /area/medical/surgery/south)
 "tZs" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/obj/machinery/light,
-/turf/simulated/floor/wood,
-/area/maintenance/tourist)
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "tZI" = (
 /obj/structure/disposalpipe/junction{
 	dir = 2;
@@ -121600,11 +123779,12 @@
 	},
 /area/security/processing)
 "ubu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/comfy/beige{
+	dir = 1
 	},
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/turf/simulated/floor/carpet/royalblue,
+/area/crew_quarters/theatre)
 "ubA" = (
 /obj/structure/table,
 /obj/item/clipboard,
@@ -121895,19 +124075,11 @@
 	},
 /area/maintenance/asmaint)
 "uex" = (
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "sw_maint_airlock";
-	name = "interior access button";
-	pixel_x = -24;
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "uey" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -123007,6 +125179,13 @@
 	icon_state = "diagonalWall3"
 	},
 /area/shuttle/syndicate_sit)
+"uqg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "chapel"
+	},
+/area/crew_quarters/theatre)
 "uqq" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/alarm{
@@ -123068,6 +125247,18 @@
 	icon_state = "tranquillite"
 	},
 /area/maintenance/kitchen)
+"urh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint3)
 "urn" = (
 /obj/structure/rack{
 	dir = 8;
@@ -123119,6 +125310,22 @@
 "usd" = (
 /turf/simulated/floor/carpet/royalblack,
 /area/maintenance/asmaint3)
+"usi" = (
+/obj/structure/chair/wood/wings{
+	dir = 8;
+	tag = "icon-wooden_chair_wings (WEST)"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "usx" = (
 /obj/machinery/light/small,
 /obj/item/radio/intercom{
@@ -123192,9 +125399,14 @@
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
 "utb" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "utf" = (
 /obj/effect/landmark/burnturf,
 /obj/effect/landmark/damageturf,
@@ -123350,6 +125562,24 @@
 	icon_state = "whitepurple"
 	},
 /area/medical/genetics)
+"uuE" = (
+/obj/item/radio/intercom{
+	pixel_x = 28
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "uuH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -123608,6 +125838,15 @@
 	icon_state = "dark"
 	},
 /area/chapel/main)
+"uxG" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken3";
+	tag = "icon-wood-broken3"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "uxL" = (
 /obj/machinery/recharge_station,
 /obj/effect/decal/warning_stripes/red/hollow,
@@ -123726,6 +125965,12 @@
 	icon_state = "white"
 	},
 /area/toxins/mixing)
+"uyG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/crew_quarters/theatre)
 "uyI" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -123991,17 +126236,18 @@
 	},
 /area/security/hos)
 "uBM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/light/small,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/turf/simulated/floor/engine,
+/area/toxins/ab_sm)
 "uBQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -124253,10 +126499,8 @@
 /turf/simulated/floor/plasteel,
 /area/medical/virology/lab)
 "uFo" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/maintenance/tourist)
+/turf/simulated/wall/r_wall,
+/area/toxins/ab_sm)
 "uFp" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -124404,6 +126648,23 @@
 	icon_state = "neutralfull"
 	},
 /area/crew_quarters/locker)
+"uHi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_spawners/grille_maybe,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "uHk" = (
 /obj/structure/closet/secure_closet/security,
 /obj/machinery/alarm{
@@ -124429,12 +126690,29 @@
 	},
 /area/turret_protected/aisat_interior)
 "uHq" = (
-/obj/structure/bed,
-/obj/item/bedsheet/rainbow,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/westright{
+	dir = 4
 	},
-/area/maintenance/tourist)
+/obj/structure/sign/poster/official/nanotrasen_logo{
+	pixel_y = 32
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "ramptop"
+	},
+/area/crew_quarters/theatre)
 "uHt" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/structure/cable{
@@ -124630,14 +126908,23 @@
 	},
 /area/medical/research/nhallway)
 "uJd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/remains/human,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/area/maintenance/gambling_den)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "uJi" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -124689,12 +126976,13 @@
 	},
 /area/medical/research/nhallway)
 "uJw" = (
-/obj/structure/table/wood/poker,
 /turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
+	icon_state = "wood-broken3";
+	tag = "icon-wood-broken3"
 	},
-/area/maintenance/gambling_den)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "uJx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -124806,9 +127094,19 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/test_chamber)
 "uKQ" = (
-/obj/structure/table/wood/poker,
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/secure/briefcase{
+	pixel_x = 8;
+	pixel_y = 4
+	},
+/obj/structure/chair/comfy/beige{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "uKR" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -125042,12 +127340,9 @@
 	},
 /area/security/brigstaff)
 "uNV" = (
-/obj/structure/chair/wood/wings{
-	dir = 8;
-	tag = "icon-wooden_chair_wings (WEST)"
-	},
+/obj/structure/grille,
 /turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/area/maintenance/asmaint3)
 "uNZ" = (
 /obj/machinery/computer/pandemic,
 /obj/effect/decal/warning_stripes/northeast,
@@ -125284,19 +127579,13 @@
 	},
 /area/medical/medbay)
 "uPX" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/confetti,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken7";
+	tag = "icon-wood-broken7"
 	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "uQb" = (
 /obj/structure/disposalpipe/sortjunction{
 	name = "CE's Junction";
@@ -125339,28 +127628,10 @@
 	},
 /area/security/main)
 "uQr" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/gambling_den)
+/turf/simulated/wall/rust,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "uQy" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
@@ -125455,19 +127726,14 @@
 	},
 /area/maintenance/bar)
 "uRn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 10;
+	icon_state = "purple"
 	},
-/area/maintenance/gambling_den)
+/area/toxins/ab_sm)
 "uRr" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -125506,6 +127772,17 @@
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/aft)
+"uRK" = (
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "purple"
+	},
+/area/toxins/ab_sm)
 "uRL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -125553,12 +127830,14 @@
 	},
 /area/security/processing)
 "uSt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/area/maintenance/gambling_den)
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/theatre)
 "uSv" = (
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
@@ -125572,6 +127851,23 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/lawoffice)
+"uSy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/semki{
+	pixel_x = 2;
+	pixel_y = -12
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "uSB" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
@@ -126036,10 +128332,15 @@
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "uXU" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/crew_quarters/theatre)
 "uXX" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -126366,8 +128667,16 @@
 	},
 /area/hallway/primary/port)
 "vbw" = (
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/structure/sign/poster/random{
+	pixel_x = -32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "vbJ" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -126419,15 +128728,13 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "vcj" = (
-/obj/effect/decal/cleanable/vomit,
-/obj/effect/landmark{
-	name = "blobstart"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/confetti,
+/turf/simulated/floor/wood{
+	broken = 1;
+	icon_state = "wood-broken"
 	},
-/obj/item/flag/syndi,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "vct" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/power/port_gen/pacman,
@@ -126591,6 +128898,12 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/port)
+"vfw" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken"
+	},
+/area/crew_quarters/theatre)
 "vfC" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -126871,15 +129184,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "vik" = (
-/obj/structure/table/reinforced,
-/obj/item/camera,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/random{
+	pixel_x = -32
+	},
 /obj/machinery/light/small{
-	dir = 1
+	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "viq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -127001,9 +129314,20 @@
 	},
 /area/medical/genetics)
 "vkm" = (
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/obj/item/trash/spentcasing,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "vku" = (
 /turf/simulated/wall,
 /area/security/permahallway)
@@ -127058,19 +129382,21 @@
 	},
 /area/medical/genetics)
 "vlf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint3)
 "vlh" = (
 /obj/machinery/bodyscanner,
 /obj/machinery/light/spot,
@@ -127279,6 +129605,19 @@
 	icon_state = "purple"
 	},
 /area/assembly/chargebay)
+"vnN" = (
+/obj/machinery/power/apc/worn_out{
+	cell_type = 0;
+	dir = 1;
+	pixel_y = 26
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/toxins/ab_sm)
 "vnQ" = (
 /obj/item/chair/wood/wings,
 /turf/simulated/floor/plating,
@@ -127328,12 +129667,14 @@
 	},
 /area/medical/genetics)
 "vor" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/structure/girder,
-/turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/turf/simulated/floor/engine,
+/area/toxins/ab_sm)
 "vos" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -127572,6 +129913,14 @@
 	icon_state = "red"
 	},
 /area/security/processing)
+"vqD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_x = -32;
+	pixel_y = 32
+	},
+/turf/simulated/floor/plating,
+/area/toxins/ab_sm)
 "vqK" = (
 /obj/structure/bed,
 /obj/item/bedsheet/cmo,
@@ -127665,6 +130014,11 @@
 	icon_state = "grimy"
 	},
 /area/library)
+"vrC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/wood,
+/area/crew_quarters/theatre)
 "vrH" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -128263,6 +130617,18 @@
 	tag = "icon-vault (NORTHEAST)"
 	},
 /area/crew_quarters/heads/hop)
+"vxX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate{
+	icon_state = "crateopen";
+	opened = 1
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitehall"
+	},
+/area/maintenance/asmaint3)
 "vye" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -128387,12 +130753,12 @@
 	},
 /area/hallway/primary/central/south)
 "vzx" = (
-/obj/structure/chair/stool/bar,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/comfy/brown{
+	dir = 1
 	},
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "vzz" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -128426,11 +130792,18 @@
 /turf/simulated/wall,
 /area/maintenance/kitchen)
 "vzN" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display{
+	pixel_y = 32
 	},
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "vzV" = (
 /obj/machinery/door/window/brigdoor{
 	base_state = "rightsecure";
@@ -128566,14 +130939,16 @@
 	},
 /area/maintenance/asmaint)
 "vAN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/grown/tomato{
+	pixel_x = 10;
+	pixel_y = 12
 	},
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/black,
+/area/crew_quarters/theatre)
 "vAZ" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -129184,6 +131559,14 @@
 	dir = 1
 	},
 /area/security/customs)
+"vGS" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA"
+	},
+/turf/simulated/wall/r_wall/rust,
+/area/toxins/ab_sm)
 "vHg" = (
 /obj/item/radio/intercom{
 	dir = 1;
@@ -129226,6 +131609,12 @@
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
+"vHy" = (
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/toxins/ab_sm)
 "vHA" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -129252,6 +131641,22 @@
 	},
 /turf/simulated/floor/engine/insulated/vacuum,
 /area/toxins/mixing)
+"vHU" = (
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1379;
+	master_tag = "sw_maint_airlock";
+	name = "interior access button";
+	pixel_x = -24;
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "vIi" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -130029,6 +132434,18 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"vRS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/clipboard,
+/obj/item/folder,
+/turf/simulated/floor/plasteel{
+	icon_state = "purple"
+	},
+/area/toxins/ab_sm)
 "vSm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -130166,6 +132583,30 @@
 	icon_state = "dark"
 	},
 /area/maintenance/electrical)
+"vTi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/obj/item/trash/syndi_cakes{
+	pixel_y = 7
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "vTj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -130494,10 +132935,14 @@
 	},
 /area/hallway/primary/starboard/east)
 "vVL" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/area/space/nearstation)
 "vVR" = (
 /obj/effect/decal/warning_stripes/northeast,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -130846,6 +133291,17 @@
 	icon_state = "dark"
 	},
 /area/security/prisonershuttle)
+"vZv" = (
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/toxins/ab_sm)
 "vZy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -131163,9 +133619,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "wcN" = (
-/obj/structure/table/wood,
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/writing{
+	dir = 8
+	},
+/obj/item/trash/spentcasing,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "wcO" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -131274,25 +133741,19 @@
 	},
 /area/crew_quarters/fitness)
 "wdH" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/closet{
+	icon_closed = "cabinet_closed";
+	icon_opened = "cabinet_open";
+	icon_state = "cabinet_closed"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/gambling_den)
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "wdO" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -131532,6 +133993,21 @@
 	icon_state = "yellow"
 	},
 /area/engine/break_room)
+"whz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/crew_quarters/theatre)
 "whO" = (
 /turf/simulated/wall/r_wall/coated,
 /area/crew_quarters/hor)
@@ -131854,17 +134330,25 @@
 	},
 /area/crew_quarters/sleep)
 "wlX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/chair/wood{
-	dir = 8
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 28
 	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "wmd" = (
 /obj/structure/window/plasmareinforced{
 	dir = 4
@@ -132195,18 +134679,29 @@
 	},
 /area/medical/medbay)
 "wqc" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "darkblue"
 	},
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "wqd" = (
 /obj/structure/table,
 /obj/item/paper/deltainfo,
@@ -132500,6 +134995,19 @@
 	icon_state = "darkblue"
 	},
 /area/chapel/main)
+"wsD" = (
+/obj/machinery/constructable_frame/machine_frame,
+/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purple"
+	},
+/area/toxins/ab_sm)
 "wsG" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start{
@@ -132623,9 +135131,14 @@
 	},
 /area/hallway/primary/port)
 "wtZ" = (
-/obj/effect/decal/cleanable/blood/xeno,
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/crew_quarters/theatre)
 "wua" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -133396,6 +135909,27 @@
 	icon_state = "darkred"
 	},
 /area/security/securearmory)
+"wCP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkbluecorners"
+	},
+/area/crew_quarters/theatre)
 "wCS" = (
 /obj/structure/engineeringcart,
 /obj/effect/decal/cleanable/dirt,
@@ -133416,6 +135950,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
 "wDh" = (
@@ -133717,11 +136252,23 @@
 	},
 /area/medical/morgue)
 "wFY" = (
-/obj/machinery/light/small{
+/obj/effect/decal/cleanable/blood/writing{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/bananium,
+/obj/item/soap/nanotrasen,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "wGd" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -133787,16 +136334,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "wGH" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/gambling_den)
+/obj/structure/lattice,
+/turf/simulated/wall/r_wall/coated,
+/area/toxins/ab_sm)
 "wGM" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -134117,9 +136657,8 @@
 	},
 /area/crew_quarters/fitness)
 "wLd" = (
-/obj/effect/spawner/random_spawners/wall_rusted_probably,
 /turf/simulated/wall,
-/area/maintenance/gambling_den)
+/area/crew_quarters/theatre)
 "wLq" = (
 /obj/structure/chair{
 	dir = 4
@@ -134432,16 +136971,10 @@
 	},
 /area/medical/research/restroom)
 "wOn" = (
-/obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
-/area/maintenance/gambling_den)
+/obj/item/trash/popcorn,
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "wOo" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
@@ -134748,11 +137281,15 @@
 	},
 /area/medical/surgery/south)
 "wSc" = (
-/obj/structure/table/wood/poker,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 28
 	},
-/area/maintenance/gambling_den)
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "wSh" = (
 /obj/structure/sign/poster/contraband/communist_state{
 	pixel_x = 33
@@ -134904,9 +137441,24 @@
 /turf/simulated/floor/plating/airless,
 /area/toxins/test_area)
 "wUr" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/engine,
+/area/toxins/ab_sm)
 "wUu" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -135021,11 +137573,14 @@
 /area/space/nearstation)
 "wVP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/structure/railing{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/tomato_smudge,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/crew_quarters/theatre)
 "wVQ" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Toxin Mixing";
@@ -135421,10 +137976,17 @@
 	},
 /area/security/lobby)
 "xbh" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "xbk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
@@ -135487,11 +138049,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
@@ -135506,8 +138063,11 @@
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /obj/structure/disposalpipe/segment{
-	dir = 2;
+	dir = 8;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
@@ -135629,10 +138189,15 @@
 /turf/simulated/floor/bluegrid,
 /area/assembly/chargebay)
 "xcJ" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet/crate{
+	icon_state = "crateopen";
+	opened = 1
+	},
+/obj/random/tool,
 /turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "xcN" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/light{
@@ -135673,6 +138238,10 @@
 	icon_state = "neutralfull"
 	},
 /area/assembly/robotics)
+"xdf" = (
+/obj/effect/spawner/random_spawners/oil_maybe,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint3)
 "xdo" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -135870,17 +138439,15 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
 "xeP" = (
-/obj/machinery/door/window/brigdoor{
-	name = "Creature Pen"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
 	},
-/obj/machinery/door/window/brigdoor{
-	dir = 8;
-	name = "Creature Pen"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "xeQ" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -136105,6 +138672,14 @@
 	icon_state = "whitepurplefull"
 	},
 /area/assembly/robotics)
+"xhl" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE"
+	},
+/turf/simulated/wall,
+/area/toxins/ab_sm)
 "xhn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -136289,8 +138864,12 @@
 /turf/simulated/floor/plasteel,
 /area/bridge/vip)
 "xji" = (
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/comfy/beige{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/theatre)
 "xjj" = (
 /obj/structure/table,
 /obj/item/paper/deltainfo,
@@ -136309,15 +138888,14 @@
 	},
 /area/chapel/office)
 "xjm" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/xenozoo)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/writing,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "xjr" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -137000,9 +139578,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "xrC" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/xenozoo)
+/turf/simulated/floor/plasteel,
+/area/toxins/ab_sm)
 "xsa" = (
 /obj/machinery/door/window{
 	base_state = "right";
@@ -137656,6 +140243,11 @@
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain/bedroom)
+"xxa" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/barricade/wooden,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint3)
 "xxb" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Checkpoint";
@@ -137939,8 +140531,18 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/engineering)
+/mob/living/simple_animal/mouse,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/grille/broken,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "xzg" = (
 /turf/simulated/wall,
 /area/medical/psych)
@@ -138341,9 +140943,14 @@
 	},
 /area/medical/research/shallway)
 "xDB" = (
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "xDD" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -139109,8 +141716,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1
+	},
 /area/maintenance/asmaint3)
 "xKH" = (
 /obj/structure/closet/secure_closet/engineering_chief,
@@ -139356,9 +141965,15 @@
 	},
 /area/engine/engineering/monitor)
 "xMC" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/maintenance/tourist)
+/obj/effect/spawner/window/reinforced/plasma,
+/obj/machinery/door/poddoor{
+	name = "Supermatter Blast Doors";
+	density = 0;
+	opacity = 0;
+	id_tag = "engsm1"
+	},
+/turf/simulated/floor/plating,
+/area/toxins/ab_sm)
 "xME" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -139577,6 +142192,25 @@
 	icon_state = "neutralfull"
 	},
 /area/bridge/checkpoint/south)
+"xPc" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "xPe" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxin Test Firing Range";
@@ -140001,6 +142635,23 @@
 	icon_state = "whitegreencorner"
 	},
 /area/medical/virology)
+"xSz" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "xSG" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
@@ -140335,6 +142986,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai)
+"xWs" = (
+/obj/machinery/power/smes,
+/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purple"
+	},
+/area/toxins/ab_sm)
 "xWx" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/structure/morgue{
@@ -140348,6 +143012,16 @@
 	icon_state = "darkblue"
 	},
 /area/medical/morgue)
+"xWH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_spawners/grille_often,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitehall"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "xWJ" = (
 /obj/machinery/cryopod,
 /turf/simulated/floor/plasteel{
@@ -140440,9 +143114,13 @@
 /area/quartermaster/miningdock)
 "xXu" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/maintenance/gambling_den)
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/crew_quarters/theatre)
 "xXA" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -141006,9 +143684,13 @@
 /area/chapel/main)
 "ycE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken6";
+	tag = "icon-wood-broken6"
+	},
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "ycJ" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -141418,8 +144100,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	dir = 1
+	},
 /area/maintenance/asmaint3)
 "ygC" = (
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -141788,6 +144471,20 @@
 	icon_state = "solarpanel"
 	},
 /area/maintenance/starboardsolar)
+"ykm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_spawners/grille_maybe,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2{
+	name = "Tourist Area Maintenance"
+	})
 "yko" = (
 /obj/structure/chair/office/dark,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -142002,10 +144699,11 @@
 	},
 /area/hallway/primary/aft)
 "ylW" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/turf/simulated/floor/plating,
-/area/maintenance/tourist)
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/turf/simulated/floor/engine,
+/area/toxins/ab_sm)
 
 (1,1,1) = {"
 aaq
@@ -155524,25 +158222,25 @@ aaq
 aaq
 aaq
 aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
+dZq
+dZq
+abj
+bCI
+bCI
+abj
+bCI
+bCI
+bCI
+abj
+bCI
+bCI
+abj
+bCI
+bCI
+abj
+abj
+dZq
+dZq
 aaq
 aaq
 abj
@@ -155781,25 +158479,25 @@ aaq
 aaq
 aaq
 aaq
+dZq
+abj
 aaq
+abj
 aaq
+abj
 aaq
+abj
 aaq
+abj
 aaq
+abj
 aaq
+abj
 aaq
+abj
 aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
+abj
+dZq
 aaq
 aaq
 abj
@@ -156038,25 +158736,25 @@ aaq
 aaq
 aaq
 aaq
+abj
 aaq
+bCI
+bCI
+abj
+bCI
+bCI
+bCI
+abj
+bCI
+abj
+bCI
+bCI
+abj
+abj
+dZq
+bqc
 aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
+abj
 aaq
 aaq
 abj
@@ -156295,25 +158993,25 @@ aaq
 aaq
 aaq
 aaq
+abj
+abj
 aaq
+abj
+abj
+abj
 aaq
+abj
+abj
+abj
 aaq
+abj
+abj
+abj
 aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
+abj
+abj
+abj
+dZq
 aaq
 aaq
 aaq
@@ -156552,25 +159250,25 @@ aaq
 aaq
 aaq
 aaq
+dZq
 aaq
+kwN
+kwN
+gZP
+uQr
+kwN
+jel
+gZP
+kwN
+kwN
+uQr
+gZP
+kwN
+kwN
 aaq
+dZq
 aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
+dZq
 aaq
 aaq
 aaq
@@ -156801,33 +159499,33 @@ aaq
 aaq
 aaq
 aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
+dZq
+dZq
+acF
+dZq
+bCI
+bCI
+abj
+dZq
+dZq
+abj
+kwN
+wdH
+lxD
+twh
+kwN
+wdH
+meM
+lkh
+kwN
+wdH
+kwD
+aGP
+kwN
+abj
+abj
+abj
+abj
 aaq
 aaq
 aaq
@@ -157058,33 +159756,33 @@ aaq
 aaq
 aaq
 aaq
+dZq
+abj
+acF
+abj
+aaq
+abj
 aaq
 abj
 abj
+aaq
+kwN
+rUW
+uxG
+eYo
+uQr
+cKc
+cKc
+hWA
+jel
+iXy
+lxD
+ntI
+kwN
 abj
-bCI
-bCI
-bCI
-abj
-bCI
-bCI
-bCI
-abj
-bCI
-bCI
-abj
-bCI
-bCI
+dZq
 aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
+dZq
 aaq
 aaq
 aaq
@@ -157315,33 +160013,33 @@ aaq
 aaq
 aaq
 aaq
-aaq
-abj
-aaq
-abj
-aaq
-abj
-aaq
-abj
-aaq
-abj
-aaq
-abj
-aaq
 abj
 abj
-aaq
+acF
+abj
+dZq
 bCI
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
+dZq
+abj
+abj
+abj
+kwN
+edJ
+ive
+iWq
+kwN
+fWb
+oec
+usi
+kwN
+edJ
+srO
+teC
+kwN
+abj
+dZq
+abj
+dZq
 aaq
 aaq
 aaq
@@ -157572,33 +160270,33 @@ aaq
 aaq
 aaq
 aaq
+dZq
+abj
+acF
 abj
 abj
 abj
-bCI
-bCI
-bCI
 abj
-bCI
-bCI
-bCI
-abj
-bCI
-abj
-bCI
-bCI
-aaq
 abj
 aaq
 aaq
+kwN
+nOl
+gkG
+cKc
+kwN
+dYH
+qFy
+ycE
+uQr
+nlP
+cwi
+uJw
+kwN
+abj
+abj
 aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
+abj
 aaq
 aaq
 aaq
@@ -157829,33 +160527,33 @@ bCI
 abj
 abj
 abj
+dZq
 abj
 acF
+uFo
+kDr
+kDr
+uFo
+wGH
+nTk
+qog
+nTk
+nTk
+pDf
+kwN
+kwN
+kwN
+pDf
+uQr
+kwN
+uQr
+pDf
+kwN
+kwN
 aaq
-abj
-aaq
-abj
-abj
-abj
-aaq
-abj
-abj
-abj
-aaq
-abj
-abj
-abj
+dZq
 abj
 dZq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
 aaq
 aaq
 aaq
@@ -158087,36 +160785,36 @@ aaq
 aaq
 abj
 abj
-wYL
-hsp
-hsp
-qGR
-iSO
-hsp
-nTk
-qGR
-hsp
-hsp
-iSO
-qGR
-hsp
-hsp
 abj
+wYL
+uFo
+qGR
+txl
+qNG
+nTk
+txl
+txl
+txl
+nTk
+ihy
+mLS
+cHe
+frM
+gkG
+ltR
+mLS
+cHe
+gkG
+hcC
+kwN
+abj
+abj
+abj
+acF
 aaq
+acF
 dZq
-bCI
-aaq
-bqc
 dZq
-aaq
-bCI
-bCI
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
 aaq
 aaq
 aaq
@@ -158343,37 +161041,37 @@ bCI
 bCI
 bCI
 abj
-ePn
-cLL
-hsp
-qVB
-ete
+abj
+naC
+nXQ
+uFo
+iyj
 ylW
-hsp
+qFt
 qVB
 aKL
 oYl
-hsp
-qVB
+txl
+nTk
 cpP
 tZs
-hsp
+ykm
+giV
+xSz
+xzc
+giV
+uHi
+nVz
+qwg
+kwN
 abj
-aaq
 abj
 abj
+acF
+vVL
+acF
 abj
-abj
-abj
-abj
-abj
-abj
-abj
-aaq
-aaq
-aaq
-aaq
-aaq
+dZq
 aaq
 aaq
 aaq
@@ -158600,37 +161298,37 @@ aaq
 abj
 aaq
 abj
-ePn
+abj
 naC
-iSO
-hWA
+ePn
+uFo
 kNU
 oss
-iSO
-pxR
-pxR
+jJF
+nTk
 txl
-hsp
-deX
+txl
+ttp
+nTk
 ete
 goA
-nTk
-abj
-abj
-abj
+wLd
+wLd
+wLd
+wLd
+wLd
+wLd
+jDz
+wLd
+wLd
+wLd
 dbz
 dbz
-aMW
-dbz
-aMW
-dbz
-dbz
+wLd
+uyG
+wLd
 abj
 abj
-dZq
-aaq
-dZq
-dZq
 aaq
 aaq
 aaq
@@ -158857,39 +161555,39 @@ lnn
 lnn
 lnn
 bXU
-ePn
-nGj
+naC
+naC
 avX
 uFo
 lmf
 lvo
-hsp
-pxR
+vGS
+cBQ
 xMC
-uNV
-iSO
-uFo
-wUr
+xMC
+nbm
+nTk
+kcA
 rYz
-hsp
-abj
-abj
-abj
-dbz
-xDB
+wLd
+qlL
+tLo
+tUn
+sul
+csO
 fJh
-wSc
-frM
+pAU
+dhw
 vbw
-dbz
+far
 pnM
-abj
-abj
+vik
+ovB
+wLd
 abj
 abj
 dZq
-aaq
-aaq
+dZq
 aaq
 aaq
 aaq
@@ -159116,37 +161814,37 @@ bXU
 bXU
 jAR
 uex
-hsp
-uHq
-wUr
-pxR
-hsp
+vHU
+iqN
+uRK
+vqD
+uRn
 kOD
 pLR
-egO
-nTk
-ive
-sbF
-oRQ
-hsp
-csO
-dbz
+txl
+vZv
+iqN
+mLS
+hKl
+ejo
+fVr
+jZo
 aMW
-dbz
-vbw
+idC
+csO
 bbA
-hDv
-exN
-xji
-dbz
 jIV
-dbz
-csO
-aMW
+uSy
+mvv
+lon
+jIV
+ope
+ndz
+wLd
 abj
-aaq
-aaq
-aaq
+abj
+abj
+dZq
 aaq
 aaq
 aaq
@@ -159371,39 +162069,39 @@ ldN
 fsc
 ldN
 bXU
-gEJ
-pxR
-hOT
-hsp
-jDz
-hsp
+cDu
+cKc
+mLS
+iqN
+aWO
+tJV
+jMJ
+vHy
+kWY
 iSO
+uBM
+qQQ
+cLL
 hsp
-jDz
-iSO
-hsp
-iSO
-jDz
-hsp
-bCK
+wLd
 uXU
-vbw
-jnc
-pzu
-xji
+nfm
+dfQ
+iXI
+wLd
 wSc
 hDv
 exN
-xji
+gze
 epM
 ghg
 evo
 xDB
-aMW
+wLd
+wLd
+wLd
 abj
-dZq
-aaq
-aaq
+abj
 aaq
 aaq
 aaq
@@ -159628,42 +162326,42 @@ aaq
 abj
 cbb
 bXU
-ePn
-pxR
-jDz
-pxR
-pxR
-wUr
+bXU
+mLS
+cKc
+iqN
+gmj
+lQT
 qta
-fIg
+sbF
 wUr
-olA
+rdF
 vor
-wUr
-wUr
+iqN
+pVC
 nsU
-wLd
-vbw
+csO
+eXq
 kHJ
 uSt
 tfr
-qNu
-kCF
-kCF
+wLd
+iNR
+pFD
 kCF
 rzQ
 gze
-wqc
-dYs
+nfm
+sgc
 kay
-dbz
+deX
+nKR
+wLd
 abj
 abj
-aaq
-aaq
-aaq
-aaq
-aaq
+abj
+abj
+abj
 tKX
 dZq
 jlK
@@ -159886,40 +162584,40 @@ hdZ
 cbb
 tzi
 bXU
-pxR
-ycE
-fIg
-olA
-pxR
-wUr
-wUr
-pxR
-pxR
-wUr
-pxR
-pxR
-pxR
+nMF
+cKc
+iqN
+gYP
+lQT
+vRS
+vHy
+mTl
+lnT
+gHE
+iqN
+mLS
+fSK
 wLd
 hfq
-uBM
+nfm
 kZh
 iXI
-vbw
+wLd
 vzN
-iFD
-kay
+wVP
+gAD
 dqk
 wVP
 xXu
-kfT
+nLj
 nLj
 bCK
+mdb
+dbz
+dbz
 abj
 abj
 abj
-aaq
-aaq
-aaq
 aaq
 tKX
 dZq
@@ -160143,41 +162841,41 @@ rfZ
 cbb
 tzi
 bXU
-pxR
-cUS
-cUS
-cUS
+dNP
+cKc
+iqN
+vnN
 jFg
-cUS
+geu
 qQf
 cUS
-cUS
-cUS
-cUS
-qGR
+sdH
+nWk
+iqN
+cLL
 hKl
 wLd
 ouO
-uRn
+dfQ
 sfq
 egh
+wLd
+tig
+hOT
 sxS
-sxS
-sxS
-sxS
-sxS
+oNB
 sMF
-oTb
+wtZ
 flH
 kJr
+mZq
+nfm
+qdn
 dbz
-dbz
-dbz
 abj
-abj
-abj
-abj
-abj
+aaq
+dZq
+aaq
 tKX
 abj
 jlK
@@ -160400,40 +163098,40 @@ rfZ
 pyN
 kZJ
 bXU
-pxR
-cUS
+sVz
+qjB
 iqN
-iXv
+hFa
 lQT
 iXv
-bwy
-cTL
+gSo
+lQT
 nWY
 okD
-cUS
-pxR
-pxR
-aMW
+iqN
+mVw
+gdD
+csO
 hLZ
-rRM
-xji
+pMH
+sgC
 hGI
-dYs
+pcj
 dYv
-gAD
-gAD
-vbw
-uPX
-rUS
+qkb
+sMd
+lBB
+axV
+wtZ
 ubu
 xji
-vbw
-vbw
-dbz
-abj
+iUq
+nfm
+ayN
+wLd
 abj
 aaq
-aaq
+dZq
 aaq
 tKX
 dZq
@@ -160657,41 +163355,41 @@ rfZ
 cbb
 cDv
 bXU
-pxR
-bwy
+kFv
+lff
 edF
-fsp
-xrC
+nGj
+sCt
 cJK
 lFw
 xrC
 tgM
 fyJ
-cUS
+kNr
 pxR
-olA
-aMW
+fSL
+wLd
 jxo
 iFq
-xji
+sFX
 pKP
-dYs
+kTD
 scD
-vbw
+sxS
 mYk
-dYs
-uPX
-vbw
+dEw
+sxS
+kgW
 vzx
-eYo
+ubu
 rUS
 nfm
-aMW
+iYt
+dbz
 abj
-dZq
-aaq
-aaq
-aaq
+abj
+abj
+abj
 tKX
 dZq
 jlK
@@ -160914,40 +163612,40 @@ rfZ
 pUS
 ufl
 bXU
-nlR
-cUS
+egO
+mLS
 rtB
-fsp
+fjQ
 sRM
 kPC
 ibA
-cPG
+lIb
 tmR
 rBh
-cUS
+xhl
 eCP
 fSK
-aMW
-xDB
-wdH
+wLd
+deL
+nfm
 sRN
-pMH
-gAD
-dYs
+kfT
+iFD
+hmA
 vcj
-gAD
-bmJ
+sxS
+vrC
 uPX
-twh
-vzx
-uJw
-vbw
-wcN
-dbz
-aaq
+wtZ
+ubu
+ubu
+rUS
+nfm
+sWt
+wLd
 abj
 aaq
-aaq
+dZq
 aaq
 tKX
 abj
@@ -161171,40 +163869,40 @@ cbb
 cDv
 bXU
 bXU
-pxR
-qQf
-cUS
+egO
+oUj
+iqN
 qol
 fsp
 pVo
 cTi
-bwy
-bwy
-bwy
-cUS
+wsD
+xWs
+mbR
+iqN
 bLm
 olA
-aMW
+oHO
 nBy
-iFq
-epM
-pMH
-gAD
-vbw
-gAD
-dYs
-dYs
-uPX
+hZy
+uuE
+mIU
+wLd
+uHq
+sMF
+sxS
+orr
+vfw
 wtZ
-vzx
+oRb
 uKQ
-xji
-fjQ
-aMW
+wqc
+nfm
+qbg
+dbz
+abj
 aaq
 dZq
-aaq
-aaq
 aaq
 tKX
 dZq
@@ -161428,40 +164126,40 @@ cbb
 pBi
 bXU
 cDu
-wUr
-cUS
-npg
-mbR
-fsp
-kgB
-cLz
-vVL
-lxD
+swa
+cKc
+iqN
 qQQ
-cUS
+iqN
+iqN
+iqN
+iqN
+iqN
+qQQ
+iqN
 nnt
-pxR
+qNu
 csO
-vbw
-wdH
-kDr
+wLd
+wLd
+wLd
 pMH
-vbw
+wLd
 bmJ
-vbw
-dYv
+gEJ
+oTb
 gAD
-uPX
+gEJ
 rzO
 wOn
-uJw
-vbw
-qbq
+pnM
+wCP
+nfm
 dbz
-aaq
+dbz
 abj
-aaq
-aaq
+abj
+abj
 aaq
 tKX
 abj
@@ -161685,39 +164383,39 @@ cbb
 cDv
 bXU
 bXU
-pxR
-bwy
-kwN
-kTD
-cHe
-fsp
-kSW
-kSW
-xrC
-utb
-cUS
+jOH
 mLS
-pxR
-iWq
-vbw
+eAg
+mLS
+cHe
+utb
+kSW
+utb
+mLS
+utb
+pCz
+mLS
+qNu
+wLd
+pkp
 gPK
-uKQ
+poa
 dfQ
-jUs
-jUs
+wLd
+vTi
 jUs
 iHF
-wGH
+cWb
 pfa
-rUS
+nfm
 dmM
 qWC
-dbz
-dbz
-dbz
+mZb
+kgB
+wLd
 abj
 abj
-bCI
+abj
 abj
 abj
 tKX
@@ -161942,37 +164640,37 @@ rfZ
 oak
 xqC
 bXU
-pxR
-bwy
-kwN
-far
-kUR
+xPc
+loN
+gaS
+lvs
+pCz
 fXD
 kUR
-kUR
+lvs
 lvs
 xjm
 muf
 jHx
 fFT
-deL
-vlf
-uQr
-sCt
+wLd
+wLd
+wLd
+wLd
 cXZ
-pCz
+wLd
 wlX
 cWb
 qQl
 vAN
 dDI
-kZh
+ghg
 uJd
 mdb
-aMW
+wLd
+wLd
+wLd
 abj
-aaq
-aaq
 aaq
 bCI
 aaq
@@ -162199,34 +164897,34 @@ rfZ
 cbb
 cDv
 bXU
-pxR
-bwy
+gTM
+cKc
 kwN
 gPw
 iVo
-fsp
+hAI
 gNY
-xrC
+arH
 oUj
 xbh
-cUS
-pxR
-puK
+xWH
+ktU
+npg
 wLd
 pkp
 jMH
 poa
 dYs
-dYs
+csO
 mWw
-dYs
-dYs
-vbw
+mvv
+whz
+hVq
 otP
 oYL
 khz
-dYv
-dbz
+mdb
+wLd
 abj
 abj
 abj
@@ -162456,34 +165154,34 @@ rfZ
 pyN
 kHo
 bXU
-pxR
-cUS
-vik
-fsp
-xrC
-pVo
+qMK
+cKc
+kwN
+kwN
+kwN
+kwN
 wFY
 eAg
-iNR
-xrC
-qQf
-fIg
+kwN
+eAg
+kwN
+jjY
 kxN
 wLd
-dYs
-dYs
-vbw
-dYs
-dYs
-vbw
+wLd
+csO
+wLd
+xxa
+wLd
+qej
 pzu
 dhw
 gaJ
 deE
-dYs
+iWo
 pfA
-dYs
-dbz
+uqg
+wLd
 abj
 aaq
 aaq
@@ -162714,33 +165412,33 @@ cbb
 cDv
 bXU
 mBV
-cUS
-cUS
+cKc
+kwN
 bwy
 cIx
-bwy
-cUS
-bwy
+hZK
+wcN
+kwN
 xeP
-bwy
-cUS
-fIg
-kxN
+kKW
+kwN
+qGP
+rRM
+pmu
+qLb
+pmu
+olr
+pmu
+wLd
 csO
+wLd
 csO
-aMW
-aMW
 wLd
+csO
 wLd
-wLd
-aMW
-wLd
-aMW
-wLd
-aMW
 dfT
-aMW
 wLd
+csO
 kms
 kBv
 kBv
@@ -162970,31 +165668,31 @@ tgf
 uJj
 gHc
 bXU
-pxR
+jOH
 cKc
-cUS
+kwN
 cTL
-pVo
+lwf
 vkm
-bwy
-kWY
-pVo
-okD
-cUS
+jHM
+kwN
+jeR
+syd
+eAg
 nlR
 puK
-hsp
+jnc
 soZ
 kNj
-iYl
+aXW
+urh
+urh
+urh
+urh
+urh
+urh
 wDg
-iYl
-iYl
-iYl
-iYl
-iYl
-wDg
-iYl
+urh
 dmN
 pmu
 kBv
@@ -163227,28 +165925,28 @@ bXU
 ePR
 bXU
 bXU
-pxR
+jOH
 pGX
-bwy
+kwN
 mRE
-fsp
+kyP
 kkV
-bwy
+oRQ
 kWn
 sic
 qXu
-qQf
-olA
-bVJ
-hsp
-qGP
-jHw
+kwN
 pmu
+bVJ
+jnc
+jcX
+pzS
+feG
 pzS
 szQ
 pzS
 hUL
-tWL
+xdf
 szQ
 pzS
 pzS
@@ -163484,23 +166182,23 @@ bXU
 rRf
 pZM
 bXU
-wUr
+swa
 xcJ
-cUS
+kwN
 cPG
-cOC
+kSW
 lRT
-bwy
+paw
 jjY
 cOC
 rQm
-cUS
+kwN
 fIg
 ksN
-hsp
-qGP
-jHw
-pmu
+jnc
+soZ
+hUL
+mFv
 kBv
 sRk
 vmP
@@ -163742,22 +166440,22 @@ gFc
 wnb
 bXU
 jDz
-cUS
-cUS
-cUS
-cUS
-qQf
-cUS
-cUS
-cUS
-cUS
-cUS
-hsp
-aSP
-hsp
-pzS
-jHw
+kwN
+eAg
+kwN
+kwN
+eAg
+kwN
+kwN
+eAg
+kwN
+eAg
 pmu
+aSP
+pmu
+nuz
+vxX
+kCH
 kBv
 fDU
 cOP
@@ -163765,7 +166463,7 @@ joX
 kRM
 rfK
 gKK
-edJ
+pzS
 dDW
 pmu
 kBv
@@ -164000,20 +166698,20 @@ oGZ
 bXU
 iOv
 nUy
-nUy
+qbq
 qtq
-xzc
+nUy
 nUy
 jZA
 nUy
-nUy
+qbq
 mQO
-dgd
-hoX
+cLz
+luN
 xbS
 ygy
 xKF
-arH
+iYl
 jvC
 vmP
 usd
@@ -164256,21 +166954,21 @@ hSF
 wGU
 bXU
 hGZ
-cbC
-kjT
-lGR
-cbC
-cbC
+eQq
+mbO
+jjO
+eQq
+eQq
 fVN
-yhX
-cbC
-kBv
-pzS
-pzS
-prC
-pzS
-pzS
-pzS
+eQq
+eQq
+soZ
+jgq
+kfz
+efo
+pmu
+pmu
+kfz
 efE
 gKK
 pmu
@@ -164524,9 +167222,9 @@ lpm
 lpm
 lpm
 lpm
-prC
-pzS
-qGP
+vlf
+soZ
+kBv
 kBv
 bLd
 kBv
@@ -164781,9 +167479,9 @@ dah
 dah
 dah
 lpm
-ocD
+prC
 pmu
-qGP
+xAj
 kBv
 kYM
 roR
@@ -165297,7 +167995,7 @@ dah
 lpm
 prC
 pmu
-lVe
+sRF
 kBv
 wcS
 gkD
@@ -165552,7 +168250,7 @@ vVo
 dah
 dah
 lpm
-prC
+ocD
 szQ
 oOo
 oOo
@@ -165810,7 +168508,7 @@ dah
 dah
 lpm
 prC
-hUL
+uNV
 oOo
 cIM
 cIM

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -49487,13 +49487,7 @@
 /area/atmos)
 "edF" = (
 /obj/structure/barricade/wooden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -53005,11 +52999,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
-"eQq" = (
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
 "eQA" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -57981,9 +57970,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
+/area/maintenance/engineering)
 "fVO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -66005,9 +65992,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
+/area/maintenance/engineering)
 "hHa" = (
 /turf/simulated/wall,
 /area/hallway/primary/central/north)
@@ -71306,9 +71291,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
+/area/maintenance/engineering)
 "iOx" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -73038,12 +73021,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/toxins/test_chamber)
-"jjO" = (
-/obj/structure/grille,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
 "jjT" = (
 /obj/machinery/dna_scannernew,
 /turf/simulated/floor/plasteel{
@@ -76691,9 +76668,7 @@
 /obj/structure/girder,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
+/area/maintenance/engineering)
 "jZI" = (
 /obj/structure/lattice,
 /turf/space,
@@ -79929,8 +79904,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/research{
@@ -85288,16 +85261,6 @@
 /obj/item/lighter,
 /turf/simulated/floor/engine,
 /area/security/execution)
-"mbO" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
 "mbR" = (
 /obj/machinery/constructable_frame/machine_frame,
 /obj/structure/cable,
@@ -94425,9 +94388,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
+/area/maintenance/engineering)
 "nUI" = (
 /obj/docking_port/mobile/supply,
 /obj/docking_port/stationary{
@@ -104599,9 +104560,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
+/area/maintenance/engineering)
 "qbt" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -106539,9 +106498,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/starboard{
-	name = "Engineering Maintenance"
-	})
+/area/maintenance/engineering)
 "qtv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -166954,14 +166911,14 @@ hSF
 wGU
 bXU
 hGZ
-eQq
-mbO
-jjO
-eQq
-eQq
+cbC
+kjT
+lGR
+cbC
+cbC
 fVN
-eQq
-eQq
+cbC
+cbC
 soZ
 jgq
 kfz

--- a/code/game/area/ss13_areas.dm
+++ b/code/game/area/ss13_areas.dm
@@ -1916,6 +1916,10 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "\improper Experimentation Lab"
 	icon_state = "toxmisc"
 
+/area/toxins/ab_sm
+	name = "\improper SuperMatter Abandoned Test Room"
+	icon_state = "yellow"
+
 //Storage
 
 /area/storage


### PR DESCRIPTION
По результату: https://discord.com/channels/617003227182792704/755125334097133628/1043909798988628051

## What Does This PR Do
Изменение и увеличение количества возможных маршрутов в техах, расширение коридоров до 2 тайлов, улучшенная детализация.
Бойцовский клуб заменён на театр с разделением на два помещения - сцены и кулис.
Старое ксено заменено на тестовою зону СМа(принадлежность-инженерия/РнД).
Старые комнатушки перемещены чуть ниже с добавлением коридора.
В дополнение к кулисам добавлена клоунская.

## Why It's Good For The Game
Продолжение расширения 1-тайловых техов и переработки заброшенных зон РнД.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![2022 11 21-15 43 43](https://user-images.githubusercontent.com/110329212/202993240-8b31e11c-c094-4855-ab9f-31eb888c5319.png)
