### PR TITLE
Fix: Исправлен показ Orbit'ом всей станции как антагов

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -40,7 +40,6 @@
 
 	var/list/alive = list()
 	var/list/antagonists = list()
-	var/list/other_antags = list()
 	var/list/dead = list()
 	var/list/ghosts = list()
 	var/list/misc = list()
@@ -77,6 +76,7 @@
 				alive += list(serialized)
 
 				var/datum/mind/mind = M.mind
+				var/list/other_antags = list()
 
 				if(GLOB.ts_spiderlist.len && M.ckey)
 					var/list/spider_minds = list()
@@ -84,7 +84,7 @@
 						if(S.key)
 							spider_minds += S.mind
 					other_antags += list(
-						"Terror Spiders ([spider_minds.len])" = GLOB.ts_spiderlist.Find(mind.current),
+						"Terror Spiders ([spider_minds.len])" = (mind.current in GLOB.ts_spiderlist),
 					)
 
 				if(user.antagHUD)


### PR DESCRIPTION
## What Does This PR Do
Исправлен [показ Orbit'ом всей станции как антагов](https://discord.com/channels/617003227182792704/734823601110515882/1071399650352975944).

## Images of changes
![изображение](https://user-images.githubusercontent.com/3854741/216768552-66ab1a69-b2e2-4771-903c-25fc0dd40b45.png)
![изображение](https://user-images.githubusercontent.com/3854741/216768554-14c98f01-aec9-447e-ad88-d17f7e6d2782.png)

## Changelog
:cl:
fix: Orbit shows antags correctly
/:cl: