### PR TITLE
Fix: Нельзя телепортировать прикрученные шкафчики

### DIFF
--- a/code/modules/telesci/rcs.dm
+++ b/code/modules/telesci/rcs.dm
@@ -124,6 +124,9 @@
 	if(!is_level_reachable(C.z))
 		to_chat(user, "<span class='warning'>Warning: No telepads in range!</span>")
 		return
+	if(C.anchored)
+		to_chat(user, "<span class ='warning'>Ошибка: Ящик прикручен! Отмена операции.</span>")
+		return
 
 	teleport(user, C, pad)
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Запрещает телепортировать через RCS (телепортер ящиков у карготехов) прикрученные ящики
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багфикс, репорт - https://discord.com/channels/617003227182792704/1074354590843146280
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->