### PR TITLE
Фикс абуза крови зессул

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -1342,6 +1342,7 @@
 	metabolization_rate = REAGENTS_METABOLISM
 	shock_reduction = 20
 	taste_description = "blessing"
+	can_synth = FALSE
 
 /datum/reagent/medicine/zessulblood/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE


### PR DESCRIPTION

## Описание
Удаляет кровь зессул из ботаники и отключает возможность ее синтезировать
## Ссылка на предложение/Причина создания ПР
При создании реворка унатхов я забыл добавить невозможность синтезировать кровь зессул, из-за чего ее можно фармить одиссеем и добыть в ботанике. Такого быть не должно, ибо не задумано так, реагент уникальный, и должен добываться только из унатхов.
