### PR TITLE
feat: random jobs button in "Join Game"

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -357,6 +357,15 @@
 	else
 		return 0
 
+/mob/new_player/proc/random_job()
+	var/jobs_available = list()
+	for(var/datum/job/job in SSjobs.occupations)
+		if(job && IsJobAvailable(job.title) && !job.barred_by_disability(client))
+			jobs_available += job.title
+	if(!length(jobs_available))
+		return FALSE
+	return pick(jobs_available)
+
 /mob/new_player/proc/AttemptLateSpawn(rank,var/spawning_at)
 	if(src != usr)
 		return FALSE
@@ -366,6 +375,13 @@
 	if(!GLOB.enter_allowed)
 		to_chat(usr, "<span class='notice'>Администратор заблокировал вход в игру!</span>")
 		return FALSE
+	if(rank == "RandomJob")
+		rank = random_job()
+		if(!rank)
+			var/msg = "Нет свободных ролей. Пожалуйста, попробуйте позже."
+			to_chat(src, msg)
+			alert(msg)
+			return FALSE
 	if(!IsJobAvailable(rank))
 		var/msg = "Должность [rank] недоступна. Пожалуйста, попробуйте другую."
 		to_chat(src, msg)
@@ -583,6 +599,8 @@
 			var/color = categorizedJobs[jobcat]["color"]
 			dat += "<fieldset style='border: 2px solid [color]; display: inline'>"
 			dat += "<legend align='center' style='color: [color]'>[jobcat]</legend>"
+			if(jobcat == "Miscellaneous")
+				dat += "<a href='byond://?src=[UID()];SelectedJob=RandomJob'>Random (free jobs)</a><br>"
 			for(var/datum/job/job in categorizedJobs[jobcat]["jobs"])
 				if(job in SSjobs.prioritized_jobs)
 					dat += "<a href='byond://?src=[UID()];SelectedJob=[job.title]'><font color='lime'><B>[job.title] ([job.current_positions]) (Active: [activePlayers[job]])</B></font></a><br>"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет в выбор профессий при "Join Game" кнопку random в раздел "Miscellaneous". Она закидывает вас в раунд за случайную из открытых профессий.
Не совсем уверен именно в таком варианте положения и оформления кнопки, но я не придумал другое.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Аголосование: https://discord.com/channels/617003227182792704/755125334097133628/1087277439970988105
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
![Снимок экрана 2023-03-21 092859](https://user-images.githubusercontent.com/120549107/226533691-8462651d-4920-4cca-bf21-1d2f8895eba2.png)

<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
