### PR TITLE
Fix: Vampire and crayons

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -110,12 +110,14 @@
 				return
 		playsound(loc, 'sound/items/eatfood.ogg', 50, 0)
 		to_chat(user, "<span class='notice'>You take a [huffable ? "huff" : "bite"] of the [name]. Delicious!</span>")
-		user.adjust_nutrition(5)
+		if(!user.mind.vampire)
+			user.adjust_nutrition(5)
 		if(uses)
 			uses -= 5
 			if(uses <= 0)
 				to_chat(user, "<span class='warning'>There is no more of [name] left!</span>")
 				qdel(src)
+
 	else
 		..()
 

--- a/code/modules/food_and_drinks/item_food/eat_items.dm
+++ b/code/modules/food_and_drinks/item_food/eat_items.dm
@@ -78,7 +78,8 @@
 
 	current_bites++
 	playsound(user.loc, 'sound/items/eatfood.ogg', 50, 0)
-	target.adjust_nutrition(nutritional_value)
+	if(!target.mind.vampire) //Не дает сытости вампирам
+		target.adjust_nutrition(nutritional_value)
 	obj_integrity = max(obj_integrity - integrity_bite, 0)
 	colour_change()
 	if(current_bites >= max_bites)

--- a/code/modules/food_and_drinks/item_food/eat_items.dm
+++ b/code/modules/food_and_drinks/item_food/eat_items.dm
@@ -78,7 +78,7 @@
 
 	current_bites++
 	playsound(user.loc, 'sound/items/eatfood.ogg', 50, 0)
-	if(!target.mind.vampire) //Не дает сытости вампирам
+	if(!target.mind.vampire) //Dont give nutrition to vampires
 		target.adjust_nutrition(nutritional_value)
 	obj_integrity = max(obj_integrity - integrity_bite, 0)
 	colour_change()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Убирает добавление сытости вампирам за счет мелка и поедания некоторых предметов (моли/воксы)
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багфикс
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->