### PR TITLE
FIX: Исправление дублирования кнопок снятия голобейджика и экипировки нескольких значков одновременно.

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -77,9 +77,10 @@
 		add_fingerprint(user)
 		user.put_in_hands(attached_badge)
 
-		for(var/X in actions)
-			var/datum/action/A = X
-			A.Remove(user)
+		for(var/action in actions)
+			var/datum/action/A = action
+			if(istype(A, /datum/action/item_action/remove_badge))
+				src.actions.Remove(A)
 
 		icon_state = "armor"
 		user.update_inv_wear_suit()

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -58,7 +58,7 @@
 	var/obj/item/clothing/accessory/holobadge/attached_badge
 
 /obj/item/clothing/suit/armor/vest/security/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/clothing/accessory/holobadge) && !attached_badge) //preventing from equipping more than one badge
+	if(istype(I, /obj/item/clothing/accessory/holobadge) && !attached_badge)
 		if(user.unEquip(I))
 			add_fingerprint(user)
 			I.forceMove(src)
@@ -78,8 +78,8 @@
 		user.put_in_hands(attached_badge)
 
 		for(var/datum/action/item_action/remove_badge/action in actions)
-			src.actions.Remove(action) //remove action from vest
-			action.Remove(user) //remove action from user
+			src.actions.Remove(action)
+			action.Remove(user)
 
 		icon_state = "armor"
 		user.update_inv_wear_suit()

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -58,7 +58,7 @@
 	var/obj/item/clothing/accessory/holobadge/attached_badge
 
 /obj/item/clothing/suit/armor/vest/security/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/clothing/accessory/holobadge))
+	if(istype(I, /obj/item/clothing/accessory/holobadge) && !attached_badge) //preventing from equipping more than one badge
 		if(user.unEquip(I))
 			add_fingerprint(user)
 			I.forceMove(src)
@@ -77,10 +77,9 @@
 		add_fingerprint(user)
 		user.put_in_hands(attached_badge)
 
-		for(var/action in actions)
-			var/datum/action/A = action
-			if(istype(A, /datum/action/item_action/remove_badge))
-				src.actions.Remove(A)
+		for(var/datum/action/item_action/remove_badge/action in actions)
+			src.actions.Remove(action) //remove action from vest
+			action.Remove(user) //remove action from user
 
 		icon_state = "armor"
 		user.update_inv_wear_suit()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

Данный фикс убирает дублирование иконок снятия голобейджика с бронежилета СБ (Некорректно удалялись действия у бронежилета. Точнее говоря, вообще не убирались)

Также убирает возможность прикрепить больше одного бейджика на бронежилет (раньше можно было вставить неограниченное количество, но при изъятии бейджика с жилета выдавался только один)


## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

https://discord.com/channels/617003227182792704/1079280271360278558/1079280271360278558

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->

До изменения дублирование выглядело так:

![изображение](https://user-images.githubusercontent.com/73733747/221571469-4bc161c1-2a18-47e2-985c-afccb410c8c5.png)

После (дублирования нет):
![изображение](https://user-images.githubusercontent.com/73733747/221571727-ca8b48dc-ed9f-4ba9-bc70-9a5b3d91e3af.png)



