### PR TITLE
FIX: infinite guardian bombs and distance explosions

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/types/bomb.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/bomb.dm
@@ -78,6 +78,8 @@
 /obj/item/guardian_bomb/proc/detonate(var/mob/living/user)
 	if(!istype(user))
 		return
+	if(get_dist(get_turf(src), get_turf(user)) > 1)
+		return
 	to_chat(user, "<span class='danger'>The [src] was boobytrapped!</span>")
 	if(istype(spawner, /mob/living/simple_animal/hostile/guardian))
 		var/mob/living/simple_animal/hostile/guardian/G = spawner
@@ -92,6 +94,7 @@
 	stored_obj.forceMove(get_turf(loc))
 	playsound(get_turf(src),'sound/effects/explosion2.ogg', 200, 1)
 	user.ex_act(2)
+	qdel(src)
 	qdel(src)
 
 /obj/item/guardian_bomb/attackby(obj/item/W, mob/living/user)

--- a/code/game/gamemodes/miniantags/guardian/types/bomb.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/bomb.dm
@@ -88,6 +88,7 @@
 			to_chat(user, "<span class='danger'>You knew this because of your link with your guardian, so you smartly defuse the bomb.</span>")
 			stored_obj.forceMove(get_turf(loc))
 			qdel(src)
+			qdel(src)
 			return
 	add_attack_logs(user, stored_obj, "booby trap TRIGGERED (spawner: [spawner])")
 	to_chat(spawner, "<span class='danger'>Success! Your trap on [src] caught [user]!</span>")


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

Исправление, призванное убрать бесконечную привязку и дублирование бомб голопаразита/стража к предметам/шлюзам.
Также убирает возможность подрыва киборгов/ИИ через попытку удаленного доступа к двери. (Все ещё можно подорваться при таких действиях, если стоять вплотную к двери.)
При этом дверь будет все ещё невозможно открыть или как-либо взаимодействовать с ней удаленно.
-Теперь корректно обрабатывается случай, когда в одном месте установлено несколько бомб (Теперь каждая из них ТОЧНО разминируется/детонирует)

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

https://discord.com/channels/617003227182792704/1080881865981952060/1080881865981952060

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
Изменения для игроков:
-Бомбы все ещё взрываются по одной.
-Хозяин стража/голопаразита теперь точно может разминировать дверь/предмет, куда была заложена бомба больше двух раз.
-Теперь ИИ/киборги/дроны при попытке удаленного доступа к двери/предмету на расстоянии больше, чем в радиусе одной клетки не подрываются, а бомба на двери не взрывается.
-Удаленный доступ на расстоянии больше одной клетки не будет как-либо действовать на заминированные двери.




