### PR TITLE
FIX: Odysseus doesn't count syringe_gun_upgrade as a equipment

### DIFF
--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -544,9 +544,9 @@
 	var/imrov_synth_speed = 20
 
 /obj/item/mecha_parts/mecha_equipment/medical/syringe_gun_upgrade/can_attach(obj/mecha/M)
-	..()
-	for(var/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/S in M.equipment)
-		return 1
+	if(..())
+		for(var/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/S in M.equipment)
+			return 1
 	return 0
 
 /obj/item/mecha_parts/mecha_equipment/medical/syringe_gun_upgrade/attach(obj/mecha/M)


### PR DESCRIPTION

## Описание
Исправил ошибочную возможность поставить апргейд для шприцемёта Одиссея 4 модулем при наличии установленного шприцемёта.

## Ссылка на предложение/Причина создания ПР
Про баг сообщили в лс.
