### PR TITLE
Make Korobka Great Again | Part 6

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -49194,7 +49194,6 @@
 	pixel_y = -24
 	},
 /obj/structure/cable,
-/obj/structure/cable,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurplefull"
@@ -51122,8 +51121,8 @@
 	},
 /obj/machinery/suit_storage_unit/rd/secure,
 /turf/simulated/floor/plasteel{
-	icon_state = "darkpurple";
-	dir = 5
+	dir = 5;
+	icon_state = "darkpurple"
 	},
 /area/crew_quarters/hor)
 "ceT" = (
@@ -52035,8 +52034,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "darkpurple";
-	dir = 6
+	dir = 6;
+	icon_state = "darkpurple"
 	},
 /area/crew_quarters/hor)
 "cgy" = (
@@ -52748,8 +52747,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "darkpurple";
-	dir = 9
+	dir = 9;
+	icon_state = "darkpurple"
 	},
 /area/crew_quarters/hor)
 "chQ" = (
@@ -52785,8 +52784,8 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "darkpurple";
-	dir = 1
+	dir = 1;
+	icon_state = "darkpurple"
 	},
 /area/crew_quarters/hor)
 "chS" = (
@@ -52805,8 +52804,8 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "darkpurple";
-	dir = 1
+	dir = 1;
+	icon_state = "darkpurple"
 	},
 /area/crew_quarters/hor)
 "chT" = (
@@ -52838,8 +52837,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "darkpurple";
-	dir = 1
+	dir = 1;
+	icon_state = "darkpurple"
 	},
 /area/crew_quarters/hor)
 "chW" = (
@@ -52847,8 +52846,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "darkpurple";
-	dir = 1
+	dir = 1;
+	icon_state = "darkpurple"
 	},
 /area/crew_quarters/hor)
 "chX" = (
@@ -53754,8 +53753,8 @@
 	},
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/plasteel{
-	icon_state = "darkpurple";
-	dir = 10
+	dir = 10;
+	icon_state = "darkpurple"
 	},
 /area/crew_quarters/hor)
 "cjP" = (

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -86,10 +86,7 @@
 	},
 /area/security/securearmory)
 "acc" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack/gunrack,
 /obj/item/gun/energy/gun{
 	pixel_x = -3;
 	pixel_y = 3
@@ -230,8 +227,7 @@
 "acx" = (
 /obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/range)
 "acy" = (
@@ -312,8 +308,7 @@
 "acF" = (
 /mob/living/simple_animal/crab/Coffee,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	tag = "icon-vault"
+	icon_state = "vault"
 	},
 /area/crew_quarters/dorms)
 "acG" = (
@@ -430,10 +425,6 @@
 /area/security/securearmory)
 "acV" = (
 /obj/structure/table,
-/obj/item/storage/ashtray/bronze{
-	pixel_x = -1;
-	pixel_y = 1
-	},
 /obj/item/storage/fancy/cigarettes/cigpack_robust,
 /obj/machinery/alarm{
 	dir = 4;
@@ -509,6 +500,10 @@
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "HoSPriv"
+	},
 /turf/simulated/floor/plating,
 /area/security/hos)
 "adg" = (
@@ -534,6 +529,10 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "HoSPriv"
+	},
 /turf/simulated/floor/plating,
 /area/security/hos)
 "adh" = (
@@ -553,6 +552,10 @@
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "HoSPriv"
+	},
 /turf/simulated/floor/plating,
 /area/security/hos)
 "adi" = (
@@ -649,6 +652,9 @@
 	},
 /obj/item/toy/figure/hos,
 /obj/item/lighter/zippo/hos,
+/obj/machinery/newscaster/security_unit{
+	pixel_x = -30
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -762,8 +768,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/security/medbay)
 "adG" = (
@@ -889,6 +894,8 @@
 	},
 /area/security/main)
 "adR" = (
+/obj/vehicle/secway,
+/obj/item/key/security,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -1078,8 +1085,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/security/medbay)
 "aeq" = (
@@ -1089,8 +1095,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/security/medbay)
 "aer" = (
@@ -1105,8 +1110,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/security/medbay)
 "aeu" = (
@@ -1125,8 +1129,7 @@
 /obj/machinery/vending/medical,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/security/medbay)
 "aey" = (
@@ -1151,8 +1154,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/security/medbay)
 "aeA" = (
@@ -1168,8 +1170,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/security/medbay)
 "aeB" = (
@@ -1283,8 +1284,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/security/medbay)
 "aeK" = (
@@ -1314,8 +1314,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/security/medbay)
 "aeM" = (
@@ -1350,8 +1349,7 @@
 /obj/machinery/bodyscanner,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/security/medbay)
 "aeR" = (
@@ -1402,9 +1400,6 @@
 /area/security/medbay)
 "aeU" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/light_switch{
 	name = "west light switch";
 	pixel_x = -24
@@ -1540,8 +1535,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/security/medbay)
 "afe" = (
@@ -1595,8 +1589,7 @@
 /obj/item/reagent_containers/spray/cleaner,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/security/medbay)
 "afj" = (
@@ -1691,14 +1684,12 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/security/medbay)
 "afs" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/security/medbay)
 "afu" = (
@@ -1719,8 +1710,7 @@
 /obj/machinery/sleeper,
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/security/medbay)
 "afx" = (
@@ -1742,8 +1732,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/security/podbay)
 "afM" = (
@@ -1772,8 +1761,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/security/podbay)
 "afO" = (
@@ -1966,8 +1954,8 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkredcorners"
+	dir = 1;
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "ags" = (
@@ -1997,6 +1985,9 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id_tag = "HoSPriv"
+	},
 /turf/simulated/floor/plating,
 /area/security/hos)
 "agu" = (
@@ -2005,8 +1996,9 @@
 /obj/effect/landmark/start{
 	name = "Head of Security"
 	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = -30
+/obj/machinery/camera{
+	c_tag = "Brig HoS Bedroom";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -2073,8 +2065,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkred"
+	dir = 4;
+	icon_state = "darkredcorners"
 	},
 /area/security/brig)
 "agP" = (
@@ -2083,7 +2075,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 4;
 	icon_state = "darkredcorners"
 	},
 /area/security/brig)
@@ -2146,8 +2138,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "bluered";
-	tag = "icon-siding1 (NORTH)"
+	icon_state = "bluered"
 	},
 /area/crew_quarters/dorms)
 "agV" = (
@@ -2350,7 +2341,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 4;
 	icon_state = "darkredcorners"
 	},
 /area/security/brig)
@@ -2775,6 +2766,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "darkredcorners"
 	},
 /area/security/brig)
@@ -2800,7 +2792,6 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkredcorners"
 	},
 /area/security/brig)
@@ -2838,7 +2829,6 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkredcorners"
 	},
 /area/security/brig)
@@ -2959,6 +2949,9 @@
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id_tag = "HoSPriv"
+	},
 /turf/simulated/floor/plating,
 /area/security/hos)
 "ajk" = (
@@ -2986,6 +2979,14 @@
 /area/security/brig)
 "ajn" = (
 /obj/structure/dresser,
+/obj/item/radio/intercom{
+	name = "west station intercom (General)";
+	pixel_x = -28
+	},
+/obj/machinery/light_switch{
+	name = "south light switch";
+	pixel_y = -24
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -3140,7 +3141,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 4;
 	icon_state = "darkredcorners"
 	},
 /area/security/brig)
@@ -3166,7 +3167,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "darkred"
+	icon_state = "dark"
 	},
 /area/security/brig)
 "ajP" = (
@@ -3179,7 +3180,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "darkred"
+	dir = 8;
+	icon_state = "darkredcorners"
 	},
 /area/security/brig)
 "ajQ" = (
@@ -3203,7 +3205,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "darkred"
+	dir = 8;
+	icon_state = "darkredcorners"
 	},
 /area/security/brig)
 "ajR" = (
@@ -3263,7 +3266,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 4;
 	icon_state = "darkredcorners"
 	},
 /area/security/brig)
@@ -3465,6 +3468,11 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
+/obj/machinery/door_control{
+	id = "HoSPriv";
+	name = "HoS Office Privacy Shutters Control";
+	pixel_y = -24
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -3523,6 +3531,9 @@
 	},
 /obj/structure/cable,
 /obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id_tag = "HoSPriv"
+	},
 /turf/simulated/floor/plating,
 /area/security/hos)
 "aku" = (
@@ -3609,7 +3620,6 @@
 "akD" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkredcorners"
 	},
 /area/security/brig)
@@ -3623,7 +3633,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "darkredcorners"
 	},
 /area/security/brig)
 "akF" = (
@@ -3923,8 +3934,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "ale" = (
@@ -4291,7 +4301,6 @@
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "darkredcorners"
 	},
 /area/security/prison/cell_block/A)
@@ -4305,7 +4314,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 8;
 	icon_state = "darkredcorners"
 	},
 /area/security/prison/cell_block/A)
@@ -4547,8 +4556,7 @@
 	name = "Head of Security"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/main)
 "ams" = (
@@ -4651,7 +4659,6 @@
 	pixel_x = -8;
 	pixel_y = 12
 	},
-/obj/item/storage/ashtray/bronze,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "escape"
@@ -4716,8 +4723,7 @@
 /area/maintenance/fsmaint)
 "amL" = (
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/structure/curtain/open/shower,
 /turf/simulated/floor/plating,
@@ -4741,8 +4747,7 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/main)
 "amO" = (
@@ -4773,8 +4778,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/main)
 "amR" = (
@@ -5185,10 +5189,7 @@
 /turf/space,
 /area/solar/auxport)
 "anH" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack/gunrack,
 /obj/item/gun/energy/laser{
 	pixel_x = -2;
 	pixel_y = 3
@@ -5344,7 +5345,7 @@
 	dir = 1;
 	icon_state = "darkredcorners"
 	},
-/area/security/lobby)
+/area/security/brig)
 "anY" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -5365,8 +5366,7 @@
 	pixel_y = 2
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "aoa" = (
@@ -5382,8 +5382,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "aob" = (
@@ -5392,8 +5391,7 @@
 	name = "Internal Affairs Agent"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "aoc" = (
@@ -5421,8 +5419,7 @@
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "aof" = (
@@ -5448,11 +5445,15 @@
 /turf/simulated/floor/plating,
 /area/security/hos)
 "aog" = (
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "redcorner"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/security/lobby)
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/medical/research/restroom)
 "aoh" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -5494,7 +5495,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/security/lobby)
+/area/security/brig)
 "aok" = (
 /obj/structure/table,
 /obj/item/book/manual/security_space_law,
@@ -5520,7 +5521,7 @@
 	dir = 9;
 	icon_state = "darkred"
 	},
-/area/security/lobby)
+/area/security/brig)
 "aon" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -5534,7 +5535,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/lobby)
+/area/security/brig)
 "aoo" = (
 /obj/machinery/light{
 	dir = 8
@@ -5653,8 +5654,7 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "bcarpet05"
 	},
 /area/security/prison/cell_block/A)
 "aox" = (
@@ -5915,7 +5915,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredcorners"
 	},
-/area/security/lobby)
+/area/security/brig)
 "aoP" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -5989,8 +5989,7 @@
 	c_tag = "Brig Cell 1"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "bcarpet05"
 	},
 /area/security/prison/cell_block/A)
 "aoV" = (
@@ -6014,7 +6013,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 8;
 	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
@@ -6028,14 +6027,14 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
 "aoY" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/security/prison/cell_block/A)
 "aoZ" = (
@@ -6047,8 +6046,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/security/prison/cell_block/A)
 "apa" = (
@@ -6109,6 +6107,7 @@
 	pixel_x = -9;
 	pixel_y = 10
 	},
+/obj/item/folder/red,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "darkred"
@@ -6116,11 +6115,7 @@
 /area/security/warden)
 "apf" = (
 /obj/structure/table,
-/obj/item/book/manual/security_space_law{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/item/toy/figure/warden,
+/obj/machinery/recharger,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
 	},
@@ -6128,8 +6123,11 @@
 "apg" = (
 /obj/structure/table,
 /obj/item/book/manual/sop_legal,
-/obj/item/paper/armory,
-/obj/item/clipboard,
+/obj/item/book/manual/security_space_law{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/toy/figure/warden,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
 	},
@@ -6160,8 +6158,9 @@
 /area/security/warden)
 "apj" = (
 /obj/structure/table/reinforced,
-/obj/item/folder/red,
 /obj/item/megaphone,
+/obj/item/clipboard,
+/obj/item/paper/armory,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
 	},
@@ -6257,6 +6256,10 @@
 "apA" = (
 /obj/machinery/vending/coffee,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "escape"
 	},
@@ -6590,8 +6593,7 @@
 "aqt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitegreenfull"
 	},
 /area/security/permabrig)
 "aqu" = (
@@ -6937,8 +6939,7 @@
 "aqY" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "aqZ" = (
@@ -6963,8 +6964,7 @@
 /obj/item/stamp/law,
 /obj/item/pen/multi,
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "arb" = (
@@ -6991,7 +6991,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/security/lobby)
+/area/security/brig)
 "ari" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -7021,7 +7021,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/lobby)
+/area/security/brig)
 "arl" = (
 /obj/machinery/computer/security{
 	network = list("SS13","Research Outpost","Mining Outpost")
@@ -7030,7 +7030,7 @@
 	dir = 8;
 	icon_state = "darkred"
 	},
-/area/security/lobby)
+/area/security/brig)
 "arm" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -7050,7 +7050,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/security/lobby)
+/area/security/brig)
 "arn" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -7067,7 +7067,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 8;
 	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
@@ -7079,6 +7079,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
@@ -7287,12 +7288,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
-"arD" = (
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkred"
-	},
-/area/security/brig)
 "arE" = (
 /obj/structure/chair{
 	dir = 1
@@ -7801,7 +7796,6 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkredcorners"
 	},
 /area/security/brig)
@@ -8037,8 +8031,7 @@
 	req_access_txt = "2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "asP" = (
@@ -8046,8 +8039,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "asQ" = (
@@ -8059,7 +8051,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	dir = 1;
 	icon_state = "redcorner"
 	},
 /area/security/lobby)
@@ -8067,14 +8059,14 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
 	},
-/area/security/lobby)
+/area/security/brig)
 "asX" = (
 /obj/machinery/computer/secure_data,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "darkred"
 	},
-/area/security/lobby)
+/area/security/brig)
 "asY" = (
 /obj/structure/chair/office/dark,
 /obj/item/radio/intercom{
@@ -8123,7 +8115,7 @@
 	dir = 6;
 	icon_state = "darkred"
 	},
-/area/security/lobby)
+/area/security/brig)
 "asZ" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor{
@@ -8147,7 +8139,8 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bcarpet05"
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
 "atb" = (
@@ -8159,7 +8152,8 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bcarpet05"
+	dir = 8;
+	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
 "atc" = (
@@ -8184,7 +8178,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 8;
 	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
@@ -8197,6 +8191,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
@@ -8212,8 +8207,8 @@
 /area/lawoffice)
 "atg" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	dir = 10;
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "ath" = (
@@ -8402,6 +8397,7 @@
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "darkredcorners"
 	},
 /area/security/brig)
@@ -8444,7 +8440,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkredcorners"
 	},
 /area/security/brig)
@@ -8680,8 +8675,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/permabrig)
 "aue" = (
@@ -8699,8 +8693,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/permabrig)
 "auf" = (
@@ -8893,8 +8886,7 @@
 "aur" = (
 /obj/structure/filingcabinet/employment,
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "aut" = (
@@ -8902,8 +8894,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "auy" = (
@@ -8918,7 +8909,6 @@
 "auA" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1450;
-	icon_state = "door_locked";
 	id_tag = "dorms_maint_inner";
 	locked = 1;
 	name = "External Access";
@@ -8980,7 +8970,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/security/lobby)
+/area/security/brig)
 "auE" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -9012,7 +9002,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/security/lobby)
+/area/security/brig)
 "auH" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -9032,7 +9022,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/security/lobby)
