### PR TITLE
Fix: prison_break event

### DIFF
--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -7,7 +7,7 @@
 
 	var/eventDept = "Security"			//Department name in announcement
 	var/list/areaName = list("Brig")	//Names of areas mentioned in AI and Engineering announcements
-	var/list/areaType = list(/area/security/prison, /area/security/brig, /area/security/permabrig)	//Area types to include.
+	var/list/areaType = list(/area/security/prison, /area/security/brig, /area/security/permabrig, /area/security/permahallway)	//Area types to include.
 	var/list/areaNotType = list()		//Area types to specifically exclude.
 
 /datum/event/prison_break/virology
@@ -24,7 +24,7 @@
 /datum/event/prison_break/station
 	eventDept = "Station"
 	areaName = list("Brig","Virology","Xenobiology")
-	areaType = list(/area/security/prison, /area/security/brig, /area/security/permabrig, /area/medical/virology, /area/medical/virology/lab, /area/toxins/xenobiology)
+	areaType = list(/area/security/prison, /area/security/brig, /area/security/permabrig,  /area/security/permahallway, /area/medical/virology, /area/medical/virology/lab, /area/toxins/xenobiology)
 	areaNotType = list(/area/toxins/xenobiology/xenoflora, /area/toxins/xenobiology/xenoflora_storage)
 
 


### PR DESCRIPTION
Добавляет в список зон для ивента побега из брига зону permahallway, которая в ходе ивента не дает сбежать заключенным из пермы, при условии, что остальной путь открыт.
Скриншот куска коридора про который все забыли:
![image](https://user-images.githubusercontent.com/91949115/220430701-25d03f7c-f997-457f-be05-5d8d1c5dd438.png)
