### PR TITLE
Фикс бага с нахождением одежды бригмеда в секмате.

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1179,7 +1179,7 @@
 	products = list(/obj/item/restraints/handcuffs = 8,/obj/item/restraints/handcuffs/cable/zipties = 8,/obj/item/grenade/flashbang = 4,/obj/item/flash = 5,
 					/obj/item/reagent_containers/food/snacks/donut = 12,/obj/item/storage/box/evidence = 6,/obj/item/flashlight/seclite = 4,/obj/item/restraints/legcuffs/bola/energy = 7,
 					/obj/item/clothing/mask/muzzle/safety = 4, /obj/item/storage/box/swabs = 6, /obj/item/storage/box/fingerprints = 6, /obj/item/eftpos/sec = 4,
-					/obj/item/clothing/suit/storage/suragi_jacket/medsec = 2, /obj/item/clothing/suit/storage/brigdoc = 2, /obj/item/clothing/under/rank/security/brigphys = 2)
+					)
 	contraband = list(/obj/item/clothing/glasses/sunglasses = 2,/obj/item/storage/fancy/donut_box = 2,/obj/item/hailer = 5)
 	refill_canister = /obj/item/vending_refill/security
 
@@ -1824,7 +1824,11 @@
 		/obj/item/clothing/under/pants/red 			= 10,
 		/obj/item/clothing/under/pants/track 		= 5,
 
+		/obj/item/clothing/under/rank/security/brigphys = 3
 		/obj/item/clothing/under/rank/security/brigphys/skirt 	= 3,
+		/obj/item/clothing/suit/storage/suragi_jacket/medsec = 3,
+		/obj/item/clothing/suit/storage/brigdoc = 3,
+
 		)
 
 

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1824,11 +1824,10 @@
 		/obj/item/clothing/under/pants/red 			= 10,
 		/obj/item/clothing/under/pants/track 		= 5,
 
-		/obj/item/clothing/under/rank/security/brigphys = 3
+		/obj/item/clothing/under/rank/security/brigphys = 3,
 		/obj/item/clothing/under/rank/security/brigphys/skirt 	= 3,
 		/obj/item/clothing/suit/storage/suragi_jacket/medsec = 3,
-		/obj/item/clothing/suit/storage/brigdoc = 3,
-
+		/obj/item/clothing/suit/storage/brigdoc = 3
 		)
 
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Перенёс одежду бригмеда в вендомат одежды СБ.
## Ссылка на предложение/Причина создания ПР
Баг-репорт
https://discord.com/channels/617003227182792704/1079188949601361920/1079188949601361920
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
![image](https://user-images.githubusercontent.com/108519426/221385854-3722ac86-fb72-4cd0-b414-93cf5c863b94.png)
