### PR TITLE
fix: Forbid AI from yoinking magboots

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -652,7 +652,8 @@
 		return
 	else
 		helmet.forceMove(loc)
-		usr.put_in_active_hand(helmet)
+		if(ishuman(usr))
+			usr.put_in_active_hand(helmet)
 		helmet = null
 
 /obj/machinery/suit_storage_unit/proc/dispense_suit()
@@ -660,7 +661,8 @@
 		return
 	else
 		suit.forceMove(loc)
-		usr.put_in_active_hand(suit)
+		if(ishuman(usr))
+			usr.put_in_active_hand(suit)
 		suit = null
 
 /obj/machinery/suit_storage_unit/proc/dispense_mask()
@@ -668,7 +670,8 @@
 		return
 	else
 		mask.forceMove(loc)
-		usr.put_in_active_hand(mask)
+		if(ishuman(usr))
+			usr.put_in_active_hand(mask)
 		mask = null
 
 /obj/machinery/suit_storage_unit/proc/dispense_magboots()
@@ -676,7 +679,8 @@
 		return
 	else
 		magboots.forceMove(loc)
-		usr.put_in_active_hand(magboots)
+		if(ishuman(usr))
+			usr.put_in_active_hand(magboots)
 		magboots = null
 
 /obj/machinery/suit_storage_unit/proc/dispense_storage()
@@ -684,7 +688,8 @@
 		return
 	else
 		storage.forceMove(loc)
-		usr.put_in_active_hand(storage)
+		if(ishuman(usr))
+			usr.put_in_active_hand(storage)
 		storage = null
 
 /obj/machinery/suit_storage_unit/proc/toggle_open(mob/user as mob)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Исправляет баг, позволяющий ИИ украсть одну вещь из диспенсера ригов.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багфикс. https://discord.com/channels/617003227182792704/734823601110515882/1088527099586957474 (на скрине у ИИ магбутсы в левом верхнем углу)
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
