### PR TITLE
feat: Setting EPSILON when calling the Death Squad

### DIFF
--- a/code/modules/admin/verbs/striketeam.dm
+++ b/code/modules/admin/verbs/striketeam.dm
@@ -45,6 +45,9 @@ GLOBAL_VAR_INIT(sent_strike_team, 0)
 
 	GLOB.sent_strike_team = 1
 
+	// Sets the EPSILON code automatically after spawn
+	set_security_level(epsilon)
+
 	// Spawns commandos and equips them.
 	var/commando_number = COMMANDOS_POSSIBLE //for selecting a leader
 	var/is_leader = TRUE // set to FALSE after leader is spawned


### PR DESCRIPTION
## What Does This PR Do
При вызове Отряда Смерти через панель "Secrets" и успешном спавне членов Отряда автоматически устанавливает код Эпсилон

## Why It's Good For The Game
Автоматическое установление кода сразу после вызова ОС, а не в моменты, когда ОС уже прибыл на ИСН.

## Images of changes
Видео представление - https://youtu.be/5T2Uu2pXXio
Дискорд голосование - https://discord.com/channels/617003227182792704/618952559607939072/1060556297151463434

## Changelog
add: Смена кода угрозы на ЭПСИЛОН при спавне Отряда Смерти