### PR TITLE
Fix: SIT & SST equipment now give syndie faction

### DIFF
--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -72,6 +72,11 @@
 	. = H.equip_syndicate_infiltrator(0, 20, FALSE)
 	H.sec_hud_set_ID()
 
+/datum/outfit/admin/syndicate_infiltrator/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	if(visualsOnly)
+		return
+	H.faction += "syndicate"
 
 /datum/outfit/admin/syndicate/operative
 	name = "Syndicate Nuclear Operative"
@@ -117,6 +122,11 @@
 /datum/outfit/admin/syndicate_strike_team/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	return H.equip_syndicate_commando(FALSE, TRUE)
 
+/datum/outfit/admin/syndicate_strike_team/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	if(visualsOnly)
+		return
+	H.faction += "syndicate"
 
 /datum/outfit/admin/syndicate/spy
 	name = "Syndicate Spy"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Экипировка СИТ и ССТ теперь даёт фракцию синдиката, чтобы по куклам не стреляли туррели когда их спавнишь

