### PR TITLE
Fix: Spawners - TTS after Qdel

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -168,6 +168,7 @@
 				break
 	else
 		M.tts_seed = pick(SStts.tts_seeds)
+
 // Base version - place these on maps/templates.
 /obj/effect/mob_spawn/human
 	mob_type = /mob/living/carbon/human

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -158,16 +158,16 @@
 		M.mind.offstation_role = offstation_role
 		special(M, name)
 		MM.name = M.real_name
+	if(uses > 0)
+		uses--
+	if(!permanent && !uses)
+		qdel(src)
+	if(plr)
 		for(var/i in 1 to 10)
 			if(M.change_voice())
 				break
 	else
 		M.tts_seed = pick(SStts.tts_seeds)
-	if(uses > 0)
-		uses--
-	if(!permanent && !uses)
-		qdel(src)
-
 // Base version - place these on maps/templates.
 /obj/effect/mob_spawn/human
 	mob_type = /mob/living/carbon/human


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Переносит выбор голоса ТТС персонажем, который уже заспавнился, после удаления спавнера. Сейчас спавнер не удалится, пока голос не выберут. Можно было заходить другим гостам в это время.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Чинит баг: https://discord.com/channels/617003227182792704/617004034405957642/1051229542905294858
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
Было:
![Снимок экрана 2023-01-08 150713](https://user-images.githubusercontent.com/120549107/211817572-d77e52f5-7c51-4f0d-882e-5ecde714eaca.png)

Теперь:
![Снимок экрана 2023-01-11 162415](https://user-images.githubusercontent.com/120549107/211817541-213c4cb2-eb93-41b9-995d-9183f13f9c2a.png)


<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->