### PR TITLE
Tweak: borgs disabled synchronize with ghostize ai

### DIFF
--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -115,4 +115,7 @@
 	while(AI && AI.stat != DEAD)
 		AI.adjustOxyLoss(2)
 		sleep(10)
+	for(var/mob/living/silicon/robot/R in AI.connected_robots)
+		R.disconnect_from_ai()
+		R.show_laws()
 	flush = FALSE

--- a/code/modules/mob/living/silicon/ai/latejoin.dm
+++ b/code/modules/mob/living/silicon/ai/latejoin.dm
@@ -14,6 +14,10 @@ GLOBAL_LIST_EMPTY(empty_playable_ai_cores)
 	GLOB.empty_playable_ai_cores += new /obj/structure/AIcore/deactivated(loc)
 	GLOB.global_announcer.autosay("[src] has been moved to intelligence storage.", "Artificial Intelligence Oversight")
 
+	for(var/mob/living/silicon/robot/R in connected_robots)
+		R.disconnect_from_ai()
+		R.show_laws()
+
 	//Handle job slot/tater cleanup.
 	var/job = mind.assigned_role
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Нужно отвязывать боргов от ИИ, который вышел через ooc - wipe core, потому что иначе боргам можно сменить законы лишь пересборкой (но не через аплоуд), что не очень хорошо, при этом этот ИИ не вернётся в раунд. Теперь, если ИИ выходит через wipe core борги отвязываются от него и оповещаются. Тоже самое при смерти Ии на интелкарте.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Авоуты:
https://discord.com/channels/617003227182792704/755125334097133628/1083927917005897808
https://discord.com/channels/617003227182792704/755125334097133628/1083927680090652712
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->