### PR TITLE
Added disks, seeds and other, upgraded machinery to Lavaland Seed Vault

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -26,7 +26,14 @@
 /area/ruin/powered/seedvault)
 "e" = (
 /obj/structure/table/wood,
-/obj/item/storage/box/disks_plantgene,
+/obj/item/storage/box/disks_plantgene{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/item/storage/box/disks_plantgene{
+	pixel_x = 3;
+	pixel_y = -2
+	},
 /turf/simulated/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "f" = (
@@ -38,7 +45,7 @@
 /area/ruin/powered/seedvault)
 "g" = (
 /obj/structure/table/wood,
-/obj/machinery/smartfridge/disks{
+/obj/machinery/smartfridge/disks/seedvault{
 	pixel_y = 2
 	},
 /turf/simulated/floor/plasteel/freezer,
@@ -66,7 +73,9 @@
 /area/lavaland/surface/outdoors)
 "k" = (
 /obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/seed_vault,
+/obj/item/seeds/apple/poisoned,
+/obj/item/seeds/apple/poisoned,
+/obj/item/seeds/apple/poisoned,
 /turf/simulated/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "l" = (
@@ -84,7 +93,7 @@
 /turf/simulated/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "n" = (
-/obj/machinery/smartfridge,
+/obj/machinery/smartfridge/seedvault,
 /turf/simulated/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "o" = (
@@ -111,6 +120,14 @@
 /obj/item/hatchet,
 /obj/item/storage/bag/plants,
 /obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/beaker/bluespace{
+	pixel_x = -4;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/glass/beaker/bluespace{
+	pixel_x = 6;
+	pixel_y = 2
+	},
 /obj/structure/table/wood,
 /turf/simulated/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
@@ -120,6 +137,14 @@
 /obj/item/storage/bag/plants,
 /obj/item/storage/bag/plants,
 /obj/item/storage/bag/plants,
+/obj/item/reagent_containers/glass/beaker/bluespace{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/glass/beaker/bluespace{
+	pixel_x = -6;
+	pixel_y = 7
+	},
 /turf/simulated/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "s" = (
@@ -128,7 +153,18 @@
 /obj/item/gun/energy/floragun,
 /obj/item/gun/energy/floragun,
 /obj/item/gun/energy/floragun,
-/obj/item/storage/box/disks_plantgene,
+/obj/item/storage/box/disks_plantgene{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/storage/box/disks_plantgene{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/storage/box/disks_plantgene{
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /turf/simulated/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "t" = (
@@ -157,14 +193,26 @@
 /turf/simulated/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "x" = (
-/obj/machinery/reagentgrinder{
+/obj/machinery/reagentgrinder/seedvault{
 	pixel_y = 5
 	},
 /obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/bluespace,
-/obj/item/reagent_containers/glass/beaker/bluespace,
-/obj/item/reagent_containers/glass/beaker/bluespace,
-/obj/item/reagent_containers/glass/beaker/bluespace,
+/obj/item/reagent_containers/glass/beaker/bluespace{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/glass/beaker/bluespace{
+	pixel_x = -1;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/glass/beaker/bluespace{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/glass/beaker/bluespace{
+	pixel_x = 8;
+	pixel_y = 1
+	},
 /turf/simulated/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "y" = (
@@ -198,15 +246,15 @@
 /turf/simulated/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "C" = (
-/obj/machinery/seed_extractor,
+/obj/machinery/seed_extractor/seedvault,
 /turf/simulated/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "D" = (
-/obj/machinery/biogenerator,
+/obj/machinery/biogenerator/seedvault,
 /turf/simulated/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "E" = (
-/obj/machinery/chem_dispenser/mutagensaltpeter,
+/obj/machinery/chem_dispenser/botanical/seedvault,
 /turf/simulated/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "F" = (
@@ -219,10 +267,14 @@
 /obj/item/clothing/under/rank/hydroponics,
 /obj/item/clothing/under/rank/hydroponics,
 /obj/item/clothing/under/rank/hydroponics,
+/obj/item/clothing/glasses/hud/hydroponic,
+/obj/item/clothing/glasses/hud/hydroponic,
+/obj/item/clothing/glasses/hud/hydroponic,
+/obj/item/clothing/glasses/hud/hydroponic,
 /turf/simulated/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "H" = (
-/obj/machinery/chem_master/condimaster,
+/obj/machinery/chem_master/condimaster/seedvault,
 /turf/simulated/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "I" = (
@@ -234,8 +286,9 @@
 /turf/simulated/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "J" = (
-/obj/item/storage/toolbox/syndicate,
+/obj/item/storage/toolbox/electrical,
 /obj/structure/table/wood,
+/obj/item/multitool,
 /turf/simulated/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "K" = (
@@ -262,7 +315,13 @@
 /area/lavaland/surface/outdoors)
 "N" = (
 /obj/structure/table/wood,
-/obj/item/storage/box/disks_plantgene,
+/obj/item/storage/box/disks_plantgene{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/storage/box/disks_plantgene{
+	pixel_y = -1
+	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -333,6 +392,13 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"Z" = (
+/obj/structure/closet/crate,
+/obj/item/seeds/cherry/bomb,
+/obj/item/seeds/cherry/bomb,
+/obj/item/seeds/cherry/bomb,
+/turf/simulated/floor/plasteel/freezer,
+/area/ruin/powered/seedvault)
 
 (1,1,1) = {"
 a
@@ -427,7 +493,7 @@ a
 a
 Q
 Q
-k
+Z
 Q
 n
 R

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -344,6 +344,17 @@
 /obj/machinery/smartfridge/proc/accept_check(obj/item/O)
 	return is_type_in_typecache(O, accepted_items_typecache)
 
+/obj/machinery/smartfridge/seedvault/Initialize()
+	. = ..()
+
+	QDEL_LIST(component_parts)
+	var/obj/item/circuitboard/smartfridge/board = new(null)
+	board.set_type(type)
+	component_parts += board
+	component_parts += new /obj/item/stock_parts/matter_bin/bluespace(null)
+	RefreshParts()
+
+
 /**
   * # Syndie Fridge
   */
@@ -533,6 +544,20 @@
 	accepted_items_typecache = typecacheof(list(
 		/obj/item/disk,
 	))
+
+/obj/machinery/smartfridge/disks/seedvault/Initialize()
+	. = ..()
+	accepted_items_typecache = typecacheof(list(
+		/obj/item/disk,
+	))
+
+	QDEL_LIST(component_parts)
+	component_parts = list()
+	var/obj/item/circuitboard/smartfridge/board = new(null)
+	board.set_type(type)
+	component_parts += board
+	component_parts += new /obj/item/stock_parts/matter_bin/bluespace(null)
+	RefreshParts()
 
 /**
   * # Smart Virus Storage

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -30,6 +30,18 @@
 	component_parts += new /obj/item/stack/cable_coil(null, 1)
 	RefreshParts()
 
+/obj/machinery/biogenerator/seedvault/New()
+	..()
+	files = new /datum/research/biogenerator(src)
+	create_reagents(1000)
+	component_parts = list()
+	component_parts += new /obj/item/circuitboard/biogenerator(null)
+	component_parts += new /obj/item/stock_parts/matter_bin/bluespace(null)
+	component_parts += new /obj/item/stock_parts/manipulator/femto(null)
+	component_parts += new /obj/item/stack/sheet/glass(null)
+	component_parts += new /obj/item/stack/cable_coil(null, 1)
+	RefreshParts()
+
 /obj/machinery/biogenerator/Destroy()
 	QDEL_NULL(beaker)
 	QDEL_NULL(files)

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -40,7 +40,7 @@
 	component_parts += new /obj/item/stack/sheet/glass(null)
 	component_parts += new /obj/item/stock_parts/scanning_module/triphasic(null)
 	component_parts += new /obj/item/stock_parts/micro_laser/quadultra(null)
-	component_parts += new /obj/item/stock_parts/manipulator/pico(null)
+	component_parts += new /obj/item/stock_parts/manipulator/femto(null)
 	RefreshParts()
 
 /obj/machinery/plantgenes/Destroy()

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -56,6 +56,14 @@
 	component_parts += new /obj/item/stock_parts/manipulator(null)
 	RefreshParts()
 
+/obj/machinery/seed_extractor/seedvault/New()
+	..()
+	component_parts = list()
+	component_parts += new /obj/item/circuitboard/seed_extractor(null)
+	component_parts += new /obj/item/stock_parts/matter_bin/bluespace(null)
+	component_parts += new /obj/item/stock_parts/manipulator/femto(null)
+	RefreshParts()
+
 /obj/machinery/seed_extractor/Destroy()
 	QDEL_LIST(piles)
 	return ..()

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -430,6 +430,26 @@
 	component_parts += new cell_type(null)
 	RefreshParts()
 
+//upgraded botanical chemical dispenser
+/obj/machinery/chem_dispenser/botanical/seedvault
+	name = "botanical chemical dispenser"
+	desc = "A botanical chemical dispenser on a budget."
+	ui_title = "Botanical Chem Dispenser"
+	dispensable_reagents = list("mutagen", "saltpetre", "ammonia", "water", "atrazine", "glyphosate", "pestkiller", "diethylamine", "ash")
+
+
+/obj/machinery/chem_dispenser/botanical/seedvault/New()
+	..()
+	QDEL_LIST(component_parts)
+	component_parts += new /obj/item/circuitboard/chem_dispenser/botanical(null)
+	component_parts += new /obj/item/stock_parts/matter_bin/bluespace(null)
+	component_parts += new /obj/item/stock_parts/matter_bin/bluespace(null)
+	component_parts += new /obj/item/stock_parts/capacitor/quadratic(null)
+	component_parts += new /obj/item/stock_parts/manipulator/femto(null)
+	component_parts += new /obj/item/stack/sheet/glass(null)
+	component_parts += new /obj/item/stock_parts/cell/bluespace(null)
+	RefreshParts()
+
 // Handheld chem dispenser
 /obj/item/handheld_chem_dispenser
 	name = "handheld chem dispenser"

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -575,6 +575,16 @@
 	component_parts += new /obj/item/reagent_containers/glass/beaker(null)
 	RefreshParts()
 
+/obj/machinery/chem_master/condimaster/seedvault/New()
+	..()
+	QDEL_LIST(component_parts)
+	component_parts += new /obj/item/circuitboard/chem_master/condi_master(null)
+	component_parts += new /obj/item/stock_parts/manipulator/femto(null)
+	component_parts += new /obj/item/stack/sheet/glass(null)
+	component_parts += new /obj/item/reagent_containers/glass/beaker/bluespace(null)
+	component_parts += new /obj/item/reagent_containers/glass/beaker/bluespace(null)
+	RefreshParts()
+
 #undef MAX_PILL_SPRITE
 #undef MAX_MULTI_AMOUNT
 #undef MAX_UNITS_PER_PILL

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -104,6 +104,18 @@
 	component_parts += new /obj/item/stock_parts/matter_bin(null)
 	RefreshParts()
 
+
+/obj/machinery/reagentgrinder/seedvault/New()
+	..()
+	component_parts = list()
+	component_parts += new /obj/item/circuitboard/reagentgrinder(null)
+	component_parts += new /obj/item/stock_parts/manipulator/femto(null)
+	component_parts += new /obj/item/stock_parts/manipulator/femto(null)
+	component_parts += new /obj/item/stock_parts/matter_bin/bluespace(null)
+	RefreshParts()
+
+	beaker = new /obj/item/reagent_containers/glass/beaker/bluespace
+
 /obj/machinery/reagentgrinder/RefreshParts()
 	var/H
 	var/T


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
- Созданы и расставлены максимально улучшенные версии автоматов, стoящих в Seed Vault
- Добавлены коробки с дисками, бикеры, ХУДы, семена сделаны нерандомными - всегда есть по три Cherry Bomb и Poisoned Apple (Гатфрута не будет)
- Чемодан Синдиката (пустой) заменен на электрический - с ним можно разобрать любой автомат и там есть провода для картофельных батареек, к нему добавил мультитул

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
https://discord.com/channels/617003227182792704/1059381086469234728/1059381086469234728
https://discord.com/channels/617003227182792704/618952559607939072/1062643931533291631

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
Основное - ботанический раздатчик теперь можно разобрать и вставить туда картофельную батарейку