### PR TITLE
TWEAK: отмена шаттла при биоугрозе

### DIFF
--- a/code/game/gamemodes/miniantags/morph/morph.dm
+++ b/code/game/gamemodes/miniantags/morph/morph.dm
@@ -69,6 +69,7 @@
 	if((length(GLOB.morphs_alive_list) >= MORPHS_ANNOUNCE_THRESHOLD) && (!GLOB.morphs_announced))
 		GLOB.command_announcement.Announce("Внимание! Зафиксированы множественные биоугрозы 6 уровня на [station_name()]. Необходима ликвидация угрозы для продолжения безопасной работы.", "Отдел Центрального Командования по биологическим угрозам.", 'sound/AI/commandreport.ogg')
 		GLOB.morphs_announced = TRUE
+		cancel_call_proc(usr)
 	else
 		return
 

--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -10,7 +10,8 @@
 
 /datum/event/alien_infestation/announce()
 	if(successSpawn)
-		GLOB.event_announcement.Announce("Обнаружены неопознанные формы жизни на борту станции [station_name()]. Обезопасьте все наружные входы и выходы, включая вентиляцию и вытяжки.", "ВНИМАНИЕ: НЕОПОЗНАННЫЕ ФОРМЫ ЖИЗНИ.", new_sound = 'sound/AI/aliens.ogg')
+		GLOB.event_announcement.Announce("Вспышка биологической угрозы 2-го уровня зафиксирована на борту станции [station_name()]. Всему персоналу надлежит сдержать её распространение любой ценой!", "ВНИМАНИЕ: БИОЛОГИЧЕСКАЯ УГРОЗА.", 'sound/effects/siren-spooky.ogg')
+		cancel_call_proc(usr)
 	else
 		log_and_message_admins("Warning: Could not spawn any mobs for event Alien Infestation")
 

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -7,6 +7,7 @@
 /datum/event/blob/announce()
 	if(successSpawn)
 		GLOB.event_announcement.Announce("Вспышка биологической угрозы 5-го уровня зафиксирована на борту станции [station_name()]. Всему персоналу надлежит сдержать её распространение любой ценой!", "ВНИМАНИЕ: БИОЛОГИЧЕСКАЯ УГРОЗА.", 'sound/AI/outbreak5.ogg')
+		cancel_call_proc(usr)
 	else
 		log_and_message_admins("Warning: Could not spawn any mobs for event Blob")
 

--- a/code/modules/events/spider_terror.dm
+++ b/code/modules/events/spider_terror.dm
@@ -13,6 +13,7 @@
 /datum/event/spider_terror/announce()
 	if(successSpawn)
 		GLOB.command_announcement.Announce("Вспышка биологической угрозы 3-го уровня зафиксирована на борту станции [station_name()]. Всему персоналу надлежит сдержать её распространение любой ценой!", "ВНИМАНИЕ: БИОЛОГИЧЕСКАЯ УГРОЗА.", 'sound/effects/siren-spooky.ogg')
+		cancel_call_proc(usr)
 	else
 		log_and_message_admins("Warning: Could not spawn any mobs for event Terror Spiders")
 


### PR DESCRIPTION
Теперь шаттл автоматически отзывается при объявлении биоугрозы. Только при объявлении, а не пока биоугроза будет устранена.

Авоут:
https://discord.com/channels/617003227182792704/755125334097133628/1084607797796290640