### PR TITLE
feat: Selector overlay for active click spells

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -42,6 +42,7 @@
 		return
 	usr.next_click = world.time + 1
 	linked_action.Trigger()
+	linked_action.UpdateButtonIcon() //redraw button
 	return TRUE
 
 //Hide/Show Action Buttons ... Button

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -82,6 +82,9 @@
 			return FALSE
 	return TRUE
 
+/datum/action/proc/IsActive()
+	return FALSE
+
 /datum/action/proc/UpdateButtonIcon()
 	if(button)
 		if(owner && owner.client && background_icon_state == "bg_default") // If it's a default action background, apply the custom HUD style
@@ -100,6 +103,8 @@
 		// If the action isn't available, darken the button
 		if(!IsAvailable())
 			apply_unavailable_effect()
+		if(IsActive())
+			apply_active_overlay()
 		else
 			return TRUE
 
@@ -119,6 +124,9 @@
 		img.pixel_x = 0
 		img.pixel_y = 0
 		current_button.add_overlay(img)
+
+/datum/action/proc/apply_active_overlay()
+	return
 
 //Presets for item actions
 /datum/action/item_action
@@ -576,6 +584,24 @@
 	if(owner)
 		return spell.can_cast(owner)
 	return FALSE
+
+/datum/action/spell_action/IsActive()
+	if(!target)
+		return FALSE
+	var/obj/effect/proc_holder/spell/targeted/click/S = target
+	if(!istype(S))
+		return ..()
+	return TRUE
+
+/datum/action/spell_action/apply_active_overlay()
+	var/obj/effect/proc_holder/spell/targeted/click/S = target
+	var/image/I = image('icons/mob/screen_gen.dmi', icon_state = "selector")
+	I.plane = FLOAT_PLANE + 1.1
+	I.layer = FLOAT_LAYER
+	if(S.active)
+		button.overlays += I
+	else
+		button.overlays -= I
 
 /datum/action/spell_action/apply_unavailable_effect()
 	var/obj/effect/proc_holder/spell/S = target

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -82,7 +82,7 @@
 			return FALSE
 	return TRUE
 
-/datum/action/proc/IsActive()
+/datum/action/proc/IsMayActive()
 	return FALSE
 
 /datum/action/proc/UpdateButtonIcon()
@@ -100,11 +100,12 @@
 
 		ApplyIcon(button)
 
+		if(IsMayActive())
+			toggle_active_overlay()
+
 		// If the action isn't available, darken the button
 		if(!IsAvailable())
 			apply_unavailable_effect()
-		if(IsActive())
-			apply_active_overlay()
 		else
 			return TRUE
 
@@ -125,7 +126,7 @@
 		img.pixel_y = 0
 		current_button.add_overlay(img)
 
-/datum/action/proc/apply_active_overlay()
+/datum/action/proc/toggle_active_overlay()
 	return
 
 //Presets for item actions
@@ -585,7 +586,7 @@
 		return spell.can_cast(owner)
 	return FALSE
 
-/datum/action/spell_action/IsActive()
+/datum/action/spell_action/IsMayActive()
 	if(!target)
 		return FALSE
 	var/obj/effect/proc_holder/spell/targeted/click/S = target
@@ -593,7 +594,7 @@
 		return ..()
 	return TRUE
 
-/datum/action/spell_action/apply_active_overlay()
+/datum/action/spell_action/toggle_active_overlay()
 	var/obj/effect/proc_holder/spell/targeted/click/S = target
 	var/image/I = image('icons/mob/screen_gen.dmi', icon_state = "selector")
 	I.plane = FLOAT_PLANE + 1.1

--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -6,6 +6,7 @@
 	var/active = FALSE //Used by toggle based abilities.
 	var/ranged_mousepointer
 	var/mob/ranged_ability_user
+	var/datum/action/spell_action/action = null
 
 /obj/effect/proc_holder/singularity_act()
 	return
@@ -49,6 +50,8 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell))
 	user.client.click_intercept = new /datum/click_intercept/proc_holder(user.client, user.ranged_ability)
 	add_mousepointer(user.client)
 	active = TRUE
+	if(action)
+		action.UpdateButtonIcon()
 	if(msg)
 		to_chat(user, msg)
 	update_icon()
@@ -64,9 +67,11 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell))
 /obj/effect/proc_holder/proc/remove_ranged_ability(mob/user, var/msg)
 	if(!user || (user.ranged_ability && user.ranged_ability != src)) //To avoid removing the wrong ability
 		return
+	active = FALSE
+	if(user.ranged_ability.action)
+		user.ranged_ability.action.UpdateButtonIcon()
 	user.ranged_ability = null
 	ranged_ability_user = null
-	active = FALSE
 	if(user.client)
 		qdel(user.client.click_intercept)
 		user.client.click_intercept = null
@@ -123,7 +128,6 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell))
 	var/critfailchance = 0
 	var/centcom_cancast = 1 //Whether or not the spell should be allowed on z2
 
-	var/datum/action/spell_action/action = null
 	var/action_icon = 'icons/mob/actions/actions.dmi'
 	var/action_icon_state = "spell_default"
 	var/action_background_icon_state = "bg_spell"

--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -514,8 +514,8 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell))
 		revert_cast(user)
 		return FALSE
 
-	perform(targets, user = user, make_attack_logs = create_logs)
 	remove_ranged_ability(user)
+	perform(targets, user = user, make_attack_logs = create_logs)
 	return TRUE
 
 /* Checks if a target is valid


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет к активному выбранному клик спеллу свою рамку, тем самым показывая, что он выбран.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Напомню, что клик спеллы блокируют любую возможность взаимодействия с чем либо кроме целей, пока на этот спелл не нажмут ещё раз, или пока не найдут цель. Достаточно часто можно видеть вопросы от теней или священника с этой проблемой. Такое решение должно помочь понять что данная способность активна и с ней нужно что-то делать.
По-своему закрывает багрепорт: https://discord.com/channels/617003227182792704/1071850788932026528
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений

https://user-images.githubusercontent.com/120549107/217859601-65c036aa-927a-4e83-a661-fc0a5f119db5.mp4


<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
