### PR TITLE
FIX: конфликт рецептов

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -91,7 +91,7 @@
 	result = "antiburn_stimulant"
 	required_reagents = list("synthflesh" = 40)
 	result_amount = 1
-	min_temp = T0C + 100
+	min_temp = T0C + 200
 
 /datum/chemical_reaction/styptic_powder
 	name = "Styptic Powder"


### PR DESCRIPTION
Жизнь и Антиожоговый стимулятор имеют одинаковую температуру нагрева, что приводит к появлению АБ стимулятора в рецепте с жизнью, что руинит рецепт. Повысил температуру стимулятора во избежание этой оказии.

<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
