### PR TITLE
BUFF Сумка Синдиката

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1471,7 +1471,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/device_tools/surgerybag
 	name = "Syndicate Surgery Duffelbag"
-	desc = "The Syndicate surgery duffelbag comes with a full set of surgery tools, a straightjacket and a muzzle. The bag itself is also made of very light materials and won't slow you down while it is equipped."
+	desc = "The Syndicate Surgical Bag comes with a complete set of everything you need for quality surgery, including a straitjacket and muzzle. The bag itself is unprecedentedly light, doesn't slow you down, and is completely silent."
 	reference = "SSDB"
 	item = /obj/item/storage/backpack/duffel/syndie/surgery
 	cost = 2

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -581,17 +581,21 @@
 
 /obj/item/storage/backpack/duffel/syndie/surgery/New()
 	..()
-	new /obj/item/scalpel(src)
+	new /obj/item/stack/medical/bruise_pack/advanced(src)
+	new /obj/item/scalpel/laser/laser2(src)
 	new /obj/item/hemostat(src)
 	new /obj/item/retractor(src)
 	new /obj/item/circular_saw(src)
 	new /obj/item/surgicaldrill(src)
-	new /obj/item/cautery(src)
 	new /obj/item/bonegel(src)
 	new /obj/item/bonesetter(src)
 	new /obj/item/FixOVein(src)
+	new /obj/item/reagent_containers/glass/bottle/morphine(src)
+	new /obj/item/reagent_containers/syringe/antiviral(src)
 	new /obj/item/clothing/suit/straight_jacket(src)
 	new /obj/item/clothing/mask/muzzle(src)
+	new /obj/item/stack/sheet/plasteel(src)
+			amount = 5
 
 /obj/item/storage/backpack/duffel/syndie/surgery_fake //for maint spawns
 	name = "surgery duffelbag"

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -594,9 +594,7 @@
 	new /obj/item/reagent_containers/syringe/antiviral(src)
 	new /obj/item/clothing/suit/straight_jacket(src)
 	new /obj/item/clothing/mask/muzzle(src)
-	new /obj/item/stack/sheet/plasteel{
-		amount = 5
-		}(src)
+	new /obj/item/stack/sheet/plasteel(src, 5)
 
 /obj/item/storage/backpack/duffel/syndie/surgery_fake //for maint spawns
 	name = "surgery duffelbag"

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -594,8 +594,9 @@
 	new /obj/item/reagent_containers/syringe/antiviral(src)
 	new /obj/item/clothing/suit/straight_jacket(src)
 	new /obj/item/clothing/mask/muzzle(src)
-	new /obj/item/stack/sheet/plasteel(src)
-			amount = 5
+	new /obj/item/stack/sheet/plasteel{
+		amount = 5
+		}(src)
 
 /obj/item/storage/backpack/duffel/syndie/surgery_fake //for maint spawns
 	name = "surgery duffelbag"


### PR DESCRIPTION
Покупная сумка для операций теперь содержит полный набор для полевой хирургии, затрагивая 95% всех хирургических операций в игре.

## Описание
Добавлены бутылка морфия, 5 листов пластали, шприц с спейсой, улучшенный лазерный скальпель, бруткит для лечения органов.

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1082754230995132486

