### PR TITLE
fix: ghostize targets

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -33,7 +33,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 		return TARGET_INVALID_NOT_HUMAN
 	if(possible_target.current.stat == DEAD)
 		return TARGET_INVALID_DEAD
-	if(!possible_target.key)
+	if(!possible_target.key || !possible_target.current.ckey)
 		return TARGET_INVALID_NOCKEY
 	if(possible_target.current)
 		var/turf/current_location = get_turf(possible_target.current)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Цель не будет выпадать на персонажей что ушли в крио, вышли из тела через ooc->ghost, а также на старую куклу администратора, если он уже в другой кукле(при простом агосте ckey  остаётся). В mindе у них остаётся их key, но в теле их уже нет, у гостов минд привязан к их старому живому телу, даже если они ушли в крио.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Закрывает багрепорт: https://discord.com/channels/617003227182792704/1079912114677891223
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->