+/area/security/brig)
 "auI" = (
 /obj/structure/closet,
 /turf/simulated/floor/plasteel{
@@ -9066,10 +9056,9 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
-/area/security/lobby)
+/area/security/brig)
 "auK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -9618,8 +9607,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/permabrig)
 "avE" = (
@@ -9638,8 +9626,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/permabrig)
 "avF" = (
@@ -9794,8 +9781,7 @@
 	},
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "avR" = (
@@ -9806,8 +9792,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "avS" = (
@@ -9845,8 +9830,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "avX" = (
@@ -9858,14 +9842,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "darkredcorners"
 	},
 /area/security/prison/cell_block/A)
 "avY" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/security/prison/cell_block/A)
 "avZ" = (
@@ -9882,7 +9866,7 @@
 	req_access_txt = "63"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	dir = 1;
 	icon_state = "darkredcorners"
 	},
 /area/security/prison/cell_block/A)
@@ -9897,8 +9881,7 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 1;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2"
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel,
 /area/security/lobby)
@@ -10178,7 +10161,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "darkredcorners"
 	},
 /area/security/prison/cell_block/A)
 "awK" = (
@@ -10190,8 +10174,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/security/prison/cell_block/A)
 "awO" = (
@@ -10411,7 +10394,6 @@
 "axg" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1450;
-	icon_state = "door_locked";
 	id_tag = "dorms_maint_inner";
 	locked = 1;
 	name = "External Access";
@@ -10451,8 +10433,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "axq" = (
@@ -10469,8 +10450,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "axs" = (
@@ -10497,6 +10477,7 @@
 	pixel_y = -31
 	},
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "redcorner"
 	},
 /area/security/lobby)
@@ -10671,7 +10652,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "darkredcorners"
 	},
 /area/security/prison/cell_block/A)
 "axH" = (
@@ -10711,6 +10693,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "darkredcorners"
 	},
 /area/security/prison/cell_block/A)
@@ -10953,7 +10936,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "darkred"
+	icon_state = "darkredcorners"
 	},
 /area/security/prison/cell_block/A)
 "ayo" = (
@@ -11179,8 +11162,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/security/permabrig)
 "ayH" = (
@@ -11191,15 +11173,13 @@
 	},
 /obj/machinery/vending/coffee/free,
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "ayI" = (
 /obj/structure/chair/comfy/brown,
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "ayJ" = (
@@ -11226,7 +11206,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 8;
 	icon_state = "redcorner"
 	},
 /area/security/lobby)
@@ -11299,8 +11279,7 @@
 /area/security/lobby)
 "ayQ" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/security/permabrig)
 "ayR" = (
@@ -11724,8 +11703,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "azB" = (
@@ -11739,8 +11717,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "azC" = (
@@ -11750,14 +11727,14 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "azD" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	dir = 6;
+	icon_state = "red"
 	},
 /area/security/lobby)
 "azE" = (
@@ -11851,7 +11828,6 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
 	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
@@ -11920,8 +11896,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkred"
+	dir = 1;
+	icon_state = "darkredcorners"
 	},
 /area/security/prison/cell_block/A)
 "azR" = (
@@ -11937,7 +11913,6 @@
 "azT" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1450;
-	icon_state = "door_locked";
 	id_tag = "dorms_maint_outer";
 	locked = 1;
 	name = "External Access";
@@ -12042,7 +12017,6 @@
 "aAl" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "solar_tool_outer";
 	locked = 1;
 	name = "Engineering External Access";
@@ -12239,8 +12213,7 @@
 "aAD" = (
 /obj/structure/closet/lawcloset,
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "aAE" = (
@@ -12272,8 +12245,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "aAF" = (
@@ -12287,8 +12259,7 @@
 	name = "Internal Affairs Agent"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "aAH" = (
@@ -12298,8 +12269,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "aAI" = (
@@ -12311,8 +12281,7 @@
 	},
 /obj/item/paper_bin/nanotrasen,
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "aAJ" = (
@@ -12323,8 +12292,7 @@
 /area/maintenance/fsmaint)
 "aAK" = (
 /obj/machinery/atmospherics/binary/valve/open{
-	dir = 4;
-	tag = "icon-map_valve1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -12465,8 +12433,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkred"
+	dir = 1;
+	icon_state = "darkredcorners"
 	},
 /area/security/prison/cell_block/A)
 "aAY" = (
@@ -12553,15 +12521,13 @@
 /area/maintenance/bar)
 "aBd" = (
 /obj/structure/chair/wood/wings{
-	dir = 4;
-	tag = "icon-wooden_chair_wings (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
 "aBe" = (
 /obj/structure/chair/wood/wings{
-	dir = 8;
-	tag = "icon-wooden_chair_wings (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/wood{
 	broken = 1;
@@ -12570,8 +12536,7 @@
 /area/maintenance/bar)
 "aBf" = (
 /obj/structure/chair/wood/wings{
-	dir = 4;
-	tag = "icon-wooden_chair_wings (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/maintenance/bar)
@@ -12930,8 +12895,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "aCd" = (
@@ -12943,8 +12907,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/magistrateoffice)
 "aCe" = (
@@ -12961,8 +12924,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/magistrateoffice)
 "aCf" = (
@@ -12975,8 +12937,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/magistrateoffice)
 "aCh" = (
@@ -13009,8 +12970,7 @@
 "aCl" = (
 /obj/structure/closet/secure_closet/magistrate,
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/magistrateoffice)
 "aCm" = (
@@ -13101,8 +13061,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkred"
+	dir = 1;
+	icon_state = "darkredcorners"
 	},
 /area/security/prison/cell_block/A)
 "aCu" = (
@@ -13184,7 +13144,6 @@
 "aCD" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "solar_tool_inner";
 	locked = 1;
 	name = "Engineering External Access";
@@ -13469,14 +13428,12 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/magistrateoffice)
 "aDi" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/magistrateoffice)
 "aDj" = (
@@ -13537,8 +13494,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/security/prison/cell_block/A)
 "aDo" = (
@@ -13555,8 +13511,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/security/prison/cell_block/A)
 "aDp" = (
@@ -13761,7 +13716,6 @@
 	},
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "solar_chapel_outer";
 	locked = 1;
 	name = "Engineering External Access";
@@ -13793,8 +13747,7 @@
 "aDQ" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "ramptop";
-	tag = "icon-stage_stairs"
+	icon_state = "ramptop"
 	},
 /area/crew_quarters/courtroom)
 "aDR" = (
@@ -13804,8 +13757,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/magistrateoffice)
 "aDS" = (
@@ -13829,8 +13781,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/magistrateoffice)
 "aDV" = (
@@ -13894,8 +13845,7 @@
 "aEg" = (
 /obj/structure/filingcabinet,
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/magistrateoffice)
 "aEh" = (
@@ -13939,7 +13889,6 @@
 /area/crew_quarters/courtroom)
 "aEm" = (
 /obj/structure/table/wood/poker,
-/obj/item/storage/ashtray/bronze,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkred"
@@ -14011,7 +13960,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "darkredcorners"
+	icon_state = "dark"
 	},
 /area/security/prison/cell_block/A)
 "aEr" = (
@@ -14032,8 +13981,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	icon_state = "dark"
 	},
 /area/security/prison/cell_block/A)
 "aEs" = (
@@ -14381,8 +14329,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/crew_quarters/courtroom)
 "aFj" = (
@@ -14391,8 +14338,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/crew_quarters/courtroom)
 "aFl" = (
@@ -14403,8 +14349,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/crew_quarters/courtroom)
 "aFm" = (
@@ -14417,8 +14362,7 @@
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/magistrateoffice)
 "aFn" = (
@@ -14438,8 +14382,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/magistrateoffice)
 "aFp" = (
@@ -14453,8 +14396,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/magistrateoffice)
 "aFq" = (
@@ -14467,8 +14409,7 @@
 	pixel_y = 7
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/magistrateoffice)
 "aFr" = (
@@ -14486,8 +14427,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/magistrateoffice)
 "aFs" = (
@@ -14495,8 +14435,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/magistrateoffice)
 "aFt" = (
@@ -14512,8 +14451,7 @@
 	pixel_y = -31
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/magistrateoffice)
 "aFu" = (
@@ -14558,8 +14496,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/junction{
-	dir = 1;
-	tag = "icon-pipe-j1 (EAST)"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
@@ -14626,7 +14563,6 @@
 	pixel_y = 8
 	},
 /obj/item/storage/fancy/cigarettes/dromedaryco,
-/obj/item/storage/ashtray/bronze,
 /obj/item/radio/intercom/department/security{
 	name = "east station intercom (Security)";
 	pixel_x = 28
@@ -14799,7 +14735,6 @@
 "aFY" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "eva_outer";
 	locked = 1;
 	name = "EVA External Access";
@@ -14815,7 +14750,6 @@
 	},
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "solar_chapel_inner";
 	locked = 1;
 	name = "Engineering External Access";
@@ -14880,8 +14814,7 @@
 "aGl" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/maintenance/fpmaint)
 "aGm" = (
@@ -14910,8 +14843,7 @@
 "aGp" = (
 /obj/machinery/vending/coffee/free,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/maintenance/fpmaint)
 "aGq" = (
@@ -14923,8 +14855,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/crew_quarters/courtroom)
 "aGr" = (
@@ -15342,7 +15273,6 @@
 /area/maintenance/fpmaint)
 "aHh" = (
 /obj/machinery/door/airlock/engineering{
-	icon_state = "door_closed";
 	name = "North-West Solar Access";
 	req_access_txt = "10"
 	},
@@ -15376,8 +15306,7 @@
 "aHm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/maintenance/fpmaint)
 "aHn" = (
@@ -15784,7 +15713,6 @@
 "aIm" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "eva_inner";
 	locked = 1;
 	name = "EVA Internal Access";
@@ -15968,7 +15896,6 @@
 "aIG" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "arrivals_outer";
 	locked = 1;
 	name = "Engineering External Access";
@@ -16002,8 +15929,7 @@
 /area/maintenance/fpmaint)
 "aIL" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/maintenance/fpmaint)
 "aIM" = (
@@ -16013,8 +15939,7 @@
 	req_access_txt = "74"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/magistrateoffice)
 "aIN" = (
@@ -16044,6 +15969,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/fore)
@@ -16362,7 +16288,6 @@
 "aJC" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1450;
-	icon_state = "door_locked";
 	id_tag = "bar_maint_outer";
 	locked = 1;
 	name = "External Access";
@@ -16377,7 +16302,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/engineering{
-	icon_state = "door_closed";
 	name = "North-East Solar Access";
 	req_access_txt = "10"
 	},
@@ -16398,7 +16322,6 @@
 "aJG" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "eva_inner";
 	locked = 1;
 	name = "EVA Internal Access";
@@ -16463,8 +16386,7 @@
 /area/maintenance/fpmaint)
 "aJW" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/maintenance/fpmaint)
 "aJX" = (
@@ -16532,8 +16454,7 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 1;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2"
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
@@ -16609,8 +16530,7 @@
 /area/crew_quarters/courtroom)
 "aKs" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "aKt" = (
@@ -16624,8 +16544,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/crew_quarters/courtroom)
 "aKu" = (
@@ -16635,8 +16554,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/crew_quarters/courtroom)
 "aKv" = (
@@ -16649,15 +16567,13 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/crew_quarters/courtroom)
 "aKw" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "aKx" = (
@@ -16675,8 +16591,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/magistrateoffice)
 "aKy" = (
@@ -17026,8 +16941,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/maintenance/fpmaint)
 "aLo" = (
@@ -17134,7 +17048,6 @@
 "aLy" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "arrivals_inner";
 	locked = 1;
 	name = "Engineering External Access";
@@ -17209,8 +17122,7 @@
 /area/maintenance/fpmaint)
 "aLL" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/maintenance/fpmaint)
 "aLM" = (
@@ -17293,8 +17205,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/crew_quarters/courtroom)
 "aLV" = (
@@ -17416,7 +17327,6 @@
 "aMf" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1450;
-	icon_state = "door_locked";
 	id_tag = "bar_maint_inner";
 	locked = 1;
 	name = "External Access";
@@ -17672,8 +17582,7 @@
 /obj/item/pen,
 /obj/item/paper_bin/nanotrasen,
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/lawoffice)
 "aMP" = (
@@ -17729,8 +17638,7 @@
 /obj/machinery/door/window/southleft,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/maintenance/fpmaint)
 "aMY" = (
@@ -17763,7 +17671,6 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/fore)
@@ -18044,8 +17951,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/crew_quarters/courtroom)
 "aNK" = (
@@ -18057,7 +17963,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/camera{
-	c_tag = "North Primary Hallway South";
+	c_tag = "Fore Primary Hallway South";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -18076,8 +17982,7 @@
 "aNM" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2 (EAST)"
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bluecorner"
@@ -18155,7 +18060,6 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/fore)
@@ -18937,8 +18841,7 @@
 	name = "JoinLateCryo"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitegreenfull"
 	},
 /area/crew_quarters/sleep)
 "aPM" = (
@@ -19101,8 +19004,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitegreenfull"
 	},
 /area/crew_quarters/sleep)
 "aQg" = (
@@ -19148,8 +19050,7 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 4;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2 (EAST)"
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -19242,8 +19143,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 8;
-	tag = "icon-pipe-j1 (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -19265,8 +19165,7 @@
 "aQv" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "bluered";
-	tag = "icon-siding1 (NORTH)"
+	icon_state = "bluered"
 	},
 /area/crew_quarters/dorms)
 "aQw" = (
@@ -19313,8 +19212,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "bluered";
-	tag = "icon-siding1 (NORTH)"
+	icon_state = "bluered"
 	},
 /area/crew_quarters/dorms)
 "aQA" = (
@@ -19327,8 +19225,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "bluered";
-	tag = "icon-siding1 (NORTH)"
+	icon_state = "bluered"
 	},
 /area/crew_quarters/dorms)
 "aQB" = (
@@ -19455,8 +19352,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "blue"
+	icon_state = "bluecorner"
 	},
 /area/hallway/primary/fore)
 "aQT" = (
@@ -19504,7 +19400,6 @@
 "aQX" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "sol_outer";
 	locked = 1;
 	name = "Arrivals External Access"
@@ -19535,8 +19430,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitegreenfull"
 	},
 /area/crew_quarters/sleep)
 "aRa" = (
@@ -19575,8 +19469,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitegreenfull"
 	},
 /area/crew_quarters/sleep)
 "aRd" = (
@@ -20058,8 +19951,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitegreenfull"
 	},
 /area/crew_quarters/sleep)
 "aSi" = (
@@ -20748,16 +20640,14 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "aTM" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (EAST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "aTN" = (
@@ -20841,16 +20731,14 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "aTT" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "aTU" = (
@@ -20861,8 +20749,7 @@
 	pixel_y = 34
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
 "aTV" = (
@@ -20879,8 +20766,7 @@
 	name = "Civilian"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
 "aTW" = (
@@ -20888,8 +20774,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
 "aTX" = (
@@ -20906,8 +20791,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
 "aTZ" = (
@@ -21206,8 +21090,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/chapel/office)
 "aUM" = (
@@ -21233,8 +21116,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "aUP" = (
@@ -21248,8 +21130,7 @@
 /obj/structure/table,
 /obj/item/folder/white,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
 "aUQ" = (
@@ -21536,8 +21417,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "aVy" = (
@@ -21857,7 +21737,6 @@
 	},
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "sol_inner";
 	locked = 1;
 	name = "Arrivals External Access"
@@ -22101,7 +21980,6 @@
 /area/crew_quarters/dorms)
 "aWD" = (
 /obj/structure/table/wood,
-/obj/item/storage/ashtray/bronze,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/dorms)
 "aWE" = (
@@ -22253,8 +22131,7 @@
 /area/medical/chemistry)
 "aWT" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	tag = "icon-vault"
+	icon_state = "vault"
 	},
 /area/crew_quarters/dorms)
 "aWU" = (
@@ -22348,8 +22225,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/chapel/office)
 "aXd" = (
@@ -22364,8 +22240,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/maintenance/fsmaint2)
 "aXe" = (
@@ -22373,8 +22248,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/chapel/office)
 "aXf" = (
@@ -22395,8 +22269,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/chapel/office)
 "aXh" = (
@@ -22420,8 +22293,7 @@
 	name = "revenantspawn"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/chapel/office)
 "aXk" = (
@@ -22429,8 +22301,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/chapel/office)
 "aXl" = (
@@ -22458,8 +22329,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/chapel/office)
 "aXp" = (
@@ -22895,8 +22765,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitegreenfull"
 	},
 /area/crew_quarters/sleep)
 "aYq" = (
@@ -22973,8 +22842,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitegreenfull"
 	},
 /area/crew_quarters/sleep)
 "aYw" = (
@@ -22990,8 +22858,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitegreenfull"
 	},
 /area/crew_quarters/sleep)
 "aYx" = (
@@ -23000,8 +22867,7 @@
 	name = "revenantspawn"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/chapel/office)
 "aYy" = (
@@ -23070,8 +22936,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitegreenfull"
 	},
 /area/crew_quarters/sleep)
 "aYJ" = (
@@ -23424,16 +23289,6 @@
 	icon_state = "arrival"
 	},
 /area/crew_quarters/dorms)
-"aZx" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "blue"
-	},
-/area/hallway/primary/fore)
 "aZy" = (
 /mob/living/simple_animal/hostile/carp/koi{
 	name = "Jeremy"
@@ -23481,8 +23336,7 @@
 "aZE" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/crew_quarters/dorms)
 "aZF" = (
@@ -23962,10 +23816,7 @@
 	name = "Central Access"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "blue"
-	},
+/turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
 "baG" = (
 /obj/structure/rack{
@@ -24168,8 +24019,7 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 4;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2 (EAST)"
+	icon_state = "pipe-j2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -24199,7 +24049,6 @@
 /area/maintenance/fsmaint2)
 "bbf" = (
 /obj/machinery/door/airlock/vault{
-	icon_state = "door_locked";
 	locked = 1;
 	req_access_txt = "53"
 	},
@@ -24230,8 +24079,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/crew_quarters/sleep)
 "bbh" = (
@@ -24298,8 +24146,7 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "ramptop";
-	tag = "icon-stage_stairs"
+	icon_state = "ramptop"
 	},
 /area/crew_quarters/dorms)
 "bbp" = (
@@ -24323,8 +24170,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 4;
-	tag = "icon-pipe-j1 (EAST)"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -24348,8 +24194,7 @@
 /area/crew_quarters/dorms)
 "bbu" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/crew_quarters/dorms)
 "bbv" = (
@@ -24386,8 +24231,7 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
 	name = "Kitchen";
-	sortType = 20;
-	tag = "icon-pipe-j1s (EAST)"
+	sortType = 20
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -24602,8 +24446,7 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
 	name = "Botany";
-	sortType = 21;
-	tag = "icon-pipe-j1s (EAST)"
+	sortType = 21
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -25051,8 +24894,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/hydroponics)
 "bcT" = (
@@ -26257,8 +26099,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 4;
-	tag = "icon-pipe-j1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -26330,7 +26171,6 @@
 "bfu" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "ai_outer";
 	locked = 1;
 	name = "MiniSat External Access";
@@ -27309,7 +27149,6 @@
 "bhy" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "ai_inner";
 	locked = 1;
 	name = "MiniSat External Access";
@@ -27396,8 +27235,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/gateway)
 "bhH" = (
@@ -27420,8 +27258,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/gateway)
 "bhJ" = (
@@ -27432,8 +27269,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/gateway)
 "bhK" = (
@@ -28315,8 +28151,7 @@
 "bjs" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/chapel/main)
 "bjt" = (
@@ -28960,8 +28795,7 @@
 	name = "Forbidden Knowledge"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/library)
 "bkY" = (
@@ -28986,8 +28820,7 @@
 /obj/item/stack/tape_roll,
 /obj/item/pen/multi,
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/library)
 "bla" = (
@@ -28995,8 +28828,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/chapel/main)
 "blb" = (
@@ -29472,8 +29304,7 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 4;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2 (EAST)"
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
@@ -29507,8 +29338,7 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bmi" = (
@@ -29600,8 +29430,7 @@
 	},
 /obj/machinery/disposal,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bmu" = (
