### PR TITLE
fix: Fix blindness overlay not updating sometimes

### DIFF
--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -233,7 +233,9 @@
 
 /mob/living/SetEyeBlind(amount, updating = TRUE)
 	. = STATUS_UPDATE_BLIND
-	if((!!amount) == (!!eye_blind)) // We're not changing from + to 0 or vice versa
+	var/should_have_blindness_overlay = !!amount
+	var/has_blindness_overlay = ("blind" in screens)
+	if(should_have_blindness_overlay == has_blindness_overlay)
 		updating = FALSE
 		. = STATUS_UPDATE_NONE
 	eye_blind = max(amount, 0)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Фикс прока наложения/убирания оверлея слепоты. Значение переменной `eye_blind` не всегда кореллировало с наличием/отсутствием оверлея слепоты. Теперь условие срабатывает, когда нужно.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/734823601110515882/1085200665783050260
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->