### PR TITLE
Acidproof potion

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -6,6 +6,7 @@
 	var/list/species_restricted = null //Only these species can wear this kit.
 	var/scan_reagents = 0 //Can the wearer see reagents while it's equipped?
 	var/gunshot_residue //Used by forensics.
+	var/is_improoved_by_potion = FALSE //used for xenobio potions
 
 	/*
 		Sprites used when the clothing item is refit. This is done by setting icon_override.

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -54,6 +54,20 @@
 /datum/chemical_reaction/slimemutate/on_reaction(datum/reagents/holder)
 	SSblackbox.record_feedback("tally", "slime_cores_used", 1, type)
 
+/datum/chemical_reaction/slimeacidproof
+	name = "Slime Acidproof"
+	id = "m_acidproof"
+	result = null
+	required_reagents = list("water" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/green
+	required_other = 1
+
+/datum/chemical_reaction/slimeacidproof/on_reaction(datum/reagents/holder)
+	SSblackbox.record_feedback("tally", "slime_cores_used", 1, type)
+	var/obj/item/slimepotion/acidproof/P = new /obj/item/slimepotion/acidproof
+	P.forceMove(get_turf(holder.my_atom))
+
 //Metal
 /datum/chemical_reaction/slimemetal
 	name = "Slime Metal"

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -546,13 +546,16 @@
 	if(!istype(C))
 		to_chat(user, "<span class='warning'>The potion can only be used on clothing!</span>")
 		return
-	if(C.resistance_flags & ACID_PROOF)
+	if(C.resistance_flags & ACID_PROOF && istype(C.armor) && C.armor.acid == 100)
 		to_chat(user, "<span class='warning'>[C] is already acidproof!</span>")
 		return ..()
-	to_chat(user, "<span class='notice'>You slather the green gunk over [C], acidproofing it.</span>")
 	C.name = "acidproofed [C.name]"
 	C.add_atom_colour("#008000", WASHABLE_COLOUR_PRIORITY)
 	C.resistance_flags |= ACID_PROOF
+	if(istype(C.armor))
+		C.armor.acid = 100
+	to_chat(user, "<span class='notice'>You slather the green gunk over [C], acidproofing it.</span>")
+	qdel(src)
 
 /obj/item/slimepotion/fireproof/MouseDrop(obj/over_object)
 	if(usr.incapacitated())

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -531,6 +531,36 @@
 	if(loc == usr && loc.Adjacent(over_object))
 		afterattack(over_object, usr, TRUE)
 
+/obj/item/slimepotion/acidproof
+	name = "slime acidproof potion"
+	desc = "A potent chemical mix that will acidproof any article of clothing."
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "bottle17"
+	origin_tech = "biotech=5"
+	resistance_flags = ACID_PROOF
+
+/obj/item/slimepotion/acidproof/afterattack(obj/item/clothing/C, mob/user, proximity_flag)
+	..()
+	if(!proximity_flag)
+		return
+	if(!istype(C))
+		to_chat(user, "<span class='warning'>The potion can only be used on clothing!</span>")
+		return
+	if(C.resistance_flags & ACID_PROOF)
+		to_chat(user, "<span class='warning'>[C] is already acidproof!</span>")
+		return ..()
+	to_chat(user, "<span class='notice'>You slather the green gunk over [C], acidproofing it.</span>")
+	C.name = "acidproofed [C.name]"
+	C.add_atom_colour("#008000", WASHABLE_COLOUR_PRIORITY)
+	C.resistance_flags |= ACID_PROOF
+
+/obj/item/slimepotion/fireproof/MouseDrop(obj/over_object)
+	if(usr.incapacitated())
+		return
+	if(loc == usr && loc.Adjacent(over_object))
+		afterattack(over_object, usr, TRUE)
+
+
 /obj/effect/timestop
 	anchored = 1
 	name = "chronofield"

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -567,7 +567,7 @@
 	to_chat(user, "<span class='notice'>You slather the green gunk over [C], acidproofing it.</span>")
 	qdel(src)
 
-/obj/item/slimepotion/fireproof/MouseDrop(obj/over_object)
+/obj/item/slimepotion/acidproof/MouseDrop(obj/over_object)
 	if(usr.incapacitated())
 		return
 	if(loc == usr && loc.Adjacent(over_object))

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -515,12 +515,17 @@
 	if(C.max_heat_protection_temperature == FIRE_IMMUNITY_MAX_TEMP_PROTECT)
 		to_chat(user, "<span class='warning'>[C] is already fireproof!</span>")
 		return ..()
+	if(C.is_improoved_by_potion)
+		to_chat(user, "<span class='warning'>[C] is already improoved by some potion!</span>")
+		return ..()
+
 	to_chat(user, "<span class='notice'>You slather the blue gunk over [C], fireproofing it.</span>")
 	C.name = "fireproofed [C.name]"
 	C.add_atom_colour("#000080", WASHABLE_COLOUR_PRIORITY)
 	C.max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	C.heat_protection = C.body_parts_covered
 	C.resistance_flags |= FIRE_PROOF
+	C.is_improoved_by_potion = TRUE
 	uses --
 	if(!uses)
 		qdel(src)
@@ -549,9 +554,14 @@
 	if(C.resistance_flags & ACID_PROOF && istype(C.armor) && C.armor.acid == 100)
 		to_chat(user, "<span class='warning'>[C] is already acidproof!</span>")
 		return ..()
+	if(C.is_improoved_by_potion)
+		to_chat(user, "<span class='warning'>[C] is already improoved by some potion!</span>")
+		return ..()
+
 	C.name = "acidproofed [C.name]"
 	C.add_atom_colour("#008000", WASHABLE_COLOUR_PRIORITY)
 	C.resistance_flags |= ACID_PROOF
+	C.is_improoved_by_potion = TRUE
 	if(istype(C.armor))
 		C.armor.acid = 100
 	to_chat(user, "<span class='notice'>You slather the green gunk over [C], acidproofing it.</span>")

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -535,7 +535,7 @@
 	name = "slime acidproof potion"
 	desc = "A potent chemical mix that will acidproof any article of clothing."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle17"
+	icon_state = "bottle16"
 	origin_tech = "biotech=5"
 	resistance_flags = ACID_PROOF
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет возможность создать анти-кислотное зелье в ксенобиологии. Для этого нужно в зелёный экстракт вколоть воды. Создаётся одноразовое зелье, улучшающее показатель брони от кислоты у одежды при нанесении до 100, а так же добавляющее флаг защиты от кислоты, не позволяющий вещи расплавиться от кислоты. 

Так же добавляет невозможность нанести одновременно синее и зелёное зелье на одну и ту же одежду.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1056650409592238100
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
https://www.youtube.com/watch?v=Ca8FoxU8MPc
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
