### PR TITLE
Fix nuclear operatives implants bundle

### DIFF
--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -401,7 +401,7 @@
 /obj/item/storage/box/cyber_implants/bundle
 	name = "boxed cybernetic implants"
 	var/list/boxed = list(/obj/item/organ/internal/cyberimp/eyes/xray,/obj/item/organ/internal/cyberimp/eyes/thermals,
-						/obj/item/organ/internal/cyberimp/brain/anti_stun, /obj/item/organ/internal/cyberimp/chest/reviver/hardened)
+						/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened, /obj/item/organ/internal/cyberimp/chest/reviver/hardened)
 	var/amount = 5
 
 /obj/item/storage/box/cyber_implants/bundle/New()


### PR DESCRIPTION
Заменяет обычный ЦНС имплант из набора имплантов ядерного оперативника на защищенный от эми,4 года этой строчке кода, емае.(в аплинке нюкера можно купить полноценный защищенный ЦНС имплант, почему в наборе же выдают дешевую подделку?)



