### PR TITLE
fix: Chasm send to CC

### DIFF
--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -40,6 +40,10 @@
 	if(!drop_stuff())
 		STOP_PROCESSING(SSprocessing, src)
 
+/turf/simulated/floor/chasm/Initialize()
+	. = ..()
+	drop_z = level_name_to_num(MAIN_STATION)
+
 /turf/simulated/floor/chasm/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
 	underlay_appearance.icon = 'icons/turf/floors.dmi'
 	underlay_appearance.icon_state = "basalt"
@@ -128,7 +132,7 @@
 	falling_atoms -= AM
 
 /turf/simulated/floor/chasm/straight_down/Initialize()
-	. = ..()
+	..()
 	drop_x = x
 	drop_y = y
 	drop_z = z - 1


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Меняет локацию, куда отправляет чазм (обычный, не лаваленда) с ЦК, на уровень станции.
Баг был вызван с изменением уровня станции с 1 на другой, 3.

## Ссылка на предложение/Причина создания ПР
[Ссылка](https://discord.com/channels/617003227182792704/1084152965083975800/1084160932449620028)

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
