### PR TITLE
fix: Fix Poly floating state and buckled icon

### DIFF
--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -287,6 +287,16 @@
 	if(pulledby && stat == CONSCIOUS)
 		icon_state = "parrot_fly"
 
+	if (buckled && icon_state == "parrot_fly")
+		icon_state = "parrot_sit"
+	else if (!buckled && icon_state == "parrot_sit")
+		icon_state = "parrot_fly"
+
+	if (floating && icon_state == "parrot_sit")
+		float(FALSE)
+	else if (!floating && icon_state == "parrot_fly")
+		float(TRUE)
+
 /mob/living/simple_animal/parrot/proc/update_speak()
 	speak.Cut()
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Корректно переключает Поли анимацию парения в зависимости от состояния "летит"/"сидит". Корректно переключает состояние при пристегивании/отстегивании.

## Ссылка на предложение/Причина создания ПР
Тривиальный фикс
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
![Poly](https://user-images.githubusercontent.com/5000549/225527960-19a708bc-5ec1-4399-8146-d79d09b0b892.gif)
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
