### PR TITLE
Fix: broken shuttle engines rotation

### DIFF
--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -6,10 +6,7 @@
 	armor = list(melee = 100, bullet = 10, laser = 10, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 70) //default + ignores melee
 
 /obj/structure/shuttle/shuttleRotate(rotation)
-	..()
-	var/matrix/M = transform
-	M.Turn(rotation)
-	transform = M
+	return // This override is needed to properly rotate the object when on a shuttle that is rotated.
 
 /obj/structure/shuttle/window
 	name = "shuttle window"
@@ -54,14 +51,11 @@
 	opacity = 1
 
 /obj/structure/shuttle/engine/propulsion/burst
-	name = "burst"
 
 /obj/structure/shuttle/engine/propulsion/burst/left
-	name = "left"
 	icon_state = "burst_l"
 
 /obj/structure/shuttle/engine/propulsion/burst/right
-	name = "right"
 	icon_state = "burst_r"
 
 /obj/structure/shuttle/engine/router

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -7,6 +7,9 @@
 	canSmoothWith = null
 	smooth = SMOOTH_TRUE
 
+/turf/simulated/wall/mineral/shuttleRotate(rotation)
+	return // This override is needed to properly rotate the object when on a shuttle that is rotated.
+
 /turf/simulated/wall/mineral/gold
 	name = "gold wall"
 	desc = "A wall with gold plating. Swag!"

--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -56,6 +56,9 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 		d2 = temp
 	update_icon()
 
+/obj/structure/shuttle/engine/shuttleRotate(rotation, params)
+	setDir(angle2dir(rotation+dir2angle(dir)))
+
 //Fixes dpdir on shuttle rotation
 /obj/structure/disposalpipe/shuttleRotate(rotation, params)
 	. = ..()


### PR DESCRIPTION
### Исправляет сломанное направление движков при изменении направления шаттлов и подов.

Теперь выглядит корректно:

![scrnshot1](https://user-images.githubusercontent.com/20109643/203189486-62707cd8-bd2c-47e2-8f45-120b8494ae2c.png)

Фикс взят с оффов:
https://github.com/ParadiseSS13/Paradise/pull/16154