### PR TITLE
Fix: BFL crack zone

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_BFL_crack.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_BFL_crack.dmm
@@ -1,9 +1,17 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
+/turf/template_noop,
+/area/template_noop)
+"j" = (
+/turf/simulated/mineral/random/volcanic,
+/area/lavaland/surface/outdoors)
+"n" = (
+/obj/bfl_crack,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "R" = (
-/obj/bfl_crack,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 
@@ -13,29 +21,57 @@ a
 a
 a
 a
+a
+a
 "}
 (2,1,1) = {"
 a
-a
-a
-a
+j
+j
+R
+R
+j
 a
 "}
 (3,1,1) = {"
 a
-a
+j
 R
-a
+R
+R
+R
 a
 "}
 (4,1,1) = {"
 a
-a
-a
-a
+j
+R
+n
+R
+j
 a
 "}
 (5,1,1) = {"
+a
+R
+R
+R
+R
+j
+a
+"}
+(6,1,1) = {"
+a
+j
+R
+R
+R
+R
+a
+"}
+(7,1,1) = {"
+a
+a
 a
 a
 a


### PR DESCRIPTION
## Изменения
 - Убирает возможность появления лавы в зоне пролома.
 - Теперь зона выглядит "живее", так как убрана коробочность зоны.

## Медиа
![image](https://user-images.githubusercontent.com/20109643/204508893-7358fa06-0474-4a51-a38a-ea58ec36d58a.png)