### PR TITLE
FIX: Wrong blood on the Nuclear Team shuttle

### DIFF
--- a/_maps/map_files/generic/CentComm.dmm
+++ b/_maps/map_files/generic/CentComm.dmm
@@ -43449,7 +43449,6 @@
 /obj/item/robot_parts/l_arm,
 /obj/item/robot_parts/r_arm,
 /obj/item/clothing/mask/surgical,
-/obj/item/reagent_containers/iv_bag/bloodsynthetic/nitrogenis,
 /obj/item/tank/internals/anesthetic,
 /obj/item/clothing/mask/breath/medical,
 /obj/item/robot_parts/l_leg,
@@ -43457,6 +43456,7 @@
 /obj/item/radio/intercom/syndicate{
 	pixel_x = -28
 	},
+/obj/item/reagent_containers/iv_bag/blood/OMinus,
 /turf/simulated/floor/shuttle{
 	icon_state = "floor3"
 	},


### PR DESCRIPTION
## Описание
Заменяет пакет с кровью для воксов, на О- кровь на шаттле АТОМа. 

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1082290694489653269
