### PR TITLE
feat: some spawn features for some spawners

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/oldstation.dmm
@@ -1668,7 +1668,7 @@
 /obj/effect/decal/warning_stripes/southeast,
 /obj/effect/decal/warning_stripes/northwest,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mob_spawn/human/oldeng,
+/obj/effect/mob_spawn/human/oldstation/oldeng,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/ancientstation)
 "mF" = (
@@ -4298,7 +4298,7 @@
 /obj/effect/decal/warning_stripes/southeast,
 /obj/effect/decal/warning_stripes/northwest,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mob_spawn/human/oldsec,
+/obj/effect/mob_spawn/human/oldstation/oldsec,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/ancientstation)
 "IH" = (
@@ -5082,7 +5082,7 @@
 /obj/effect/decal/warning_stripes/southeast,
 /obj/effect/decal/warning_stripes/northwest,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mob_spawn/human/oldsci,
+/obj/effect/mob_spawn/human/oldstation/oldsci,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/ancientstation)
 "NX" = (
@@ -6199,7 +6199,7 @@
 /obj/effect/decal/warning_stripes/southeast,
 /obj/effect/decal/warning_stripes/northwest,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mob_spawn/human/oldmed,
+/obj/effect/mob_spawn/human/oldstation/oldmed,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/ancientstation)
 "VS" = (

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -30,6 +30,7 @@
 	var/burn_damage = 0
 	var/datum/disease/disease = null //Do they start with a pre-spawned disease?
 	var/mob_color //Change the mob's color
+	var/allow_prefs_prompt = FALSE //for mob_spawn/human
 	var/assignedrole
 	var/banType = ROLE_GHOST
 	var/ghost_usable = TRUE
@@ -79,9 +80,10 @@
 	if(use_prefs_prompt(user))
 		mob_use_prefs = TRUE
 	else
-		var/randomize_alert = alert("Your character will be randomized for this role, continue?",,"Yes","No")
-		if(randomize_alert == "No")
-			return
+		if(allow_prefs_prompt)
+			var/randomize_alert = alert("Your character will be randomized for this role, continue?",,"Yes","No")
+			if(randomize_alert == "No")
+				return
 		if(!species_prompt())
 			return
 
@@ -178,7 +180,7 @@
 	//Human specific stuff.
 	var/mob_species = null		//Set species
 	var/allow_species_pick = FALSE
-	var/allow_prefs_prompt = FALSE
+	allow_prefs_prompt = FALSE
 	var/allow_gender_pick = FALSE
 	var/allow_name_pick = FALSE
 	var/list/pickable_species = list("Human", "Vulpkanin", "Tajaran", "Unathi", "Skrell", "Diona")

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -137,12 +137,11 @@
 		M.faction = list(faction)
 	if(disease)
 		M.ForceContractDisease(new disease)
-	if(death)
-		M.death() //Kills the new mob
-
 	M.adjustOxyLoss(oxy_damage)
 	M.adjustBruteLoss(brute_damage)
 	M.adjustFireLoss(burn_damage)
+	if(death)
+		M.death() //Kills the new mob
 	M.color = mob_color
 	if(plr)
 		if(prefs)

--- a/code/modules/awaymissions/mission_code/ghost_role_spawners/oldstation.dm
+++ b/code/modules/awaymissions/mission_code/ghost_role_spawners/oldstation.dm
@@ -1,6 +1,6 @@
 //Ancient cryogenic sleepers. Players become NT crewmen from a hundred year old space station, now on the verge of collapse.
 
-/obj/effect/mob_spawn/human/oldsec
+/obj/effect/mob_spawn/human/oldstation/oldsec
 	name = "old cryogenics pod"
 	desc = "A humming cryo pod. You can barely recognise a security uniform underneath the built up ice. The machine is attempting to wake up its occupant."
 	mob_name = "a security officer"
@@ -8,25 +8,21 @@
 	icon_state = "sleeper"
 	roundstart = FALSE
 	death = FALSE
-	random = TRUE
+	allow_species_pick = TRUE
+	allow_prefs_prompt = TRUE
+	allow_gender_pick = TRUE
+	allow_name_pick = TRUE
+	pickable_species = list("Human")
+	outfit = /datum/outfit/oldstation/officer
 	mob_species = /datum/species/human
 	description = "Work as a team with your fellow survivors aboard a ruined, ancient space station."
 	important_info = ""
 	flavour_text = "You are a security officer working for Nanotrasen, stationed onboard a state of the art research station. You vaguely recall rushing into a \
 	cryogenics pod due to an oncoming radiation storm. The last thing you remember is the station's Artificial Program telling you that you would only be asleep for eight hours. As you open \
 	your eyes, everything seems rusted and broken, a dark feeling swells in your gut as you climb out of your pod."
-	uniform = /obj/item/clothing/under/retro/security
-	shoes = /obj/item/clothing/shoes/jackboots
-	id = /obj/item/card/id/away/old/sec
-	r_pocket = /obj/item/restraints/handcuffs
-	l_pocket = /obj/item/flash
 	assignedrole = "Ancient Crew"
 
-/obj/effect/mob_spawn/human/oldsec/Destroy()
-	new /obj/structure/showcase/machinery/oldpod/used(drop_location())
-	return ..()
-
-/obj/effect/mob_spawn/human/oldmed
+/obj/effect/mob_spawn/human/oldstation/oldmed
 	name = "old cryogenics pod"
 	desc = "A humming cryo pod. You can barely recognise a medical uniform underneath the built up ice. The machine is attempting to wake up its occupant."
 	mob_name = "a medical doctor"
@@ -34,25 +30,21 @@
 	icon_state = "sleeper"
 	roundstart = FALSE
 	death = FALSE
-	random = TRUE
+	allow_species_pick = TRUE
+	allow_prefs_prompt = TRUE
+	allow_gender_pick = TRUE
+	allow_name_pick = TRUE
+	pickable_species = list("Human")
+	outfit = /datum/outfit/oldstation/medic
 	mob_species = /datum/species/human
 	description = "Work as a team with your fellow survivors aboard a ruined, ancient space station."
 	important_info = ""
 	flavour_text = "You are a medical doctor working for Nanotrasen, stationed onboard a state of the art research station. You vaguely recall rushing into a \
 	cryogenics pod due to an oncoming radiation storm. The last thing you remember is the station's Artificial Program telling you that you would only be asleep for eight hours. As you open \
 	your eyes, everything seems rusted and broken, a dark feeling swells in your gut as you climb out of your pod."
-	uniform = /obj/item/clothing/under/retro/medical
-	shoes = /obj/item/clothing/shoes/black
-	id = /obj/item/card/id/away/old/med
-	l_pocket = /obj/item/stack/medical/ointment
-	r_pocket = /obj/item/stack/medical/ointment
 	assignedrole = "Ancient Crew"
 
-/obj/effect/mob_spawn/human/oldmed/Destroy()
-	new /obj/structure/showcase/machinery/oldpod/used(drop_location())
-	return ..()
-
-/obj/effect/mob_spawn/human/oldeng
+/obj/effect/mob_spawn/human/oldstation/oldeng
 	name = "old cryogenics pod"
 	desc = "A humming cryo pod. You can barely recognise an engineering uniform underneath the built up ice. The machine is attempting to wake up its occupant."
 	mob_name = "an engineer"
@@ -60,25 +52,21 @@
 	icon_state = "sleeper"
 	roundstart = FALSE
 	death = FALSE
-	random = TRUE
+	allow_species_pick = TRUE
+	allow_prefs_prompt = TRUE
+	allow_gender_pick = TRUE
+	allow_name_pick = TRUE
+	pickable_species = list("Human")
+	outfit = /datum/outfit/oldstation/engineer
 	mob_species = /datum/species/human
 	description = "Work as a team with your fellow survivors aboard a ruined, ancient space station."
 	important_info = ""
 	flavour_text = "You are an engineer working for Nanotrasen, stationed onboard a state of the art research station. You vaguely recall rushing into a \
 	cryogenics pod due to an oncoming radiation storm. The last thing you remember is the station's Artificial Program telling you that you would only be asleep for eight hours. As you open \
 	your eyes, everything seems rusted and broken, a dark feeling swells in your gut as you climb out of your pod."
-	uniform = /obj/item/clothing/under/retro/engineering
-	shoes = /obj/item/clothing/shoes/workboots
-	id = /obj/item/card/id/away/old/eng
-	gloves = /obj/item/clothing/gloves/color/fyellow/old
-	l_pocket = /obj/item/tank/internals/emergency_oxygen
 	assignedrole = "Ancient Crew"
 
-/obj/effect/mob_spawn/human/oldeng/Destroy()
-	new /obj/structure/showcase/machinery/oldpod/used(drop_location())
-	return ..()
-
-/obj/effect/mob_spawn/human/oldsci
+/obj/effect/mob_spawn/human/oldstation/oldsci
 	name = "old cryogenics pod"
 	desc = "A humming cryo pod. You can barely recognise a science uniform underneath the built up ice. The machine is attempting to wake up its occupant."
 	mob_name = "a scientist"
@@ -86,22 +74,19 @@
 	icon_state = "sleeper"
 	roundstart = FALSE
 	death = FALSE
-	random = TRUE
+	allow_species_pick = TRUE
+	allow_prefs_prompt = TRUE
+	allow_gender_pick = TRUE
+	allow_name_pick = TRUE
+	pickable_species = list("Human")
+	outfit = /datum/outfit/oldstation/scientist
 	mob_species = /datum/species/human
 	description = "Work as a team with your fellow survivors aboard a ruined, ancient space station."
 	important_info = ""
 	flavour_text = "You are a scientist working for Nanotrasen, stationed onboard a state of the art research station. You vaguely recall rushing into a \
 	cryogenics pod due to an oncoming radiation storm. The last thing you remember is the station's Artificial Program telling you that you would only be asleep for eight hours. As you open \
 	your eyes, everything seems rusted and broken, a dark feeling swells in your gut as you climb out of your pod."
-	uniform = /obj/item/clothing/under/retro/science
-	shoes = /obj/item/clothing/shoes/laceup
-	id = /obj/item/card/id/away/old/sci
-	l_pocket = /obj/item/stack/medical/bruise_pack
 	assignedrole = "Ancient Crew"
-
-/obj/effect/mob_spawn/human/oldsci/Destroy()
-	new /obj/structure/showcase/machinery/oldpod/used(drop_location())
-	return ..()
 
 /obj/structure/showcase/machinery/oldpod
 	name = "damaged cryogenic pod"
@@ -112,3 +97,42 @@
 /obj/structure/showcase/machinery/oldpod/used
 	name = "opened cryogenic pod"
 	desc = "A cryogenic pod that has recently discharged its occupant. The pod appears non-functional."
+
+/datum/outfit/oldstation/officer
+	name = "Old station officer"
+	uniform = /obj/item/clothing/under/retro/security
+	shoes = /obj/item/clothing/shoes/jackboots
+	id = /obj/item/card/id/away/old/sec
+	r_pocket = /obj/item/restraints/handcuffs
+	l_pocket = /obj/item/flash
+
+/datum/outfit/oldstation/medic
+	name = "Old station medic"
+	uniform = /obj/item/clothing/under/retro/medical
+	shoes = /obj/item/clothing/shoes/black
+	id = /obj/item/card/id/away/old/med
+	l_pocket = /obj/item/stack/medical/ointment
+	r_pocket = /obj/item/stack/medical/ointment
+
+/datum/outfit/oldstation/engineer
+	name = "Old station engineer"
+	uniform = /obj/item/clothing/under/retro/engineering
+	shoes = /obj/item/clothing/shoes/workboots
+	id = /obj/item/card/id/away/old/eng
+	gloves = /obj/item/clothing/gloves/color/fyellow/old
+	l_pocket = /obj/item/tank/internals/emergency_oxygen
+
+/datum/outfit/oldstation/scientist
+	name = "Old station scientist"
+	uniform = /obj/item/clothing/under/retro/science
+	shoes = /obj/item/clothing/shoes/laceup
+	id = /obj/item/card/id/away/old/sci
+	l_pocket = /obj/item/stack/medical/bruise_pack
+
+/obj/effect/mob_spawn/human/oldstation/special(mob/living/carbon/human/H)
+	GLOB.human_names_list += H.real_name
+	return ..()
+
+/obj/effect/mob_spawn/human/oldstation/Destroy()
+	new /obj/structure/showcase/machinery/oldpod/used(drop_location())
+	return ..()

--- a/code/modules/awaymissions/mission_code/ruins/crashedipcship.dm
+++ b/code/modules/awaymissions/mission_code/ruins/crashedipcship.dm
@@ -47,8 +47,8 @@
 	gloves = /obj/item/clothing/gloves/color/black
 
 /obj/effect/mob_spawn/human/corpse/ipc/Initialize()
-	brute_damage = rand(50, 100)
-	burn_damage = rand(120, 200)
+	brute_damage = rand(50, 99)
+	burn_damage = rand(50, 99)
 	return ..()
 
 // Headcrab corpse

--- a/code/modules/mob/living/simple_animal/hostile/mining/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/hivelord.dm
@@ -330,7 +330,7 @@
 
 //Legion infested mobs
 
-/obj/effect/mob_spawn/human/corpse/damaged/legioninfested/dwarf/equip(mob/living/carbon/human/H, use_prefs = FALSE)
+/obj/effect/mob_spawn/human/corpse/damaged/legioninfested/dwarf/equip(mob/living/carbon/human/H, use_prefs = FALSE, _mob_name = FALSE, _mob_gender = FALSE, _mob_species = FALSE)
 	. = ..()
 	H.dna.SetSEState(GLOB.smallsizeblock, 1, 1)
 	H.mutations.Add(DWARF)

--- a/code/modules/ruins/lavalandruin_code/animal_hospital.dm
+++ b/code/modules/ruins/lavalandruin_code/animal_hospital.dm
@@ -11,13 +11,33 @@
 	everyone's gone. One of the cats scratched you just a few minutes ago. That's why you were in the pod - to heal the scratch. The scabs are still fresh; you see them right now. So where is \
 	everyone? Where did they go? What happened to the hospital? And is that smoke you smell? You need to find someone else. Maybe they can tell you what happened."
 	assignedrole = "Translocated Vet"
+	random = FALSE
 	allow_species_pick = TRUE
+	allow_prefs_prompt = TRUE
+	allow_gender_pick = TRUE
+	allow_name_pick = TRUE
+	outfit = /datum/outfit/job/doctor/alive/lavaland
 
-/obj/effect/mob_spawn/human/doctor/alive/lavaland/equip(mob/living/carbon/human/H, use_prefs = FALSE)
-	..()
-	H.rename_self(assignedrole)
+/datum/outfit/job/doctor/alive/lavaland
+	name = "Medical Doctor"
+	uniform = /obj/item/clothing/under/rank/medical
+	suit = /obj/item/clothing/suit/storage/labcoat
+	shoes = /obj/item/clothing/shoes/white
+	l_ear = /obj/item/radio/headset/headset_med
+	id = /obj/item/card/id/medical
+	suit_store = /obj/item/flashlight/pen
+	l_hand = /obj/item/storage/firstaid/doctor
+	pda = /obj/item/pda/medical
+
+	backpack = /obj/item/storage/backpack/medic
+	satchel = /obj/item/storage/backpack/satchel_med
+	dufflebag = /obj/item/storage/backpack/duffel/medical
 
 /obj/effect/mob_spawn/human/doctor/alive/lavaland/Destroy()
 	var/obj/structure/fluff/empty_sleeper/S = new(drop_location())
 	S.setDir(dir)
+	return ..()
+
+/obj/effect/mob_spawn/human/doctor/alive/lavaland/special(mob/living/carbon/human/H)
+	GLOB.human_names_list += H.real_name
 	return ..()

--- a/code/modules/ruins/lavalandruin_code/ash_walker_den.dm
+++ b/code/modules/ruins/lavalandruin_code/ash_walker_den.dm
@@ -62,6 +62,7 @@
 	icon_state = "large_egg"
 	mob_species = /datum/species/unathi/ashwalker
 	outfit = /datum/outfit/ashwalker
+	mob_gender = MALE
 	roundstart = FALSE
 	death = FALSE
 	anchored = FALSE

--- a/code/modules/ruins/lavalandruin_code/hermit.dm
+++ b/code/modules/ruins/lavalandruin_code/hermit.dm
@@ -7,14 +7,20 @@
 	icon_state = "cryostasis_sleeper"
 	roundstart = FALSE
 	death = FALSE
-	random = TRUE
 	allow_species_pick = TRUE
+	allow_prefs_prompt = TRUE
+	allow_gender_pick = TRUE
+	allow_name_pick = TRUE
+	outfit = /datum/outfit/hermit
 	mob_species = /datum/species/human
 	description = "You are a single survivor stranded on lavaland in a makeshift shelter. Try to survive with barely any equipment. For when miner is just too boring."
 	flavour_text = "You've been stranded in this godless prison of a planet for longer than you can remember. Each day you barely scrape by, and between the terrible \
 	conditions of your makeshift shelter, the hostile creatures, and the ash drakes swooping down from the cloudless skies, all you can wish for is the feel of soft grass between your toes and \
 	the fresh air of Earth. These thoughts are dispelled by yet another recollection of how you got here... "
 	assignedrole = "Hermit"
+
+/datum/outfit/hermit
+	name = "Lavaland Survivor"
 
 /obj/effect/mob_spawn/human/hermit/Initialize(mapload)
 	. = ..()
@@ -51,4 +57,8 @@
 
 /obj/effect/mob_spawn/human/hermit/Destroy()
 	new/obj/structure/fluff/empty_cryostasis_sleeper(get_turf(src))
+	return ..()
+
+/obj/effect/mob_spawn/human/hermit/special(mob/living/carbon/human/H)
+	GLOB.human_names_list += H.real_name
 	return ..()

--- a/code/modules/ruins/syndicate_space_base.dm
+++ b/code/modules/ruins/syndicate_space_base.dm
@@ -31,6 +31,8 @@
 	del_types = list() // Necessary to prevent del_types from removing radio!
 	allow_prefs_prompt = TRUE
 	allow_species_pick = TRUE
+	allow_gender_pick = TRUE
+	allow_name_pick = TRUE
 	pickable_species = list("Human", "Vulpkanin", "Tajaran", "Unathi", "Skrell", "Diona", "Drask", "Vox", "Plasmaman", "Machine", "Kidan", "Grey", "Nucleation", "Slime People", "Wryn")
 	faction = list("syndicate")
 	min_hours = 10
@@ -40,32 +42,6 @@
     var/obj/machinery/cryopod/syndie/S = new(get_turf(src))
     S.setDir(dir)
     return ..()
-
-/obj/effect/mob_spawn/human/space_base_syndicate/species_prompt()
-	if(allow_species_pick)
-		//пол
-		var/new_gender = alert("Please select gender.",, "Male","Female")
-		if(new_gender == "Male")
-			mob_gender = MALE
-		else
-			mob_gender = FEMALE
-		//раса
-		var/selected_species = input("Select a species", "Species Selection") as null|anything in pickable_species
-		if(!selected_species)
-			to_chat(usr, "<span class='warning'>Spawning stopped.</span>")
-			return	FALSE	// You didn't pick, abort
-		var/datum/species/S = GLOB.all_species[selected_species]
-		mob_species = S.type
-		//имя
-		var/new_name = input("Enter your name:") as text
-		if(new_name)
-			mob_name = new_name
-		else
-			mob_name = random_name(mob_gender, selected_species)
-		//цвет кожи
-		skin_tone = rand(-25, 0)
-
-	return TRUE
 
 /datum/outfit/space_base_syndicate
 	name = "Space Base Syndicate Scientist"
@@ -121,16 +97,11 @@
 		H.update_action_buttons_icon()
 		H.rejuvenate() //fix any damage taken by naked vox/plasmamen/etc
 
-	H.dna.blood_type = pick("A+", "A-", "B+", "B-", "AB+", "AB-", "O+", "O-") //Чтобы им всем подряд не требовалась кровь одного типа
-// Это фиксит белую кожу. Костяк, увы.
-	var/datum/dna/D = H.dna
-	if(!D.species.is_small)
-		H.change_dna(D, TRUE, TRUE)
-
 /obj/effect/mob_spawn/human/space_base_syndicate/special(mob/living/carbon/human/H)
 	GLOB.human_names_list += H.real_name
 	SEND_SOUND(H, 'sound/effects/taipan_start.ogg')
 	H.give_taipan_hud()
+	return ..()
 
 /obj/effect/mob_spawn/human/space_base_syndicate/medic
 	name = "Syndicate Medic sleeper"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание

В соответствии с предложкой:`Возможность выбрать пол, имя персонажа при спавне на гостролях (аботч (тета), ветеринары на лаве, челы с пляжа на лаве, выживший с лавы), а так же возможность заспавниться выбранным в префах персонажем (разумеется, в случае, например, АБОТЧ, только хуманом). Типа того, как оно реализовано на Тайпане.`
Перемещает часть механик спавнеров тайпана в общие, делая их для всех спавнеров.
Гендер ксенорас у заспавленных не из преф теперь может быть не только MALE.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Аголосование: https://discord.com/channels/617003227182792704/755125334097133628/1074435377319903325
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения --!>
