### PR TITLE
Feat: Смена режима на эксту при лоупопе

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -306,6 +306,9 @@
 	var/tts_enabled = FALSE // Global switch
 	var/tts_cache = FALSE // Store generated tts files and reuse them, instead of always requesting new
 
+	/// the amount of players needed to automatically switch gamemode to extended. Doesn't work if set to zero
+	var/auto_extended_players_num = 0
+
 /datum/configuration/New()
 	for(var/T in subtypesof(/datum/game_mode))
 		var/datum/game_mode/M = T
@@ -871,6 +874,9 @@
 
 				if("tts_cache")
 					config.tts_cache = TRUE
+
+				if("auto_extended_players_num")
+					config.auto_extended_players_num = text2num(value)
 
 				else
 					log_config("Unknown setting in configuration: '[name]'")

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -200,6 +200,8 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	if(!current_runlevel)
 		SetRunLevel(1)
 
+	world.check_for_lowpop()
+
 	// Sort subsystems by display setting for easy access.
 	sortTim(subsystems, /proc/cmp_subsystem_display)
 	// Set world options.

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -181,6 +181,9 @@ SUBSYSTEM_DEF(ticker)
 		force_start = FALSE
 		SSjobs.ResetOccupations()
 		Master.SetRunLevel(RUNLEVEL_LOBBY)
+
+		world.check_for_lowpop()
+
 		return FALSE
 
 	//Configure mode and assign player to special mode stuff
@@ -196,6 +199,9 @@ SUBSYSTEM_DEF(ticker)
 		force_start = FALSE
 		SSjobs.ResetOccupations()
 		Master.SetRunLevel(RUNLEVEL_LOBBY)
+
+		world.check_for_lowpop()
+
 		return FALSE
 
 	if(hide_mode)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -186,6 +186,18 @@ GLOBAL_LIST_EMPTY(world_topic_handlers)
 	fdel(F)
 	F << the_mode
 
+/world/proc/check_for_lowpop()
+	if(!config.auto_extended_players_num)
+		return
+
+	if(length(GLOB.clients) <= config.auto_extended_players_num)
+		GLOB.master_mode = "extended"
+		to_chat(world, "<span class='boldnotice'>Due to the lowpop the mode has been changed.</span>")
+	else
+		GLOB.master_mode = "secret"
+	to_chat(world, "<span class='boldnotice'>The mode is now: [GLOB.master_mode]</span>")
+	world.save_mode(GLOB.master_mode)
+
 /world/proc/load_motd()
 	GLOB.join_motd = file2text("config/motd.txt")
 	GLOB.join_tos = file2text("config/tos.txt")

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -549,3 +549,6 @@ TOPIC_FILTERING_WHITELIST 127.0.0.1
 #TTS_TOKEN_SILERO mytoken
 #TTS_ENABLED
 #TTS_CACHE
+ 
+# Number of players required for automatic gamemode change to extended. Doesn't work if set to zero or commented
+#AUTO_EXTENDED_PLAYERS_NUM 10


### PR DESCRIPTION
## Описание
Добавляет в конфиг значение `AUTO_EXTENDED_PLAYERS_NUM`, изменение которого приведёт к автоматическому включению режима extended при величине онлайна ниже числа, прописанного в `AUTO_EXTENDED_PLAYERS_NUM` (и наоборот, включению режима secret) на момент окончания инициализации сабсистем (либо при неудачной инициализации гейммода)

## Ссылка на предложение/Причина создания ПР
Муниверс в дом-люксе написал, чтобы админы автоматически ставили эксту когда нет стримов и возвращали сикрет, когда стримеры играют. Зачем это делать ручками и тыкать каждый раз каких-то людей, если можно легко автоматизировать. 

## Демонстрация изменений
Всё работает, базарю, я протестировал 😎 