### PR TITLE
fix: Fix layer and position of roundstart showers and sinks

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -8476,7 +8476,8 @@
 "bdz" = (
 /obj/structure/sink{
 	dir = 1;
-	pixel_y = -2
+	pixel_y = -5;
+	layer = 5
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -81906,7 +81907,9 @@
 /area/quartermaster/storage)
 "mbs" = (
 /obj/structure/sink{
-	dir = 1
+	dir = 1;
+	pixel_y = -5;
+	layer = 5
 	},
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/carpet,
@@ -82107,7 +82110,9 @@
 /area/quartermaster/storage)
 "mdx" = (
 /obj/structure/sink{
-	dir = 1
+	dir = 1;
+	pixel_y = -5;
+	layer = 5
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/mirror{
@@ -97567,7 +97572,9 @@
 /area/maintenance/library)
 "psE" = (
 /obj/structure/sink{
-	dir = 1
+	dir = 1;
+	pixel_y = -5;
+	layer = 5
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue";
@@ -125136,7 +125143,9 @@
 /area/security/processing)
 "vmn" = (
 /obj/structure/sink{
-	dir = 1
+	dir = 1;
+	pixel_y = -5;
+	layer = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -17797,7 +17797,9 @@
 	dir = 8
 	},
 /obj/machinery/shower{
-	dir = 1
+	dir = 1;
+	pixel_y = -5;
+	layer = 5
 	},
 /obj/effect/turf_decal/siding/wideplating/end{
 	dir = 1
@@ -65123,7 +65125,9 @@
 	dir = 4
 	},
 /obj/machinery/shower{
-	dir = 1
+	dir = 1;
+	pixel_y = -5;
+	layer = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -122308,7 +122312,9 @@
 /obj/structure/curtain/open/shower/security,
 /obj/item/restraints/handcuffs/pinkcuffs,
 /obj/machinery/shower{
-	dir = 1
+	dir = 1;
+	pixel_y = -5;
+	layer = 5
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -139024,7 +139030,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/shower{
-	dir = 1
+	dir = 1;
+	pixel_y = -5;
+	layer = 5
 	},
 /obj/structure/sink{
 	dir = 4;


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
У раундстартовых раковин и душей, направленных на север, `layer` и `pixel_y` отличаются от построенных в раунде. Они отрисовываются под мобами, что крайне затрудняет их использование. Этот PR исправляет этот недочет.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Тривиальный фикс
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
Душ, без фикса:
![image](https://user-images.githubusercontent.com/5000549/226113103-4bce3523-fdf6-4640-b7de-5ccf486f9b98.png)
Душ, с фиксом:
![image](https://user-images.githubusercontent.com/5000549/226113138-8cb1c65d-4ab7-44a0-adbc-799b54c25655.png)
Раковина, без фикса:
![image](https://user-images.githubusercontent.com/5000549/226113148-32854d29-eb12-495d-98dc-152689cd519e.png)
Раковина, с фиксом:
![image](https://user-images.githubusercontent.com/5000549/226113165-7c9d69bb-8521-4120-9d90-18b95a280631.png)
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
