### PR TITLE
Fix: Insta-use deadly patches

### DIFF
--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -6,6 +6,7 @@
 	item_state = "bandaid"
 	possible_transfer_amounts = null
 	volume = 20
+	container_type = 0 //nooo my insta-kill patch!!!
 	apply_type = REAGENT_TOUCH
 	apply_method = "apply"
 	transfer_efficiency = 0.5 //patches aren't as effective at getting chemicals into the bloodstream.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Удаляет возможность добавлять реагенты в патчи, что фиксит возможность создания убийственных патчей с мгновенным применением (некоторые патчи применяются мгновенно, если в них только полезные вещества. Но можно вколоть неполезные уже после создания, что никак не проверяется)
Да и логично что нельзя просто взять и вколоть в уже созданный патч новые реагенты, имхо.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Фикс бага
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Insta-use deadly patches is fixed :(
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
