### PR TITLE
Fix: Bunch of runtimes and exploits

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -147,6 +147,8 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		return FALSE
 	if(A.tele_proof)
 		return TRUE
+	if(!is_teleport_allowed(O.z))
+		return TRUE
 	else
 		return FALSE
 

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -454,6 +454,8 @@
 	set category = "Object"
 	set src in oview(1)
 
+	if(usr.default_can_use_topic(src) != STATUS_INTERACTIVE)
+		return
 	if(usr.incapacitated()) //are you cuffed, dying, lying, stunned or other
 		return
 

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -482,6 +482,8 @@
 			return
 		go_out()//and release him from the eternal prison.
 	else
+		if(usr.default_can_use_topic(src) != STATUS_INTERACTIVE)
+			return
 		if(usr.incapacitated()) //are you cuffed, dying, lying, stunned or other
 			return
 		add_attack_logs(usr, occupant, "Ejected from cryo cell at [COORD(src)]")

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -366,7 +366,8 @@
 
 /obj/machinery/teleport/hub/Bumped(M as mob|obj)
 	if(!is_teleport_allowed(z) && !admin_usage)
-		to_chat(M, "You can't use this here.")
+		if(ismob(M))
+			to_chat(M, "You can't use this here.")
 		return
 	if(power_station && power_station.engaged && !panel_open && !blockAI(M) && !istype(M, /obj/spacepod))
 		if(!teleport(M) && isliving(M)) // the isliving(M) is needed to avoid triggering errors if a spark bumps the telehub

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -216,7 +216,7 @@
 	if(!mob_name)
 		mob_name = id_job
 	return ..()
-	
+
 /obj/effect/mob_spawn/human/use_prefs_prompt(mob/user)
 	if(allow_prefs_prompt)
 		if(!(user.client))
@@ -282,7 +282,8 @@
 		H.equipOutfit(outfit)
 		for(var/del_type in del_types)
 			var/obj/item/I = locate(del_type) in H
-			qdel(I)
+			if(I)
+				qdel(I)
 
 		if(disable_pda)
 			// We don't want corpse PDAs to show up in the messenger list.

--- a/code/modules/mining/lavaland/loot/hierophant_loot.dm
+++ b/code/modules/mining/lavaland/loot/hierophant_loot.dm
@@ -159,6 +159,9 @@
 	if(get_dist(user, beacon) <= 2) //beacon too close abort
 		to_chat(user, "<span class='warning'>You are too close to the beacon to teleport to it!</span>")
 		return
+	if(is_in_teleport_proof_area(beacon))
+		to_chat(user, "<span class='warning'>[src] sparks and fizzles.</span>")
+		return
 	if(is_blocked_turf(get_turf(beacon), TRUE))
 		to_chat(user, "<span class='warning'>The beacon is blocked by something, preventing teleportation!</span>")
 		return

--- a/code/modules/mining/lavaland/loot/hierophant_loot.dm
+++ b/code/modules/mining/lavaland/loot/hierophant_loot.dm
@@ -133,7 +133,7 @@
 	if(user.is_in_active_hand(src) && user.is_in_inactive_hand(src)) //you need to hold the staff to teleport
 		to_chat(user, "<span class='warning'>You need to hold the club in your hands to [beacon ? "teleport with it":"detach the beacon"]!</span>")
 		return
-	if(is_in_teleport_proof_area(user) && tele_proof_bypass == FALSE)
+	if(is_in_teleport_proof_area(user) && !tele_proof_bypass)
 		to_chat(user, "<span class='warning'>[src] sparks and fizzles.</span>")
 		return
 	if(!beacon || QDELETED(beacon))
@@ -160,7 +160,7 @@
 	if(get_dist(user, beacon) <= 2) //beacon too close abort
 		to_chat(user, "<span class='warning'>You are too close to the beacon to teleport to it!</span>")
 		return
-	if(is_in_teleport_proof_area(beacon) && tele_proof_bypass == FALSE)
+	if(is_in_teleport_proof_area(beacon) && !tele_proof_bypass)
 		to_chat(user, "<span class='warning'>[src] sparks and fizzles.</span>")
 		return
 	if(is_blocked_turf(get_turf(beacon), TRUE))

--- a/code/modules/mining/lavaland/loot/hierophant_loot.dm
+++ b/code/modules/mining/lavaland/loot/hierophant_loot.dm
@@ -24,6 +24,7 @@
 	var/blast_range = 13 //how long the cardinal blast's walls are
 	var/obj/effect/hierophant/beacon //the associated beacon we teleport to
 	var/teleporting = FALSE //if we ARE teleporting
+	var/tele_proof_bypass = FALSE //for admins to bypass tele_proof with VV
 	var/friendly_fire_check = FALSE //if the blasts we make will consider our faction against the faction of hit targets
 
 /obj/item/hierophant_club/examine(mob/user)
@@ -132,7 +133,7 @@
 	if(user.is_in_active_hand(src) && user.is_in_inactive_hand(src)) //you need to hold the staff to teleport
 		to_chat(user, "<span class='warning'>You need to hold the club in your hands to [beacon ? "teleport with it":"detach the beacon"]!</span>")
 		return
-	if(is_in_teleport_proof_area(user))
+	if(is_in_teleport_proof_area(user) && tele_proof_bypass == FALSE)
 		to_chat(user, "<span class='warning'>[src] sparks and fizzles.</span>")
 		return
 	if(!beacon || QDELETED(beacon))
@@ -159,7 +160,7 @@
 	if(get_dist(user, beacon) <= 2) //beacon too close abort
 		to_chat(user, "<span class='warning'>You are too close to the beacon to teleport to it!</span>")
 		return
-	if(is_in_teleport_proof_area(beacon))
+	if(is_in_teleport_proof_area(beacon) && tele_proof_bypass == FALSE)
 		to_chat(user, "<span class='warning'>[src] sparks and fizzles.</span>")
 		return
 	if(is_blocked_turf(get_turf(beacon), TRUE))

--- a/code/modules/shuttle/shuttle_manipulator.dm
+++ b/code/modules/shuttle/shuttle_manipulator.dm
@@ -105,6 +105,8 @@
 	data["shuttles"] = list()
 	for(var/i in SSshuttle.mobile)
 		var/obj/docking_port/mobile/M = i
+		if(!M)
+			continue
 		var/list/L = list()
 		L["name"] = M.name
 		L["id"] = M.id


### PR DESCRIPTION
## Изменения
 - Предметы с возможностью телепортации больше не обходят блоки телепортов Z-лвла (например: посох Иерофанта, кубы).
 - Спавнеры мобов больше не пытаются использовать qdel на несуществующие вещи.
 - Манипулятор шаттла больше не рантаймит.
 - Фикс рантайма телепортера.
 - Фикс эксплойта, когда Ревенант мог вытаскивать из слипера, или крио.

