### PR TITLE
Ref/Feat: smoke reagents now splits between affected tiles, prevent reagents duping

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -117,12 +117,12 @@
 	var/turf/location = get_turf(src)
 
 	// Create the reagents to put into the air
-	create_reagents(8)
+	create_reagents(200)
 
 	if(overmind && overmind.blob_reagent_datum)
-		reagents.add_reagent(overmind.blob_reagent_datum.id, 8)
+		reagents.add_reagent(overmind.blob_reagent_datum.id, 200)
 	else
-		reagents.add_reagent("spore", 8)
+		reagents.add_reagent("spore", 200)
 
 	// Setup up the smoke spreader and start it.
 	S.set_up(reagents, location, TRUE)

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -410,15 +410,11 @@
 		target.visible_message("<span class='warning'>[target] suddenly bends over and coughs out a cloud of black smoke, which begins to spread rapidly!</span>")
 		to_chat(target, "<span class='deadsay'>You regurgitate a vast cloud of blinding smoke.</span>")
 		playsound(target, 'sound/effects/bamf.ogg', 50, 1)
-		var/obj/item/reagent_containers/glass/beaker/large/B = new /obj/item/reagent_containers/glass/beaker/large(target.loc)
-		B.reagents.clear_reagents() //Just in case!
-		B.icon_state = null //Invisible
-		B.reagents.add_reagent("blindness_smoke", 10)
+		var/datum/reagents/reagents_list = new (1000)
+		reagents_list.add_reagent("blindness_smoke", 810)
 		var/datum/effect_system/smoke_spread/chem/S = new
-		if(S)
-			S.set_up(B.reagents, B.loc, TRUE)
-			S.start(4)
-		qdel(B)
+		S.set_up(reagents_list, target.loc, TRUE)
+		S.start(4, apply_once = TRUE)
 
 /datum/reagent/shadowling_blindness_smoke //Blinds non-shadowlings, heals shadowlings/thralls
 	name = "odd black liquid"

--- a/code/game/objects/effects/effect_system/effects_chem_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_chem_smoke.dm
@@ -47,7 +47,6 @@
 /datum/effect_system/smoke_spread/chem
 	var/obj/chemholder
 	var/list/smoked_atoms = list()
-	var/static/list/process_locations = list()
 
 /datum/effect_system/smoke_spread/chem/New()
 	..()
@@ -95,35 +94,37 @@
 	set waitfor = FALSE
 
 	var/color = mix_color_from_reagents(chemholder.reagents.reagent_list)
+	var/obj/tile_reagents = new
+	tile_reagents.create_reagents(1000)
+	tile_reagents.reagents.set_reacting(FALSE) // Just in case
+	var/square_size = effect_range * 2 + 1
+	chemholder.reagents.copy_to(tile_reagents, chemholder.reagents.total_volume, 1 / (square_size * square_size))
 
-	if(!(location in process_locations))
-		process_locations |= list(location)
-		for(var/x in 0 to 99)
-			addtimer(CALLBACK(src, .proc/SmokeEffects, effect_range, color), 1 * x, TIMER_STOPPABLE | TIMER_DELETE_ME)
-	for(var/x in 0 to 10)
-		addtimer(CALLBACK(src, .proc/SmokeEm, effect_range), 1 SECONDS * x, TIMER_STOPPABLE | TIMER_DELETE_ME)
-	QDEL_IN(src, 10 SECONDS)
+	for(var/x in 0 to 99)
+		for(var/i = 0, i < rand(2, 6), i++)
+			if(effect_range < 3)
+				new /obj/effect/particle_effect/chem_smoke/small(location, color)
+			else
+				new /obj/effect/particle_effect/chem_smoke(location, color)
 
-/datum/effect_system/smoke_spread/chem/proc/SmokeEffects(effect_range, color)
-	for(var/i = 0, i < rand(2, 6), i++)
-		if(effect_range < 3)
-			new /obj/effect/particle_effect/chem_smoke/small(location, color)
-		else
-			new /obj/effect/particle_effect/chem_smoke(location, color)
+		if(x % 10 == 0) //Once every 10 ticks.
+			INVOKE_ASYNC(src, .proc/SmokeEm, effect_range, tile_reagents.reagents)
 
-/datum/effect_system/smoke_spread/chem/proc/SmokeEm(effect_range = 2)
-	for(var/atom/A in view(effect_range, get_turf(location)))
-		if(istype(A, /obj/effect/particle_effect)) // Don't impact particle effects, as there can be hundreds of them in a small area. Also, we don't want smoke particles adding themselves to this list. Major performance issue.
-			continue
-		if(A in smoked_atoms)
-			continue
-		smoked_atoms += A
-		chemholder.reagents.reaction(A)
-		if(iscarbon(A))
-			var/mob/living/carbon/C = A
-			if(C.can_breathe_gas())
-				chemholder.reagents.copy_to(C, chemholder.reagents.total_volume)
+		sleep(1)
+	qdel(src)
 
