### PR TITLE
feat: cqc kick now stuns on impact with any dense atom

### DIFF
--- a/code/modules/martial_arts/combos/cqc/kick.dm
+++ b/code/modules/martial_arts/combos/cqc/kick.dm
@@ -10,7 +10,8 @@
 							"<span class='userdanger'>[user] kicks you back!</span>")
 		playsound(get_turf(user), 'sound/weapons/cqchit1.ogg', 50, 1, -1)
 		var/atom/throw_target = get_edge_target_turf(target, user.dir)
-		target.throw_at(throw_target, 1, 14, user)
+		RegisterSignal(target, COMSIG_MOVABLE_IMPACT, .proc/bump_impact)
+		target.throw_at(throw_target, 1, 14, user, callback = CALLBACK(src, .proc/unregister_bump_impact, target))
 		target.apply_damage(10, BRUTE)
 		add_attack_logs(user, target, "Melee attacked with martial-art [src] : Kick", ATKLOG_ALL)
 		. = MARTIAL_COMBO_DONE
@@ -22,3 +23,11 @@
 		target.adjustBrainLoss(5)
 		add_attack_logs(user, target, "Knocked out with martial-art [src] : Kick", ATKLOG_ALL)
 		. = MARTIAL_COMBO_DONE
+
+/datum/martial_combo/cqc/kick/proc/bump_impact(mob/living/target, atom/hit_atom, throwingdatum)
+	if(target && !iscarbon(hit_atom) && hit_atom.density)
+		target.Weaken(1)
+		target.take_organ_damage(10)
+
+/datum/martial_combo/cqc/kick/proc/unregister_bump_impact(mob/living/target)
+	UnregisterSignal(target, COMSIG_MOVABLE_IMPACT)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Пинок CQC теперь станит при столкновении с любым атомом с `density`

[Предложка пройдена](https://discord.com/channels/617003227182792704/755125334097133628/1042754375455613021)

## Changelog
:cl:
tweak: cqc kick now stuns on impact with any dense atom
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
