### PR TITLE
fix: infinity sits kitten

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -177,10 +177,7 @@
 		if("purr")
 			on_CD = handle_emote_CD()
 		if("sit")
-			icon_state = "[icon_living]_sit"
-			collar_type = "[initial(collar_type)]_sit"
-			resting = TRUE
-			update_canmove()
+			on_CD = handle_emote_CD()
 		else
 			on_CD = 0
 
@@ -198,6 +195,13 @@
 		if("purr")
 			message = "purrs."
 			m_type = 2
+		if("sit")
+			message = "sits down."
+			m_type = 1 //visible
+			icon_state = "[icon_living]_sit"
+			collar_type = "[initial(collar_type)]_sit"
+			resting = TRUE
+			update_canmove()
 		if("help")
 			to_chat(src, "scream, meow, hiss, purr, sit")
 
@@ -215,7 +219,7 @@
 	icon_state = "kitten"
 	icon_living = "kitten"
 	icon_dead = "kitten_dead"
-	icon_resting = null
+	icon_resting = "kitten_sit"
 	gender = NEUTER
 	density = 0
 	pass_flags = PASSMOB


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Из-за того что у котёнка нет своей иконки rest он не мог встать после того как сел и всегда ходил сидя(иконки не обновлялись при shift+B). Спрайт resta у котёнка будет спрайт сидячего.
Также из-за того что не было сообщения у эмоции каждый раз выдавалось при использовании что эмоции нет(выполнялось, но было неприятно получать это), поэтому  будет sits down. Добавляет к эмоции стандартное кд для предотвращения спама.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Котята, что не могли встать и ходили задом - нехорошо. :mericCat:
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
