### PR TITLE
fix: Lesser & greater forms icons fixes

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -280,3 +280,5 @@
 #define HEARING_PROTECTION_MINOR	1
 #define HEARING_PROTECTION_MAJOR	2
 #define HEARING_PROTECTION_TOTAL	3
+
+#define FIRE_DMI (issmall(src) ? 'icons/mob/species/monkey/OnFire.dmi' : 'icons/mob/OnFire.dmi')

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -23,9 +23,6 @@ Gunshots/explosions/opening doors/less rare audio (done)
 	var/hal_screwyhud = SCREWYHUD_NONE
 	var/handling_hal = FALSE
 
-	var/genetic_mutable = 'icons/effects/genetics.dmi'
-
-
 /mob/living/carbon/proc/handle_hallucinations()
 	if(handling_hal)
 		return

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1899,9 +1899,9 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	return getBrainLoss() < 100
 
 
-/mob/living/carbon/human/fakefire(var/fire_icon = "Generic_mob_burning")
+/mob/living/carbon/human/fakefire()
 	if(!overlays_standing[FIRE_LAYER])
-		overlays_standing[FIRE_LAYER] = image("icon"=fire_dmi, "icon_state"=fire_icon)
+		overlays_standing[FIRE_LAYER] = image(FIRE_DMI, icon_state = "Generic_mob_burning")
 		update_icons()
 
 /mob/living/carbon/human/fakefireextinguish()

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -62,9 +62,6 @@
 	var/heartbeat = 0
 	var/receiving_cpr = FALSE
 
-	var/fire_dmi = 'icons/mob/OnFire.dmi'
-	var/fire_sprite = "Standing"
-
 	var/datum/body_accessory/body_accessory = null
 	/// Name of tail image in species effects icon file.
 	var/tail

--- a/code/modules/mob/living/carbon/human/monkey.dm
+++ b/code/modules/mob/living/carbon/human/monkey.dm
@@ -1,6 +1,5 @@
 /mob/living/carbon/human/lesser
 	var/master_commander = null //переменная хранящая владельца "животного"
-	fire_dmi = 'icons/mob/species/monkey/OnFire.dmi'
 	genetic_mutable = 'icons/mob/species/monkey/genetics.dmi'
 	var/sentience_type = SENTIENCE_ORGANIC
 	//holder_type = /obj/item/holder/monkey	//Задыхается сидя на голове или в сумке, временно отключен

--- a/code/modules/mob/living/carbon/human/monkey.dm
+++ b/code/modules/mob/living/carbon/human/monkey.dm
@@ -1,6 +1,5 @@
 /mob/living/carbon/human/lesser
 	var/master_commander = null //переменная хранящая владельца "животного"
-	genetic_mutable = 'icons/mob/species/monkey/genetics.dmi'
 	var/sentience_type = SENTIENCE_ORGANIC
 	//holder_type = /obj/item/holder/monkey	//Задыхается сидя на голове или в сумке, временно отключен
 

--- a/code/modules/mob/living/carbon/human/monkey.dm
+++ b/code/modules/mob/living/carbon/human/monkey.dm
@@ -5,6 +5,10 @@
 	var/sentience_type = SENTIENCE_ORGANIC
 	//holder_type = /obj/item/holder/monkey	//Задыхается сидя на голове или в сумке, временно отключен
 
+/mob/living/carbon/human/lesser/Initialize(mapload, species)
+	icon = null
+	. = ..(mapload, species)
+
 /mob/living/carbon/human/lesser/monkey/Initialize(mapload)
 	. = ..(mapload, /datum/species/monkey)
 	tts_seed = "Sniper"

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -509,7 +509,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	remove_overlay(FIRE_LAYER)
 	if(on_fire)
 		if(!overlays_standing[FIRE_LAYER])
-			overlays_standing[FIRE_LAYER] = mutable_appearance(fire_dmi, fire_sprite, layer = -FIRE_LAYER)
+			overlays_standing[FIRE_LAYER] = mutable_appearance(FIRE_DMI, icon_state = "Standing", layer = -FIRE_LAYER)
 	apply_overlay(FIRE_LAYER)
 
 /* --------------------------------------- */

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -465,7 +465,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 
 /mob/living/carbon/human/update_mutations()
 	remove_overlay(MUTATIONS_LAYER)
-	var/mutable_appearance/standing = mutable_appearance(genetic_mutable, layer = -MUTATIONS_LAYER)
+	var/mutable_appearance/standing = mutable_appearance(issmall(src) ? 'icons/mob/species/monkey/genetics.dmi' : 'icons/effects/genetics.dmi', layer = -MUTATIONS_LAYER)
 	var/add_image = 0
 	var/g = "m"
 	if(gender == FEMALE)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
* Убирает мапперские иконки у раундспавновых мобов низшей формы, иначе при смене формы на высшую может просвечивать иконка низшей, типа такого:
![image](https://user-images.githubusercontent.com/5000549/226069230-ad05c85a-0cdb-4c98-aadf-3a3928d1d440.png)

* Заставляет спрайт горения учитывать текущую форму моба (а не только начальную), чтоб не было вот такого:
![image](https://user-images.githubusercontent.com/5000549/226069390-b5eb2265-3dd4-4c87-83f3-92c3271f8406.png)

* Заставляет спрайты мутаций учитывать текущую форму моба (а не только начальную), чтоб не было вот такого:
![image](https://user-images.githubusercontent.com/5000549/226069420-75b83c6f-69be-4d0a-ad4e-1711d14851a9.png)

<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР
Фиксы багов
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->