### PR TITLE
Fix: Return Lavaland rivers and boats

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -38,7 +38,7 @@ SUBSYSTEM_DEF(mapping)
 	log_startup_progress("Populating lavaland...")
 	var/lavaland_setup_timer = start_watch()
 	seedRuins(list(level_name_to_num(MINING)), config.lavaland_budget, /area/lavaland/surface/outdoors/unexplored, GLOB.lava_ruins_templates)
-	spawn_rivers(list(level_name_to_num(MINING)))
+	spawn_rivers(level_name_to_num(MINING))
 	log_startup_progress("Successfully populated lavaland in [stop_watch(lavaland_setup_timer)]s.")
 
 	// Now we make a list of areas for teleport locs

--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -166,6 +166,8 @@
 	icon = 'icons/obj/lavaland/dragonboat.dmi'
 	held_key_type = /obj/item/oar
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
+	/// The last time we told the user that they can't drive on land, so we don't spam them
+	var/last_message_time = 0
 
 /obj/vehicle/lavaboat/relaymove(mob/user, direction)
 	var/turf/next = get_step(src, direction)
@@ -174,8 +176,23 @@
 	if(istype(next, /turf/simulated/floor/plating/lava/smooth) || istype(current, /turf/simulated/floor/plating/lava/smooth)) //We can move from land to lava, or lava to land, but not from land to land
 		..()
 	else
-		to_chat(user, "<span class='warning'>Boats don't go on land!</span>")
+		if(last_message_time + 1 SECONDS < world.time)
+			to_chat(user, "<span class='warning'>Boats don't go on land!</span>")
+			last_message_time = world.time
 		return FALSE
+
+/obj/vehicle/lavaboat/Destroy()
+	for(var/mob/living/M in buckled_mobs)
+		M.weather_immunities -= "lava"
+	return ..()
+
+/obj/vehicle/lavaboat/user_buckle_mob(mob/living/M, mob/user)
+	M.weather_immunities |= "lava"
+	return ..()
+
+/obj/vehicle/lavaboat/unbuckle_mob(mob/living/buckled_mob, force)
+	. = ..()
+	buckled_mob.weather_immunities -= "lava"
 
 /obj/item/oar
 	name = "oar"


### PR DESCRIPTION
## Что делает этот PR
- Возвращает лавовые реки, которые были в билде всю жизнь, но какой-то апдейт их сломал
(примечание: лавовые реки не спавнятся на руинах и на "рабочих" текстурах, опередляющих запрет лавы)
- Чинит лодки так, что теперь в них не загораешься и можно спокойно кататься по лаве

## Почему это нужно
+ Усложнение Лаваленда (для кого-то минус бтв)
+ Толк от лодок
+ Оно было всю жизнь в билде
+ Если захотеть, их всё еще можно обойти (хотя тут уже как решит рандомайзер)
+ Они спавнятся только в дали Лаваленда, они не будут вблизи аванпостов

## Медиа
![2](https://user-images.githubusercontent.com/20109643/203460477-d3bfa083-ab27-42bc-ace8-62b8df29c395.png)
![1](https://user-images.githubusercontent.com/20109643/203460480-6ad5ff62-4c50-467b-b33e-6c70e0f33ffc.png)
![image](https://user-images.githubusercontent.com/20109643/203663781-0ab0129b-8ec5-4575-b904-5ca927e7ec33.png)

[Оригинальный PR рек](https://github.com/ParadiseSS13/Paradise/pull/16573)
[Оригинальный PR лодок](https://github.com/ParadiseSS13/Paradise/pull/19405)