### PR TITLE
fix: дюп солнечных очков на голодеке

### DIFF
--- a/_maps/map_files/generic/Admin_Zone.dmm
+++ b/_maps/map_files/generic/Admin_Zone.dmm
@@ -2846,7 +2846,7 @@
 /area/tdome/arena_source)
 "GF" = (
 /obj/item/clothing/under/rainbow,
-/obj/item/clothing/glasses/sunglasses,
+/obj/item/clothing/glasses/sunglasses_fake/holo,
 /turf/simulated/floor/beach/sand,
 /area/holodeck/source_beach)
 "GQ" = (

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -348,6 +348,10 @@
 		"Stok" = 'icons/mob/species/monkey/eyes.dmi'
 		)
 
+/obj/item/clothing/glasses/sunglasses_fake/holo
+	desc = "Protects against the holographic UV rays of the holographic sun."
+	name = "holographic sunglasses"
+
 /obj/item/clothing/glasses/thermal_fake
 	desc = "Cheap plastic sunglasses. Wear thoze if yu are kool."
 	name = "Phirmel Soonglesas"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Солнечные очки бесконечно спавнятся на голодеке. Таким образом можно было дюпать себе ХУД на любой вкус. Бесконечный спавн я не убрал, но теперь скрафтить из этих очков больше ничего нельзя.