### PR TITLE
Feat: change vox raiders starting equipment

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -1003,23 +1003,18 @@
 /area/shuttle/vox)
 "aet" = (
 /obj/structure/rack,
-/obj/item/clothing/accessory/storage/black_vest,
-/obj/item/clothing/suit/space/vox/carapace,
-/obj/item/clothing/head/helmet/space/vox/carapace,
-/obj/item/clothing/mask/breath,
-/obj/item/storage/backpack/duffel/syndie{
-	slowdown = 1
-	},
+/obj/item/gun/dartgun/vox/raider,
+/obj/item/gun/dartgun/vox/raider,
+/obj/item/dart_cartridge,
+/obj/item/dart_cartridge,
+/obj/item/dart_cartridge,
+/obj/item/dart_cartridge,
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
 "aeu" = (
 /obj/structure/rack,
-/obj/item/gun/dartgun/vox/raider,
-/obj/item/gun/dartgun/vox/medical,
-/obj/item/dart_cartridge,
-/obj/item/dart_cartridge,
-/obj/item/dart_cartridge,
-/obj/item/dart_cartridge,
+/obj/item/gun/energy/spikethrower,
+/obj/item/gun/energy/spikethrower,
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
 "aey" = (
@@ -1236,10 +1231,12 @@
 /area/shuttle/syndicate)
 "afj" = (
 /obj/structure/rack,
-/obj/item/clothing/accessory/storage/black_vest,
-/obj/item/clothing/suit/space/vox/medic,
-/obj/item/clothing/head/helmet/space/vox/medic,
-/obj/item/clothing/mask/breath,
+/obj/item/gun/dartgun/vox/medical,
+/obj/item/gun/dartgun/vox/medical,
+/obj/item/dart_cartridge,
+/obj/item/dart_cartridge,
+/obj/item/dart_cartridge,
+/obj/item/dart_cartridge,
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
 "afn" = (
@@ -1417,6 +1414,12 @@
 	dir = 4;
 	tag = "icon-tube1 (EAST)"
 	},
+/obj/item/pneumatic_cannon,
+/obj/item/harpoon,
+/obj/item/harpoon,
+/obj/item/harpoon,
+/obj/item/harpoon,
+/obj/item/tank/internals/nitrogen,
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
 "afQ" = (
@@ -1563,10 +1566,11 @@
 /area/toxins/launch)
 "agt" = (
 /obj/structure/rack,
-/obj/item/clothing/accessory/storage/black_vest,
-/obj/item/clothing/suit/space/vox/pressure,
-/obj/item/clothing/head/helmet/space/vox/pressure,
-/obj/item/clothing/mask/breath,
+/obj/item/card/emag,
+/obj/item/chameleon,
+/obj/item/clothing/glasses/thermal/monocle{
+	pixel_x = -5
+	},
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
 "agA" = (
@@ -1641,10 +1645,9 @@
 /area/shuttle/administration)
 "agQ" = (
 /obj/structure/rack,
-/obj/item/clothing/accessory/storage/black_vest,
-/obj/item/clothing/suit/space/vox/stealth,
-/obj/item/clothing/head/helmet/space/vox/stealth,
-/obj/item/clothing/mask/breath,
+/obj/item/flash/cameraflash,
+/obj/item/pen/edagger,
+/obj/item/storage/box/emps,
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
 "agR" = (
@@ -1695,22 +1698,9 @@
 /area/shuttle/pod_2)
 "ahg" = (
 /obj/structure/rack,
-/obj/item/storage/belt/military{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/belt/military{
-	pixel_x = -1;
-	pixel_y = 1
-	},
-/obj/item/storage/belt/military{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/storage/belt/military{
-	pixel_x = 3;
-	pixel_y = -3
-	},
+/obj/item/aiModule/syndicate,
+/obj/item/multitool/ai_detect,
+/obj/item/jammer,
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
 "ahh" = (
@@ -2026,11 +2016,6 @@
 	icon_state = "neutral"
 	},
 /area/engine/mechanic_workshop/expedition)
-"aiU" = (
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/clothing/mask/breath,
-/turf/simulated/shuttle/floor4/vox,
-/area/shuttle/vox)
 "aiX" = (
 /obj/item/radio/intercom/syndicate{
 	pixel_x = -28
@@ -2231,10 +2216,13 @@
 	},
 /area/hallway/primary/central/se)
 "akh" = (
-/obj/item/clothing/head/collectable/xenom,
-/obj/item/clothing/head/chicken,
-/obj/item/aiModule/syndicate,
-/turf/simulated/shuttle/floor4/vox,
+/obj/machinery/atmospherics/unary/tank/nitrogen{
+	dir = 8
+	},
+/turf/simulated/shuttle/wall{
+	dir = 4;
+	icon_state = "wall3"
+	},
 /area/shuttle/vox)
 "akk" = (
 /obj/item/stack/spacecash/c1000,
@@ -60669,12 +60657,13 @@
 	},
 /area/chapel/office)
 "gGF" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 1;
-	frequency = 1331;
-	id_tag = "vox_east_vent"
+/obj/machinery/atmospherics/unary/tank/nitrogen{
+	dir = 4
 	},
-/turf/simulated/shuttle/plating/vox,
+/turf/simulated/shuttle/wall{
+	dir = 4;
+	icon_state = "wall3"
+	},
 /area/shuttle/vox)
 "gGI" = (
 /obj/machinery/atmospherics/unary/portables_connector,
@@ -108229,9 +108218,9 @@
 /area/hallway/secondary/exit)
 "reZ" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 1;
+	dir = 4;
 	frequency = 1331;
-	id_tag = "vox_west_vent"
+	id_tag = "vox_east_vent"
 	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
@@ -109929,7 +109918,11 @@
 	},
 /area/chapel/office)
 "rxO" = (
-/obj/machinery/atmospherics/unary/tank/nitrogen,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1331;
+	id_tag = "vox_west_vent"
+	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
 "ryp" = (
@@ -197819,7 +197812,7 @@ aaq
 aaq
 aaq
 aad
-aat
+gGF
 aat
 aat
 aaf
@@ -198077,7 +198070,7 @@ aaq
 aaq
 aaf
 rxO
-reZ
+aer
 abX
 aer
 aer
@@ -199889,7 +199882,7 @@ aec
 aec
 ahT
 aiR
-akh
+aec
 alx
 aaf
 aaq
@@ -200402,7 +200395,7 @@ aec
 aec
 aec
 ahn
-aiU
+aec
 akk
 idn
 aaf
@@ -202188,8 +202181,8 @@ aaq
 aaq
 aaq
 aaf
-rxO
-gGF
+reZ
+aer
 acJ
 aer
 aer
@@ -202445,7 +202438,7 @@ aaq
 aaq
 aaq
 aak
-aat
+akh
 aat
 aat
 aaf

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -2561,22 +2561,9 @@
 /area/shuttle/vox)
 "agb" = (
 /obj/structure/rack,
-/obj/item/storage/belt/military{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/belt/military{
-	pixel_x = -1;
-	pixel_y = 1
-	},
-/obj/item/storage/belt/military{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/storage/belt/military{
-	pixel_x = 3;
-	pixel_y = -3
-	},
+/obj/item/aiModule/syndicate,
+/obj/item/multitool/ai_detect,
+/obj/item/jammer,
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
 "agc" = (
@@ -2824,11 +2811,6 @@
 /obj/machinery/light/spot{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8;
-	frequency = 1331;
-	id_tag = "vox_west_vent"
-	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
 "agy" = (
@@ -2868,11 +2850,6 @@
 	},
 /obj/machinery/light/spot{
 	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
-	frequency = 1331;
-	id_tag = "vox_east_vent"
 	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
@@ -3255,13 +3232,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/security/hos)
-"ahn" = (
-/turf/space,
-/turf/simulated/shuttle/wall{
-	dir = 4;
-	icon_state = "diagonalWall3"
-	},
-/area/shuttle/vox)
 "aho" = (
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
@@ -3321,10 +3291,10 @@
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
 "ahs" = (
-/turf/space,
-/turf/simulated/shuttle/wall{
-	icon_state = "diagonalWall3"
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "152"
 	},
+/turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
 "ahu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -3526,13 +3496,6 @@
 /area/shuttle/vox)
 "ahK" = (
 /obj/machinery/light/spot,
-/turf/simulated/shuttle/floor4/vox,
-/area/shuttle/vox)
-"ahL" = (
-/obj/item/clothing/head/collectable/petehat{
-	desc = "It smells faintly of reptile.";
-	name = "fancy leader hat"
-	},
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
 "ahM" = (
@@ -3792,8 +3755,10 @@
 	},
 /area/security/customs)
 "ail" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1331;
+	id_tag = "vox_west_vent"
 	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
@@ -4533,14 +4498,6 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/syndicate)
-"ajC" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 1;
-	frequency = 1331;
-	id_tag = "vox_west_vent"
-	},
-/turf/simulated/shuttle/plating/vox,
-/area/shuttle/vox)
 "ajD" = (
 /obj/item/storage/toolbox/electrical,
 /obj/item/storage/toolbox/emergency,
@@ -4549,33 +4506,21 @@
 /area/shuttle/vox)
 "ajE" = (
 /obj/structure/rack,
-/obj/item/clothing/accessory/storage/black_vest,
-/obj/item/clothing/suit/space/vox/carapace,
-/obj/item/clothing/head/helmet/space/vox/carapace,
-/obj/item/clothing/mask/breath,
-/obj/item/storage/backpack/duffel/syndie{
-	slowdown = 1
-	},
+/obj/item/gun/dartgun/vox/raider,
+/obj/item/gun/dartgun/vox/raider,
+/obj/item/dart_cartridge,
+/obj/item/dart_cartridge,
+/obj/item/dart_cartridge,
+/obj/item/dart_cartridge,
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
 "ajF" = (
 /obj/structure/rack,
-/obj/item/gun/dartgun/vox/raider,
-/obj/item/gun/dartgun/vox/medical,
-/obj/item/dart_cartridge,
-/obj/item/dart_cartridge,
-/obj/item/dart_cartridge,
-/obj/item/dart_cartridge,
-/obj/item/gun/dartgun/vox/medical,
-/obj/item/gun/dartgun/vox/medical,
+/obj/item/gun/energy/spikethrower,
+/obj/item/gun/energy/spikethrower,
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
 "ajG" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 1;
-	frequency = 1331;
-	id_tag = "vox_east_vent"
-	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
 "ajH" = (
@@ -4765,13 +4710,12 @@
 /area/shuttle/vox)
 "ajZ" = (
 /obj/structure/rack,
-/obj/item/clothing/accessory/storage/black_vest,
-/obj/item/clothing/suit/space/vox/medic,
-/obj/item/clothing/head/helmet/space/vox/medic,
-/obj/item/clothing/mask/breath,
-/obj/machinery/light/spot{
-	dir = 8
-	},
+/obj/item/gun/dartgun/vox/medical,
+/obj/item/gun/dartgun/vox/medical,
+/obj/item/dart_cartridge,
+/obj/item/dart_cartridge,
+/obj/item/dart_cartridge,
+/obj/item/dart_cartridge,
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
 "aka" = (
@@ -4783,8 +4727,15 @@
 /obj/item/harpoon,
 /obj/item/tank/internals/nitrogen,
 /obj/machinery/light/spot{
-	dir = 4
+	dir = 4;
+	tag = "icon-tube1 (EAST)"
 	},
+/obj/item/pneumatic_cannon,
+/obj/item/harpoon,
+/obj/item/harpoon,
+/obj/item/harpoon,
+/obj/item/harpoon,
+/obj/item/tank/internals/nitrogen,
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
 "akb" = (
@@ -4992,10 +4943,11 @@
 /area/shuttle/vox)
 "akq" = (
 /obj/structure/rack,
-/obj/item/clothing/accessory/storage/black_vest,
-/obj/item/clothing/suit/space/vox/pressure,
-/obj/item/clothing/head/helmet/space/vox/pressure,
-/obj/item/clothing/mask/breath,
+/obj/item/card/emag,
+/obj/item/chameleon,
+/obj/item/clothing/glasses/thermal/monocle{
+	pixel_x = -5
+	},
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
 "akr" = (
@@ -5110,10 +5062,9 @@
 /area/security/podbay)
 "akA" = (
 /obj/structure/rack,
-/obj/item/clothing/accessory/storage/black_vest,
-/obj/item/clothing/suit/space/vox/stealth,
-/obj/item/clothing/head/helmet/space/vox/stealth,
-/obj/item/clothing/mask/breath,
+/obj/item/flash/cameraflash,
+/obj/item/pen/edagger,
+/obj/item/storage/box/emps,
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
 "akC" = (
@@ -5706,11 +5657,6 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
-"alz" = (
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/clothing/mask/breath,
-/turf/simulated/shuttle/floor4/vox,
-/area/shuttle/vox)
 "alA" = (
 /obj/item/clothing/head/bearpelt,
 /obj/item/xenos_claw,
@@ -6079,10 +6025,12 @@
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
 "amj" = (
-/obj/item/clothing/head/collectable/xenom,
-/obj/item/clothing/head/chicken,
-/obj/item/aiModule/syndicate,
-/turf/simulated/shuttle/floor4/vox,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1331;
+	id_tag = "vox_east_vent"
+	},
+/turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
 "amk" = (
 /obj/item/stack/spacecash/c1000,
@@ -152613,7 +152561,7 @@ aaa
 aaa
 agZ
 ail
-ajC
+ajG
 adV
 aha
 anK
@@ -153912,7 +153860,7 @@ agw
 agw
 agw
 agw
-ahs
+bRC
 aaa
 aaa
 aaa
@@ -154160,7 +154108,7 @@ aha
 aha
 agZ
 aha
-agZ
+ahs
 aha
 ajE
 ajZ
@@ -154170,7 +154118,7 @@ akR
 alx
 ami
 agZ
-ahs
+bRC
 aaa
 aaa
 aaa
@@ -154425,7 +154373,7 @@ aha
 aha
 akP
 aly
-amj
+aha
 amY
 agZ
 aaa
@@ -154671,16 +154619,16 @@ ahz
 agB
 ahc
 aha
-ahL
-ahZ
 aha
 ahZ
 aha
+ahs
 aha
 aha
 aha
 aha
-ahZ
+aha
+ahs
 aha
 aha
 amZ
@@ -154938,7 +154886,7 @@ aha
 aha
 aha
 akR
-alz
+aha
 amk
 ana
 agZ
@@ -155188,7 +155136,7 @@ aha
 aha
 agZ
 aha
-agZ
+ahs
 aha
 ajF
 aka
@@ -155198,7 +155146,7 @@ akP
 alA
 aml
 agZ
-ahn
+bWI
 aaa
 aaa
 aaa
@@ -155454,7 +155402,7 @@ agw
 agw
 agw
 agw
-ahn
+bWI
 aaa
 aaa
 aaa
@@ -156724,7 +156672,7 @@ aaa
 aaa
 aaa
 agZ
-ail
+amj
 ajG
 aen
 aha

--- a/_maps/map_files/cyberiad/z2.dmm
+++ b/_maps/map_files/cyberiad/z2.dmm
@@ -6691,18 +6691,6 @@
 	tag = "icon-floor"
 	},
 /area/admin)
-"eSH" = (
-/obj/structure/table/reinforced/brass,
-/obj/item/book/manual/nuclear{
-	pixel_x = 5
-	},
-/turf/unsimulated/floor{
-	icon_state = "darkfull";
-	nitrogen = 100;
-	oxygen = 0;
-	tag = "icon-dark"
-	},
-/area/vox_station)
 "eSX" = (
 /obj/structure/sign/goldenplaque{
 	desc = "Лучший сотрудник века";
@@ -13129,10 +13117,18 @@
 	},
 /area/centcom/evac)
 "jga" = (
-/turf/unsimulated/wall{
-	icon_state = "iron12"
+/obj/structure/table/reinforced/brass,
+/obj/item/clothing/head/collectable/petehat{
+	desc = "It smells faintly of reptile.";
+	name = "fancy leader hat"
 	},
-/area/syndicate_mothership)
+/turf/unsimulated/floor{
+	icon_state = "darkfull";
+	nitrogen = 100;
+	oxygen = 0;
+	tag = "icon-dark"
+	},
+/area/vox_station)
 "jgy" = (
 /turf/unsimulated/wall/abductor{
 	icon_state = "alien23"
@@ -20847,6 +20843,9 @@
 	},
 /obj/structure/table/reinforced/brass,
 /obj/item/trash/can,
+/obj/item/book/manual/nuclear{
+	pixel_x = 5
+	},
 /turf/unsimulated/floor{
 	icon_state = "darkfull";
 	nitrogen = 100;
@@ -23092,11 +23091,6 @@
 	icon_state = "swall_s5"
 	},
 /area/shuttle/escape)
-"pBn" = (
-/turf/unsimulated/wall{
-	icon_state = "iron14";
-	},
-/area/syndicate_mothership)
 "pBo" = (
 /obj/structure/table/wood,
 /obj/item/paicard/syndicate,
@@ -25799,7 +25793,7 @@
 /area/centcom/specops)
 "rkr" = (
 /turf/unsimulated/wall{
-	icon_state = "iron12";
+	icon_state = "iron12"
 	},
 /area/syndicate_mothership)
 "rlj" = (
@@ -26576,15 +26570,19 @@
 /area/centcom/zone3)
 "rFK" = (
 /obj/structure/table/reinforced/brass,
-/obj/item/clothing/glasses/hud/security/sunglasses/fluff/voxxyhud,
-/obj/item/clothing/glasses/hud/security/sunglasses/fluff/voxxyhud,
-/obj/item/clothing/glasses/hud/security/sunglasses/fluff/voxxyhud,
-/obj/item/clothing/glasses/hud/security/sunglasses/fluff/voxxyhud,
-/obj/item/clothing/glasses/hud/security/sunglasses/fluff/voxxyhud,
-/obj/item/clothing/glasses/hud/security/sunglasses/fluff/voxxyhud,
-/obj/item/clothing/glasses/hud/security/sunglasses/fluff/voxxyhud,
-/obj/item/clothing/glasses/hud/security/sunglasses/fluff/voxxyhud,
+/obj/item/clothing/glasses/hud/security/sunglasses/fluff/voxxyhud{
+	pixel_x = -5
+	},
 /obj/effect/turf_decal/bot_red,
+/obj/item/clothing/glasses/hud/security/sunglasses/fluff/voxxyhud{
+	pixel_x = -5
+	},
+/obj/item/clothing/glasses/hud/health{
+	pixel_x = 15
+	},
+/obj/item/clothing/glasses/hud/health{
+	pixel_x = 15
+	},
 /turf/unsimulated/floor{
 	icon_state = "darkfull";
 	nitrogen = 100;
@@ -28398,15 +28396,22 @@
 /area/centcom)
 "sLM" = (
 /obj/structure/table/reinforced/brass,
-/obj/item/clothing/shoes/magboots/vox,
-/obj/item/clothing/shoes/magboots/vox,
-/obj/item/clothing/shoes/magboots/vox,
-/obj/item/clothing/shoes/magboots/vox,
-/obj/item/clothing/shoes/magboots/vox,
-/obj/item/clothing/shoes/magboots/vox,
-/obj/item/clothing/shoes/magboots/vox,
-/obj/item/clothing/shoes/magboots/vox,
 /obj/effect/turf_decal/bot_red,
+/obj/item/clothing/glasses/meson{
+	pixel_x = 5
+	},
+/obj/item/clothing/glasses/meson{
+	pixel_x = 5
+	},
+/obj/item/clothing/glasses/meson{
+	pixel_x = 5
+	},
+/obj/item/clothing/glasses/meson{
+	pixel_x = 5
+	},
+/obj/item/clothing/glasses/meson{
+	pixel_x = 5
+	},
 /turf/unsimulated/floor{
 	icon_state = "darkfull";
 	nitrogen = 100;
@@ -42495,7 +42500,7 @@ wKJ
 dhe
 njL
 njL
-jga
+rkr
 uPA
 uPA
 xAa
@@ -42752,7 +42757,7 @@ njL
 rrf
 njL
 njL
-jga
+rkr
 vGw
 xAa
 xAa
@@ -43009,7 +43014,7 @@ wKJ
 dhe
 wYg
 njL
-jga
+rkr
 hTW
 xAa
 wcf
@@ -43266,7 +43271,7 @@ wfJ
 duM
 njL
 njL
-jga
+rkr
 mly
 xAa
 wcf
@@ -44802,22 +44807,22 @@ mPL
 mPL
 mPL
 mPL
-jga
+rkr
 sfT
 oxv
-jga
+rkr
 jcp
 njL
-jga
+rkr
 njL
 njL
 njL
-jga
+rkr
 amx
 pFs
 dVm
 jeT
-pBn
+mKI
 pUb
 lZI
 aND
@@ -45059,17 +45064,17 @@ mPL
 mPL
 mPL
 mPL
-jga
+rkr
 njL
 njL
-jga
+rkr
 njL
 kmG
-jga
+rkr
 njL
 njL
 njL
-jga
+rkr
 amx
 ezB
 hdH
@@ -45316,22 +45321,22 @@ mPL
 mPL
 mPL
 mPL
-jga
+rkr
 njL
 njL
-jga
+rkr
 jcp
 njL
-jga
+rkr
 njL
 njL
 njL
-jga
+rkr
 veR
 pFs
 dVm
 jeT
-pBn
+mKI
 iMk
 xpe
 mKI
@@ -45576,14 +45581,14 @@ jEz
 xug
 bst
 hJf
-jga
+rkr
 cNr
 cNr
-jga
+rkr
 djG
 njL
 dgj
-jga
+rkr
 pvQ
 pFs
 hdH
@@ -45806,7 +45811,7 @@ wID
 wID
 wID
 lcX
-jga
+rkr
 oYZ
 oYZ
 oYZ
@@ -45818,10 +45823,10 @@ oYZ
 oYZ
 oYZ
 oYZ
-jga
+rkr
 njL
 njL
-jga
+rkr
 qaK
 kzK
 mRa
@@ -45833,19 +45838,19 @@ qrv
 qrv
 xAa
 hYv
-jga
+rkr
 jcp
 njL
-jga
+rkr
 njL
 njL
 njL
-jga
+rkr
 pvQ
 pFs
 dVm
 jeT
-pBn
+mKI
 iMk
 xpe
 mKI
@@ -46063,7 +46068,7 @@ kXa
 yix
 wID
 lcX
-jga
+rkr
 oYZ
 oYZ
 oYZ
@@ -46075,10 +46080,10 @@ oYZ
 oYZ
 oYZ
 oYZ
-jga
+rkr
 njL
 njL
-jga
+rkr
 mpH
 lgJ
 mRa
@@ -46090,14 +46095,14 @@ tcz
 tcz
 xAa
 xAa
-jga
+rkr
 njL
 hDv
-jga
+rkr
 njL
 njL
 njL
-jga
+rkr
 pvQ
 ezB
 hdH
@@ -46320,7 +46325,7 @@ kXa
 yix
 wID
 lcX
-jga
+rkr
 oYZ
 oYZ
 oYZ
@@ -46332,10 +46337,10 @@ oYZ
 oYZ
 oYZ
 oYZ
-jga
+rkr
 njL
 njL
-jga
+rkr
 mpH
 iUr
 mRa
@@ -46347,14 +46352,14 @@ tcz
 tcz
 xAa
 xAa
-jga
+rkr
 njL
 njL
-jga
+rkr
 njL
 njL
 njL
-jga
+rkr
 pFs
 pFs
 fEa
@@ -46577,7 +46582,7 @@ kXa
 yix
 wID
 lcX
-jga
+rkr
 oYZ
 oYZ
 oYZ
@@ -46589,7 +46594,7 @@ oYZ
 oYZ
 oYZ
 oYZ
-jga
+rkr
 njL
 ayZ
 pwO
@@ -46607,11 +46612,11 @@ xAa
 pwO
 mfF
 njL
-jga
+rkr
 vED
 vED
 vED
-jga
+rkr
 exo
 exo
 aND
@@ -46834,7 +46839,7 @@ kXa
 yix
 wID
 lcX
-jga
+rkr
 oYZ
 oYZ
 oYZ
@@ -46846,7 +46851,7 @@ lVz
 oYZ
 oYZ
 oYZ
-jga
+rkr
 njL
 njL
 adO
@@ -47121,7 +47126,7 @@ nSq
 tEG
 njL
 njL
-jga
+rkr
 vCX
 qYY
 sbD
@@ -47355,7 +47360,7 @@ mKI
 iMk
 byO
 tkV
-jga
+rkr
 qaB
 gAu
 njL
@@ -47378,7 +47383,7 @@ jEz
 pUb
 njL
 hDv
-jga
+rkr
 cIb
 raO
 raO
@@ -47612,7 +47617,7 @@ jHb
 xug
 njL
 njL
-jga
+rkr
 xyg
 njL
 njL
@@ -47620,7 +47625,7 @@ njL
 ewW
 njL
 njL
-jga
+rkr
 iCh
 njL
 njL
@@ -47632,10 +47637,10 @@ flI
 ssS
 qqs
 vCX
-jga
+rkr
 njL
 njL
-jga
+rkr
 qUv
 raO
 raO
@@ -48379,7 +48384,7 @@ lcX
 mPL
 mPL
 fAh
-jga
+rkr
 dBT
 njL
 njL
@@ -48679,7 +48684,7 @@ afn
 bky
 sfT
 wDG
-jga
+rkr
 mPL
 mPL
 mPL
@@ -48936,7 +48941,7 @@ djx
 njL
 wPJ
 ceq
-jga
+rkr
 fAh
 fAh
 mPL
@@ -49154,7 +49159,7 @@ aND
 pUb
 njL
 njL
-jga
+rkr
 qaB
 njL
 njL
@@ -49162,7 +49167,7 @@ njL
 qPd
 njL
 njL
-jga
+rkr
 iCh
 njL
 njL
@@ -49174,10 +49179,10 @@ cEI
 thL
 ccC
 vCX
-jga
+rkr
 njL
 hDv
-jga
+rkr
 msY
 raO
 raO
@@ -49193,7 +49198,7 @@ djx
 njL
 njL
 giz
-jga
+rkr
 mPL
 wfJ
 mPL
@@ -49411,7 +49416,7 @@ mKI
 iMk
 bEx
 fDK
-jga
+rkr
 xyg
 fso
 njL
@@ -49434,7 +49439,7 @@ jEz
 xug
 njL
 njL
-jga
+rkr
 ccC
 raO
 raO
@@ -49450,7 +49455,7 @@ djx
 djx
 njL
 cIF
-jga
+rkr
 mPL
 mPL
 mPL
@@ -49691,7 +49696,7 @@ xAa
 enf
 njL
 njL
-jga
+rkr
 ssS
 raO
 raO
@@ -49707,7 +49712,7 @@ djx
 hSy
 uSb
 dzB
-jga
+rkr
 hSw
 fAh
 mPL
@@ -49918,7 +49923,7 @@ vUE
 qIa
 wID
 lcX
-jga
+rkr
 oYZ
 oYZ
 oYZ
@@ -49930,7 +49935,7 @@ fKp
 oYZ
 oYZ
 oYZ
-jga
+rkr
 njL
 njL
 adO
@@ -49948,7 +49953,7 @@ xAa
 enf
 njL
 njL
-jga
+rkr
 qqs
 xEm
 raO
@@ -50175,7 +50180,7 @@ vUE
 qIa
 wID
 lcX
-jga
+rkr
 oYZ
 oYZ
 oYZ
@@ -50187,7 +50192,7 @@ oYZ
 oYZ
 oYZ
 oYZ
-jga
+rkr
 njL
 ayZ
 wIx
@@ -50221,7 +50226,7 @@ njL
 biT
 iiz
 sfT
-jga
+rkr
 mPL
 wfJ
 mPL
@@ -50432,7 +50437,7 @@ vUE
 qIa
 wID
 lcX
-jga
+rkr
 oYZ
 oYZ
 oYZ
@@ -50444,10 +50449,10 @@ oYZ
 oYZ
 oYZ
 oYZ
-jga
+rkr
 njL
 njL
-jga
+rkr
 jIe
 tcz
 tcz
@@ -50459,10 +50464,10 @@ gyc
 ard
 gyc
 tcz
-jga
+rkr
 njL
 njL
-jga
+rkr
 rvl
 dfd
 vcx
@@ -50478,7 +50483,7 @@ rJn
 duM
 njL
 lUT
-jga
+rkr
 mPL
 mPL
 mPL
@@ -50689,7 +50694,7 @@ vUE
 qIa
 wID
 lcX
-jga
+rkr
 oYZ
 oYZ
 oYZ
@@ -50701,10 +50706,10 @@ oYZ
 oYZ
 oYZ
 oYZ
-jga
+rkr
 njL
 njL
-jga
+rkr
 smG
 tcz
 tcz
@@ -50716,10 +50721,10 @@ gyc
 ard
 gyc
 tcz
-jga
+rkr
 jcp
 njL
-jga
+rkr
 mIO
 vcx
 bxc
@@ -50946,7 +50951,7 @@ vUE
 qIa
 wID
 lcX
-jga
+rkr
 oYZ
 oYZ
 oYZ
@@ -50958,10 +50963,10 @@ oYZ
 oYZ
 oYZ
 oYZ
-jga
+rkr
 njL
 njL
-jga
+rkr
 puq
 svW
 cLr
@@ -50973,10 +50978,10 @@ puq
 meL
 puq
 tcz
-jga
+rkr
 njL
 hDv
-jga
+rkr
 fuo
 vcx
 vcx
@@ -50986,13 +50991,13 @@ rkr
 sMH
 qHX
 eMx
-jga
+rkr
 njL
 njL
 biT
 szy
 sfT
-jga
+rkr
 mPL
 mPL
 fAh
@@ -51233,7 +51238,7 @@ jEz
 iMk
 mfF
 njL
-jga
+rkr
 pOd
 fbu
 gly
@@ -51249,7 +51254,7 @@ rJn
 duM
 njL
 lUT
-jga
+rkr
 mPL
 wfJ
 mPL
@@ -51475,7 +51480,7 @@ mPL
 mPL
 fAh
 mPL
-jga
+rkr
 psG
 lZo
 psG
@@ -51487,7 +51492,7 @@ pwO
 qOI
 qOI
 qOI
-jga
+rkr
 njL
 tsP
 jHb
@@ -51744,7 +51749,7 @@ njL
 njL
 njL
 njL
-jga
+rkr
 njL
 njL
 mJI
@@ -51763,7 +51768,7 @@ njL
 biT
 iiz
 sfT
-jga
+rkr
 mPL
 mPL
 mPL
@@ -51988,7 +51993,7 @@ mPL
 mPL
 fAh
 mPL
-jga
+rkr
 eKf
 njL
 njL
@@ -52001,7 +52006,7 @@ njL
 njL
 njL
 rJn
-jga
+rkr
 mfF
 njL
 mJI
@@ -52014,13 +52019,13 @@ tRF
 njL
 xAW
 pZQ
-jga
+rkr
 njL
 rJn
 riL
 njL
 lUT
-jga
+rkr
 mPL
 hSw
 mPL
@@ -52245,7 +52250,7 @@ mPL
 mPL
 mPL
 mPL
-jga
+rkr
 jNu
 njL
 njL
@@ -52258,7 +52263,7 @@ njL
 njL
 njL
 njL
-jga
+rkr
 iSV
 iSV
 aND
@@ -52502,7 +52507,7 @@ fAh
 mPL
 mPL
 mPL
-jga
+rkr
 jPz
 tPs
 njL
@@ -52515,7 +52520,7 @@ wIx
 qOI
 qOI
 qOI
-jga
+rkr
 tcz
 wAy
 mKI
@@ -52525,7 +52530,7 @@ bag
 lwT
 wsG
 rhz
-jga
+rkr
 wOq
 lnX
 aPu
@@ -52534,7 +52539,7 @@ kiB
 oNW
 ygF
 qhl
-jga
+rkr
 mPL
 wfJ
 mPL
@@ -52775,14 +52780,14 @@ jEz
 iMk
 tcz
 tcz
-jga
+rkr
 iEl
 dFP
 dFP
 dFP
 dFP
 por
-jga
+rkr
 jRu
 pFs
 vWR
@@ -52791,7 +52796,7 @@ pFs
 pFs
 pFs
 gii
-jga
+rkr
 mPL
 mPL
 mPL
@@ -53016,7 +53021,7 @@ mPL
 dBD
 mPL
 mPL
-jga
+rkr
 jPz
 njL
 njL
@@ -53029,7 +53034,7 @@ pwO
 wZp
 giR
 mtJ
-jga
+rkr
 mgy
 wAy
 pwO
@@ -53039,7 +53044,7 @@ dFP
 dFP
 dFP
 vyk
-jga
+rkr
 aVe
 kbg
 jwy
@@ -53048,7 +53053,7 @@ vMX
 pFs
 pFs
 iDU
-jga
+rkr
 mPL
 mPL
 fAh
@@ -53273,7 +53278,7 @@ mPL
 mPL
 fAh
 mPL
-jga
+rkr
 jNu
 njL
 njL
@@ -53286,7 +53291,7 @@ yjq
 njL
 njL
 rJn
-jga
+rkr
 mpH
 tcz
 lKj
@@ -53305,7 +53310,7 @@ vEc
 pFs
 pFs
 ndb
-jga
+rkr
 mPL
 mPL
 wfJ
@@ -53530,7 +53535,7 @@ mPL
 dBD
 mPL
 mPL
-jga
+rkr
 eKf
 njL
 njL
@@ -53543,7 +53548,7 @@ yjq
 njL
 njL
 njL
-jga
+rkr
 mpH
 tcz
 tcz
@@ -53562,7 +53567,7 @@ pFs
 pFs
 pFs
 asG
-jga
+rkr
 mPL
 mPL
 mPL
@@ -53800,7 +53805,7 @@ yjq
 njL
 njL
 rJn
-jga
+rkr
 pCl
 qqR
 gzA
@@ -53819,7 +53824,7 @@ pFs
 pFs
 pFs
 skb
-jga
+rkr
 mPL
 mPL
 hSw
@@ -54045,7 +54050,7 @@ mPL
 mPL
 mPL
 mPL
-jga
+rkr
 wax
 xgb
 wax
@@ -54057,7 +54062,7 @@ wIx
 rSR
 giR
 hnI
-jga
+rkr
 odP
 uti
 rdj
@@ -54067,7 +54072,7 @@ pjo
 yae
 vKh
 kIf
-jga
+rkr
 sTX
 nKW
 sTX
@@ -54076,7 +54081,7 @@ gTh
 fxa
 coD
 ndb
-jga
+rkr
 mPL
 mPL
 mPL
@@ -58427,7 +58432,7 @@ piw
 azc
 azc
 gDX
-eSH
+shG
 azc
 kID
 xWx
@@ -58684,7 +58689,7 @@ azc
 azc
 azc
 gDX
-shG
+jga
 bGr
 kID
 ssW

--- a/code/modules/admin/verbs/vox_raiders.dm
+++ b/code/modules/admin/verbs/vox_raiders.dm
@@ -1,56 +1,22 @@
-GLOBAL_VAR_INIT(vox_tick, 1)
+GLOBAL_VAR_INIT(vox_raiders_radio_freq, PUBLIC_LOW_FREQ + rand(0, 8) * 2) //Random freq every round
 
 /mob/living/carbon/human/proc/equip_vox_raider()
-
-	var/obj/item/radio/R = new /obj/item/radio/headset/syndicate(src)
-	R.set_frequency(SYND_FREQ) //Same frequency as the syndicate team in Nuke mode.
+	equip_to_slot_or_del(new /obj/item/radio/headset(src), slot_r_ear) //radio hedset with common freq, for communicate with station
+	var/obj/item/radio/R = new /obj/item/radio/headset(src)
+	R.set_frequency(GLOB.vox_raiders_radio_freq) //radio hedset with random vox freq, for raders communication
 	equip_to_slot_or_del(R, slot_l_ear)
 
 	equip_to_slot_or_del(new /obj/item/clothing/under/vox/vox_robes(src), slot_w_uniform)
-	equip_to_slot_or_del(new /obj/item/clothing/shoes/magboots/vox(src), slot_shoes) // REPLACE THESE WITH CODED VOX ALTERNATIVES.
-	equip_to_slot_or_del(new /obj/item/clothing/gloves/color/yellow/vox(src), slot_gloves) // AS ABOVE.
-
-	switch(GLOB.vox_tick)
-		if(1) // Vox raider!
-			equip_to_slot_or_del(new /obj/item/clothing/suit/space/vox/carapace(src), slot_wear_suit)
-			equip_to_slot_or_del(new /obj/item/clothing/head/helmet/space/vox/carapace(src), slot_head)
-			equip_to_slot_or_del(new /obj/item/melee/classic_baton/telescopic(src), slot_belt)
-			equip_to_slot_or_del(new /obj/item/clothing/glasses/thermal/monocle(src), slot_glasses) // REPLACE WITH CODED VOX ALTERNATIVE.
-			equip_to_slot_or_del(new /obj/item/chameleon(src), slot_l_store)
-
-			var/obj/item/gun/energy/spikethrower/W = new(src)
-			equip_to_slot_or_del(W, slot_r_hand)
-
-
-		if(2) // Vox engineer!
-			equip_to_slot_or_del(new /obj/item/clothing/suit/space/vox/pressure(src), slot_wear_suit)
-			equip_to_slot_or_del(new /obj/item/clothing/head/helmet/space/vox/pressure(src), slot_head)
-			equip_to_slot_or_del(new /obj/item/storage/belt/utility/full(src), slot_belt)
-			equip_to_slot_or_del(new /obj/item/clothing/glasses/meson(src), slot_glasses) // REPLACE WITH CODED VOX ALTERNATIVE.
-			equip_to_slot_or_del(new /obj/item/storage/box/emps(src), slot_r_hand)
-			equip_to_slot_or_del(new /obj/item/multitool(src), slot_l_hand)
-
-
-		if(3) // Vox saboteur!
-			equip_to_slot_or_del(new /obj/item/clothing/suit/space/vox/stealth(src), slot_wear_suit)
-			equip_to_slot_or_del(new /obj/item/clothing/head/helmet/space/vox/stealth(src), slot_head)
-			equip_to_slot_or_del(new /obj/item/storage/belt/utility/full(src), slot_belt)
-			equip_to_slot_or_del(new /obj/item/clothing/glasses/thermal/monocle(src), slot_glasses) // REPLACE WITH CODED VOX ALTERNATIVE.
-			equip_to_slot_or_del(new /obj/item/card/emag(src), slot_l_store)
-			equip_to_slot_or_del(new /obj/item/gun/dartgun/vox/raider(src), slot_r_hand)
-			equip_to_slot_or_del(new /obj/item/multitool(src), slot_l_hand)
-
-		if(4) // Vox medic!
-			equip_to_slot_or_del(new /obj/item/clothing/suit/space/vox/medic(src), slot_wear_suit)
-			equip_to_slot_or_del(new /obj/item/clothing/head/helmet/space/vox/medic(src), slot_head)
-			equip_to_slot_or_del(new /obj/item/storage/belt/utility/full(src), slot_belt) // Who needs actual surgical tools?
-			equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/health(src), slot_glasses) // REPLACE WITH CODED VOX ALTERNATIVE.
-			equip_to_slot_or_del(new /obj/item/circular_saw(src), slot_l_store)
-			equip_to_slot_or_del(new /obj/item/gun/dartgun/vox/medical, slot_r_hand)
-
-	equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vox(src), slot_wear_mask)
-	equip_to_slot_or_del(new /obj/item/tank/internals/nitrogen(src), slot_back)
+	equip_to_slot_or_del(new /obj/item/clothing/shoes/magboots/vox(src), slot_shoes)
+	equip_to_slot_or_del(new /obj/item/clothing/gloves/color/yellow/vox(src), slot_gloves)
+	equip_to_slot_or_del(new /obj/item/storage/belt/utility/full(src), slot_belt)
+	equip_to_slot_or_del(new /obj/item/storage/backpack(src), slot_back)
 	equip_to_slot_or_del(new /obj/item/flashlight(src), slot_r_store)
+	equip_to_slot_or_del(new /obj/item/melee/classic_baton/telescopic(src), slot_l_store)
+	equip_to_slot_or_del(new /obj/item/tank/internals/nitrogen(src), slot_in_backpack)
+	equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vox(src), slot_in_backpack)
+	equip_to_slot_or_del(new /obj/item/restraints/handcuffs/cable/zipties(src), slot_in_backpack)
+	equip_to_slot_or_del(new /obj/item/restraints/handcuffs/cable/zipties(src), slot_in_backpack)
 
 	var/obj/item/card/id/syndicate/vox/W = new(src)
 	W.name = "[real_name]'s Legitimate Human ID Card"
@@ -58,8 +24,5 @@ GLOBAL_VAR_INIT(vox_tick, 1)
 	W.registered_name = real_name
 	W.registered_user = src
 	equip_to_slot_or_del(W, slot_wear_id)
-
-	GLOB.vox_tick++
-	if(GLOB.vox_tick > 4) GLOB.vox_tick = 1
 
 	return 1


### PR DESCRIPTION
Изменил стартовую экипу воксов а так же то что лежит у них на шаттле
Рейдеры теперь появляются с рюкзаками
У рейдеров теперь по 2 наушника, один настроен на common частоту, а второй на генерирующуюся каждый раунд случайную частоту
Шляпа лидера теперь лежит на столе совещаний у воксов, чтобы они сразу могли решить кто из них главный
Убрал тройной спавн ригов, теперь их всего по 2 штуки каждого из 4 видов, лежат на базе
Убрал двойной спавн магклавсов
Оружие теперь лежит на скипджеке, 4 вида, по 2 штуки каждого вида
Синди шмот тоже лежит на скипджеке
Добавил чуть больше синди шмота (в основном дешевые предметы за 2-4 ТК)