### PR TITLE
fix: спрайт КПБ теперь обновляется после починки

### DIFF
--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -17,7 +17,7 @@
 	if(!get_amount())
 		to_chat(user, "<span class='danger'>Not enough nanopaste!</span>")
 		return
-	else 
+	else
 		. = ..()
 
 /obj/item/stack/nanopaste/attack(mob/living/M as mob, mob/user as mob)
@@ -66,6 +66,7 @@
 					E.heal_damage(remheal, 0, 0, 1) //Healing Brute
 					E.heal_damage(0, remheal, 0, 1) //Healing Burn
 					remheal = nremheal
+					H.UpdateDamageIcon()
 					user.visible_message("<span class='notice'>\The [user] applies some nanite paste at \the [M]'s [E.name] with \the [src].</span>")
 				if(H.bleed_rate && ismachineperson(H))
 					H.bleed_rate = 0

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -67,6 +67,7 @@ emp_act
 	return (..(P , def_zone))
 
 /mob/living/carbon/human/welder_act(mob/user, obj/item/I)
+	var/mob/living/carbon/human/H = user
 	if(user.a_intent != INTENT_HELP)
 		return
 	if(!I.tool_use_check(user, 1))
@@ -114,6 +115,7 @@ emp_act
 		nrembrute = max(rembrute - E.brute_dam, 0)
 		E.heal_damage(rembrute,0,0,1)
 		rembrute = nrembrute
+		H.UpdateDamageIcon()
 		user.visible_message("<span class='alert'>[user] patches some dents on [src]'s [E.name] with [I].</span>")
 	if(bleed_rate && ismachineperson(src))
 		bleed_rate = 0

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -568,6 +568,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 				use(1)
 				cable_used += 1
 				E.heal_damage(0, HEALPERCABLE, 0, 1)
+				H.UpdateDamageIcon()
 			user.visible_message("<span class='alert'>\The [user] repairs some burn damage on \the [M]'s [E.name] with \the [src].</span>")
 		return 1
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
damage overlay не удалялся после починки. В итоге кпб ходили с потрёпанным лицом при полном здоровье. Исправил это