### PR TITLE
Tweak: Cd for emotes and me emotes

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -177,6 +177,8 @@
 			on_CD = handle_emote_CD()
 		if("gasp", "gasps")
 			on_CD = handle_emote_CD()
+		if("salute", "salutes")
+			on_CD = handle_emote_CD()
 		if("deathgasp", "deathgasps")
 			on_CD = handle_emote_CD(50)
 		if("sneeze", "sneezes")
@@ -185,7 +187,10 @@
 			on_CD = handle_emote_CD()
 		//Everything else, including typos of the above emotes
 		else
-			on_CD = FALSE	//If it doesn't induce the cooldown, we won't check for the cooldown
+			if(last_emote == act)
+				on_CD = handle_emote_CD(10)
+			else
+				on_CD = handle_emote_CD(5)		//no "snuffle" "sniff" spam
 
 	if(!force && on_CD == 1)		// Check if we need to suppress the emote attempt.
 		return			// Suppress emote, you're still cooling off.
@@ -453,8 +458,6 @@
 
 		if("salute", "salutes")
 			if(!restrained())
-				if(handle_emote_CD())
-					return
 				var/M = handle_emote_param(param)
 
 				message = "салюту[pluralize_ru(src.gender,"ет","ют")][M ? " [M]" : ""]!"
@@ -1202,6 +1205,9 @@
 			to_chat(src, emotelist)
 		else
 			to_chat(src, "<span class='notice'>Неизвестный эмоут '[act]'. Введи *help для отображения списка.</span>")
+
+	last_emote = act
+
 	..()
 
 /mob/living/carbon/human/verb/pose()

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -184,6 +184,10 @@ GLOBAL_LIST_EMPTY(channel_to_radio_key)
 
 /mob/living/custom_emote(var/m_type=EMOTE_VISUAL,var/message = null)
 	if(client)
+		if(last_emote == "me")
+			if(handle_emote_CD(10) == 1)
+				return
+		last_emote = "me"
 		client.check_say_flood(5)
 		if(client.prefs.muted & MUTE_IC)
 			to_chat(src, "<span class='danger'>You cannot speak in IC (Muted).</span>")

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -128,6 +128,7 @@
 	var/stuttering = 0
 	var/weakened = 0
 	var/disgust = 0
+	var/last_emote = null
 
 // RESTING
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Даёт эмоциям, у которых не было кд, кд на использование ~1 секунду, если до этого была эта эмоция. Иначе даёт кд ~полсекунды (сделано для предотвращения спама эмоция1, эмоция2, эмоция1...)
Даёт ме эмоутам кд на 1 секунду.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Авоут обычных эмоутов: https://discord.com/channels/617003227182792704/755125334097133628/1057739642419548190
Авоут ме эмоутов: https://discord.com/channels/617003227182792704/755125334097133628/1057739577726599180
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->