### PR TITLE
fix: Correct location lungs

### DIFF
--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -88,7 +88,7 @@
 		return
 
 	if(!breath || (breath.total_moles() == 0))
-		if(isspaceturf(loc))
+		if(isspaceturf(H.loc))
 			H.adjustOxyLoss(10)
 		else
 			H.adjustOxyLoss(5)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Теперь проверяется на спейстурф не локация лёгких (которой можно сказать нет), а локация носителя этих лёгких. Должно быть в космосе по 10 окси урона, как и задумывалось.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Очевидно это баг. 
Обсуждение: https://discord.com/channels/617003227182792704/734823601110515882/1058058759257210960
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