-/datum/effect_system/smoke_spread/chem/Destroy()
-	process_locations -= list(location)
-	return ..()
+/datum/effect_system/smoke_spread/chem/proc/SmokeEm(effect_range, var/datum/reagents/reagents)
+	for(var/turf/T in view(effect_range, get_turf(location)))
+		var/list/mob/living/carbon/carbons = list()
+		for(var/atom/A in T.contents)
+			if(istype(A, /obj/effect/particle_effect)) // Don't impact particle effects, as there can be hundreds of them in a small area. Also, we don't want smoke particles adding themselves to this list. Major performance issue.
+				continue
+			if(!(A in smoked_atoms))
+				smoked_atoms += A
+				reagents.reaction(A)
+			if(iscarbon(A))
+				var/mob/living/carbon/C = A
+				if(C.can_breathe_gas())
+					carbons += C
+		for(var/mob/living/carbon/C in carbons)
+			reagents.copy_to(C, reagents.total_volume, 0.1 / carbons.len)

--- a/code/game/objects/items/weapons/alien_specific.dm
+++ b/code/game/objects/items/weapons/alien_specific.dm
@@ -61,8 +61,8 @@
 /obj/item/reagent_containers/spray/alien/stun/afterattack(atom/A as mob|obj, mob/user as mob)
 	reagents.remove_reagent(reagents.get_master_reagent_id(),25)
 	var/location = get_turf(user)
-	var/datum/reagents/reagents_list = new
-	reagents_list.add_reagent("cryogenic_liquid", 5)
+	var/datum/reagents/reagents_list = new (250)
+	reagents_list.add_reagent("cryogenic_liquid", 245)
 	var/datum/effect_system/smoke_spread/chem/smoke = new
 	smoke.set_up(reagents_list, location)
 	smoke.start(3)

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -490,14 +490,14 @@
 
 /obj/item/grenade/chem_grenade/antiweed/New()
 	..()
-	var/obj/item/reagent_containers/glass/beaker/B1 = new(src)
-	var/obj/item/reagent_containers/glass/beaker/B2 = new(src)
+	var/obj/item/reagent_containers/glass/beaker/large/B1 = new(src)
+	var/obj/item/reagent_containers/glass/beaker/large/B2 = new(src)
 
-	B1.reagents.add_reagent("atrazine", 30)
-	B1.reagents.add_reagent("potassium", 20)
-	B2.reagents.add_reagent("phosphorus", 20)
-	B2.reagents.add_reagent("sugar", 20)
-	B2.reagents.add_reagent("atrazine", 10)
+	B1.reagents.add_reagent("atrazine", 85)
+	B1.reagents.add_reagent("potassium", 15)
+	B2.reagents.add_reagent("phosphorus", 15)
+	B2.reagents.add_reagent("sugar", 15)
+	B2.reagents.add_reagent("atrazine", 70)
 
 	beakers += B1
 	beakers += B2
@@ -530,13 +530,14 @@
 
 /obj/item/grenade/chem_grenade/teargas/New()
 	..()
-	var/obj/item/reagent_containers/glass/beaker/B1 = new(src)
-	var/obj/item/reagent_containers/glass/beaker/B2 = new(src)
+	var/obj/item/reagent_containers/glass/beaker/large/B1 = new(src)
+	var/obj/item/reagent_containers/glass/beaker/large/B2 = new(src)
 
-	B1.reagents.add_reagent("condensedcapsaicin", 25)
-	B1.reagents.add_reagent("potassium", 25)
-	B2.reagents.add_reagent("phosphorus", 25)
-	B2.reagents.add_reagent("sugar", 25)
+	B1.reagents.add_reagent("condensedcapsaicin", 85)
+	B1.reagents.add_reagent("potassium", 15)
+	B2.reagents.add_reagent("phosphorus", 15)
+	B2.reagents.add_reagent("sugar", 15)
+	B2.reagents.add_reagent("condensedcapsaicin", 70)
 
 	beakers += B1
 	beakers += B2
@@ -552,11 +553,11 @@
 	var/obj/item/reagent_containers/glass/beaker/large/B1 = new(src)
 	var/obj/item/reagent_containers/glass/beaker/large/B2 = new(src)
 
