### PR TITLE
Fix: Beartrap icon

### DIFF
--- a/code/game/objects/items/weapons/legcuffs.dm
+++ b/code/game/objects/items/weapons/legcuffs.dm
@@ -15,7 +15,7 @@
 	name = "bear trap"
 	throw_speed = 1
 	throw_range = 1
-	icon_state = "beartrap1"
+	icon_state = "beartrap"
 	desc = "A trap used to catch bears and other legged creatures."
 	origin_tech = "engineering=4"
 	var/armed = 0


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
https://github.com/ss220-space/Paradise/pull/2146
Момо захотел видимость капкана для мапперов, но не увидел, что там незамудренная тема изменения icon_state'а с добавлением нулей и единичек

До фикса:
![image](https://user-images.githubusercontent.com/20109643/226308213-ec5487c2-a931-4937-b2a6-521bef7e5e95.png)
После фикса:
![image](https://user-images.githubusercontent.com/20109643/226308167-c69015cb-445b-4ac2-b5d7-368d67a82caf.png)
