### PR TITLE
Fix: noise lang handling in radio

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1294,7 +1294,7 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 	var/message_clean = combine_message(message_pieces, M)
 	message_clean = replace_characters(message_clean, list("+"))
 
-	var/message = verb_message(message_clean, verb)
+	var/message = verb_message(message_pieces, message_clean, verb)
 
 	var/name_used = M.GetVoice()
 	//This communication is imperfect because the holopad "filters" voices and is only designed to connect to the master only.

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -79,7 +79,7 @@
 		var/message_clean = combine_message(message_pieces, src)
 		message_clean = replace_characters(message_clean, list("+"))
 
-		var/message = verb_message(message_clean, verb)
+		var/message = verb_message(message_pieces, message_clean, verb)
 		var/message_tts = combine_message_tts(message_pieces, src)
 
 		if ((client?.prefs.toggles2 & PREFTOGGLE_2_RUNECHAT) && can_hear())


### PR DESCRIPTION
Вернул правильную обработку "noise lang", языка который используется в основном для того чтобы воспроизводить эмоуты по рации