### PR TITLE
fix: custom head's job names are denied access by the departament manager console

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -660,7 +660,7 @@ SUBSYSTEM_DEF(jobs)
 	if(tgtcard)
 		var/mob/M = tgtcard.getPlayer()
 		for(var/datum/job/job in occupations)
-			if(tgtcard.assignment && tgtcard.assignment == job.title)
+			if(tgtcard.rank && tgtcard.rank == job.title)
 				jobs_to_formats[job.title] = "green" // the job they already have is pre-selected
 			else if(tgtcard.assignment == "Demoted" || tgtcard.assignment == "Terminated")
 				jobs_to_formats[job.title] = "grey"

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -244,7 +244,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 		return TRUE
 	if(!targetjob || !targetjob.title)
 		return FALSE
-	if(targetjob.title in get_subordinates(scan.assignment, includecivs))
+	if(targetjob.title in get_subordinates(scan.rank, includecivs))
 		return TRUE
 	return FALSE
 
@@ -331,7 +331,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 				if(!scan)
 					return data
 				else if(target_dept)
-					data["jobs_dept"] = get_subordinates(scan.assignment, FALSE)
+					data["jobs_dept"] = get_subordinates(scan.rank, FALSE)
 					data["canterminate"] = has_idchange_access()
 				else
 					data["account_number"] = modify ? modify.associated_account_number : null
@@ -372,7 +372,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 				data["records"] = SSjobs.format_job_change_records(data["iscentcom"])
 		if(IDCOMPUTER_SCREEN_DEPT) // DEPARTMENT EMPLOYEE LIST
 			if(is_authenticated(user) && scan) // .requires both (aghosts don't count)
-				data["jobs_dept"] = get_subordinates(scan.assignment, FALSE)
+				data["jobs_dept"] = get_subordinates(scan.rank, FALSE)
 				data["people_dept"] = get_employees(data["jobs_dept"])
 	return data
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Даёт возможность главам с кастомными наименованиями пользоваться своими консолями.
Также чинит отображение альтернативного текущего названия на консолях перевода.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Исправляет старую логику, созданную ещё до возможности кастомных профессий.
То, что главы не могут переводить и нанимать сотрудников, когда они главы - плохо.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
![Снимок экрана 2023-03-02 091817](https://user-images.githubusercontent.com/120549107/222380730-7ee30a6a-4913-4a6f-846f-2c8ec6b78c51.png)

<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
