### PR TITLE
Feat: integrate Replays 2.0 by monster860

### DIFF
--- a/code/__DEFINES/demo.dm
+++ b/code/__DEFINES/demo.dm
@@ -1,0 +1,27 @@
+#ifndef DEMO_WRITER
+// Default automatic demo-writer detection.
+// On Windows, looks in the standard places for `demo-writer.dll`.
+// On Linux, looks in `.`, `$LD_LIBRARY_PATH`, and `~/.byond/bin` for either of
+// `libdemo-writer.so` (preferred) or `demo-writer` (old).
+
+/* This comment bypasses grep checks */ /var/__demo_writer
+
+/proc/__detect_demo_writer()
+	if (world.system_type == UNIX)
+		if (fexists("./libdemo-writer.so"))
+			// No need for LD_LIBRARY_PATH badness.
+			return __demo_writer = "./libdemo-writer.so"
+		else if (fexists("./demo-writer"))
+			// Old dumb filename.
+			return __demo_writer = "./demo-writer"
+		else if (fexists("[world.GetConfig("env", "HOME")]/.byond/bin/demo-writer"))
+			// Old dumb filename in `~/.byond/bin`.
+			return __demo_writer = "demo-writer"
+		else
+			// It's not in the current directory, so try others
+			return __demo_writer = "libdemo-writer.so"
+	else
+		return __demo_writer = "demo-writer.dll"
+
+#define DEMO_WRITER (__demo_writer || __detect_demo_writer())
+#endif

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -504,3 +504,5 @@
 #define TTS_SEED_DEFAULT_FEMALE "tyrande"
 #define TTS_SEED_DEFAULT_MALE "arthas"
 #define TTS_SEED_ANNOUNCER "anubarak"
+
+#define CLIENT_FROM_VAR(I) (ismob(I) ? I:client : (istype(I, /client) ? I : (istype(I, /datum/mind) ? I:current?:client : null)))

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -87,6 +87,7 @@
 #define INIT_ORDER_SQUEAK -40
 #define INIT_ORDER_PATH -50
 #define INIT_ORDER_PERSISTENCE -95
+#define INIT_ORDER_DEMO -99 // To avoid a bunch of changes related to initialization being written, do this last
 
 // Subsystem fire priority, from lowest to highest priority
 // If the subsystem isn't listed here it's either DEFAULT or PROCESS (if it's a processing subsystem child)

--- a/code/_globalvars/logging.dm
+++ b/code/_globalvars/logging.dm
@@ -23,6 +23,8 @@ GLOBAL_VAR(sql_log)
 GLOBAL_PROTECT(sql_log)
 GLOBAL_VAR(round_id)
 GLOBAL_PROTECT(round_id)
+GLOBAL_VAR(demo_log)
+GLOBAL_PROTECT(demo_log)
 
 GLOBAL_LIST_EMPTY(jobMax)
 GLOBAL_PROTECT(jobMax)

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -314,6 +314,9 @@
 	var/default_map = null
 	var/override_map = null
 
+	/// Whether demos are written, if not set demo SS never initializes
+	var/demos_enabled = FALSE
+
 /datum/configuration/New()
 	for(var/T in subtypesof(/datum/game_mode))
 		var/datum/game_mode/M = T
@@ -900,6 +903,9 @@
 
 				if("override_map")
 					config.override_map = value
+
+				if("demos_enabled")
+					config.demos_enabled = TRUE
 
 				else
 					log_config("Unknown setting in configuration: '[name]'")

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -316,6 +316,8 @@
 
 	/// Whether demos are written, if not set demo SS never initializes
 	var/demos_enabled = FALSE
+	/// Whether demos should include TTS sounds (storage expensive)
+	var/demos_embed_tts = FALSE
 
 /datum/configuration/New()
 	for(var/T in subtypesof(/datum/game_mode))
@@ -906,6 +908,9 @@
 
 				if("demos_enabled")
 					config.demos_enabled = TRUE
+
+				if("demos_embed_tts")
+					config.demos_embed_tts = TRUE
 
 				else
 					log_config("Unknown setting in configuration: '[name]'")

--- a/code/controllers/subsystem/demo.dm
+++ b/code/controllers/subsystem/demo.dm
@@ -60,6 +60,11 @@ SUBSYSTEM_DEF(demo)
 		chat_list[++chat_list.len] = list(world.time, target_list, message_str, is_text)
 
 /datum/controller/subsystem/demo/Initialize()
