### PR TITLE
feat: Can't change sensors when being NECK grabbed

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -308,16 +308,20 @@ BLIND     // can't see anything
 	else
 		return ..()
 
-/obj/item/clothing/under/proc/set_sensors(mob/user as mob)
-	var/mob/M = user
-	if(istype(M, /mob/dead/)) return
-	if(user.stat || user.restrained()) return
+/obj/item/clothing/under/proc/set_sensors(mob/living/user)
+	if(user.stat || user.restrained())
+		return
+	if(length(user.grabbed_by))
+		for(var/obj/item/grab/grabbed in user.grabbed_by)
+			if(grabbed.state >= GRAB_NECK)
+				to_chat(user, "You can't reach the controls.")
+				return
 	if(has_sensor >= 2)
 		to_chat(user, "The controls are locked.")
-		return 0
+		return
 	if(has_sensor <= 0)
 		to_chat(user, "This suit does not have any sensors.")
-		return 0
+		return
 
 	var/list/modes = list("Off", "Binary sensors", "Vitals tracker", "Tracking beacon")
 	var/switchMode = input("Select a sensor mode:", "Suit Sensor Mode", modes[sensor_mode + 1]) in modes

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -91,7 +91,7 @@
 
 	var/research_scanner = 0 //For research scanner equipped mobs. Enable to show research data when examining.
 
-	var/list/grabbed_by = list()
+	var/list/obj/item/grab/grabbed_by = list()
 	var/lighting_alpha = LIGHTING_PLANE_ALPHA_VISIBLE
 	var/list/mapobjs = list()
 


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Автор: @ZoNeSRuS 
PARADISE
Предложение:
Отключить возможность взаимодействовать со своими датчиками, если ты попал в красный/удушающий захват.
Кодер: @Larentoun 
Причины для ввода:
Фичча мало кому известная, но очень сильно бесящая. Дело в том что если ты играешь от стелса, через гарроту, CQC, карпа, и берешь противника в захват и душишь, то начинается настоящая клоунада с "Выключил датчики" "Включил датчики", что играет ни хрена не на руку убийце. По механу находясь в этих захватах, ты вообще не можешь ни с чем взаимодействовать, однако включать датчики ты почему-то все еще можешь. Вещь которая выглядит как "баг" назвали фичей, что же, пора это исправить.

[Предложка пройдена](https://discord.com/channels/617003227182792704/755125334097133628/1044980972606738442)

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: Can't change sensors when being NECK grabbed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
