### PR TITLE
CQC Upgrade implant

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -238,6 +238,15 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 2
 	job = list("Chef")
 
+/datum/uplink_item/jobspecific/CQC_upgrade
+	name = "CQC Upgrade implant"
+	desc = "Contain special implant for chefs, which destroy safety check their innate CQC implant, allow them to use martial art outside the kitchen. Use in hand."
+	reference = "CUI"
+	item = /obj/item/CQC_manual/chef
+	cost = 6
+	job = list("Chef")
+	surplus = 0 //because it's useless for all non-chefs
+
 //Chaplain
 
 /datum/uplink_item/jobspecific/voodoo

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -297,6 +297,36 @@
 	new /obj/effect/decal/cleanable/ash(get_turf(src))
 	qdel(src)
 
+/obj/item/CQC_manual/chef
+	name = "CQC Upgrade implant"
+	desc = "Gives you to remember what you always forget"
+	icon = 'icons/obj/items.dmi'
+	icon_state = "implanter1"
+	item_state = "syringe_0"
+
+/obj/item/CQC_manual/chef/attack_self(mob/living/carbon/human/user)
+	if(!istype(user) || !user)
+		return
+	if(user.mind && user.mind.assigned_role == "Chef")
+		to_chat(user, "<span class='boldannounce'>You completely memorise the basics of CQC.</span>")
+		var/datum/martial_art/cqc/CQC = new(null)
+		CQC.teach(user)
+		user.drop_item()
+		visible_message("<span class='warning'>[src] beeps ominously, and a moment later it blow up.</span>")
+		new /obj/effect/decal/cleanable/ash(get_turf(src))
+		qdel(src)
+	else
+		to_chat(user, "<span class='notice'>You implant yourself, but nanobots can't find their target. You feel sharp pain in head!</span>")
+		if(isliving(user))
+			var/mob/living/L = user
+			L.adjustBrainLoss(20)
+			L.adjustFireLoss(20)
+		user.drop_item()
+		visible_message("<span class='warning'>[src] beeps ominously, and a moment later it blow up!</span>")
+		playsound(get_turf(src),'sound/effects/explosion2.ogg', 100, 1)
+		new /obj/effect/decal/cleanable/ash(get_turf(src))
+		qdel(src)
+
 /obj/item/twohanded/bostaff
 	name = "bo staff"
 	desc = "A long, tall staff made of polished wood. Traditionally used in ancient old-Earth martial arts. Can be wielded to both kill and incapacitate."


### PR DESCRIPTION
Добавил апгрейд поварского сикуси, который могут юзать только повара, остальные получат микровзрыв и урон мозгу. Его нет в лутбоксах, так как он совершенно бесполезен не-поварам.

Авоут: https://discord.com/channels/617003227182792704/755125334097133628/1079513298329927830