@@ -29733,8 +29562,7 @@
 "bmE" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/library)
 "bmF" = (
@@ -29744,8 +29572,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/library)
 "bmG" = (
@@ -29756,8 +29583,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/library)
 "bmH" = (
@@ -30440,8 +30266,7 @@
 /area/hallway/primary/central/ne)
 "bof" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bog" = (
@@ -30462,8 +30287,7 @@
 	req_access_txt = "28"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "boh" = (
@@ -30485,8 +30309,7 @@
 	name = "Chef"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "boj" = (
@@ -30534,8 +30357,7 @@
 	},
 /obj/machinery/kitchen_machine/candy_maker,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "boo" = (
@@ -30545,8 +30367,7 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bop" = (
@@ -30564,8 +30385,7 @@
 "boq" = (
 /obj/machinery/cooker/deepfryer,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bor" = (
@@ -30600,8 +30420,7 @@
 	},
 /obj/machinery/kitchen_machine/oven,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bot" = (
@@ -30649,8 +30468,7 @@
 	req_access_txt = "37"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/library)
 "boz" = (
@@ -30834,8 +30652,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "asteroid";
-	tag = "icon-asteroid (NORTH)"
+	icon_state = "asteroid"
 	},
 /area/hydroponics)
 "boY" = (
@@ -31180,8 +30997,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "asteroid";
-	tag = "icon-asteroid (NORTH)"
+	icon_state = "asteroid"
 	},
 /area/hydroponics)
 "bpI" = (
@@ -31232,8 +31048,7 @@
 	req_access_txt = "28"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bpO" = (
@@ -31276,8 +31091,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bpT" = (
@@ -31297,8 +31111,7 @@
 "bpV" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/hydroponics)
 "bpW" = (
@@ -31408,8 +31221,7 @@
 /area/maintenance/fsmaint2)
 "bqk" = (
 /obj/structure/chair/wood/wings{
-	dir = 8;
-	tag = "icon-wooden_chair_wings (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -31556,8 +31368,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bqC" = (
@@ -31595,8 +31406,7 @@
 	req_access_txt = "28"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bqI" = (
@@ -31857,8 +31667,7 @@
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "brn" = (
@@ -31880,8 +31689,7 @@
 "bro" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "brp" = (
@@ -32108,8 +31916,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "brZ" = (
@@ -32375,8 +32182,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "browncorner";
-	tag = "icon-browncorner (EAST)"
+	icon_state = "browncorner"
 	},
 /area/bridge)
 "bsF" = (
@@ -32390,8 +32196,7 @@
 "bsG" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "browncorner";
-	tag = "icon-browncorner (EAST)"
+	icon_state = "browncorner"
 	},
 /area/bridge)
 "bsH" = (
@@ -32520,8 +32325,7 @@
 /obj/structure/table,
 /obj/item/book/manual/sop_service,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bsU" = (
@@ -32628,8 +32432,7 @@
 /area/hallway/primary/starboard/east)
 "btf" = (
 /obj/structure/chair/wood/wings{
-	dir = 4;
-	tag = "icon-wooden_chair_wings (EAST)"
+	dir = 4
 	},
 /obj/effect/landmark/start{
 	name = "Civilian"
@@ -32689,8 +32492,7 @@
 /area/crew_quarters/bar)
 "btp" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/hallway/secondary/exit)
 "btr" = (
@@ -32719,8 +32521,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/chair/wood/wings{
-	dir = 4;
-	tag = "icon-wooden_chair_wings (EAST)"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
@@ -32768,8 +32569,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "btJ" = (
@@ -32777,8 +32577,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "btK" = (
@@ -32791,8 +32590,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "btL" = (
@@ -32811,8 +32609,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "btN" = (
@@ -32824,8 +32621,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "btO" = (
@@ -32844,8 +32640,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "btQ" = (
@@ -33061,8 +32856,7 @@
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bus" = (
@@ -33081,8 +32875,7 @@
 /obj/structure/table,
 /obj/item/kitchen/knife,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "buu" = (
@@ -33095,8 +32888,7 @@
 "buv" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "buw" = (
@@ -33228,8 +33020,7 @@
 	name = "Chef"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "buK" = (
@@ -33302,15 +33093,13 @@
 "buQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/chair/wood/wings{
-	dir = 1;
-	tag = "icon-wooden_chair_wings (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "buR" = (
 /obj/structure/chair/wood/wings{
-	dir = 1;
-	tag = "icon-wooden_chair_wings (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -33672,8 +33461,7 @@
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bvN" = (
@@ -33955,8 +33743,7 @@
 	req_access_txt = "28"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bwo" = (
@@ -33967,8 +33754,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bwp" = (
@@ -33981,8 +33767,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bwq" = (
@@ -34005,8 +33790,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bws" = (
@@ -34079,8 +33863,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 1;
-	tag = "icon-pipe-j1 (EAST)"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
@@ -34106,8 +33889,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "bwK" = (
@@ -34594,15 +34376,13 @@
 	},
 /obj/machinery/vending/dinnerware,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bxG" = (
 /obj/machinery/icemachine,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bxH" = (
@@ -34623,8 +34403,7 @@
 	req_access_txt = "28"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bxI" = (
@@ -34644,8 +34423,7 @@
 	req_access_txt = "28"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bxJ" = (
@@ -34665,8 +34443,7 @@
 	req_access_txt = "28"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bxK" = (
@@ -35146,8 +34923,7 @@
 /area/quartermaster/office)
 "byD" = (
 /obj/structure/chair/wood/wings{
-	dir = 4;
-	tag = "icon-wooden_chair_wings (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -35156,8 +34932,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "byF" = (
@@ -35507,8 +35282,7 @@
 "bzo" = (
 /obj/machinery/light,
 /obj/structure/chair/wood/wings{
-	dir = 4;
-	tag = "icon-wooden_chair_wings (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -36077,8 +35851,7 @@
 "bAE" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/hallway/secondary/exit)
 "bAF" = (
@@ -36093,8 +35866,7 @@
 /obj/effect/decal/warning_stripes/yellow,
 /obj/structure/disposalpipe/junction{
 	dir = 8;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j1 (WEST)"
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
@@ -36512,8 +36284,7 @@
 "bBL" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/reception)
 "bBM" = (
@@ -36535,8 +36306,7 @@
 "bBO" = (
 /obj/machinery/shower{
 	dir = 4;
-	pixel_x = 5;
-	tag = "icon-shower (EAST)"
+	pixel_x = 5
 	},
 /obj/structure/curtain/open/shower,
 /obj/effect/turf_decal/siding/wideplating{
@@ -36673,8 +36443,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/junction{
 	dir = 1;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2"
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
@@ -36764,8 +36533,7 @@
 	},
 /obj/machinery/light/small,
 /obj/structure/chair/wood/wings{
-	dir = 8;
-	tag = "icon-wooden_chair_wings (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -36954,8 +36722,7 @@
 /obj/item/roller,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bCX" = (
@@ -37006,8 +36773,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bDd" = (
@@ -37017,14 +36783,12 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bDe" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
 "bDf" = (
@@ -37040,12 +36804,6 @@
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "white"
-	},
-/area/medical/reception)
-"bDh" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
 	},
 /area/medical/reception)
 "bDi" = (
@@ -38072,8 +37830,7 @@
 	icon_state = "siding1"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "asteroid";
-	tag = "icon-asteroid (NORTH)"
+	icon_state = "asteroid"
 	},
 /area/hydroponics)
 "bFK" = (
@@ -38133,8 +37890,7 @@
 /area/engine/gravitygenerator)
 "bFQ" = (
 /obj/structure/morgue{
-	dir = 8;
-	tag = "icon-morgue1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -38164,8 +37920,7 @@
 /area/crew_quarters/toilet)
 "bFT" = (
 /obj/structure/morgue{
-	dir = 8;
-	tag = "icon-morgue1 (WEST)"
+	dir = 8
 	},
 /obj/effect/landmark{
 	name = "revenantspawn"
@@ -38299,8 +38054,7 @@
 /area/assembly/robotics)
 "bGd" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bGe" = (
@@ -38317,8 +38071,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bGg" = (
@@ -38336,8 +38089,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/paramedic)
 "bGh" = (
@@ -38427,8 +38179,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bGr" = (
@@ -38442,8 +38193,7 @@
 "bGt" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (EAST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bGu" = (
@@ -39036,8 +38786,7 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
 	name = "Sci Robotics";
-	sortType = 24;
-	tag = "icon-pipe-j1s (EAST)"
+	sortType = 24
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -39101,8 +38850,7 @@
 "bHO" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bHP" = (
@@ -39178,8 +38926,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "ramptop";
-	tag = "icon-stage_stairs"
+	icon_state = "ramptop"
 	},
 /area/hallway/primary/starboard/east)
 "bHU" = (
@@ -39191,8 +38938,7 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 8;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j1 (WEST)"
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -39330,8 +39076,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bIi" = (
@@ -39358,8 +39103,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bIk" = (
@@ -39458,8 +39202,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/lab)
 "bIv" = (
@@ -39472,8 +39215,7 @@
 /obj/item/reagent_containers/dropper,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/lab)
 "bIw" = (
@@ -40015,8 +39757,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bJB" = (
@@ -40034,8 +39775,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/paramedic)
 "bJD" = (
@@ -40069,8 +39809,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/paramedic)
 "bJG" = (
@@ -40104,8 +39843,7 @@
 /obj/machinery/computer/crew,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/paramedic)
 "bJK" = (
@@ -40128,8 +39866,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bJN" = (
@@ -40164,8 +39901,7 @@
 /obj/structure/closet/walllocker/emerglocker/south,
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bJQ" = (
@@ -40199,8 +39935,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "bJU" = (
@@ -40421,8 +40156,7 @@
 /area/maintenance/asmaint2)
 "bKn" = (
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
@@ -40636,8 +40370,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bKP" = (
@@ -40806,8 +40539,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
 "bLi" = (
@@ -40865,8 +40597,7 @@
 	icon_state = "siding1"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "asteroid";
-	tag = "icon-asteroid (NORTH)"
+	icon_state = "asteroid"
 	},
 /area/hydroponics)
 "bLo" = (
@@ -40951,8 +40682,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/paramedic)
 "bLu" = (
@@ -40970,8 +40700,7 @@
 /obj/machinery/computer/med_data,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bLv" = (
@@ -40990,8 +40719,7 @@
 	name = "Chemist"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
 "bLw" = (
@@ -41008,8 +40736,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/paramedic)
 "bLx" = (
@@ -41021,22 +40748,19 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
 "bLy" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/reception)
 "bLz" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/reception)
 "bLA" = (
@@ -41053,8 +40777,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bLC" = (
@@ -41200,8 +40923,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bLT" = (
@@ -41255,8 +40977,7 @@
 	icon_state = "siding1"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "asteroid";
-	tag = "icon-asteroid (NORTH)"
+	icon_state = "asteroid"
 	},
 /area/hydroponics)
 "bLV" = (
@@ -41275,8 +40996,7 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bLW" = (
@@ -41780,8 +41500,7 @@
 /obj/item/storage/firstaid/fire,
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bMY" = (
@@ -41798,8 +41517,7 @@
 	c_tag = "Medbay Medicine Storage"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bMZ" = (
@@ -42027,8 +41745,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bNp" = (
@@ -42063,8 +41780,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bNs" = (
@@ -42141,8 +41857,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
 "bNz" = (
@@ -42152,8 +41867,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bNA" = (
@@ -42296,8 +42010,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bNM" = (
@@ -42758,8 +42471,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bOC" = (
@@ -42776,8 +42488,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/reception)
 "bOE" = (
@@ -42803,8 +42514,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/reception)
 "bOG" = (
@@ -42934,8 +42644,7 @@
 	pixel_y = -4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bOS" = (
@@ -42955,8 +42664,7 @@
 	pixel_x = 27
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bOU" = (
@@ -42964,8 +42672,7 @@
 /area/medical/chemistry)
 "bOV" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bOW" = (
@@ -43037,8 +42744,7 @@
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/paramedic)
 "bPf" = (
@@ -43052,8 +42758,7 @@
 /obj/item/clothing/glasses/hud/health,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/paramedic)
 "bPg" = (
@@ -43071,8 +42776,7 @@
 /obj/item/clothing/mask/muzzle,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bPh" = (
@@ -43101,8 +42805,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bPi" = (
@@ -43164,8 +42867,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bPn" = (
@@ -43316,8 +43018,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/lab)
 "bPE" = (
@@ -43325,12 +43026,9 @@
 /obj/item/paper_bin/nanotrasen,
 /obj/item/book/manual/sop_science,
 /obj/item/paper_bin/nanotrasen,
-/obj/effect/turf_decal/siding{
-	color = "#3E3E3E"
-	},
 /obj/item/pen/multi,
 /obj/item/lighter/zippo/rd,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/carpet/purple,
 /area/crew_quarters/hor)
 "bPF" = (
 /obj/structure/chair/stool,
@@ -43394,8 +43092,7 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 2;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2"
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -43408,8 +43105,7 @@
 	req_access_txt = "28"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bPO" = (
@@ -43759,8 +43455,7 @@
 	name = "Shower"
 	},
 /obj/machinery/shower{
-	dir = 4;
-	tag = "icon-shower (EAST)"
+	dir = 4
 	},
 /obj/item/soap/deluxe,
 /obj/item/bikehorn/rubberducky,
@@ -43806,15 +43501,13 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bQC" = (
 /obj/structure/closet/secure_closet/medical3,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bQD" = (
@@ -43843,8 +43536,7 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bQF" = (
@@ -43959,8 +43651,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/paramedic)
 "bQQ" = (
@@ -43976,8 +43667,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bQS" = (
@@ -43999,8 +43689,7 @@
 /obj/item/storage/belt/medical,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bQU" = (
@@ -44073,8 +43762,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bRc" = (
@@ -44099,8 +43787,7 @@
 	pixel_y = -3
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bRd" = (
@@ -44645,8 +44332,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "bSp" = (
@@ -44681,8 +44367,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bSr" = (
@@ -44690,15 +44375,13 @@
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "bSs" = (
 /obj/machinery/vending/medical,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bSt" = (
@@ -44741,8 +44424,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "bSw" = (
@@ -44977,8 +44659,7 @@
 /obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "bSP" = (
@@ -45012,8 +44693,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "bSS" = (
@@ -45028,8 +44708,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "bST" = (
@@ -45063,8 +44742,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "bSW" = (
@@ -45203,8 +44881,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "bTi" = (
@@ -45440,8 +45117,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/paramedic)
 "bTJ" = (
@@ -45459,8 +45135,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/paramedic)
 "bTM" = (
@@ -45476,8 +45151,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bTN" = (
@@ -45513,8 +45187,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
 "bTR" = (
@@ -45548,8 +45221,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bTV" = (
@@ -45779,8 +45451,7 @@
 	},
 /obj/structure/table/tray,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/surgery/north)
 "bUv" = (
@@ -45987,8 +45658,7 @@
 	},
 /obj/item/reagent_containers/iv_bag/salglu,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "bUN" = (
@@ -46753,8 +46423,7 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "bWi" = (
@@ -46814,8 +46483,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "bWn" = (
@@ -46845,8 +46513,7 @@
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "bWp" = (
@@ -46916,8 +46583,7 @@
 /obj/structure/table,
 /obj/item/soap/nanotrasen,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "bWt" = (
@@ -46958,8 +46624,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "bWy" = (
@@ -47093,8 +46758,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "ramptop";
-	tag = "icon-stage_stairs"
+	icon_state = "ramptop"
 	},
 /area/escapepodbay)
 "bWS" = (
@@ -47155,8 +46819,7 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "bWY" = (
@@ -47344,8 +47007,7 @@
 /obj/machinery/disposal,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/genetics)
 "bXt" = (
@@ -47388,8 +47050,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (EAST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/genetics)
 "bXw" = (
@@ -47443,8 +47104,7 @@
 "bXA" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "bXB" = (
@@ -47477,8 +47137,7 @@
 /obj/item/roller,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "bXF" = (
@@ -47491,16 +47150,14 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "bXG" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "bXH" = (
@@ -47520,8 +47177,7 @@
 /obj/machinery/vending/medical,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "bXJ" = (
@@ -47564,8 +47220,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "bXK" = (
@@ -47626,8 +47281,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "bXQ" = (
@@ -47638,8 +47292,7 @@
 "bXR" = (
 /obj/structure/closet/walllocker/emerglocker/east,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "bXS" = (
@@ -47695,8 +47348,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/genetics)
 "bXW" = (
@@ -47804,8 +47456,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "bYe" = (
@@ -47838,7 +47489,7 @@
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
 	dir = 2;
-	icon_state = "shutter0";
+	icon_state = "open";
 	id_tag = "rdprivacy";
 	name = "Research Director Office Shutters";
 	opacity = 0
@@ -47852,8 +47503,7 @@
 "bYi" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bYj" = (
@@ -47869,8 +47519,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (EAST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/genetics)
 "bYl" = (
@@ -47943,8 +47592,7 @@
 /obj/item/bedsheet/medical,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "bYu" = (
@@ -47964,8 +47612,7 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bYw" = (
@@ -48019,8 +47666,7 @@
 /obj/item/roller,
 /obj/item/soap/nanotrasen,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "bYD" = (
@@ -48336,15 +47982,13 @@
 "bZh" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/sleeper)
 "bZi" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/sleeper)
 "bZj" = (
@@ -48359,8 +48003,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "bZk" = (
@@ -48380,8 +48023,7 @@
 	},
 /obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/junction{
-	dir = 1;
-	tag = "icon-pipe-j1 (EAST)"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -48393,8 +48035,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "bZn" = (
@@ -48576,8 +48217,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurplefull";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurplefull"
 	},
 /area/medical/genetics)
 "bZC" = (
@@ -48605,8 +48245,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 8;
-	tag = "icon-pipe-j1 (EAST)"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -48632,8 +48271,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay2)
 "bZF" = (
@@ -48746,8 +48384,7 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 8;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j1 (WEST)"
+	icon_state = "pipe-j2"
 	},
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -48878,8 +48515,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 8;
-	tag = "icon-pipe-j1 (EAST)"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -48933,13 +48569,13 @@
 	pixel_x = -3
 	},
 /obj/item/paicard,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/carpet/purple,
 /area/crew_quarters/hor)
 "bZU" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	icon_state = "shutter0";
+	icon_state = "open";
 	id_tag = "rdprivacy";
 	name = "Research Director Office Shutters";
 	opacity = 0
@@ -48955,7 +48591,7 @@
 /obj/structure/sign/cave{
 	pixel_y = 31
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/carpet/purple,
 /area/crew_quarters/hor)
 "bZW" = (
 /obj/structure/table/glass,
@@ -49119,8 +48755,7 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "cao" = (
@@ -49211,8 +48846,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "caA" = (
@@ -49244,7 +48878,7 @@
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
 	dir = 2;
-	icon_state = "shutter0";
+	icon_state = "open";
 	id_tag = "rdprivacy";
 	name = "Research Director Office Shutters";
 	opacity = 0
@@ -49330,8 +48964,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "caI" = (
@@ -49530,8 +49163,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (SOUTHWEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/genetics)
 "caX" = (
@@ -49539,8 +49171,7 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurplefull";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurplefull"
 	},
 /area/medical/genetics)
 "caY" = (
@@ -49552,8 +49183,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (SOUTHEAST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/genetics)
 "caZ" = (
@@ -49567,8 +49197,7 @@
 /obj/structure/cable,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurplefull";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurplefull"
 	},
 /area/medical/genetics)
 "cba" = (
@@ -49725,13 +49354,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/carpet/purple,
 /area/crew_quarters/hor)
 "cbq" = (
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/carpet/purple,
 /area/crew_quarters/hor)
 "cbr" = (
 /obj/machinery/door/firedoor,
@@ -49748,8 +49377,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "cbs" = (
@@ -49791,8 +49419,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay2)
 "cbv" = (
@@ -49801,8 +49428,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "cbw" = (
@@ -49817,8 +49443,7 @@
 	req_access_txt = "5"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "cbz" = (
@@ -49923,15 +49548,13 @@
 "cbO" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "cbP" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "cbQ" = (
@@ -49968,8 +49591,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "cbU" = (
@@ -49986,8 +49608,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "cbW" = (
@@ -50062,8 +49683,7 @@
 /obj/machinery/iv_drip,
 /obj/item/reagent_containers/iv_bag/salglu,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "ccb" = (
@@ -50242,8 +49862,7 @@
 	},
 /obj/item/reagent_containers/iv_bag/salglu,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/surgery/north)
 "ccm" = (
@@ -50307,8 +49926,7 @@
 /obj/structure/cable,
 /obj/item/roller,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "ccr" = (
@@ -50318,7 +49936,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/carpet/purple,
 /area/crew_quarters/hor)
 "ccs" = (
 /obj/machinery/sleeper{
@@ -50329,8 +49947,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "cct" = (
@@ -50343,14 +49960,12 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "ccu" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "ccv" = (
@@ -50364,8 +49979,7 @@
 /obj/machinery/bodyscanner,
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "ccx" = (
@@ -50468,8 +50082,7 @@
 /obj/machinery/vending/medical,
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay2)
 "ccD" = (
@@ -50491,8 +50104,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "ccF" = (
@@ -50636,8 +50248,7 @@
 "ccQ" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/genetics)
 "ccR" = (
@@ -50663,8 +50274,7 @@
 "ccT" = (
 /obj/machinery/r_n_d/server/robotics,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6;
-	tag = "icon-intact (SOUTHEAST)"
+	dir = 6
 	},
 /turf/simulated/floor/bluegrid/telecomms/server,
 /area/toxins/server)
@@ -50753,8 +50363,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	tag = "icon-vault"
+	icon_state = "vault"
 	},
 /area/engine/gravitygenerator)
 "cdb" = (
@@ -50779,7 +50388,7 @@
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	icon_state = "shutter0";
+	icon_state = "open";
 	id_tag = "rdprivacy";
 	name = "Research Director Office Shutters";
 	opacity = 0
@@ -50815,7 +50424,7 @@
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	icon_state = "shutter0";
+	icon_state = "open";
 	id_tag = "rdprivacy";
 	name = "Research Director Office Shutters";
 	opacity = 0
@@ -50832,8 +50441,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "cdi" = (
@@ -51054,7 +50662,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/carpet/purple,
 /area/crew_quarters/hor)
 "cdN" = (
 /turf/simulated/floor/plasteel,
@@ -51217,8 +50825,7 @@
 "ceh" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "cei" = (
@@ -51236,8 +50843,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "cej" = (
@@ -51490,16 +51096,13 @@
 	},
 /area/medical/research)
 "ceO" = (
-/obj/effect/turf_decal/siding{
-	color = "#3E3E3E"
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	name = "standard air scrubber";
 	on = 1;
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/carpet/purple,
 /area/crew_quarters/hor)
 "ceP" = (
 /obj/machinery/light_switch{
@@ -51519,7 +51122,8 @@
 	},
 /obj/machinery/suit_storage_unit/rd/secure,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkpurple";
+	dir = 5
 	},
 /area/crew_quarters/hor)
 "ceT" = (
@@ -51805,8 +51409,7 @@
 /obj/structure/table/glass,
 /obj/item/storage/toolbox/surgery,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/surgery/north)
 "cfy" = (
@@ -51831,8 +51434,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/surgery/north)
 "cfB" = (
@@ -51849,8 +51451,7 @@
 	},
 /obj/item/reagent_containers/iv_bag/salglu,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/medical/surgery/south)
 "cfD" = (
@@ -51936,16 +51537,14 @@
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/surgery/south)
 "cfL" = (
 /obj/structure/table/glass,
 /obj/item/storage/toolbox/surgery,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/medical/surgery/south)
 "cfM" = (
@@ -51958,8 +51557,7 @@
 	},
 /obj/structure/table/tray,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/medical/surgery/south)
 "cfN" = (
@@ -52028,8 +51626,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay2)
 "cfR" = (
@@ -52199,8 +51796,7 @@
 "cgc" = (
 /obj/machinery/r_n_d/server/core,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5;
-	tag = "icon-intact (NORTHEAST)"
+	dir = 5
 	},
 /turf/simulated/floor/bluegrid/telecomms/server,
 /area/toxins/server)
@@ -52268,8 +51864,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 4;
-	tag = "icon-pipe-j1 (EAST)"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -52404,7 +51999,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkpurple"
 	},
 /area/crew_quarters/hor)
 "cgr" = (
@@ -52440,7 +52035,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkpurple";
+	dir = 6
 	},
 /area/crew_quarters/hor)
 "cgy" = (
@@ -52785,8 +52381,7 @@
 "chl" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/surgery/north)
 "chm" = (
@@ -52840,8 +52435,7 @@
 "chq" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/surgery/south)
 "chr" = (
@@ -52936,8 +52530,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "chy" = (
@@ -52988,8 +52581,7 @@
 /area/medical/cmo)
 "chC" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/medical/medbreak)
 "chD" = (
@@ -53156,7 +52748,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkpurple";
+	dir = 9
 	},
 /area/crew_quarters/hor)
 "chQ" = (
@@ -53181,8 +52774,7 @@
 	req_access_txt = "30"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/hor)
 "chR" = (
@@ -53193,7 +52785,8 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkpurple";
+	dir = 1
 	},
 /area/crew_quarters/hor)
 "chS" = (
@@ -53212,7 +52805,8 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkpurple";
+	dir = 1
 	},
 /area/crew_quarters/hor)
 "chT" = (
@@ -53244,7 +52838,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkpurple";
+	dir = 1
 	},
 /area/crew_quarters/hor)
 "chW" = (
@@ -53252,7 +52847,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkpurple";
+	dir = 1
 	},
 /area/crew_quarters/hor)
 "chX" = (
@@ -53612,8 +53208,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "ciU" = (
@@ -53631,8 +53226,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "ciV" = (
@@ -53906,8 +53500,7 @@
 /obj/item/clothing/under/rank/medical/green,
 /obj/item/clothing/under/rank/medical/purple,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/medical/medbreak)
 "cjw" = (
@@ -53940,8 +53533,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/surgery/north)
 "cjy" = (
@@ -53999,8 +53591,7 @@
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 1;
-	tag = "icon-pipe-j1 (EAST)"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -54092,8 +53683,7 @@
 /area/toxins/explab_chamber)
 "cjH" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
-	dir = 8;
-	tag = "icon-intact (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/bluegrid/telecomms/server,
 /area/toxins/server)
@@ -54164,7 +53754,8 @@
 	},
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkpurple";
+	dir = 10
 	},
 /area/crew_quarters/hor)
 "cjP" = (
@@ -54185,7 +53776,7 @@
 /obj/item/clothing/glasses/welding/superior,
 /obj/structure/table/glass,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkpurple"
 	},
 /area/crew_quarters/hor)
 "cjQ" = (
@@ -54197,7 +53788,7 @@
 	},
 /obj/structure/table/glass,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkpurple"
 	},
 /area/crew_quarters/hor)
 "cjR" = (
@@ -54212,7 +53803,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkpurple"
 	},
 /area/crew_quarters/hor)
 "cjV" = (
@@ -54367,8 +53958,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/surgery/south)
 "cks" = (
@@ -54455,8 +54045,7 @@
 /obj/structure/closet/walllocker/emerglocker/west,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "ckC" = (
@@ -54469,8 +54058,7 @@
 /obj/item/screwdriver,
 /obj/item/reagent_containers/food/drinks/britcup,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/medical/medbreak)
 "ckE" = (
@@ -54487,8 +54075,7 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/medical/medbreak)
 "ckF" = (
@@ -54506,8 +54093,7 @@
 	c_tag = "Medbay Break Room"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/medical/medbreak)
 "ckG" = (
@@ -54641,16 +54227,14 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/surgery/north)
 "ckV" = (
 /obj/machinery/bodyscanner,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/surgery/north)
 "ckW" = (
@@ -54661,15 +54245,13 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/surgery/north)
 "ckX" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/surgery/north)
 "ckY" = (
@@ -54736,16 +54318,14 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/surgery/south)
 "cld" = (
 /obj/structure/closet/secure_closet/medical2,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/surgery/south)
 "cle" = (
@@ -54765,8 +54345,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/surgery/south)
 "clf" = (
@@ -54781,8 +54360,7 @@
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/surgery/south)
 "clg" = (
@@ -54808,8 +54386,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "cli" = (
@@ -54820,8 +54397,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/medical/medbreak)
 "clj" = (
@@ -54841,8 +54417,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/medical/medbreak)
 "cll" = (
@@ -54852,8 +54427,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/medical/medbreak)
 "clm" = (
@@ -55302,8 +54876,7 @@
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (NORTHWEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology)
 "cmo" = (
@@ -55314,8 +54887,7 @@
 /obj/machinery/vending/medical,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (NORTHEAST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology)
 "cmq" = (
@@ -55377,8 +54949,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/medical/medbreak)
 "cmt" = (
@@ -55398,8 +54969,7 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/medical/medbreak)
 "cmv" = (
@@ -55415,8 +54985,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/medical/medbreak)
 "cmw" = (
@@ -55425,8 +54994,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/medical/medbreak)
 "cmx" = (
@@ -55483,8 +55051,7 @@
 "cmD" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/medical/medbreak)
 "cmE" = (
@@ -55554,8 +55121,7 @@
 /obj/item/reagent_containers/iv_bag/salglu,
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (SOUTHWEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology)
 "cmP" = (
@@ -55695,37 +55261,13 @@
 	},
 /area/toxins/mixing)
 "cnc" = (
-/obj/structure/grille,
-/obj/structure/window/plasmareinforced{
-	dir = 8
-	},
-/obj/structure/window/plasmareinforced,
-/obj/structure/window/plasmareinforced{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/machinery/meter,
+/obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
 "cnd" = (
-/obj/structure/grille,
-/obj/structure/window/plasmareinforced,
-/obj/structure/window/plasmareinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/toxins/mixing)
-"cne" = (
-/obj/structure/grille,
-/obj/structure/window/plasmareinforced{
-	dir = 4
-	},
-/obj/structure/window/plasmareinforced,
-/obj/structure/window/plasmareinforced{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/machinery/meter,
+/obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
 "cnf" = (
@@ -55871,8 +55413,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology)
 "cnA" = (
@@ -55890,8 +55431,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology)
 "cnC" = (
@@ -55916,8 +55456,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology)
 "cnE" = (
@@ -55933,8 +55472,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology)
 "cnG" = (
@@ -55962,16 +55500,14 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology)
 "cnJ" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology)
 "cnK" = (
@@ -55983,8 +55519,7 @@
 "cnL" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "cnM" = (
@@ -55997,8 +55532,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/medbay2)
 "cnN" = (
@@ -56011,29 +55545,25 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/medical/medbreak)
 "cnO" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/medical/medbreak)
 "cnP" = (
 /obj/machinery/vending/chinese,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/medical/medbreak)
 "cnQ" = (
 /obj/machinery/computer/med_data,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/medical/medbreak)
 "cnR" = (
@@ -56043,8 +55573,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/medical/medbreak)
 "cnS" = (
@@ -56166,8 +55695,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreen";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology)
 "cob" = (
@@ -56195,8 +55723,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreen";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology)
 "cod" = (
@@ -56229,8 +55756,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreen";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology)
 "cog" = (
@@ -56370,8 +55896,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "cov" = (
@@ -56518,16 +56043,6 @@
 	},
 /area/blueshield)
 "coI" = (
-/obj/structure/grille,
-/obj/structure/window/plasmareinforced{
-	dir = 4
-	},
-/obj/structure/window/plasmareinforced{
-	dir = 8
-	},
-/obj/structure/window/plasmareinforced{
-	dir = 1
-	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "open";
@@ -56535,10 +56050,12 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
+/obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
 /area/toxins/launch)
 "coJ" = (
 /obj/effect/decal/warning_stripes/southwest,
+/obj/machinery/light,
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "coK" = (
@@ -56689,8 +56206,7 @@
 	step_size = 0
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreen";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology)
 "cpc" = (
@@ -56714,8 +56230,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreen";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology)
 "cpd" = (
@@ -56735,8 +56250,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreen";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology)
 "cpe" = (
@@ -56760,8 +56274,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreen";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology)
 "cpf" = (
@@ -56804,13 +56317,11 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 8;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j1 (WEST)"
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/medbay2)
 "cpi" = (
@@ -56877,8 +56388,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/surgery/north)
 "cpo" = (
@@ -56894,8 +56404,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/surgery/south)
 "cpp" = (
@@ -57039,8 +56548,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (SOUTHEAST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology)
 "cpB" = (
@@ -57157,16 +56665,14 @@
 /obj/machinery/computer/pandemic,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cpM" = (
 /obj/machinery/smartfridge/secure/chemistry/virology,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (NORTHWEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cpN" = (
@@ -57180,8 +56686,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (NORTHEAST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cpO" = (
@@ -57192,8 +56697,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cpP" = (
@@ -57206,7 +56710,6 @@
 /obj/machinery/door/airlock/medical{
 	autoclose = 0;
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "viro_lab_airlock_exterior";
 	locked = 1;
 	name = "Virology Lab External Airlock";
@@ -57252,8 +56755,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "cpT" = (
@@ -57277,8 +56779,7 @@
 /obj/structure/closet/radiation,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTHWEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/explab)
 "cpV" = (
@@ -57287,16 +56788,14 @@
 /obj/item/book/manual/experimentor,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTHEAST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/explab)
 "cpW" = (
 /obj/machinery/computer/rdconsole/experiment,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/explab)
 "cpX" = (
@@ -57323,8 +56822,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTHEAST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/explab)
 "cpZ" = (
@@ -57714,23 +57212,6 @@
 /obj/structure/table,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
-"cqC" = (
-/obj/structure/grille,
-/obj/structure/window/plasmareinforced{
-	dir = 4
-	},
-/obj/structure/window/plasmareinforced{
-	dir = 8
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/toxins/launch)
 "cqE" = (
 /obj/structure/sink{
 	dir = 8;
@@ -57749,8 +57230,7 @@
 /area/maintenance/apmaint)
 "cqG" = (
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -57820,8 +57300,7 @@
 "cqN" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreen";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cqO" = (
@@ -58043,8 +57522,7 @@
 /obj/structure/closet/l3closet/scientist,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTHWEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/explab)
 "cri" = (
@@ -58088,8 +57566,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "crn" = (
@@ -58127,8 +57604,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (NORTHWEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "crq" = (
@@ -58145,8 +57621,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "crs" = (
@@ -58177,8 +57652,7 @@
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (EAST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "crv" = (
@@ -58244,8 +57718,7 @@
 "crA" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "crB" = (
@@ -58526,8 +57999,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "csb" = (
@@ -58542,8 +58014,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/medical/medbreak)
 "csc" = (
@@ -58700,23 +58171,8 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
 "csr" = (
-/obj/structure/grille,
-/obj/structure/window/plasmareinforced{
-	dir = 4
-	},
-/obj/structure/window/plasmareinforced{
-	dir = 8
-	},
-/obj/structure/window/plasmareinforced,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/toxins/launch)
+/turf/simulated/wall/r_wall,
+/area/medical/research/restroom)
 "css" = (
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel/airless,
@@ -59014,8 +58470,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "csT" = (
@@ -59185,7 +58640,6 @@
 /obj/machinery/door/airlock/medical{
 	autoclose = 0;
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "viro_lab_airlock_interior";
 	locked = 1;
 	name = "Virology Lab Internal Airlock";
@@ -59417,8 +58871,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/medical/medbreak)
 "ctA" = (
@@ -59566,29 +59019,14 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
-/turf/simulated/floor/plating,
-/area/toxins/launch)
-"ctP" = (
-/obj/structure/grille,
-/obj/structure/window/plasmareinforced{
-	dir = 4
-	},
 /obj/structure/window/plasmareinforced{
 	dir = 8
 	},
-/obj/structure/window/plasmareinforced,
-/obj/structure/window/plasmareinforced{
-	dir = 1
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
 /turf/simulated/floor/plating,
 /area/toxins/launch)
+"ctP" = (
+/turf/simulated/wall/r_wall/coated,
+/area/toxins/misc_lab)
 "ctQ" = (
 /obj/machinery/door/window/southright{
 	name = "Toxins Launcher";
@@ -59621,8 +59059,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/junction{
 	dir = 2;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2"
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
@@ -59711,8 +59148,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cue" = (
@@ -59729,8 +59165,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitegreenfull"
 	},
 /area/medical/virology/lab)
 "cug" = (
@@ -59744,8 +59179,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (SOUTHWEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cuh" = (
@@ -59754,8 +59188,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreen";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cui" = (
@@ -59771,8 +59204,7 @@
 /area/engine/controlroom)
 "cuj" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreen";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cuk" = (
@@ -59795,8 +59227,7 @@
 /obj/item/reagent_containers/dropper/precision,
 /obj/item/reagent_containers/spray/cleaner,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreen";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cum" = (
@@ -59826,8 +59257,7 @@
 /obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (SOUTHEAST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cuo" = (
@@ -59848,8 +59278,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreen";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cuq" = (
@@ -59915,8 +59344,7 @@
 /area/engine/equipmentstorage)
 "cuv" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "cuw" = (
@@ -59970,8 +59398,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology)
 "cuC" = (
@@ -60014,8 +59441,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (SOUTHWEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cuG" = (
@@ -60025,8 +59451,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology)
 "cuI" = (
@@ -60036,8 +59461,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreen";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cuJ" = (
@@ -60358,6 +59782,12 @@
 "cvh" = (
 /obj/item/radio/beacon,
 /obj/effect/decal/warning_stripes/red/hollow,
+/obj/machinery/camera{
+	armor = list("melee"=50,"bullet"=20,"laser"=20,"energy"=20,"bomb"=100,"bio"=0,"rad"=0,"fire"=90,"acid"=50);
+	c_tag = "Research Toxins Test Chamber West";
+	dir = 8;
+	network = list("Toxins","Research","SS13")
+	},
 /turf/simulated/floor/plasteel/airless/indestructible,
 /area/toxins/test_area)
 "cvi" = (
@@ -60640,8 +60070,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitegreenfull"
 	},
 /area/medical/virology/lab)
 "cvP" = (
@@ -60760,16 +60189,14 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (NORTHWEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cwb" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (NORTHEAST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cwc" = (
@@ -60784,8 +60211,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cwd" = (
@@ -60808,8 +60234,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (NORTHEAST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cwf" = (
@@ -60821,8 +60246,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cwg" = (
@@ -60834,8 +60258,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (NORTHWEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cwh" = (
@@ -60851,8 +60274,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitegreenfull"
 	},
 /area/medical/virology/lab)
 "cwi" = (
@@ -60862,8 +60284,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (NORTHEAST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cwj" = (
@@ -61364,8 +60785,7 @@
 	req_access_txt = "5"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/medical/medbay2)
 "cxk" = (
@@ -61441,8 +60861,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitegreenfull"
 	},
 /area/medical/virology/lab)
 "cxt" = (
@@ -61452,8 +60871,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cxu" = (
@@ -61463,8 +60881,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (EAST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cxv" = (
@@ -61482,8 +60899,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cxx" = (
@@ -61495,8 +60911,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (EAST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cxy" = (
@@ -61578,22 +60993,19 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (SOUTHWEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cxG" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (SOUTHEAST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cxH" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitegreenfull"
 	},
 /area/medical/virology/lab)
 "cxI" = (
@@ -61637,8 +61049,7 @@
 /obj/machinery/computer/med_data/laptop,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (EAST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cxM" = (
@@ -61668,8 +61079,7 @@
 "cxP" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitegreenfull"
 	},
 /area/medical/virology/lab)
 "cxQ" = (
@@ -61758,7 +61168,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/toxins/xenobiology)
+/area/medical/research)
 "cxX" = (
 /obj/machinery/atmospherics/unary/outlet_injector/on{
 	dir = 4
@@ -62039,7 +61449,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/toxins/xenobiology)
+/area/medical/research)
 "cyC" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -62053,15 +61463,14 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 1;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2"
+	icon_state = "pipe-j2"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/toxins/xenobiology)
+/area/medical/research)
 "cyD" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -62201,7 +61610,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/toxins/xenobiology)
+/area/medical/research)
 "cyU" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/extinguisher_cabinet{
@@ -62210,8 +61619,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreen";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cyV" = (
@@ -62238,8 +61646,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (SOUTHWEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cyW" = (
@@ -62253,24 +61660,21 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (SOUTHEAST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cyX" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreen";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cyY" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (SOUTHWEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cyZ" = (
@@ -62285,8 +61689,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (SOUTHEAST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "czb" = (
@@ -62594,8 +61997,7 @@
 	},
 /mob/living/carbon/human/lesser/monkey,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitegreenfull"
 	},
 /area/medical/virology/lab)
 "czH" = (
@@ -62622,8 +62024,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "czJ" = (
@@ -62854,10 +62255,9 @@
 "cAf" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreen";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whitegreen"
 	},
-/area/toxins/xenobiology)
+/area/medical/research)
 "cAg" = (
 /obj/machinery/computer/atmos_alert,
 /turf/simulated/floor/plasteel{
@@ -62885,10 +62285,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreen";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whitegreen"
 	},
-/area/toxins/xenobiology)
+/area/medical/research)
 "cAj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
@@ -62966,8 +62365,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitegreenfull"
 	},
 /area/medical/virology/lab)
 "cAr" = (
@@ -62980,8 +62378,7 @@
 	},
 /mob/living/carbon/human/lesser/monkey,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitegreenfull"
 	},
 /area/medical/virology/lab)
 "cAs" = (
@@ -63003,8 +62400,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay2)
 "cAt" = (
@@ -63023,8 +62419,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay2)
 "cAu" = (
@@ -63096,9 +62491,17 @@
 	},
 /area/maintenance/asmaint)
 "cAD" = (
-/obj/structure/sign/securearea,
-/turf/simulated/wall/r_wall,
-/area/toxins/xenobiology)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/scientist,
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/medical/research/restroom)
 "cAE" = (
 /obj/structure/closet,
 /obj/item/card/id,
@@ -63280,8 +62683,7 @@
 	},
 /mob/living/carbon/human/lesser/monkey,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitegreenfull"
 	},
 /area/medical/virology/lab)
 "cAZ" = (
@@ -63592,7 +62994,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/toxins/xenobiology)
+/area/medical/research)
 "cBB" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
@@ -63604,8 +63006,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/toxins/misc_lab)
 "cBD" = (
@@ -63719,7 +63120,7 @@
 "cBS" = (
 /obj/structure/sign/biohazard,
 /turf/simulated/wall/r_wall,
-/area/toxins/xenobiology)
+/area/medical/research)
 "cBT" = (
 /obj/structure/chair{
 	dir = 1
@@ -63831,7 +63232,7 @@
 	name = "west light switch";
 	pixel_x = -24
 	},
-/obj/structure/rack,
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -63850,7 +63251,13 @@
 	c_tag = "Research Test Lab West";
 	network = list("Research","SS13")
 	},
-/obj/structure/table,
+/obj/structure/rack,
+/obj/item/storage/bag/chemistry,
+/obj/item/storage/bag/chemistry,
+/obj/item/storage/bag/chemistry,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -63909,8 +63316,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/toxins/misc_lab)
 "cCk" = (
@@ -63920,8 +63326,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/toxins/misc_lab)
 "cCl" = (
@@ -63934,8 +63339,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/toxins/misc_lab)
 "cCm" = (
@@ -63946,16 +63350,14 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/toxins/misc_lab)
 "cCn" = (
 /obj/machinery/chem_heater,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/toxins/misc_lab)
 "cCo" = (
@@ -64046,7 +63448,6 @@
 	autoclose = 0;
 	frequency = 1449;
 	heat_proof = 1;
-	icon_state = "door_locked";
 	id_tag = "incinerator_airlock_exterior";
 	locked = 1;
 	name = "Mixing Room Exterior Airlock";
@@ -64066,7 +63467,6 @@
 	autoclose = 0;
 	frequency = 1449;
 	heat_proof = 1;
-	icon_state = "door_locked";
 	id_tag = "incinerator_airlock_interior";
 	locked = 1;
 	name = "Mixing Room Interior Airlock";
@@ -64344,10 +63744,15 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/toxins/xenobiology)
+/area/medical/research)
 "cCV" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -64598,7 +64003,7 @@
 "cDq" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/toxins/xenobiology)
+/area/medical/research/restroom)
 "cDr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -64628,8 +64033,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/toxins/misc_lab)
 "cDu" = (
@@ -64653,7 +64057,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/toxins/xenobiology)
+/area/medical/research)
 "cDw" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -64680,7 +64084,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/toxins/xenobiology)
+/area/medical/research)
 "cDz" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Access";
@@ -64732,8 +64136,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/toxins/misc_lab)
 "cDE" = (
@@ -64750,15 +64153,13 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/toxins/misc_lab)
 "cDG" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/toxins/misc_lab)
 "cDH" = (
@@ -64766,8 +64167,7 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/toxins/misc_lab)
 "cDI" = (
@@ -65047,12 +64447,8 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/toxins/xenobiology)
+/area/medical/research)
 "cEl" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/machinery/light,
 /obj/effect/decal/warning_stripes/southwestcorner,
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -65065,7 +64461,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/toxins/xenobiology)
+/area/medical/research)
 "cEm" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -65082,7 +64478,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/toxins/xenobiology)
+/area/medical/research)
 "cEn" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -65385,8 +64781,7 @@
 /obj/machinery/chem_master,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/toxins/misc_lab)
 "cFc" = (
@@ -65564,8 +64959,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cFy" = (
@@ -65578,8 +64972,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (EAST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cFz" = (
@@ -65591,8 +64984,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitegreenfull"
 	},
 /area/medical/virology/lab)
 "cFA" = (
@@ -65632,7 +65024,6 @@
 /obj/machinery/door/airlock/research{
 	autoclose = 0;
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "xeno_airlock_exterior";
 	locked = 1;
 	name = "Xenobiology External Airlock";
@@ -65643,7 +65034,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/toxins/xenobiology)
+/area/medical/research)
 "cFE" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -65882,8 +65273,7 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/toxins/misc_lab)
 "cFV" = (
@@ -65905,8 +65295,7 @@
 /obj/structure/closet/secure_closet/research_reagents,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/toxins/misc_lab)
 "cFZ" = (
@@ -65927,8 +65316,7 @@
 /obj/item/storage/box/pillbottles,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/toxins/misc_lab)
 "cGa" = (
@@ -65942,8 +65330,7 @@
 /obj/item/reagent_containers/dropper/precision,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/toxins/misc_lab)
 "cGb" = (
@@ -65964,8 +65351,7 @@
 /obj/machinery/reagentgrinder,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/toxins/misc_lab)
 "cGg" = (
@@ -66046,8 +65432,7 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 8;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j1 (WEST)"
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
@@ -66160,8 +65545,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cGx" = (
@@ -66177,8 +65561,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cGy" = (
@@ -66191,8 +65574,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (EAST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cGz" = (
@@ -66212,7 +65594,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/toxins/xenobiology)
+/area/medical/research)
 "cGA" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
@@ -66223,7 +65605,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/toxins/xenobiology)
+/area/medical/research)
 "cGB" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -66238,7 +65620,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/toxins/xenobiology)
+/area/medical/research)
 "cGC" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -66645,20 +66027,11 @@
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cHn" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/gas{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas{
-	pixel_x = -2;
-	pixel_y = -2
-	},
 /obj/item/radio/intercom{
 	name = "south station intercom (General)";
 	pixel_y = -28
 	},
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -66764,10 +66137,6 @@
 /area/atmos/control)
 "cHz" = (
 /obj/structure/closet/l3closet/scientist,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -66775,7 +66144,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/toxins/xenobiology)
+/area/medical/research)
 "cHA" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -66787,7 +66156,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/toxins/xenobiology)
+/area/medical/research)
 "cHB" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -66832,7 +66201,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
-	icon_state = "door_locked";
 	locked = 1;
 	name = "Assembly Line Maintenance";
 	req_access_txt = "32"
@@ -67039,8 +66407,7 @@
 "cHW" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology)
 "cHX" = (
@@ -67184,8 +66551,7 @@
 /area/engine/break_room)
 "cIj" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/maintenance/asmaint)
 "cIk" = (
@@ -67195,8 +66561,7 @@
 "cIl" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/maintenance/asmaint)
 "cIm" = (
@@ -67366,7 +66731,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/toxins/xenobiology)
+/area/medical/research)
 "cIC" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -67473,7 +66838,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/toxins/xenobiology)
+/area/medical/research)
 "cIM" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -67498,20 +66863,19 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/toxins/xenobiology)
+/area/medical/research)
 "cIO" = (
 /obj/structure/sign/securearea{
 	pixel_x = -32
 	},
 /obj/machinery/shower{
-	dir = 4;
-	tag = "icon-shower (EAST)"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/toxins/xenobiology)
+/area/medical/research)
 "cIP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -67657,20 +67021,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "xeno_airlock_control";
-	name = "Xenobiology Access Button";
-	pixel_x = -28;
-	pixel_y = 8;
-	req_access_txt = "55"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
 	autoclose = 0;
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "xeno_airlock_interior";
 	locked = 1;
 	name = "Xenobiology Internal Airlock";
@@ -67678,10 +67032,18 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1379;
+	master_tag = "xeno_airlock_control";
+	name = "Xenobiology Access Button";
+	pixel_x = -24;
+	req_access_txt = "55"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/toxins/xenobiology)
+/area/medical/research)
 "cJf" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -67717,7 +67079,6 @@
 "cJj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
-	icon_state = "door_locked";
 	locked = 1;
 	name = "Assembly Line (KEEP OUT)";
 	req_access_txt = "32"
@@ -67840,8 +67201,7 @@
 /area/toxins/xenobiology)
 "cJs" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/maintenance/asmaint)
 "cJt" = (
@@ -67853,8 +67213,7 @@
 /area/maintenance/asmaint)
 "cJv" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/maintenance/asmaint)
 "cJw" = (
@@ -68108,7 +67467,7 @@
 /area/toxins/misc_lab)
 "cJP" = (
 /obj/structure/disposalpipe/segment,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_wall/coated,
 /area/toxins/misc_lab)
 "cJQ" = (
 /obj/structure/closet,
@@ -68123,15 +67482,8 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
-/obj/structure/grille,
-/obj/structure/window/plasmareinforced,
-/obj/structure/window/plasmareinforced{
-	dir = 4
-	},
-/obj/structure/window/plasmareinforced{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/engine,
 /area/toxins/misc_lab)
 "cJS" = (
@@ -68152,14 +67504,7 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
-/obj/structure/grille,
-/obj/structure/window/plasmareinforced,
-/obj/structure/window/plasmareinforced{
-	dir = 8
-	},
-/obj/structure/window/plasmareinforced{
-	dir = 1
-	},
+/obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/engine,
 /area/toxins/misc_lab)
 "cJU" = (
@@ -68438,14 +67783,13 @@
 	tag_exterior_door = "xeno_airlock_exterior";
 	tag_interior_door = "xeno_airlock_interior"
 	},
-/obj/machinery/light_switch{
-	name = "custom light switch";
-	pixel_x = -6;
-	pixel_y = 24
-	},
 /obj/effect/decal/warning_stripes/northeastcorner,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/light_switch{
+	name = "north light switch";
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -68459,19 +67803,16 @@
 /area/maintenance/asmaint)
 "cKv" = (
 /obj/structure/chair/wood/wings{
-	dir = 4;
-	tag = "icon-wooden_chair_wings (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/maintenance/asmaint)
 "cKw" = (
 /obj/structure/chair/wood/wings{
-	dir = 8;
-	tag = "icon-wooden_chair_wings (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/maintenance/asmaint)
 "cKx" = (
@@ -68634,8 +67975,7 @@
 "cKM" = (
 /obj/item/kitchen/utensil/fork,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/maintenance/asmaint)
 "cKN" = (
@@ -68672,8 +68012,7 @@
 /area/toxins/xenobiology)
 "cKS" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/maintenance/asmaint)
 "cKT" = (
@@ -68781,7 +68120,7 @@
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology)
 "cLb" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_wall/coated,
 /area/toxins/test_chamber)
 "cLc" = (
 /obj/machinery/disposal,
@@ -68821,7 +68160,7 @@
 /area/assembly/assembly_line)
 "cLg" = (
 /obj/structure/disposalpipe/segment,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_wall/coated,
 /area/toxins/test_chamber)
 "cLh" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -68927,8 +68266,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engine/mechanic_workshop)
 "cLt" = (
@@ -69213,14 +68551,12 @@
 "cLY" = (
 /obj/item/stack/sheet/wood,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/maintenance/asmaint)
 "cLZ" = (
 /obj/structure/chair/wood/wings{
-	dir = 8;
-	tag = "icon-wooden_chair_wings (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/maintenance/asmaint)
@@ -69244,8 +68580,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/maintenance/asmaint)
 "cMc" = (
@@ -71321,7 +70656,7 @@
 /area/toxins/xenobiology)
 "cQv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/purple,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_wall/coated,
 /area/toxins/test_chamber)
 "cQw" = (
 /obj/structure/closet,
@@ -71677,7 +71012,6 @@
 "cQY" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "engineering_west_inner";
 	locked = 1;
 	name = "Engineering External Access";
@@ -71779,7 +71113,6 @@
 "cRh" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "engineering_east_inner";
 	locked = 1;
 	name = "Engineering External Access";
@@ -72288,8 +71621,7 @@
 "cSc" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5;
-	tag = "icon-intact (NORTHEAST)"
+	dir = 5
 	},
 /turf/space,
 /area/space/nearstation)
@@ -72498,7 +71830,6 @@
 "cSz" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "engineering_west_outer";
 	locked = 1;
 	name = "Engineering External Access";
@@ -72523,7 +71854,6 @@
 "cSB" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "engineering_east_outer";
 	locked = 1;
 	name = "Engineering External Access";
@@ -73199,8 +72529,7 @@
 "cTP" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6;
-	tag = "icon-intact (SOUTHEAST)"
+	dir = 6
 	},
 /turf/space,
 /area/space/nearstation)
@@ -73313,7 +72642,6 @@
 	},
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "robotics_solar_outer";
 	locked = 1;
 	name = "Engineering External Access";
@@ -73354,7 +72682,6 @@
 	},
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "robotics_solar_inner";
 	locked = 1;
 	name = "Engineering External Access";
@@ -74657,8 +73984,7 @@
 /obj/machinery/door/window/southleft{
 	dir = 8;
 	name = "Bar Delivery";
-	req_access_txt = "25";
-	tag = "icon-left (WEST)"
+	req_access_txt = "25"
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -74921,8 +74247,7 @@
 "cXh" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "ramptop";
-	tag = "icon-stage_stairs"
+	icon_state = "ramptop"
 	},
 /area/hallway/primary/starboard/east)
 "cXi" = (
@@ -75668,8 +74993,7 @@
 "cYI" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 5;
-	tag = "icon-intact-y (NORTHWEST)"
+	dir = 5
 	},
 /turf/space,
 /area/space/nearstation)
@@ -76711,8 +76035,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 5;
-	tag = "icon-intact-y (NORTHWEST)"
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -76871,8 +76194,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 5;
-	tag = "icon-intact-y (NORTHWEST)"
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -77376,8 +76698,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 9;
-	tag = "icon-intact-y (NORTHWEST)"
+	dir = 9
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -78492,7 +77813,6 @@
 "dfm" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "atmospherics_south_outer";
 	locked = 1;
 	name = "Atmospherics External Access";
@@ -78565,7 +77885,6 @@
 	},
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "solar_xeno_inner";
 	locked = 1;
 	name = "Engineering External Access";
@@ -78789,7 +78108,6 @@
 	},
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "solar_xeno_outer";
 	locked = 1;
 	name = "Engineering External Access";
@@ -79725,8 +79043,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/aisat_interior)
 "diC" = (
@@ -79734,8 +79051,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/aisat_interior)
 "diD" = (
@@ -79751,8 +79067,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/aisat_interior)
 "diE" = (
@@ -79782,8 +79097,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/aisat_interior)
 "diH" = (
@@ -79812,8 +79126,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/aisat_interior)
 "diK" = (
@@ -79832,8 +79145,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/aisat_interior)
 "diM" = (
@@ -79861,8 +79173,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/aisat_interior)
 "diO" = (
@@ -79890,8 +79201,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/aisat_interior)
 "diR" = (
@@ -79914,8 +79224,7 @@
 /area/space/nearstation)
 "diY" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5;
-	tag = "icon-intact (NORTHEAST)"
+	dir = 5
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -80088,8 +79397,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/aisat_interior)
 "djq" = (
@@ -80111,8 +79419,7 @@
 /obj/machinery/door/window/eastright{
 	dir = 2;
 	name = "Hydroponics Delivery";
-	req_access_txt = "35";
-	tag = "icon-right"
+	req_access_txt = "35"
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /obj/structure/disposalpipe/segment{
@@ -80256,8 +79563,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/aisat_interior)
 "djH" = (
@@ -80289,8 +79595,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/aisat_interior)
 "djJ" = (
@@ -80303,8 +79608,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/aisat_interior)
 "djM" = (
@@ -80355,8 +79659,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/aisat_interior)
 "djS" = (
@@ -80430,8 +79733,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/aisat_interior)
 "dkb" = (
@@ -80493,8 +79795,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/aisat_interior)
 "dkg" = (
@@ -80722,8 +80023,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/aisat/maintenance)
 "dkJ" = (
@@ -80754,8 +80054,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/aisat/maintenance)
 "dkL" = (
@@ -80789,8 +80088,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/aisat/atmospherics)
 "dkN" = (
@@ -80850,8 +80148,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/aisat/atmospherics)
 "dkV" = (
@@ -80876,8 +80173,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/aisat/atmospherics)
 "dkX" = (
@@ -80897,8 +80193,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/aisat/atmospherics)
 "dkY" = (
@@ -80925,8 +80220,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/aisat_interior)
 "dkZ" = (
@@ -80955,8 +80249,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/aisat_interior)
 "dlc" = (
@@ -80978,8 +80271,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/aisat/maintenance)
 "dld" = (
@@ -81004,8 +80296,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/aisat/maintenance)
 "dle" = (
@@ -81024,7 +80315,6 @@
 "dlh" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1450;
-	icon_state = "door_locked";
 	id_tag = "south_maint_outer";
 	locked = 1;
 	name = "External Access";
@@ -81054,8 +80344,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/aisat/maintenance)
 "dll" = (
@@ -81086,8 +80375,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/aisat/maintenance)
 "dlp" = (
@@ -81100,8 +80388,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/aisat/atmospherics)
 "dls" = (
@@ -81134,8 +80421,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/aisat_interior)
 "dlu" = (
@@ -81171,7 +80457,6 @@
 	autoclose = 0;
 	frequency = 1449;
 	heat_proof = 1;
-	icon_state = "door_locked";
 	id_tag = "gas_turbine_interior";
 	locked = 1;
 	name = "Turbine Interior Airlock";
@@ -81243,8 +80528,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/aisat/maintenance)
 "dlN" = (
@@ -81310,8 +80594,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/aisat)
 "dlV" = (
@@ -81415,8 +80698,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/aisat)
 "dmg" = (
@@ -81438,7 +80720,6 @@
 	autoclose = 0;
 	frequency = 1449;
 	heat_proof = 1;
-	icon_state = "door_locked";
 	id_tag = "gas_turbine_exterior";
 	locked = 1;
 	name = "Turbine Exterior Airlock";
@@ -81501,8 +80782,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/aisat)
 "dmt" = (
@@ -81666,8 +80946,7 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/aisat)
 "dmM" = (
@@ -81758,8 +81037,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/aisat)
 "dmU" = (
@@ -81785,8 +81063,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/aisat)
 "dmW" = (
@@ -81815,8 +81092,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/ai)
 "dmZ" = (
@@ -81856,8 +81132,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/ai)
 "dng" = (
@@ -81884,8 +81159,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/ai)
 "dni" = (
@@ -81894,8 +81168,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/ai)
 "dnj" = (
@@ -81910,8 +81183,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/ai)
 "dnk" = (
@@ -81926,8 +81198,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/ai)
 "dnm" = (
@@ -81945,8 +81216,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/ai)
 "dnn" = (
@@ -81983,8 +81253,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/ai)
 "dnr" = (
@@ -81998,8 +81267,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/ai)
 "dns" = (
@@ -82030,8 +81298,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/ai)
 "dnu" = (
@@ -82055,8 +81322,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/ai)
 "dnx" = (
@@ -82072,8 +81338,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/ai)
 "dnz" = (
@@ -82088,8 +81353,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/ai)
 "dnA" = (
@@ -82099,8 +81363,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/ai)
 "dnB" = (
@@ -82114,8 +81377,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/ai)
 "dnC" = (
@@ -82149,8 +81411,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/ai)
 "dnG" = (
@@ -82238,8 +81499,7 @@
 	},
 /obj/item/book/codex_gigas,
 /turf/simulated/floor/plasteel{
-	icon_state = "cult";
-	tag = "icon-cult"
+	icon_state = "cult"
 	},
 /area/library)
 "dnN" = (
@@ -82253,7 +81513,6 @@
 "dnO" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1450;
-	icon_state = "door_locked";
 	id_tag = "south_maint_inner";
 	locked = 1;
 	name = "External Access";
@@ -82287,7 +81546,6 @@
 "dnR" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1450;
-	icon_state = "door_locked";
 	id_tag = "sci_inner";
 	locked = 1;
 	name = "External Access";
@@ -82422,8 +81680,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 9;
-	tag = "icon-intact-y (NORTHWEST)"
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior)
@@ -82512,7 +81769,6 @@
 "dom" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1450;
-	icon_state = "door_locked";
 	id_tag = "sci_outer";
 	locked = 1;
 	name = "External Access";
@@ -82526,7 +81782,6 @@
 	},
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "atmospherics_south_inner";
 	locked = 1;
 	name = "Atmospherics External Access";
@@ -82588,8 +81843,7 @@
 /obj/item/pen/multi,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/aisat_interior)
 "doB" = (
@@ -82651,8 +81905,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/aisat_interior)
 "doW" = (
@@ -82669,8 +81922,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/aisat_interior)
 "doY" = (
@@ -82724,8 +81976,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/aisat_interior)
 "dpl" = (
@@ -82759,8 +82010,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/turret_protected/aisat_interior)
 "dpv" = (
@@ -82792,8 +82042,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/aisat_interior)
 "dpx" = (
@@ -82805,8 +82054,7 @@
 /obj/item/toy/figure/borg,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/aisat_interior)
 "dpA" = (
@@ -82900,8 +82148,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/aisat/atmospherics)
 "dpO" = (
@@ -82909,8 +82156,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/aisat/atmospherics)
 "dpV" = (
@@ -83000,8 +82246,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/aisat/atmospherics)
 "dqv" = (
@@ -83044,8 +82289,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/aisat/maintenance)
 "dqL" = (
@@ -83131,8 +82375,7 @@
 /obj/item/pen/multi,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/ai)
 "drq" = (
@@ -83144,8 +82387,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/ai)
 "drt" = (
@@ -83153,8 +82395,7 @@
 /obj/item/folder,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/ai)
 "dru" = (
@@ -83176,23 +82417,20 @@
 /obj/structure/chair/office/dark,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/ai)
 "drB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/ai)
 "drE" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/ai)
 "drG" = (
@@ -83217,8 +82455,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/ai)
 "drM" = (
@@ -83385,8 +82622,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/ai)
 "dsc" = (
@@ -83431,8 +82667,7 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/ai)
 "dsi" = (
@@ -83443,8 +82678,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/ai)
 "dsj" = (
@@ -83476,8 +82710,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/maintenance/asmaint2)
 "dsy" = (
@@ -83800,7 +83033,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/toxins/xenobiology)
+/area/medical/research/restroom)
 "dEP" = (
 /obj/structure/rack{
 	dir = 8;
@@ -83824,10 +83057,7 @@
 	},
 /area/security/securearmory)
 "dEQ" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack/gunrack,
 /obj/item/gun/projectile/shotgun/riot{
 	pixel_x = -1;
 	pixel_y = 3
@@ -84201,8 +83431,7 @@
 	req_access_txt = "1"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/range)
 "eve" = (
@@ -84450,7 +83679,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/toxins/xenobiology)
+/area/medical/research/restroom)
 "eRE" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -84691,8 +83920,7 @@
 "fqB" = (
 /obj/machinery/shower{
 	dir = 4;
-	pixel_x = 5;
-	tag = "icon-shower (EAST)"
+	pixel_x = 5
 	},
 /obj/structure/curtain/open/shower,
 /obj/effect/turf_decal/siding/wideplating{
@@ -85083,7 +84311,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/toxins/xenobiology)
+/area/medical/research/restroom)
 "gmX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb2,
@@ -85287,11 +84515,7 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
-/obj/structure/grille,
-/obj/structure/window/plasmareinforced,
-/obj/structure/window/plasmareinforced{
-	dir = 1
-	},
+/obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
 "gOz" = (
@@ -85362,8 +84586,7 @@
 /obj/item/paper_bin/nanotrasen,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "gUQ" = (
@@ -85412,15 +84635,12 @@
 /turf/simulated/floor/grass,
 /area/hallway/secondary/exit)
 "gWS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment,
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/toxins/xenobiology)
+/area/medical/research/restroom)
 "gXh" = (
 /obj/effect/decal/cleanable/dust,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -85569,14 +84789,7 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
-/obj/structure/grille,
-/obj/structure/window/plasmareinforced{
-	dir = 4
-	},
-/obj/structure/window/plasmareinforced,
-/obj/structure/window/plasmareinforced{
-	dir = 1
-	},
+/obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
 "hsz" = (
@@ -85770,8 +84983,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/toxins/xenobiology)
 "hNY" = (
@@ -86086,14 +85298,7 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
-/obj/structure/grille,
-/obj/structure/window/plasmareinforced{
-	dir = 8
-	},
-/obj/structure/window/plasmareinforced,
-/obj/structure/window/plasmareinforced{
-	dir = 1
-	},
+/obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
 "iJx" = (
@@ -86102,8 +85307,7 @@
 /area/security/permabrig)
 "iJG" = (
 /obj/structure/chair/wood/wings{
-	dir = 8;
-	tag = "icon-wooden_chair_wings (WEST)"
+	dir = 8
 	},
 /obj/effect/landmark/start{
 	name = "Civilian"
@@ -86354,6 +85558,12 @@
 /obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor/plasteel,
 /area/maintenance/xenozoo)
+"jGQ" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry)
 "jLB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -86575,9 +85785,6 @@
 	},
 /area/security/prisonershuttle)
 "kfC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -86585,10 +85792,18 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/toxins/xenobiology)
+/area/medical/research/restroom)
 "khg" = (
 /turf/simulated/floor/carpet,
 /area/chapel/main)
@@ -86717,8 +85932,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/range)
 "kuy" = (
@@ -86742,11 +85956,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/toxins/xenobiology)
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/medical/research/restroom)
 "kxm" = (
 /obj/structure/sign/botany,
 /turf/simulated/wall,
@@ -86797,7 +86015,6 @@
 "kCL" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
 	id_tag = "sol_outer";
 	locked = 1;
 	name = "Arrivals External Access"
@@ -86907,16 +86124,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/server)
-"kWZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkred"
-	},
-/area/security/prison/cell_block/A)
 "kYF" = (
 /obj/structure/target_stake,
 /obj/effect/decal/warning_stripes/northeast,
@@ -86924,8 +86131,7 @@
 /area/security/range)
 "kZd" = (
 /obj/structure/chair/wood/wings{
-	dir = 4;
-	tag = "icon-wooden_chair_wings (EAST)"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
@@ -86949,8 +86155,7 @@
 /obj/effect/decal/warning_stripes/south,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreen";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/toxins/xenobiology)
 "lbH" = (
@@ -86981,7 +86186,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/toxins/xenobiology)
+/area/medical/research/restroom)
 "lcE" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
@@ -87013,6 +86218,16 @@
 	icon_state = "white"
 	},
 /area/toxins/xenobiology)
+"lix" = (
+/obj/item/radio/intercom/department/security{
+	name = "north station intercom (Security)";
+	pixel_y = 25
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkredcorners"
+	},
+/area/security/brig)
 "lki" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Prison Library"
@@ -87116,7 +86331,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/toxins/xenobiology)
+/area/medical/research/restroom)
 "ltW" = (
 /obj/structure/bedsheetbin,
 /obj/structure/table,
@@ -87270,10 +86485,14 @@
 /obj/structure/chair/sofa/left{
 	dir = 8
 	},
+/obj/item/radio/intercom{
+	name = "south station intercom (General)";
+	pixel_y = -28
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/toxins/xenobiology)
+/area/medical/research/restroom)
 "lOM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -87355,8 +86574,7 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 4;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2 (EAST)"
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
@@ -87403,20 +86621,20 @@
 	},
 /area/maintenance/library)
 "mcq" = (
-/obj/item/radio/intercom{
-	name = "east station intercom (General)";
-	pixel_x = 28
-	},
 /obj/item/storage/box/donkpockets,
 /obj/structure/table,
 /obj/machinery/newscaster{
 	name = "north newscaster";
 	pixel_y = 34
 	},
+/obj/machinery/light_switch{
+	name = "east light switch";
+	pixel_x = 24
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/toxins/xenobiology)
+/area/medical/research/restroom)
 "mdm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -87896,8 +87114,7 @@
 "njX" = (
 /obj/structure/foodcart,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "nkK" = (
@@ -88136,7 +87353,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -88323,7 +87539,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/toxins/xenobiology)
+/area/medical/research/restroom)
 "ooN" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
@@ -88337,12 +87553,11 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/dorms)
 "orW" = (
-/obj/structure/table,
-/obj/machinery/recharger,
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_y = 32
 	},
+/obj/machinery/suit_storage_unit/security/warden,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -88449,7 +87664,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/toxins/xenobiology)
+/area/medical/research/restroom)
 "oNA" = (
 /obj/effect/landmark{
 	color = "#00ae00";
@@ -88526,8 +87741,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/tcommsat/chamber)
 "oQF" = (
@@ -88599,8 +87813,7 @@
 "pea" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay2)
 "pee" = (
@@ -88621,8 +87834,7 @@
 /obj/structure/table/glass,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/security/medbay)
 "pjs" = (
@@ -88662,21 +87874,17 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/security/medbay)
 "pmj" = (
-/obj/effect/turf_decal/siding{
-	color = "#3E3E3E"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/carpet/purple,
 /area/crew_quarters/hor)
 "poX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -88794,16 +88002,14 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/security/medbay)
 "pEe" = (
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/effect/decal/warning_stripes/red/partial,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/range)
 "pFU" = (
@@ -88884,8 +88090,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "pSJ" = (
@@ -88901,8 +88106,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/security/medbay)
 "pUB" = (
@@ -88917,8 +88121,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/blue,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/security/medbay)
 "pVU" = (
@@ -88978,7 +88181,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/toxins/xenobiology)
+/area/medical/research/restroom)
 "qcp" = (
 /obj/structure/rack{
 	dir = 8;
@@ -89149,19 +88352,23 @@
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "qrU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/toxins/xenobiology)
+/area/medical/research/restroom)
 "qsT" = (
 /obj/structure/closet/wardrobe/red,
 /obj/item/clothing/suit/tracksuit/red,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/range)
 "qtB" = (
@@ -89179,17 +88386,13 @@
 /area/maintenance/server)
 "qus" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/toxins/xenobiology)
+/area/medical/research/restroom)
 "qwN" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -89199,7 +88402,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/toxins/xenobiology)
+/area/medical/research/restroom)
 "qxK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -89270,7 +88473,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/toxins/xenobiology)
+/area/medical/research/restroom)
 "qBn" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 2;
@@ -89417,13 +88620,17 @@
 	},
 /area/toxins/xenobiology)
 "qOb" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 4;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/toxins/xenobiology)
+/area/medical/research/restroom)
 "qOo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -89525,7 +88732,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/toxins/xenobiology)
+/area/medical/research/restroom)
 "rbW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -89548,8 +88755,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/security/medbay)
 "rgv" = (
@@ -89793,8 +88999,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/security/medbay)
 "rwJ" = (
@@ -89803,6 +89008,9 @@
 /area/security/permabrig)
 "rAi" = (
 /obj/machinery/computer/brigcells,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "darkred"
@@ -89833,8 +89041,7 @@
 	name = "Isolation Desk"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/security/medbay)
 "rBV" = (
@@ -89857,8 +89064,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/security/medbay)
 "rGg" = (
@@ -89902,8 +89108,7 @@
 /obj/structure/table/wood,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/security/medbay)
 "rIN" = (
@@ -89989,8 +89194,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/turret_protected/aisat_interior)
 "rWs" = (
@@ -90018,8 +89222,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/aisat)
 "rZU" = (
@@ -90211,8 +89414,7 @@
 /area/hallway/primary/central/sw)
 "sDN" = (
 /obj/structure/morgue{
-	dir = 8;
-	tag = "icon-morgue1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -90240,8 +89442,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "sFB" = (
@@ -90312,8 +89513,7 @@
 "sQD" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "browncorner";
-	tag = "icon-browncorner (EAST)"
+	icon_state = "browncorner"
 	},
 /area/quartermaster/office)
 "sQL" = (
@@ -90394,10 +89594,14 @@
 /obj/structure/table/wood,
 /obj/item/kitchen/utensil/spoon,
 /obj/item/kitchen/utensil/fork,
+/obj/machinery/camera{
+	c_tag = "Research Break Room";
+	network = list("Research","SS13")
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/toxins/xenobiology)
+/area/medical/research/restroom)
 "sZh" = (
 /obj/machinery/light{
 	dir = 4
@@ -90409,12 +89613,20 @@
 /area/security/permabrig)
 "tab" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/toxins/xenobiology)
+/area/medical/research/restroom)
 "taf" = (
 /obj/structure/rack{
 	dir = 8;
@@ -90511,13 +89723,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	icon_state = "darkred"
+	dir = 8;
+	icon_state = "darkredcorners"
 	},
 /area/security/brig)
 "tip" = (
@@ -90584,15 +89793,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/toxins/xenobiology)
+/area/medical/research)
 "tsS" = (
 /obj/machinery/vending/security/training,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/range)
 "tuP" = (
@@ -90646,8 +89859,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/aisat)
 "txA" = (
@@ -90750,8 +89962,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/security/medbay)
 "tQb" = (
@@ -90830,7 +90041,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/toxins/xenobiology)
+/area/medical/research/restroom)
 "ueF" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -90856,7 +90067,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/toxins/xenobiology)
+/area/medical/research/restroom)
 "ugE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -90951,8 +90162,7 @@
 /obj/item/reagent_containers/iv_bag/salglu,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/security/medbay)
 "uBA" = (
@@ -90970,8 +90180,7 @@
 /area/maintenance/xenozoo)
 "uDK" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5;
-	tag = "icon-intact (NORTHEAST)"
+	dir = 5
 	},
 /turf/space,
 /area/space/nearstation)
