### PR TITLE
FIX: Убираем баги с абстрактными орудиями ниндзя

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -2,20 +2,21 @@
 #define NONE 0
 
 //FLAGS BITMASK
-#define STOPSPRESSUREDMAGE 		1		//This flag is used on the flags variable for SUIT and HEAD items which stop pressure damage. Note that the flag 1 was previous used as ONBACK, so it is possible for some code to use (flags & 1) when checking if something can be put on your back. Replace this code with (inv_flags & SLOT_BACK) if you see it anywhere To successfully stop you taking all pressure damage you must have both a suit and head item with this flag.
+#define STOPSPRESSUREDMAGE 		1		// This flag is used on the flags variable for SUIT and HEAD items which stop pressure damage. Note that the flag 1 was previous used as ONBACK, so it is possible for some code to use (flags & 1) when checking if something can be put on your back. Replace this code with (inv_flags & SLOT_BACK) if you see it anywhere To successfully stop you taking all pressure damage you must have both a suit and head item with this flag.
 #define NODROP					2		// This flag makes it so that an item literally cannot be removed at all, or at least that's how it should be. Only deleted.
-#define NOBLUDGEON  			4		// when an item has this it produces no "X has been hit by Y with Z" message with the default handler
-#define AIRTIGHT				8		// mask allows internals
-#define HANDSLOW        		16		// If an item has this flag, it will slow you to carry it
-#define CONDUCT					32		// conducts electricity (metal etc.)
-#define ABSTRACT				64		// for all things that are technically items but used for various different stuff, made it 128 because it could conflict with other flags other way
-#define ON_BORDER				128		// item has priority to check when entering or leaving
-#define PREVENT_CLICK_UNDER		256
-#define NODECONSTRUCT			512
+#define NOPICKUP				4		// This flags makes it so an item cannot be picked in hands
+#define NOBLUDGEON  			8		// when an item has this it produces no "X has been hit by Y with Z" message with the default handler
+#define AIRTIGHT				16		// mask allows internals
+#define HANDSLOW        		32		// If an item has this flag, it will slow you to carry it
+#define CONDUCT					64		// conducts electricity (metal etc.)
+#define ABSTRACT				128		// for all things that are technically items but used for various different stuff, made it 128 because it could conflict with other flags other way
+#define ON_BORDER				256		// item has priority to check when entering or leaving
+#define PREVENT_CLICK_UNDER		512
+#define NODECONSTRUCT			1024
 
-#define EARBANGPROTECT			1024
+#define EARBANGPROTECT			2048
 
-#define NOSLIP					1024 	//prevents from slipping on wet floors, in space etc
+#define NOSLIP					2048 	//prevents from slipping on wet floors, in space etc
 
 #define HEADBANGPROTECT			4096
 

--- a/code/game/gamemodes/spaceninja/ninja/suit/ninja_equipment_actions/ninja_chameleon.dm
+++ b/code/game/gamemodes/spaceninja/ninja/suit/ninja_equipment_actions/ninja_chameleon.dm
@@ -39,9 +39,9 @@
 	icon = 'icons/obj/ninjaobjects.dmi'
 	icon_state = "chameleon_device"
 	item_state = ""
-	w_class = WEIGHT_CLASS_SMALL
+	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = 0
-	flags =  DROPDEL | ABSTRACT
+	flags =  DROPDEL | ABSTRACT | NOBLUDGEON | NOPICKUP
 	var/effect_color = "#ffaa00"
 	var/obj/item/clothing/suit/space/space_ninja/my_suit = null
 	var/datum/action/item_action/advanced/ninja/ninja_chameleon/my_action = null
@@ -58,8 +58,6 @@
 /obj/item/ninja_chameleon_scanner/attack_self(mob/user)
 	ninja_chameleon(user, user)
 
-/obj/item/ninja_chameleon_scanner/attack()
-	return
 
 /obj/item/ninja_chameleon_scanner/afterattack(atom/target, mob/living/user, proximity)
 	var/mob/target_mob = get_mob_in_atom_without_warning(target)

