### PR TITLE
Fix: Unathi and Tajaran lang in silicon lang menu.

### DIFF
--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -300,7 +300,7 @@
 			if(L == default_language)
 				default_str = " - default - <a href='byond://?src=[UID()];default_lang=reset'>reset</a>"
 			else
-				default_str = " - <a href='byond://?src=[UID()];default_lang=[L]'>set default</a>"
+				default_str = " - <a href=\"byond://?src=[UID()];default_lang=[L]\">set default</a>"
 
 			var/synth = (L in speech_synthesizer_langs)
 			. += "<b>[L.name] (:[L.key])</b>[synth ? default_str : null]<br>Speech Synthesizer: <i>[synth ? "YES" : "NOT SUPPORTED"]</i><br>[L.desc]<br><br>"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Заменяет апострофы в функции смены дефолтного языка менюшки Check Known Languages, которые конфликтовали с названиями Сиик'тайра и Синта'унати, не давая их выбрать.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1082061008346026044 - ссылка на баг-репорт.<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->