### PR TITLE
[PRIME] Prohibition on using emote panel while stunned/paralysed/sleeping/etc.

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -29,7 +29,7 @@
 					return target
 
 /mob/proc/user_triggered_emote(act, type, message, force)
-	if(stat || !use_me && usr == src)
+	if(IsWeakened() || stunned || paralysis || sleeping || stat || (!use_me && usr == src))
 		if(usr)
 			to_chat(usr, "You are unable to emote.")
 		return

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -29,7 +29,7 @@
 					return target
 
 /mob/proc/user_triggered_emote(act, type, message, force)
-	if(IsWeakened() || stunned || paralysis || sleeping || stat || (!use_me && usr == src))
+	if(stunned || paralysis || sleeping || stat || (!use_me && usr == src))
 		if(usr)
 			to_chat(usr, "You are unable to emote.")
 		return

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1047,7 +1047,6 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 	playsound(loc, 'sound/misc/slip.ogg', 50, 1, -3)
 	// Something something don't run with scissors
 	moving_diagonally = 0 //If this was part of diagonal move slipping will stop it.
-	Stun(stun)
 	Weaken(weaken)
 	return TRUE
 


### PR DESCRIPTION
## Описание
ПР запрещает использование эмоутов из эмоут панельки когда человек в стане, спит, парализован и прочее (обычные рандомные крики от боли и т.д. всё еще будут воспроизводиться)

## Ссылка на предложение/Причина создания ПР
![image](https://user-images.githubusercontent.com/10997188/215264079-1f39ac34-9325-408d-94c5-61246861d948.png)

~~*От себя: в билде нет четкого разделения на то, от чего произошёл стан, поэтому невозможность эмоутить будет и при подскальзывании на кожурке от банана, слиппере и так далее и тому подобное.*~~

Подсказльзывание теперь не накладывает стан, непонятно вообще зачем там был стан, но в принципе не удивительно. Работает так же как и раньше, накладывание `weakened` осталось