### PR TITLE
fix: Prevent radial menu from floating with floating player

### DIFF
--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -253,7 +253,6 @@ GLOBAL_LIST_EMPTY(radial_menus)
 		screen_center = new
 		screen_center.screen_loc = "CENTER,CENTER"
 		current_user.screen += screen_center
-
 		menu_holder_location = screen_center
 
 	//Blank

--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -52,6 +52,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	var/obj/screen/radial/center/close_button
 	var/client/current_user
 	var/atom/anchor
+	var/obj/screen/screen_center
 	var/image/menu_holder
 	var/finished = FALSE
 	var/datum/callback/custom_check_callback
@@ -246,8 +247,17 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	if(!M.client || !anchor)
 		return
 	current_user = M.client
+
+	var/atom/menu_holder_location = anchor
+	if (M == anchor)
+		screen_center = new
+		screen_center.screen_loc = "CENTER,CENTER"
+		current_user.screen += screen_center
+
+		menu_holder_location = screen_center
+
 	//Blank
-	menu_holder = image(icon = 'icons/effects/effects.dmi', loc = anchor,icon_state = "nothing", layer = ABOVE_HUD_LAYER)
+	menu_holder = image(icon = 'icons/effects/effects.dmi', loc = menu_holder_location, icon_state = "nothing", layer = ABOVE_HUD_LAYER)
 	menu_holder.appearance_flags |= KEEP_APART
 	menu_holder.vis_contents += elements + close_button
 	current_user.images += menu_holder
@@ -255,6 +265,9 @@ GLOBAL_LIST_EMPTY(radial_menus)
 /datum/radial_menu/proc/hide()
 	if(current_user)
 		current_user.images -= menu_holder
+		if (screen_center)
+			menu_holder.loc = null
+			current_user.screen -= screen_center
 
 /datum/radial_menu/proc/wait(mob/user, atom/anchor, require_near = FALSE)
 	while(current_user && !finished && !selected_choice)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Убирает покачивание радиального меню при парении куклы игрока.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР
Улучшение UI/UX. Нужно для летающих боргов, реализация которых сейчас в процессе.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
Без фикса:
![floating_overlay](https://user-images.githubusercontent.com/5000549/225598546-153ce03f-e6c8-49ed-86a0-dd03a181c429.gif)
С фиксом:
![floating_overlay_fixed](https://user-images.githubusercontent.com/5000549/225598594-a7cc1f5d-f338-4330-8dcf-305b9afdd637.gif)