@@ -91121,8 +90330,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/toxins/xenobiology)
 "uWp" = (
@@ -91379,6 +90587,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -91460,8 +90669,7 @@
 /obj/structure/table/wood,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/security/medbay)
 "vKI" = (
@@ -91596,7 +90804,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/toxins/xenobiology)
+/area/medical/research/restroom)
 "wbr" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -91656,10 +90864,15 @@
 "wfm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/scientist,
+/obj/machinery/firealarm{
+	dir = 1;
+	name = "south fire alarm";
+	pixel_y = -24
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/toxins/xenobiology)
+/area/medical/research/restroom)
 "wgy" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -91796,16 +91009,15 @@
 /turf/simulated/wall/r_wall,
 /area/maintenance/xenozoo)
 "wuv" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light_switch{
+	name = "east light switch";
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkred"
+	dir = 4;
+	icon_state = "escape"
 	},
-/area/security/brig)
+/area/security/customs2)
 "wvx" = (
 /obj/structure/table/reinforced,
 /obj/item/gun/energy/laser/practice,
@@ -91870,6 +91082,11 @@
 	icon_state = "grimy"
 	},
 /area/maintenance/library)
+"wBA" = (
+/turf/simulated/wall/shuttle/nosmooth{
+	icon = 'icons/turf/walls/shuttle/gray_shuttle_wall.dmi'
+	},
+/area/toxins/test_area)
 "wCS" = (
 /obj/structure/extinguisher_cabinet{
 	name = "east extinguisher cabinet";
@@ -92135,7 +91352,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/toxins/xenobiology)
+/area/medical/research/restroom)
 "xeW" = (
 /obj/structure/rack{
 	dir = 8;
@@ -92289,8 +91506,7 @@
 /obj/item/clothing/accessory/stethoscope,
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/security/medbay)
 "xlI" = (
@@ -92361,6 +91577,13 @@
 	icon_state = "black"
 	},
 /area/space)
