### PR TITLE
fix: only one sound of laugh

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -704,9 +704,9 @@
 				if(!muzzled)
 					message = "хихика[pluralize_ru(src.gender,"ет","ют")]."
 					if(gender == FEMALE)
-						playsound(src, dna.species.female_giggle_sound, 70, 1, frequency = get_age_pitch())
+						playsound(src, pick(dna.species.female_giggle_sound), 70, 1, frequency = get_age_pitch())
 					else
-						playsound(src, dna.species.male_giggle_sound, 70, 1, frequency = get_age_pitch())
+						playsound(src, pick(dna.species.male_giggle_sound), 70, 1, frequency = get_age_pitch())
 					m_type = 2
 				else
 					message = "изда[pluralize_ru(src.gender,"ет","ют")] шум."
@@ -785,9 +785,9 @@
 				if(!muzzled)
 					message = "сме[pluralize_ru(src.gender,"ет","ют")]ся[M ? " над [M]" : ""]."
 					if(gender == FEMALE)
-						playsound(src, dna.species.female_laugh_sound, 70, 1, frequency = get_age_pitch())
+						playsound(src, pick(dna.species.female_laugh_sound), 70, 1, frequency = get_age_pitch())
 					else
-						playsound(src, dna.species.male_laugh_sound, 70, 1, frequency = get_age_pitch())
+						playsound(src, pick(dna.species.male_laugh_sound), 70, 1, frequency = get_age_pitch())
 					m_type = 2
 				else
 					message = "изда[pluralize_ru(src.gender,"ет","ют")] шум."


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет pick к листу эмоций у смеха и хихиканья. Сейчас без этого проигрывается только одна эмоция.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Закрывает багрепорт: https://discord.com/channels/617003227182792704/1070841473576222850
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
