### PR TITLE
fix: infinity resin walls/etc on one tile

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -221,6 +221,10 @@ Doesn't work on other aliens/AI.*/
 		var/choice = input("Choose what you wish to shape.","Resin building") as null|anything in list("resin wall","resin membrane","resin nest") //would do it through typesof but then the player choice would have the type path and we don't want the internal workings to be exposed ICly - Urist
 
 		if(!choice || !plasmacheck(55))	return
+		var/turf/T = get_turf(host.loc)
+		if(locate(/obj/structure/alien) in T.contents || locate(/obj/structure/bed/nest) in T.contents)
+			to_chat(host, "<span class ='warning'>Это место уже занято!</span>")
+			return
 		host.adjustPlasma(-55)
 		for(var/mob/O in viewers(host, null))
 			O.show_message(text("<span class='alertalien'>[host] vomits up a thick purple substance and shapes it!</span>"), 1)

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -222,7 +222,7 @@ Doesn't work on other aliens/AI.*/
 
 		if(!choice || !plasmacheck(55))	return
 		var/turf/T = get_turf(host.loc)
-		if(locate(/obj/structure/alien) in T.contents || locate(/obj/structure/bed/nest) in T.contents)
+		if(locate(/obj/structure/alien/wall) in T.contents || locate(/obj/structure/bed/nest) in T.contents || locate(/obj/structure/alien/wall) in T.contents)
 			to_chat(host, "<span class ='warning'>Это место уже занято!</span>")
 			return
 		host.adjustPlasma(-55)

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -222,7 +222,7 @@ Doesn't work on other aliens/AI.*/
 
 		if(!choice || !plasmacheck(55))	return
 		var/turf/T = get_turf(host.loc)
-		if(locate(/obj/structure/alien/wall) in T.contents || locate(/obj/structure/bed/nest) in T.contents || locate(/obj/structure/alien/wall) in T.contents)
+		if(locate(/obj/structure/alien/resin) in T.contents || locate(/obj/structure/bed/nest) in T.contents)
 			to_chat(host, "<span class ='warning'>Это место уже занято!</span>")
 			return
 		host.adjustPlasma(-55)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет проверку не занят ли этот тайл уже resin_wall/resin_membrane/nest-ом перед попыткой создания новой резиновой структуры ксеноморфом. В теории можно было бы заменить просто на проверку занятости тайла, но я хз насколько ли это касается прямо бага, а насколько уже требует предложки, так что хватит и этого.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багфикс, репорт - https://discord.com/channels/617003227182792704/617004034405957642/1062062494488735865
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->