+	if(!config.demos_enabled)
+		flags |= SS_NO_FIRE
+		can_fire = FALSE
+		return ..()
+
 	dummy_observer = new
 	dummy_observer.forceMove(null)
 	dummy_observer.key = dummy_observer.ckey = ckey
@@ -74,7 +79,7 @@ SUBSYSTEM_DEF(demo)
 	var/result = call(DEMO_WRITER, "demo_start")(GLOB.demo_log, revdata_str)
 
 	if(result == "SUCCESS")
-		demo_started = 1
+		demo_started = TRUE
 		for(var/L in embed_list)
 			embed_resource(arglist(L))
 
@@ -104,7 +109,8 @@ SUBSYSTEM_DEF(demo)
 		last_size = text2num(call(DEMO_WRITER, "demo_flush")())
 
 /datum/controller/subsystem/demo/Shutdown()
-	call(DEMO_WRITER, "demo_end")()
+	if(demo_started)
+		call(DEMO_WRITER, "demo_end")()
 
 /datum/controller/subsystem/demo/stat_entry(msg)
 	msg += "ALL: [format_size(last_size)] | RSC: [format_size(last_embedded_size)]"

--- a/code/controllers/subsystem/demo.dm
+++ b/code/controllers/subsystem/demo.dm
@@ -111,9 +111,11 @@ SUBSYSTEM_DEF(demo)
 /datum/controller/subsystem/demo/Shutdown()
 	if(demo_started)
 		call(DEMO_WRITER, "demo_end")()
+		can_fire = FALSE
 
 /datum/controller/subsystem/demo/stat_entry(msg)
-	msg += "ALL: [format_size(last_size)] | RSC: [format_size(last_embedded_size)]"
+	var/demos_embed_tts = config.demos_embed_tts ? "on" : "off"
+	msg += "ALL: [format_size(last_size)] | RSC: [format_size(last_embedded_size)] | TTS: [demos_embed_tts]"
 	return ..(msg)
 
 /datum/controller/subsystem/demo/proc/format_size(size)

--- a/code/controllers/subsystem/demo.dm
+++ b/code/controllers/subsystem/demo.dm
@@ -68,7 +68,7 @@ SUBSYSTEM_DEF(demo)
 	var/revdata_list = list()
 	if(GLOB.revision_info)
 		revdata_list["commit"] = "[GLOB.revision_info.commit_hash]"
-		// if(GLOB.revision_info.originmastercommit) revdata_list["originmastercommit"] = "[GLOB.revision_info.originmastercommit]"
+		if(GLOB.revision_info.originmastercommit) revdata_list["originmastercommit"] = "[GLOB.revision_info.originmastercommit]"
 		revdata_list["repo"] = "ss220-space/Paradise"
 	var/revdata_str = json_encode(revdata_list);
 	var/result = call(DEMO_WRITER, "demo_start")(GLOB.demo_log, revdata_str)

