### PR TITLE
HOTFIX: Escape and external airlocks locked

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -1667,10 +1667,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "aoS" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "admin_home"
-	},
 /obj/effect/decal/warning_stripes/north,
+/obj/machinery/door/airlock/external{
+	id_tag = "admin_home";
+	locked = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "aoU" = (
@@ -6350,7 +6351,8 @@
 /area/quartermaster/office)
 "aRL" = (
 /obj/machinery/door/airlock/external{
-	id_tag = "ferry_home"
+	id_tag = "ferry_home";
+	locked = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -8535,10 +8537,11 @@
 	},
 /area/space)
 "bfF" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "specops_home"
-	},
 /obj/effect/decal/warning_stripes/north,
+/obj/machinery/door/airlock/external{
+	id_tag = "specops_home";
+	locked = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "bfL" = (
@@ -9834,7 +9837,8 @@
 /area/medical/virology/lab)
 "blv" = (
 /obj/machinery/door/airlock/external{
-	id_tag = "trade_dock"
+	id_tag = "trade_dock";
+	locked = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -33232,11 +33236,6 @@
 "dex" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/external{
-	hackProof = 1;
-	id_tag = "emergency_home";
-	name = "Escape Airlock"
-	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit/maint)
@@ -48962,6 +48961,16 @@
 	icon_state = "darkblue"
 	},
 /area/turret_protected/ai)
+"eIy" = (
+/obj/machinery/door/airlock/external{
+	hackProof = 1;
+	id_tag = "emergency_home";
+	name = "Security Escape Airlock";
+	req_access_txt = "1";
+	locked = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit)
 "eIQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -58838,7 +58847,8 @@
 	hackProof = 1;
 	id_tag = "emergency_home";
 	name = "Security Escape Airlock";
-	req_access_txt = "1"
+	req_access_txt = "1";
+	locked = 1
 	},
 /obj/effect/turf_decal/caution/red{
 	dir = 8
@@ -62770,6 +62780,14 @@
 	icon_state = "whitepurple"
 	},
 /area/toxins/mixing)
+"hJS" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "admin_home";
+	locked = 1
+	},
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/entry/additional)
 "hJX" = (
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -71326,7 +71344,8 @@
 /obj/machinery/door/airlock/external{
 	hackProof = 1;
 	id_tag = "emergency_home";
-	name = "Escape Airlock"
+	name = "Escape Airlock";
+	locked = 1
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
@@ -76367,6 +76386,14 @@
 	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
+"kSK" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "admin_home";
+	locked = 1
+	},
+/obj/effect/decal/warning_stripes/northwest,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/entry/additional)
 "kSR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -99030,12 +99057,6 @@
 	},
 /area/crew_quarters/theatre)
 "pMQ" = (
-/obj/machinery/door/airlock/external{
-	hackProof = 1;
-	id_tag = "emergency_home";
-	name = "Security Escape Airlock";
-	req_access_txt = "1"
-	},
 /obj/effect/turf_decal/caution{
 	dir = 1
 	},
@@ -99049,6 +99070,13 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/machinery/door/airlock/external{
+	hackProof = 1;
+	id_tag = "emergency_home";
+	name = "Security Escape Airlock";
+	req_access_txt = "1";
+	locked = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -116598,6 +116626,14 @@
 	icon_state = "grimy"
 	},
 /area/chapel/main)
+"tDv" = (
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/door/airlock/external{
+	id_tag = "admin_home";
+	locked = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/entry/additional)
 "tDB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -116882,11 +116918,6 @@
 /area/turret_protected/aisat_interior)
 "tGb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/external{
-	hackProof = 1;
-	id_tag = "emergency_home";
-	name = "Escape Airlock"
-	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -118674,16 +118705,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/detectives_office)
 "tYi" = (
-/obj/machinery/door/airlock/external{
-	hackProof = 1;
-	id_tag = "emergency_home";
-	name = "Escape Airlock"
-	},
 /obj/effect/turf_decal/caution{
 	dir = 8
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	hackProof = 1;
+	id_tag = "emergency_home";
+	name = "Escape Airlock";
+	locked = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -126084,11 +126116,6 @@
 /area/chapel/office)
 "vCC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/external{
-	hackProof = 1;
-	id_tag = "emergency_home";
-	name = "Escape Airlock"
-	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit/maint)
@@ -168723,8 +168750,8 @@ aaq
 aaq
 aaq
 dft
-aoS
-aoS
+kSK
+hJS
 dft
 abj
 abj
@@ -169238,7 +169265,7 @@ dft
 aFu
 dft
 aoS
-aoS
+tDv
 dft
 dft
 aFu
@@ -178138,7 +178165,7 @@ eXW
 ruH
 qpH
 iOD
-jGz
+eIy
 kUB
 jGz
 kUB


### PR DESCRIPTION
## Описание
Закрывает внешние аирлоки у шаттлов: карго, торговцев, ОБР, админ, фейри, ескейп, а так же 4 внешний порт(в прибытии). 

## Ссылка на предложение/Причина создания ПР
После установки обновления подов фиксы внешних шлюзов слетели.