### PR TITLE
fix: update mob icon when painting/unpainting equipped items

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -166,11 +166,16 @@
 			I.layer = FLOAT_LAYER //AAAH
 			I.plane = FLOAT_PLANE //^ what that guy said
 			I.appearance_flags |= RESET_COLOR | RESET_ALPHA
+			if(I.outline_filter)
+				I.filters -= I.outline_filter
 			current_button.cut_overlays()
 			current_button.add_overlay(I)
 			I.layer = old_layer
 			I.plane = old_plane
 			I.appearance_flags = old_appearance_flags
+			if(I.outline_filter)
+				I.filters -= I.outline_filter
+				I.filters += I.outline_filter
 	else
 		..()
 

--- a/code/datums/components/paintable.dm
+++ b/code/datums/components/paintable.dm
@@ -10,7 +10,7 @@
 
 /datum/component/spraycan_paintable/proc/RemoveCurrentCoat()
 	var/atom/A = parent
-	A.remove_atom_colour(FIXED_COLOUR_PRIORITY, current_paint)
+	A.remove_atom_colour(WASHABLE_COLOUR_PRIORITY, current_paint)
 
 /datum/component/spraycan_paintable/proc/Repaint(datum/source, obj/item/toy/crayon/spraycan/spraycan, mob/living/user)
 	if(!istype(spraycan) || user.a_intent == INTENT_HARM)
@@ -26,6 +26,6 @@
 	var/colour = spraycan.colour
 	current_paint = colour
 	var/atom/A = parent