--- a/code/game/gamemodes/spaceninja/ninja/suit/ninja_equipment_actions/ninja_energy_stars.dm
+++ b/code/game/gamemodes/spaceninja/ninja/suit/ninja_equipment_actions/ninja_energy_stars.dm
@@ -33,10 +33,10 @@
 	icon_state = "shuriken_emitter"
 	item_state = ""
 	ninja_weapon = TRUE
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_MEDIUM
 	slot_flags = 0
-	flags = DROPDEL | ABSTRACT
+	flags = DROPDEL | ABSTRACT | NOBLUDGEON | NOPICKUP
 	ammo_type = list(/obj/item/ammo_casing/energy/shuriken)
 	can_charge = 0
 	burst_size = 3

--- a/code/game/gamemodes/spaceninja/ninja/suit/ninja_equipment_actions/ninja_johyo.dm
+++ b/code/game/gamemodes/spaceninja/ninja/suit/ninja_equipment_actions/ninja_johyo.dm
@@ -39,15 +39,16 @@
 	max_charges = 1
 	recharge_rate = 0
 	charge_tick = 1
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_MEDIUM
 	slot_flags = 0
-	flags = DROPDEL | ABSTRACT | NOBLUDGEON
+	flags = DROPDEL | ABSTRACT | NOBLUDGEON | NOPICKUP
 	force = 10
 	ninja_weapon = TRUE
 	var/cost = 500
 	var/obj/item/clothing/suit/space/space_ninja/my_suit = null
 	var/datum/action/item_action/advanced/ninja/johyo/my_action = null
+
 
 /obj/item/gun/magic/johyo/Destroy()
 	. = ..()

--- a/code/game/gamemodes/spaceninja/ninja/suit/ninja_equipment_actions/ninja_net.dm
+++ b/code/game/gamemodes/spaceninja/ninja/suit/ninja_equipment_actions/ninja_net.dm
@@ -30,9 +30,9 @@
 	icon = 'icons/obj/ninjaobjects.dmi'
 	icon_state = "net_emitter"
 	item_state = ""
-	w_class = WEIGHT_CLASS_SMALL
+	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = 0
-	flags = DROPDEL | ABSTRACT
+	flags = DROPDEL | ABSTRACT | NOBLUDGEON | NOPICKUP
 	var/obj/item/clothing/suit/space/space_ninja/my_suit = null
 	var/datum/action/item_action/advanced/ninja/ninjanet/my_action = null
 
@@ -50,8 +50,6 @@
 /obj/item/ninja_net_emitter/attack_self(mob/user)
 	return
 
-/obj/item/ninja_net_emitter/attack()
-	return
 
 /obj/item/ninja_net_emitter/afterattack(atom/target, mob/living/user, proximity)
 	var/mob/target_mob = get_mob_in_atom_without_warning(target)

--- a/code/game/gamemodes/spaceninja/ninja/suit/suit.dm
+++ b/code/game/gamemodes/spaceninja/ninja/suit/suit.dm
@@ -15,7 +15,6 @@
 	icon_state = "ninja_suit"
 	item_state = "ninja_suit"
 	allowed = list(
-		/obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing,
 		/obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/tank,
 		/obj/item/stock_parts/cell, /obj/item/grenade/plastic/c4/ninja)
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -270,6 +270,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /image, image("icon" = 'icons/goonstation/effect
 
 /obj/item/attack_hand(mob/user as mob, pickupfireoverride = FALSE)
 	if(!user) return 0
+	if(flags & NOPICKUP) return 0
 	if(hasorgans(user))
 		var/mob/living/carbon/human/H = user
 		var/obj/item/organ/external/temp = H.bodyparts_by_name["r_hand"]


### PR DESCRIPTION

<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
* Джохьё, Хамелион, Сюрикены и Сетку больше нельзя поместить в карманы/слот костюма. А так же взять в другую руку (Это ломало их, делая невидимыми)
* Убрала возможность помещать в слот костюма пушки и патроны. По двум причинам. Первая: это давало поместить туда пушки ниндзя... Вторая: Ниндзя всё равно не может пользоваться пушками. Ему оно не надо.
* Дополнительно был добавлен флаг позволяющий запретить поднимать любой item объект