### PR TITLE
Система доступности тайпана

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -36,3 +36,5 @@ GLOBAL_LIST_EMPTY(surgeries_list)
 GLOBAL_LIST_EMPTY(hear_radio_list)			//Mobs that hear the radio even if there's no client
 
 GLOBAL_LIST_EMPTY(human_names_list)			//List of names for all humans that have ever entered the round
+
+GLOBAL_LIST_EMPTY(taipan_players_active)	//List of all Taipan operatives active

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -2476,6 +2476,7 @@
 	mind.assigned_role = "Cyborg"
 	if(is_taipan(z))
 		give_taipan_hud()
+		GLOB.taipan_players_active += mind
 
 //PAI
 /mob/living/silicon/pai/mind_initialize()

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -400,6 +400,10 @@
 		if(!SSticker.mode.cult_objs.find_new_sacrifice_target())
 			SSticker.mode.cult_objs.ready_to_summon()
 
+	// We should track when taipan players get despawned
+	if(occupant.mind in GLOB.taipan_players_active)
+		GLOB.taipan_players_active -= occupant.mind
+
 	//Update any existing objectives involving this mob.
 	if(occupant.mind)
 		for(var/datum/objective/O in GLOB.all_objectives)

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -113,6 +113,7 @@
 		return
 
 	if(destination_z && destination_x && destination_y)
+		destination_z = check_taipan_availability(A, destination_z)
 		A.forceMove(locate(destination_x, destination_y, destination_z))
 
 		if(isliving(A))
@@ -124,6 +125,39 @@
 		//now we're on the new z_level, proceed the space drifting
 		sleep(0)//Let a diagonal move finish, if necessary
 		A.newtonian_move(A.inertia_dir)
+
+/turf/space/proc/check_taipan_availability(atom/movable/A as mob|obj, destination_z)
+	var/mob/living/check_mob = A
+	// if we are from taipan's crew, then we can easily access it.
+	if(istype(check_mob) && is_taipan(destination_z))
+		if(check_mob.mind in GLOB.taipan_players_active)
+			to_chat(A, span_info("Вы вернулись в ваш родной скрытый от чужих глаз сектор..."))
+			return destination_z
+	// if we are not from taipan's crew, then we cannot get there until there is enought players on Taipan
+	if(is_taipan(destination_z) && length(GLOB.taipan_players_active) < 6)
+		var/datum/space_level/taipan_zlvl
+		var/datum/space_level/direct
+		for(var/list_parser in GLOB.space_manager.z_list)
+			var/datum/space_level/lvl = GLOB.space_manager.z_list[list_parser]
+			if(TAIPAN in lvl.flags)
+				taipan_zlvl = lvl
+		switch(A.dir)
+			if(NORTH)
+				direct = taipan_zlvl.get_connection(Z_LEVEL_NORTH)
+			if(SOUTH)
+				direct = taipan_zlvl.get_connection(Z_LEVEL_SOUTH)
+			if(EAST)
+				direct = taipan_zlvl.get_connection(Z_LEVEL_EAST)
+			if(WEST)
+				direct = taipan_zlvl.get_connection(Z_LEVEL_WEST)
+		destination_z = direct.zpos
+		// if we are still going to get to taipan after all the checks... Then get random available z_lvl instead
+		if(is_taipan(destination_z))
+			destination_z = pick(get_all_linked_levels_zpos())
+	//notification if we do get to taipan
+	if(is_taipan(destination_z))
+		to_chat(check_mob, span_warning("Вы попадаете в загадочный сектор полный астероидов... Тут стоит быть осторожнее..."))
+	return destination_z
 
 /turf/space/proc/Sandbox_Spacemove(atom/movable/A as mob|obj)
 	var/cur_x

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -511,18 +511,19 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 						Встроенное в вас LMG самостоятельно производит патроны используя вашу батарею. \
 						Ваш пинпоинтер позволяет вам найти Ядерных Оперативников синдиката из вашей группы, если вас к таковой приставят."
 
-	var/datum/robot_component/cell/C = R.components["power cell"]
-
-	var/obj/item/stock_parts/cell/CC = get_cell(M)
-	CC.loc = src
-	R.cell = new CC.type
-	C.installed = 1
-	C.wrapped = CC
-	C.install()
-	C.external_type = CC.type
-	C.brute_damage = 0
-	C.electronics_damage = 0
-	diag_hud_set_borgcell()
+	var/datum/robot_component/cell/cell_component = R.components["power cell"]
+	var/obj/item/stock_parts/cell/borg_cell = get_cell(M)
+	if(borg_cell)
+		QDEL_NULL(R.cell)
+		borg_cell.forceMove(R)
+		R.cell = borg_cell
+		cell_component.installed = 1
+		cell_component.external_type = borg_cell.type
+		cell_component.wrapped = borg_cell
+		cell_component.install()
+		cell_component.brute_damage = 0
+		cell_component.electronics_damage = 0
+		diag_hud_set_borgcell()
 
 	R.mmi = new /obj/item/mmi/robotic_brain/syndicate(M)
 	M.mind.transfer_to(R)

--- a/code/modules/ruins/syndicate_space_base.dm
+++ b/code/modules/ruins/syndicate_space_base.dm
@@ -100,6 +100,7 @@
 /obj/effect/mob_spawn/human/space_base_syndicate/special(mob/living/carbon/human/H)
 	GLOB.human_names_list += H.real_name
 	SEND_SOUND(H, 'sound/effects/taipan_start.ogg')
+	GLOB.taipan_players_active += H.mind
 	H.give_taipan_hud()
 	return ..()
 

--- a/code/modules/space_management/level_traits.dm
+++ b/code/modules/space_management/level_traits.dm
@@ -72,11 +72,14 @@ GLOBAL_LIST_INIT(default_map_traits, MAP_TRANSITION_CONFIG)
   * Proc to get a list of all the linked-together Z-Levels
   *
   * Returns a list of zlevel numbers which can be accessed from travelling space naturally
+  * ignores Taipan tho
   */
 /proc/get_all_linked_levels_zpos()
 	var/list/znums = list()
 	for(var/i in GLOB.space_manager.z_list)
 		var/datum/space_level/SL = GLOB.space_manager.z_list[i]
 		if(SL.linkage == CROSSLINKED)
+			znums |= SL.zpos
+		if(TAIPAN in SL.flags)
 			znums |= SL.zpos
 	return znums


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
* Теперь на тайпан из космоса смогут попасть только если на тайпане уже набралось минимум 6 игроков
* Сами тайпановцы как и их борги спокойно смогут влетать и вылетать из сектора.
* Не тайпановцы, будут пролетать в следующий после тайпана сектор. Или в случайный сектор космоса (В крайнем случае)
* При влёте в сектор так же добавлены оповещающие об этом сообщения.

### Дополнительно: 
* Правка кода переноса батареек собранных синдиборгов