### PR TITLE
Fix: T-4 bomb flexible timer.

### DIFF
--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -250,7 +250,6 @@
 	name = "T4"
 	desc = "A wall breaching charge, containing fuel, metal oxide and metal powder mixed in just the right way. One hell of a combination. Effective against walls, ineffective against airlocks..."
 	det_time = 2
-	min_time = 2
 	icon_state = "t4breach0"
 	item_state = "t4breach"
 

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -8,6 +8,7 @@
 	display_timer = 0
 	origin_tech = "syndicate=1"
 	toolspeed = 1
+	var/min_time = 10
 	var/atom/target = null
 	var/image_overlay = null
 	var/obj/item/assembly_holder/nadeassembly = null
@@ -62,7 +63,7 @@
 		return
 	var/newtime = input(usr, "Please set the timer.", "Timer", det_time) as num
 	if(user.is_in_active_hand(src))
-		newtime = clamp(newtime, 10, 60000)
+		newtime = clamp(newtime, min_time, 60000)
 		det_time = newtime
 		to_chat(user, "Timer set for [det_time] seconds.")
 
@@ -250,6 +251,7 @@
 	name = "T4"
 	desc = "A wall breaching charge, containing fuel, metal oxide and metal powder mixed in just the right way. One hell of a combination. Effective against walls, ineffective against airlocks..."
 	det_time = 2
+	min_time = 2
 	icon_state = "t4breach0"
 	item_state = "t4breach"
 

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -8,7 +8,6 @@
 	display_timer = 0
 	origin_tech = "syndicate=1"
 	toolspeed = 1
-	var/min_time = 10
 	var/atom/target = null
 	var/image_overlay = null
 	var/obj/item/assembly_holder/nadeassembly = null
@@ -63,7 +62,7 @@
 		return
 	var/newtime = input(usr, "Please set the timer.", "Timer", det_time) as num
 	if(user.is_in_active_hand(src))
-		newtime = clamp(newtime, min_time, 60000)
+		newtime = clamp(newtime, initial(det_time), 60000)
 		det_time = newtime
 		to_chat(user, "Timer set for [det_time] seconds.")
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Даёт таймерам бомб стартовое время, которое учитывается как минимальное для установки в бомбах. Тоесть С4 и подобные со стартовым таймером в 10 секунд могут иметь свои 10 секунд при манипуляциях с таймером, Т4 же со своими стартовыми 2 секундами можно ставить минимум на её родные 2 секунды.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
[Ссылка на баг-репорт.](https://discord.com/channels/617003227182792704/1084890649083519007)<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
![image](https://user-images.githubusercontent.com/115735095/225067738-a0d3854a-0dde-4c00-b6a1-8aa27d353012.png)
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
