### PR TITLE
Fix: griefsky crafting with different sword types.

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -502,7 +502,10 @@
 
 /obj/item/griefsky_assembly/attackby(obj/item/I, mob/user, params)
 	..()
-	if((istype(I, /obj/item/melee/energy/sword)) && (build_step < 3 ))
+	if((istype(I, /obj/item/melee/energy/sword)) && (!toy_step == 0 ))
+		to_chat(user, "<span class='notice'>You can't add an energy sword to [src]!.</span>")
+
+	else if((istype(I, /obj/item/melee/energy/sword)) && (build_step < 3 ))
 		if(!user.unEquip(I))
 			return
 		build_step++
@@ -516,6 +519,9 @@
 		new /mob/living/simple_animal/bot/secbot/griefsky(get_turf(src))
 		qdel(I)
 		qdel(src)
+
+	else if((istype(I, /obj/item/toy/sword)) && (!build_step == 0 ))
+		to_chat(user, "<span class='notice'>You can't add a toy sword to [src]!.</span>")
 
 	else if((istype(I, /obj/item/toy/sword)) && (toy_step < 3 ))
 		if(!user.unEquip(I))


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
 **Фикс добавляет проверку на наличие идентичного есворда внутри заготовки грифски при попытке добавить ещё один.**

<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР
**На данный момент в griefsky assembly можно вставлять и настоящие есворды, и игрушки одновременно, из-за чего можно потерять 3 есворда, если после них вставить в заготовку грифски 4 игрушечных есворда (кто такое будет делать, я ХЗ, но возможность такая имеется). Также, скорее всего, кому-то придётся переписывать всё это, ибо это мой первый ПР.** 
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
