### PR TITLE
Tweak: Vortex Wall lower duration

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -443,4 +443,4 @@
 		new /obj/effect/temp_visual/hierophant/wall/crusher(otherT, user)
 
 /obj/effect/temp_visual/hierophant/wall/crusher
-	duration = 75
+	duration = 1.5 SECONDS


### PR DESCRIPTION
## Изменение
Уменьшает время нахождения стены Вортекс Талисмана с 7.5 секунд до 1.5 секунд.

## Причины для ввода
Трофейная стена Вортекс Талисмана, падающая с Иерофанта позволяет справляться без проблем с любой Мегафауной просто стоя за стеной. Самый яркий пример - ставить стену и херачить афк Колосса за стенкой, в которую он упирается. Уменьшение таймера стены должно заставить людей двигаться.
Примечание: Перезарядка способности Крашера составляет 1.5 секунд.