### PR TITLE
fix: start position new_player in 1,1,1 

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -290,6 +290,7 @@
 	icon_state = "codes"
 
 /obj/effect/landmark/start
+	name = "start"
 //Landmark icons added only for renders
 //Same orders as jobs in lobby
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Базовая ландмарка start используется для точки спавна игроков new_player в лобби, из-за того что ни у одной ландмарки нет имени "start" все новые игроки будут в 1,1,1
Поэтому ставим имя "start" нужной ландмарке.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Не видеть прекрасные картинки лобби - плохо.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
