### PR TITLE
FIX: Исправление смещения шапок при использовании платы Reset на киборгах.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -549,6 +549,8 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 
 	update_icons()
 	update_headlamp()
+	robot_module_hat_offset(icon_state)
+	drop_hat()
 
 	for(var/obj/item/borg/upgrade/upgrade in upgrades) //remove all upgrades, cuz we reseting
 		qdel(upgrade)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

Исправляет смещение шапок при использовании платы Reset на киборгах.
Теперь шапка опадает на землю при Reset'е и её можно надеть на киборга с корректным смещением.

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

https://discord.com/channels/617003227182792704/1079491336350216262/1079491336350216262

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->

![var1](https://user-images.githubusercontent.com/73733747/221519363-36347f8c-fd64-44c5-b8e9-60233195c229.png)

Слева-направо: 

1. Первоначальное положение шапки 
2. Неправильное смещение шапки после применения платы Reset
3. Правильное положение шапки
