### PR TITLE
feat: RCD ammos can be eaten by RCDs attack

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -169,20 +169,21 @@
 /obj/item/rcd/attackby(obj/item/W, mob/user, params)
 	if(!istype(W, /obj/item/rcd_ammo))
 		return ..()
+	rcd_reload(W, user)
 
-	var/obj/item/rcd_ammo/R = W
-	if((matter + R.ammoamt) > max_matter)
+/obj/item/rcd/proc/rcd_reload(obj/item/rcd_ammo/rcd_ammo, mob/user)
+	if(matter >= max_matter)
 		to_chat(user, "<span class='notice'>The RCD can't hold any more matter-units.</span>")
 		return
 
-	if(!user.unEquip(R))
-		to_chat(user, "<span class='warning'>[R] is stuck to your hand!</span>")
+	if(!user.unEquip(rcd_ammo))
+		to_chat(user, "<span class='warning'>[rcd_ammo] is stuck to your hand!</span>")
 		return
 
-	user.put_in_active_hand(R)
-	if(R.type == matter_type || R.type == matter_type_large)
-		matter += R.ammoamt
-		qdel(R)
+	user.put_in_active_hand(rcd_ammo)
+	if(rcd_ammo.type == matter_type || rcd_ammo.type == matter_type_large)
+		matter = min(matter + rcd_ammo.ammoamt, max_matter)
+		qdel(rcd_ammo)
 		playsound(loc, 'sound/machines/click.ogg', 50, 1)
 		to_chat(user, "<span class='notice'>The RCD now holds [matter]/[max_matter] matter-units.</span>")
 	else
@@ -360,6 +361,9 @@
 
 /obj/item/rcd/afterattack(atom/target, mob/user, proximity)
 	if(!proximity)
+		return
+	if(istype(target, /obj/item/rcd_ammo))
+		rcd_reload(target, user)
 		return
 	var/area/check_area = get_area(target)
 	if(check_area?.type in areas_blacklist)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
- Добавляет возможность RCD при атаке rcd_ammo заряжаться от этих rcd_ammo
- Добавляет возможность RCD пополняться до 100%, даже если `дополнительная материя + текущая материя` больше максимальной, но берется минимальное значение из двух.

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
QoL