### PR TITLE
fix: не-используемые роды при крафте пода

### DIFF
--- a/code/modules/spacepods/parts.dm
+++ b/code/modules/spacepods/parts.dm
@@ -62,10 +62,12 @@
 		if(!linkedparts)
 			to_chat(user, "<span class='rose'>You cannot assemble a pod frame because you do not have the necessary assembly.</span>")
 			return
+		if(!R.use(10))
+			to_chat(user, "<span class='warning'>Вам не хватает арматуры! Нужно минимум десять!</span>")
+			return
 		var/obj/structure/spacepod_frame/pod = new /obj/structure/spacepod_frame(src.loc)
 		pod.dir = src.dir
 		to_chat(user, "<span class='notice'>You strut the pod frame together.</span>")
-		R.use(10)
 		for(var/obj/item/pod_parts/pod_frame/F in linkedparts)
 			if(1 == turn(F.dir, -F.link_angle)) //if the part links north during construction, as the bottom left part always does
 				//log_admin("Repositioning")


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
До этого если у вас не хватало 10 родов для постройки пода то оно не сжирало их, но продолжало крафт. Теперь нет.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багфикс. Репорт - https://discord.com/channels/617003227182792704/617004034405957642/1062384324512600084
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->