### PR TITLE
FIX: Russian letter not showing in Spirit Board interface

### DIFF
--- a/code/game/objects/structures/spirit_board.dm
+++ b/code/game/objects/structures/spirit_board.dm
@@ -32,7 +32,7 @@
 		used = TRUE
 		notify_ghosts("Someone has begun playing with a [src.name] in [get_area(src)]!", source = src)
 
-	planchette = input("Choose the letter.", "Seance!") in list("А","Б","В","Г","Д","Е","Ё","Ж","З","И","Й","К","Л","М","Н","О","П","Р","С","Т","У","Ф","Х","Ц","Ч","Ш","Щ","Ъ","Ы","Ь","Э","Ю","Я")
+	planchette = input("Choose the letter.", "Seance!") in list("А","Б","В","Г","Д","Е","Ё","Ж","З","И","Й","К","Л","М","Н","О","П","Р","С","T","У","Ф","Х","Ц","Ч","Ш","Щ","Ъ","Ы","Ь","Э","Ю","Я")
 	add_attack_logs(M, src, "Picked a letter on [src] which was \"[planchette]\".")
 	cooldown = world.time
 	lastuser = M.ckey


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание

Исправление странного бага, при котором русский символ "Т" не показывался в интерфейсе выбора букв на спиритической доске. Исправлено изменением русской буквы "Т" в списке разрешенных символов на английский аналог.

## Ссылка на предложение/Причина создания ПР

https://discord.com/channels/617003227182792704/1079122494117654578/1079122494117654578

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->

![image](https://user-images.githubusercontent.com/73733747/221401243-97896a66-33b3-411c-9167-b1ca46c05dea.png)
![image1](https://user-images.githubusercontent.com/73733747/221401246-1145acbb-8b38-40c7-8c58-6d743f870d33.png)
