### PR TITLE
Tweak: Stop loot necropolis while Legion live

### DIFF
--- a/_maps/map_files/Delta/Lavaland.dmm
+++ b/_maps/map_files/Delta/Lavaland.dmm
@@ -6624,6 +6624,18 @@
 /obj/effect/turf_decal/bot,
 /turf/simulated/floor/plasteel,
 /area/mine/production)
+"JL" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile,
+/turf/simulated/wall/indestructible/boss/two{
+	layer = 2.05
+	},
+/area/lavaland/surface/outdoors/necropolis)
 "JP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
@@ -8220,18 +8232,19 @@
 	},
 /area/lavaland/surface/outdoors/necropolis)
 "YI" = (
-/obj/structure/stone_tile/cracked{
+/obj/structure/stone_tile,
+/obj/structure/stone_tile{
 	dir = 4
 	},
 /obj/structure/stone_tile{
 	dir = 1
 	},
-/obj/structure/stone_tile,
 /obj/structure/stone_tile{
 	dir = 8
 	},
-/obj/structure/table/reinforced/brass,
-/turf/simulated/floor/indestructible/boss,
+/turf/simulated/wall/indestructible/boss/two{
+	layer = 2.05
+	},
 /area/lavaland/surface/outdoors/necropolis)
 "YJ" = (
 /obj/machinery/door/airlock{
@@ -37956,7 +37969,7 @@ qS
 RD
 mS
 no
-YI
+XW
 hG
 RD
 RD
@@ -39749,7 +39762,7 @@ RD
 RD
 RD
 RD
-gC
+YI
 RD
 RD
 RD
@@ -41805,7 +41818,7 @@ RD
 RD
 RD
 RD
-mY
+JL
 RD
 RD
 RD

--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -4991,18 +4991,19 @@
 	},
 /area/mine/laborcamp)
 "sQ" = (
-/obj/structure/stone_tile/cracked{
+/obj/structure/stone_tile,
+/obj/structure/stone_tile{
 	dir = 4
 	},
 /obj/structure/stone_tile{
 	dir = 1
 	},
-/obj/structure/stone_tile,
 /obj/structure/stone_tile{
 	dir = 8
 	},
-/obj/structure/table/reinforced/brass,
-/turf/simulated/floor/indestructible/boss,
+/turf/simulated/wall/indestructible/boss/two{
+	layer = 2.05
+	},
 /area/lavaland/surface/outdoors/necropolis)
 "sR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6986,6 +6987,18 @@
 /obj/structure/stone_tile/slab/cracked,
 /obj/structure/table/reinforced/brass,
 /turf/simulated/floor/indestructible/boss,
+/area/lavaland/surface/outdoors/necropolis)
+"SQ" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile,
+/turf/simulated/wall/indestructible/boss/two{
+	layer = 2.05
+	},
 /area/lavaland/surface/outdoors/necropolis)
 "Tj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -37076,7 +37089,7 @@ gS
 oG
 mS
 tY
-sQ
+Nk
 XC
 oG
 oG
@@ -38869,7 +38882,7 @@ oG
 oG
 oG
 oG
-gC
+sQ
 oG
 oG
 oG
@@ -40925,7 +40938,7 @@ oG
 oG
 oG
 oG
-mY
+SQ
 oG
 oG
 oG

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -16,6 +16,7 @@ GLOBAL_LIST_INIT(prisoncomputer_list, list())
 GLOBAL_LIST_INIT(celltimers_list, list()) // list of all cell timers
 GLOBAL_LIST_INIT(cell_logs, list())
 GLOBAL_LIST_INIT(navigation_computers, list())
+GLOBAL_LIST_INIT(boss_walls, list())
 
 GLOBAL_LIST_INIT(all_areas, list())
 GLOBAL_LIST_INIT(machines, list())

--- a/code/game/turfs/simulated/walls_indestructible.dm
+++ b/code/game/turfs/simulated/walls_indestructible.dm
@@ -108,13 +108,32 @@
 	desc = "A thick, seemingly indestructible stone wall."
 	icon = 'icons/turf/walls/boss_wall.dmi'
 	icon_state = "wall"
-	canSmoothWith = list(/turf/simulated/wall/indestructible/boss, /turf/simulated/wall/indestructible/boss/see_through)
+	canSmoothWith = list(/turf/simulated/wall/indestructible/boss, /turf/simulated/wall/indestructible/boss/see_through, /turf/simulated/wall/indestructible/boss/two)
 	explosion_block = 50
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt
 	smooth = SMOOTH_TRUE
 
 /turf/simulated/wall/indestructible/boss/see_through
 	opacity = FALSE
+
+/turf/simulated/wall/indestructible/boss/two
+	baseturf = /turf/simulated/floor/indestructible/boss
+
+/turf/simulated/wall/indestructible/boss/two/Initialize(mapload)
+	. = ..()
+	GLOB.boss_walls += src
+
+/turf/simulated/wall/indestructible/boss/two/BeforeChange()
+	GLOB.boss_walls -= src
+	return ..()
+
+/turf/simulated/wall/indestructible/boss/two/proc/collapse()
+	if(prob(25))
+		visible_message("<span class='warning'>[src] starts rumbling and groaning and it's falling apart!</span>",\
+		"<span class='warning'>You hear metal groaning and tearing!</span>")
+		ChangeTurf(/turf/simulated/floor/indestructible/boss)
+		return
+	addtimer(CALLBACK(src, .proc/collapse), 5 SECONDS)
 
 /turf/simulated/wall/indestructible/hierophant
 	name = "wall"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -135,6 +135,8 @@ Difficulty: Medium
 		if(last_legion)
 			loot = list(/obj/item/staff/storm)
 			elimination = 0
+			for(var/turf/simulated/wall/indestructible/boss/two/T in GLOB.boss_walls)
+				T.collapse()
 		else if(prob(5))
 			loot = list(/obj/structure/closet/crate/necropolis/tendril)
 			if(!true_spawn)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет стенки рядом справа и слева от Легиона в некрополисе.  Как только легион будет мёртв стены удалятся через время (25% каждые 5 секунд). Прошлый автор предложки ушёл, но мне хотелось увидеть это изменение.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Авоут: https://discord.com/channels/617003227182792704/755125334097133628/1040089025995878450
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений

![Снимок экрана 2023-01-23 194656](https://user-images.githubusercontent.com/120549107/214101410-fb5c440b-2ca4-4a2a-a7fd-a91688a9ffb4.png)

<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
