### PR TITLE
Feat/fix:containers small qols and fixes

### DIFF
--- a/code/modules/detective_work/footprints_and_rag.dm
+++ b/code/modules/detective_work/footprints_and_rag.dm
@@ -16,7 +16,7 @@
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "rag"
 	amount_per_transfer_from_this = 5
-	possible_transfer_amounts = list(5)
+	possible_transfer_amounts = null
 	volume = 5
 	flags = NOBLUDGEON
 	container_type = OPENCONTAINER

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -61,6 +61,9 @@
 	if(!(container_type & DRAINABLE))
 		to_chat(chugger, "<span class='notice'>You need to open [src] first!</span>")
 		return
+	if(!get_location_accessible(chugger, "mouth"))
+		to_chat(chugger, "<span class='notice'>Your face is obscured, so you cant [pick("chugging","gulping")].</span>")
+		return
 	if(reagents.total_volume && loc == chugger && src == chugger.get_active_hand())
 		chugger.visible_message("<span class='notice'>[chugger] raises [src] to [chugger.p_their()] mouth and starts [pick("chugging","gulping")] it down like [pick("a savage","a mad beast","it's going out of style","there's no tomorrow")]!</span>",
 			"<span class='notice'>You start chugging [src].</span>",

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -9,9 +9,11 @@
 	container_type = OPENCONTAINER
 	consume_sound = 'sound/items/drink.ogg'
 	possible_transfer_amounts = list(5,10,15,20,25,30,50)
+	visible_transfer_rate = TRUE
 	volume = 50
 	resistance_flags = NONE
 	antable = FALSE
+	var/chugging = FALSE
 	foodtype = ALCOHOL
 
 /obj/item/reagent_containers/food/drinks/New()
@@ -53,21 +55,32 @@
 	return FALSE
 
 /obj/item/reagent_containers/food/drinks/MouseDrop(atom/over_object) //CHUG! CHUG! CHUG!
+	if(!iscarbon(over_object))
+		return
 	var/mob/living/carbon/chugger = over_object
-	if (!(container_type & DRAINABLE))
+	if(!(container_type & DRAINABLE))
 		to_chat(chugger, "<span class='notice'>You need to open [src] first!</span>")
 		return
-	if(istype(chugger) && loc == chugger && src == chugger.get_active_hand() && reagents.total_volume)
-		chugger.visible_message("<span class='notice'>[chugger] raises the [src] to [chugger.p_their()] mouth and starts [pick("chugging","gulping")] it down like [pick("a savage","a mad beast","it's going out of style","there's no tomorrow")]!</span>", "<span class='notice'>You start chugging [src].</span>", "<span class='notice'>You hear what sounds like gulping.</span>")
-		while(do_mob(chugger, chugger, 40)) //Between the default time for do_mob and the time it takes for a vampire to suck blood.
+	if(reagents.total_volume && loc == chugger && src == chugger.get_active_hand())
+		chugger.visible_message("<span class='notice'>[chugger] raises [src] to [chugger.p_their()] mouth and starts [pick("chugging","gulping")] it down like [pick("a savage","a mad beast","it's going out of style","there's no tomorrow")]!</span>",
+			"<span class='notice'>You start chugging [src].</span>",
+			"<span class='notice'>You hear what sounds like gulping.</span>")
+		chugging = TRUE
+		while(do_after_once(chugger, 4 SECONDS, TRUE, chugger, null, "You stop chugging [src]."))
 			chugger.eat(src, chugger, 25) //Half of a glass, quarter of a bottle.
 			if(!reagents.total_volume) //Finish in style.
 				chugger.emote("gasp")
-				chugger.visible_message("<span class='notice'>[chugger] [pick("finishes","downs","polishes off","slams")] the entire [src], what a [pick("savage","monster","champ","beast")]!</span>", "<span class='notice'>You finish off the [src]![prob(50) ? " Maybe that wasn't such a good idea..." : ""]</span>", "<span class='notice'>You hear a gasp and a clink.</span>")
+				chugger.visible_message("<span class='notice'>[chugger] [pick("finishes","downs","polishes off","slams")] the entire [src], what a [pick("savage","monster","champ","beast")]!</span>",
+					"<span class='notice'>You finish off [src]![prob(50) ? " Maybe that wasn't such a good idea..." : ""]</span>",
+					"<span class='notice'>You hear a gasp and a clink.</span>")
 				break
+		chugging = FALSE
 
 /obj/item/reagent_containers/food/drinks/afterattack(obj/target, mob/user, proximity)
 	if(!proximity)
+		return
+
+	if(chugging)
 		return
 
 	if(target.is_refillable() && is_drainable()) //Something like a glass. Player probably wants to transfer TO it.
@@ -142,7 +155,7 @@
 	throwforce = 1
 	amount_per_transfer_from_this = 5
 	materials = list(MAT_METAL=100)
-	possible_transfer_amounts = list()
+	possible_transfer_amounts = null
 	volume = 5
 	flags = CONDUCT
 	container_type = OPENCONTAINER
@@ -268,7 +281,7 @@
 	desc = "A paper water cup."
 	icon_state = "water_cup_e"
 	item_state = "coffee"
-	possible_transfer_amounts = list()
+	possible_transfer_amounts = null
 	volume = 10
 
 /obj/item/reagent_containers/food/drinks/sillycup/on_reagent_change()

--- a/code/modules/food_and_drinks/drinks/drinks/cans.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/cans.dm
@@ -1,5 +1,6 @@
 /obj/item/reagent_containers/food/drinks/cans
 	var/canopened = FALSE
+	container_type = NONE
 	var/is_glass = 0
 	var/is_plastic = 0
 	var/times_shaken = 0
@@ -8,16 +9,18 @@
 	var/burst_chance = 0
 	foodtype = SUGAR
 
-/obj/item/reagent_containers/food/drinks/cans/New()
+/obj/item/reagent_containers/food/drinks/cans/empty()
+	if(!canopened)
+		to_chat(usr, "<span class='warning'>Open [src] first.</span>")
+		return
 	..()
-	flags &= ~OPENCONTAINER
 
 /obj/item/reagent_containers/food/drinks/cans/examine(mob/user)
 	. = ..()
 	if(canopened)
 		. += "<span class='notice'>It has been opened.</span>"
 	else
-		. += "<span class='info'>Alt-Click to shake it up!</span>"
+		. += "<span class='info'>Ctrl-Click to shake it up!</span>"
 
 /obj/item/reagent_containers/food/drinks/cans/attack_self(mob/user)
 	if(canopened)
@@ -27,7 +30,7 @@
 		return ..()
 	playsound(loc, 'sound/effects/canopen.ogg', rand(10, 50), 1)
 	canopened = TRUE
-	flags |= OPENCONTAINER
+	container_type |= OPENCONTAINER
 	to_chat(user, "<span class='notice'>You open the drink with an audible pop!</span>")
 	return ..()
 
@@ -45,7 +48,7 @@
 	qdel(src)
 	return crushed_can
 
-/obj/item/reagent_containers/food/drinks/cans/AltClick(mob/living/user)
+/obj/item/reagent_containers/food/drinks/cans/CtrlClick(mob/living/user)
 	if(!istype(user) || user.incapacitated())
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
@@ -54,7 +57,7 @@
 	var/mob/living/carbon/human/H = user
 	if(canopened)
 		to_chat(H, "<span class='warning'>You can't shake up an already opened drink!")
-		return ..()
+		return
 	if(src == H.l_hand || src == H.r_hand)
 		can_shake = FALSE
 		addtimer(CALLBACK(src, .proc/reset_shakable), 1 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
@@ -113,7 +116,7 @@
 /obj/item/reagent_containers/food/drinks/cans/proc/fizzy_open(mob/user, burstopen = FALSE)
 	playsound(loc, 'sound/effects/canopenfizz.ogg', rand(10, 50), 1)
 	canopened = TRUE
-	flags |= OPENCONTAINER
+	container_type |= OPENCONTAINER
 
 	if(!burstopen && user)
 		to_chat(user, "<span class='notice'>You open the drink with an audible pop!</span>")

--- a/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
@@ -17,6 +17,10 @@
 	set hidden = FALSE
 	..()
 
+/obj/item/reagent_containers/food/drinks/empty()
+	set hidden = FALSE
+	..()
+
 /obj/item/reagent_containers/food/drinks/drinkingglass/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/reagent_containers/food/snacks/egg)) //breaking eggs
 		var/obj/item/reagent_containers/food/snacks/egg/E = I

--- a/code/modules/food_and_drinks/food.dm
+++ b/code/modules/food_and_drinks/food.dm
@@ -9,6 +9,7 @@
 /obj/item/reagent_containers/food
 	possible_transfer_amounts = null
 	volume = 50 //Sets the default container amount for all food items.
+	visible_transfer_rate = FALSE
 	var/filling_color = "#FFFFFF" //Used by sandwiches.
 	var/junkiness = 0  //for junk food. used to lower human satiety.
 	var/bitesize = 2
@@ -50,6 +51,10 @@
 		check_for_ants()
 
 /obj/item/reagent_containers/food/set_APTFT()
+	set hidden = TRUE
+	..()
+
+/obj/item/reagent_containers/food/empty()
 	set hidden = TRUE
 	..()
 

--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -12,6 +12,7 @@
 	icon_state = "emptycondiment"
 	container_type = OPENCONTAINER
 	possible_transfer_amounts = list(1, 5, 10, 15, 20, 25, 30, 50)
+	visible_transfer_rate = TRUE
 	volume = 50
 	//Possible_states has the reagent id as key and a list of, in order, the icon_state, the name and the desc as values. Used in the on_reagent_change() to change names, descs and sprites.
 	var/list/possible_states = list(
@@ -30,6 +31,10 @@
 	return
 
 /obj/item/reagent_containers/food/condiment/set_APTFT()
+	set hidden = FALSE
+	..()
+
+/obj/item/reagent_containers/food/condiment/empty()
 	set hidden = FALSE
 	..()
 
@@ -208,7 +213,7 @@
 	icon_state = "condi_empty"
 	volume = 10
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list()
+	possible_transfer_amounts = null
 	possible_states = list("ketchup" = list("condi_ketchup", "Ketchup", "You feel more American already."), "capsaicin" = list("condi_hotsauce", "Hotsauce", "You can almost TASTE the stomach ulcers now!"), "soysauce" = list("condi_soysauce", "Soy Sauce", "A salty soy-based flavoring"), "frostoil" = list("condi_frostoil", "Coldsauce", "Leaves the tongue numb in it's passage"), "sodiumchloride" = list("condi_salt", "Salt Shaker", "Salt. From space oceans, presumably"), "blackpepper" = list("condi_pepper", "Pepper Mill", "Often used to flavor food or make people sneeze"), "cornoil" = list("condi_cornoil", "Corn Oil", "A delicious oil used in cooking. Made from corn"), "sugar" = list("condi_sugar", "Sugar", "Tasty spacey sugar!"))
 
 /obj/item/reagent_containers/food/condiment/pack/attack(mob/M, mob/user, def_zone) //Can't feed these to people directly.

--- a/code/modules/hydroponics/beekeeping/honeycomb.dm
+++ b/code/modules/hydroponics/beekeeping/honeycomb.dm
@@ -4,7 +4,8 @@
 	desc = "A hexagonal mesh of honeycomb."
 	icon = 'icons/obj/hydroponics/harvest.dmi'
 	icon_state = "honeycomb"
-	possible_transfer_amounts = list()
+	possible_transfer_amounts = null
+	visible_transfer_rate = FALSE
 	disease_amount = 0
 	volume = 10
 	amount_per_transfer_from_this = 0
@@ -18,6 +19,9 @@
 	update_icon()
 
 /obj/item/reagent_containers/honeycomb/set_APTFT()
+	set hidden = TRUE
+
+/obj/item/reagent_containers/honeycomb/empty()
 	set hidden = TRUE
 
 /obj/item/reagent_containers/honeycomb/update_icon()

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -14,6 +14,7 @@
 	var/has_lid = FALSE // Used for containers where we want to put lids on and off
 	var/temperature_min = 0 // To limit the temperature of a reagent container can atain when exposed to heat/cold
 	var/temperature_max = 10000
+	var/pass_open_check = FALSE // Pass open check in empty verb
 
 /obj/item/reagent_containers/verb/set_APTFT() //set amount_per_transfer_from_this
 	set name = "Set transfer amount"
@@ -55,7 +56,7 @@
 	if(!usr.Adjacent(src) || usr.stat || !usr.canmove || usr.incapacitated())
 		return
 	if(isturf(usr.loc) && loc == usr)
-		if(!is_open_container())
+		if(!is_open_container() && !pass_open_check)
 			to_chat(usr, "<span class='warning'>Open [src] first.</span>")
 			return
 		if(reagents.total_volume)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -5,6 +5,7 @@
 	icon_state = null
 	w_class = WEIGHT_CLASS_TINY
 	var/amount_per_transfer_from_this = 5
+	var/visible_transfer_rate = TRUE
 	var/possible_transfer_amounts = list(5,10,15,25,30)
 	var/volume = 30
 	var/list/list_reagents = null
@@ -17,16 +18,52 @@
 /obj/item/reagent_containers/verb/set_APTFT() //set amount_per_transfer_from_this
 	set name = "Set transfer amount"
 	set category = "Object"
-	set src in range(0)
+	set src in usr
 
-	if(usr.incapacitated())
+	if(!usr.Adjacent(src) || !ishuman(usr) || usr.incapacitated())
 		return
 	var/default = null
 	if(amount_per_transfer_from_this in possible_transfer_amounts)
 		default = amount_per_transfer_from_this
 	var/N = input("Amount per transfer from this:", "[src]", default) as null|anything in possible_transfer_amounts
-	if(N)
-		amount_per_transfer_from_this = N
+
+	if(!N)
+		return
+	if(!usr.Adjacent(src))
+		to_chat(usr, "<span class='warning'>You have moved too far away!</span>")
+		return
+	if(!ishuman(usr) || usr.incapacitated())
+		to_chat(usr, "<span class='warning'>You can't use your hands!</span>")
+		return
+
+	amount_per_transfer_from_this = N
+	to_chat(usr, "<span class='notice'>[src] will now transfer [N] units at a time.</span>")
+
+/obj/item/reagent_containers/AltClick()
+	set_APTFT()
+
+/obj/item/reagent_containers/verb/empty()
+
+	set name = "Empty Container"
+	set category = "Object"
+	set src in usr
+
+	if(!usr.Adjacent(src) || usr.stat || !usr.canmove || usr.incapacitated())
+		return
+	if(alert(usr, "Are you sure you want to empty that?", "Empty Container:", "Yes", "No") != "Yes")
+		return
+	if(!usr.Adjacent(src) || usr.stat || !usr.canmove || usr.incapacitated())
+		return
+	if(isturf(usr.loc) && loc == usr)
+		if(!is_open_container())
+			to_chat(usr, "<span class='warning'>Open [src] first.</span>")
+			return
+		if(reagents.total_volume)
+			to_chat(usr, "<span class='notice'>You empty [src] onto the floor.</span>")
+			reagents.reaction(usr.loc)
+			reagents.clear_reagents()
+		else
+			to_chat(usr, "<span class='notice'>You tried emptying [src], but there's nothing in it.</span>")
 
 /obj/item/reagent_containers/New()
 	create_reagents(volume, temperature_min, temperature_max)
@@ -84,3 +121,11 @@
 			to_chat(user, "<span class='notice'>You fill [src] from [source].</span>")
 			return
 	..()
+
+/obj/item/reagent_containers/examine(mob/user)
+	. = ..()
+	if(visible_transfer_rate)
+		. += "<span class='notice'>It will transfer [amount_per_transfer_from_this] unit[amount_per_transfer_from_this != 1 ? "s" : ""] at a time.</span>"
+
+	if(possible_transfer_amounts)
+		. += "<span class='notice'>Alt-click to change the transfer amount.</span>"

--- a/code/modules/reagents/reagent_containers/applicator.dm
+++ b/code/modules/reagents/reagent_containers/applicator.dm
@@ -6,6 +6,7 @@
 	item_state = "mender"
 	volume = 200
 	possible_transfer_amounts = null
+	visible_transfer_rate = FALSE
 	resistance_flags = ACID_PROOF
 	container_type = REFILLABLE | AMOUNT_VISIBLE
 	temperature_min = 270
@@ -24,6 +25,9 @@
 		to_chat(user, "<span class='warning'>You short out the safeties on [src].</span>")
 
 /obj/item/reagent_containers/applicator/set_APTFT()
+	set hidden = TRUE
+
+/obj/item/reagent_containers/applicator/empty()
 	set hidden = TRUE
 
 /obj/item/reagent_containers/applicator/on_reagent_change()
@@ -110,7 +114,7 @@
 
 		playsound(get_turf(src), pick('sound/goonstation/items/mender.ogg', 'sound/goonstation/items/mender2.ogg'), 50, 1)
 
-/obj/item/reagent_containers/applicator/verb/empty()
+/obj/item/reagent_containers/applicator/verb/empty_mender()
 	set name = "Empty Applicator"
 	set category = "Object"
 	set src in usr

--- a/code/modules/reagents/reagent_containers/applicator.dm
+++ b/code/modules/reagents/reagent_containers/applicator.dm
@@ -11,6 +11,7 @@
 	container_type = REFILLABLE | AMOUNT_VISIBLE
 	temperature_min = 270
 	temperature_max = 350
+	pass_open_check = TRUE
 	var/ignore_flags = FALSE
 	var/emagged = FALSE
 	var/applied_amount = 8 // How much it applies
@@ -25,9 +26,6 @@
 		to_chat(user, "<span class='warning'>You short out the safeties on [src].</span>")
 
 /obj/item/reagent_containers/applicator/set_APTFT()
-	set hidden = TRUE
-
-/obj/item/reagent_containers/applicator/empty()
 	set hidden = TRUE
 
 /obj/item/reagent_containers/applicator/on_reagent_change()
@@ -113,20 +111,6 @@
 		reagents.remove_any(total_applied_amount * 0.5)
 
 		playsound(get_turf(src), pick('sound/goonstation/items/mender.ogg', 'sound/goonstation/items/mender2.ogg'), 50, 1)
-
-/obj/item/reagent_containers/applicator/verb/empty_mender()
-	set name = "Empty Applicator"
-	set category = "Object"
-	set src in usr
-
-	if(usr.incapacitated())
-		return
-	if(alert(usr, "Are you sure you want to empty [src]?", "Empty Applicator:", "Yes", "No") != "Yes")
-		return
-	if(!usr.incapacitated() && isturf(usr.loc) && loc == usr)
-		to_chat(usr, "<span class='notice'>You empty [src] onto the floor.</span>")
-		reagents.reaction(usr.loc)
-		reagents.clear_reagents()
 
 /obj/item/reagent_containers/applicator/brute
 	name = "brute auto-mender"

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -54,6 +54,9 @@
 		"oculine" = list('icons/obj/surgery.dmi', "eyes"))
 
 
+/obj/item/reagent_containers/borghypo/empty()
+	set hidden = TRUE
+
 /obj/item/reagent_containers/borghypo/New()
 	..()
 	for(var/R in reagent_ids)

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -10,6 +10,7 @@
 	amount_per_transfer_from_this = 5
 	possible_transfer_amounts = list(1, 2, 3, 4, 5)
 	volume = 5
+	pass_open_check = TRUE
 
 /obj/item/reagent_containers/dropper/on_reagent_change()
 	if(!reagents.total_volume)

--- a/code/modules/reagents/reagent_containers/glass_containers.dm
+++ b/code/modules/reagents/reagent_containers/glass_containers.dm
@@ -238,7 +238,7 @@
 	desc = "A baggie. Can hold up to 10 units."
 	icon_state = "baggie"
 	amount_per_transfer_from_this = 2
-	possible_transfer_amounts = 2
+	possible_transfer_amounts = null
 	volume = 10
 	container_type = OPENCONTAINER
 	can_assembly = 0
@@ -248,7 +248,7 @@
 	desc = "A baggie. Can hold up to 20 units."
 	icon_state = "baggie"
 	amount_per_transfer_from_this = 20
-	possible_transfer_amounts = 20
+	possible_transfer_amounts = null
 	volume = 20
 	container_type = OPENCONTAINER
 	can_assembly = 0

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -89,7 +89,7 @@
 	name = "combat stimulant injector"
 	desc = "A modified air-needle autoinjector, used by support operatives to quickly heal injuries in combat."
 	amount_per_transfer_from_this = 15
-	possible_transfer_amounts = list(15)
+	possible_transfer_amounts = null
 	icon_state = "combat_hypo"
 	volume = 90
 	ignore_flags = 1 // So they can heal their comrades.
@@ -162,12 +162,15 @@
 	icon_state = "autoinjector"
 	item_state = "autoinjector"
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(10)
+	possible_transfer_amounts = null
 	volume = 10
 	ignore_flags = TRUE //so you can medipen through hardsuits
 	container_type = DRAWABLE
 	flags = null
 	list_reagents = list("epinephrine" = 10)
+
+/obj/item/reagent_containers/hypospray/autoinjector/empty()
+	set hidden = TRUE
 
 /obj/item/reagent_containers/hypospray/autoinjector/attack(mob/M, mob/user)
 	if(!reagents.total_volume)
@@ -213,7 +216,6 @@
 	desc = "Rapidly stimulates and regenerates the body's organ system."
 	icon_state = "stimpen"
 	amount_per_transfer_from_this = 50
-	possible_transfer_amounts = list(50)
 	volume = 50
 	list_reagents = list("stimulants" = 50)
 
@@ -230,7 +232,6 @@
 	desc = "After a short period of time the nanites will slow the body's systems and assist with bone repair. Nanomachines son."
 	icon_state = "bonepen"
 	amount_per_transfer_from_this = 30
-	possible_transfer_amounts = list(30)
 	volume = 30
 	list_reagents = list("nanocalcium" = 30)
 

--- a/code/modules/reagents/reagent_containers/iv_bag.dm
+++ b/code/modules/reagents/reagent_containers/iv_bag.dm
@@ -17,6 +17,9 @@
 	var/mode = IV_INJECT
 	var/mob/living/carbon/human/injection_target
 
+/obj/item/reagent_containers/iv_bag/empty()
+	set hidden = TRUE
+
 /obj/item/reagent_containers/iv_bag/Destroy()
 	end_processing()
 	return ..()

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -92,20 +92,6 @@
 	if(get_dist(user, src) && user == loc)
 		. += "<span class='notice'>[round(reagents.total_volume)] units left.</span>"
 
-/obj/item/reagent_containers/spray/verb/empty()
-
-	set name = "Empty Spray Bottle"
-	set category = "Object"
-	set src in usr
-	if(usr.stat || !usr.canmove || usr.restrained())
-		return
-	if(alert(usr, "Are you sure you want to empty that?", "Empty Bottle:", "Yes", "No") != "Yes")
-		return
-	if(isturf(usr.loc) && loc == usr)
-		to_chat(usr, "<span class='notice'>You empty [src] onto the floor.</span>")
-		reagents.reaction(usr.loc)
-		reagents.clear_reagents()
-
 //space cleaner
 /obj/item/reagent_containers/spray/cleaner
 	name = "space cleaner"

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -9,7 +9,7 @@
 	item_state = "syringe_0"
 	icon_state = "0"
 	amount_per_transfer_from_this = 5
-	possible_transfer_amounts = list()
+	possible_transfer_amounts = null
 	volume = 15
 	sharp = TRUE
 	var/busy = FALSE

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -12,6 +12,7 @@
 	possible_transfer_amounts = null
 	volume = 15
 	sharp = TRUE
+	pass_open_check = TRUE
 	var/busy = FALSE
 	var/mode = SYRINGE_DRAW
 	var/projectile_type = /obj/item/projectile/bullet/dart/syringe


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->
## Описание
Добавляет верб на опустошение контейнера, чтобы была альтернатива хармом по полу. Добавляет этот верб стаканам, относительно старого.
Добавляет хоткей на set transfer amount(altclick) для контейнеров с возможностью APTFT, из-за этого взбалтывать cans теперь нужно на ctrl click. Добавляет в описание, на сколько выставлен set transfer amount и подсказку о альтклике.
Чинит <a href="https://discord.com/channels/617003227182792704/734823601110515882/1079678553882374265">вечное и немного от этого лагучее </a>выпивание залпом. Теперь нельзя более одного выпивания залпом а раз.
Чинит возможность пить залпом сквозь неоткрытые банки пива, газировки и т.п.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Fixes and qols
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
