### PR TITLE
Fix: Больше нельзя сунуть не разрушаемые предметы в автолат

### DIFF
--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -155,6 +155,8 @@
 		return FALSE
 	if(istype(I, /obj/item/stack))
 		return insert_stack(I, stack_amt, multiplier)
+	if(I.resistance_flags & INDESTRUCTIBLE)
+		return FALSE
 
 	var/material_amount = get_item_material_amount(I)
 	if(!material_amount || !has_space(material_amount))


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет проверку при попытке сунуть в автолат нечто на то, имеет ли этот предмет флаг `INDESTRUCTIBLE` и ретурнает, если такой флаг есть, что не позволяет сунуть хайриски в автолат

(P.S. Из тех вещей что в автолат сунуть можно было - только хайриски. Этот флаг кроме хайрисков и машинерии/Турфов есть разве что у парочки "Эфемерных" предметов, по типу "Off-hand"-а, который появляется если взять предмет в две руки, но их и так сунуть нельзя)
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1075420376311537664
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->