--- a/code/controllers/subsystem/demo.dm
+++ b/code/controllers/subsystem/demo.dm
@@ -1,0 +1,171 @@
+// #define DEMO_WRITER (world.system_type == MS_WINDOWS ? "demo-writer.dll" : "libdemo-writer.so")
+
+// #ifndef DEMO_WRITER
+// // Default automatic demo-writer detection.
+// // On Windows, looks in the standard places for `demo-writer.dll`.
+// // On Linux, looks in `.`, `$LD_LIBRARY_PATH`, and `~/.byond/bin` for either of
+// // `libdemo-writer.so` (preferred) or `demo-writer` (old).
+
+// /* This comment bypasses grep checks */ /var/__demo_writer
+
+// /proc/__detect_demo_writer()
+// 	if (world.system_type == UNIX)
+// 		if (fexists("./libdemo-writer.so"))
+// 			// No need for LD_LIBRARY_PATH badness.
+// 			return __demo_writer = "./libdemo-writer.so"
+// 		else if (fexists("./demo-writer"))
+// 			// Old dumb filename.
+// 			return __demo_writer = "./demo-writer"
+// 		else if (fexists("[world.GetConfig("env", "HOME")]/.byond/bin/demo-writer"))
+// 			// Old dumb filename in `~/.byond/bin`.
+// 			return __demo_writer = "demo-writer"
+// 		else
+// 			// It's not in the current directory, so try others
+// 			return __demo_writer = "libdemo-writer.so"
+// 	else
+// 		return __demo_writer = "demo-writer.dll"
+
+// #define DEMO_WRITER (__demo_writer || __detect_demo_writer())
+// #endif
+
+#define DEMO_WRITER "./libdemo-writer.so"
+
+SUBSYSTEM_DEF(demo)
+	name = "Demo"
+	wait = 1
+	flags = SS_TICKER | SS_BACKGROUND
+	init_order = INIT_ORDER_DEMO
+	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
+
+	// loading_points = 1 SECONDS // Yogs -- loading times
+
+	var/last_size = 0
+	var/last_embedded_size = 0
+	var/demo_started = 0
+
+	var/ckey = "@@demoobserver"
+	var/mob/dead/observer/dummy_observer
+
+	var/list/embed_list = list()
+	var/list/embedded_list = list()
+	var/list/chat_list = list()
+
+/datum/controller/subsystem/demo/proc/write_chat(target, message)
+	if(!demo_started && !chat_list)
+		return
+	var/list/target_list
+	if(target == GLOB.clients || target == world)
+		target_list = list(world)
+	else if(istype(target, /datum/controller/subsystem/demo) || target == dummy_observer || target == "d")
+		target_list = list("d")
+	else if(islist(target))
+		target_list = list()
+		for(var/T in target)
+			if(istype(T, /datum/controller/subsystem/demo) || T == dummy_observer || T == "d")
+				target_list += "d"
+			else
+				var/client/C = CLIENT_FROM_VAR(target)
+				if(C)
+					target_list += C
+	else
+		var/client/C = CLIENT_FROM_VAR(target)
+		if(C)
+			target_list = list(C)
+	if(!target_list || !target_list.len)
+		return
+
+	var/message_str = ""
+	var/is_text = FALSE
+	if(islist(message))
+		if(message["text"])
+			is_text = TRUE
+			message_str = message["text"]
+		else
+			message_str = message["html"]
+	else if(istext(message))
+		message_str = message
+	if(demo_started)
+		for(var/I in 1 to target_list.len)
+			if(!istext(target_list[I])) target_list[I] = "\ref[target_list[I]]"
+		call(DEMO_WRITER, "demo_chat")(target_list.Join(","), "\ref[message_str]", "[is_text]")
+	else if(chat_list)
+		chat_list[++chat_list.len] = list(world.time, target_list, message_str, is_text)
+
+/datum/controller/subsystem/demo/Initialize()
+	dummy_observer = new
+	dummy_observer.forceMove(null)
+	dummy_observer.key = dummy_observer.ckey = ckey
+	dummy_observer.name = dummy_observer.real_name = "SSdemo Dummy Observer"
+
+	var/revdata_list = list()
+	if(GLOB.revision_info)
+		revdata_list["commit"] = "[GLOB.revision_info.commit_hash]"
+		// if(GLOB.revision_info.originmastercommit) revdata_list["originmastercommit"] = "[GLOB.revision_info.originmastercommit]"
+		revdata_list["repo"] = "ss220-space/Paradise"
+	var/revdata_str = json_encode(revdata_list);
+	var/result = call(DEMO_WRITER, "demo_start")(GLOB.demo_log, revdata_str)
+
+	if(result == "SUCCESS")
+		demo_started = 1
+		for(var/L in embed_list)
+			embed_resource(arglist(L))
+
+		for(var/list/L in chat_list)
+			call(DEMO_WRITER, "demo_set_time_override")(L[1])
+			var/list/target_list = L[2]
+			for(var/I in 1 to target_list.len)
+				if(!istext(target_list[I])) target_list[I] = "\ref[target_list[I]]"
+			call(DEMO_WRITER, "demo_chat")(target_list.Join(","), "\ref[L[3]]", "[L[4]]")
+		call(DEMO_WRITER, "demo_set_time_override")("null")
+
+		last_size = text2num(call(DEMO_WRITER, "demo_get_size")())
+	else
+		log_world("Failed to initialize demo system: [result]")
+
+	embed_list = null
+	chat_list = null
+
+	return ..()
+
+/datum/controller/subsystem/demo/fire()
+	if(demo_started)
+		last_size = text2num(call(DEMO_WRITER, "demo_flush")())
+
+/datum/controller/subsystem/demo/proc/flush()
+	if(demo_started)
+		last_size = text2num(call(DEMO_WRITER, "demo_flush")())
+
+/datum/controller/subsystem/demo/Shutdown()
+	call(DEMO_WRITER, "demo_end")()
+
+/datum/controller/subsystem/demo/stat_entry(msg)
+	msg += "ALL: [format_size(last_size)] | RSC: [format_size(last_embedded_size)]"
+	return ..(msg)
+
+/datum/controller/subsystem/demo/proc/format_size(size)
+	if(size < 1000000)
+		return "[round(size / 1000, 0.01)]kB"
+	return "[round(size / 1000000, 0.01)]MB"
+
+/datum/controller/subsystem/demo/proc/embed_resource(res, path)
+	res = fcopy_rsc(res)
+	if(!demo_started)
+		if(embed_list)
+			embed_list += list(list(res, path))
+		return res
+	if(!res || embedded_list[res])
+		return res
+	var/do_del = FALSE
+	if(!istext(path))
+		path = "tmp/rsc_[ckey("\ref[res]")]_[rand(0, 100000)]"
+		fcopy(res, path)
+		do_del = TRUE
+	var/size = length(file(path))
+	last_embedded_size += size
+	log_world("Embedding \ref[res] [res] from [path] ([size] bytes)")
+	if(call(DEMO_WRITER, "demo_embed_resource")("\ref[res]", path) != "SUCCESS")
+		log_world("Failed to copy \ref[res] [res] from [path]!")
+	embedded_list[res] = 1
+	if(do_del)
+		fdel(path)
+	return res