-	A.add_atom_colour(colour, FIXED_COLOUR_PRIORITY)
+	A.add_atom_colour(colour, WASHABLE_COLOUR_PRIORITY)
 	playsound(spraycan, 'sound/effects/spray.ogg', 5, 1, 5)
 	to_chat(user, "<span class='notice'>You spray [spraycan] on [A], painting it.</span>")

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -786,3 +786,12 @@ GLOBAL_DATUM_INIT(fire_overlay, /image, image("icon" = 'icons/goonstation/effect
 	if(enchant_action)
 		qdel(enchant_action)
 	update_icon()
+
+/obj/item/update_atom_colour()
+	. = ..()
+	if(!is_equipped())
+		return
+	update_slot_icon()
+	for(var/action in actions)
+		var/datum/action/myaction = action
+		myaction.UpdateButtonIcon()

--- a/code/modules/reagents/chemistry/reagents/paint.dm
+++ b/code/modules/reagents/chemistry/reagents/paint.dm
@@ -8,11 +8,11 @@
 
 /datum/reagent/paint/reaction_turf(turf/T, volume)
 	if(!isspaceturf(T))
-		T.color = color
+		T.add_atom_colour(color, WASHABLE_COLOUR_PRIORITY)
 
 /datum/reagent/paint/reaction_obj(obj/O, volume)
 	if(istype(O, /obj/item/light))
-		O.color = color
+		O.add_atom_colour(color, WASHABLE_COLOUR_PRIORITY)
 
 /datum/reagent/paint/red
 	name = "Red Paint"
@@ -59,4 +59,4 @@
 
 /datum/reagent/paint_remover/reaction_turf(turf/T, volume)
 	if(!isspaceturf(T))
-		T.color = initial(T.color)
+		T.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)

--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -63,7 +63,7 @@
 			qdel(O)
 	else
 		if(O.simulated)
-			O.color = initial(O.color)
+			O.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
 		O.clean_blood()
 
 /datum/reagent/space_cleaner/reaction_turf(turf/T, volume)
@@ -75,7 +75,7 @@
 				floor_only = FALSE
 			else
 				qdel(C)
-		T.color = initial(T.color)
+		T.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
 		if(floor_only)
 			T.clean_blood()
 

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -72,9 +72,9 @@
 	D.create_reagents(amount_per_transfer_from_this)
 	reagents.trans_to(D, amount_per_transfer_from_this, 1/spray_currentrange)
 	D.icon += mix_color_from_reagents(D.reagents.reagent_list)
-
+	var/turf/target_turf = get_turf(A)
 	for(var/i in 1 to spray_currentrange)
-		step_towards(D, A)
+		step_towards(D, target_turf)
 		if(will_not_miss)
 			D.reagents.reaction(A)
 		else

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -43,7 +43,8 @@
 		return
 
 	var/contents_log = reagents.reagent_list.Join(", ")
-	INVOKE_ASYNC(src, .proc/spray, A)
+	var/will_not_miss = !isturf(A) && A.Adjacent(user)
+	INVOKE_ASYNC(src, .proc/spray, A, will_not_miss)
 
 	playsound(loc, 'sound/effects/spray2.ogg', 50, 1, -6)
 	user.changeNext_move(CLICK_CD_RANGE*2)
@@ -66,7 +67,7 @@
 	return
 
 
-/obj/item/reagent_containers/spray/proc/spray(atom/A)
+/obj/item/reagent_containers/spray/proc/spray(atom/A, will_not_miss = FALSE)
 	var/obj/effect/decal/chempuff/D = new /obj/effect/decal/chempuff(get_turf(src))
 	D.create_reagents(amount_per_transfer_from_this)
 	reagents.trans_to(D, amount_per_transfer_from_this, 1/spray_currentrange)
@@ -74,9 +75,12 @@
 
 	for(var/i in 1 to spray_currentrange)
 		step_towards(D, A)
-		D.reagents.reaction(get_turf(D))
-		for(var/atom/T in get_turf(D))
-			D.reagents.reaction(T)
+		if(will_not_miss)
+			D.reagents.reaction(A)
+		else
+			D.reagents.reaction(get_turf(D))
+			for(var/atom/T in get_turf(D))
+				D.reagents.reaction(T)
 		sleep(3)
 	qdel(D)
 

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -518,7 +518,8 @@
 		return ..()
 	to_chat(user, "<span class='notice'>You slather the blue gunk over [C], fireproofing it.</span>")
 	C.name = "fireproofed [C.name]"
-	C.color = "#000080"
+	C.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
+	C.add_atom_colour("#000080", FIXED_COLOUR_PRIORITY)
 	C.max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	C.heat_protection = C.body_parts_covered
 	C.resistance_flags |= FIRE_PROOF

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -484,8 +484,7 @@
 		V.vehicle_move_delay = vehicle_speed_mod
 
 	to_chat(user, "<span class='notice'>You slather the red gunk over [O], making it faster.</span>")
-	O.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
-	O.add_atom_colour("#FF0000", FIXED_COLOUR_PRIORITY)
+	O.add_atom_colour("#FF0000", WASHABLE_COLOUR_PRIORITY)
 	qdel(src)
 
 /obj/item/slimepotion/speed/MouseDrop(obj/over_object)
@@ -518,8 +517,7 @@
 		return ..()
 	to_chat(user, "<span class='notice'>You slather the blue gunk over [C], fireproofing it.</span>")
 	C.name = "fireproofed [C.name]"
-	C.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
-	C.add_atom_colour("#000080", FIXED_COLOUR_PRIORITY)
+	C.add_atom_colour("#000080", WASHABLE_COLOUR_PRIORITY)
 	C.max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	C.heat_protection = C.body_parts_covered
 	C.resistance_flags |= FIRE_PROOF


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Иконка человечка теперь обновляется при покраске надетых предметов.
Иконки действий (e.g. "toggle helmet") также обновляются.
Пшикалкой с клинером теперь можно пшикнуть на надетый предмет. А также можно пшикнуть на предмет внутри сумки или просто на предмет лежащий не дальше соседнего тайла. При этом реагенты попадут только на кликнутый предмет.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Images of changes
https://user-images.githubusercontent.com/79848183/205101583-222a2219-adb5-4465-8cb6-2331293f734e.mp4
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
fix: update mob icon when painting equipped items
tweak: cleaner can be used on equipped items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
