### PR TITLE
FIX: Дельта наслоение текстур на апц генетика/морг

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -50594,6 +50594,16 @@
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/storage)
+"eZC" = (
+/obj/effect/decal/warning_stripes/south,
+/obj/structure/closet/walllocker{
+	pixel_y = -28;
+	layer = 2.8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkblue"
+	},
+/area/medical/morgue)
 "eZH" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -128819,18 +128829,18 @@
 	},
 /area/security/permabrig)
 "wkt" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/morgue{
 	dir = 8
 	},
 /obj/effect/landmark{
 	name = "revenantspawn"
 	},
+/obj/machinery/light/small,
 /obj/structure/extinguisher_cabinet{
-	pixel_y = 32
+	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
 	icon_state = "darkblue"
 	},
 /area/medical/morgue)
@@ -178548,11 +178558,11 @@ dnD
 aaH
 aaJ
 duk
-wkt
+mcf
 swV
 ylJ
 mcf
-xWx
+wkt
 duk
 iUx
 oIw
@@ -178809,7 +178819,7 @@ pem
 dCc
 ylJ
 xGL
-jxO
+eZC
 duk
 flw
 jIo


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Перенес огнетушитель в морге на противоположную стену, было наслоение текстур, ИИ плохо видел АПЦ. Также в морге понизил слой настенного шкафа, чтобы АПЦ в техах было чуть лучше видно для ИИ.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
https://discord.com/channels/617003227182792704/904864726973046834/1060675851525554176
## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
До:
![screenshot 5115](https://user-images.githubusercontent.com/87157426/211131474-5f46fd91-0b32-4ace-8aec-767f2dad648a.jpg)
После:
![screenshot 5117](https://user-images.githubusercontent.com/87157426/211131482-a2e3ad36-3576-4aa7-b07e-ce7359b1e376.jpg)
