### PR TITLE
Временное удаление дефайлеров из ротации

### DIFF
--- a/code/modules/events/spider_terror.dm
+++ b/code/modules/events/spider_terror.dm
@@ -24,31 +24,22 @@
 	var/spider_type
 	var/infestation_type
 	if((length(GLOB.clients)) <= TS_MIDPOP_TRIGGER)
-		infestation_type = pick(1, 2)
+		infestation_type = 1
 	else if((length(GLOB.clients)) >= TS_HIGHPOP_TRIGGER)
-		infestation_type = pick(5, 6, 7)
-	else
 		infestation_type = pick(3, 4)
+	else
+		infestation_type = 2
 	switch(infestation_type)
 		if(1)
-			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/defiler
-			spawncount = 3
-		if(2)
 			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/queen/princess
 			spawncount = 2
-		if(3)
-			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/defiler
-			spawncount = 4
-		if(4)
+		if(2)
 			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/queen/princess
 			spawncount = 3
-		if(5)
+		if(3)
 			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/queen
 			spawncount = 1
-		if(6)
-			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/defiler
-			spawncount = 6
-		if(7)
+		if(4)
 			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/queen/princess
 			spawncount = 4
 	var/list/candidates = SSghost_spawns.poll_candidates("Вы хотите занять роль Паука Террора?", null, TRUE, source = spider_type)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Ивент с пауками ужаса больше не спавнит дефайлеров

## Ссылка на предложение/Причина создания ПР
На тестах эти пауки показали себя чрезмерно сильными. В отличии от королевы и принцессы они не позволяют экипажу даже подготовиться к наплыву пауков. До их переработки следует отключить чтобы не возникало таких неприятных ситуаций.

