### PR TITLE
GYM теперь не увеличивает существо в размерах.

### DIFF
--- a/code/modules/ruins/objects_and_mobs/gym.dm
+++ b/code/modules/ruins/objects_and_mobs/gym.dm
@@ -55,7 +55,6 @@
 		var/finishmessage = pick("You feel stronger!","You feel like you can take on the world!","You feel robust!","You feel indestructible!")
 		icon_state = initial(icon_state)
 		to_chat(user, finishmessage)
-		user.reagents.add_reagent("growthserum", 10)
 		user.apply_status_effect(STATUS_EFFECT_EXERCISED)
 
 /obj/structure/weightmachine/wrench_act(mob/living/user, obj/item/I)


### PR DESCRIPTION
## Описание
Действие в GYM(кач железа) теперь больше не вырабатывает в кукле growth serum(реагент ботаников), который увеличивал существо в размерах пока оно в организме.

## Ссылка на предложение/Причина создания ПР
Причина создания: ответ предложению _epik_ на откат всей предложки -> https://discord.com/channels/617003227182792704/1079521205217919006 (#paradise-vote)
Которая сама по себе полезная лишь тем, что даёт возможность переносить GYM машину из точки A в точку B.
Но и соглашусь с теми кто упоминал про "рост" куклы, сомнительное решение, которое даёт визуал игрокам (типо они большие накаченные гигачады, гачимучи и тд.) что сразу побуждает их на неоднозначные фразочки. Поэтому лучше избавиться только от этого, а не от всего предложенного предложкой вообще.

(на скриншоте моя локалка)
## Демонстрация изменений
![Снимок3333](https://user-images.githubusercontent.com/126337700/221528479-3a0a1cc5-a298-4b8b-8ff3-30ea78ae0b52.PNG)