### PR TITLE
fix: disable tracking on syndie-gps

### DIFF
--- a/_maps/map_files/generic/CentComm.dmm
+++ b/_maps/map_files/generic/CentComm.dmm
@@ -18203,7 +18203,9 @@
 /area/shuttle/gamma/space)
 "jVI" = (
 /obj/item/flashlight,
-/obj/item/gps,
+/obj/item/gps{
+	tracking = 0
+	},
 /obj/item/radio{
 	pixel_y = 6
 	},


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Переключает одно значение у GPS на ЦК, чтобы шахтёры и другие пользователи шаттла не видели синди-карго.

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/617004034405957642/1055451809986138152

## Демонстрация изменений
![image](https://user-images.githubusercontent.com/87372121/209130036-21932a30-7e6c-475c-a82c-e406bf2ea72e.png)
