### PR TITLE
Fix: Delta extra airlock delete

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -119615,12 +119615,6 @@
 	},
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
-/obj/machinery/door/airlock/glass{
-	name = "Courtroom";
-	req_access_txt = "63";
-	id_tag = "courtroombolts";
-	id = "courtroom"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"


### PR DESCRIPTION
## Описание
Удаляет лишний аирлок около суда.

## Ссылка на предложение/Причина создания ПР
Он появился из-за пака фиксов. Местами мышка срабатывает без щелчка, а расположение аирлока было очень неприметным

## Демонстрация изменений
![Безымянный](https://user-images.githubusercontent.com/110329212/223733936-81de8137-d147-4e2f-84f1-7000bdc634f6.png)