+"xxk" = (
+/obj/effect/decal/warning_stripes/northwest,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/airless,
+/area/toxins/test_area)
 "xyo" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -92450,7 +91673,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/toxins/xenobiology)
+/area/medical/research/restroom)
 "xFN" = (
 /obj/machinery/hologram/holopad{
 	pixel_x = -16
@@ -92561,8 +91784,7 @@
 /area/crew_quarters/dorms)
 "xWg" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6;
-	tag = "icon-intact (SOUTHEAST)"
+	dir = 6
 	},
 /turf/space,
 /area/space/nearstation)
@@ -92631,8 +91853,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/security/medbay)
 "ygO" = (
@@ -92671,8 +91892,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/security/medbay)
 "yjn" = (
@@ -101585,7 +100805,7 @@ uTI
 uTI
 uTI
 aSd
-aOQ
+jGQ
 aPI
 aSd
 djT
@@ -118009,7 +117229,7 @@ afq
 aef
 ago
 aie
-tio
+gSV
 alc
 anZ
 aqY
@@ -118523,7 +117743,7 @@ afs
 aeg
 ago
 aie
-tio
+atE
 alc
 aob
 ara
@@ -119042,7 +118262,7 @@ aIo
 aod
 aod
 aIo
-aAz
+avd
 avT
 axu
 aIo
@@ -119296,8 +118516,8 @@ ahC
 aig
 ajS
 alr
-aog
-aog
+avd
+avd
 asQ
 avd
 avV
@@ -120320,7 +119540,7 @@ amC
 aos
 apg
 aqw
-arD
+aqX
 ase
 ajW
 alK
@@ -120577,7 +119797,7 @@ anz
 aou
 apf
 aqw
-ago
+aqX
 ase
 ajW
 alK
@@ -121091,7 +120311,7 @@ any
 aot
 amy
 aqx
-aqX
+ago
 ase
 ajX
 aDv
@@ -121348,7 +120568,7 @@ aou
 afl
 apj
 aqx
-aqX
+ago
 ase
 akd
 alt
@@ -121382,7 +120602,7 @@ aST
 bdF
 jgn
 jgn
-aZx
+baF
 bkC
 dcb
 bdv
@@ -121605,7 +120825,7 @@ anB
 aov
 api
 eZh
-aqX
+ago
 akV
 alb
 anI
@@ -121885,9 +121105,9 @@ aGx
 aHT
 aIO
 aKz
-oOv
+aHT
 aNc
-oOv
+aHT
 aNT
 aQS
 aHT
@@ -123399,14 +122619,14 @@ acy
 acE
 aiv
 xzR
-amJ
+wuv
 amJ
 aoD
 apE
 auc
 agW
 asp
-aty
+tio
 awK
 aoX
 aro
@@ -124188,7 +123408,7 @@ axK
 ayW
 ayn
 aAV
-kWZ
+art
 aDn
 aEq
 aFE
@@ -124691,7 +123911,7 @@ ahR
 anx
 aqX
 aso
-tio
+gSV
 auE
 apa
 axt
@@ -125974,7 +125194,7 @@ aoJ
 aoL
 apM
 apR
-wuv
+ahC
 ast
 atR
 auE
@@ -126231,7 +125451,7 @@ anS
 aoM
 rjA
 anx
-ago
+aqX
 aiT
 akx
 auE
@@ -127002,7 +126222,7 @@ alF
 afn
 apO
 anx
-aqX
+ago
 aiW
 akC
 avF
@@ -128030,8 +127250,8 @@ ajV
 aiY
 apV
 aqG
-ahW
-asA
+lix
+aiT
 aFL
 aFL
 aFL
@@ -128287,7 +127507,7 @@ ahm
 aiY
 apU
 aqG
-aqX
+ago
 asA
 atg
 awl
@@ -128599,7 +127819,7 @@ bHy
 bDb
 aTL
 bLz
-bDh
+bGd
 bYi
 bOD
 bHO
@@ -128801,7 +128021,7 @@ aeV
 aoS
 apW
 aih
-ago
+aqX
 asd
 wyy
 ame
@@ -129058,7 +128278,7 @@ aih
 aih
 aih
 aih
-ago
+aqX
 asd
 akE
 amw
@@ -129113,7 +128333,7 @@ bHy
 bDb
 aTM
 bBL
-bDh
+bGd
 bYi
 bOF
 bLB
@@ -136343,19 +135563,19 @@ jib
 skM
 mxl
 qSQ
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
+ndH
+ndH
+ndH
+cep
+cep
+cep
+cep
+cep
+cep
+cep
+cep
+cep
+cep
 cIs
 bQX
 cKF
@@ -136600,7 +135820,7 @@ luR
 ndH
 hFN
 hFN
-cBR
+ndH
 cKP
 cJK
 cJK
@@ -136612,7 +135832,7 @@ cxN
 cKP
 cJK
 cJK
-cBR
+cep
 ciY
 ciY
 ciY
@@ -136850,14 +136070,14 @@ cuS
 cpR
 cxI
 cxO
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
+csr
+csr
+csr
+csr
+csr
+csr
+csr
+csr
 cKQ
 cMg
 cJK
@@ -136869,7 +136089,7 @@ cxN
 cKQ
 cMg
 cJK
-cBR
+cep
 cIu
 cJz
 cKG
@@ -137107,14 +136327,14 @@ cuR
 cpR
 cpH
 cxO
-cBR
+csr
 sYE
 glM
 xdd
 oLU
 lta
 uew
-cBR
+csr
 cKR
 cJK
 cJK
@@ -137126,7 +136346,7 @@ cxN
 cKR
 cJK
 cJK
-cBR
+cep
 cIt
 thk
 rDc
@@ -137364,14 +136584,14 @@ cuX
 bIi
 cpI
 cxO
-cBR
+csr
 rac
 dEO
 eRa
 eRa
 lcl
 lOD
-cBR
+csr
 cKW
 cMl
 cNm
@@ -137383,14 +136603,14 @@ cxN
 cTJ
 cVe
 cWi
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
+cep
+cep
+cep
+cep
+cep
+cep
+cep
+cep
 uTI
 uTI
 uTI
@@ -137621,14 +136841,14 @@ cuV
 bIi
 cAc
 cxO
-cBR
+csr
 qwN
 qbV
 qOb
 qus
 eRa
 wfm
-cBR
+csr
 cIU
 cJr
 cJJ
@@ -137647,7 +136867,7 @@ lLZ
 cMk
 dbR
 rgI
-cBR
+cep
 djT
 djT
 djT
@@ -137878,14 +137098,14 @@ cvF
 bIi
 cxU
 cxO
-cBR
+csr
 onN
 ugD
 tab
 qrU
-ugD
-wfm
-cBR
+aog
+cAD
+csr
 cKY
 cEH
 cPp
@@ -137904,7 +137124,7 @@ wEX
 cJK
 cKZ
 cJK
-cBR
+cep
 uTI
 uTI
 uTI
@@ -138135,14 +137355,14 @@ cvF
 bIi
 cxM
 cxO
-cBR
+csr
 mcq
 qAN
 kfC
 gWS
 xFK
 waC
-cBR
+csr
 cIA
 cVf
 cKq
@@ -138161,7 +137381,7 @@ sqW
 cJK
 cJK
 cJK
-cBR
+cep
 uTI
 uTI
 uTI
@@ -138390,18 +137610,18 @@ crR
 bLR
 cvG
 bIi
-cxN
+bIi
 czx
-cBR
-cBR
+csr
+csr
 cDq
 kwM
 cDq
 cBS
-cBR
-cBR
-cxN
-cxN
+bPt
+bPt
+bIi
+bIi
 cKx
 cPp
 cEH
@@ -138418,7 +137638,7 @@ cxN
 cxN
 cxN
 cxN
-cBR
+cep
 uTI
 uTI
 uTI
@@ -138647,18 +137867,18 @@ csF
 bLR
 cvF
 cwo
-cxN
+bIi
 cxW
 cAf
 cBS
 cDy
 tou
 cEk
-cBR
+bPt
 cGz
 cIO
 cIB
-cxN
+bIi
 cKt
 cPp
 cEH
@@ -138675,7 +137895,7 @@ gKI
 cMk
 dbR
 rgI
-cBR
+cep
 uTI
 uTI
 uTI
@@ -139161,18 +138381,18 @@ bLR
 bLR
 bLR
 cwp
-cxN
+bIi
 cyB
 cAf
-cAD
+bUh
 cDy
-cCT
+bWn
 cEl
-cBR
+bPt
 cGA
 cHz
 cIL
-cxN
+bIi
 cKy
 cMR
 cNr
@@ -139418,7 +138638,7 @@ bPt
 bIi
 bIi
 bIi
-cxN
+bIi
 cAG
 cAP
 cAP
@@ -139426,10 +138646,10 @@ cDu
 cCX
 cDu
 cBS
-cBR
-cxN
-cxN
-cxN
+bPt
+bIi
+bIi
+bIi
 cxN
 cxN
 cNL
@@ -141226,7 +140446,7 @@ cDe
 cDw
 cHw
 cIC
-cAP
+ctP
 cLb
 cLb
 cLb
@@ -141740,7 +140960,7 @@ cDs
 cEu
 cFJ
 cID
-cAP
+ctP
 cLj
 cMm
 cLe
@@ -142783,7 +142003,7 @@ uoG
 taM
 uoG
 uoG
-cBR
+bGH
 dbg
 bGG
 cuQ
@@ -143034,13 +142254,13 @@ bGH
 bGH
 bGH
 bGH
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
-cBR
+bGH
+bGH
+bGH
+bGH
+bGH
+bGH
+bGH
 bGG
 bGG
 cuQ
@@ -143266,7 +142486,7 @@ cgy
 cib
 cjX
 cnE
-cne
+cnc
 cqh
 crJ
 cse
@@ -145326,7 +144546,7 @@ iNz
 coG
 cqx
 csq
-ctP
+coI
 doF
 cgE
 uTI
@@ -145581,8 +144801,8 @@ uxy
 afO
 iNz
 coI
-cqC
-csr
+coI
+coI
 cgE
 cvr
 cgE
@@ -151231,7 +150451,7 @@ uTI
 uTI
 djT
 cie
-cie
+wBA
 clH
 ckb
 ckb
@@ -151245,7 +150465,7 @@ ckb
 ckb
 ckb
 cDN
-cie
+wBA
 cie
 djT
 uTI
@@ -151495,8 +150715,8 @@ ckb
 ckb
 cmz
 coJ
-ckb
-cbw
+wBA
+xxk
 cst
 ckb
 ckb
@@ -153037,7 +152257,7 @@ djT
 cie
 cie
 ckb
-cie
+wBA
 ckb
 cie
 cie

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -2000,6 +2000,10 @@
 	c_tag = "Brig HoS Bedroom";
 	dir = 4
 	},
