### PR TITLE
Fix: remove ability to change card HUD icon using assignment name

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -565,16 +565,13 @@
 	return GLOB.joblist + list("Prisoner")
 
 /obj/item/proc/GetJobName() //Used in secHUD icon generation
-	var/assignmentName = "Unknown"
 	var/rankName = "Unknown"
 	if(istype(src, /obj/item/pda))
 		var/obj/item/pda/P = src
-		assignmentName = P.ownjob
 		rankName = P.ownrank
 	else
 		var/obj/item/card/id/id = GetID()
 		if(istype(id))
-			assignmentName = id.assignment
 			rankName = id.rank
 
 	var/job_icons = get_all_job_icons()
@@ -583,27 +580,19 @@
 	var/soviet = get_all_soviet_jobs()
 	var/special = get_all_special_jobs()
 
-	if(assignmentName in centcom) //Return with the NT logo if it is a Centcom job
-		return "Centcom"
-	if(rankName in centcom)
+	if(rankName in centcom) //Return with the NT logo if it is a Centcom job
 		return "Centcom"
 
-	if(assignmentName in solgov) //Return with the SolGov logo if it is a SolGov job
-		return "solgov"
-	if(rankName in solgov)
+	if(rankName in solgov) //Return with the SolGov logo if it is a SolGov job
 		return "solgov"
 
-	if(assignmentName in soviet) //Return with the U.S.S.P logo if it is a Soviet job
-		return "soviet"
-	if(rankName in soviet)
+	if(rankName in soviet) //Return with the U.S.S.P logo if it is a Soviet job
 		return "soviet"
 
 	if(rankName in special)
 		return "srt"
 
-	if(assignmentName in job_icons) //Check if the job has a hud icon
-		return assignmentName
-	if(rankName in job_icons)
+	if(rankName in job_icons) //Check if the job has a hud icon
 		return rankName
 
 	return "Unknown" //Return unknown if none of the above apply


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
->
Убирает возможность ставить себе любые иконки на секхуде (в том числе центкомовские) используя просто консоль ГП. Это все еще возможно сделать с картой хамелеоном. 
assigmentName просто не должен использоваться для определения иконки, мы разделили эту механику - rank для рации и иконок, name чисто для имени на карте