### PR TITLE
MapFix: Animals Cerestation

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -51844,7 +51844,7 @@
 /area/maintenance/asmaint4)
 "fTl" = (
 /obj/structure/flora/ausbushes/ywflowers,
-/mob/living/simple_animal/cock,
+/mob/living/simple_animal/cock/Commandor,
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "fTp" = (

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -3584,6 +3584,7 @@
 	pixel_x = -32
 	},
 /obj/item/soap/deluxe,
+/obj/item/bikehorn/rubberducky/captain,
 /turf/simulated/floor/plasteel/freezer,
 /area/crew_quarters/captain)
 "auZ" = (
@@ -3621,9 +3622,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore2)
 "avk" = (
-/obj/structure/toilet{
-	dir = 8
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -3633,6 +3631,9 @@
 	normaldoorcontrol = 1;
 	pixel_x = 24;
 	specialfunctions = 4
+	},
+/obj/structure/toilet/captain_toilet{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel/freezer,
 /area/crew_quarters/captain)
@@ -9084,6 +9085,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/mob/living/simple_animal/mouse/rat/irish/Remi,
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "baH" = (
@@ -53464,6 +53466,10 @@
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/aft/east)
+"jmu" = (
+/obj/effect/decal/remains/mouse/Pinkie,
+/turf/simulated/floor/plasteel/dark/telecomms,
+/area/toxins/server_coldroom)
 "jmF" = (
 /obj/machinery/camera{
 	c_tag = "Service Asteroid Hallway 5";
@@ -62706,13 +62712,13 @@
 /area/maintenance/port)
 "mNA" = (
 /obj/structure/flora/ausbushes/ywflowers,
-/mob/living/simple_animal/cock,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/mob/living/simple_animal/cock/Commandor,
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "mNG" = (
@@ -69506,6 +69512,9 @@
 "pop" = (
 /obj/machinery/igniter{
 	id = "Incinerator"
+	},
+/obj/effect/decal/remains/mouse{
+	name = "Джерри"
 	},
 /turf/simulated/floor/engine,
 /area/toxins/mixing)
@@ -108171,7 +108180,7 @@ kal
 iid
 wXW
 ejh
-fIu
+jmu
 ejh
 wXW
 lZz


### PR DESCRIPTION
## Описание
Дополнение недостающих конструкций и животных для карты Cere-Station, которые есть на Дельте, но нету тут.
Ну и фикс на на петуха на Дельте. Оказывается он там не именной был, хотя на Коробке всё ок.
https://github.com/ss220-space/Paradise/pull/2308