### PR TITLE
Fix: багоюза питания слаймом КПБ

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -186,8 +186,13 @@
 
 	if(iscarbon(M))
 		var/mob/living/carbon/C = M
-		C.adjustCloneLoss(rand(2, 4) + round(age_state.feed/3))
-		C.adjustToxLoss(rand(1, 2) + round(age_state.feed/3))
+
+		var/feed_mod = round(age_state.feed/3)
+		if(C.dna.species.clone_mod > 0)
+			C.adjustCloneLoss(rand(2, 4) + feed_mod)
+			C.adjustToxLoss(rand(1, 2) + feed_mod)
+		else
+			C.adjustFireLoss(rand(2, 5) + feed_mod)
 
 		if(prob(10) && C.client)
 			to_chat(C, "<span class='userdanger'>[pick("You can feel your body becoming weak!", \

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -390,7 +390,7 @@
 
 /mob/living/simple_animal/slime/water_act(volume, temperature, source, method = REAGENT_TOUCH)
 	. = ..()
-	var/water_damage = rand(10, 15) * volume - age_state.attacked
+	var/water_damage = (rand(10, 15) - age_state.attacked) * volume
 
 	adjustBruteLoss(water_damage)
 	if(!client && Target && volume >= 3) // Like cats


### PR DESCRIPTION
## What Does This PR Do
Теперь нельзя питаться расами с нулевыми и отрицательными модификаторами урона клонирования

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![image](https://user-images.githubusercontent.com/41479614/205046662-1d0967d9-5f0d-4376-9cd6-6d33be292946.png)
