### PR TITLE
fix: Remove redundant var for ears damage

### DIFF
--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -79,10 +79,10 @@
 					var/mob/living/carbon/C = M
 					var/obj/item/organ/internal/ears/ears = C.get_int_organ(/obj/item/organ/internal/ears)
 					if(istype(ears))
-						if(ears.ear_damage >= 15)
+						if(ears.damage >= 15)
 							to_chat(M, "<span class='warning'>Your ears start to ring badly!</span>")
-							if(prob(ears.ear_damage - 5))
+							if(prob(ears.damage - 5))
 								to_chat(M, "<span class='warning'>You can't hear anything!</span>")
 								M.BecomeDeaf()
-						else if(ears.ear_damage >= 5)
+						else if(ears.damage >= 5)
 							to_chat(M, "<span class='warning'>Your ears start to ring!</span>")

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -657,7 +657,7 @@
 			var/obj/item/organ/internal/ears/ears = C.get_int_organ(/obj/item/organ/internal/ears)
 			if(istype(ears))
 				ears.AdjustEarDamage(-1)
-				if(ears.ear_damage < 25 && prob(30))
+				if(ears.damage < 25 && prob(30))
 					ears.deaf = 0
 		update_flags |= M.AdjustEyeBlurry(-1, FALSE)
 		update_flags |= M.AdjustEarDamage(-1)

--- a/code/modules/reagents/chemistry/reagents/ninja.dm
+++ b/code/modules/reagents/chemistry/reagents/ninja.dm
@@ -98,7 +98,7 @@
 				var/obj/item/organ/internal/ears/our_ears = mob_human.get_int_organ(/obj/item/organ/internal/ears)
 				if(istype(our_ears))
 					our_ears.AdjustEarDamage(-5)
-					if(our_ears.ear_damage < 25 && prob(30))
+					if(our_ears.damage < 25 && prob(30))
 						our_ears.deaf = 0
 				//ALL viruses
 				for(var/thing in mob_human.viruses)

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -9,10 +9,10 @@
 	// `deaf` measures "ticks" of deafness. While > 0, the person is deaf.
 	var/deaf = 0
 
-	// `ear_damage` measures long term damage to the ears, if too high,
-	// the person will not have either `deaf` or `ear_damage` decrease
+	// `damage` measures long term damage to the ears, if too high,
+	// the person will not have either `deaf` or `damage` decrease
 	// without external aid (earmuffs, drugs)
-	var/ear_damage = 0
+	damage = 0
 
 /obj/item/organ/internal/ears/on_life()
 	if(!iscarbon(owner))
@@ -26,22 +26,22 @@
 			var/mob/living/carbon/human/H = C
 			if((H.l_ear && H.l_ear.flags_2 & HEALS_EARS_2) || (H.r_ear && H.r_ear.flags_2 & HEALS_EARS_2))
 				deaf = max(deaf - 1, 1)
-				ear_damage = max(ear_damage - 0.10, 0)
+				damage = max(damage - 0.10, 0)
 		// if higher than UNHEALING_EAR_DAMAGE, no natural healing occurs.
-		if(ear_damage < UNHEALING_EAR_DAMAGE)
-			ear_damage = max(ear_damage - 0.05, 0)
+		if(damage < UNHEALING_EAR_DAMAGE)
+			damage = max(damage - 0.05, 0)
 			deaf = max(deaf - 1, 0)
 
 /obj/item/organ/internal/ears/proc/RestoreEars()
 	deaf = 0
-	ear_damage = 0
+	damage = 0
 
 	var/mob/living/carbon/C = owner
 	if(istype(C) && (DEAF in C.mutations))
 		deaf = 1
 
 /obj/item/organ/internal/ears/proc/AdjustEarDamage(ddmg, ddeaf)
-	ear_damage = max(ear_damage + ddmg, 0)
+	damage = max(damage + ddmg, 0)
 	deaf = max(deaf + ddeaf, 0)
 
 /obj/item/organ/internal/ears/proc/MinimumDeafTicks(value)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Фикс окулина, не снижающего значение урона ушам.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
У `/obj/item/organ/internal/ears` есть значение `damage`. Оно отнаследовано от `/obj/item/organ` и отображается на медицинских приборах. А еще у ушей есть `ear_damage`, на который воздействуют оглушающие эффекты, высокое значение которого вызывает глухоту. Окулин сейчас лечит глухоту и `ear_damage`, но не лечит урон ушам как органу (`damage`). То есть можно отлично слышать с ушами с миллионом урона, а можно и быть глухим (не генетически) с 0 урона ушам.

PR удаляет использование избыточной переменной `ear_damage`, привязывая все к `damage`.

Должно привести к ожидаемому поведению излечения ушей окулином. Не должно повлиять ни на что другое. Если обнаружатся баги — откатим.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->