### PR TITLE
Fix: Turretid area_control name to path

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -15897,7 +15897,7 @@
 "bLO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/turretid/stun{
-	control_area = "\improper AI Satellite Antechamber";
+	control_area = /area/turret_protected/aisat_interior;
 	name = "AI Antechamber Turret Control";
 	pixel_y = 28;
 	req_access_txt = "75"
@@ -17384,7 +17384,7 @@
 	dir = 4
 	},
 /obj/machinery/turretid/stun{
-	control_area = "\improper AI Satellite";
+	control_area = /area/turret_protected/aisat;
 	name = "AI Antechamber Turret Control";
 	pixel_x = -32;
 	req_access_txt = "75"
@@ -17562,7 +17562,7 @@
 	dir = 4
 	},
 /obj/machinery/turretid/stun{
-	control_area = "\improper AI Satellite";
+	control_area = /area/turret_protected/aisat;
 	name = "AI Antechamber Turret Control";
 	pixel_x = 32;
 	req_access_txt = "75"
@@ -87622,10 +87622,6 @@
 	},
 /area/hydroponics)
 "nlf" = (
-/obj/machinery/door/airlock/glass{
-	name = "Hydroponics";
-	req_access_txt = "35"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 4;
@@ -87637,6 +87633,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/door/airlock{
+	name = "Hydroponics";
+	req_access = "35"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -92975,7 +92975,7 @@
 	dir = 1
 	},
 /obj/machinery/turretid/stun{
-	control_area = "\improper AI Upload Chamber";
+	control_area = /area/turret_protected/ai_upload;
 	name = "AI Upload Turret Control";
 	pixel_y = -24;
 	req_access = list(75)
@@ -113770,7 +113770,7 @@
 "sNY" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/turretid/stun{
-	control_area = "\improper Telecoms Central Compartment";
+	control_area = /area/tcommsat/chamber;
 	name = "AI Antechamber Turret Control";
 	pixel_y = -26;
 	req_access_txt = "75"

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -919,7 +919,7 @@
 /obj/machinery/turretid/lethal{
 	ailock = 1;
 	check_synth = 0;
-	control_area = "Syndicate Lavaland Primary Hallway";
+	control_area = /area/ruin/unpowered/syndicate_lava_base/main;
 	dir = 1;
 	faction = "syndicate";
 	name = "Base turret controls";

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -32972,7 +32972,7 @@
 /area/hydroponics)
 "bxO" = (
 /obj/machinery/turretid/stun{
-	control_area = "\improper AI Upload Chamber";
+	control_area = /area/turret_protected/ai_upload;
 	name = "AI Upload Turret Control";
 	pixel_y = -24;
 	req_access = list(75)
@@ -72883,7 +72883,7 @@
 "djR" = (
 /obj/machinery/light/small,
 /obj/machinery/turretid/stun{
-	control_area = "\improper AI Satellite Antechamber";
+	control_area = /area/turret_protected/aisat_interior;
 	name = "AI Antechamber Turret Control";
 	pixel_y = -24;
 	req_access_txt = "75"
@@ -73212,7 +73212,7 @@
 	dir = 4
 	},
 /obj/machinery/turretid/stun{
-	control_area = "\improper AI Satellite Service";
+	control_area = /area/aisat/maintenance;
 	name = "AI Satellite Service Bay Turret Control";
 	pixel_x = 24;
 	req_access_txt = "75"
@@ -73584,7 +73584,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/turretid/stun{
-	control_area = "\improper AI Satellite Hallway";
+	control_area = /area/aisat;
 	name = "AI Chamber Hallway Turret Control";
 	pixel_x = 24;
 	pixel_y = -24;
@@ -80452,7 +80452,7 @@
 	dir = 4
 	},
 /obj/machinery/turretid/stun{
-	control_area = "\improper AI Satellite Atmospherics";
+	control_area = /area/aisat/atmospherics;
 	name = "AI Satellite Atmospherics Turret Control";
 	pixel_x = -28;
 	req_access_txt = "75"

--- a/_maps/map_files/generic/syndicatebase.dmm
+++ b/_maps/map_files/generic/syndicatebase.dmm
@@ -6204,7 +6204,7 @@
 "fFd" = (
 /obj/machinery/turretid/lethal{
 	ailock = 1;
-	control_area = "Syndicate Space Teleporter";
+	control_area = /area/syndicate/unpowered/syndicate_space_base/teleporter;
 	dir = 1;
 	faction = "syndicate";
 	name = "Teleporter turret controls";
@@ -22278,7 +22278,7 @@
 "svC" = (
 /obj/machinery/turretid/lethal{
 	ailock = 1;
-	control_area = "Syndicate Space Arrivals";
+	control_area = /area/syndicate/unpowered/syndicate_space_base/teleporter/arrivals;
 	dir = 1;
 	faction = "syndicate";
 	name = "Arrivals turret controls";
@@ -22924,7 +22924,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/turretid/lethal{
-	control_area = "Syndicate Space Turrets";
+	control_area = /area/syndicate/unpowered/syndicate_space_base/turrets;
 	faction = "syndicate";
 	name = "External turrets control panel";
 	pixel_y = 6;
@@ -24518,7 +24518,7 @@
 	},
 /obj/machinery/turretid/lethal{
 	ailock = 1;
-	control_area = "Syndicate Space Armory";
+	control_area = /area/syndicate/unpowered/syndicate_space_base/armory;
 	dir = 1;
 	faction = "syndicate";
 	name = "Armory turret controls";


### PR DESCRIPTION
## Описание
Заменяет параметр area_control у консолей управления турелями на путь зон.
Откатить когда димач починит мапридер.

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1087206715537240174

## Демонстрация изменений
Почему такое решение:
![Безымянный](https://user-images.githubusercontent.com/110329212/226321381-44b99fbc-5668-4e5e-a807-dfbd8ca7948d.png)

