### PR TITLE
Ребаланс голопоросят

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/types/ranged.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/ranged.dm
@@ -1,9 +1,8 @@
 /obj/item/projectile/guardian
 	name = "crystal spray"
 	icon_state = "guardian"
-	damage = 25
+	damage = 20
 	damage_type = BRUTE
-	armour_penetration = 100
 
 /mob/living/simple_animal/hostile/guardian/ranged
 	friendly = "quietly assesses"

--- a/code/game/gamemodes/miniantags/guardian/types/standard.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/standard.dm
@@ -1,6 +1,7 @@
 /mob/living/simple_animal/hostile/guardian/punch
 	melee_damage_lower = 20
 	melee_damage_upper = 20
+	armour_penetration = 100
 	obj_damage = 80
 	damage_transfer = 0.4
 	playstyle_string = "As a <b>Standard</b> type you have no special abilities, but have a high damage resistance and a powerful attack capable of smashing through walls."


### PR DESCRIPTION
Согласно ПРу о нерфе голопоросят, дальнобойный голопоросенок теперь наносит в разы меньше урона, в то время как стандарт теперь обладает бронепробоем.

Код похуй так же указал, что добавлять снос укрепстен не нужно, так что и ладно. Пройдено согласно авоуту:
https://discord.com/channels/617003227182792704/755125334097133628/1075078927288123503

