### PR TITLE
Борер в режиме контроля носителя не отображается в мед. худе

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -192,7 +192,7 @@
 	else if(status_flags & XENO_HOST)
 		holder.icon_state = "hudxeno"
 	else if(B && B.controlling)
-		holder.icon_state = "hudbrainworm"
+		holder.icon_state = "hudhealthy"
 	else if(is_in_crit())
 		holder.icon_state = "huddefib"
 	else if(has_virus())

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -179,7 +179,6 @@
 //called when a carbon changes stat, virus or XENO_HOST
 /mob/living/carbon/med_hud_set_status()
 	var/image/holder = hud_list[STATUS_HUD]
-	var/mob/living/simple_animal/borer/B = has_brain_worms()
 	// To the right of health bar
 	if(stat == DEAD || (status_flags & FAKEDEATH))
 		var/revivable = timeofdeath && (round(world.time - timeofdeath) < DEFIB_TIME_LIMIT)
@@ -191,8 +190,6 @@
 			holder.icon_state = "huddead"
 	else if(status_flags & XENO_HOST)
 		holder.icon_state = "hudxeno"
-	else if(B && B.controlling)
-		holder.icon_state = "hudhealthy"
 	else if(is_in_crit())
 		holder.icon_state = "huddefib"
 	else if(has_virus())


### PR DESCRIPTION
## Описание
Борер захвативший контроль над жертвой больше не будет отображаться отдельной иконкой в медицинском худе, просто и весело

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/618952559607939072/1052044680335994990

## Демонстрация изменений

![image](https://user-images.githubusercontent.com/48346456/207202646-ec32df1e-9811-48f6-ae39-1b7ec20d4312.png)

