### PR TITLE
FIX: рабочие рецепты оливье

### DIFF
--- a/code/modules/food_and_drinks/recipes/recipes_microwave.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_microwave.dm
@@ -554,19 +554,19 @@
 	result = /obj/item/reagent_containers/food/snacks/validsalad
 
 /datum/recipe/microwave/vegisalad
-	reagents = list("salt" = 1, "cream" = 5)
+	reagents = list("sodiumchloride" = 1, "cream" = 5)
 	items = list(/obj/item/reagent_containers/food/snacks/grown/cucumber, /obj/item/reagent_containers/food/snacks/grown/tomato)
 	result = /obj/item/reagent_containers/food/snacks/vegisalad
 
 /datum/recipe/microwave/oliviersalad
-	reagents = list("salt" = 5, "cream" = 10)
+	reagents = list("sodiumchloride" = 5, "cream" = 10)
 	items = list(/obj/item/reagent_containers/food/snacks/grown/cucumber, /obj/item/reagent_containers/food/snacks/friedegg,
 				 /obj/item/reagent_containers/food/snacks/grown/potato, /obj/item/reagent_containers/food/snacks/grown/carrot,
 				 /obj/item/reagent_containers/food/snacks/sausage)
 	result = /obj/item/reagent_containers/food/snacks/oliviersalad
 
 /datum/recipe/microwave/weirdoliviersalad
-	reagents = list("salt" = 5, "cream" = 10)
+	reagents = list("sodiumchloride" = 5, "cream" = 10)
 	items = list(/obj/item/reagent_containers/food/snacks/grown/cucumber, /obj/item/reagent_containers/food/snacks/friedegg,
 				 /obj/item/reagent_containers/food/snacks/grown/potato, /obj/item/reagent_containers/food/snacks/grown/carrot,
 				 /obj/item/reagent_containers/food/snacks/sausage, /obj/item/reagent_containers/food/snacks/grown/apple)


### PR DESCRIPTION
Автор вместо содиум хлорида указал соль, а соли как реагента у нас нет, как итог вышла накладка спагетти кода. "Оперативно" исправлена ошибка рецепта.