--- a/code/controllers/subsystem/demo.dm
+++ b/code/controllers/subsystem/demo.dm
@@ -1,35 +1,3 @@
-// #define DEMO_WRITER (world.system_type == MS_WINDOWS ? "demo-writer.dll" : "libdemo-writer.so")
-
-// #ifndef DEMO_WRITER
-// // Default automatic demo-writer detection.
-// // On Windows, looks in the standard places for `demo-writer.dll`.
-// // On Linux, looks in `.`, `$LD_LIBRARY_PATH`, and `~/.byond/bin` for either of
-// // `libdemo-writer.so` (preferred) or `demo-writer` (old).
-
-// /* This comment bypasses grep checks */ /var/__demo_writer
-
-// /proc/__detect_demo_writer()
-// 	if (world.system_type == UNIX)
-// 		if (fexists("./libdemo-writer.so"))
-// 			// No need for LD_LIBRARY_PATH badness.
-// 			return __demo_writer = "./libdemo-writer.so"
-// 		else if (fexists("./demo-writer"))
-// 			// Old dumb filename.
-// 			return __demo_writer = "./demo-writer"
-// 		else if (fexists("[world.GetConfig("env", "HOME")]/.byond/bin/demo-writer"))
-// 			// Old dumb filename in `~/.byond/bin`.
-// 			return __demo_writer = "demo-writer"
-// 		else
-// 			// It's not in the current directory, so try others
-// 			return __demo_writer = "libdemo-writer.so"
-// 	else
-// 		return __demo_writer = "demo-writer.dll"
-
-// #define DEMO_WRITER (__demo_writer || __detect_demo_writer())
-// #endif
-
-#define DEMO_WRITER "./libdemo-writer.so"
-
 SUBSYSTEM_DEF(demo)
 	name = "Demo"
 	wait = 1

--- a/code/controllers/subsystem/text_to_speech.dm
+++ b/code/controllers/subsystem/text_to_speech.dm
@@ -407,14 +407,16 @@ SUBSYSTEM_DEF(tts)
 			play_sfx(listener, preSFX, output.channel, output.volume, output.environment)
 
 		SEND_SOUND(listener, output)
-		SSdemo.embed_resource(output)
+		if(config.demos_embed_tts)
+			SSdemo.embed_resource(output)
 		return
 
 	if(preSFX)
 		play_sfx(listener, preSFX, output.channel, output.volume, output.environment)
 
 	output = listener.playsound_local(turf_source, output, volume, S = output, wait = TRUE, channel = channel)
