### PR TITLE
Fix: Бесконечный фарм крови через заклинание

### DIFF
--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -851,6 +851,9 @@
 	var/choice = input(user, "Choose a greater blood rite...", "Greater Blood Rites") as null|anything in options
 	switch(choice)
 		if("Blood Spear (150)")
+			if(!Adjacent(user))
+				to_chat(user, "<span class='cultitalic'>Вы не можете использовать это заклинание без самого заклинания!</span>")
+				return
 			if(uses < BLOOD_SPEAR_COST)
 				to_chat(user, "<span class='warning'>You need [BLOOD_SPEAR_COST] charges to perform this rite.</span>")
 			else
@@ -868,6 +871,9 @@
 					"<span class='cult'>A [rite.name] materializes at your feet.</span>")
 
 		if("Blood Bolt Barrage (300)")
+			if(!Adjacent(user))
+				to_chat(user, "<span class='cultitalic'>Вы не можете использовать это заклинание без самого заклинания!</span>")
+				return
 			if(uses < BLOOD_BARRAGE_COST)
 				to_chat(user, "<span class='cultitalic'>You need [BLOOD_BARRAGE_COST] charges to perform this rite.</span>")
 			else
@@ -884,6 +890,9 @@
 					qdel(rite)
 
 		if("Blood Orb (50)")
+			if(!Adjacent(user))
+				to_chat(user, "<span class='cultitalic'>Вы не можете использовать это заклинание без самого заклинания!</span>")
+				return
 			if(uses < BLOOD_ORB_COST)
 				to_chat(user, "<span class='warning'>You need [BLOOD_ORB_COST] charges to perform this rite.</span>")
 			else
@@ -906,6 +915,9 @@
 					"<span class='cult'>A [rite.name] materializes at your feet.</span>")
 
 		if("Blood Recharge (75)")
+			if(!Adjacent(user))
+				to_chat(user, "<span class='cultitalic'>Вы не можете использовать это заклинание без самого заклинания!</span>")
+				return
 			if(uses < BLOOD_RECHARGE_COST)
 				to_chat(user, "<span class='cultitalic'>You need [BLOOD_RECHARGE_COST] charges to perform this rite.</span>")
 			else

--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -849,11 +849,11 @@
 /obj/item/melee/blood_magic/manipulator/attack_self(mob/living/user)
 	var/list/options = list("Blood Orb (50)", "Blood Recharge (75)", "Blood Spear (150)", "Blood Bolt Barrage (300)")
 	var/choice = input(user, "Choose a greater blood rite...", "Greater Blood Rites") as null|anything in options
+	if(!Adjacent(user))
+		to_chat(user, "<span class='cultitalic'>Вы не можете использовать это заклинание без самого заклинания!</span>")
+		return
 	switch(choice)
 		if("Blood Spear (150)")
-			if(!Adjacent(user))
-				to_chat(user, "<span class='cultitalic'>Вы не можете использовать это заклинание без самого заклинания!</span>")
-				return
 			if(uses < BLOOD_SPEAR_COST)
 				to_chat(user, "<span class='warning'>You need [BLOOD_SPEAR_COST] charges to perform this rite.</span>")
 			else
@@ -871,9 +871,6 @@
 					"<span class='cult'>A [rite.name] materializes at your feet.</span>")
 
 		if("Blood Bolt Barrage (300)")
-			if(!Adjacent(user))
-				to_chat(user, "<span class='cultitalic'>Вы не можете использовать это заклинание без самого заклинания!</span>")
-				return
 			if(uses < BLOOD_BARRAGE_COST)
 				to_chat(user, "<span class='cultitalic'>You need [BLOOD_BARRAGE_COST] charges to perform this rite.</span>")
 			else
@@ -890,9 +887,6 @@
 					qdel(rite)
 
 		if("Blood Orb (50)")
-			if(!Adjacent(user))
-				to_chat(user, "<span class='cultitalic'>Вы не можете использовать это заклинание без самого заклинания!</span>")
-				return
 			if(uses < BLOOD_ORB_COST)
 				to_chat(user, "<span class='warning'>You need [BLOOD_ORB_COST] charges to perform this rite.</span>")
 			else
@@ -915,9 +909,6 @@
 					"<span class='cult'>A [rite.name] materializes at your feet.</span>")
 
 		if("Blood Recharge (75)")
-			if(!Adjacent(user))
-				to_chat(user, "<span class='cultitalic'>Вы не можете использовать это заклинание без самого заклинания!</span>")
-				return
 			if(uses < BLOOD_RECHARGE_COST)
 				to_chat(user, "<span class='cultitalic'>You need [BLOOD_RECHARGE_COST] charges to perform this rite.</span>")
 			else


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
До этого у заклинания Blood Rites не было проверки на то есть ли у тебя само заклинание в руках, и если бросить заклинания до выбора инпута - без потери крови у тебя просто появляется то что ты там выбрал.

Добавляет проверку на то, есть ли эта хрень у тебя в руках (для удобства сделано через `Adjacent`, ибо энивей предмет не может быть в рюкзаке/ещё где, так что и смысла дополнительно проверять в руках ли он попросту нет.)
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багфикс, репорт - https://discord.com/channels/617003227182792704/1075668298169073664
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->