### PR TITLE
Fix: gps syndiborgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -683,7 +683,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	if(client.statpanel == "Status")
 		show_cell_power()
 	var/total_user_contents = GetAllContents()
-	if(locate(/obj/item/gps/cyborg) in total_user_contents)
+	if(locate(/obj/item/gps) in total_user_contents)
 		var/turf/T = get_turf(src)
 		stat(null, "GPS: [COORD(T)]")
 	if(module)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -550,7 +550,7 @@
 	modules += new /obj/item/pinpointer/operative(src)
 	modules += new /obj/item/pinpointer/nukeop(src)
 	modules += new /obj/item/gripper/nuclear(src)
-	modules += new /obj/item/gps/cyborg(src)
+	modules += new /obj/item/gps/syndiecyborg(src)
 	emag = null
 
 	fix_modules()

--- a/code/modules/mob/living/silicon/robot/syndicate.dm
+++ b/code/modules/mob/living/silicon/robot/syndicate.dm
@@ -70,6 +70,7 @@
 
 /mob/living/silicon/robot/syndicate/medical/init(alien = FALSE, mob/living/silicon/ai/ai_to_sync_to = null)
 	..()
+	QDEL_NULL(module)
 	module = new /obj/item/robot_module/syndicate_medical(src)
 
 /mob/living/silicon/robot/syndicate/saboteur
@@ -94,6 +95,7 @@
 
 /mob/living/silicon/robot/syndicate/saboteur/init(alien = FALSE, mob/living/silicon/ai/ai_to_sync_to = null)
 	..()
+	QDEL_NULL(module)
 	module = new /obj/item/robot_module/syndicate_saboteur(src)
 
 	var/obj/item/borg/upgrade/selfrepair/SR = new /obj/item/borg/upgrade/selfrepair(src)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Меняет обычный гпс у ассаулт борга на синдиверсию, как у саботёра и медицинского.
В статус панели у боргов отображается локация, если у них в модулях или в contents есть любой GPS.
Удаляет у мед и саботёр боргов перед инициализацией их модулей  старый модуль ассаулт, который оставался в contents и давал неотключаемый сигнал GPS. (как сделано у ниндзя борга)
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Чинит баг: https://discord.com/channels/617003227182792704/617004034405957642/1062547525510365224
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
