### PR TITLE
fix: irreplaceable turfs after crystall and non-icon floor in lavalend skin

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -141,6 +141,8 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 	update_icon()
 
 /turf/simulated/floor/proc/make_plating()
+	if(underturf)
+		return ChangeTurf(underturf)
 	return ChangeTurf(/turf/simulated/floor/plating)
 
 /turf/simulated/floor/ChangeTurf(turf/simulated/floor/T, defer_change = FALSE, keep_icon = TRUE, ignore_air = FALSE)

--- a/code/game/turfs/simulated/floor/asteroid.dm
+++ b/code/game/turfs/simulated/floor/asteroid.dm
@@ -131,7 +131,7 @@
 	set_light(0)
 	return ..()
 
-/proc/set_basalt_light(turf/simulated/floor/B)
+/turf/simulated/floor/plating/asteroid/basalt/proc/set_basalt_light(turf/simulated/floor/B)
 	switch(B.icon_state)
 		if("basalt1", "basalt2", "basalt3")
 			B.set_light(2, 0.6, LIGHT_COLOR_LAVA) //more light

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -345,6 +345,28 @@
 /turf/simulated/floor/snow/pry_tile(obj/item/C, mob/user, silent = FALSE)
 	return
 
+/turf/simulated/floor/snow/attackby(obj/item/C, mob/user, params)
+	if(..())
+		return TRUE
+	if(istype(C, /obj/item/shovel))
+		var/obj/item/shovel/S = C
+		user.visible_message("<span class='notice'>[user] is clearing away [src]...</span>", "<span class='notice'>You begin clearing away [src]...</span>", "<span class='warning'>You hear a wettish digging sound.</span>")
+		playsound(get_turf(user), S.usesound, 50, TRUE)
+		if(do_after(user, 5 SECONDS * S.toolspeed * gettoolspeedmod(user), target = src) && istype(src, /turf/simulated/floor/snow))
+			user.visible_message("<span class='notice'>[user] clears away [src]!</span>", "<span class='notice'>You clear away [src]!</span>")
+			new /obj/item/snowball(src)
+			make_plating()
+			return
+
+
+/turf/simulated/floor/snow/attack_hand(mob/living/carbon/human/user)
+	if(!istype(user)) //Nonhumans don't have the balls to fight in the snow
+		return
+	user.changeNext_move(CLICK_CD_MELEE)
+	var/obj/item/snowball/SB = new(get_turf(user))
+	user.put_in_hands(SB)
+	to_chat(user, "<span class='notice'>You scoop up some snow and make \a [SB]!</span>")
+
 /turf/simulated/floor/plating/metalfoam
 	name = "foamed metal plating"
 	icon_state = "metalfoam"

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -40,6 +40,7 @@
 	var/barefootstep = null
 	var/clawfootstep = null
 	var/heavyfootstep = null
+	var/turf/underturf = null
 
 /turf/Initialize(mapload)
 	SHOULD_CALL_PARENT(FALSE)

--- a/code/modules/mining/lavaland/loot/colossus_loot.dm
+++ b/code/modules/mining/lavaland/loot/colossus_loot.dm
@@ -148,7 +148,10 @@
 				if(isturf(Stuff))
 					var/turf/T = Stuff
 					if((isspaceturf(T) || isfloorturf(T)) && NewTerrainFloors)
-						var/turf/simulated/O = T.ChangeTurf(NewTerrainFloors)
+						var/turf/simulated/floor/O = T.ChangeTurf(NewTerrainFloors)
+						if(ispath(NewTerrainFloors, /turf/simulated/floor/plating))
+							O.icon_plating = "basalt"
+							O.icon_state = "basalt"
 						if(O.air)
 							var/datum/gas_mixture/G = O.air
 							G.copy_from(O.air)
@@ -156,7 +159,7 @@
 							var/atom/Picked = pick(NewFlora)
 							new Picked(O)
 						continue
-					if(iswallturf(T) && NewTerrainWalls)
+					if(iswallturf(T) && NewTerrainWalls && !istype(T, /turf/simulated/wall/indestructible))
 						T.ChangeTurf(NewTerrainWalls)
 						continue
 				if(istype(Stuff, /obj/structure/chair) && NewTerrainChairs)

--- a/code/modules/mining/lavaland/loot/colossus_loot.dm
+++ b/code/modules/mining/lavaland/loot/colossus_loot.dm
@@ -148,10 +148,7 @@
 				if(isturf(Stuff))
 					var/turf/T = Stuff
 					if((isspaceturf(T) || isfloorturf(T)) && NewTerrainFloors)
-						var/turf/simulated/floor/O = T.ChangeTurf(NewTerrainFloors)
-						if(ispath(NewTerrainFloors, /turf/simulated/floor/plating))
-							O.icon_plating = "basalt"
-							O.icon_state = "basalt"
+						var/turf/simulated/floor/O = T.ChangeTurf(NewTerrainFloors, keep_icon = FALSE)
 						if(O.air)
 							var/datum/gas_mixture/G = O.air
 							G.copy_from(O.air)

--- a/code/modules/mining/lavaland/loot/colossus_loot.dm
+++ b/code/modules/mining/lavaland/loot/colossus_loot.dm
@@ -148,7 +148,9 @@
 				if(isturf(Stuff))
 					var/turf/T = Stuff
 					if((isspaceturf(T) || isfloorturf(T)) && NewTerrainFloors)
+						var/old_floor = (T.underturf) ? T.underturf : T.type
 						var/turf/simulated/floor/O = T.ChangeTurf(NewTerrainFloors, keep_icon = FALSE)
+						O.underturf = old_floor
 						if(O.air)
 							var/datum/gas_mixture/G = O.air
 							G.copy_from(O.air)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Из незаменяемых полов был лишь снег, теперь его можно откопать лопатой и удалить. + возможность снежка, также как и у снега после снегмашины.
У asteroid полов нет иконки после change turfa, чинит это для кристалла.
Также теперь, если вы будете убирать темы снега или джунглей -  вам вернётся старый турф. Стоит ли возвращать для остальных не знаю.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Закрывает багрепорт: https://discord.com/channels/617003227182792704/1078378165254238268
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
![Снимок экрана 2023-03-02 114839](https://user-images.githubusercontent.com/120549107/222379778-47074c74-566a-46ca-8cad-35a20611a7d2.png)
![Снимок экрана 2023-03-04 135517](https://user-images.githubusercontent.com/120549107/222896185-012b9235-b0a5-41a2-b0da-049e961b196d.png)


<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
