### PR TITLE
Deleted telecrystal 

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -29657,7 +29657,6 @@
 /obj/item/stack/ore/bluespace_crystal,
 /obj/item/grown/bananapeel/bluespace,
 /obj/item/slime_extract/bluespace,
-/obj/item/stack/telecrystal,
 /turf/simulated/floor/plating,
 /area/teleporter/abandoned)
 "cQW" = (


### PR DESCRIPTION
Из текста предложения:
"Удалить телекристалл из сейфа в старой телепортной. А причина этого решения довольно простая - он слишком сильно влияет на игру. Это гарантированный 3 нелегал, который почти всегда изучают. Для рнд антагов - мана небесная, ибо им не надо ничем жертвовать, чтоб получить себе возможность печатать импланты и арбалет. Иногда им даже и сейф открывать не надо - ученные сами с удовольствием побегут плавить его в деструкторе. Для нюкеров этот кристалл - головная боль, ибо с ним станция гарантированно встретит их с адреналами в жопе и арбалетами. Теперь чтобы изучить нелегал, придётся либо вкладываться своими кровными из аплинка, либо драться с ассистентом в техах за темно-красный тулбокс (и то, если он там появится конечно)."
ссылка на воут:
https://discord.com/channels/617003227182792704/757200958349377617/1067433413461688382