-	SSdemo.embed_resource(output)
+	if(config.demos_embed_tts)
+		SSdemo.embed_resource(output)
 
 	if(!output || output.volume <= 0)
 		return

--- a/code/controllers/subsystem/text_to_speech.dm
+++ b/code/controllers/subsystem/text_to_speech.dm
@@ -407,12 +407,14 @@ SUBSYSTEM_DEF(tts)
 			play_sfx(listener, preSFX, output.channel, output.volume, output.environment)
 
 		SEND_SOUND(listener, output)
+		SSdemo.embed_resource(output)
 		return
 
 	if(preSFX)
 		play_sfx(listener, preSFX, output.channel, output.volume, output.environment)
 
 	output = listener.playsound_local(turf_source, output, volume, S = output, wait = TRUE, channel = channel)
+	SSdemo.embed_resource(output)
 
 	if(!output || output.volume <= 0)
 		return

--- a/code/controllers/subsystem/titlescreen.dm
+++ b/code/controllers/subsystem/titlescreen.dm
@@ -30,7 +30,7 @@ SUBSYSTEM_DEF(title)
 
 		var/file_path = "config/title_screens/images/[pick(title_screens)]"
 
-		var/icon/icon = new(fcopy_rsc(file_path))
+		var/icon/icon = new(SSdemo.embed_resource(fcopy_rsc(file_path)))
 
 		for(var/turf/simulated/wall/indestructible/splashcreen/splash in world)
 			splash.icon = icon

--- a/code/datums/mutable_appearance.dm
+++ b/code/datums/mutable_appearance.dm
@@ -16,7 +16,6 @@
 	MA.icon_state = icon_state
 	MA.layer = layer
 	MA.plane = plane
-	SSdemo.embed_resource(icon)
 	return MA
 
 

--- a/code/datums/mutable_appearance.dm
+++ b/code/datums/mutable_appearance.dm
@@ -16,6 +16,7 @@
 	MA.icon_state = icon_state
 	MA.layer = layer
 	MA.plane = plane
+	SSdemo.embed_resource(icon)
 	return MA
 
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -272,6 +272,7 @@ GLOBAL_LIST_EMPTY(world_topic_handlers)
 	GLOB.tgui_log = "[GLOB.log_directory]/tgui.log"
 	GLOB.http_log = "[GLOB.log_directory]/http.log"
 	GLOB.sql_log = "[GLOB.log_directory]/sql.log"
+	GLOB.demo_log = "[GLOB.log_directory]/demo.txt"
 	start_log(GLOB.world_game_log)
 	start_log(GLOB.world_href_log)
 	start_log(GLOB.world_runtime_log)
@@ -302,6 +303,7 @@ GLOBAL_LIST_EMPTY(world_topic_handlers)
 	var/debug_server = world.GetConfig("env", "AUXTOOLS_DEBUG_DLL")
 	if (debug_server)
 		call(debug_server, "auxtools_shutdown")()
+	SSdemo?.Shutdown()
 	..()
 
 /world/proc/init_byond_tracy()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -245,6 +245,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 			husk_over.Blend(mask, ICON_ADD)
 			base_icon.Blend(husk_over, ICON_OVERLAY)
 
+		SSdemo.embed_resource(base_icon)
 		var/mutable_appearance/new_base = mutable_appearance(base_icon, layer = -LIMBS_LAYER)
 		GLOB.human_icon_cache[icon_key] = new_base
 		standing += new_base

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1088,6 +1088,8 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 				"[round(SStime_track.time_dilation_avg,1)]%, " + \
 				"[round(SStime_track.time_dilation_avg_slow,1)]%)")
 	stat(null, "Ping: [round(client.lastping, 1)]ms (Average: [round(client.avgping, 1)]ms)")
+	var/demo_status = SSdemo.demo_started ? (SSdemo.can_fire ? "Recording..." : "Recording Ended!") : "Not Recording!"
+	stat(null, "Demo: [demo_status]")
 
 // this function displays the shuttles ETA in the status panel if the shuttle has been called
 /mob/proc/show_stat_emergency_shuttle_eta()

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -339,6 +339,7 @@
 			animate(C, pixel_x = rand(min, max), pixel_y = rand(min, max), time = 1)
 		else
 			animate(pixel_x = rand(min, max), pixel_y = rand(min, max), time = 1)
