### PR TITLE
FIX: Маячок тайпана заменён на раундстартово неактивный

### DIFF
--- a/_maps/map_files/generic/syndicatebase.dmm
+++ b/_maps/map_files/generic/syndicatebase.dmm
@@ -16618,7 +16618,6 @@
 /turf/simulated/floor/carpet/black,
 /area/syndicate/unpowered/syndicate_space_base/main/north)
 "ojC" = (
-/obj/machinery/bluespace_beacon/syndicate,
 /obj/structure/window/plasmareinforced{
 	color = "#d70000";
 	dir = 8
@@ -16627,6 +16626,7 @@
 	color = "#d70000"
 	},
 /obj/effect/turf_decal/box/red,
+/obj/machinery/bluespace_beacon/syndicate/infiltrator,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "dark"


### PR DESCRIPTION

<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Его всё ещё может включить оффком. 

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
Это необходимо чтобы исследователи не могли попасть на пустой тайпан с депота и т.д. по маячку, что включился с шансом в 50% раундстартом.
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
