### PR TITLE
Fix: DNA pressure for changeling

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -241,6 +241,7 @@ GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","E
 	var/geneticdamage = 0
 	var/isabsorbing = 0
 	var/islinking = 0
+	var/isDNApressured = FALSE //Находиться ли ДНК под "Давлением" (от некоторых способностей). Мешает Readapt-у и Lesser Form-е.
 	var/geneticpoints = 10
 	var/purchasedpowers = list()
 	var/mimicing = ""

--- a/code/game/gamemodes/changeling/changeling_power.dm
+++ b/code/game/gamemodes/changeling/changeling_power.dm
@@ -13,6 +13,7 @@
 	var/req_dna = 0  //amount of dna needed to use this ability. Changelings always have atleast 1
 	var/req_human = 0 //if you need to be human to use this ability
 	var/req_stat = CONSCIOUS // CONSCIOUS, UNCONSCIOUS or DEAD
+	var/DNApressure = FALSE //Будет ли нагружать ДНК. Для проверки на возможность Readapt-а, Lesser form-а и т.д. При использовании не забывайте прописать возврат состояния.
 	var/genetic_damage = 0 // genetic damage caused by using the sting. Nothing to do with cloneloss.
 	var/max_genetic_damage = 100 // hard counter for spamming abilities. Not used/balanced much yet.
 	var/always_keep = 0 // important for abilities like regenerate that screw you if you lose them.
@@ -41,6 +42,8 @@ the same goes for Remove(). if you override Remove(), call parent or else your p
 		return
 	if(!can_sting(user, target))
 		return
+	if(DNApressure)
+		user.mind.changeling.isDNApressured = TRUE
 	var/datum/changeling/c = user.mind.changeling
 	if(sting_action(user, target))
 		sting_feedback(user, target)

--- a/code/game/gamemodes/changeling/evolution_menu.dm
+++ b/code/game/gamemodes/changeling/evolution_menu.dm
@@ -67,6 +67,9 @@
 		if("readapt")
 			if(!cling.lingRespec(owner))
 				return FALSE
+			if(cling.isDNApressured)
+				to_chat(cling, "<span class='warning'>Ваша структура ДНК слишком напряжена сейчас, выключите ваши способности!</span>")
+				return
 			purchased_abilities.Cut()
 			return TRUE
 

--- a/code/game/gamemodes/changeling/powers/lesserform.dm
+++ b/code/game/gamemodes/changeling/powers/lesserform.dm
@@ -23,6 +23,10 @@
 		to_chat(user, "<span class='warning'>We cannot perform this ability in this form!</span>")
 		return
 
+	if(user.mind.changeling.isDNApressured)
+		to_chat(user, "<span class='warning'>Вы не можете использовать эту способность сейчас, когда ваше ДНК нестабильно! Выключите ваши способности!</span>")
+		return
+
 	user.visible_message("<span class='warning'>[user] transforms!</span>")
 
 	// Add genetic damage to add cooldown.

--- a/code/game/gamemodes/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/changeling/powers/mutations.dm
@@ -16,6 +16,7 @@
 	chemical_cost = 1000
 	dna_cost = -1
 	genetic_damage = 1000
+	DNApressure = TRUE
 
 	var/silent = FALSE
 	var/weapon_type
@@ -27,12 +28,14 @@
 		if(!silent)
 			user.visible_message("<span class='warning'>With a sickening crunch, [user] reforms [user.p_their()] [weapon_name_simple] into an arm!</span>", "<span class='notice'>We assimilate the [weapon_name_simple] back into our body.</span>", "<span class='warning'>You hear organic matter ripping and tearing!</span>")
 		user.update_inv_l_hand()
+		user.mind.changeling.isDNApressured = FALSE
 		return
 	if(istype(user.r_hand, weapon_type))
 		qdel(user.r_hand)
 		if(!silent)
 			user.visible_message("<span class='warning'>With a sickening crunch, [user] reforms [user.p_their()] [weapon_name_simple] into an arm!</span>", "<span class='notice'>We assimilate the [weapon_name_simple] back into our body.</span>", "<span class='warning'>You hear organic matter ripping and tearing!</span>")
 		user.update_inv_r_hand()
+		user.mind.changeling.isDNApressured = FALSE
 		return
 	..(user, target)
 
@@ -49,6 +52,7 @@
 	name = "Organic Suit"
 	desc = "Go tell a coder if you see this"
 	helptext = "Yell at coderbus"
+	DNApressure = TRUE
 	chemical_cost = 1000
 	dna_cost = -1
 	genetic_damage = 1000
@@ -74,6 +78,7 @@
 		H.update_inv_head()
 		H.update_hair()
 		H.update_fhair()
+		user.mind.changeling.isDNApressured = FALSE
 
 		if(blood_on_castoff)
 			H.add_splatter_floor()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Добавляет зародышную механика давления на ДНК для генокрадов.
Кратко – использование части способностей нагружает их ДНК, из-за чего они не могут использовать часть способностей (если конкретно – использование органического костюма, щита, тентакли, руки-мечи и Strained muscles).
При нагрузке на ДНК генокрад не сможет превращаться в макаку (Lesser Form) или использовать Readapt.

Основная причина - фикс возможности Readapt-а с рукой-мечом и схожим, что оставляет её вам, фикс возможности дюпа армблейда через макаку (армблейд выпадает как предмет, его можно подобрать и т.д.). Да и просто логика
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Фикс бага/микро-механика
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Генокрад не сможет превращаться в макаку/использовать Readapt если использует некоторые способности
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