+/obj/item/radio/intercom{
+	name = "west station intercom (General)";
+	pixel_x = -28
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -2979,13 +2983,14 @@
 /area/security/brig)
 "ajn" = (
 /obj/structure/dresser,
-/obj/item/radio/intercom{
-	name = "west station intercom (General)";
-	pixel_x = -28
-	},
 /obj/machinery/light_switch{
 	name = "south light switch";
 	pixel_y = -24
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	name = "west fire alarm";
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"


### PR DESCRIPTION
## Информация:
**Голосования:**
https://discord.com/channels/617003227182792704/930740675350233098/1052883883634479114
https://discord.com/channels/617003227182792704/930740675350233098/1052662852827238440
https://discord.com/channels/617003227182792704/930740675350233098/1045858268905480242

**Diff:**
https://mdb2.affectedarc07.co.uk/images/365505203/10112008021/m/0/0-diff.png

## Изменения

### Отдел исследований:

 - Визуальное оформление офиса РД было изменено.
 
![image](https://user-images.githubusercontent.com/20109643/207821319-aad08c3a-0147-468d-8897-4f66da059602.png)

 - Химики получили укреплённую стену с покрытием.
 
![image](https://user-images.githubusercontent.com/20109643/207827856-93b59251-b3a6-42ca-9d86-323ae374f341.png)

 - У полигона добавлены 4 неразрушаемые стены и камера по центру
 
![image](https://user-images.githubusercontent.com/20109643/207828367-dec296a2-4046-482e-8651-490ddd0d32bd.png)
 
 **Остальное:**
 - Были добавлены 3 химические сумки в химию РНД.
 - Комната отдыха в РНД теперь имеет собственную зону, выключатель, APC, алармы и камеру.
 - Зона коридора РНД была продлена до Ксено.
 - Пофикшен баг, при котором в Ксено можно было выйти камерой за пределы её зоны.
 
## Бриг:

 - В офис ГСБ добавлены ставни, выключатель света, интерком и камера.
 
![image](https://user-images.githubusercontent.com/20109643/207826950-5561bddc-1494-4ec5-a37f-0cf282c7f08a.png)

 - Варден получил индивидуальный риг и сегвей "secway".
 
![image](https://user-images.githubusercontent.com/20109643/207827079-f9d53d66-1a61-4d02-bbfe-ed96e78c8f47.png)
 
 **Остальное:**
 - Плитки были выровнены.
 - Подставки под оружие были заменены на верные аналоги (gunrack).
 
 ## Общие изменения:
 
  - У всех турфов были очищены тэги по типу "icon_".
  - Проставлены иконки для шлюзов, дабы они были видны для редактора.
  - Все найденые мною "мануально сделаные" окна заменены на имеющиеся спавнеры окон.