### PR TITLE
Fix: Safe map and shuttle template placers

### DIFF
--- a/code/datums/helper_datums/map_template.dm
+++ b/code/datums/helper_datums/map_template.dm
@@ -49,14 +49,20 @@
 	// if given a multi-z template
 	// it might need to be adapted for that when that time comes
 	GLOB.space_manager.add_dirt(placement.z)
-	var/list/bounds = GLOB.maploader.load_map(get_file(), min_x, min_y, placement.z, shouldCropMap = TRUE)
-	if(!bounds)
-		return 0
-	if(bot_left == null || top_right == null)
-		log_runtime(EXCEPTION("One of the late setup corners is bust"), src)
-
-	if(ST_bot_left == null || ST_top_right == null)
-		log_runtime(EXCEPTION("One of the smoothing corners is bust"), src)
+	try
+		var/list/bounds = GLOB.maploader.load_map(get_file(), min_x, min_y, placement.z, shouldCropMap = TRUE)
+		if(!bounds)
+			return 0
+		if(bot_left == null || top_right == null)
+			stack_trace("One of the late setup corners is bust")
+		if(ST_bot_left == null || ST_top_right == null)
+			stack_trace("One of the smoothing corners is bust")
+	catch(var/exception/e)
+		GLOB.space_manager.remove_dirt(placement.z)
+		late_setup_level(block(bot_left, top_right), block(ST_bot_left, ST_top_right))
+		message_admins("Map template [name] threw an error while loading. Safe exit attempted, but check for errors at [ADMIN_COORDJMP(placement)].")
+		log_admin("Map template [name] threw an error while loading. Safe exit attempted.")
+		throw e
 
 	GLOB.space_manager.remove_dirt(placement.z)
 	late_setup_level(

--- a/code/modules/shuttle/shuttle_manipulator.dm
+++ b/code/modules/shuttle/shuttle_manipulator.dm
@@ -1,3 +1,5 @@
+/// We really would rather not have admins altering this, this is the cooldown for the preview/shuttle spawning on the shuttle manipulator
+#define PREVIEW_OR_SHUTTLE_SPAWN_COOLDOWN 2 SECONDS
 
 /obj/machinery/shuttle_manipulator
 	name = "shuttle manipulator"
@@ -10,8 +12,9 @@
 	icon = 'icons/obj/machines/shuttle_manipulator.dmi'
 	icon_state = "holograph_on"
 
-	var/busy
-	// UI state variables
+	/// Used for cooldown, very obvious name, required due to shuttles spawning in the same location and causing the server to implode
+	var/shuttle_and_preview_cooldown = 0
+	/// UI state variables
 	var/datum/map_template/shuttle/selected
 
 	var/obj/docking_port/mobile/existing_shuttle
@@ -57,6 +60,11 @@
 /obj/machinery/shuttle_manipulator/attack_hand(mob/user)
 	ui_interact(user)
 
+/obj/machinery/shuttle_manipulator/vv_edit_var(var_name, var_value)
+	switch(var_name)
+		if("shuttle_and_preview_cooldown")
+			log_and_message_admins("has attempted to change the [var_name] variable. Please do not do this, this can cause entire Z levels to freeze if spammed too quickly.")
+			return FALSE // Extremely important that this doesn't get varedited by mistake, otherwise horrible, horrible things can happen to the server.
 
 /obj/machinery/shuttle_manipulator/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.admin_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
@@ -127,7 +135,9 @@
 /obj/machinery/shuttle_manipulator/ui_act(action, list/params, datum/tgui/ui)
 	if(..())
 		return
-
+	if(shuttle_and_preview_cooldown > world.time)
+		to_chat(usr, "<span class='warning'>Please wait until the desired shuttle has finished being loaded.</span>")
+		return
 	. = TRUE
 
 	switch(action)
@@ -160,6 +170,7 @@
 					break
 
 		if("preview")
+			shuttle_and_preview_cooldown = world.time + PREVIEW_OR_SHUTTLE_SPAWN_COOLDOWN
 			var/datum/map_template/shuttle/S = GLOB.shuttle_templates[params["shuttle_id"]]
 			if(S)
 				unload_preview()
@@ -169,6 +180,7 @@
 					usr.forceMove(get_turf(preview_shuttle))
 
 		if("load")
+			shuttle_and_preview_cooldown = world.time + PREVIEW_OR_SHUTTLE_SPAWN_COOLDOWN
 			var/datum/map_template/shuttle/S = GLOB.shuttle_templates[params["shuttle_id"]]
 			if(existing_shuttle == SSshuttle.backup_shuttle)
 				// TODO make the load button disabled
@@ -293,3 +305,5 @@
 	if(preview_shuttle)
 		preview_shuttle.jumpToNullSpace()
 	preview_shuttle = null
+
+#undef PREVIEW_OR_SHUTTLE_SPAWN_COOLDOWN


### PR DESCRIPTION
## Описание <!-- Название -->
 - Добавляет дополнительный обработчик исключений при загрузке карты, чтобы гарантировать, что рантайм не будет бексонечным, зависая на Z-уровне.
 
 - Добавляет 2-секундный кулдаун для предварительного просмотра и загрузки в манипуляторе шаттлов. Предотвращает ошибки загрузки шаттлов из-за того, что первый шаттл еще не был прогружен, дает ему достаточно времени, чтобы сделать это.

## Причина создание ПР
 - Пилил свои изменения, заметил недочёты, нашёл решение у оффов - перенёс.
 
 Ссылки на PRы с оффов:
 https://github.com/ParadiseSS13/Paradise/pull/19690
 https://github.com/ParadiseSS13/Paradise/pull/19790