-	B1.reagents.add_reagent("facid", 80)
-	B1.reagents.add_reagent("potassium", 20)
-	B2.reagents.add_reagent("phosphorus", 20)
-	B2.reagents.add_reagent("sugar", 20)
-	B2.reagents.add_reagent("facid", 60)
+	B1.reagents.add_reagent("facid", 85)
+	B1.reagents.add_reagent("potassium", 15)
+	B2.reagents.add_reagent("phosphorus", 15)
+	B2.reagents.add_reagent("sugar", 15)
+	B2.reagents.add_reagent("facid", 70)
 
 	beakers += B1
 	beakers += B2
@@ -572,10 +573,11 @@
 	var/obj/item/reagent_containers/glass/beaker/B1 = new(src)
 	var/obj/item/reagent_containers/glass/beaker/B2 = new(src)
 
-	B1.reagents.add_reagent("sarin", 25)
-	B1.reagents.add_reagent("potassium", 25)
-	B2.reagents.add_reagent("phosphorus", 25)
-	B2.reagents.add_reagent("sugar", 25)
+	B1.reagents.add_reagent("sarin", 85)
+	B1.reagents.add_reagent("potassium", 15)
+	B2.reagents.add_reagent("phosphorus", 15)
+	B2.reagents.add_reagent("sugar", 15)
+	B2.reagents.add_reagent("sarin", 70)
 
 	beakers += B1
 	beakers += B2

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -24,9 +24,9 @@
 							"blood","morphine","ether","fluorine","mutadone","mutagen","hydrocodone","fuel",
 							"haloperidol","lsd","syndicate_nanites","lipolicide","frostoil","salglu_solution","beepskysmash",
 							"omnizine", "amanitin", "neurotoxin", "synaptizine", "rotatium")
-		var/datum/reagents/R = new/datum/reagents(50)
+		var/datum/reagents/R = new (2500)
 		R.my_atom = vent
-		R.add_reagent(pick(gunk), 50)
+		R.add_reagent(pick(gunk), 2450)
 
 		var/datum/effect_system/smoke_spread/chem/smoke = new
 		smoke.set_up(R, vent, TRUE)

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -312,9 +312,9 @@
 		if(prob(EFFECT_PROB_VERYLOW-badThingCoeff))
 			visible_message("<span class='danger'>[src] destroys [exp_on], leaking dangerous gas!</span>")
 			chosenchem = pick("carbon","radium","toxin","condensedcapsaicin","psilocybin","space_drugs","ethanol","beepskysmash")
-			var/datum/reagents/R = new/datum/reagents(15)
+			var/datum/reagents/R = new/datum/reagents(400)
 			R.my_atom = src
-			R.add_reagent(chosenchem , 15)
+			R.add_reagent(chosenchem , 375)
 			investigate_log("Experimentor has released [chosenchem] smoke.", INVESTIGATE_EXPERIMENTOR)
 			var/datum/effect_system/smoke_spread/chem/smoke = new
 			smoke.set_up(R, src, TRUE)
@@ -325,9 +325,9 @@
 		if(prob(EFFECT_PROB_VERYLOW-badThingCoeff))
 			visible_message("<span class='danger'>[src]'s chemical chamber has sprung a leak!</span>")
 			chosenchem = pick("mutationtoxin","nanomachines","sacid")
-			var/datum/reagents/R = new/datum/reagents(15)
+			var/datum/reagents/R = new/datum/reagents(400)
 			R.my_atom = src
-			R.add_reagent(chosenchem , 15)
+			R.add_reagent(chosenchem , 375)
 			var/datum/effect_system/smoke_spread/chem/smoke = new
 			smoke.set_up(R, src, TRUE)
 			playsound(src.loc, 'sound/effects/smoke.ogg', 50, 1, -3)
@@ -411,9 +411,9 @@
 			investigate_log("Experimentor has made a cup of [chosenchem] coffee.", INVESTIGATE_EXPERIMENTOR)
 		if(prob(EFFECT_PROB_VERYLOW-badThingCoeff))
 			visible_message("<span class='danger'>[src] malfunctions, shattering [exp_on] and releasing a dangerous cloud of coolant!</span>")
-			var/datum/reagents/R = new/datum/reagents(15)
+			var/datum/reagents/R = new/datum/reagents(400)
 			R.my_atom = src
-			R.add_reagent("frostoil" , 15)
+			R.add_reagent("frostoil" , 375)
 			investigate_log("Experimentor has released frostoil gas.", INVESTIGATE_EXPERIMENTOR)
 			var/datum/effect_system/smoke_spread/chem/smoke = new
 			smoke.set_up(R, src, TRUE)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Стянул у оффов небольшой рефактор дыма, теперь он не создаёт 110 таймеров а использует один прок со слипом
Переработал механику дыма - реагенты теперь делятся между тайлами на которые попадают
Добавил защиту от дюпа реагентов
Увеличил количество реагентов в раундстартовых гранатах и эффектах вроде выброса газа из труб чтобы они работали также как и до этого

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1052489979881853009
