### PR TITLE
Fix: atmos firealarm

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -69146,10 +69146,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "caution"
@@ -101362,6 +101358,10 @@
 	c_tag = "Atmospherics Front Desk";
 	dir = 4;
 	network = list("SS13","Engineering")
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;


### PR DESCRIPTION
## Описание
Перемещает пожарную тревогу на тайл ниже.

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1081956656306454678

