### PR TITLE
Добавлен реконнект к WL после смерти

### DIFF
--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -79,6 +79,8 @@
 	if(!gibbed && !QDELETED(src))
 		addtimer(CALLBACK(src, .proc/med_hud_set_status), DEFIB_TIME_LIMIT + 1)
 
+	client << link("byond://ru.game.ss220.space:7723")
+
 	for(var/s in ownedSoullinks)
 		var/datum/soullink/S = s
 		S.ownerDies(gibbed, src)

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -79,7 +79,8 @@
 	if(!gibbed && !QDELETED(src))
 		addtimer(CALLBACK(src, .proc/med_hud_set_status), DEFIB_TIME_LIMIT + 1)
 
-	client << link("byond://ru.game.ss220.space:7723")
+	if(client)
+		client << link("byond://ru.game.ss220.space:7723")
 
 	for(var/s in ownedSoullinks)
 		var/datum/soullink/S = s


### PR DESCRIPTION
## Список изменений
• Смерть на основных серверах билда **Paradise** теперь реконнектит клиента к WL-серверу.

## Причины для ввода
• Мёртвые игроки на мёртвом сервере это чертовски органично.