### PR TITLE
Fix: meteors wrong z-level

### DIFF
--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -102,6 +102,10 @@ GLOBAL_LIST_INIT(meteors_ops, list(/obj/effect/meteor/goreops)) //Meaty Ops
 	var/meteordrop = /obj/item/stack/ore/iron
 	var/dropamt = 2
 
+/obj/effect/meteor/Initialize(mapload)
+	. = ..()
+	z_original = z
+
 /obj/effect/meteor/Move()
 	if(z != z_original || loc == dest)
 		qdel(src)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

Метеориты деспавнятся поскольку неправильно рассчитывают свой z-уровень
