### PR TITLE
Feat(fix?):Add de-sign for ghost roles with timer

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -572,6 +572,8 @@ so as to remain in compliance with the most up-to-date laws."
 		if(poll.sign_up(G))
 			// Add a small overlay to indicate we've signed up
 			display_signed_up()
+		else
+			display_signed_down()
 	else if(target)
 		switch(action)
 			if(NOTIFY_ATTACK)
@@ -592,6 +594,12 @@ so as to remain in compliance with the most up-to-date laws."
 	I.layer = FLOAT_LAYER
 	I.plane = FLOAT_PLANE + 2
 	overlays += I
+
+/obj/screen/alert/notify_action/proc/display_signed_down()
+	var/image/I = image('icons/mob/screen_gen.dmi', icon_state = "selector")
+	I.layer = FLOAT_LAYER
+	I.plane = FLOAT_PLANE + 2
+	overlays -= I
 
 /obj/screen/alert/notify_action/proc/display_stacks(stacks = 1)
 	if(stacks <= 1)

--- a/code/controllers/subsystem/ghost_spawns.dm
+++ b/code/controllers/subsystem/ghost_spawns.dm
@@ -240,7 +240,8 @@ SUBSYSTEM_DEF(ghost_spawns)
 		return
 	if(M in signed_up)
 		if(!silent)
-			to_chat(M, "<span class='warning'>You have already signed up for this!</span>")
+			signed_up -= M
+			to_chat(M, "<span class='warning'>You removed from registration list.</span>")
 		return
 	if(time_left() <= 0)
 		if(!silent)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет возможность отказаться от гост роли с таймером. Сейчас такое доступно лишь у робомозга.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Гост-роли с таймером, работают не как робо-мозг, т.е ты "участвовать" можешь, а отменить участие можно только уйдя из гостов (переселившись в мышку или т.п.), зачем так делать, когда можно разрешить выходить из этого списка по нормальному. Так удобнее.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
https://user-images.githubusercontent.com/120549107/208245030-951739bf-b2de-4208-9e62-1a9a4231bef7.mp4
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
