### PR TITLE
fix: hydroponics examine runtime

### DIFF
--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -175,7 +175,7 @@
 	desc = "A heads-up display capable of analyzing the health and status of plants growing in hydro trays and soil."
 	icon_state = "hydroponichud"
 	HUDType = DATA_HUD_HYDROPONIC
-
+	examine_extensions = list(DATA_HUD_HYDROPONIC)
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/eyes.dmi',
 		"Drask" = 'icons/mob/species/drask/eyes.dmi',

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -342,11 +342,11 @@
 		overlays += image('icons/obj/hydroponics/equipment.dmi', icon_state = "over_harvest3")
 
 
-/obj/machinery/hydroponics/examine(mob/living/carbon/human/H)
+/obj/machinery/hydroponics/examine(mob/user)
 	. = ..()
 	if(myseed)
 		. += "<span class='notice'>It has <span class='name'>[myseed.plantname]</span> planted.</span>"
-		if (H.glasses && istype(H.glasses, /obj/item/clothing/glasses/hud/hydroponic))
+		if(hasHUD(user, DATA_HUD_HYDROPONIC) || isobserver(user))
 			. += myseed.get_analyzer_text()
 			. += "<span class='notice'>Weed: [weedlevel] / 10</span>"
 			. += "<span class='notice'>Pest: [pestlevel] / 10</span>"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Сейчас, при осмотре ботанического лотка, у вас проверяется наличие очков. Если вы осмотрите лоток не хуманом, игра пожалуется и не сообщит вам о растении, даже если у вас есть худ. Поэтому проверяем на наличие худов или призрака, вместо очков.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Исправляем этот рантайм:
![Снимок экрана 2023-03-20 171258](https://user-images.githubusercontent.com/120549107/226366622-d8fb5779-e159-4901-a51c-2093ae76ae23.png)

<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