+		SSdemo.flush()
 	animate(pixel_x = oldx, pixel_y = oldy, time = 1)
 
 

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -410,6 +410,7 @@ GLOBAL_LIST_INIT(SpookyGhosts, list("ghost","shade","shade2","ghost-narsie","hor
 		Photo.blueprints = 1
 		blueprints = 0
 	Photo.construct(P)
+	SSdemo.embed_resource(Photo.icon)
 
 /obj/item/photo/proc/construct(var/datum/picture/P)
 	name = P.fields["name"]

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -591,3 +591,6 @@ DEFAULT_MAP /datum/map/cyberiad
 
 ## Enable the demo subsystem (requires external demo-writer lib)
 #DEMOS_ENABLED
+
+## Whether demos should include TTS sounds (storage expensive)
+#DEMOS_EMBED_TTS

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -589,3 +589,5 @@ DEFAULT_MAP /datum/map/cyberiad
 ## Override server map by specified, uncomment to apply
 #OVERRIDE_MAP /datum/map/delta
 
+## Enable the demo subsystem (requires external demo-writer lib)
+#DEMOS_ENABLED

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -347,5 +347,6 @@ var/to_chat_src
 			output_message += "&[url_encode(flag)]"
 
 		target << output(output_message, "browseroutput:output")
+		SSdemo.write_chat(target, message)
 
 #undef MAX_COOKIE_LENGTH

--- a/paradise.dme
+++ b/paradise.dme
@@ -246,6 +246,7 @@
 #include "code\controllers\subsystem\changelog.dm"
 #include "code\controllers\subsystem\cleanup.dm"
 #include "code\controllers\subsystem\dbcore.dm"
+#include "code\controllers\subsystem\demo.dm"
 #include "code\controllers\subsystem\discord.dm"
 #include "code\controllers\subsystem\events.dm"
 #include "code\controllers\subsystem\fires.dm"

--- a/paradise.dme
+++ b/paradise.dme
@@ -38,6 +38,7 @@
 #include "code\__DEFINES\crafting.dm"
 #include "code\__DEFINES\criminal_status.dm"
 #include "code\__DEFINES\cult.dm"
+#include "code\__DEFINES\demo.dm"
 #include "code\__DEFINES\dmjit.dm"
 #include "code\__DEFINES\dna.dm"
 #include "code\__DEFINES\error_handler.dm"


### PR DESCRIPTION
## Описание
Интеграция кода из https://github.com/yogstation13/Yogstation/pull/16211

Форки:
- https://github.com/ss220-space/demo-writer - внешняя библиотека, которая осуществляет запись
- https://github.com/ss220-space/demo-viewer - веб-приложение для показа реплеев

## Ссылка на предложение/Причина создания ПР
Literally 1984

## Баги
- [ ] При Follow Client накладывается чёрный оверлей, что мешает видеть карту, его можно отключить через Toggle Darkness и тогда оно заработает, но потеряются тени. Причём вне контекста игрока всё отлично работает, возможно где-то конфликт. Если заблокировать 'icons/mob/screen_gen.dmi', то чёрного экрана не будет
- [ ] Почему-то не прорисовываются столы и скрытые стенки (что-то связанное со smoothing?)
- [x] Не показываются персонажи (решил это через embed всех иконок mutable_appearance в демку, звучит костыльно и затратно)

## TODO:
- [ ] Добавить типы сообщений в чат, чтобы отличать конфиденциальные
- [ ] Добавить запись PDA сообщений
- [ ] Добавить запись радиального меню
- [x] Добавить опциональную запись TTS сообщений (потребляет много памяти)

## Интересное
- Чтобы слышать звуки, надо Follow Client
- Содержимое чата различается в зависимости от контекста (мир или просмотр за игроком)
- Смена Z уровней через Page Up/Down или кнопки в меню
- Ctrl + клавиша влево/вправо = замедленный просмотр назад/вперёд
- Shift + клавиша влево/вправо = ускоренный просмотр назад/вперёд

## Демонстрация изменений
https://replays.ss220.space/?demo_url=https://files.ss220.space/replays/demo-round-18629.txt.xz#268;248.50;248.50;2;azizonkg;1.5
