### PR TITLE
fix: nodeconstruct coathanger

### DIFF
--- a/code/game/objects/structures/coathanger.dm
+++ b/code/game/objects/structures/coathanger.dm
@@ -18,20 +18,23 @@
 	. = ..()
 	icon_state = "coatrack[rand(0, 1)]"
 
-/obj/structure/coatrack/attack_hand(mob/user as mob)
-	user.visible_message("[user] takes [coat] off \the [src].", "You take [coat] off the \the [src]")
-	if(!user.put_in_active_hand(coat))
-		coat.loc = get_turf(user)
-	coat = null
-	update_icon()
+/obj/structure/coatrack/attack_hand(mob/living/user)
+	if(coat)
+		user.visible_message("[user] takes [coat] off \the [src].", "You take [coat] off the \the [src].")
+		if(!user.put_in_active_hand(coat))
+			coat.loc = get_turf(user)
+		coat = null
+		update_icon()
 
-/obj/structure/coatrack/attackby(obj/item/W as obj, mob/user as mob, params)
-	var/can_hang = 0
+/obj/structure/coatrack/attackby(obj/item/W, mob/living/user, params)
+	var/can_hang = FALSE
 	for(var/T in allowed)
 		if(istype(W,T))
-			can_hang = 1
+			can_hang = TRUE
+			continue
+
 	if(can_hang && !coat)
-		user.visible_message("[user] hangs [W] on \the [src].", "You hang [W] on the \the [src]")
+		user.visible_message("[user] hangs [W] on \the [src].", "You hang [W] on the \the [src].")
 		coat = W
 		user.drop_item(src)
 		coat.loc = src
@@ -40,13 +43,14 @@
 		return ..()
 
 /obj/structure/coatrack/CanPass(atom/movable/mover, turf/target, height=0)
-	var/can_hang = 0
+	var/can_hang = FALSE
 	for(var/T in allowed)
 		if(istype(mover,T))
-			can_hang = 1
+			can_hang = TRUE
+			continue
 
 	if(can_hang && !coat)
-		src.visible_message("[mover] lands on \the [src].")
+		visible_message("[mover] lands on \the [src].")
 		coat = mover
 		coat.loc = src
 		update_icon()
@@ -83,8 +87,6 @@
 
 /obj/structure/coatrack/crowbar_act(mob/user, obj/item/I)
 	. = TRUE
-	if(!I.use_tool(src, user, 0))
-		return
 	TOOL_ATTEMPT_DISMANTLE_MESSAGE
 	if(I.use_tool(src, user, 50, volume = I.tool_volume))
 		TOOL_DISMANTLE_SUCCESS_MESSAGE
@@ -99,6 +101,7 @@
 	if(disassembled)
 		mat_drop = 10
 	new /obj/item/stack/sheet/wood(drop_location(), mat_drop)
-	coat.loc = get_turf(src)
-	coat = null
+	if(coat)
+		coat.loc = get_turf(src)
+		coat = null
 	..()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет проверку на наличие coat при деконструкте, иначе, если вешалка была пустой, рантаймит и появляется только дерево без разбора самой вешалки. Добавляет такую же проверку в attack_hand.
Добавил точки в конце предложений о том, что мы положили/сняли халат.
Некоторые малые улучшения.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Закрывает багрепорт: https://discord.com/channels/617003227182792704/1076970457879810062
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->