### PR TITLE
Отображение тегов игроков для персонажей

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -9,6 +9,7 @@
 /atom
 	layer = TURF_LAYER
 	plane = GAME_PLANE
+	var/nametag
 	var/level = 2
 	var/flags = NONE
 	var/flags_2 = NONE

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -33,6 +33,7 @@
 
 	client.images = null				//remove the images such as AIs being unable to see runes
 	client.screen = list()				//remove hud items just in case
+	instantiate_nametag(client)
 	if(client.click_intercept)
 		client.click_intercept.quit() // Let's not keep any old click_intercepts
 

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -1,4 +1,5 @@
 /mob/Logout()
+	dismiss_nametag()
 	SStgui.on_logout(src) // Cleanup any TGUIs the user has open
 	unset_machine()
 	GLOB.player_list -= src

--- a/code/modules/nametags/nametag.dm
+++ b/code/modules/nametags/nametag.dm
@@ -1,12 +1,12 @@
 /atom/proc/instantiate_nametag(client/C)
 	maptext_width = 128
 	maptext_height = 64
-	maptext_y = -10
+	maptext_y = -12
 	maptext_x = -48 // Не спрашивайте, зачем это нужно.
 	nametag = TRUE
-	maptext = "<center><span class='chatOverhead' style='color: white;'>[C.key]</span></center>"
+	maptext = "<center><span style = 'color:white;'>[C.key]</span></center>"
 
-/atom/proc/dismiss_nametag(client/C)
+/atom/proc/dismiss_nametag()
 	if(!nametag)
 		return
 	nametag = FALSE

--- a/code/modules/nametags/nametag.dm
+++ b/code/modules/nametags/nametag.dm
@@ -1,0 +1,23 @@
+/atom/proc/instantiate_nametag(client/C)
+	maptext_width = 128
+	maptext_height = 64
+	maptext_y = -10
+	maptext_x = -48 // Не спрашивайте, зачем это нужно.
+	nametag = TRUE
+	maptext = "<center><span class='chatOverhead' style='color: white;'>[C.key]</span></center>"
+
+/atom/proc/dismiss_nametag(client/C)
+	if(!nametag)
+		return
+	nametag = FALSE
+	maptext = null
+
+/mob/verb/toggle_key_view()
+	set name = "Toggle Key View"
+	set category = "Preferences"
+	if(!nametag)
+		instantiate_nametag(src)
+		to_chat(src, "You will see nametags.")
+	else
+		dismiss_nametag(src)
+		to_chat(src, "You will no longer see nametags.")

--- a/paradise.dme
+++ b/paradise.dme
@@ -2263,6 +2263,7 @@
 #include "code\modules\mob\new_player\sprite_accessories\vulpkanin\vulpkanin_head_markings.dm"
 #include "code\modules\mob\new_player\sprite_accessories\vulpkanin\vulpkanin_tail_markings.dm"
 #include "code\modules\mob\new_player\sprite_accessories\wryn\wryn_face.dm"
+#include "code\modules\nametags\nametag.dm"
 #include "code\modules\newscaster\datums.dm"
 #include "code\modules\newscaster\defines.dm"
 #include "code\modules\newscaster\obj\newscaster.dm"


### PR DESCRIPTION
## Список изменений
• Добавлено отображение тегов игроков для их персонажей.
• Добавлен переключатель видимости тегов в стат-панельку.

## Причина для введения
• Теперь значительно проще своевременно отыскать злостного нарушителя правил и накатать на него жалобу.
• Теперь значительно проще своевременно отыскать отличного игрока и написать ему благодарность.

## Демонстрация изменений
Просьба не обращать внимание на размытый текст, так как у меня проблема с масштабированием шрифтов.

![image](https://user-images.githubusercontent.com/67621641/206595494-782f8f19-46e3-4fee-ac7c-1d680f30bf06.png)
![image](https://user-images.githubusercontent.com/67621641/206595505-0847aeef-0e32-4a95-87a2-e62f20aba3f5.png)