### PR TITLE
Fix: Map: Cerestation (part 2)

### DIFF
--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -44,8 +44,7 @@
 "aan" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/machinery/dnaforensics,
 /turf/simulated/floor/plasteel{
@@ -53,11 +52,12 @@
 	},
 /area/security/detectives_office)
 "aas" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/structure/table/wood,
+/obj/item/candle,
+/turf/simulated/floor/plasteel{
+	icon_state = "redyellowfull"
 	},
-/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "aay" = (
 /obj/machinery/camera{
@@ -207,7 +207,6 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/stripes/end{
@@ -233,7 +232,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/simulated/floor/plating,
@@ -246,11 +244,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/external/north)
 "abL" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull";
+	tag = "icon-redfull (NORTHWEST)"
 	},
-/turf/simulated/floor/wood,
-/area/library)
+/area/crew_quarters/kitchen)
 "abO" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/firedoor,
@@ -310,8 +309,7 @@
 	dir = 4
 	},
 /obj/machinery/newscaster{
-	pixel_y = 28;
-	name = "north bump"
+	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -441,8 +439,7 @@
 "acJ" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -467,8 +464,7 @@
 	pixel_y = 25
 	},
 /obj/item/radio/intercom{
-	pixel_x = -28;
-	name = "custom placement"
+	pixel_x = -28
 	},
 /obj/item/radio/intercom/private{
 	pixel_x = -28;
@@ -512,13 +508,6 @@
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/mine/unexplored/cere/command)
-"adm" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/vending/clothing,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
 "adr" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -699,8 +688,7 @@
 /area/security/permabrig)
 "aeK" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/structure/closet/secure_closet/injection,
 /turf/simulated/floor/plasteel{
@@ -729,14 +717,6 @@
 	icon_state = "dark"
 	},
 /area/turret_protected/ai)
-"aeV" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/crew_quarters/fitness)
 "afd" = (
 /turf/simulated/wall/r_wall,
 /area/security/permabrig)
@@ -872,27 +852,14 @@
 /turf/simulated/mineral/ancient,
 /area/civilian/vacantoffice)
 "agm" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/random_barrier/wall_probably,
-/turf/simulated/floor/plating,
-/area/maintenance/fore2)
+/obj/structure/beebox/unwrenched,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "agn" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/spray/waterflower,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
-	},
 /obj/machinery/camera{
 	c_tag = "Mime's Office";
 	dir = 1
 	},
-/obj/item/toy/figure/mime,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_regular_floor = "yellowsiding";
@@ -1039,18 +1006,15 @@
 /obj/effect/landmark/start/ai,
 /obj/item/radio/intercom{
 	listening = 0;
-	name = "custom placement";
 	pixel_y = 6;
 	pixel_x = -27
 	},
 /obj/item/radio/intercom{
 	frequency = 1447;
-	name = "custom placement";
 	pixel_x = -27;
 	pixel_y = 28
 	},
 /obj/item/radio/intercom{
-	name = "custom placement";
 	pixel_x = -27;
 	pixel_y = 17
 	},
@@ -1084,12 +1048,14 @@
 	},
 /area/turret_protected/ai)
 "ail" = (
-/obj/machinery/camera{
-	c_tag = "Library East";
-	dir = 9
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/library)
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull";
+	tag = "icon-redfull (NORTHWEST)"
+	},
+/area/crew_quarters/kitchen)
 "aix" = (
 /obj/structure/cable/orange{
 	icon_state = "2-8"
@@ -1142,12 +1108,10 @@
 /obj/machinery/power/apc{
 	cell_type = 25000;
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/machinery/newscaster{
 	pixel_y = -28;
-	name = "south bump";
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -1155,17 +1119,18 @@
 	},
 /area/turret_protected/ai)
 "aiR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "kitchen2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/door/airlock/public/glass{
+	name = "Kitchen";
+	req_access_txt = "28"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/turf/simulated/floor/wood,
-/area/library)
+/area/crew_quarters/kitchen)
 "aiT" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -1358,7 +1323,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/simulated/floor/plasteel{
@@ -1375,8 +1339,7 @@
 /area/security/permabrig)
 "aka" = (
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -1678,8 +1641,7 @@
 "ali" = (
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -1772,16 +1734,15 @@
 "aly" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -26
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /obj/structure/cable/orange{
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
+	dir = 0;
 	icon_state = "whitered"
 	},
 /area/security/medbay)
@@ -1872,7 +1833,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1949,7 +1909,6 @@
 /obj/machinery/power/apc{
 	cell_type = 25000;
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -2210,13 +2169,15 @@
 	},
 /area/toxins/mixing)
 "anS" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Bar"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/carpet,
-/area/crew_quarters/bar)
+/area/hallway/primary/port/east)
 "anW" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2424,8 +2385,7 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
@@ -2474,8 +2434,7 @@
 	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
@@ -2566,8 +2525,7 @@
 "apA" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -2592,10 +2550,13 @@
 "apM" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/closet/secure_closet/reagents,
+/obj/item/storage/bag/chemistry,
+/obj/item/storage/bag/chemistry,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -2628,7 +2589,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -2764,13 +2724,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "aqx" = (
-/obj/machinery/door/airlock{
-	name = "Shower Room"
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -25
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
+/turf/simulated/floor/plasteel{
+	icon_state = "redyellowfull"
+	},
+/area/crew_quarters/bar)
 "aqC" = (
 /turf/simulated/wall,
 /area/crew_quarters/locker)
@@ -2842,8 +2803,7 @@
 "arb" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
@@ -2892,7 +2852,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
@@ -3195,8 +3154,7 @@
 /area/security/hos)
 "atd" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/suit_storage_unit/security/hos,
 /turf/simulated/floor/wood,
@@ -3206,15 +3164,14 @@
 	dir = 1
 	},
 /obj/structure/table/wood,
-/obj/machinery/photocopier/faxmachine{
+/obj/machinery/photocopier/faxmachine/longrange{
 	department = "Head of Security's Office"
 	},
 /turf/simulated/floor/wood,
 /area/security/hos)
 "atf" = (
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/structure/closet/secure_closet/hos,
 /obj/item/megaphone,
@@ -3248,6 +3205,10 @@
 /obj/item/restraints/handcuffs,
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
+"att" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "atB" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -3296,8 +3257,7 @@
 "atT" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -3342,7 +3302,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -3418,8 +3377,7 @@
 	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/camera{
 	c_tag = "Brig Main Hall West 1"
@@ -3450,7 +3408,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -3534,8 +3491,7 @@
 /area/maintenance/fore2)
 "auP" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -3577,8 +3533,7 @@
 /area/crew_quarters/captain)
 "auT" = (
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/captain)
@@ -3832,6 +3787,7 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -4264,7 +4220,6 @@
 "ayH" = (
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -4343,7 +4298,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/stripes/asteroid/end,
@@ -4413,8 +4367,7 @@
 /area/maintenance/fore2)
 "azy" = (
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -4424,7 +4377,6 @@
 "azD" = (
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -4436,7 +4388,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/simulated/floor/plating,
@@ -4445,8 +4396,7 @@
 /obj/machinery/light/small,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4489,8 +4439,7 @@
 	icon_state = "plant-21"
 	},
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -4533,8 +4482,7 @@
 /obj/machinery/tcomms/core/station,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -4561,7 +4509,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -4569,12 +4516,22 @@
 	},
 /area/security/interrogation)
 "aAG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull"
+/obj/machinery/door_control{
+	desiredstate = 1;
+	id = "cabin2";
+	name = "Door Bolt Control";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	pixel_y = -26
 	},
-/area/crew_quarters/sleep)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/cabin2)
 "aAI" = (
 /obj/structure/chair{
 	dir = 4
@@ -4656,6 +4613,24 @@
 	icon_state = "dark"
 	},
 /area/tcommsat/computer)
+"aBs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/primary/port/south)
 "aBG" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -4675,12 +4650,11 @@
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/maintenance/fore)
 "aBK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/railing/corner{
+	dir = 1
 	},
-/obj/structure/table/wood/fancy/black,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
+/turf/simulated/floor/carpet/green,
+/area/library)
 "aBM" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -4824,19 +4798,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/northwest)
-"aCC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull"
-	},
-/area/crew_quarters/sleep)
 "aCO" = (
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redcorner"
@@ -4849,9 +4814,8 @@
 	},
 /area/security/main)
 "aCZ" = (
-/obj/structure/closet/wardrobe/xenos,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/turf/simulated/wall,
+/area/engine/engineering)
 "aDa" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
@@ -4926,11 +4890,22 @@
 /turf/simulated/mineral/ancient,
 /area/storage/tech)
 "aDz" = (
-/obj/machinery/door/airlock{
-	id_tag = "b1"
+/obj/machinery/door_control{
+	desiredstate = 1;
+	id = "cabin4";
+	name = "Door Bolt Control";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	pixel_y = 26
 	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/locker)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/cabin4)
 "aDC" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -4997,8 +4972,7 @@
 "aEb" = (
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -5030,8 +5004,7 @@
 	dir = 4
 	},
 /obj/machinery/firealarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -5090,16 +5063,14 @@
 /obj/machinery/light,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/carpet/black,
 /area/crew_quarters/captain)
 "aES" = (
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -5107,10 +5078,9 @@
 /turf/simulated/floor/carpet/black,
 /area/crew_quarters/captain)
 "aET" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/turf/simulated/floor/carpet,
+/obj/structure/chair/comfy/black,
+/obj/effect/landmark/start/civilian,
+/turf/simulated/floor/carpet/orange,
 /area/crew_quarters/bar)
 "aEU" = (
 /turf/simulated/floor/carpet/black,
@@ -5118,8 +5088,7 @@
 "aEV" = (
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5208,7 +5177,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5258,7 +5226,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/stripes/end{
@@ -5350,8 +5317,7 @@
 	dir = 1
 	},
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -5454,8 +5420,7 @@
 	dir = 1
 	},
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/structure/railing/corner{
 	pixel_y = -11
@@ -5509,23 +5474,19 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "aHw" = (
-/obj/structure/chair/stool/bar{
-	dir = 1
-	},
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
+	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
-/area/crew_quarters/bar)
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "aHL" = (
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/brig)
+/obj/effect/landmark/start/librarian,
+/turf/simulated/floor/carpet,
+/area/library)
 "aHN" = (
 /obj/machinery/cryopod/robot,
 /turf/simulated/floor/plasteel{
@@ -5533,6 +5494,15 @@
 	icon_state = "whiteyellow"
 	},
 /area/assembly/chargebay)
+"aHR" = (
+/obj/structure/chair/sofa/left{
+	dir = 8
+	},
+/obj/effect/landmark/start/civilian,
+/turf/simulated/floor/plasteel{
+	icon_state = "redyellowfull"
+	},
+/area/crew_quarters/bar)
 "aIa" = (
 /obj/structure/cable/orange{
 	icon_state = "1-8"
@@ -5623,8 +5593,7 @@
 /area/maintenance/disposal/northwest)
 "aIT" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -5660,8 +5629,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/machinery/flasher/portable,
 /obj/effect/decal/warning_stripes/red/hollow,
@@ -5669,14 +5637,6 @@
 	icon_state = "dark"
 	},
 /area/security/armory)
-"aJe" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
 "aJf" = (
 /obj/structure/chair/sofa/corp,
 /turf/simulated/floor/carpet,
@@ -5691,11 +5651,12 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "aJj" = (
-/obj/structure/chair/office/dark{
-	dir = 1
+/obj/effect/turf_decal/bot/right,
+/obj/machinery/portable_atmospherics/pump,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/cabin3)
+/area/atmos)
 "aJk" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -5723,7 +5684,6 @@
 "aJo" = (
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/structure/cable/orange{
@@ -5779,7 +5739,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel,
@@ -5874,8 +5833,7 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/vending/clothing/departament/security,
 /turf/simulated/floor/plasteel{
@@ -5984,7 +5942,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -6047,8 +6004,7 @@
 "aLx" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -6159,8 +6115,7 @@
 "aMx" = (
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -6173,8 +6128,7 @@
 "aMJ" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -6302,8 +6256,7 @@
 "aNr" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -6411,18 +6364,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/fore)
-"aNQ" = (
-/obj/structure/sign/poster/random{
-	name = "random official poster";
-	pixel_x = -32;
-	random_basetype = /obj/structure/sign/poster/official
-	},
-/obj/structure/bed/dogbed/pet,
-/mob/living/simple_animal/pet/cat/white/Penny,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/locker)
 "aNY" = (
 /obj/machinery/status_display{
 	layer = 4
@@ -6533,7 +6474,6 @@
 "aOJ" = (
 /obj/structure/cable/orange,
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6609,7 +6549,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -6624,7 +6563,6 @@
 "aPd" = (
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -6636,20 +6574,22 @@
 /turf/simulated/floor/plating,
 /area/bridge)
 "aPf" = (
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/locker)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/crew_quarters/cabin1)
 "aPg" = (
 /obj/machinery/camera{
 	c_tag = "Bridge Meeting West"
 	},
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6728,8 +6668,7 @@
 "aPp" = (
 /obj/machinery/computer/supplycomp,
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -6776,8 +6715,7 @@
 "aPD" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/machinery/camera{
 	c_tag = "AI Asteroid Hallway 4";
@@ -6796,11 +6734,18 @@
 	},
 /area/turret_protected/aisat_interior)
 "aPK" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock{
+	id_tag = "cabin4";
+	name = "Cabin"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/wood,
+/area/crew_quarters/cabin4)
 "aPL" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 8;
@@ -6829,8 +6774,7 @@
 /area/quartermaster/office)
 "aPT" = (
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redcorner"
@@ -6926,8 +6870,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/start/captain,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/landmark/start/nanotrasen_rep,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -6958,13 +6902,11 @@
 	},
 /area/quartermaster/office)
 "aQA" = (
-/obj/machinery/autolathe,
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/machinery/newscaster{
-	pixel_y = 28;
-	name = "north bump"
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -7097,16 +7039,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"aRi" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	name = "Dormitories"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
 "aRj" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -7170,8 +7102,7 @@
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/light_switch{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -7235,11 +7166,18 @@
 /turf/simulated/floor/grass,
 /area/hallway/secondary/exit)
 "aSb" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/door/airlock{
+	id_tag = "cabin2";
+	name = "Cabin"
 	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/locker)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/cabin2)
 "aSf" = (
 /obj/machinery/light,
 /obj/item/twohanded/required/kirbyplants{
@@ -7291,8 +7229,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/security/range)
@@ -7309,15 +7246,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/security/range)
 "aSq" = (
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/magistrateoffice)
@@ -7412,26 +7347,26 @@
 /obj/item/assembly/mousetrap/armed,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/fore2)
 "aSL" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fore2)
+/turf/simulated/mineral/ancient,
+/area/crew_quarters/cabin1)
 "aSO" = (
-/obj/machinery/door_control{
-	id = "b3";
-	name = "Privacy Bolts";
-	normaldoorcontrol = 1;
-	pixel_x = 24;
-	specialfunctions = 4
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/obj/machinery/recharge_station,
-/turf/simulated/floor/plasteel/freezer,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "aSU" = (
 /obj/structure/cable/orange{
@@ -7448,7 +7383,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
@@ -7459,7 +7393,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/stripes/end{
@@ -7498,19 +7431,11 @@
 	},
 /area/maintenance/fore2)
 "aTh" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Kitchen";
-	req_access = list(28)
+/obj/machinery/atm{
+	pixel_y = -32
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "kitchen1"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "aTj" = (
 /obj/machinery/camera{
 	c_tag = "Quartermaster's Office";
@@ -7558,8 +7483,7 @@
 "aTs" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7600,18 +7524,15 @@
 	},
 /area/security/prison/cell_block/A)
 "aTF" = (
-/obj/structure/mirror{
-	pixel_x = 32
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/locker)
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/item/clothing/head/kitty,
+/obj/item/clothing/suit/browntrenchcoat,
+/obj/item/clothing/under/maid,
+/turf/simulated/floor/wood,
+/area/crew_quarters/cabin4)
 "aTH" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
@@ -7628,8 +7549,7 @@
 /area/maintenance/fore)
 "aTP" = (
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
@@ -7641,17 +7561,30 @@
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
 "aTT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+/obj/item/radio/intercom{
+	pixel_x = 26;
+	pixel_y = 28
 	},
-/area/crew_quarters/fitness)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 26
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/crew_quarters/cabin1)
 "aTV" = (
 /obj/machinery/newscaster{
-	pixel_y = 28;
-	name = "north bump"
+	pixel_y = 32
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
@@ -7675,27 +7608,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/prison/cell_block/A)
-"aUb" = (
-/obj/machinery/door/airlock{
-	id_tag = "b2"
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/locker)
 "aUc" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/door_control{
-	id = "b2";
-	name = "Privacy Bolts";
-	normaldoorcontrol = 1;
-	pixel_x = -24;
-	specialfunctions = 4
-	},
-/turf/simulated/floor/plasteel/freezer,
+/turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "aUe" = (
 /obj/structure/cable/orange{
@@ -7894,8 +7813,7 @@
 "aUL" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -7927,7 +7845,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/simulated/floor/plasteel{
@@ -8053,15 +7970,15 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore/east)
 "aVG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/hologram/holopad,
-/mob/living/simple_animal/pet/cat/birman/Crusher,
-/turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/obj/item/storage/box/donkpockets,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
 "aVJ" = (
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/stripes/end,
@@ -8078,8 +7995,7 @@
 	pixel_y = 3
 	},
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /obj/item/stack/packageWrap,
 /obj/item/destTagger,
@@ -8146,9 +8062,6 @@
 /area/quartermaster/office)
 "aWh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -8249,7 +8162,6 @@
 /obj/item/storage/belt/utility,
 /obj/item/extinguisher,
 /obj/machinery/firealarm{
-	name = "north fire alarm";
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -8322,8 +8234,7 @@
 /obj/machinery/light,
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -8331,7 +8242,6 @@
 /area/tcommsat/computer)
 "aWT" = (
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -8348,8 +8258,7 @@
 /obj/item/multitool,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -8546,8 +8455,7 @@
 /obj/machinery/hydroponics/soil,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/machinery/camera{
 	c_tag = "Rehabilitation Dome East 1";
@@ -8560,7 +8468,6 @@
 /area/mine/unexplored/cere/engineering)
 "aYk" = (
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -24
 	},
 /obj/structure/cable/orange,
@@ -8590,8 +8497,7 @@
 /obj/machinery/hydroponics/soil,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /mob/living/simple_animal/butterfly,
 /turf/simulated/floor/grass,
@@ -8697,8 +8603,7 @@
 	pixel_y = 5
 	},
 /obj/item/radio/intercom{
-	pixel_x = -28;
-	name = "custom placement"
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -8708,8 +8613,7 @@
 "aYY" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -8741,7 +8645,6 @@
 /area/hallway/primary/port/north)
 "aZc" = (
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -26
 	},
 /obj/structure/cable/orange{
@@ -8755,14 +8658,14 @@
 /turf/simulated/floor/plasteel,
 /area/engine/mechanic_workshop/expedition)
 "aZd" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -8832,8 +8735,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -8936,8 +8838,7 @@
 "baa" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9034,8 +8935,7 @@
 /obj/item/flashlight/lamp,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -9069,7 +8969,6 @@
 "bax" = (
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -9082,13 +8981,8 @@
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/maintenance/port)
 "baz" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/port/north)
@@ -9113,14 +9007,19 @@
 /turf/simulated/wall,
 /area/crew_quarters/kitchen)
 "baG" = (
-/obj/structure/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/mob/living/simple_animal/mouse/rat/irish/Remi,
-/turf/simulated/floor/grass,
-/area/hydroponics)
+/obj/machinery/camera{
+	c_tag = "Crematorium"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/office)
 "baH" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/blood/old,
@@ -9142,7 +9041,6 @@
 "baK" = (
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -9168,8 +9066,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	pixel_x = 28;
-	name = "custom placement"
+	pixel_x = 28
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9235,36 +9132,49 @@
 /turf/simulated/floor/plasteel,
 /area/security/range)
 "bbf" = (
-/turf/simulated/floor/plasteel,
-/area/hydroponics)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/carpet/black,
+/area/chapel/office)
 "bbg" = (
-/obj/effect/landmark/start/botanist,
+/obj/structure/table,
 /turf/simulated/floor/plasteel,
-/area/hydroponics)
+/area/crew_quarters/locker)
 "bbh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/hydroponics)
-"bbi" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/grass,
-/area/hydroponics)
-"bbj" = (
-/obj/effect/landmark/start/botanist,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/grass,
-/area/hydroponics)
-"bbk" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/grass,
-/area/hydroponics)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/green,
+/area/library)
+"bbi" = (
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
+/obj/effect/landmark/start/librarian,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/library)
+"bbj" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/purple,
+/area/crew_quarters/bar)
+"bbk" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "bbl" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/machinery/camera{
@@ -9322,8 +9232,7 @@
 /obj/structure/table,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/machinery/camera{
 	c_tag = "Arcade West";
@@ -9333,28 +9242,40 @@
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
 "bbI" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/window/westright{
-	req_access = list(35)
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/grass,
-/area/hydroponics)
-"bbJ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor/grass,
-/area/hydroponics)
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/port/south)
+"bbJ" = (
+/obj/machinery/hologram/holopad,
+/obj/structure/disposalpipe/sortjunction/reversed{
+	dir = 2;
+	name = "disposal pipe - Library";
+	sort_type_txt = "16";
+	sortType = 16
+	},
+/turf/simulated/floor/carpet/green,
+/area/library)
 "bbK" = (
-/obj/structure/kitchenspike,
-/turf/simulated/floor/plasteel/freezer,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/crew_quarters/kitchen)
 "bbM" = (
 /obj/machinery/door/airlock/public/glass{
@@ -9481,6 +9402,9 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/maintenance/port)
 "bcn" = (
@@ -9493,7 +9417,11 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/structure/cable/orange,
+/obj/machinery/power/smes/engineering{
+	input_level = 95000;
+	output_level = 90000
+	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/maintenance/port)
 "bcp" = (
@@ -9508,26 +9436,29 @@
 	},
 /area/turret_protected/aisat_interior)
 "bct" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance";
+	req_access = list(12)
 	},
-/turf/simulated/floor/grass,
-/area/hydroponics)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/carpet/green,
+/area/maintenance/port)
 "bcu" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/door/airlock/public/glass{
+	name = "Holodeck Door"
 	},
-/turf/simulated/floor/grass,
-/area/hydroponics)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "rampbottom"
+	},
+/area/crew_quarters/fitness)
 "bcv" = (
-/obj/machinery/camera{
-	c_tag = "Hydroponics Bee Reserve South";
-	dir = 9
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "rampbottom"
 	},
-/mob/living/simple_animal/chicken/Wife,
-/turf/simulated/floor/grass,
-/area/hydroponics)
+/area/crew_quarters/fitness)
 "bcx" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/machinery/light{
@@ -9558,8 +9489,7 @@
 "bcB" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4
@@ -9862,19 +9792,14 @@
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "bdR" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/hallway/primary/port/north)
+/obj/machinery/vending/boozeomat,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "bdX" = (
-/obj/machinery/chem_master/condimaster,
-/obj/machinery/light,
+/obj/machinery/door/firedoor,
+/obj/structure/spacepoddoor,
 /turf/simulated/floor/plasteel,
-/area/hydroponics)
+/area/engine/mechanic_workshop)
 "bdY" = (
 /obj/structure/cable/orange{
 	icon_state = "2-4"
@@ -9885,9 +9810,11 @@
 	},
 /area/maintenance/fore2)
 "bdZ" = (
-/obj/structure/beebox,
-/turf/simulated/floor/grass,
-/area/hydroponics)
+/obj/machinery/computer/HolodeckControl{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "beb" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/grass,
@@ -10076,16 +10003,11 @@
 	},
 /area/civilian/barber)
 "beQ" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	name = "north bump"
-	},
-/obj/machinery/seed_extractor,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkgreenfull"
-	},
-/area/hydroponics)
+/obj/structure/table/wood,
+/obj/structure/table/wood,
+/obj/item/eftpos,
+/turf/simulated/floor/carpet/black,
+/area/chapel/office)
 "beR" = (
 /obj/structure/flora/grass/jungle,
 /turf/simulated/floor/grass,
@@ -10113,7 +10035,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/maintenance/engineering)
+/area/engine/engineering)
 "beV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -10279,72 +10201,54 @@
 	dir = 8
 	},
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
 "bfI" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24;
-	name = "custom placement"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkgreen"
-	},
-/area/hydroponics)
-"bfJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkgreenfull"
+/turf/simulated/floor/carpet,
+/area/library)
+"bfJ" = (
+/obj/machinery/door/firedoor,
+/obj/structure/spacepoddoor,
+/obj/machinery/door/poddoor/multi_tile/two_tile_ver{
+	id_tag = "mechanicgate"
 	},
-/area/hydroponics)
+/turf/simulated/floor/plasteel,
+/area/engine/mechanic_workshop)
 "bfK" = (
-/obj/machinery/disposal,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 28;
-	name = "custom placement"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/disposalpipe/trunk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "darkgreenfull"
+	icon_state = "neutralfull"
 	},
-/area/hydroponics)
+/area/hallway/primary/port/south)
 "bfL" = (
-/obj/machinery/plantgenes,
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkgreenfull"
-	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass,
 /area/hydroponics)
 "bfO" = (
-/obj/machinery/camera{
-	c_tag = "Hydroponics South 2";
-	dir = 8;
-	start_active = 1
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
-	},
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/item/clothing/glasses/hud/hydroponic,
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "darkgreen"
+	dir = 8;
+	icon_state = "darkgreenfull"
 	},
 /area/hydroponics)
 "bfQ" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/flora/grass/jungle,
 /turf/simulated/floor/grass,
@@ -10352,8 +10256,7 @@
 "bfR" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/flora/grass/jungle,
 /turf/simulated/floor/grass,
@@ -10393,8 +10296,7 @@
 "bfW" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8
@@ -10461,8 +10363,7 @@
 /area/hallway/primary/central)
 "bgg" = (
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -10728,88 +10629,65 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/theatre)
 "bgR" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	name = "Bathroom"
+/obj/structure/chair/comfy/black{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/toilet)
+/turf/simulated/floor/carpet/green,
+/area/library)
 "bgS" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/hologram/holopad,
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "whitegreenfull"
+	},
+/area/crew_quarters/sleep)
+"bgT" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/mob/living/simple_animal/chicken/Wife,
+/turf/simulated/floor/grass,
+/area/hydroponics)
+"bgV" = (
+/obj/structure/chair/sofa/pew/left{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/hydroponics)
-"bgT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/area/chapel/main)
+"bgY" = (
+/obj/machinery/newscaster{
+	pixel_y = 32
 	},
-/obj/structure/cable/orange{
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/wood,
+/area/library)
+"bgZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/hydroponics/constructable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "darkgreenfull"
+	icon_state = "neutralfull"
 	},
-/area/hydroponics)
-"bgV" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkgreenfull"
-	},
-/area/hydroponics)
-"bgY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkgreen"
-	},
-/area/hydroponics)
-"bgZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/storage/box/donkpockets,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/kitchen)
+/area/hallway/primary/port/north)
 "bha" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/kitchen)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/landmark/event/lightsout,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "bhd" = (
 /turf/simulated/wall/r_wall,
 /area/engine/engineering)
@@ -10857,8 +10735,7 @@
 /obj/item/hand_tele,
 /obj/item/radio/beacon,
 /obj/item/radio/intercom{
-	pixel_x = -28;
-	name = "custom placement"
+	pixel_x = -28
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -10878,8 +10755,7 @@
 /area/hallway/primary/starboard/north)
 "bhq" = (
 /obj/machinery/newscaster{
-	pixel_y = 28;
-	name = "north bump"
+	pixel_y = 32
 	},
 /obj/machinery/vending/suitdispenser,
 /turf/simulated/floor/plasteel,
@@ -10898,12 +10774,13 @@
 /area/crew_quarters/locker)
 "bhw" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/bed/dogbed/pet,
+/mob/living/simple_animal/pet/cat/white/Penny,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bhy" = (
@@ -10922,33 +10799,29 @@
 "bhJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkgreen"
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
-/area/hydroponics)
-"bhK" = (
-/obj/structure/table,
-/obj/item/storage/bag/plants/portaseeder,
-/obj/item/storage/bag/plants/portaseeder,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/plants,
-/obj/machinery/light{
+/obj/machinery/camera{
+	c_tag = "Crew Quarters";
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkgreen"
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
+"bhK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/hydroponics)
+/mob/living/simple_animal/crab{
+	desc = "The local trainer hired to keep the crew in shape by aggressively snipping at them.";
+	name = "Crabohydrates"
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "bhN" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/item/toy/figure/chef,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/kitchen)
+/obj/structure/chair/stool,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "bhO" = (
 /turf/simulated/floor/plating/asteroid/ancient/airless,
 /area/mine/unexplored/cere/civilian)
@@ -11004,8 +10877,7 @@
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/machinery/requests_console{
 	department = "EVA";
@@ -11024,8 +10896,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -11162,12 +11033,11 @@
 /area/maintenance/starboardaux)
 "biG" = (
 /obj/structure/table,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/obj/item/kitchen/knife,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "biI" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -11196,13 +11066,11 @@
 	},
 /area/maintenance/fore2)
 "biT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
+/obj/machinery/cooker/deepfryer,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
 	},
-/turf/simulated/floor/carpet/green,
-/area/library)
+/area/crew_quarters/kitchen)
 "biU" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -11260,11 +11128,9 @@
 /obj/machinery/dye_generator,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/item/radio/intercom{
-	name = "custom placement";
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
@@ -11290,8 +11156,9 @@
 	},
 /area/crew_quarters/bar)
 "bjs" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -11310,12 +11177,8 @@
 /area/quartermaster/office)
 "bjz" = (
 /obj/structure/table,
-/obj/item/reagent_containers/glass/beaker,
-/obj/item/reagent_containers/food/condiment/enzyme,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "bjD" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/structure/lattice,
@@ -11360,11 +11223,13 @@
 /turf/simulated/floor/plating,
 /area/medical/cmo)
 "bjJ" = (
-/obj/machinery/disposal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/structure/disposalpipe/trunk,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkblue"
@@ -11601,7 +11466,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/machinery/camera{
@@ -11678,25 +11542,25 @@
 /turf/space,
 /area/hallway/spacebridge/serveng)
 "blf" = (
-/obj/machinery/icemachine,
-/obj/machinery/door_control{
-	id = "kitchen1";
-	name = "Privacy Shutters";
-	pixel_y = -24
+/mob/living/simple_animal/hostile/retaliate/goat{
+	name = "Pete"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "blg" = (
-/obj/machinery/disposal,
+/obj/item/radio/intercom{
+	pixel_y = -30
+	},
 /obj/structure/disposalpipe/trunk{
-	dir = 8
+	dir = 4
 	},
+/obj/machinery/disposal,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 10;
+	icon_state = "whitered"
 	},
-/area/security/brig)
+/area/security/medbay)
 "blh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11858,17 +11722,9 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/central)
 "blC" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/computer/podtracker{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "yellow"
+	icon_state = "yellowcorner"
 	},
 /area/engine/mechanic_workshop)
 "blE" = (
@@ -11917,8 +11773,7 @@
 "blJ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -11926,23 +11781,12 @@
 	},
 /area/quartermaster/storage)
 "blL" = (
-/obj/structure/rack,
-/obj/item/extinguisher,
-/obj/item/storage/belt/utility,
-/obj/item/storage/toolbox/electrical,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/radio{
-	pixel_y = 6
-	},
-/obj/item/weldingtool/largetank,
 /obj/machinery/camera{
 	c_tag = "Mechanic's Office";
 	dir = 8;
 	network = list("Engineering","SS13")
 	},
+/obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellow"
@@ -11985,8 +11829,7 @@
 /obj/item/clothing/mask/muzzle,
 /obj/structure/table/glass,
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -12020,8 +11863,7 @@
 "bmf" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
@@ -12049,31 +11891,35 @@
 	},
 /area/atmos/break_room)
 "bmj" = (
-/obj/machinery/camera{
-	c_tag = "Hydroponics North 1";
+/obj/machinery/cryopod{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "darkgreen"
+/obj/item/radio/intercom{
+	pixel_y = -28
 	},
-/area/hydroponics)
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitegreen"
+	},
+/area/crew_quarters/sleep)
 "bmk" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "darkgreen"
+/obj/machinery/cryopod{
+	dir = 1
 	},
-/area/hydroponics)
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitegreen"
+	},
+/area/crew_quarters/sleep)
 "bmm" = (
-/obj/machinery/camera{
-	c_tag = "Hydroponics South 1";
-	dir = 8;
-	start_active = 1
-	},
-/obj/machinery/vending/hydroseeds,
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "darkgreen"
-	},
-/area/hydroponics)
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "bmv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12185,7 +12031,6 @@
 "bmX" = (
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/structure/cable/orange{
@@ -12314,8 +12159,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /obj/structure/closet/secure_closet/brig/evidence,
 /turf/simulated/floor/plasteel{
@@ -12325,8 +12169,7 @@
 "bnw" = (
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/closet/secure_closet/brig/evidence,
 /turf/simulated/floor/plasteel{
@@ -12409,7 +12252,6 @@
 "bnM" = (
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/stripes/asteroid/end,
@@ -12454,7 +12296,16 @@
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "bnV" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Dormitories"
+	},
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bnZ" = (
@@ -12537,8 +12388,7 @@
 "bov" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel,
 /area/security/range)
@@ -12820,7 +12670,6 @@
 /obj/effect/turf_decal/stripes/end,
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -12833,8 +12682,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/light{
 	dir = 1
@@ -12847,8 +12695,7 @@
 "bpC" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
@@ -12984,6 +12831,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -13010,8 +12860,7 @@
 /area/hallway/primary/central)
 "bqp" = (
 /obj/item/radio/intercom{
-	pixel_x = 28;
-	name = "custom placement"
+	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -13020,8 +12869,7 @@
 /area/hallway/primary/central)
 "bqq" = (
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
@@ -13334,7 +13182,6 @@
 	},
 /obj/machinery/newscaster{
 	pixel_x = -28;
-	name = "west bump";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -13478,7 +13325,6 @@
 	},
 /obj/machinery/newscaster{
 	pixel_y = -28;
-	name = "south bump";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -13528,8 +13374,7 @@
 "brY" = (
 /obj/structure/bed/dogbed,
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /mob/living/simple_animal/pet/dog/corgi/Ian,
 /obj/item/toy/figure/ian,
@@ -13620,7 +13465,6 @@
 	},
 /obj/machinery/newscaster{
 	pixel_y = -28;
-	name = "south bump";
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -13710,17 +13554,12 @@
 	},
 /area/security/processing)
 "bsI" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/item/reagent_containers/glass/bucket,
-/obj/machinery/camera{
-	c_tag = "Hydroponics North 2";
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkgreenfull"
-	},
-/area/hydroponics)
+/turf/simulated/floor/wood,
+/area/library)
 "bsK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -13781,8 +13620,7 @@
 /obj/machinery/syndicatebomb/training,
 /obj/structure/closet/bombclosetsecurity,
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel,
 /area/security/range)
@@ -13840,7 +13678,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/hallway/primary/port/north)
+/area/storage/primary)
 "bti" = (
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
@@ -13878,8 +13716,7 @@
 /obj/machinery/light_switch{
 	dir = 4;
 	pixel_x = -4;
-	pixel_y = -32;
-	name = "custom placement"
+	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -14036,15 +13873,19 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/central)
 "btN" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -14081,8 +13922,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
@@ -14173,8 +14013,7 @@
 "buz" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -14200,26 +14039,21 @@
 	},
 /area/toxins/hallway)
 "buG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/glass{
-	name = "Bar"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet,
-/area/crew_quarters/bar)
+/area/hallway/primary/port/east)
 "buH" = (
-/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet,
-/area/crew_quarters/bar)
+/area/hallway/primary/port/east)
 "buI" = (
 /obj/machinery/prize_counter,
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
 "buJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "buM" = (
@@ -14575,8 +14409,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -14596,14 +14429,6 @@
 	icon_state = "neutralfull"
 	},
 /area/turret_protected/aisat_interior)
-"bvX" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/crew_quarters/fitness)
 "bvY" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/orange,
@@ -14767,7 +14592,6 @@
 	},
 /obj/structure/table/glass,
 /obj/machinery/alarm{
-	name = "north bump";
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -14893,15 +14717,21 @@
 	},
 /area/hallway/primary/port/north)
 "bxo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bxp" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -14911,8 +14741,8 @@
 	},
 /area/crew_quarters/heads/hop)
 "bxs" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
@@ -14969,8 +14799,7 @@
 /obj/structure/table/wood,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/item/megaphone,
 /turf/simulated/floor/carpet/blue,
@@ -15087,8 +14916,7 @@
 /area/security/prison/cell_block/A)
 "bxM" = (
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -15197,10 +15025,13 @@
 "bym" = (
 /obj/machinery/newscaster{
 	pixel_x = -28;
-	name = "west bump";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/camera{
+	c_tag = "Service Asteroid Hallway 3";
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -15353,8 +15184,7 @@
 /area/security/processing)
 "byS" = (
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/bottle/morphine{
@@ -15385,8 +15215,7 @@
 /area/medical/virology)
 "byZ" = (
 /obj/item/radio/intercom{
-	pixel_x = 28;
-	name = "custom placement"
+	pixel_x = 28
 	},
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 32
@@ -15444,27 +15273,22 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/port/north)
 "bzq" = (
-/obj/machinery/door_control{
-	desiredstate = 1;
-	id = "cabin1";
-	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
-	specialfunctions = 4;
-	pixel_x = 25
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
-/obj/structure/dresser,
-/obj/item/radio/intercom{
-	pixel_x = 26;
-	pixel_y = -28
+/obj/machinery/camera{
+	c_tag = "Medbay Escape Pod";
+	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/cabin1)
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/maintenance/starboard)
 "bzv" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
 /obj/item/radio/intercom{
-	pixel_x = 28;
-	name = "custom placement"
+	pixel_x = 28
 	},
 /obj/item/storage/briefcase/inflatable,
 /obj/item/flashlight,
@@ -15659,6 +15483,7 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -15668,15 +15493,9 @@
 /turf/simulated/wall/r_wall,
 /area/medical/virology)
 "bAe" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/fitness)
+/obj/effect/landmark/event/lightsout,
+/turf/simulated/floor/wood,
+/area/library)
 "bAf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15713,8 +15532,7 @@
 	dir = 8
 	},
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -15744,8 +15562,12 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
+	},
+/obj/machinery/door/window/southleft{
+	name = "Public Fridge";
+	req_access = list(33);
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -15755,8 +15577,7 @@
 "bAl" = (
 /obj/structure/closet/secure_closet/security,
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -15821,7 +15642,6 @@
 	},
 /obj/machinery/newscaster{
 	pixel_x = -28;
-	name = "west bump";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
@@ -15923,8 +15743,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/machinery/camera{
 	c_tag = "Morgue West";
@@ -16109,8 +15928,7 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Lobby";
@@ -16127,8 +15945,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/effect/landmark/start/civilian,
 /turf/simulated/floor/plasteel{
@@ -16139,15 +15956,16 @@
 /turf/simulated/wall/r_wall,
 /area/medical/chemistry)
 "bCj" = (
-/obj/effect/landmark/start/chaplain,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/red,
-/area/chapel/main)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/hydroponics)
 "bCm" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/firedoor,
@@ -16204,8 +16022,7 @@
 /obj/structure/chair/stool,
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/effect/landmark/start/civilian,
 /turf/simulated/floor/carpet/arcade,
@@ -16423,8 +16240,7 @@
 	pixel_y = -11
 	},
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/carpet/black,
 /area/bridge)
@@ -16523,6 +16339,10 @@
 /obj/item/storage/fancy/candle_box/eternal,
 /obj/item/storage/fancy/candle_box/eternal,
 /obj/item/storage/fancy/candle_box/eternal,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bDR" = (
@@ -16624,12 +16444,6 @@
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/fore)
-"bEl" = (
-/obj/structure/chair/stool,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/maintenance/engineering)
 "bEm" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel{
@@ -16676,8 +16490,7 @@
 /area/medical/chemistry)
 "bEv" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/structure/closet/secure_closet/reagents,
 /turf/simulated/floor/plasteel{
@@ -16696,15 +16509,16 @@
 	},
 /area/medical/medbay)
 "bEy" = (
-/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/carpet/red,
-/area/chapel/main)
+/area/hydroponics)
 "bEz" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -16766,7 +16580,6 @@
 "bEP" = (
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -16833,44 +16646,44 @@
 /obj/item/stack/rods{
 	amount = 50
 	},
+/obj/item/stack/sheet/glass/fifty,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow";
 	dir = 1
 	},
 /area/atmos)
 "bFb" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/structure/rack,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/head/welding,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow";
 	dir = 1
 	},
 /area/atmos)
 "bFc" = (
-/obj/structure/closet/wardrobe/atmospherics_yellow,
+/obj/structure/closet/secure_closet/atmos_personal,
+/obj/item/pickaxe/mini,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow";
 	dir = 1
 	},
 /area/atmos)
 "bFd" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/head/welding,
-/obj/item/clothing/head/welding,
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
+/obj/structure/closet/secure_closet/atmos_personal,
+/obj/item/pickaxe/mini,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow";
 	dir = 1
@@ -16973,8 +16786,7 @@
 	dir = 5
 	},
 /obj/machinery/newscaster{
-	pixel_y = 28;
-	name = "north bump"
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -17029,7 +16841,7 @@
 	dir = 4;
 	icon_state = "darkyellowcorners"
 	},
-/area/maintenance/engineering)
+/area/engine/break_room)
 "bFv" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil,
@@ -17038,8 +16850,7 @@
 	dir = 9
 	},
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/item/storage/belt/utility,
 /obj/item/stack/sheet/plasteel,
@@ -17138,6 +16949,9 @@
 	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/computer/guestpass{
+	pixel_x = -30
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -17327,9 +17141,8 @@
 	},
 /area/medical/medbay)
 "bGf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/chair/sofa/left,
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
@@ -17346,17 +17159,15 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "bGo" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/structure/closet/wardrobe/black,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/obj/structure/chair/office/dark,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/cabin2)
 "bGq" = (
 /turf/simulated/wall,
 /area/library)
@@ -17375,8 +17186,7 @@
 "bGz" = (
 /obj/structure/chair/comfy/black,
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -17392,9 +17202,9 @@
 /area/quartermaster/miningdock)
 "bGB" = (
 /obj/effect/spawner/window/reinforced/polarized{
-	id = "IAA"
+	id = "privateroom"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plating,
 /area/crew_quarters/bar)
 "bGC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -17408,24 +17218,30 @@
 	},
 /area/assembly/robotics)
 "bGD" = (
-/obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/turf/simulated/floor/wood,
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	name = "disposal pipe - Chapel";
+	sort_type_txt = "17";
+	sortType = 17
+	},
+/turf/simulated/floor/carpet/green,
 /area/library)
 "bGE" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 28;
-	name = "custom placement"
+/obj/structure/table/wood,
+/obj/item/reagent_containers/spray/waterflower,
+/obj/item/toy/figure/mime,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
 	},
-/obj/structure/bed/dogbed/pet,
-/mob/living/simple_animal/pet/dog/bullterrier/Genn,
-/turf/simulated/floor/wood,
-/area/library)
+/area/mimeoffice)
 "bGF" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "mining_home";
@@ -17440,11 +17256,11 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "bGI" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/kitchen)
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "bGK" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5
@@ -17868,8 +17684,7 @@
 /area/medical/medbay)
 "bHy" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -17893,20 +17708,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/maintenance/engineering)
+/area/engine/break_room)
 "bHF" = (
-/obj/docking_port/stationary{
-	height = 22;
-	id = "syndicate_s";
-	name = "south of station";
-	width = 18;
-	dir = 4;
-	dheight = 8
+/obj/machinery/door/airlock/public/glass{
+	name = "Fitness Room"
 	},
-/turf/space{
-	icon_state = "black"
-	},
-/area/space)
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "bHT" = (
 /obj/machinery/light{
 	dir = 8
@@ -17949,7 +17757,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/simulated/floor/carpet/arcade,
@@ -18093,8 +17900,7 @@
 	dir = 6
 	},
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18107,10 +17913,6 @@
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/fore)
-"bID" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/engine/break_room)
 "bIF" = (
 /turf/simulated/wall/r_wall/coated,
 /area/atmos/distribution)
@@ -18150,8 +17952,7 @@
 "bIM" = (
 /obj/machinery/light_switch{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/structure/table/glass,
 /obj/item/toy/figure/chemist,
@@ -18217,19 +18018,16 @@
 /turf/simulated/floor/plasteel,
 /area/security/processing)
 "bIT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/brig)
+/obj/structure/flora/ausbushes/ppflowers,
+/mob/living/simple_animal/pig/Sanya,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "bIV" = (
 /obj/structure/cable/orange{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
@@ -18313,23 +18111,15 @@
 /turf/simulated/floor/plating/airless,
 /area/toxins/test_area)
 "bJx" = (
-/obj/machinery/light/small,
+/obj/effect/landmark/event/lightsout,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/library)
+/area/hydroponics)
 "bJy" = (
-/obj/structure/chair/comfy/black{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
+/obj/structure/flora/ausbushes/grassybush,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "bJz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18337,8 +18127,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/chair/stool,
-/obj/effect/landmark/start/civilian,
+/obj/structure/table/wood,
+/obj/structure/table/wood,
+/obj/item/candle,
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
@@ -18365,13 +18156,15 @@
 	dir = 4
 	},
 /obj/structure/table/wood,
-/obj/item/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = -29
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -2;
+	pixel_y = 4
 	},
-/obj/item/kitchen/utensil/fork,
-/obj/machinery/light,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 2;
+	pixel_y = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
@@ -18382,7 +18175,7 @@
 	dir = 4;
 	network = list("SS13","CE")
 	},
-/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/computer/area_atmos,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -18494,8 +18287,7 @@
 /area/engine/gravitygenerator)
 "bJY" = (
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /obj/machinery/light{
 	dir = 1
@@ -18540,12 +18332,6 @@
 	icon_state = "redcorner"
 	},
 /area/security/lobby)
-"bKn" = (
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/fitness)
 "bKp" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -18556,16 +18342,18 @@
 /turf/simulated/floor/plasteel,
 /area/security/seceqstorage)
 "bKq" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/camera{
-	c_tag = "Fitness North";
-	dir = 9
+/obj/machinery/door/airlock{
+	id_tag = "cabin3";
+	name = "Cabin"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
-/area/crew_quarters/fitness)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/wood,
+/area/crew_quarters/cabin3)
 "bKr" = (
 /obj/structure/cable/orange{
 	icon_state = "1-8"
@@ -18577,23 +18365,17 @@
 /turf/simulated/floor/plasteel,
 /area/security/seceqstorage)
 "bKu" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -32
+/obj/machinery/door/airlock{
+	name = "Bar Access";
+	req_access = list(25)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/chair/stool,
-/obj/machinery/camera{
-	c_tag = "Bar South";
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bKx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -18627,8 +18409,7 @@
 /obj/item/pickaxe/mini,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -18692,8 +18473,7 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -18738,6 +18518,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -18761,8 +18544,7 @@
 /area/medical/medbreak)
 "bLb" = (
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/door_control{
 	id = "Secure Armory";
@@ -18854,7 +18636,6 @@
 /obj/effect/landmark/start/geneticist,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/simulated/floor/plasteel{
@@ -18971,103 +18752,67 @@
 /obj/item/storage/belt/medical,
 /obj/item/storage/pill_bottle,
 /obj/item/storage/pill_bottle/patch_pack,
-/obj/item/radio/intercom{
-	pixel_y = -30
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
+	dir = 8;
 	icon_state = "whitered"
 	},
 /area/security/medbay)
-"bLA" = (
-/obj/machinery/door_control{
-	desiredstate = 1;
-	id = "cabin4";
-	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
-	specialfunctions = 4;
-	pixel_x = 26
+"bLC" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
-/obj/structure/dresser,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
+"bLD" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
+"bLF" = (
+/obj/structure/rack,
+/obj/item/grown/log,
+/obj/item/grown/log,
+/obj/item/grown/log,
+/obj/item/grown/log,
+/obj/item/hatchet,
+/turf/simulated/floor/wood,
+/area/library)
+"bLG" = (
+/obj/structure/weightmachine/stacklifter,
 /obj/item/radio/intercom{
-	pixel_x = 26;
 	pixel_y = 28
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/crew_quarters/cabin4)
-"bLC" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/item/clothing/under/lawyer/black,
-/obj/item/clothing/under/lawyer/blue,
-/obj/item/clothing/under/kilt,
-/obj/item/clothing/head/beret,
-/obj/machinery/light{
-	dir = 1;
-	in_use = 1
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/cabin3)
-"bLD" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
+/turf/simulated/floor/carpet/cyan,
 /area/crew_quarters/fitness)
-"bLF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/crew_quarters/fitness)
-"bLG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/port/south)
 "bLH" = (
-/obj/structure/disposaloutlet,
-/obj/effect/turf_decal/stripes/full,
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/machinery/newscaster{
+	pixel_y = -28;
+	dir = 1
 	},
-/area/library)
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/item/clothing/glasses/hud/hydroponic,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkgreenfull"
+	},
+/area/hydroponics)
 "bLI" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/machinery/door/airlock/public/glass{
+	name = "Library"
 	},
-/obj/item/pen/invisible,
-/obj/item/stack/packageWrap,
-/obj/item/destTagger,
-/obj/item/toy/figure/librarian,
-/obj/item/book/codex_gigas,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/carpet/green,
 /area/library)
 "bLO" = (
 /obj/machinery/door/window/eastright{
@@ -19116,10 +18861,11 @@
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "bLT" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 1
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/turf/simulated/floor/plasteel,
 /area/hallway/primary/fore/west)
 "bLU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -19135,8 +18881,7 @@
 "bLW" = (
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/machinery/vending/engivend,
 /turf/simulated/floor/plasteel{
@@ -19214,8 +18959,7 @@
 	network = list("SS13","CE")
 	},
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -19290,8 +19034,7 @@
 "bMj" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical{
@@ -19374,8 +19117,7 @@
 /obj/machinery/light,
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -19467,16 +19209,19 @@
 /turf/simulated/wall,
 /area/crew_quarters/cabin4)
 "bNb" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/crew_quarters/fitness)
-"bNc" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/hallway/primary/fore/west)
 "bNf" = (
 /obj/machinery/status_display{
 	layer = 4
@@ -19484,25 +19229,26 @@
 /turf/simulated/wall,
 /area/teleporter/quantum/security)
 "bNg" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/simulated/floor/carpet,
-/area/library)
+/obj/machinery/reagentgrinder{
+	pixel_x = -1;
+	pixel_y = 9
+	},
+/obj/structure/table/reinforced,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
 "bNh" = (
-/obj/structure/table/wood,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
 	},
-/area/library)
+/area/mimeoffice)
 "bNi" = (
 /obj/structure/table/wood,
 /obj/item/folder,
@@ -19621,8 +19367,7 @@
 	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/chiefs_office)
@@ -19664,11 +19409,11 @@
 /turf/simulated/wall,
 /area/engine/engine_smes)
 "bNz" = (
-/obj/structure/table,
+/obj/structure/railing,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
+	icon_state = "dark"
 	},
-/area/crew_quarters/kitchen)
+/area/crew_quarters/fitness)
 "bNA" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow{
@@ -19730,12 +19475,9 @@
 /turf/simulated/wall,
 /area/crew_quarters/cabin2)
 "bOd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/carpet,
-/area/library)
+/obj/structure/flora/ausbushes/palebush,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "bOf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19809,8 +19551,7 @@
 /area/atmos)
 "bOr" = (
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /obj/structure/chair/stool/bar{
 	dir = 8
@@ -19860,8 +19601,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -20023,8 +19763,7 @@
 "bOG" = (
 /obj/machinery/computer/station_alert,
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -20111,11 +19850,12 @@
 /turf/simulated/floor/wood,
 /area/security/hos)
 "bOV" = (
-/obj/machinery/alarm{
-	pixel_y = 24
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/cabin2)
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/wood,
+/area/library)
 "bOW" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/structure/ore_box,
@@ -20123,41 +19863,43 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "bOX" = (
-/obj/structure/weightmachine/stacklifter,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/turf/simulated/floor/carpet/cyan,
-/area/crew_quarters/fitness)
-"bOY" = (
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/fitness)
-"bPa" = (
-/obj/structure/railing{
+/obj/machinery/shower{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/effect/turf_decal/bot_red,
+/turf/simulated/floor/plasteel/white,
+/area/toxins/xenobiology)
+"bPa" = (
+/obj/item/radio/intercom{
+	pixel_x = -28
 	},
-/area/crew_quarters/fitness)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "bPf" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Library"
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "escape"
 	},
-/turf/simulated/floor/carpet/green,
-/area/library)
+/area/space)
 "bPi" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/wood,
 /area/library)
 "bPj" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/carpet/green,
-/area/library)
+/obj/structure/table/reinforced,
+/obj/item/toy/figure/chef,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
 "bPo" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
@@ -20249,8 +19991,7 @@
 /obj/machinery/light,
 /obj/machinery/suit_storage_unit/ce,
 /obj/machinery/computer/guestpass{
-	pixel_x = -28;
-	pixel_y = null
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/chiefs_office)
@@ -20263,8 +20004,7 @@
 "bPB" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/machinery/computer/card/minor/ce{
 	dir = 1
@@ -20288,7 +20028,6 @@
 "bPD" = (
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -20332,7 +20071,7 @@
 	dir = 5;
 	icon_state = "darkyellow"
 	},
-/area/maintenance/engineering)
+/area/engine/engineering)
 "bPG" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -20412,7 +20151,6 @@
 "bPN" = (
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -20467,81 +20205,56 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/processing)
-"bQe" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/fitness)
 "bQg" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
 /area/medical/research/restroom)
-"bQh" = (
-/obj/structure/railing{
-	dir = 4
-	},
+"bQj" = (
+/obj/structure/cult/archives,
+/obj/item/book/codex_gigas,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/crew_quarters/fitness)
-"bQj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Library"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/green,
 /area/library)
 "bQk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id_tag = "kitchen1"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/door/window/westright{
+	dir = 4;
+	name = "Kitchen";
+	req_access_txt = "28"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/light/small,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
 	},
-/turf/simulated/floor/carpet/green,
-/area/library)
+/area/crew_quarters/kitchen)
 "bQl" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/door_control{
+	id = "kitchen1";
+	name = "Privacy Shutters";
+	pixel_y = -24
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table/reinforced,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
 	},
-/turf/simulated/floor/carpet/green,
-/area/library)
+/area/crew_quarters/kitchen)
 "bQm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/structure/table/reinforced,
+/obj/machinery/kitchen_machine/microwave{
+	pixel_y = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/green,
-/area/library)
+/area/crew_quarters/kitchen)
 "bQq" = (
 /obj/machinery/light{
 	dir = 8
@@ -20633,8 +20346,7 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -20655,6 +20367,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -20698,8 +20411,7 @@
 "bQK" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering Power Storage";
@@ -20796,15 +20508,18 @@
 	},
 /area/crew_quarters/sleep/secondary)
 "bRd" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
+/obj/machinery/requests_console{
+	department = "Crew Quarters";
+	name = "Crew Quarters Requests Console";
+	pixel_y = 30
 	},
-/obj/machinery/vending/snack,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/area/crew_quarters/fitness)
+/area/crew_quarters/locker)
 "bRf" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -20815,30 +20530,48 @@
 	},
 /area/storage/primary)
 "bRg" = (
-/obj/structure/railing{
-	dir = 6
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/crew_quarters/fitness)
-"bRh" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/brute,
 /turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
-"bRi" = (
+/area/crew_quarters/locker)
+"bRh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/green,
-/area/library)
-"bRj" = (
-/obj/item/radio/intercom{
-	pixel_x = -28;
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/primary/fore/west)
+"bRi" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24;
 	name = "custom placement"
 	},
+/obj/machinery/camera{
+	c_tag = "Service Asteroid Hallway 6";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/port/south)
+"bRj" = (
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -20860,8 +20593,7 @@
 /area/crew_quarters/sleep/secondary)
 "bRn" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -20905,42 +20637,23 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/maintenance/engineering)
+/area/engine/break_room)
 "bRt" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_y = 28;
-	name = "north bump"
-	},
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/suit_storage_unit/atmos,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/atmos)
 "bRu" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
-	},
+/obj/machinery/suit_storage_unit/atmos,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkyellow"
 	},
 /area/atmos)
-"bRv" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 10
-	},
-/obj/effect/spawner/window/reinforced/plasma,
-/turf/simulated/floor/plating,
-/area/atmos/distribution)
 "bRw" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 6
@@ -21052,8 +20765,7 @@
 /area/engine/engine_smes)
 "bRJ" = (
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plasteel{
@@ -21100,14 +20812,22 @@
 /turf/simulated/floor/carpet/black,
 /area/bridge)
 "bRP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "kitchen2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/door/window/westleft{
+	dir = 2;
+	name = "Kitchen";
+	req_access_txt = "28"
 	},
-/turf/simulated/floor/carpet/green,
-/area/library)
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull";
+	tag = "icon-redfull (NORTHWEST)"
+	},
+/area/crew_quarters/kitchen)
 "bRQ" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/carpet/black,
@@ -21130,17 +20850,12 @@
 /turf/simulated/floor/carpet/black,
 /area/bridge)
 "bSf" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/port/south)
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "bSg" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -21191,14 +20906,14 @@
 /turf/simulated/floor/engine/o2,
 /area/atmos)
 "bSn" = (
-/obj/machinery/door/airlock{
-	id_tag = "cabin1";
-	name = "Cabin"
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/cabin1)
+/turf/simulated/floor/carpet/green,
+/area/library)
 "bSp" = (
 /obj/machinery/space_heater,
+/obj/effect/turf_decal/bot,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "bSq" = (
@@ -21329,13 +21044,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/port)
-"bSS" = (
-/obj/structure/closet/boxinggloves,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
 "bST" = (
 /obj/machinery/door_control{
 	id = "CargoWarehouse";
@@ -21350,9 +21058,11 @@
 	},
 /area/quartermaster/storage)
 "bSU" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/wood,
-/area/library)
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
 "bSW" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
@@ -21411,11 +21121,6 @@
 	icon_state = "darkyellow"
 	},
 /area/atmos)
-"bTc" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/effect/spawner/window/reinforced/plasma,
-/turf/simulated/floor/plating,
-/area/atmos/distribution)
 "bTd" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow";
@@ -21434,8 +21139,7 @@
 "bTf" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -21555,7 +21259,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
 /area/atmos/distribution)
@@ -21602,8 +21305,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plasteel{
@@ -21625,8 +21327,7 @@
 /area/maintenance/fpmaint)
 "bTN" = (
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/structure/closet/wardrobe/virology_white,
 /turf/simulated/floor/plasteel{
@@ -21692,60 +21393,49 @@
 	},
 /area/security/seceqstorage)
 "bTZ" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	name = "north bump"
-	},
+/obj/item/soap/nanotrasen,
+/obj/structure/curtain/open/shower,
 /turf/simulated/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "bUb" = (
-/obj/structure/mirror{
-	pixel_y = 32
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/sink{
-	pixel_y = 24
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
+/area/library)
 "bUc" = (
 /turf/simulated/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "bUe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24;
+	name = "custom placement"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "neutralcorner"
 	},
-/area/crew_quarters/fitness)
+/area/hallway/primary/port/south)
 "bUf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/vending/autodrobe,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/fitness)
+/obj/effect/landmark/event/lightsout,
+/turf/simulated/floor/carpet/red,
+/area/chapel/main)
 "bUg" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/fitness)
+/turf/simulated/floor/carpet/green,
+/area/library)
 "bUj" = (
 /turf/simulated/floor/engine{
 	name = "air floor";
@@ -21835,8 +21525,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/engine{
 	slowdown = -0.3
@@ -21882,19 +21571,18 @@
 	},
 /area/security/seceqstorage)
 "bUH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/machinery/door_control{
+	id = "mechanicgate";
+	name = "Mechanic Pod Door";
+	pixel_x = 24;
+	pixel_y = 24;
+	req_access = list(70)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/light_switch{
+/turf/simulated/floor/plasteel{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	icon_state = "darkyellow"
 	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
+/area/engine/mechanic_workshop/hangar)
 "bUK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -22033,8 +21721,7 @@
 "bVb" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/machinery/porta_turret,
 /turf/simulated/floor/plasteel{
@@ -22057,7 +21744,6 @@
 "bVj" = (
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -22069,7 +21755,7 @@
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/crew_quarters/toilet)
+/area/chapel/office)
 "bVm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -22256,36 +21942,27 @@
 	},
 /area/medical/medbay)
 "bVL" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/storage/firstaid/o2,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/fitness)
-"bVM" = (
-/obj/effect/spawner/random_spawners/cobweb_left_frequent,
-/turf/simulated/floor/plating,
-/area/maintenance/port)
-"bVN" = (
-/obj/machinery/camera{
-	c_tag = "Chapel West";
-	dir = 6
-	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "chapel"
 	},
 /area/chapel/main)
+"bVM" = (
+/obj/effect/spawner/random_spawners/cobweb_left_frequent,
+/turf/simulated/floor/plating,
+/area/maintenance/port)
+"bVN" = (
+/obj/item/radio/intercom{
+	pixel_y = 28
+	},
+/obj/machinery/hydroponics/constructable,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkgreenfull"
+	},
+/area/hydroponics)
 "bVO" = (
 /obj/structure/sign/holy,
 /turf/simulated/wall,
@@ -22295,18 +21972,18 @@
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/apmaint2)
 "bVR" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	name = "north bump"
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/camera/autoname{
+	dir = 6
 	},
-/obj/structure/chair/sofa/pew/right{
-	dir = 4
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "chapel"
+	dir = 8;
+	icon_state = "darkgreenfull"
 	},
-/area/chapel/main)
+/area/hydroponics)
 "bVS" = (
 /turf/simulated/floor/carpet/red,
 /area/chapel/main)
@@ -22359,12 +22036,11 @@
 	},
 /area/atmos)
 "bWa" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan,
-/obj/effect/spawner/window/reinforced/plasma,
-/turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "darkyellow"
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
 	},
+/obj/effect/spawner/window/reinforced/plasma,
+/turf/simulated/floor/plating,
 /area/atmos/distribution)
 "bWb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
@@ -22400,18 +22076,18 @@
 	},
 /area/atmos)
 "bWe" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 9
-	},
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
 /area/atmos/distribution)
 "bWf" = (
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
@@ -22424,18 +22100,19 @@
 /obj/structure/closet,
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/maintenance/fore2)
+"bWl" = (
+/obj/machinery/chem_master/condimaster,
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/kitchen)
 "bWm" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/chair/sofa/pew/right{
-	dir = 4
+/obj/structure/sink{
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "chapel"
+	dir = 8;
+	icon_state = "darkgreenfull"
 	},
-/area/chapel/main)
+/area/hydroponics)
 "bWn" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -22499,10 +22176,13 @@
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/port)
 "bWG" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating/asteroid/ancient,
-/area/maintenance/port)
+/obj/structure/table/wood,
+/obj/item/storage/bag/books,
+/obj/item/taperecorder,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/library)
 "bWJ" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/crayons,
@@ -22514,9 +22194,24 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/locker)
 "bWL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet/red,
-/area/chapel/main)
+/obj/machinery/door_control{
+	desiredstate = 1;
+	id = "privateroom";
+	name = "Privacy Room Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_y = -26;
+	specialfunctions = 4
+	},
+/obj/machinery/button/windowtint{
+	anchored = 1;
+	id = "privateroom";
+	pixel_y = -36
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "bWN" = (
 /obj/machinery/atmospherics/unary/outlet_injector/on{
 	dir = 1;
@@ -22525,12 +22220,14 @@
 /turf/simulated/floor/engine/co2,
 /area/atmos)
 "bWO" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/machinery/light{
-	on = 1
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/orange{
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/cabin2)
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "bWP" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
@@ -22629,8 +22326,7 @@
 	pixel_y = -32
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -22783,30 +22479,20 @@
 	},
 /area/bridge)
 "bXV" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "redyellowfull"
 	},
-/area/crew_quarters/fitness)
+/area/crew_quarters/bar)
 "bXW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/railing{
+	dir = 10
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Holodeck"
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
 "bXX" = (
 /obj/structure/cable/orange{
@@ -22824,25 +22510,21 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/port/south)
 "bYa" = (
-/obj/structure/chair/sofa/pew/right{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
+/obj/effect/landmark/start/botanist,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "chapel"
+	icon_state = "dark"
 	},
-/area/chapel/main)
+/area/hydroponics)
 "bYc" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/engine/co2,
@@ -22886,8 +22568,7 @@
 /area/bridge)
 "bYu" = (
 /obj/item/radio/intercom{
-	pixel_x = -28;
-	name = "custom placement"
+	pixel_x = -28
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -22896,30 +22577,33 @@
 	},
 /area/hallway/primary/port/north)
 "bYw" = (
-/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "white"
 	},
-/area/crew_quarters/fitness)
+/area/crew_quarters/kitchen)
 "bYx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/structure/janitorialcart,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/turf/simulated/floor/plating,
+/area/space)
+"bYy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/civilian,
+/turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
 "bYz" = (
 /obj/machinery/computer/card{
@@ -22935,15 +22619,9 @@
 /turf/simulated/floor/carpet/black,
 /area/bridge)
 "bYC" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/closet/coffin,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "bYE" = (
 /obj/machinery/computer/communications{
 	dir = 1
@@ -22985,8 +22663,7 @@
 	dir = 6
 	},
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/light{
@@ -23073,26 +22750,31 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/port/south)
 "bZf" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Broom Closet"
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "library"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/port/south)
+/area/library)
 "bZg" = (
-/turf/simulated/mineral/ancient,
-/area/chapel/main)
+/obj/structure/flora/ausbushes/reedbush,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "bZi" = (
-/obj/structure/chair{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/machinery/light/small,
-/turf/simulated/floor/plasteel,
-/area/chapel/main)
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/toilet)
 "bZj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23113,19 +22795,17 @@
 	},
 /area/ai_monitored/storage/eva)
 "bZl" = (
-/obj/machinery/door/morgue{
-	name = "Confession Room";
-	req_access = list(22)
-	},
-/turf/simulated/floor/plating,
-/area/chapel/office)
+/obj/structure/flora/ausbushes/stalkybush,
+/obj/machinery/light,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "bZm" = (
-/obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/carpet/black,
-/area/chapel/office)
+/turf/simulated/floor/carpet/green,
+/area/library)
 "bZs" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -23163,15 +22843,22 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/port/south)
 "bZJ" = (
-/obj/machinery/camera{
-	c_tag = "Chapel Office";
-	dir = 5
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/disposal,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkgreenfull"
 	},
-/turf/simulated/floor/carpet/black,
-/area/chapel/office)
+/area/hydroponics)
+"bZN" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/library)
 "bZQ" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -23205,12 +22892,10 @@
 	},
 /area/medical/research/restroom)
 "bZX" = (
-/obj/machinery/newscaster{
-	pixel_x = -28;
-	name = "west bump";
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -23246,7 +22931,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -23258,10 +22942,11 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/port/south)
 "cau" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/carpet/black,
-/area/chapel/office)
+/obj/machinery/status_display{
+	layer = 4
+	},
+/turf/simulated/mineral/ancient,
+/area/library)
 "cav" = (
 /turf/simulated/wall,
 /area/maintenance/auxsolarport)
@@ -23357,7 +23042,6 @@
 "caX" = (
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/structure/cable/orange{
@@ -23376,104 +23060,77 @@
 /area/clownoffice/secret)
 "cbd" = (
 /obj/machinery/disposal,
-/obj/machinery/newscaster{
-	pixel_x = -28;
-	name = "west bump";
-	dir = 4
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/port/south)
 "cbe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/port/south)
 "cbf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/wood,
+/area/library)
 "cbg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -24
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/turf/simulated/floor/carpet/green,
+/area/library)
 "cbh" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
 	},
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 32
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/port/south)
+"cbl" = (
+/obj/structure/table,
+/obj/item/desk_bell{
+	pixel_x = 7;
+	pixel_y = 7;
+	anchored = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
-"cbl" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/obj/item/assembly/mousetrap/armed,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/maintenance/gambling_den2)
 "cbn" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
+/obj/structure/cable/orange{
+	icon_state = "2-4"
 	},
-/area/maintenance/gambling_den2)
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/port/south)
 "cbw" = (
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/fore2)
@@ -23529,14 +23186,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -23604,22 +23260,21 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/item/folder,
 /obj/item/toy/figure/miner,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "cbT" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/tranquillite{
 	name = "Mime's Office";
 	req_access = list(44)
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
+/obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
@@ -23678,8 +23333,7 @@
 /obj/item/restraints/handcuffs,
 /obj/machinery/light,
 /obj/item/radio/intercom{
-	pixel_x = -28;
-	name = "custom placement"
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -23729,8 +23383,7 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
@@ -23754,8 +23407,7 @@
 /obj/machinery/light,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -23870,16 +23522,12 @@
 /turf/simulated/mineral/ancient,
 /area/mine/unexplored/cere/research)
 "ccY" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/green,
 /area/library)
 "ccZ" = (
 /obj/structure/cable/orange{
@@ -23890,7 +23538,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -24043,7 +23690,6 @@
 "cdS" = (
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -24088,7 +23734,6 @@
 "ceb" = (
 /obj/machinery/newscaster{
 	pixel_x = -28;
-	name = "west bump";
 	dir = 4
 	},
 /obj/machinery/recharge_station,
@@ -24159,7 +23804,6 @@
 "cet" = (
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -24179,8 +23823,7 @@
 "cex" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/wood,
 /area/security/hos)
@@ -24303,7 +23946,7 @@
 "ceY" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
+/obj/structure/cable/orange{
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/wood,
@@ -24325,8 +23968,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -24382,7 +24024,6 @@
 "cfB" = (
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -24395,13 +24036,11 @@
 "cfC" = (
 /obj/machinery/disposal,
 /obj/item/radio/intercom{
-	pixel_x = -28;
-	name = "custom placement"
+	pixel_x = -28
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -24416,8 +24055,7 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "brown"
@@ -24583,8 +24221,7 @@
 /area/security/brig)
 "cgj" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -24632,8 +24269,7 @@
 "cgz" = (
 /obj/machinery/computer/prisoner,
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/camera{
 	c_tag = "Brig Warden's Office"
@@ -24836,8 +24472,7 @@
 	dir = 6
 	},
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /obj/structure/chair/office/light,
 /turf/simulated/floor/plasteel{
@@ -24846,8 +24481,6 @@
 	},
 /area/security/checkpoint2)
 "chI" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "yellow"
@@ -24870,24 +24503,31 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/aft/west)
 "chS" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/obj/structure/toilet{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/power/apc{
+	pixel_y = -26
+	},
+/obj/structure/cable/orange,
+/obj/item/radio/intercom{
+	pixel_x = -26;
+	pixel_y = -28
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/cabin4)
+"chT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door_control{
-	id = "b1";
-	name = "Privacy Bolts";
-	normaldoorcontrol = 1;
-	pixel_x = -24;
-	specialfunctions = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/locker)
-"chT" = (
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/locker)
+/turf/simulated/floor/wood,
+/area/crew_quarters/cabin4)
 "chV" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -24923,8 +24563,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/newscaster{
-	pixel_y = 28;
-	name = "north bump"
+	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -25092,8 +24731,7 @@
 /area/hallway/spacebridge/dockmed)
 "cjd" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/structure/chair,
 /obj/structure/disposalpipe/segment{
@@ -25262,8 +24900,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -25274,13 +24911,16 @@
 	},
 /area/hallway/secondary/entry)
 "cjJ" = (
-/obj/machinery/newscaster{
-	pixel_y = 28;
-	name = "north bump"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/carpet,
-/area/library)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
 "cjL" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 1
@@ -25375,8 +25015,7 @@
 	dir = 6
 	},
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25428,8 +25067,7 @@
 	dir = 1
 	},
 /obj/machinery/newscaster{
-	pixel_y = 28;
-	name = "north bump"
+	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -25463,8 +25101,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -25493,8 +25130,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
@@ -25567,8 +25203,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel/white,
 /area/toxins/hallway)
@@ -25578,8 +25213,7 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -25609,8 +25243,7 @@
 "clH" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
@@ -25745,8 +25378,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
@@ -25834,8 +25466,7 @@
 	dir = 1
 	},
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -25845,7 +25476,6 @@
 "cnt" = (
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -25919,8 +25549,7 @@
 "cnP" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -26035,8 +25664,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/machinery/flasher/portable,
 /obj/effect/decal/warning_stripes/red/hollow,
@@ -26195,8 +25823,7 @@
 "cpF" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -26218,6 +25845,19 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/bridge)
+"cpK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/carpet/black,
+/area/chapel/office)
 "cpM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -26295,8 +25935,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo Hall West";
@@ -26351,8 +25990,7 @@
 "cqj" = (
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -26370,8 +26008,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
@@ -26383,8 +26020,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26408,7 +26044,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -26458,8 +26093,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -26597,8 +26231,7 @@
 /area/security/prison/cell_block/A)
 "crh" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
@@ -26643,7 +26276,6 @@
 "crI" = (
 /obj/machinery/newscaster{
 	pixel_y = -28;
-	name = "south bump";
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -26698,8 +26330,7 @@
 /obj/machinery/light,
 /obj/machinery/disposal,
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -26721,8 +26352,7 @@
 /area/security/armory)
 "csa" = (
 /obj/machinery/firealarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/effect/turf_decal/siding/brown,
 /turf/simulated/floor/wood/fancy/light,
@@ -26736,17 +26366,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/fore2)
-"csf" = (
-/obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
-	},
-/obj/machinery/camera{
-	c_tag = "Dorm Commons South";
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
 "csh" = (
 /turf/simulated/wall,
 /area/hallway/spacebridge/comeng)
@@ -26788,8 +26407,7 @@
 /obj/machinery/cell_charger,
 /obj/item/storage/firstaid/regular,
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27087,8 +26705,7 @@
 /obj/item/reagent_containers/dropper/precision,
 /obj/item/reagent_containers/dropper/precision,
 /obj/machinery/firealarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/camera{
 	c_tag = "Research Test Lab North";
@@ -27148,7 +26765,6 @@
 "cuz" = (
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -27236,8 +26852,7 @@
 /area/toxins/misc_lab)
 "cuT" = (
 /obj/machinery/firealarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -27369,8 +26984,7 @@
 "cvE" = (
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/machinery/door_control{
 	id = "scilockdown";
@@ -27390,8 +27004,7 @@
 /obj/machinery/light,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel/white,
 /area/crew_quarters/hor)
@@ -27415,8 +27028,7 @@
 "cvR" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/machinery/chem_heater,
 /turf/simulated/floor/engine,
@@ -27444,8 +27056,7 @@
 /obj/machinery/light,
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27477,10 +27088,15 @@
 	},
 /area/teleporter/quantum/science)
 "cww" = (
-/obj/structure/girder,
-/obj/item/stack/sheet/metal,
-/turf/simulated/floor/plating,
-/area/maintenance/fore2)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/cabin2)
 "cwE" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -27535,7 +27151,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange,
@@ -27563,7 +27178,7 @@
 	dir = 6;
 	icon_state = "darkyellow"
 	},
-/area/maintenance/engineering)
+/area/engine/break_room)
 "cxg" = (
 /turf/simulated/wall/r_wall,
 /area/toxins/storage)
@@ -27574,8 +27189,7 @@
 "cxj" = (
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "west bump";
-	pixel_x = -25
+	pixel_x = -24
 	},
 /obj/structure/table/reinforced,
 /obj/item/storage/belt/utility,
@@ -27703,13 +27317,16 @@
 /turf/simulated/floor/plating,
 /area/security/warden)
 "cxU" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
+/obj/machinery/newscaster{
+	pixel_x = -32
 	},
-/area/maintenance/fore2)
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/crew_quarters/cabin1)
 "cxW" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -27786,7 +27403,6 @@
 "cyz" = (
 /obj/machinery/light/small,
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -24
 	},
 /obj/structure/cable/orange{
@@ -27968,7 +27584,6 @@
 "czA" = (
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -28015,8 +27630,7 @@
 /area/maintenance/apmaint2)
 "czN" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
@@ -28189,8 +27803,7 @@
 /area/security/prison/cell_block/A)
 "cAs" = (
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/effect/landmark/event/lightsout,
 /turf/simulated/floor/plasteel{
@@ -28209,8 +27822,7 @@
 /area/maintenance/apmaint2)
 "cAA" = (
 /obj/machinery/firealarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -28258,8 +27870,7 @@
 "cAY" = (
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -28276,8 +27887,7 @@
 /area/security/prison/cell_block/A)
 "cBb" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -28529,9 +28139,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
-	cell_type = 25000;
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/stripes/end,
@@ -28582,34 +28190,40 @@
 	},
 /area/gateway)
 "cCp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "cCw" = (
 /turf/simulated/floor/engine,
 /area/toxins/test_chamber)
 "cCB" = (
-/obj/structure/janitorialcart,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
-/turf/simulated/floor/plating,
-/area/hallway/primary/port/south)
-"cCC" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 28;
-	name = "custom placement"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/closet/wardrobe/pjs,
+/obj/machinery/biogenerator,
 /turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkgreenfull"
+	},
+/area/hydroponics)
+"cCC" = (
+/obj/machinery/door_control{
+	desiredstate = 1;
+	id = "cabin1";
+	name = "Door Bolt Control";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	pixel_y = -26
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/area/crew_quarters/locker)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/crew_quarters/cabin1)
 "cCD" = (
-/obj/item/flag/mime,
+/obj/structure/statue/tranquillite/mime/unique,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_regular_floor = "yellowsiding";
@@ -28630,14 +28244,9 @@
 	},
 /area/hallway/primary/port/north)
 "cCJ" = (
-/obj/machinery/disposal,
-/obj/machinery/requests_console{
-	department = "Crew Quarters";
-	name = "Crew Quarters Requests Console";
-	pixel_y = 30
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -28645,15 +28254,16 @@
 	},
 /area/crew_quarters/locker)
 "cCK" = (
-/obj/machinery/newscaster{
-	pixel_y = 28;
-	name = "north bump"
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "neutralcorner"
 	},
-/area/crew_quarters/locker)
+/area/hallway/primary/fore/west)
 "cCL" = (
 /obj/structure/closet/wardrobe/black,
 /turf/simulated/floor/plasteel{
@@ -28663,8 +28273,7 @@
 /area/crew_quarters/locker)
 "cCM" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/photocopier,
 /turf/simulated/floor/wood,
@@ -28714,9 +28323,9 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
+/obj/effect/landmark/start/blueshield,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
@@ -28986,19 +28595,23 @@
 /obj/machinery/hydroponics/soil,
 /obj/machinery/newscaster{
 	pixel_y = -28;
-	name = "south bump";
 	dir = 1
 	},
 /turf/simulated/floor/grass,
 /area/hallway/secondary/garden)
 "cFe" = (
-/obj/machinery/door/window/westright{
-	dir = 2;
-	name = "Hydroponics Back Room";
-	req_access = list(35)
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel,
-/area/hydroponics)
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/landmark/start/librarian,
+/turf/simulated/floor/carpet,
+/area/library)
 "cFf" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -29010,8 +28623,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -29076,8 +28688,7 @@
 	icon_state = "2-8"
 	},
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -29097,7 +28708,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -29206,16 +28816,19 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
 "cFH" = (
-/obj/machinery/door/window/northleft{
-	name = "Chapel Mail";
-	req_access = list(22)
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/carpet/black,
-/area/chapel/office)
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkgreenfull"
+	},
+/area/hydroponics)
 "cFI" = (
 /obj/structure/chair{
 	dir = 8
@@ -29241,8 +28854,7 @@
 	icon_state = "2-8"
 	},
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -29400,29 +29012,31 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/machinery/computer/guestpass{
+	pixel_x = -30
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay)
 "cGw" = (
-/obj/item/radio/intercom{
-	pixel_x = -28;
-	name = "custom placement"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
-"cGx" = (
-/obj/machinery/status_display{
-	layer = 4
-	},
 /turf/simulated/wall,
-/area/crew_quarters/fitness)
+/area/chapel/office)
+"cGx" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/item/clothing/under/blacktango,
+/obj/item/clothing/suit/leathercoat,
+/obj/item/clothing/head/bowlerhat,
+/obj/item/clothing/head/fedora,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/crew_quarters/cabin1)
 "cGz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -29441,14 +29055,6 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
-"cGB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4
-	},
-/area/crew_quarters/locker)
 "cGC" = (
 /obj/effect/landmark/start/engineer,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -29474,12 +29080,17 @@
 	},
 /area/crew_quarters/locker)
 "cGE" = (
-/obj/structure/closet/wardrobe/grey,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/crew_quarters/locker)
+/area/hallway/primary/fore/west)
 "cGJ" = (
 /obj/machinery/drone_fabricator,
 /obj/machinery/camera/autoname,
@@ -29496,8 +29107,7 @@
 /obj/item/clothing/glasses/hud/health,
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -29545,8 +29155,7 @@
 "cHi" = (
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -29587,6 +29196,9 @@
 	dir = 8;
 	icon_state = "pipe-y"
 	},
+/obj/machinery/computer/guestpass{
+	pixel_x = 30
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkredcorners"
@@ -29596,6 +29208,7 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/event/lightsout,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -29611,15 +29224,13 @@
 "cHA" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "brown"
 	},
 /area/quartermaster/qm)
 "cHB" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -29693,8 +29304,7 @@
 /obj/machinery/light,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
@@ -29755,7 +29365,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/stripes/end{
@@ -29908,7 +29517,6 @@
 "cIO" = (
 /obj/machinery/newscaster{
 	pixel_x = 28;
-	name = "east bump";
 	dir = 8
 	},
 /obj/structure/flora/rock/jungle,
@@ -29939,13 +29547,10 @@
 /turf/simulated/floor/grass,
 /area/medical/medbay)
 "cIX" = (
-/obj/machinery/cryopod{
-	dir = 1
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreen"
+	icon_state = "dark"
 	},
-/area/crew_quarters/sleep)
+/area/library)
 "cIZ" = (
 /obj/machinery/light{
 	dir = 8
@@ -29996,8 +29601,7 @@
 /area/hallway/primary/central)
 "cJf" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30026,7 +29630,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -30247,8 +29850,7 @@
 "cJO" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -30268,8 +29870,7 @@
 "cJT" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -30290,8 +29891,7 @@
 /area/hallway/primary/central)
 "cJW" = (
 /obj/item/radio/intercom{
-	pixel_x = 28;
-	name = "custom placement"
+	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -30375,7 +29975,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -30404,8 +30003,7 @@
 "cKR" = (
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /mob/living/simple_animal/pet/dog/fox/fennec/Fenya,
 /obj/structure/bed/dogbed,
@@ -30461,8 +30059,7 @@
 /obj/item/paper_bin/nanotrasen,
 /obj/item/camera,
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /obj/item/toy/figure/lawyer,
 /turf/simulated/floor/carpet,
@@ -30479,8 +30076,7 @@
 "cLt" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -30594,7 +30190,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/closet/wardrobe/xenos,
+/obj/structure/closet/wardrobe/grey,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -30654,7 +30250,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/maintenance/engineering)
+/area/engine/engineering)
 "cMg" = (
 /obj/structure/cable/orange{
 	icon_state = "0-2"
@@ -30700,8 +30296,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -30726,9 +30321,21 @@
 	},
 /area/security/brig)
 "cMy" = (
-/obj/machinery/vending/boozeomat,
-/turf/simulated/wall,
-/area/crew_quarters/bar)
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/eastleft{
+	base_state = "right";
+	icon_state = "right";
+	name = "Hydroponics";
+	req_access_txt = "35"
+	},
+/obj/item/desk_bell{
+	pixel_x = 7;
+	pixel_y = 7;
+	anchored = 1
+	},
+/turf/simulated/floor/plating,
+/area/hydroponics)
 "cMz" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/fore)
@@ -30826,7 +30433,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -30859,8 +30465,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/machinery/quantumpad/cere/cargo_arrivals{
 	name = "quantum pad"
@@ -30949,6 +30554,12 @@
 /obj/machinery/mineral/ore_redemption,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/window/brigdoor{
+	dir = 2;
+	id = "ORM";
+	name = "ORM Access";
+	req_one_access = list(31)
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkbrownfull"
@@ -30962,19 +30573,14 @@
 	c_tag = "Theatre Stage";
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/theatre)
 "cNk" = (
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/theatre)
 "cNm" = (
 /obj/structure/table/reinforced,
@@ -31010,9 +30616,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/theatre)
 "cNz" = (
 /obj/structure/table/wood,
@@ -31025,8 +30629,7 @@
 "cNC" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/structure/chair/office/dark,
 /obj/machinery/camera{
@@ -31069,9 +30672,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/theatre)
 "cNL" = (
 /obj/structure/table/wood,
@@ -31127,29 +30728,22 @@
 /area/maintenance/port)
 "cOa" = (
 /obj/structure/piano,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/theatre)
 "cOb" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/theatre)
 "cOc" = (
 /obj/structure/rack,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/theatre)
 "cOh" = (
 /turf/simulated/floor/plasteel{
@@ -31213,8 +30807,7 @@
 /area/medical/cmo)
 "cOv" = (
 /obj/machinery/firealarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluecorner"
@@ -31266,8 +30859,7 @@
 "cOE" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bottle/ether,
@@ -31313,6 +30905,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
 	},
+/obj/machinery/mecha_part_fabricator/spacepod,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "yellow"
@@ -31351,8 +30944,7 @@
 /area/medical/virology)
 "cOR" = (
 /obj/machinery/newscaster{
-	pixel_y = 28;
-	name = "north bump"
+	pixel_y = 32
 	},
 /obj/structure/filingcabinet,
 /turf/simulated/floor/plasteel{
@@ -31375,8 +30967,7 @@
 /obj/item/bedsheet/medical,
 /obj/structure/bed,
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -31397,14 +30988,14 @@
 	},
 /area/medical/virology)
 "cOV" = (
-/obj/machinery/door_control{
-	id = "mechanicgate";
-	name = "Mechanic Pod Door";
-	pixel_x = -24;
-	pixel_y = -24;
-	req_access = list(70)
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -24
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "yellow"
+	},
 /area/engine/mechanic_workshop)
 "cOZ" = (
 /obj/structure/cable/orange{
@@ -31470,26 +31061,21 @@
 	},
 /area/engine/engineering)
 "cPz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/dresser,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	name = "Bathroom"
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/locker)
+/area/crew_quarters/cabin1)
 "cPA" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -28
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
+/turf/simulated/floor/wood,
+/area/crew_quarters/cabin3)
 "cPB" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/railing{
@@ -31537,14 +31123,6 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/spacebridge/comeng)
-"cPM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4
-	},
-/area/crew_quarters/locker)
 "cPN" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -31657,11 +31235,20 @@
 	},
 /area/medical/cmostore)
 "cQc" = (
+/obj/effect/landmark/start/chef,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den2)
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
 "cQf" = (
 /obj/structure/closet/radiation,
 /turf/simulated/floor/plasteel{
@@ -31690,6 +31277,10 @@
 	random_basetype = /obj/structure/sign/poster/official
 	},
 /obj/structure/closet/wardrobe/white,
+/obj/machinery/camera{
+	c_tag = "Dorm Lockers";
+	dir = 9
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -31745,8 +31336,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/machinery/photocopier/faxmachine/longrange{
 	department = "Head of Personnel's Office"
@@ -31771,11 +31361,11 @@
 	pixel_y = 24;
 	req_access = list(56)
 	},
-/obj/machinery/photocopier/faxmachine{
-	department = "Chief Engineer's Office"
-	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/photocopier/faxmachine/longrange{
+	department = "Chief Engineer's Office"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/chiefs_office)
@@ -31791,11 +31381,6 @@
 	},
 /obj/item/paper_bin,
 /obj/item/toy/crayon/mime,
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_regular_floor = "yellowsiding";
@@ -31863,8 +31448,7 @@
 /obj/machinery/disposal,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -32011,8 +31595,7 @@
 /area/maintenance/fsmaint3)
 "cRt" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
@@ -32055,8 +31638,7 @@
 /area/maintenance/engineering)
 "cRM" = (
 /obj/item/radio/intercom{
-	pixel_x = -28;
-	name = "custom placement"
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -32228,8 +31810,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/structure/sign/directions/evac{
 	pixel_x = -1;
@@ -32416,7 +31997,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /turf/simulated/floor/plating,
@@ -32428,8 +32008,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
@@ -32483,10 +32062,8 @@
 	},
 /area/security/prison/cell_block/A)
 "cTf" = (
-/obj/structure/table,
-/obj/item/folder/white,
-/obj/item/reagent_containers/dropper,
-/obj/item/storage/box/gloves,
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -32497,7 +32074,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/maintenance/engineering)
+/area/engine/engineering)
 "cTh" = (
 /turf/simulated/wall,
 /area/maintenance/disposal/south)
@@ -32587,16 +32164,11 @@
 	},
 /area/security/prison/cell_block/A)
 "cTD" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+/obj/machinery/vending/dinnerware,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
+/area/crew_quarters/kitchen)
 "cTF" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -32607,16 +32179,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/north)
-"cTH" = (
-/obj/machinery/washing_machine,
-/turf/simulated/floor/plasteel{
-	dir = 4
-	},
-/area/crew_quarters/locker)
 "cTJ" = (
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /obj/machinery/washing_machine,
 /turf/simulated/floor/plasteel{
@@ -32625,12 +32190,7 @@
 	},
 /area/crew_quarters/locker)
 "cTK" = (
-/obj/machinery/camera{
-	c_tag = "Dorm Lockers";
-	dir = 9
-	},
-/obj/structure/table,
-/obj/structure/bedsheetbin,
+/obj/machinery/washing_machine,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -32651,15 +32211,16 @@
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/heads/hop)
 "cTQ" = (
-/obj/machinery/door/airlock/glass{
-	name = "Hydroponics";
-	req_access = list(35)
+/obj/machinery/door/morgue{
+	name = "Private Study";
+	req_access = list(37)
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkgreenfull"
+	icon_state = "dark"
 	},
-/area/hydroponics)
+/area/library)
 "cTS" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/wood,
@@ -32990,7 +32551,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -33105,7 +32665,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 32
 	},
 /obj/machinery/embedded_controller/radio/airlock/access_controller{
@@ -33291,20 +32850,17 @@
 /turf/simulated/floor/engine/vacuum,
 /area/maintenance/turbine)
 "cVy" = (
-/obj/structure/table/wood,
-/obj/item/storage/fancy/cigarettes/cigpack_robust{
-	pixel_x = 7;
-	pixel_y = -2
+/obj/structure/chair/comfy/black{
+	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/carpet/orange,
 /area/crew_quarters/bar)
 "cVO" = (
 /obj/structure/table,
 /obj/item/clothing/shoes/orange,
 /obj/item/clothing/under/color/orange/prison,
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -33495,10 +33051,11 @@
 	},
 /area/engine/engineering)
 "cWP" = (
-/obj/structure/chair/sofa/corp{
-	dir = 1
+/obj/machinery/vending/cola,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/turf/simulated/floor/plasteel,
 /area/hallway/primary/fore/west)
 "cWQ" = (
 /turf/simulated/floor/plasteel{
@@ -33578,10 +33135,11 @@
 	},
 /area/hallway/primary/starboard/south)
 "cXk" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 1
+/obj/machinery/vending/snack,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/turf/simulated/floor/plasteel,
 /area/hallway/primary/fore/west)
 "cXo" = (
 /turf/simulated/wall/r_wall,
@@ -33762,8 +33320,7 @@
 "cYi" = (
 /obj/structure/table,
 /obj/item/radio/intercom{
-	pixel_x = 28;
-	name = "custom placement"
+	pixel_x = 28
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -33961,8 +33518,7 @@
 "dap" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/machinery/porta_turret,
 /turf/simulated/floor/plasteel{
@@ -33987,12 +33543,13 @@
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology)
 "dau" = (
-/obj/machinery/firealarm{
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/turf/simulated/floor/plasteel{
 	dir = 8;
-	pixel_x = -28
+	icon_state = "neutralfull"
 	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/cabin2)
+/area/crew_quarters/locker)
 "dax" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -34041,15 +33598,13 @@
 	},
 /area/hallway/secondary/entry/south)
 "dbs" = (
-/obj/machinery/hydroponics/constructable,
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkgreenfull"
+	icon_state = "whitegreenfull"
 	},
-/area/hydroponics)
+/area/crew_quarters/sleep)
 "dby" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -34060,11 +33615,11 @@
 	},
 /area/engine/break_room)
 "dbI" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkgreenfull"
+/obj/item/radio/intercom{
+	pixel_x = 28
 	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/grass,
 /area/hydroponics)
 "dcw" = (
 /turf/simulated/wall/r_wall,
@@ -34078,13 +33633,15 @@
 	},
 /area/civilian/barber)
 "dcz" = (
-/obj/structure/table,
-/obj/machinery/smartfridge/disks,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkgreenfull"
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access";
+	req_access = list(12)
 	},
-/area/hydroponics)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/hallway/primary/port/north)
 "dcE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -34095,19 +33652,16 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "dcF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
+	icon_state = "cafeteria"
 	},
-/area/crew_quarters/bar)
+/area/crew_quarters/kitchen)
 "dcG" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -34159,12 +33713,15 @@
 /turf/simulated/wall,
 /area/hallway/spacebridge/scidock)
 "dcS" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar";
+	req_access_txt = "12"
 	},
-/obj/effect/landmark/start/bartender,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/gambling_den2)
 "dcU" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -34188,6 +33745,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
+"dcZ" = (
+/obj/structure/chair/sofa/pew/right{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "dda" = (
 /obj/machinery/chem_dispenser/soda{
 	dir = 4
@@ -34202,14 +33767,12 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "ddb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/area/crew_quarters/fitness)
+/turf/simulated/floor/carpet/red,
+/area/chapel/main)
 "ddc" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -34217,13 +33780,6 @@
 /obj/effect/landmark/start/internal_affairs,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/lawoffice)
-"ddd" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance";
-	req_access = list(12)
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/port)
 "ddk" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -34238,8 +33794,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -34301,11 +33856,17 @@
 	},
 /area/medical/surgery/south)
 "dds" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/turf/simulated/floor/carpet/green,
-/area/library)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "redyellowfull"
+	},
+/area/crew_quarters/bar)
 "ddu" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24;
@@ -34321,6 +33882,10 @@
 /obj/structure/closet/secure_closet/atmos_personal,
 /obj/item/pickaxe/mini,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -34436,8 +34001,7 @@
 "ddP" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/firealarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -34469,11 +34033,13 @@
 /area/atmos)
 "ddW" = (
 /obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/bot,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "ddX" = (
 /obj/machinery/light,
 /obj/machinery/space_heater,
+/obj/effect/turf_decal/bot,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "ddY" = (
@@ -34575,6 +34141,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/cold_sink/freezer,
+/obj/effect/turf_decal/bot,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dek" = (
@@ -34647,8 +34214,7 @@
 "dew" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -34736,11 +34302,10 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "deD" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/effect/spawner/window/reinforced/plasma,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
+/obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
 /area/atmos/distribution)
 "deE" = (
@@ -34829,8 +34394,7 @@
 /obj/machinery/light,
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -34854,8 +34418,7 @@
 "dgr" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -35045,25 +34608,21 @@
 	},
 /area/hallway/secondary/exit)
 "diy" = (
-/obj/machinery/door/airlock{
-	id_tag = "cabin3";
-	name = "Cabin"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
+"diM" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/cabin3)
-"diM" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
-	},
-/obj/machinery/camera{
-	c_tag = "Dorm Bathroom";
-	dir = 1
-	},
-/obj/structure/closet/wardrobe/pjs,
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/locker)
+/area/crew_quarters/cabin4)
 "diO" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -35080,10 +34639,6 @@
 /obj/structure/cable/orange,
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/maintenance/fsmaint3)
-"diS" = (
-/obj/machinery/ai_status_display,
-/turf/simulated/wall,
-/area/crew_quarters/locker)
 "diU" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/simulated/floor/plasteel{
@@ -35117,7 +34672,6 @@
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/newscaster{
 	dir = 8;
-	name = "east bump";
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
@@ -35152,8 +34706,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -35162,7 +34715,6 @@
 /area/bridge)
 "dji" = (
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/stripes/end{
@@ -35257,12 +34809,12 @@
 	},
 /area/quartermaster/office)
 "djF" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -35286,7 +34838,6 @@
 "djQ" = (
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -35308,7 +34859,7 @@
 	dir = 5;
 	icon_state = "darkyellow"
 	},
-/area/maintenance/engineering)
+/area/engine/break_room)
 "djS" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall,
@@ -35360,12 +34911,9 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fore)
 "dkg" = (
-/obj/machinery/door/poddoor/multi_tile/two_tile_ver{
-	id_tag = "mechanicgate"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "dkk" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -35438,8 +34986,7 @@
 	dir = 1
 	},
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/engine{
 	slowdown = -0.3
@@ -35605,8 +35152,7 @@
 "dlk" = (
 /obj/machinery/sleeper,
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -35631,7 +35177,6 @@
 "dlq" = (
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -35697,6 +35242,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -35725,8 +35273,8 @@
 "dlK" = (
 /obj/structure/sign/pods,
 /turf/simulated/mineral/ancient,
-/area/maintenance/fore2)
-"dlL" = (
+/area/crew_quarters/cabin3)
+"dlT" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Locker Room"
 	},
@@ -35734,10 +35282,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
-"dlT" = (
-/turf/simulated/floor/plating,
 /area/crew_quarters/locker)
 "dmb" = (
 /obj/machinery/door/airlock/public/glass{
@@ -35759,9 +35307,9 @@
 /turf/simulated/mineral/ancient/outer,
 /area/engine/mechanic_workshop/hangar)
 "dmg" = (
-/obj/machinery/vending/coffee,
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/fore)
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/crew_quarters/locker)
 "dmk" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 2;
@@ -35884,11 +35432,15 @@
 	},
 /area/security/permabrig)
 "dmV" = (
-/obj/machinery/door/airlock/glass{
-	name = "Library"
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/green,
-/area/library)
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/port/north)
 "dmW" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Fore Asteroid Maintenance Access";
@@ -35932,8 +35484,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/engine{
 	slowdown = -0.3
@@ -36004,8 +35555,7 @@
 "doB" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
@@ -36448,21 +35998,14 @@
 	},
 /area/hallway/primary/fore/west)
 "drd" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Library"
-	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/soda{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/green,
-/area/library)
+/area/crew_quarters/kitchen)
 "drf" = (
 /obj/machinery/seed_extractor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -36471,12 +36014,16 @@
 	},
 /area/security/permabrig)
 "drp" = (
-/obj/structure/table/wood/fancy/black,
+/obj/structure/chair/stool/bar{
+	dir = 8
+	},
 /obj/item/radio/intercom{
 	dir = 0;
 	pixel_x = -28
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "redyellowfull"
+	},
 /area/crew_quarters/bar)
 "drq" = (
 /obj/structure/table,
@@ -36562,7 +36109,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -36677,18 +36223,19 @@
 /turf/simulated/floor/plating,
 /area/security/podbay)
 "drZ" = (
-/obj/structure/chair{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/structure/railing{
-	dir = 10
+/obj/structure/disposalpipe/sortjunction/reversed{
+	dir = 8;
+	name = "disposal pipe - Kitchen";
+	sortType = 20
 	},
-/obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/area/crew_quarters/fitness)
+/area/hallway/primary/port/east)
 "dsc" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -36799,8 +36346,7 @@
 	dir = 6
 	},
 /obj/machinery/newscaster{
-	pixel_y = 28;
-	name = "north bump"
+	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -36945,18 +36491,6 @@
 	icon_state = "darkredcorners"
 	},
 /area/security/brig)
-"dts" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-y"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
-	},
-/area/hallway/primary/fore/west)
 "dty" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -36965,14 +36499,14 @@
 	},
 /area/crew_quarters/bar)
 "dtA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-y"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -37027,10 +36561,6 @@
 	},
 /area/security/brig)
 "dtZ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 28;
-	name = "custom placement"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -37119,8 +36649,7 @@
 "dun" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -37164,7 +36693,6 @@
 "duF" = (
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -37226,8 +36754,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -37405,8 +36932,7 @@
 /area/turret_protected/ai)
 "dvX" = (
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redcorner"
@@ -37610,8 +37136,7 @@
 	network = list("SS13","Research Outpost","Mining Outpost")
 	},
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /obj/machinery/camera{
 	c_tag = "Brig Prison Control";
@@ -37634,8 +37159,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -37752,6 +37276,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -37784,6 +37309,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -37936,6 +37464,8 @@
 	range = 8;
 	pixel_y = -24
 	},
+/obj/effect/landmark/start/captain,
+/obj/structure/chair/comfy,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -38351,8 +37881,7 @@
 	},
 /obj/machinery/light_switch{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -38360,8 +37889,7 @@
 /area/medical/medbreak)
 "dAs" = (
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -38458,6 +37986,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -38560,7 +38093,6 @@
 "dBq" = (
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -38581,8 +38113,7 @@
 "dBu" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -38739,10 +38270,9 @@
 	},
 /area/toxins/hallway)
 "dCr" = (
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2"
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -38829,7 +38359,6 @@
 /obj/machinery/computer/pandemic,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -38895,7 +38424,8 @@
 /obj/machinery/smartfridge/medbay,
 /obj/machinery/door/window/southleft{
 	name = "Public Fridge";
-	req_access = list(33)
+	req_access = list(33);
+	dir = 1
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -38932,8 +38462,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -39005,15 +38534,13 @@
 "dEK" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/machinery/computer/message_monitor{
 	dir = 8
 	},
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel/dark/telecomms,
 /area/toxins/server)
@@ -39281,7 +38808,6 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -24
 	},
 /turf/simulated/floor/engine{
@@ -39387,7 +38913,7 @@
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/port)
 "dNs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/camera/autoname{
 	dir = 5
 	},
 /turf/simulated/floor/plasteel{
@@ -39428,6 +38954,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
+/obj/item/storage/fancy/candle_box/eternal,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "dNN" = (
@@ -39537,16 +39064,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/external/southwest)
 "dOy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/item/kitchen/knife,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
 	},
-/obj/structure/chair/wood/wings,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/carpet/black,
-/area/chapel/office)
+/area/crew_quarters/kitchen)
 "dOB" = (
 /obj/structure/cable/orange{
 	icon_state = "0-8"
@@ -39669,7 +39193,6 @@
 /area/library)
 "dQv" = (
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -24
 	},
 /obj/structure/cable/orange,
@@ -39736,8 +39259,7 @@
 /area/hallway/primary/fore)
 "dRx" = (
 /obj/item/radio/intercom{
-	pixel_x = -28;
-	name = "custom placement"
+	pixel_x = -28
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -39878,16 +39400,12 @@
 	},
 /area/hallway/primary/fore)
 "dTL" = (
-/obj/structure/table/wood,
-/obj/item/storage/bag/books,
-/obj/item/taperecorder,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	dir = 4;
+	icon_state = "yellow"
 	},
-/area/library)
+/area/engine/mechanic_workshop)
 "dTM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39898,25 +39416,26 @@
 	},
 /area/hallway/primary/fore)
 "dUr" = (
-/obj/machinery/hydroponics/constructable,
-/obj/structure/disposalpipe/segment{
+/obj/structure/chair/stool/bar{
+	dir = 8
+	},
+/obj/effect/landmark/start/civilian,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkgreenfull"
+	icon_state = "redyellowfull"
 	},
-/area/hydroponics)
+/area/crew_quarters/bar)
 "dUw" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -39962,12 +39481,11 @@
 	},
 /area/maintenance/starboard)
 "dVo" = (
-/obj/structure/fans/tiny/invisible,
+/obj/structure/bonfire,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "rampbottom"
+	icon_state = "dark"
 	},
-/area/crew_quarters/fitness)
+/area/library)
 "dVv" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "BrigRight";
@@ -40072,13 +39590,9 @@
 /obj/structure/chair/comfy/black{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/light/small,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "dXH" = (
@@ -40125,12 +39639,11 @@
 	},
 /area/medical/morgue)
 "dZs" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/door/poddoor/multi_tile/two_tile_ver{
+	id_tag = "mechanicgate"
 	},
-/mob/living/simple_animal/cow/Betsy,
-/turf/simulated/floor/grass,
-/area/hydroponics)
+/turf/simulated/mineral/ancient,
+/area/mine/unexplored/cere/civilian)
 "dZv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/engine{
@@ -40298,18 +39811,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint2)
 "edM" = (
-/obj/machinery/door_control{
-	id = "mechanicgate";
-	name = "Mechanic Pod Door";
-	pixel_x = 24;
-	pixel_y = -24;
-	req_access = list(70)
+/obj/structure/chair/sofa/pew/left{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkyellow"
-	},
-/area/engine/mechanic_workshop/hangar)
+/turf/simulated/floor/carpet/red,
+/area/chapel/main)
 "edT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -40370,12 +39876,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/hallway/primary/fore)
-"efU" = (
-/obj/structure/railing,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/crew_quarters/fitness)
 "ega" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Fore Asteroid Maintenance Access";
@@ -40404,14 +39904,14 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "egI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/door/airlock/public/glass{
+	name = "Chapel"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
+/turf/simulated/floor/carpet/red,
+/area/chapel/main)
 "ehk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -40482,7 +39982,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -26
 	},
 /obj/effect/turf_decal/stripes/end{
@@ -40495,10 +39994,18 @@
 /turf/simulated/wall,
 /area/storage/primary)
 "eiK" = (
-/obj/effect/decal/cleanable/cobweb,
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating/asteroid/ancient,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
 /area/maintenance/gambling_den2)
 "eiP" = (
 /obj/effect/spawner/random_barrier/wall_probably,
@@ -40579,8 +40086,7 @@
 "ekK" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/engine,
 /area/toxins/explab_chamber)
@@ -40623,7 +40129,6 @@
 /area/storage/primary)
 "elE" = (
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -40649,15 +40154,21 @@
 	},
 /area/maintenance/port)
 "emk" = (
-/obj/machinery/door/window/westleft{
-	req_access = list(22)
+/obj/machinery/door/window/northleft{
+	dir = 4
+	},
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery";
+	location = "Hydroponics"
 	},
 /turf/simulated/floor/plating,
-/area/chapel/office)
+/area/hydroponics)
 "emn" = (
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -40715,6 +40226,7 @@
 "enj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet,
 /area/hallway/primary/port/east)
 "enx" = (
@@ -40748,7 +40260,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -40836,10 +40347,30 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/port)
+"eoU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/maintenance/gambling_den2)
 "epa" = (
-/obj/item/soap/nanotrasen,
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/crew_quarters/kitchen)
 "epq" = (
 /obj/structure/rack,
 /turf/simulated/floor/plating,
@@ -40873,8 +40404,7 @@
 /obj/structure/table,
 /obj/item/stack/sheet/mineral/plasma,
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /obj/item/extinguisher,
 /obj/item/wrench,
@@ -40886,8 +40416,7 @@
 "eru" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/engine,
 /area/toxins/explab_chamber)
@@ -40937,13 +40466,9 @@
 /turf/simulated/floor/carpet/red,
 /area/chapel/main)
 "esU" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
-/area/crew_quarters/bar)
+/obj/machinery/photocopier,
+/turf/simulated/floor/wood,
+/area/library)
 "ete" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -40955,8 +40480,7 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -41008,14 +40532,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "eud" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/status_display{
+	layer = 4
 	},
-/obj/structure/disposaloutlet,
-/obj/effect/turf_decal/stripes/full,
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
+/turf/simulated/wall,
+/area/hydroponics)
 "eux" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -41025,14 +40546,19 @@
 /turf/space,
 /area/space/nearstation)
 "euQ" = (
-/obj/structure/table/wood,
-/turf/simulated/wall,
-/area/crew_quarters/bar)
+/obj/machinery/camera{
+	c_tag = "Service Asteroid Hallway 8";
+	dir = 1
+	},
+/obj/machinery/atm{
+	pixel_y = -32
+	},
+/turf/simulated/floor/carpet,
+/area/hallway/primary/port/east)
 "evb" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -41050,7 +40576,6 @@
 "evg" = (
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/structure/cable/orange{
@@ -41130,8 +40655,7 @@
 	dir = 4
 	},
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -41220,15 +40744,15 @@
 	},
 /area/hallway/spacebridge/comeng)
 "ezi" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access";
-	req_access = list(12)
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkgreenfull"
 	},
-/turf/simulated/floor/plating,
-/area/hallway/primary/port/north)
+/area/hydroponics)
 "ezu" = (
 /turf/simulated/wall,
 /area/mimeoffice)
@@ -41260,12 +40784,15 @@
 	},
 /area/teleporter)
 "ezW" = (
-/obj/machinery/camera{
-	c_tag = "Fitness South";
-	dir = 1
+/obj/machinery/door/airlock/maintenance{
+	name = "Dorm SMES Access";
+	req_access = list(10)
 	},
-/turf/simulated/floor/carpet/cyan,
-/area/crew_quarters/fitness)
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/locker)
 "eAi" = (
 /obj/structure/closet/crate{
 	name = "top secret mime supplies"
@@ -41297,16 +40824,13 @@
 	},
 /area/hallway/primary/fore/west)
 "eAq" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 28;
-	name = "custom placement"
-	},
-/obj/machinery/recharge_station,
-/turf/simulated/floor/plasteel{
+/obj/structure/curtain/open/shower,
+/obj/machinery/firealarm{
 	dir = 1;
-	icon_state = "escape"
+	pixel_y = -24
 	},
-/area/hallway/primary/port/east)
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/toilet)
 "eAw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -41318,8 +40842,7 @@
 "eAF" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41471,8 +40994,7 @@
 "eDi" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41506,16 +41028,20 @@
 /turf/simulated/mineral/ancient,
 /area/storage/tech)
 "eDz" = (
+/obj/machinery/door/airlock{
+	id_tag = "cabin1";
+	name = "Cabin"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/public/glass,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/crew_quarters/cabin1)
 "eDQ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/warning_stripes/blue,
@@ -41597,7 +41123,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/simulated/floor/plasteel{
@@ -41763,13 +41288,23 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "eJA" = (
-/obj/machinery/light,
-/obj/machinery/bookbinder,
-/turf/simulated/floor/wood,
+/obj/machinery/door/airlock/public/glass{
+	name = "Library"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/green,
 /area/library)
 "eJF" = (
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -24
 	},
 /obj/structure/cable/orange,
@@ -41778,30 +41313,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/locker)
-"eJJ" = (
-/obj/structure/cable/orange,
-/obj/machinery/power/apc{
-	cell_type = 5000;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 26
-	},
-/obj/effect/turf_decal/stripes/asteroid/end{
+"eJK" = (
+/obj/structure/chair/sofa/pew/left{
 	dir = 8
 	},
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/crew_quarters/cabin1)
-"eJK" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	dir = 4;
+	icon_state = "chapel"
 	},
-/area/crew_quarters/fitness)
+/area/chapel/main)
 "eJS" = (
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
@@ -41827,8 +41347,7 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 1;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2"
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -41868,13 +41387,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/south)
 "eLI" = (
-/obj/machinery/newscaster{
-	pixel_x = 28;
-	name = "east bump";
-	dir = 8
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/turf/simulated/floor/carpet/black,
-/area/chapel/office)
+/turf/simulated/floor/wood,
+/area/crew_quarters/theatre)
 "eLS" = (
 /obj/machinery/status_display{
 	layer = 4
@@ -41929,13 +41447,15 @@
 	},
 /area/hallway/primary/fore)
 "eMW" = (
-/obj/machinery/door/window/eastleft{
-	pixel_x = -1
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/area/crew_quarters/fitness)
+/turf/simulated/floor/wood,
+/area/crew_quarters/cabin3)
 "eMX" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
@@ -41948,22 +41468,6 @@
 	icon_state = "whitebluecorner"
 	},
 /area/medical/cmostore)
-"eNk" = (
-/obj/machinery/power/apc{
-	cell_type = 5000;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 26
-	},
-/obj/structure/cable/orange,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/cabin2)
 "eNC" = (
 /obj/structure/cable/orange{
 	icon_state = "1-4"
@@ -41973,16 +41477,22 @@
 /area/space/nearstation)
 "eNI" = (
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/engine,
 /area/toxins/explab_chamber)
 "eNP" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/door/airlock{
+	name = "Crematorium";
+	req_access_txt = "27"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/black,
 /area/chapel/office)
 "eNS" = (
 /obj/machinery/conveyor/auto{
@@ -41997,7 +41507,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /turf/simulated/floor/plating,
@@ -42050,15 +41559,13 @@
 	},
 /area/hallway/spacebridge/scidock)
 "ePs" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/structure/closet/chefcloset,
-/obj/item/soap,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/crew_quarters/fitness)
 "ePP" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -42074,7 +41581,6 @@
 "eQt" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 32
 	},
 /obj/structure/disposalpipe/trunk,
@@ -42139,16 +41645,32 @@
 	icon_state = "white"
 	},
 /area/toxins/misc_lab)
-"eRz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+"eRp" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance";
+	req_access_txt = "12"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
+/area/maintenance/port2)
+"eRz" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/hydroponics)
 "eRV" = (
-/obj/structure/sign/restroom,
-/turf/simulated/wall,
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "eRW" = (
 /obj/structure/cable{
@@ -42195,8 +41717,7 @@
 /area/maintenance/disposal/south)
 "eSk" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /mob/living/simple_animal/pet/dog/fox/Renault,
 /obj/structure/bed/dogbed{
@@ -42309,8 +41830,7 @@
 	dir = 1
 	},
 /obj/machinery/newscaster{
-	pixel_y = 32;
-	name = "north bump"
+	pixel_y = 32
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/plasteel,
@@ -42359,21 +41879,9 @@
 /turf/space,
 /area/space/nearstation)
 "eVx" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	location = "Kitchen";
-	dir = 4
-	},
-/obj/machinery/door/window/northleft{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bot"
-	},
-/area/crew_quarters/kitchen)
+/obj/machinery/light,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "eVJ" = (
 /obj/machinery/light,
 /obj/structure/cable{
@@ -42424,8 +41932,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42460,6 +41967,11 @@
 	icon_state = "darkredcorners"
 	},
 /area/security/prison/cell_block/A)
+"eXL" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/mob/living/simple_animal/cock/Commandor,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "eXQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -42519,8 +42031,7 @@
 "eZr" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42627,9 +42138,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/theatre)
 "faP" = (
 /obj/structure/cable{
@@ -42640,6 +42149,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
+"fbj" = (
+/obj/structure/table/wood,
+/obj/item/storage/pill_bottle/dice,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/library)
 "fbs" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -42651,7 +42170,6 @@
 /obj/machinery/light,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/simulated/floor/plasteel{
@@ -42699,8 +42217,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/port/south)
+"fcD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/item/candle,
+/turf/simulated/floor/plasteel{
+	icon_state = "redyellowfull"
+	},
+/area/crew_quarters/bar)
 "fcK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -42764,8 +42298,7 @@
 "fet" = (
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/machinery/atmospherics/unary/portables_connector{
 	name = "Portable Air Pump Connector"
@@ -42780,6 +42313,12 @@
 	slowdown = -0.3
 	},
 /area/hallway/spacebridge/servsci)
+"feI" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/office)
 "ffc" = (
 /obj/machinery/light{
 	dir = 8
@@ -42795,7 +42334,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -42814,8 +42352,7 @@
 /area/hallway/primary/fore)
 "fgu" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel/white,
 /area/toxins/xenobiology)
@@ -42855,21 +42392,11 @@
 	},
 /area/quartermaster/office)
 "fhb" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 28;
-	name = "custom placement"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/fitness)
+/turf/simulated/floor/wood,
+/area/library)
 "fhe" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -42935,8 +42462,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43036,6 +42562,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
@@ -43118,6 +42651,11 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -43197,8 +42735,7 @@
 "fpG" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -43216,15 +42753,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/external/southeast)
-"fpN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/crew_quarters/fitness)
 "fpS" = (
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/plating,
@@ -43296,6 +42824,16 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/fore/east)
+"frK" = (
+/mob/living/simple_animal/hostile/killertomato{
+	desc = "Прирученный ботаниками томат-убийца. Не подпускать к Сане.";
+	faction = list("plants","neutral","hostile");
+	name = "Витамин"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/hydroponics)
 "frS" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -43312,10 +42850,12 @@
 /turf/simulated/floor/carpet,
 /area/security/processing)
 "frV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/landmark/start/mechanic,
-/turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/wood,
+/area/library)
 "fsf" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -43324,8 +42864,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -43348,11 +42887,12 @@
 	},
 /area/hallway/spacebridge/scidock)
 "fso" = (
-/obj/structure/chair/stool,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
-/area/crew_quarters/bar)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/engine/mechanic_workshop)
 "fsr" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -43449,10 +42989,10 @@
 /turf/simulated/wall,
 /area/quartermaster/office)
 "fuf" = (
-/obj/machinery/portable_atmospherics/scrubber/huge,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
 	},
+/obj/machinery/portable_atmospherics/scrubber/huge/stationary,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -43461,11 +43001,11 @@
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai_upload)
 "fup" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull";
+	tag = "icon-redfull (NORTHWEST)"
 	},
-/turf/simulated/floor/wood,
-/area/library)
+/area/crew_quarters/kitchen)
 "fuE" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -43508,8 +43048,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -43673,9 +43212,6 @@
 "fxp" = (
 /turf/simulated/floor/plasteel/white,
 /area/assembly/chargebay)
-"fxA" = (
-/turf/simulated/wall,
-/area/crew_quarters/sleep)
 "fxL" = (
 /obj/machinery/computer/security{
 	dir = 1;
@@ -43749,6 +43285,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/spacebridge/sercom)
+"fze" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/port2)
 "fzj" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -43756,9 +43302,6 @@
 	},
 /area/toxins/hallway)
 "fzp" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -43861,6 +43404,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint3)
+"fDm" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 25
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
 "fDu" = (
 /obj/structure/lattice,
 /turf/simulated/mineral/ancient/outer,
@@ -43878,6 +43429,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
@@ -43930,8 +43484,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43958,8 +43511,7 @@
 	dir = 4
 	},
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -43978,7 +43530,7 @@
 "fEU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
+/obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
@@ -43993,17 +43545,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/west)
 "fFg" = (
-/obj/structure/table/wood,
-/obj/machinery/door/window/westright{
-	dir = 2;
-	name = "Front Desk";
-	req_access = list(37)
-	},
-/obj/item/storage/pill_bottle/dice,
+/obj/item/reagent_containers/food/snacks/mint,
+/obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	icon_state = "cafeteria"
 	},
-/area/library)
+/area/crew_quarters/kitchen)
 "fFl" = (
 /obj/item/clothing/head/cone,
 /obj/structure/cable/orange{
@@ -44042,16 +43589,11 @@
 	},
 /area/hallway/spacebridge/servsci)
 "fFN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "chaplain"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/hydroponics)
+/turf/simulated/floor/plating,
+/area/chapel/office)
 "fFS" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Port Asteroid Maintenance";
@@ -44072,8 +43614,7 @@
 "fGj" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/machinery/keycard_auth{
 	pixel_y = -28
@@ -44110,14 +43651,13 @@
 	},
 /area/engine/engineering)
 "fGv" = (
-/obj/machinery/door/airlock{
-	name = "Crematorium";
-	req_access = list(27)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/chapel/office)
+/area/hydroponics)
 "fGz" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -44147,13 +43687,8 @@
 	},
 /area/maintenance/apmaint2)
 "fGN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/landmark/event/lightsout,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/hydroponics)
+/turf/simulated/wall,
+/area/crew_quarters/sleep)
 "fGO" = (
 /obj/structure/chair{
 	dir = 4
@@ -44241,12 +43776,12 @@
 	},
 /area/toxins/misc_lab)
 "fHT" = (
-/obj/machinery/light{
+/obj/structure/chair/stool{
 	dir = 1
 	},
-/obj/machinery/photocopier,
-/turf/simulated/floor/carpet,
-/area/library)
+/obj/effect/landmark/start/civilian,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "fIg" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/primary/fore/west)
@@ -44260,20 +43795,10 @@
 	icon_state = "dark"
 	},
 /area/engine/mechanic_workshop/hangar)
-"fIN" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/crew_quarters/fitness)
 "fIZ" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -44392,10 +43917,6 @@
 	},
 /area/hallway/primary/fore/east)
 "fLH" = (
-/obj/effect/landmark/start/mime,
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -44403,14 +43924,6 @@
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
-"fLI" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/locker)
 "fMl" = (
 /turf/simulated/mineral/ancient/outer,
 /area/mine/unexplored/cere/medical)
@@ -44459,15 +43972,10 @@
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/aft/west)
-"fMY" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/crew_quarters/fitness)
 "fNb" = (
 /obj/structure/closet/emcloset,
-/obj/machinery/camera{
-	c_tag = "Medbay Escape Pod"
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
@@ -44547,8 +44055,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -44688,31 +44195,24 @@
 /turf/simulated/floor/plasteel/white,
 /area/medical/virology)
 "fQG" = (
-/obj/machinery/door/airlock/glass{
-	id_tag = "Cryogenics";
-	name = "Primary Cryodorms"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/closet/wardrobe/pjs,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/area/crew_quarters/fitness)
+/area/crew_quarters/locker)
 "fQI" = (
-/obj/structure/closet/coffin,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/closet/crate/freezer,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "fQK" = (
-/obj/machinery/vending/cola,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+/obj/structure/chair/office/dark{
+	dir = 4
 	},
-/area/crew_quarters/fitness)
+/obj/machinery/light,
+/turf/simulated/floor/carpet/green,
+/area/library)
 "fRa" = (
 /obj/structure/plasticflaps{
 	name = "Officer Batonga's Home"
@@ -44720,12 +44220,9 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fore/west)
 "fRn" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -28
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/cabin1)
+/obj/item/plant_analyzer,
+/turf/simulated/floor/plating,
+/area/maintenance/gambling_den2)
 "fRy" = (
 /obj/machinery/status_display{
 	layer = 4
@@ -44786,10 +44283,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding1"
 	},
-/area/chapel/main)
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "asteroid"
+	},
+/area/hydroponics)
 "fSl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 9
@@ -44888,26 +44393,14 @@
 /turf/simulated/floor/plasteel/white,
 /area/toxins/xenobiology)
 "fTK" = (
-/obj/structure/sign/poster/random{
-	name = "random official poster";
-	pixel_x = null;
-	pixel_y = -32;
-	random_basetype = /obj/structure/sign/poster/official
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 2;
-	pixel_y = 6
+/obj/structure/chair/sofa/right{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
@@ -44918,8 +44411,7 @@
 	dir = 1
 	},
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -45033,22 +44525,19 @@
 	},
 /area/clownoffice/secret)
 "fXh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/hologram/holopad,
+/obj/machinery/camera{
+	c_tag = "Library East";
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/requests_console{
-	department = "Locker Room";
-	name = "Locker Room Requests Console";
-	pixel_y = 32
-	},
-/turf/simulated/floor/plasteel{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light_switch{
 	dir = 8;
-	icon_state = "neutralfull"
+	pixel_x = 24
 	},
-/area/crew_quarters/fitness)
+/turf/simulated/floor/carpet,
+/area/library)
 "fXo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -45123,6 +44612,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/blueshield)
+"fXY" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/carpet/green,
+/area/library)
 "fYb" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -45155,18 +44651,18 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "fYA" = (
-/obj/machinery/cryopod{
+/obj/item/radio/intercom{
+	pixel_y = -28
+	},
+/obj/machinery/camera{
+	c_tag = "Dorm Commons South";
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitegreen"
-	},
-/area/crew_quarters/sleep)
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "fYD" = (
 /obj/structure/rack,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -45218,24 +44714,11 @@
 	},
 /area/hallway/spacebridge/scidock)
 "fZP" = (
-/obj/machinery/door_control{
-	desiredstate = 1;
-	id = "privateroom";
-	name = "Privacy Room Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_y = -26;
-	specialfunctions = 4
-	},
-/obj/machinery/button/windowtint{
-	anchored = 1;
-	id = "privateroom";
-	pixel_y = -36
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -45250,18 +44733,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint5)
 "gat" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/door/airlock{
+	name = "Crematorium";
+	req_access_txt = "27"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/machinery/hologram/holopad,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/green,
-/area/library)
+/area/chapel/office)
 "gaO" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -45429,13 +44908,13 @@
 /turf/simulated/floor/plating,
 /area/ntrep)
 "get" = (
-/obj/structure/urinal{
-	pixel_x = -32
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
+/turf/simulated/floor/plating,
+/area/space)
 "geD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -45447,14 +44926,12 @@
 	},
 /area/hallway/secondary/exit)
 "geR" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/photocopier,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/library)
+/obj/structure/kitchenspike,
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/kitchen)
 "gfd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/maintenance/external{
@@ -45503,9 +44980,20 @@
 /turf/simulated/floor/engine/n20,
 /area/atmos)
 "gfP" = (
-/obj/structure/closet/crate,
-/turf/simulated/floor/plating,
-/area/maintenance/fore2)
+/obj/structure/cable/orange{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/orange{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "gfW" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/engine,
@@ -45547,6 +45035,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint4)
+"ghc" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Chapel"
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/red,
+/area/chapel/main)
 "ghv" = (
 /obj/machinery/light{
 	dir = 1
@@ -45563,7 +45060,11 @@
 /turf/simulated/wall,
 /area/maintenance/fsmaint4)
 "ghB" = (
-/obj/machinery/vending/coffee,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/chair/sofa{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
@@ -45604,10 +45105,11 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
 "gio" = (
-/obj/structure/disposalpipe/sortjunction/reversed{
-	dir = 8;
-	name = "disposal pipe - Bar";
-	sortType = 19
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -45649,8 +45151,7 @@
 /area/maintenance/apmaint2)
 "giJ" = (
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -45735,7 +45236,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/maintenance/engineering)
+/area/engine/break_room)
 "glZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -45877,8 +45378,14 @@
 	},
 /area/maintenance/fpmaint)
 "goW" = (
-/turf/simulated/floor/plating,
-/area/chapel/main)
+/obj/structure/disposalpipe/segment,
+/obj/structure/chair/sofa/left{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "redyellowfull"
+	},
+/area/crew_quarters/bar)
 "gpk" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
@@ -45956,7 +45463,6 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -24
 	},
 /turf/simulated/floor/plating{
@@ -45987,14 +45493,12 @@
 /turf/simulated/floor/plating,
 /area/engine/break_room)
 "grX" = (
-/obj/structure/closet{
-	name = "Bee-keeping suits"
+/obj/machinery/door/airlock{
+	id_tag = "fb1";
+	name = "Cyborg Recharger"
 	},
-/obj/item/melee/flyswatter,
-/obj/item/clothing/suit/beekeeper_suit,
-/obj/item/clothing/head/beekeeper_head,
-/turf/simulated/floor/plasteel,
-/area/hydroponics)
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/toilet)
 "grY" = (
 /obj/machinery/telepad_cargo,
 /turf/simulated/floor/plasteel{
@@ -46008,15 +45512,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/electrical_shop)
 "gso" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/camera{
+	c_tag = "Library North"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/port/south)
+/obj/structure/bookcase,
+/turf/simulated/floor/wood,
+/area/library)
 "gsx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -46122,11 +45623,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint3)
 "guo" = (
-/obj/machinery/door/airlock{
-	id_tag = "fb1"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/primary/port/south)
 "gur" = (
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating,
@@ -46142,8 +45652,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/machinery/quantumpad/cere/science_security{
 	name = "quantum pad"
@@ -46164,14 +45673,8 @@
 	},
 /area/tcommsat/computer)
 "guA" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -28
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/crew_quarters/cabin4)
+/turf/simulated/mineral/ancient,
+/area/engine/engineering)
 "guD" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Fore Asteroid Maintenance Access";
@@ -46261,10 +45764,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore2)
 "gww" = (
-/obj/structure/table/wood,
-/obj/item/eftpos,
-/turf/simulated/floor/carpet/black,
-/area/chapel/office)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/landmark/start/botanist,
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding4"
+	},
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "asteroid"
+	},
+/area/hydroponics)
 "gwy" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -46332,7 +45845,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -46370,19 +45882,9 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fore/west)
 "gzr" = (
-/obj/structure/closet/lasertag/red,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/fitness)
+/obj/machinery/kitchen_machine/candy_maker,
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/kitchen)
 "gzu" = (
 /obj/effect/spawner/random_spawners/fungus_maybe,
 /turf/simulated/wall,
@@ -46458,17 +45960,22 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/engineering)
+/area/engine/break_room)
 "gBs" = (
 /obj/effect/spawner/random_spawners/grille_often,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/fsmaint4)
 "gBw" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/wall,
-/area/library)
+/turf/simulated/floor/plasteel{
+	icon_state = "redyellowfull"
+	},
+/area/crew_quarters/bar)
 "gBy" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -46539,25 +46046,29 @@
 	},
 /area/medical/surgery/south)
 "gCP" = (
-/obj/structure/morgue{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding1"
+	},
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "asteroid"
 	},
-/area/chapel/office)
+/area/hydroponics)
 "gCW" = (
-/obj/structure/table/wood,
-/obj/item/storage/bible,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/office)
+/obj/machinery/bookbinder,
+/turf/simulated/floor/wood,
+/area/library)
 "gDk" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/britcup,
@@ -46664,15 +46175,18 @@
 	},
 /area/medical/genetics)
 "gEA" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/structure/table,
+/obj/machinery/smartfridge/disks{
+	pixel_y = 5
 	},
-/turf/simulated/floor/carpet/red,
-/area/chapel/main)
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkgreenfull"
+	},
+/area/hydroponics)
 "gEC" = (
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -46689,7 +46203,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/cobweb,
@@ -46751,18 +46264,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -46813,19 +46321,17 @@
 	},
 /area/quartermaster/office)
 "gFA" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/hydroponics)
+/area/maintenance/port)
 "gFE" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -46850,14 +46356,14 @@
 	},
 /area/hallway/spacebridge/scidock)
 "gGt" = (
-/obj/machinery/door/window/eastleft{
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "darkgreenfull"
 	},
-/area/crew_quarters/fitness)
+/area/hydroponics)
 "gGB" = (
 /turf/simulated/mineral/ancient/outer,
 /area/crew_quarters/sleep/secondary)
@@ -46877,13 +46383,31 @@
 	},
 /area/toxins/misc_lab)
 "gGR" = (
-/obj/structure/railing{
-	dir = 10
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
-/area/crew_quarters/fitness)
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
+"gGV" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/library)
 "gHh" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -46936,24 +46460,20 @@
 /turf/simulated/floor/plating,
 /area/medical/chemistry)
 "gIp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/fitness)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/carpet/green,
+/area/library)
 "gIq" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 28;
-	name = "custom placement"
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/item/reagent_containers/glass/bucket,
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "darkgreenfull"
 	},
-/area/chapel/main)
+/area/hydroponics)
 "gID" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall,
@@ -46963,8 +46483,7 @@
 /area/janitor)
 "gJa" = (
 /obj/machinery/newscaster{
-	pixel_y = 28;
-	name = "north bump"
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
 /area/janitor)
@@ -46974,8 +46493,7 @@
 	},
 /obj/vehicle/janicart,
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/janitor)
@@ -46997,13 +46515,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/janitor)
+"gJG" = (
+/obj/item/radio/intercom{
+	pixel_y = 28
+	},
+/turf/simulated/floor/carpet/black,
+/area/chapel/office)
 "gJK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /obj/structure/janitorialcart{
 	dir = 4
@@ -47036,8 +46559,7 @@
 /obj/item/candle,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
@@ -47069,8 +46591,7 @@
 /area/toxins/misc_lab)
 "gKS" = (
 /obj/machinery/firealarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -47095,11 +46616,11 @@
 	},
 /area/maintenance/asmaint5)
 "gLo" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/carpet/black,
+/area/chapel/office)
 "gLp" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -47114,8 +46635,7 @@
 /area/space/nearstation)
 "gLu" = (
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -47123,11 +46643,15 @@
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "gLy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/carpet/black,
-/area/chapel/office)
+/obj/structure/cable/orange{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/primary/port/north)
 "gLH" = (
 /turf/simulated/mineral/ancient,
 /area/crew_quarters/courtroom)
@@ -47239,7 +46763,6 @@
 "gNc" = (
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/structure/cable/orange{
@@ -47268,11 +46791,15 @@
 	},
 /area/security/nuke_storage)
 "gNI" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/door/airlock/maintenance{
+	name = "Kitchen";
+	req_access_txt = "28"
 	},
-/area/chapel/main)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/gambling_den2)
 "gNT" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -47347,15 +46874,15 @@
 	},
 /area/engine/engine_smes)
 "gPw" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Port Asteroid Maintenance";
 	req_access = list(12)
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port2)
@@ -47374,7 +46901,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/stripes/end,
@@ -47384,11 +46910,15 @@
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/hallway/primary/aft/east)
 "gPH" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
+/obj/structure/table/wood,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/bar)
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/library)
 "gPS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 5;
@@ -47397,9 +46927,18 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fore)
 "gQb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding4"
+	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkgreen"
+	icon_state = "asteroid"
 	},
 /area/hydroponics)
 "gQc" = (
@@ -47414,10 +46953,13 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/south)
 "gQv" = (
-/obj/structure/table/wood,
-/obj/item/toy/figure/chaplain,
-/turf/simulated/floor/carpet/black,
-/area/chapel/office)
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkgreenfull"
+	},
+/area/hydroponics)
 "gQC" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -47451,8 +46993,7 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -47514,16 +47055,11 @@
 	},
 /area/hallway/primary/fore)
 "gRW" = (
-/obj/structure/cable/orange{
-	icon_state = "1-2"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 2;
-	name = "disposal pipe - Library";
-	sortType = 16
-	},
-/turf/simulated/floor/plating/asteroid/ancient,
-/area/maintenance/gambling_den2)
+/turf/simulated/floor/plating,
+/area/hallway/primary/port/north)
 "gRY" = (
 /turf/simulated/wall,
 /area/maintenance/fsmaint3)
@@ -47568,11 +47104,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
-/obj/structure/cable,
-/obj/structure/statue/tranquillite/mime/unique,
+/obj/item/flag/mime,
+/obj/structure/cable/orange,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_regular_floor = "yellowsiding";
@@ -47651,8 +47186,7 @@
 "gUW" = (
 /obj/structure/table,
 /obj/item/radio/intercom{
-	pixel_x = -28;
-	name = "custom placement"
+	pixel_x = -28
 	},
 /obj/structure/disposalpipe/segment,
 /obj/item/reagent_containers/spray/cleaner/drone,
@@ -47661,15 +47195,9 @@
 	},
 /area/engine/break_room)
 "gVy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/crew_quarters/fitness)
+/obj/effect/landmark/start/bartender,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "gVD" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/civilian,
@@ -47815,12 +47343,10 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/suit_storage_unit/blueshield,
 /turf/simulated/floor/wood,
@@ -47886,13 +47412,8 @@
 	},
 /area/security/permabrig)
 "gZm" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/recharge_station,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/hallway/primary/fore/west)
+/turf/simulated/mineral/ancient,
+/area/crew_quarters/toilet)
 "gZp" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -48025,7 +47546,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -48259,9 +47779,6 @@
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/port2)
@@ -48278,8 +47795,8 @@
 /area/maintenance/asmaint5)
 "hhz" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Chapel Maintenance";
-	req_access = list(12)
+	name = "Hydroponics Garden";
+	req_one_access_txt = "35;28"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -48308,12 +47825,22 @@
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "hit" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/shovel/spade,
+/obj/item/wirecutters,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/wrench,
+/obj/item/shovel/spade,
+/obj/structure/closet/crate/hydroponics,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -28
 	},
-/turf/simulated/floor/carpet/black,
-/area/chapel/office)
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkgreenfull"
+	},
+/area/hydroponics)
 "hiI" = (
 /obj/structure/chair/sofa/corp{
 	dir = 8
@@ -48358,15 +47885,15 @@
 	},
 /area/medical/medbay)
 "hjP" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/disposaloutlet,
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/plating,
-/area/hydroponics)
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp/right,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "hjR" = (
 /obj/item/radio/intercom{
-	pixel_x = -28;
-	name = "custom placement"
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -48384,7 +47911,6 @@
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -48473,14 +47999,11 @@
 /area/maintenance/atmospherics)
 "hmp" = (
 /obj/machinery/light,
-/obj/machinery/sleeper{
-	dir = 1
-	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
+/obj/machinery/sleeper,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
 	},
@@ -48499,8 +48022,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -48540,7 +48062,6 @@
 /area/medical/research/restroom)
 "hnL" = (
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -24
 	},
 /obj/structure/cable/orange{
@@ -48557,7 +48078,6 @@
 "hnM" = (
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -48597,6 +48117,17 @@
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
+"hoq" = (
+/obj/item/stack/packageWrap,
+/obj/item/destTagger,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
 "hoP" = (
 /obj/machinery/light{
 	dir = 8
@@ -48795,7 +48326,6 @@
 /area/security/interrogation)
 "hrT" = (
 /obj/item/radio/intercom{
-	name = "west bump";
 	pixel_x = -28
 	},
 /obj/effect/turf_decal/siding/brown{
@@ -48965,10 +48495,15 @@
 	},
 /area/hallway/secondary/entry/north)
 "hve" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
+/obj/machinery/door_control{
+	id = "mechanicgate";
+	name = "Mechanic Pod Door";
+	pixel_x = -24;
+	pixel_y = 24;
+	req_access = list(70)
+	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	dir = 1;
 	icon_state = "yellowcorner"
 	},
 /area/engine/mechanic_workshop)
@@ -48982,6 +48517,11 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/window/brigdoor/southright{
+	id = "Autolathe";
+	req_one_access = list(31);
+	name = "Autolathe Access"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkbrownfull"
@@ -49028,8 +48568,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/structure/sign/directions/security{
 	dir = 1;
@@ -49072,14 +48611,18 @@
 	},
 /area/maintenance/fpmaint)
 "hxe" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plasteel,
-/area/hydroponics)
+/obj/machinery/cryopod{
+	dir = 2
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitegreen"
+	},
+/area/crew_quarters/sleep)
 "hxh" = (
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/machinery/vending/cigarette/free,
 /turf/simulated/floor/plasteel{
@@ -49090,28 +48633,60 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
-"hxE" = (
-/obj/machinery/disposal,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+"hxD" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
-/area/engine/mechanic_workshop/hangar)
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/toilet)
+"hxE" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 24
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "chapel"
+	},
+/area/chapel/main)
 "hxO" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "hxP" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel,
-/area/hydroponics)
-"hxX" = (
-/obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/carpet/black,
-/area/chapel/office)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull";
+	tag = "icon-redfull (NORTHWEST)"
+	},
+/area/crew_quarters/kitchen)
+"hxX" = (
+/obj/machinery/door/window{
+	dir = 2;
+	icon_state = "right";
+	name = "Library Desk";
+	opacity = 1;
+	req_access = list(37)
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/library)
 "hyd" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -49191,7 +48766,6 @@
 "hzs" = (
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -49236,8 +48810,7 @@
 "hAl" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -49248,8 +48821,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light_switch{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -49257,18 +48829,12 @@
 	},
 /area/toxins/mixing)
 "hAp" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/item/pen,
-/obj/item/storage/fancy/crayons,
-/obj/item/storage/fancy/candle_box{
-	pixel_x = 1
-	},
-/turf/simulated/floor/carpet/black,
-/area/chapel/office)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/carpet/green,
+/area/library)
 "hAq" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -49344,8 +48910,7 @@
 "hBk" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49364,8 +48929,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -49590,8 +49154,7 @@
 /area/maintenance/auxsolarstarboard)
 "hGa" = (
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/engine,
 /area/toxins/test_chamber)
@@ -49697,8 +49260,7 @@
 "hHP" = (
 /obj/machinery/disposal,
 /obj/machinery/firealarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel{
@@ -49717,20 +49279,20 @@
 /area/engine/engineering)
 "hIh" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Chapel"
+/obj/machinery/door/airlock/glass{
+	name = "Hydroponics";
+	req_access_txt = "35"
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/carpet/red,
-/area/chapel/main)
+/area/hydroponics)
 "hIi" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -49788,7 +49350,6 @@
 "hIU" = (
 /obj/structure/cable/orange,
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -24
 	},
 /turf/simulated/floor/wood{
@@ -49834,8 +49395,7 @@
 "hJz" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49916,8 +49476,7 @@
 /area/medical/medbay)
 "hMg" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -49987,8 +49546,7 @@
 "hOn" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -50040,24 +49598,13 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
 "hOX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
 	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/hallway/primary/port/south)
 "hPG" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -50077,24 +49624,23 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/north)
 "hQg" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
+/obj/structure/table,
+/obj/item/eftpos,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/obj/effect/landmark/event/blobstart,
-/turf/simulated/floor/wood,
-/area/library)
+/area/crew_quarters/kitchen)
 "hQl" = (
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/carpet/black,
-/area/chapel/office)
+/area/hydroponics)
 "hQn" = (
 /obj/item/radio/intercom{
-	pixel_x = -28;
-	name = "custom placement"
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -50132,7 +49678,6 @@
 "hQJ" = (
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -50347,10 +49892,17 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/hor)
 "hTD" = (
-/obj/item/bikehorn/rubberducky,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/item/radio/intercom{
+	pixel_y = -28
+	},
+/turf/simulated/floor/carpet/black,
+/area/chapel/office)
 "hUc" = (
 /obj/machinery/door_control{
 	desc = "A remote control-switch for the pod doors.";
@@ -50430,8 +49982,7 @@
 "hVb" = (
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50518,9 +50069,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/bodyscanner{
-	dir = 2
-	},
+/obj/machinery/bodyscanner,
 /obj/item/radio/intercom{
 	pixel_y = 21
 	},
@@ -50569,7 +50118,6 @@
 	dir = 5
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/landmark/start/blueshield,
 /turf/simulated/floor/carpet/blue,
 /area/blueshield)
 "hYF" = (
@@ -50582,11 +50130,15 @@
 	},
 /area/engine/mechanic_workshop/hangar)
 "hYG" = (
-/obj/machinery/status_display{
-	layer = 4
+/obj/machinery/ai_status_display{
+	pixel_x = -32
 	},
-/turf/simulated/mineral/ancient,
-/area/mine/unexplored/cere/command)
+/obj/machinery/vending/cola,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/port/south)
 "hYW" = (
 /turf/simulated/mineral/ancient,
 /area/medical/paramedic)
@@ -50620,8 +50172,7 @@
 "hZq" = (
 /obj/machinery/light_switch{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -50714,18 +50265,17 @@
 /turf/simulated/floor/carpet/royalblack,
 /area/ntrep)
 "ibR" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/computer/cryopod{
+	pixel_y = 32
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/cryopod{
+	dir = 2
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	dir = 1;
+	icon_state = "whitegreen"
 	},
-/area/hallway/primary/port/south)
+/area/crew_quarters/sleep)
 "ice" = (
 /turf/simulated/wall,
 /area/hallway/primary/fore/west)
@@ -50759,8 +50309,7 @@
 "idg" = (
 /obj/machinery/light_switch{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/wood,
 /area/ntrep)
@@ -50808,8 +50357,7 @@
 /obj/machinery/recharger,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -50877,7 +50425,6 @@
 "ifx" = (
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/stripes/asteroid/end{
@@ -50944,11 +50491,19 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "ihR" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/black,
-/area/chapel/office)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "ihT" = (
 /obj/structure/cable/orange{
 	icon_state = "2-8"
@@ -50978,7 +50533,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /obj/machinery/vending/assist,
@@ -51036,15 +50590,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "ijF" = (
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
+/turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/port)
 "ijL" = (
 /obj/structure/girder,
@@ -51068,20 +50617,29 @@
 /turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/captain)
 "ikv" = (
-/obj/effect/landmark/start/civilian,
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
-"ikx" = (
-/obj/effect/landmark/start/civilian,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/area/crew_quarters/fitness)
-"ikB" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/alarm{
 	dir = 1;
-	icon_state = "pipe-c"
+	pixel_y = -24
+	},
+/turf/simulated/floor/carpet/black,
+/area/chapel/office)
+"ikx" = (
+/obj/machinery/camera{
+	c_tag = "Library South";
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/library)
+"ikB" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -51123,7 +50681,7 @@
 /obj/docking_port/stationary/whiteship{
 	dir = 8;
 	id = "whiteship_home";
-	name = "Near NSS Kerberos"
+	name = "Near NSS Farragus"
 	},
 /turf/space{
 	icon_state = "black"
@@ -51192,10 +50750,10 @@
 /turf/simulated/floor/carpet/green,
 /area/library)
 "ing" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/chair/stool,
-/obj/effect/landmark/start/civilian,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
@@ -51302,8 +50860,7 @@
 	},
 /obj/effect/turf_decal/loading_area,
 /obj/item/radio/intercom{
-	pixel_x = -28;
-	name = "custom placement"
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -51362,8 +50919,7 @@
 /obj/machinery/hydroponics/soil,
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/grass,
 /area/hallway/secondary/garden)
@@ -51412,8 +50968,7 @@
 /obj/effect/turf_decal/loading_area,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -51429,6 +50984,9 @@
 	},
 /obj/structure/cable/orange{
 	icon_state = "1-8"
+	},
+/obj/structure/cable/orange{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -51498,22 +51056,21 @@
 /turf/space,
 /area/solar/auxstarboard)
 "itU" = (
-/obj/structure/cable/orange{
-	icon_state = "2-8"
+/obj/item/radio/intercom{
+	pixel_x = 26;
+	pixel_y = -28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
 /obj/machinery/power/apc{
-	cell_type = 5000;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 26
+	pixel_y = -26
 	},
-/obj/structure/cable/orange{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
+/obj/structure/cable/orange,
+/turf/simulated/floor/wood,
 /area/crew_quarters/cabin3)
 "itW" = (
 /obj/machinery/power/smes,
@@ -51558,7 +51115,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -51615,8 +51171,7 @@
 /area/mine/unexplored/cere/command)
 "iwn" = (
 /obj/machinery/newscaster{
-	name = "north bump";
-	pixel_y = 28
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -51717,8 +51272,7 @@
 "iys" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
@@ -51759,7 +51313,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange,
@@ -51817,7 +51370,6 @@
 "iBy" = (
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -51896,7 +51448,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange,
@@ -51952,6 +51503,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -51965,6 +51519,12 @@
 /area/quartermaster/office)
 "iEo" = (
 /obj/machinery/hologram/holopad,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -52008,13 +51568,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Service Asteroid Hallway 8";
-	dir = 1
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -52034,24 +51587,24 @@
 	},
 /area/hallway/secondary/entry/south)
 "iFe" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
 /area/crew_quarters/bar)
 "iFh" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/vending/artvend,
-/turf/simulated/floor/plasteel{
+/obj/effect/spawner/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
 	dir = 8;
-	icon_state = "neutralcorner"
+	id_tag = "kitchen1"
 	},
-/area/crew_quarters/fitness)
+/turf/simulated/floor/plating,
+/area/crew_quarters/kitchen)
 "iFs" = (
 /turf/simulated/wall,
 /area/mine/unexplored/cere/research)
@@ -52090,8 +51643,7 @@
 "iGb" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/structure/showcase{
 	density = 0;
@@ -52147,24 +51699,28 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
 "iHF" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Holodeck"
-	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/port/south)
 "iHG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating{
@@ -52199,8 +51755,7 @@
 "iHT" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
@@ -52237,8 +51792,7 @@
 "iIv" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -52305,15 +51859,19 @@
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
-/obj/effect/landmark/start/blueshield,
 /turf/simulated/floor/carpet/blue,
 /area/blueshield)
 "iJY" = (
-/mob/living/simple_animal/mouse/rat/gray/Ratatui,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/area/crew_quarters/kitchen)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/hydroponics)
 "iKq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -52330,6 +51888,18 @@
 /obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor/plating,
 /area/maintenance/electrical_shop)
+"iKI" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/chair/stool{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/orange{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "iKV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -52356,6 +51926,12 @@
 	pixel_y = -1
 	},
 /obj/structure/table/wood/fancy/black,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "iLv" = (
@@ -52372,16 +51948,19 @@
 /turf/simulated/wall,
 /area/hallway/primary/aft/west)
 "iMc" = (
-/obj/structure/closet/lasertag/blue,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
 	},
+/obj/item/pen,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "grimy"
 	},
-/area/crew_quarters/fitness)
+/area/library)
 "iMq" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -52425,11 +52004,18 @@
 	},
 /area/maintenance/starboard)
 "iNg" = (
-/obj/machinery/door/morgue{
-	name = "Confession Room"
+/obj/machinery/crema_switch{
+	id = "creamed";
+	pixel_x = -24
 	},
-/turf/simulated/floor/plasteel,
-/area/chapel/main)
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/office)
 "iNp" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -52550,7 +52136,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 32
 	},
 /obj/effect/decal/warning_stripes/southeast,
@@ -52713,12 +52298,13 @@
 	},
 /area/toxins/mixing)
 "iSG" = (
-/obj/structure/table,
-/obj/item/deck/cards,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
+/obj/structure/noticeboard{
+	dir = 8;
+	pixel_x = 32
 	},
-/area/crew_quarters/bar)
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/carpet,
+/area/hallway/primary/port/east)
 "iSW" = (
 /obj/machinery/sleeper{
 	dir = 4
@@ -52768,14 +52354,13 @@
 /turf/simulated/floor/plasteel,
 /area/engine/mechanic_workshop/expedition)
 "iTE" = (
-/obj/machinery/crema_switch{
-	id = "creamed";
-	pixel_x = -24
+/obj/machinery/door/airlock/glass{
+	name = "Library"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/office)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/library)
 "iTF" = (
 /turf/simulated/wall,
 /area/engine/chiefs_office)
@@ -52797,16 +52382,17 @@
 	},
 /area/hallway/spacebridge/scidock)
 "iUc" = (
-/obj/effect/landmark/event/lightsout,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+/obj/item/destTagger,
+/obj/item/stack/packageWrap,
+/obj/structure/table/wood,
+/obj/machinery/light{
+	dir = 8
 	},
-/area/crew_quarters/fitness)
+/turf/simulated/floor/carpet/black,
+/area/chapel/office)
 "iUh" = (
 /obj/item/radio/intercom{
-	pixel_x = 28;
-	name = "custom placement"
+	pixel_x = 28
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -52887,13 +52473,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
-"iWO" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/obj/structure/grille,
-/turf/simulated/floor/plating,
-/area/maintenance/port)
 "iWP" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/hologram/holopad,
@@ -52991,14 +52570,10 @@
 	},
 /area/hallway/secondary/exit)
 "iXQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/chair/comfy/black{
 	dir = 4
 	},
-/obj/structure/chair/stool,
-/obj/effect/landmark/start/civilian,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/carpet/purple,
 /area/crew_quarters/bar)
 "iXV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -53028,10 +52603,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "iYY" = (
@@ -53075,8 +52646,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -53170,14 +52740,19 @@
 /area/teleporter/quantum/security)
 "jcx" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/structure/closet/secure_closet/brig/evidence,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/security/evidence)
+"jcC" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "jcD" = (
 /obj/machinery/camera{
 	c_tag = "Mech bay";
@@ -53187,7 +52762,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -53330,9 +52904,11 @@
 /turf/simulated/wall/r_wall,
 /area/medical/virology)
 "jfr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -53388,12 +52964,11 @@
 	},
 /area/toxins/mixing)
 "jgT" = (
-/obj/item/reagent_containers/glass/bucket,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkgreen"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/area/hydroponics)
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "jho" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -53448,7 +53023,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/crew_quarters/fitness)
+/area/hallway/primary/port/south)
 "jil" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -53478,7 +53053,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/maintenance/engineering)
+/area/engine/break_room)
 "jiS" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -53515,13 +53090,14 @@
 /turf/simulated/floor/engine/co2,
 /area/atmos)
 "jjq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/newscaster{
+	pixel_y = 32
 	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/port/south)
 "jjw" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -53586,13 +53162,13 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "jkW" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/obj/item/stack/packageWrap,
-/obj/item/destTagger,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/carpet/black,
-/area/chapel/office)
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/maintenance/gambling_den2)
 "jkX" = (
 /obj/structure/cable/orange{
 	icon_state = "2-8"
@@ -53645,8 +53221,7 @@
 "jlN" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -53660,7 +53235,6 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/stripes/end{
@@ -53682,8 +53256,7 @@
 "jms" = (
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53698,16 +53271,17 @@
 /turf/simulated/floor/plasteel/dark/telecomms,
 /area/toxins/server_coldroom)
 "jmF" = (
-/obj/machinery/camera{
-	c_tag = "Service Asteroid Hallway 5";
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atm{
-	pixel_x = -28
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/port/south)
@@ -53744,19 +53318,12 @@
 /turf/simulated/floor/plating,
 /area/toxins/lab)
 "jnh" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
-/area/crew_quarters/fitness)
+/turf/simulated/floor/carpet/red,
+/area/chapel/main)
 "jnB" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/engine{
@@ -53870,8 +53437,7 @@
 /obj/item/taperecorder,
 /obj/item/camera,
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -53880,10 +53446,10 @@
 "jpO" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 32
 	},
-/turf/simulated/floor/wood,
+/obj/structure/chair/comfy/black,
+/turf/simulated/floor/carpet/purple,
 /area/crew_quarters/bar)
 "jpP" = (
 /turf/simulated/mineral/ancient,
@@ -53988,8 +53554,7 @@
 /obj/structure/closet/radiation,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -54070,12 +53635,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint5)
 "jtD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/structure/table/wood,
+/obj/item/storage/fancy/candle_box{
+	pixel_x = 1
 	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
+/turf/simulated/floor/carpet/black,
+/area/chapel/office)
 "jtF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -54099,8 +53664,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/engine{
 	slowdown = -0.3
@@ -54109,8 +53673,7 @@
 "juf" = (
 /obj/structure/chair,
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -54147,7 +53710,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/newscaster{
 	dir = 4;
-	name = "west bump";
 	pixel_x = -28
 	},
 /obj/structure/disposalpipe/segment,
@@ -54162,15 +53724,13 @@
 	},
 /area/hallway/secondary/exit)
 "jvt" = (
-/obj/structure/urinal{
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
+/obj/structure/table/wood,
+/obj/item/storage/bible,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/office)
 "jvv" = (
 /obj/structure/grille/broken,
 /obj/structure/disposalpipe/segment{
@@ -54179,18 +53739,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/southwest)
-"jvx" = (
-/obj/structure/cable/orange{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/maintenance/port)
 "jvA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -54288,11 +53836,12 @@
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "jxe" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/carpet/black,
+/area/chapel/office)
 "jxi" = (
 /obj/effect/turf_decal/stripes/end,
 /obj/structure/cable/orange{
@@ -54300,7 +53849,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /turf/simulated/floor/plating,
@@ -54325,17 +53873,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/external/southwest)
 "jyO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/structure/table/wood,
+/obj/item/storage/bag/books,
+/obj/item/taperecorder,
+/obj/machinery/door/window/westleft{
+	name = "Front Desk";
+	dir = 2;
+	req_access = list(37)
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "grimy"
 	},
-/area/crew_quarters/fitness)
+/area/library)
 "jyW" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/orange{
@@ -54419,19 +53968,25 @@
 	},
 /obj/machinery/meter,
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
 "jAF" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/door/airlock/public/glass{
+	req_access_txt = "35";
+	name = "Garden"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "asteroid"
+	},
 /area/hydroponics)
 "jAN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -54506,8 +54061,7 @@
 "jBV" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -54526,7 +54080,6 @@
 "jCg" = (
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -54541,14 +54094,11 @@
 	},
 /area/assembly/chargebay)
 "jCi" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/structure/chair/sofa/corp/left{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/hydroponics)
+/turf/simulated/floor/carpet,
+/area/hallway/primary/port/east)
 "jCu" = (
 /obj/machinery/camera{
 	c_tag = "Command Asteroid Hall 10";
@@ -54668,15 +54218,8 @@
 	},
 /area/medical/cmostore)
 "jDX" = (
-/obj/machinery/door/window/northleft{
-	name = "Casket Storage";
-	req_access = list(22);
-	dir = 2
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "jEe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -54691,12 +54234,16 @@
 /turf/simulated/floor/plating,
 /area/engine/engine_smes)
 "jEG" = (
-/obj/structure/closet/walllocker/emerglocker/east,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkyellow"
+/obj/structure/morgue{
+	dir = 8
 	},
-/area/engine/mechanic_workshop/hangar)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/office)
 "jEX" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/plating,
@@ -54722,10 +54269,9 @@
 /obj/effect/landmark/start/clown,
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/orange{
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/wood,
@@ -54734,18 +54280,10 @@
 /obj/structure/closet/secure_closet/blueshield,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/simulated/floor/wood,
 /area/blueshield)
-"jFJ" = (
-/obj/machinery/door/airlock{
-	id_tag = "cabin2";
-	name = "Cabin"
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/cabin2)
 "jFN" = (
 /obj/effect/spawner/random_spawners/grille_maybe,
 /turf/simulated/floor/plating,
@@ -54762,20 +54300,19 @@
 "jGj" = (
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/hallway/spacebridge/scidock)
-"jGq" = (
-/obj/structure/punching_bag,
-/obj/structure/sign/poster/official/random{
+"jGu" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
 	pixel_y = -32
 	},
-/turf/simulated/floor/carpet/cyan,
-/area/crew_quarters/fitness)
-"jGu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/hydroponics)
+/area/hallway/primary/port/south)
 "jGA" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -54848,27 +54385,9 @@
 	},
 /turf/simulated/floor/wood,
 /area/blueshield)
-"jGS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32;
-	name = "north bump"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/crew_quarters/fitness)
 "jHd" = (
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /obj/machinery/vending/autodrobe,
 /turf/simulated/floor/plasteel,
@@ -54896,8 +54415,7 @@
 "jHz" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/structure/closet{
 	icon_closed = "cabinet_closed";
@@ -54916,6 +54434,9 @@
 "jHW" = (
 /obj/structure/cable/orange{
 	icon_state = "2-8"
+	},
+/obj/structure/cable/orange{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/maintenance/fore2)
@@ -54937,16 +54458,18 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/starboard/north)
 "jIh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
+/obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
+/obj/structure/disposalpipe/sortjunction/reversed{
+	dir = 8;
+	name = "disposal pipe - Hydroponics";
+	sortType = 21
 	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/maintenance/gambling_den2)
 "jIj" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -54988,8 +54511,7 @@
 	dir = 1
 	},
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -55068,8 +54590,7 @@
 "jKs" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/wood,
 /area/ntrep)
@@ -55123,7 +54644,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4;
+	dir = 2;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
@@ -55152,6 +54673,10 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/port)
+"jMh" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/kitchen)
 "jMr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -55304,9 +54829,19 @@
 	},
 /area/maintenance/port)
 "jPS" = (
-/obj/effect/landmark/start/librarian,
-/turf/simulated/floor/carpet,
-/area/library)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
 "jPW" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
@@ -55374,11 +54909,14 @@
 /turf/simulated/floor/plating/airless,
 /area/maintenance/disposal/west)
 "jQO" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "chapel"
 	},
-/area/crew_quarters/fitness)
+/area/chapel/main)
 "jRi" = (
 /obj/structure/table,
 /obj/item/twohanded/rcl/pre_loaded,
@@ -55402,15 +54940,10 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fore/west)
 "jRE" = (
-/obj/structure/cable/orange{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
+/obj/structure/disposalpipe/junction,
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
@@ -55498,11 +55031,16 @@
 	},
 /area/hallway/primary/aft/west)
 "jTp" = (
-/obj/machinery/mecha_part_fabricator/spacepod,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 32
+	},
+/obj/structure/table/reinforced,
+/obj/item/pod_parts/core,
+/obj/item/gps,
+/obj/item/circuitboard/mecha/pod,
+/obj/item/clothing/glasses/welding{
+	pixel_y = 12
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -55563,8 +55101,7 @@
 /area/maintenance/port)
 "jUz" = (
 /obj/item/radio/intercom{
-	pixel_x = 28;
-	name = "custom placement"
+	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -55633,11 +55170,13 @@
 /turf/simulated/wall,
 /area/hallway/primary/central)
 "jVe" = (
-/obj/machinery/door/airlock{
-	id_tag = "b3"
+/obj/machinery/newscaster{
+	pixel_x = 32
 	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/locker)
+/obj/structure/bed,
+/obj/item/bedsheet/yellow,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/cabin2)
 "jVB" = (
 /obj/machinery/light,
 /obj/structure/cable{
@@ -55678,7 +55217,6 @@
 "jWj" = (
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/structure/cable/orange,
@@ -55701,23 +55239,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/port/east)
 "jWw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "cafeteria"
 	},
-/area/hallway/primary/port/south)
+/area/crew_quarters/kitchen)
 "jWE" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -55822,6 +55357,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fore)
+"jZb" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/port/north)
 "jZd" = (
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -55882,7 +55427,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -55910,6 +55454,13 @@
 	icon_state = "white"
 	},
 /area/toxins/mixing)
+"kap" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/mineral/ancient,
+/area/library)
 "kaw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -55962,14 +55513,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/gambling_den2)
-"kbu" = (
-/obj/structure/bed,
-/obj/item/bedsheet/yellow,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/cabin2)
 "kbv" = (
 /obj/structure/closet/secure_closet/medical2,
 /turf/simulated/floor/plasteel{
@@ -55993,7 +55536,6 @@
 "kcF" = (
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -56132,11 +55674,14 @@
 /area/turret_protected/aisat_interior/secondary)
 "kek" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Chapel"
+/obj/machinery/door/airlock/glass{
+	name = "Hydroponics";
+	req_access_txt = "35"
 	},
-/turf/simulated/floor/carpet/red,
-/area/chapel/main)
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/hydroponics)
 "kel" = (
 /obj/structure/mineral_door/wood{
 	name = "Secret Clown HQ"
@@ -56157,8 +55702,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -56220,12 +55764,15 @@
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "kfs" = (
-/obj/structure/rack,
-/obj/item/pickaxe/emergency,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/port)
+/obj/item/radio/intercom{
+	pixel_x = 28
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/old,
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/kitchen)
 "kfu" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -56271,7 +55818,6 @@
 "kgP" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -56317,8 +55863,7 @@
 "kis" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -56381,8 +55926,21 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/orange{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/port/south)
 "kju" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -56397,14 +55955,11 @@
 /turf/simulated/wall,
 /area/hallway/primary/central)
 "kjG" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
-	},
+/obj/effect/turf_decal/bot_white,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "kjJ" = (
@@ -56463,8 +56018,7 @@
 /obj/item/storage/box/rxglasses,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/item/folder/white,
 /obj/item/toy/figure/geneticist,
@@ -56522,10 +56076,7 @@
 /obj/structure/chair/stool/bar{
 	dir = 4
 	},
-/obj/effect/landmark/start/civilian,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "kmi" = (
 /obj/machinery/door/airlock/maintenance{
@@ -56615,12 +56166,12 @@
 	},
 /area/clownoffice/secret)
 "knU" = (
-/obj/structure/chair{
-	dir = 8
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
-/obj/machinery/light/small,
-/turf/simulated/floor/plasteel,
-/area/chapel/main)
+/obj/machinery/light,
+/turf/simulated/floor/wood,
+/area/library)
 "kok" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -56662,23 +56213,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine/unexplored/cere/orbiting)
-"kpd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/crew_quarters/fitness)
 "kpm" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -56794,8 +56332,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/structure/table/glass,
 /obj/item/storage/box/masks{
@@ -56839,7 +56376,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/simulated/floor/plasteel{
@@ -56958,7 +56494,6 @@
 /area/gateway)
 "ktP" = (
 /obj/structure/chair/sofa/corp,
-/obj/effect/landmark/start/nanotrasen_rep,
 /turf/simulated/floor/wood,
 /area/ntrep)
 "ktS" = (
@@ -57107,7 +56642,6 @@
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
-/obj/effect/landmark/start/nanotrasen_rep,
 /turf/simulated/floor/carpet/royalblack,
 /area/ntrep)
 "kwx" = (
@@ -57146,9 +56680,6 @@
 	},
 /area/security/medbay)
 "kxf" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -57193,8 +56724,7 @@
 /area/hallway/secondary/exit)
 "kxH" = (
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hop)
@@ -57211,11 +56741,13 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/south)
 "kyB" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/computer/guestpass{
+	pixel_x = 30
 	},
-/turf/simulated/floor/carpet/black,
-/area/chapel/office)
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
 "kyP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 5
@@ -57259,7 +56791,10 @@
 /turf/simulated/floor/wood,
 /area/maintenance/asmaint5)
 "kzr" = (
-/obj/machinery/computer/rdconsole/mechanics,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "yellow"
@@ -57295,6 +56830,12 @@
 	icon_state = "white"
 	},
 /area/medical/cmostore)
+"kzY" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/purple,
+/area/crew_quarters/bar)
 "kAb" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -57446,8 +56987,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/asmaint5)
@@ -57485,7 +57025,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -57506,8 +57045,7 @@
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57520,8 +57058,7 @@
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/light_switch{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/lawoffice)
@@ -57556,8 +57093,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/structure/sign/directions/cargo{
 	dir = 1;
@@ -57576,6 +57112,16 @@
 /obj/effect/spawner/random_spawners/fungus_probably,
 /turf/simulated/wall,
 /area/maintenance/apmaint2)
+"kFg" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/storage/fancy/crayons,
+/obj/item/pen,
+/turf/simulated/floor/carpet/black,
+/area/chapel/office)
 "kFn" = (
 /obj/effect/spawner/random_spawners/wall_rusted_maybe,
 /turf/simulated/wall,
@@ -57623,7 +57169,6 @@
 "kGE" = (
 /obj/machinery/newscaster{
 	pixel_x = -28;
-	name = "west bump";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -57676,8 +57221,7 @@
 "kIo" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -57714,15 +57258,13 @@
 	},
 /area/toxins/server_coldroom)
 "kIL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/table/wood/fancy/black,
+/obj/item/storage/fancy/cigcase,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "kIM" = (
 /obj/item/radio/intercom{
-	pixel_x = -28;
-	name = "custom placement"
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -57803,6 +57345,14 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"kLc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/chair/sofa,
+/turf/simulated/floor/plasteel{
+	icon_state = "redyellowfull"
+	},
+/area/crew_quarters/bar)
 "kLd" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -57886,14 +57436,11 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/starboard/south)
 "kNx" = (
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 2;
-	pixel_y = 6
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -2;
-	pixel_y = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
@@ -57948,7 +57495,9 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating/asteroid/ancient,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
 /area/maintenance/gambling_den2)
 "kQd" = (
 /obj/machinery/camera{
@@ -57988,8 +57537,7 @@
 "kQC" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -58022,12 +57570,10 @@
 /obj/structure/closet/secure_closet/ntrep,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/simulated/floor/wood,
@@ -58155,8 +57701,7 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -58240,12 +57785,12 @@
 /turf/simulated/wall,
 /area/maintenance/fsmaint4)
 "kUt" = (
-/obj/structure/railing/corner{
-	dir = 1
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
 	},
-/obj/structure/fans/tiny/invisible,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/hallway/primary/port/south)
 "kUG" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger{
@@ -58266,8 +57811,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58311,8 +57855,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58400,8 +57943,7 @@
 "kVU" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -58412,7 +57954,6 @@
 /obj/machinery/power/apc{
 	cell_type = 25000;
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -58539,8 +58080,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/east)
 "kZz" = (
-/turf/simulated/mineral/ancient,
-/area/engine/mechanic_workshop)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "kZW" = (
 /obj/structure/flora/junglebush,
 /turf/simulated/floor/grass,
@@ -58559,21 +58105,13 @@
 /area/medical/medbreak)
 "lao" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "laC" = (
-/obj/item/pod_parts/core,
-/obj/item/circuitboard/mecha/pod,
-/obj/item/clothing/glasses/welding{
-	pixel_y = 12
-	},
-/obj/item/gps,
-/obj/structure/table/reinforced,
+/obj/machinery/computer/rdconsole/mechanics,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "yellow"
@@ -58608,8 +58146,7 @@
 /area/space)
 "lci" = (
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -58733,8 +58270,7 @@
 "leg" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58876,17 +58412,20 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
 "lhc" = (
-/obj/machinery/cryopod{
-	dir = 2
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = 32
 	},
 /obj/machinery/light{
-	dir = 8
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitegreen"
+	icon_state = "grimy"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/cabin1)
 "lhr" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Walkway"
@@ -59016,26 +58555,24 @@
 /turf/simulated/floor/wood,
 /area/civilian/vacantoffice)
 "ljD" = (
-/obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 8
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/caution/stand_clear{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/kitchen)
+/mob/living/simple_animal/pet/cat/birman/Crusher,
+/turf/simulated/floor/plasteel,
+/area/engine/mechanic_workshop)
 "ljI" = (
-/obj/structure/foodcart,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
+/obj/structure/punching_bag,
+/obj/structure/sign/poster/random{
+	name = "random official poster";
+	pixel_y = 32;
+	random_basetype = /obj/structure/sign/poster/official
 	},
-/area/crew_quarters/kitchen)
+/obj/item/radio/intercom{
+	pixel_x = 28
+	},
+/turf/simulated/floor/carpet/cyan,
+/area/crew_quarters/fitness)
 "ljV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -59272,8 +58809,7 @@
 /area/security/nuke_storage)
 "lmQ" = (
 /obj/machinery/newscaster{
-	pixel_y = 28;
-	name = "north bump"
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -59407,15 +58943,11 @@
 	},
 /area/hallway/spacebridge/comeng)
 "loQ" = (
-/obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/wood,
 /area/library)
 "lpm" = (
 /obj/machinery/door/firedoor,
@@ -59473,15 +59005,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "lpW" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Holodeck"
-	},
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/bot/right,
+/obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "dark"
 	},
-/area/crew_quarters/fitness)
+/area/atmos)
 "lqk" = (
 /obj/structure/closet/firecloset/full,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -59617,8 +59147,7 @@
 "lts" = (
 /obj/structure/chair,
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -59626,22 +59155,29 @@
 	},
 /area/hallway/secondary/exit)
 "ltD" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
-"ltL" = (
-/obj/structure/bed,
-/obj/item/bedsheet/blue,
-/obj/machinery/newscaster{
-	pixel_x = -32
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	dir = 8;
+	icon_state = "neutralcorner"
 	},
-/area/crew_quarters/cabin4)
+/area/hallway/primary/port/south)
+"ltL" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "ltQ" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes/corner{
@@ -59666,7 +59202,6 @@
 "lua" = (
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -59848,12 +59383,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint2)
 "lxm" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
+/obj/machinery/door/airlock/glass{
+	id_tag = "Cryogenics";
+	name = "Primary Cryodorms"
 	},
-/turf/simulated/floor/plating,
-/area/hallway/primary/port/south)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitegreenfull"
+	},
+/area/crew_quarters/sleep)
 "lxo" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -59956,7 +59499,7 @@
 /area/engine/mechanic_workshop/hangar)
 "lzT" = (
 /obj/effect/landmark/start/clown,
-/obj/structure/cable{
+/obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
@@ -59964,8 +59507,7 @@
 "lzY" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/structure/cable/orange{
 	icon_state = "1-4"
@@ -60017,13 +59559,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/westalt)
 "lAJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/railing{
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
+	icon_state = "dark"
 	},
-/area/crew_quarters/kitchen)
+/area/crew_quarters/fitness)
 "lAN" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/spacebridge/sercom)
@@ -60047,13 +59589,18 @@
 	},
 /area/maintenance/starboard)
 "lBB" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -24
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 0;
+	icon_state = "whitered"
 	},
-/area/security/brig)
+/area/security/medbay)
 "lBJ" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
@@ -60132,8 +59679,7 @@
 "lDt" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60152,17 +59698,12 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/south)
 "lDZ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light,
+/obj/structure/chair/sofa/corp/left{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/hallway/primary/port/south)
+/turf/simulated/floor/carpet,
+/area/hallway/primary/port/east)
 "lEb" = (
 /obj/structure/railing{
 	pixel_x = 8
@@ -60287,10 +59828,6 @@
 /obj/structure/table/wood,
 /turf/simulated/floor/wood,
 /area/civilian/vacantoffice)
-"lGk" = (
-/obj/machinery/vending/cola,
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/fore)
 "lGy" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -60328,15 +59865,13 @@
 	},
 /area/security/nuke_storage)
 "lHB" = (
-/obj/structure/noticeboard{
-	dir = 8;
-	pixel_x = 32
+/obj/machinery/newscaster{
+	pixel_y = 32
 	},
-/obj/machinery/light{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/atmos)
 "lHC" = (
 /obj/item/flashlight/lantern,
 /turf/simulated/floor/plating{
@@ -60370,14 +59905,9 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/starboard/north)
 "lIP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -60478,8 +60008,7 @@
 /area/maintenance/fsmaint3)
 "lLR" = (
 /obj/item/radio/intercom{
-	pixel_x = 28;
-	name = "custom placement"
+	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -60539,6 +60068,9 @@
 /area/toxins/test_area)
 "lNw" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/computer/guestpass{
+	pixel_x = -30
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -60749,8 +60281,7 @@
 "lRZ" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -60773,12 +60304,12 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/bodyscanner{
-	dir = 2
-	},
 /obj/structure/extinguisher_cabinet{
 	name = "custom placement";
 	pixel_y = 28
+	},
+/obj/machinery/bodyscanner{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
@@ -60829,7 +60360,6 @@
 /obj/item/wrench,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -60842,18 +60372,10 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/south)
 "lUg" = (
-/obj/machinery/cryopod{
-	dir = 2
-	},
-/obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitegreen"
-	},
-/area/crew_quarters/sleep)
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/grown/poppy/geranium,
+/turf/simulated/floor/wood,
+/area/crew_quarters/cabin3)
 "lUn" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 2;
@@ -60896,8 +60418,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/engine{
 	slowdown = -0.3
@@ -60951,29 +60472,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint3)
 "lWb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 32
-	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/port/north)
-"lWg" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull"
-	},
-/area/crew_quarters/sleep)
 "lWT" = (
 /turf/simulated/wall,
 /area/hallway/secondary/garden)
@@ -60993,14 +60499,28 @@
 	},
 /area/medical/surgery/north)
 "lXf" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/effect/landmark/start/botanist,
+/obj/structure/chair/office/light{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "darkgreenfull"
 	},
-/area/chapel/main)
+/area/hydroponics)
+"lXg" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/primary/port/east)
 "lXo" = (
 /obj/machinery/computer/drone_control,
 /turf/simulated/floor/plating,
@@ -61148,20 +60668,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint2)
 "lZD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atm{
-	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "redyellowfull"
 	},
-/area/hallway/primary/port/east)
+/area/crew_quarters/bar)
 "lZG" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 4
@@ -61198,8 +60711,7 @@
 "mau" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteyellow"
@@ -61302,12 +60814,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/northeast)
 "mcu" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/landmark/start/botanist,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkgreenfull"
+/obj/machinery/light{
+	dir = 1
 	},
+/obj/machinery/hydroponics/soil,
+/turf/simulated/floor/grass,
 /area/hydroponics)
 "mcC" = (
 /obj/machinery/power/supermatter_shard/crystal,
@@ -61366,17 +60877,16 @@
 	},
 /area/storage/primary)
 "mdP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock{
-	name = "Chaplain's Office";
-	req_access = list(22)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/chapel/office)
+/area/hydroponics)
 "mdZ" = (
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/maintenance/fsmaint3)
@@ -61414,20 +60924,13 @@
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/port)
 "meI" = (
-/obj/machinery/light/small,
-/obj/structure/toilet{
-	dir = 8
+/obj/item/twohanded/required/kirbyplants,
+/obj/machinery/button/windowtint{
+	id = "chaplain";
+	pixel_y = 24
 	},
-/obj/machinery/door_control{
-	id = "fb1";
-	name = "Privacy Bolts";
-	normaldoorcontrol = 1;
-	pixel_x = 24;
-	specialfunctions = 4
-	},
-/obj/effect/landmark/start/civilian,
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
+/turf/simulated/floor/carpet/black,
+/area/chapel/office)
 "meS" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -61482,15 +60985,11 @@
 	},
 /area/hallway/primary/fore/east)
 "mfG" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "chapel"
 	},
-/area/crew_quarters/fitness)
+/area/chapel/main)
 "mfM" = (
 /obj/machinery/camera{
 	c_tag = "Research Xenobiology-Testing Airlock";
@@ -61500,7 +60999,6 @@
 /obj/structure/cable/orange,
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -61511,15 +61009,9 @@
 /turf/simulated/wall/r_wall,
 /area/maintenance/disposal/westalt)
 "mfT" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/crew_quarters/fitness)
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/wood,
+/area/library)
 "mfV" = (
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/plating,
@@ -61638,8 +61130,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/engine{
 	slowdown = -0.3
@@ -61820,12 +61311,13 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+	dir = 1;
+	icon_state = "pipe-j2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -61835,8 +61327,7 @@
 "mnu" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -62046,10 +61537,7 @@
 	},
 /area/crew_quarters/kitchen)
 "mrF" = (
-/obj/structure/table/wood,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/carpet/purple,
 /area/crew_quarters/bar)
 "mso" = (
 /obj/structure/chair/stool/bar{
@@ -62103,8 +61591,7 @@
 	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -62145,22 +61632,13 @@
 	},
 /area/toxins/lab)
 "mup" = (
-/obj/machinery/power/apc{
-	cell_type = 5000;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 26
-	},
-/obj/structure/cable/orange{
-	icon_state = "0-8"
-	},
 /obj/effect/turf_decal/stripes/asteroid/end{
 	dir = 8
 	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/crew_quarters/cabin4)
+/area/maintenance/port)
 "muC" = (
 /obj/structure/grille,
 /obj/structure/cable/orange{
@@ -62302,16 +61780,11 @@
 	},
 /area/hallway/spacebridge/engmed)
 "myn" = (
-/obj/structure/table/wood,
-/obj/machinery/door/window/westleft{
-	name = "Front Desk";
-	dir = 2;
-	req_access = list(37)
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	icon_state = "cafeteria"
 	},
-/area/library)
+/area/crew_quarters/kitchen)
 "mys" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -62353,8 +61826,7 @@
 /obj/machinery/light,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -62409,6 +61881,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/north)
+"mBb" = (
+/obj/structure/chair/sofa/right,
+/turf/simulated/floor/plasteel{
+	icon_state = "redyellowfull"
+	},
+/area/crew_quarters/bar)
 "mBg" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -62566,11 +62044,9 @@
 /area/maintenance/disposal/westalt)
 "mCW" = (
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -26
 	},
 /obj/structure/cable/orange{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -62666,11 +62142,19 @@
 	},
 /area/hallway/primary/fore/east)
 "mGj" = (
-/obj/structure/chair/office/dark{
-	dir = 1
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id_tag = "kitchen1"
 	},
-/turf/simulated/floor/carpet,
-/area/library)
+/obj/machinery/door/window/westleft{
+	dir = 4;
+	name = "Kitchen";
+	req_access_txt = "28"
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/crew_quarters/kitchen)
 "mGE" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -62811,6 +62295,9 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -62821,11 +62308,11 @@
 	},
 /area/hallway/primary/port/east)
 "mJb" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "applebush"
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/carpet/black,
-/area/chapel/office)
+/area/hydroponics)
 "mJg" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 2;
@@ -62954,8 +62441,7 @@
 "mLk" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/engine{
 	slowdown = -0.3
@@ -63103,24 +62589,21 @@
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/port)
 "mNA" = (
-/obj/structure/flora/ausbushes/ywflowers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/landmark/event/lightsout,
+/turf/simulated/floor/plasteel{
+	icon_state = "redyellowfull"
 	},
-/mob/living/simple_animal/cock/Commandor,
-/turf/simulated/floor/grass,
-/area/hydroponics)
+/area/crew_quarters/bar)
 "mNG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/structure/table,
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -63133,15 +62616,22 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/port/east)
 "mNR" = (
-/obj/structure/closet/secure_closet/freezer/kitchen,
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/kitchen)
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/crew_quarters/fitness)
 "mOf" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -63220,23 +62710,12 @@
 /turf/simulated/floor/engine,
 /area/toxins/mixing)
 "mQk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/door/airlock{
+	id_tag = "fb2";
+	name = "Toilet"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/piano,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
-/area/crew_quarters/bar)
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/toilet)
 "mQx" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -63359,24 +62838,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/maintenance/starboard)
-"mSG" = (
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
-	},
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/item/clothing/suit/leathercoat,
-/obj/item/clothing/head/fedora,
-/obj/item/clothing/under/blacktango,
-/obj/item/clothing/head/bowlerhat,
-/obj/machinery/light{
-	dir = 1;
-	in_use = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/crew_quarters/cabin4)
 "mSK" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/plasteel{
@@ -63391,8 +62852,7 @@
 /area/toxins/test_area)
 "mSY" = (
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -63449,8 +62909,7 @@
 /area/maintenance/port)
 "mUu" = (
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /obj/machinery/light,
 /obj/structure/table,
@@ -63581,7 +63040,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -63617,7 +63075,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/simulated/floor/plasteel{
@@ -63750,15 +63207,18 @@
 	},
 /area/hallway/spacebridge/sercom)
 "naP" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutral"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
 /area/crew_quarters/locker)
 "nbn" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -63874,7 +63334,6 @@
 "ndn" = (
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -63911,8 +63370,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/landmark/start/brig_physician,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteredcorner";
-	dir = 8
+	icon_state = "white"
 	},
 /area/security/medbay)
 "ndS" = (
@@ -63983,6 +63441,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/north)
+"neU" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/green,
+/area/library)
 "neV" = (
 /obj/structure/closet/crate,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -64059,7 +63529,7 @@
 	layer = 4
 	},
 /turf/simulated/mineral/ancient,
-/area/maintenance/port)
+/area/storage/primary)
 "ngn" = (
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating,
@@ -64156,8 +63626,7 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64167,10 +63636,12 @@
 	},
 /area/quartermaster/office)
 "nhR" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/crew_quarters/fitness)
+/obj/machinery/photocopier,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/simulated/floor/carpet,
+/area/library)
 "niz" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -64199,6 +63670,21 @@
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/south)
+"niJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding4"
+	},
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "asteroid"
+	},
+/area/hydroponics)
 "njh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -64270,7 +63756,6 @@
 "nkf" = (
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -64291,7 +63776,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -64408,7 +63892,6 @@
 "nna" = (
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -64420,11 +63903,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "nnc" = (
-/obj/machinery/vending/cigarette,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
+/obj/machinery/door/airlock/freezer{
+	name = "Freezer";
+	req_access_txt = "28"
 	},
-/area/crew_quarters/bar)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/kitchen)
 "nnf" = (
 /obj/structure/closet/secure_closet/research_reagents,
 /turf/simulated/floor/plasteel{
@@ -64433,13 +63918,21 @@
 	},
 /area/toxins/misc_lab)
 "nnP" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+/obj/machinery/camera/autoname{
+	dir = 4
 	},
-/turf/simulated/floor/carpet/black,
-/area/chapel/office)
+/obj/machinery/computer/guestpass{
+	pixel_x = -28
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkgreenfull"
+	},
+/area/hydroponics)
+"nnV" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/kitchen)
 "nok" = (
 /obj/machinery/door_control{
 	id = "civeva";
@@ -64465,8 +63958,7 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/machinery/button/windowtint{
 	id = "Courtroom";
@@ -64499,9 +63991,6 @@
 	},
 /area/hallway/primary/fore/east)
 "noU" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -64515,6 +64004,9 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable/orange{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
@@ -64526,8 +64018,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/southwest)
 "noZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "npb" = (
@@ -64542,7 +64033,6 @@
 "npt" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/simulated/floor/plasteel,
@@ -64564,14 +64054,14 @@
 /turf/simulated/mineral/ancient,
 /area/hallway/primary/fore)
 "nqf" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port2)
@@ -64606,6 +64096,15 @@
 	icon_state = "dark"
 	},
 /area/atmos)
+"nqD" = (
+/obj/machinery/door/window/eastright{
+	dir = 8;
+	pixel_x = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/crew_quarters/fitness)
 "nqG" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -64613,16 +64112,11 @@
 	},
 /area/medical/medbay)
 "nqJ" = (
-/obj/structure/table/wood,
-/obj/item/camera_film,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	icon_state = "cafeteria"
 	},
-/area/library)
+/area/crew_quarters/kitchen)
 "nqK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -64650,15 +64144,15 @@
 	},
 /area/hallway/primary/starboard/south)
 "nrT" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable/orange{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port2)
@@ -64688,10 +64182,13 @@
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "nsX" = (
-/obj/structure/chair/comfy/black,
-/obj/effect/landmark/start/civilian,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/bar)
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
 "nsZ" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Secure Tech Storage";
@@ -64723,23 +64220,32 @@
 	},
 /area/turret_protected/ai_upload)
 "ntl" = (
-/obj/machinery/door/airlock{
-	id_tag = "cabin4";
-	name = "Cabin"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/structure/piano,
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	icon_state = "redyellowfull"
 	},
-/area/crew_quarters/cabin4)
+/area/crew_quarters/bar)
 "ntr" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/bananium{
 	name = "Clown's Office";
 	req_access = list(43)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
+/obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
@@ -64786,8 +64292,7 @@
 "nvb" = (
 /obj/machinery/disposal,
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -64853,6 +64358,14 @@
 	icon_state = "dark"
 	},
 /area/storage/tech)
+"nvT" = (
+/obj/machinery/icemachine{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
 "nwl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -64891,8 +64404,7 @@
 /area/hallway/spacebridge/medcargo)
 "nwI" = (
 /obj/item/radio/intercom{
-	pixel_x = -28;
-	name = "custom placement"
+	pixel_x = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -64994,13 +64506,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior)
-"nyG" = (
-/obj/structure/urinal{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/locker)
 "nyL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -65130,12 +64635,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -65146,54 +64651,43 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "nBj" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/stripes/asteroid/end{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/hydroponics)
+/area/maintenance/port2)
 "nBn" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/wood,
 /area/civilian/vacantoffice)
 "nBP" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
 	name = "disposal pipe - Hydroponics";
 	sortType = 21
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/port2)
 "nCB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/item/assembly/mousetrap/armed,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -65213,15 +64707,15 @@
 	},
 /area/space)
 "nCP" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -65253,16 +64747,7 @@
 	icon_state = "whiteyellow"
 	},
 /area/assembly/chargebay)
-"nDt" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
 "nDu" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -65270,18 +64755,21 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/port2)
 "nDx" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable/orange{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -65296,8 +64784,7 @@
 "nDQ" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -65310,7 +64797,6 @@
 "nEh" = (
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -65326,9 +64812,22 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "nEt" = (
-/obj/structure/chair/office/dark,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/cabin2)
+/obj/machinery/door_control{
+	desiredstate = 1;
+	id = "cabin3";
+	name = "Door Bolt Control";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	pixel_y = 26
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/cabin3)
 "nEw" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
@@ -65345,11 +64844,13 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/central)
 "nEJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/turf/simulated/floor/carpet/red,
-/area/chapel/main)
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
 "nEL" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -65379,8 +64880,7 @@
 "nFn" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/structure/closet/secure_closet/miner,
 /turf/simulated/floor/plasteel{
@@ -65402,22 +64902,13 @@
 	},
 /area/toxins/hallway)
 "nFC" = (
-/obj/structure/rack,
-/obj/item/grown/log,
-/obj/item/grown/log,
-/obj/item/grown/log,
-/obj/item/grown/log,
-/obj/item/hatchet,
-/obj/machinery/newscaster{
-	pixel_y = 28;
-	name = "north bump"
+/obj/structure/fans/tiny/invisible,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24;
-	name = "custom placement"
-	},
-/turf/simulated/floor/wood,
-/area/library)
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "nFH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -65533,15 +65024,19 @@
 	},
 /area/turret_protected/ai_upload)
 "nHr" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24;
-	name = "custom placement"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
 /area/hallway/primary/port/south)
 "nHy" = (
 /obj/machinery/computer/secure_data{
@@ -65561,16 +65056,13 @@
 /area/maintenance/asmaint5)
 "nHK" = (
 /obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/hallway/primary/port/north)
 "nHL" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Hydroponics Maintenance";
-	req_access = list(35)
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/hydroponics)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood,
+/area/library)
 "nIh" = (
 /obj/structure/chair/sofa/corp/right,
 /turf/simulated/floor/plasteel,
@@ -65580,19 +65072,15 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/south)
 "nIx" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	dir = 1;
-	location = "Hydroponics"
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access";
+	req_access = list(12)
 	},
-/obj/machinery/door/window/westleft{
-	dir = 1
-	},
-/obj/structure/plasticflaps{
-	opacity = 1
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/hydroponics)
+/area/hallway/primary/port/north)
 "nIF" = (
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -65611,18 +65099,18 @@
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/maintenance/apmaint2)
 "nIR" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/orange{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -65648,21 +65136,25 @@
 "nJy" = (
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/effect/turf_decal/stripes/asteroid/end,
+/obj/structure/cable/orange{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/stripes/asteroid/end,
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/port2)
 "nJA" = (
-/obj/structure/punching_bag,
-/turf/simulated/floor/carpet/cyan,
-/area/crew_quarters/fitness)
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/crew_quarters/locker)
 "nJH" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -65678,7 +65170,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -65790,11 +65281,6 @@
 	icon_state = "dark"
 	},
 /area/quartermaster/office)
-"nKJ" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/crew_quarters/fitness)
 "nKY" = (
 /obj/machinery/power/solar_control{
 	dir = 4;
@@ -65803,6 +65289,12 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
+"nLa" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/crew_quarters/kitchen)
 "nLi" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Walkway"
@@ -65865,8 +65357,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/engine{
 	slowdown = -0.3
@@ -65897,16 +65388,12 @@
 	},
 /area/toxins/hallway)
 "nMN" = (
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/kitchen_machine/oven,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "nNd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
@@ -65928,6 +65415,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
+"nNM" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/landmark/start/civilian,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "nNN" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -65951,11 +65445,18 @@
 /turf/simulated/floor/plasteel/white,
 /area/assembly/robotics)
 "nNT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/landmark/start/botanist,
-/turf/simulated/floor/plasteel,
-/area/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/theatre)
 "nOg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -65978,6 +65479,9 @@
 "nOi" = (
 /obj/structure/cable/orange{
 	icon_state = "1-8"
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/port/north)
@@ -66069,7 +65573,6 @@
 "nQC" = (
 /obj/machinery/newscaster{
 	dir = 8;
-	name = "east bump";
 	pixel_x = 28
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -66093,27 +65596,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "nSj" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
+/obj/machinery/chem_dispenser/botanical,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "darkgreenfull"
 	},
-/area/hallway/primary/port/south)
+/area/hydroponics)
 "nSn" = (
 /turf/simulated/floor/transparent/glass/reinforced{
 	slowdown = -0.3
@@ -66130,7 +65618,6 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -24
 	},
 /obj/machinery/camera/autoname{
@@ -66166,28 +65653,20 @@
 	},
 /area/maintenance/apmaint2)
 "nSS" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/kitchen)
+/obj/structure/closet/boxinggloves,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "nTs" = (
-/obj/machinery/camera{
-	c_tag = "Service Asteroid Hallway 1";
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/port/north)
 "nTL" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66197,18 +65676,11 @@
 	},
 /area/hallway/primary/fore/west)
 "nTU" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/table/reinforced,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
 	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/green,
-/area/library)
+/area/crew_quarters/kitchen)
 "nTV" = (
 /obj/structure/table,
 /obj/item/storage/firstaid{
@@ -66255,20 +65727,24 @@
 	},
 /area/maintenance/gambling_den2)
 "nVj" = (
-/obj/structure/railing{
-	dir = 9
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/area/crew_quarters/fitness)
+/turf/simulated/floor/wood,
+/area/crew_quarters/cabin4)
 "nVQ" = (
 /turf/simulated/mineral/ancient,
 /area/hallway/primary/starboard/south)
 "nVS" = (
-/obj/structure/closet/secure_closet/hydroponics,
-/turf/simulated/floor/plasteel,
-/area/hydroponics)
+/obj/machinery/door/airlock{
+	name = "Bathroom"
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/toilet)
 "nVW" = (
 /turf/simulated/mineral/ancient,
 /area/maintenance/engineering)
@@ -66292,7 +65768,6 @@
 /area/shuttle/arrival/station)
 "nWt" = (
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -24
 	},
 /obj/structure/cable/orange,
@@ -66303,7 +65778,6 @@
 "nWA" = (
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/stripes/end{
@@ -66315,11 +65789,17 @@
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/toxins/lab)
 "nWJ" = (
-/obj/machinery/alarm{
-	pixel_y = 24
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/cabin1)
+/area/crew_quarters/cabin3)
 "nWK" = (
 /obj/item/soap,
 /turf/simulated/floor/plasteel{
@@ -66327,16 +65807,17 @@
 	},
 /area/security/permabrig)
 "nWO" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	name = "north bump"
+/obj/machinery/door/airlock/glass{
+	id_tag = "Cryogenics";
+	name = "Primary Cryodorms"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
-/obj/structure/closet/secure_closet/hydroponics,
-/turf/simulated/floor/plasteel,
-/area/hydroponics)
+/turf/simulated/floor/plasteel{
+	icon_state = "whitegreenfull"
+	},
+/area/crew_quarters/sleep)
 "nWP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -66350,7 +65831,6 @@
 "nWS" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	name = "east fire alarm";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -66358,33 +65838,29 @@
 	},
 /area/gateway)
 "nWU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/hydroponics)
-"nXn" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=8";
-	dir = 8;
-	location = "Chapel"
+/obj/machinery/door/airlock/maintenance{
+	name = "Broom Closet"
 	},
 /turf/simulated/floor/plating,
-/area/chapel/office)
-"nXv" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/area/space)
+"nXn" = (
+/obj/effect/landmark/event/lightsout,
+/turf/simulated/floor/plasteel{
+	icon_state = "redyellowfull"
 	},
-/obj/structure/flora/ausbushes/sunnybush,
+/area/crew_quarters/bar)
+"nXv" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/mob/living/simple_animal/pig/Sanya,
-/turf/simulated/floor/grass,
-/area/hydroponics)
+/turf/simulated/floor/carpet/green,
+/area/library)
 "nXw" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -66397,10 +65873,18 @@
 /turf/simulated/floor/engine,
 /area/toxins/test_chamber)
 "nXW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/grass,
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding4"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "asteroid"
+	},
 /area/hydroponics)
 "nYm" = (
 /obj/structure/rack,
@@ -66451,7 +65935,6 @@
 "nYB" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/simulated/floor/plasteel{
@@ -66486,12 +65969,18 @@
 	},
 /area/hallway/primary/starboard/south)
 "nZm" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Freezer";
-	req_access = list(28)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/kitchen)
+/obj/structure/cable/orange{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/toilet)
 "nZp" = (
 /turf/simulated/wall,
 /area/space)
@@ -66510,8 +65999,7 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -66537,24 +66025,18 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/aft/west)
 "oaa" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange,
 /turf/simulated/floor/plating,
-/area/crew_quarters/kitchen)
+/area/crew_quarters/fitness)
 "oac" = (
 /obj/machinery/light{
 	dir = 1
@@ -66584,24 +66066,6 @@
 	icon_state = "dark"
 	},
 /area/security/brig)
-"oar" = (
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable/orange{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/stripes/asteroid/end{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/crew_quarters/sleep)
 "oaB" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer,
 /obj/effect/decal/warning_stripes/east,
@@ -66622,8 +66086,7 @@
 "oaS" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -66671,14 +66134,11 @@
 	},
 /area/security/medbay)
 "obz" = (
-/obj/structure/chair/comfy/brown{
-	dir = 1
-	},
-/obj/effect/landmark/start/librarian,
+/obj/machinery/kitchen_machine/grill,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "cafeteria"
 	},
-/area/library)
+/area/crew_quarters/kitchen)
 "obD" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/segment,
@@ -66733,30 +66193,26 @@
 	},
 /area/security/prison/cell_block/A)
 "ocv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/red,
-/area/chapel/main)
+/turf/simulated/mineral/ancient,
+/area/storage/primary)
 "ocw" = (
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/mine/unexplored/cere/civilian)
 "ocA" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/camera{
+	c_tag = "Chapel Office";
+	dir = 5
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/closet/secure_closet/hydroponics,
-/turf/simulated/floor/plasteel,
-/area/hydroponics)
+/turf/simulated/floor/carpet/black,
+/area/chapel/office)
+"ocC" = (
+/obj/item/twohanded/required/kirbyplants,
+/obj/item/radio/intercom{
+	pixel_y = 28
+	},
+/turf/simulated/floor/wood,
+/area/library)
 "ocZ" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -66775,7 +66231,6 @@
 /area/maintenance/apmaint2)
 "odM" = (
 /obj/item/radio/intercom{
-	name = "west station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -66783,11 +66238,9 @@
 	},
 /area/gateway)
 "odU" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/kitchen)
+/obj/machinery/camera/autoname,
+/turf/simulated/floor/carpet/cyan,
+/area/crew_quarters/fitness)
 "odZ" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
@@ -66805,26 +66258,34 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/exit)
+"oeB" = (
+/obj/machinery/computer/library,
+/obj/structure/table/wood,
+/turf/simulated/floor/carpet,
+/area/library)
 "oeP" = (
-/obj/machinery/kitchen_machine/candy_maker,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/carpet/cyan,
+/area/crew_quarters/fitness)
 "oeY" = (
-/obj/machinery/camera{
-	c_tag = "Freezer"
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/table,
-/obj/item/kitchen/knife,
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/kitchen)
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/port/south)
 "ofc" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/closet/secure_closet/freezer/meat,
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/kitchen)
+/obj/structure/closet/masks,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "ofd" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -66837,17 +66298,14 @@
 	},
 /area/solar/port)
 "ofT" = (
-/obj/machinery/door/window{
-	dir = 8;
-	icon_state = "right";
-	name = "Library Desk";
-	opacity = 1;
-	req_access = list(37)
+/obj/structure/table/reinforced,
+/obj/machinery/processor{
+	pixel_y = 9
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	icon_state = "cafeteria"
 	},
-/area/library)
+/area/crew_quarters/kitchen)
 "ogf" = (
 /obj/structure/chair{
 	dir = 8
@@ -66959,21 +66417,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "ohY" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/newscaster{
+	pixel_x = -28;
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+/obj/machinery/camera{
+	c_tag = "Service Asteroid Hallway 1";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "neutralcorner"
 	},
-/area/hallway/primary/port/south)
+/area/hallway/primary/port/north)
 "oib" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -67017,23 +66474,17 @@
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/maintenance/port)
 "oir" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/obj/machinery/camera{
-	c_tag = "Hydroponics Storage";
+/obj/structure/cable/orange{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
 	dir = 4;
-	start_active = 1
+	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
 	},
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
-	},
-/turf/simulated/floor/plasteel,
-/area/hydroponics)
+/area/library)
 "oiL" = (
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -67043,8 +66494,7 @@
 "ojn" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/machinery/disposal,
 /obj/machinery/light{
@@ -67134,16 +66584,21 @@
 /turf/simulated/floor/plasteel,
 /area/security/lobby)
 "okw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull"
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
-/area/crew_quarters/sleep)
+/obj/structure/cable/orange{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "okO" = (
 /obj/machinery/door/poddoor{
 	id_tag = "engiestoragesmes";
@@ -67161,14 +66616,12 @@
 /turf/simulated/wall/r_wall,
 /area/turret_protected/aisat_interior/secondary)
 "okR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/structure/weightmachine/stacklifter,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 8
 	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/carpet/cyan,
+/area/crew_quarters/fitness)
 "olg" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Docking Asteroid SMES Access";
@@ -67187,14 +66640,14 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/north)
 "olB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/carpet/cyan,
+/area/crew_quarters/fitness)
 "olT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -67290,27 +66743,19 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/cabin3)
 "ony" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/retaliate/goat{
-	name = "Pete";
-	real_name = "Pete"
-	},
+/obj/structure/weightmachine/weightlifter,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/carpet/cyan,
+/area/crew_quarters/fitness)
 "onH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/structure/chair/comfy/black{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/kitchen)
+/obj/effect/landmark/start/civilian,
+/turf/simulated/floor/carpet/orange,
+/area/crew_quarters/bar)
 "onO" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -67325,8 +66770,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -67406,15 +66850,13 @@
 	},
 /area/hallway/primary/aft/east)
 "opP" = (
-/obj/effect/decal/cleanable/blood/old{
-	layer = 3.1
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "opV" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/item/assembly/mousetrap/armed,
 /obj/structure/disposalpipe/segment,
@@ -67522,7 +66964,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/maintenance/engineering)
+/area/engine/engineering)
 "ori" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -67583,8 +67025,7 @@
 "oth" = (
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/simulated/floor/engine,
@@ -67718,21 +67159,17 @@
 /turf/simulated/floor/plating/airless,
 /area/turret_protected/aisat_interior/secondary)
 "ovP" = (
-/obj/machinery/camera{
-	c_tag = "Service Asteroid Hallway 3";
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/port/north)
+/obj/structure/flora/ausbushes/reedbush,
+/mob/living/simple_animal/cow/Betsy,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "ovY" = (
-/obj/machinery/light,
-/obj/structure/weightmachine/weightlifter,
-/turf/simulated/floor/carpet/cyan,
-/area/crew_quarters/fitness)
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/maintenance/fore2)
 "owb" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -67821,7 +67258,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable,
@@ -67868,6 +67304,10 @@
 "ozh" = (
 /obj/machinery/floodlight{
 	light_power = 1
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -24
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/port/north)
@@ -67921,18 +67361,9 @@
 	},
 /area/crew_quarters/kitchen)
 "oAm" = (
-/obj/structure/table,
-/obj/item/destTagger,
-/obj/item/stack/packageWrap,
-/obj/item/book/manual/hydroponics_pod_people,
-/obj/item/book/manual/hydroponics_pod_people,
-/obj/item/toy/figure/botanist,
-/obj/item/radio/intercom{
-	dir = 0;
-	pixel_x = -28
-	},
-/turf/simulated/floor/plasteel,
-/area/hydroponics)
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "oAs" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/plasteel/freezer,
@@ -68001,13 +67432,12 @@
 /turf/simulated/mineral/ancient/outer,
 /area/maintenance/apmaint)
 "oCa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/blood/old{
-	layer = 3
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "oCn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -68034,12 +67464,12 @@
 	},
 /area/hallway/spacebridge/scidock)
 "oCY" = (
-/obj/machinery/gibber,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/weightmachine/weightlifter,
+/obj/item/radio/intercom{
+	pixel_x = 28
 	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/carpet/cyan,
+/area/crew_quarters/fitness)
 "oCZ" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -68047,9 +67477,14 @@
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/hallway/primary/starboard/north)
 "oDb" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/carpet/green,
-/area/library)
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/toilet)
 "oDi" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -68179,13 +67614,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboardaux)
 "oFD" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
+/obj/effect/turf_decal/bot/left,
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "dark"
 	},
-/area/crew_quarters/fitness)
+/area/atmos)
 "oFP" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -68288,6 +67722,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboardaux)
+"oIf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/maintenance/gambling_den2)
 "oIk" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -68322,14 +67765,17 @@
 	},
 /area/engine/gravitygenerator)
 "oIV" = (
-/obj/structure/disposaloutlet{
-	dir = 1
+/obj/structure/closet{
+	name = "Bee-keeping suits"
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/item/melee/flyswatter,
+/obj/item/clothing/suit/beekeeper_suit,
+/obj/item/clothing/head/beekeeper_head,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkgreenfull"
 	},
-/turf/simulated/floor/carpet/black,
-/area/chapel/office)
+/area/hydroponics)
 "oJg" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4
@@ -68399,8 +67845,7 @@
 "oKS" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -68430,23 +67875,6 @@
 /obj/item/chair/stool,
 /turf/simulated/floor/wood,
 /area/maintenance/gambling_den2)
-"oLF" = (
-/obj/machinery/door_control{
-	desiredstate = 1;
-	id = "cabin2";
-	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
-	specialfunctions = 4;
-	pixel_x = 26
-	},
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/obj/item/radio/intercom{
-	pixel_x = 26;
-	pixel_y = -28
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/cabin2)
 "oLQ" = (
 /obj/structure/table/glass,
 /obj/item/clothing/glasses/hud/health,
@@ -68460,14 +67888,16 @@
 	},
 /area/medical/cmo)
 "oLT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/red,
-/area/chapel/main)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/hydroponics)
 "oLZ" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -68564,8 +67994,7 @@
 /area/maintenance/starboard)
 "oOe" = (
 /obj/machinery/newscaster{
-	pixel_y = 28;
-	name = "north bump"
+	pixel_y = 32
 	},
 /obj/machinery/vending/clothing/departament/medical,
 /turf/simulated/floor/plasteel{
@@ -68592,8 +68021,7 @@
 "oOP" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/machinery/camera{
 	c_tag = "Escape Wing East";
@@ -68612,8 +68040,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/newscaster{
-	name = "north bump";
-	pixel_y = 28
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -68645,7 +68072,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plating,
-/area/crew_quarters/fitness)
+/area/hallway/primary/port/south)
 "oPH" = (
 /obj/structure/chair{
 	dir = 8
@@ -68686,15 +68113,17 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/north)
 "oQS" = (
-/obj/item/honey_frame,
-/obj/item/honey_frame,
-/obj/item/shovel/spade,
-/obj/item/wirecutters,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/wrench,
-/obj/item/shovel/spade,
-/obj/structure/closet/crate/hydroponics,
-/turf/simulated/floor/plasteel,
+/obj/machinery/requests_console{
+	department = "Hydroponics";
+	departmentType = 2;
+	name = "Hydroponics Requests Console";
+	pixel_y = 30
+	},
+/obj/machinery/hydroponics/constructable,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkgreenfull"
+	},
 /area/hydroponics)
 "oQY" = (
 /obj/structure/cable/orange{
@@ -68706,10 +68135,12 @@
 	},
 /area/maintenance/apmaint2)
 "oRA" = (
+/obj/structure/chair/wood/wings{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/carpet/black,
+/area/chapel/office)
 "oRC" = (
 /turf/simulated/floor/plasteel{
 	dir = 8
@@ -68745,14 +68176,19 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/aft/west)
 "oSt" = (
-/obj/machinery/chem_master/condimaster,
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 32
+/obj/structure/table,
+/obj/item/storage/bag/plants/portaseeder,
+/obj/item/storage/bag/plants/portaseeder,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants,
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkgreenfull"
+	},
+/area/hydroponics)
 "oSw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -68760,16 +68196,17 @@
 /turf/simulated/wall,
 /area/hallway/primary/central)
 "oSE" = (
-/obj/machinery/vending/hydronutrients,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkgreen"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/area/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "oSI" = (
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -68898,11 +68335,8 @@
 	},
 /area/engine/mechanic_workshop/hangar)
 "oTZ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
@@ -68947,8 +68381,7 @@
 	icon_state = "2-8"
 	},
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -68964,8 +68397,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -69007,7 +68439,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -69027,8 +68458,7 @@
 /obj/item/flashlight/lamp/green,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/wood,
 /area/medical/psych)
@@ -69095,7 +68525,6 @@
 /area/hallway/spacebridge/scidock)
 "oXT" = (
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -24
 	},
 /obj/machinery/light/small{
@@ -69109,8 +68538,7 @@
 "oXX" = (
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/structure/showcase{
 	density = 0;
@@ -69203,14 +68631,15 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/electrical_shop)
 "oZA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/table,
+/obj/machinery/plantgenes{
+	pixel_y = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkgreenfull"
 	},
-/turf/simulated/floor/carpet/red,
-/area/chapel/main)
+/area/hydroponics)
 "oZD" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Warden's Office";
@@ -69242,13 +68671,19 @@
 /turf/simulated/floor/plating/airless,
 /area/maintenance/disposal/northwest)
 "pas" = (
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
+/obj/structure/cable/orange{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/crew_quarters/locker)
 "pay" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -32
@@ -69295,25 +68730,29 @@
 /turf/simulated/floor/wood,
 /area/clownoffice)
 "pbO" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/stripes/asteroid/end{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-4"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
 	},
-/area/hallway/primary/port/north)
+/area/crew_quarters/kitchen)
 "pbQ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "darkgreenfull"
 	},
-/area/hallway/primary/port/north)
+/area/hydroponics)
 "pcf" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -69359,13 +68798,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -69380,22 +68815,12 @@
 	},
 /area/medical/surgery/south)
 "pdc" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/chili,
-/obj/item/seeds/grape,
-/obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel,
-/area/hydroponics)
+/area/engine/mechanic_workshop)
 "pdd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/window/reinforced,
-/obj/machinery/floodlight{
-	light_power = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/hydroponics)
+/turf/simulated/floor/wood,
+/area/library)
 "pdg" = (
 /obj/structure/cable/orange,
 /obj/structure/cable/orange{
@@ -69403,7 +68828,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -69460,7 +68884,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 26
 	},
 /obj/structure/dispenser/oxygen,
@@ -69497,26 +68920,25 @@
 /turf/space,
 /area/solar/port)
 "peP" = (
-/obj/machinery/ai_status_display,
-/turf/simulated/wall,
-/area/crew_quarters/kitchen)
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/crew_quarters/fitness)
 "peQ" = (
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/turret_protected/ai)
 "peW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/freezer{
-	name = "Freezer";
-	req_access = list(28)
+/obj/structure/sink/kitchen{
+	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
@@ -69542,13 +68964,13 @@
 	},
 /area/toxins/misc_lab)
 "pfp" = (
-/obj/machinery/vending/snack,
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
 "pfM" = (
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/stripes/end{
@@ -69571,15 +68993,12 @@
 	},
 /area/security/podbay)
 "pgy" = (
-/obj/structure/railing/corner{
-	dir = 8
+/obj/structure/curtain/open/shower,
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
-/obj/structure/fans/tiny/invisible,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/fitness)
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/toilet)
 "pgJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -69641,32 +69060,32 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/north)
 "phF" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/table/wood,
-/obj/machinery/light,
+/mob/living/simple_animal/mouse/rat/gray/Ratatui,
 /turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
+	icon_state = "redfull";
+	tag = "icon-redfull (NORTHWEST)"
 	},
-/area/crew_quarters/bar)
+/area/crew_quarters/kitchen)
 "phM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/item/clothing/under/lawyer/black,
+/obj/item/clothing/under/lawyer/blue,
+/obj/item/clothing/under/kilt,
+/obj/item/clothing/head/beret,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/locker)
+/turf/simulated/floor/wood,
+/area/crew_quarters/cabin3)
 "phN" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -69711,14 +69130,6 @@
 	icon_state = "whiteyellow"
 	},
 /area/assembly/chargebay)
-"piO" = (
-/obj/structure/bed,
-/obj/item/bedsheet/red,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/cabin1)
 "piY" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/orange{
@@ -69746,11 +69157,13 @@
 	},
 /area/medical/medbay)
 "pjj" = (
-/obj/machinery/door/airlock{
-	id_tag = "fb2"
+/obj/structure/disposalpipe/segment,
+/obj/structure/table/wood,
+/obj/item/kitchen/utensil/fork,
+/turf/simulated/floor/plasteel{
+	icon_state = "redyellowfull"
 	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
+/area/crew_quarters/bar)
 "pjx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -69930,14 +69343,16 @@
 	},
 /area/security/interrogation)
 "png" = (
-/obj/machinery/photocopier,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+/obj/machinery/camera/autoname{
+	dir = 8
 	},
-/turf/simulated/floor/wood,
-/area/library)
+/obj/item/radio/intercom{
+	pixel_y = -28
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/crew_quarters/kitchen)
 "pno" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -69945,8 +69360,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -70022,8 +69436,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/wood,
 /area/medical/psych)
@@ -70123,8 +69536,7 @@
 	},
 /obj/machinery/light_switch{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/item/paper_bin,
 /turf/simulated/floor/plasteel{
@@ -70148,17 +69560,13 @@
 	},
 /area/toxins/mixing)
 "pqy" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/theatre)
 "pqU" = (
 /obj/machinery/door/window/eastright{
 	name = "Theatre Stage"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/theatre)
 "pqY" = (
 /turf/simulated/floor/plasteel{
@@ -70283,44 +69691,29 @@
 /turf/simulated/floor/wood,
 /area/civilian/vacantoffice)
 "ptB" = (
-/obj/structure/table,
-/obj/item/stack/packageWrap,
-/obj/item/destTagger,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
+	icon_state = "dark"
 	},
-/area/crew_quarters/kitchen)
+/area/crew_quarters/fitness)
 "ptK" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/kitchen)
-"ptQ" = (
-/obj/machinery/processor,
-/obj/machinery/camera{
-	c_tag = "Kitchen"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 28;
-	name = "custom placement"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/kitchen)
-"ptU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
+	icon_state = "dark"
 	},
-/area/crew_quarters/kitchen)
+/area/crew_quarters/fitness)
+"ptQ" = (
+/obj/machinery/door/window/eastleft{
+	pixel_x = -1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/crew_quarters/fitness)
+"ptU" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/library)
 "ptY" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
@@ -70340,13 +69733,19 @@
 	},
 /area/maintenance/asmaint5)
 "pus" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/camera{
+	c_tag = "Service Asteroid Hallway 5";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
+	dir = 8;
+	icon_state = "neutralcorner"
 	},
-/area/crew_quarters/kitchen)
+/area/hallway/primary/port/south)
 "puz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -70359,8 +69758,7 @@
 /area/toxins/storage)
 "puE" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -70384,8 +69782,7 @@
 /area/maintenance/engineering)
 "pvl" = (
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical{
@@ -70462,8 +69859,7 @@
 "pwb" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -70477,20 +69873,12 @@
 	},
 /area/security/podbay)
 "pwh" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/brute,
-/obj/item/radio/intercom{
-	pixel_x = 28;
-	name = "custom placement"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/area/crew_quarters/fitness)
+/turf/simulated/floor/carpet/green,
+/area/library)
 "pwj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -70573,12 +69961,12 @@
 "pyl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/cable/orange{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitered"
+	dir = 4;
+	icon_state = "whiteredfull"
 	},
 /area/security/medbay)
 "pyp" = (
@@ -70614,15 +70002,13 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "pzk" = (
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/vending/security,
 /turf/simulated/floor/plasteel{
@@ -70684,24 +70070,29 @@
 /turf/simulated/wall,
 /area/mine/unexplored/cere/medical)
 "pzM" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Fitness Room"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
+"pzN" = (
+/obj/machinery/camera{
+	c_tag = "Chapel"
+	},
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "escape"
+	icon_state = "chapel"
 	},
-/area/hallway/primary/port/east)
-"pzN" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/structure/fans/tiny/invisible,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/fitness)
+/area/chapel/main)
 "pAa" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/orange{
@@ -70725,9 +70116,7 @@
 /area/toxins/xenobiology)
 "pAj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/theatre)
 "pAr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -70744,9 +70133,7 @@
 /obj/structure/window{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/theatre)
 "pAA" = (
 /obj/effect/spawner/window/reinforced,
@@ -70804,6 +70191,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/landmark/start/civilian,
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
 "pCm" = (
@@ -70853,8 +70241,7 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -70890,20 +70277,9 @@
 /turf/simulated/mineral/ancient,
 /area/crew_quarters/cabin2)
 "pEF" = (
-/obj/machinery/light/small,
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/machinery/door_control{
-	id = "fb2";
-	name = "Privacy Bolts";
-	normaldoorcontrol = 1;
-	pixel_x = 24;
-	specialfunctions = 4
-	},
-/obj/effect/landmark/start/civilian,
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/carpet/black,
+/area/chapel/office)
 "pEH" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -70943,13 +70319,13 @@
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/maintenance/apmaint2)
 "pFC" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
+/obj/structure/railing,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
+	icon_state = "dark"
 	},
-/area/crew_quarters/kitchen)
+/area/crew_quarters/fitness)
 "pFJ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -70980,14 +70356,11 @@
 	},
 /area/space)
 "pFS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/light_switch{
+	pixel_x = -22
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "pGq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -70995,13 +70368,18 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/aft/west)
 "pGu" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
+	icon_state = "neutralcorner"
 	},
-/area/crew_quarters/kitchen)
+/area/hallway/primary/port/north)
 "pGv" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -71014,14 +70392,11 @@
 	},
 /area/bridge)
 "pGC" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
 	},
-/obj/machinery/kitchen_machine/candy_maker,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/carpet/cyan,
+/area/crew_quarters/fitness)
 "pGS" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/toxins,
@@ -71102,6 +70477,20 @@
 /obj/structure/closet,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"pIg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/chair/sofa/left{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "redyellowfull"
+	},
+/area/crew_quarters/bar)
 "pIu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -71187,8 +70576,7 @@
 /obj/structure/table/wood,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/item/toy/figure/clown,
 /turf/simulated/floor/wood,
@@ -71437,8 +70825,7 @@
 	icon_state = "4-8"
 	},
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -71485,18 +70872,17 @@
 /turf/simulated/floor/plating,
 /area/civilian/vacantoffice)
 "pPy" = (
-/obj/machinery/camera{
-	c_tag = "Crematorium";
-	dir = 9
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding1"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "asteroid"
 	},
-/area/chapel/office)
+/area/hydroponics)
 "pPN" = (
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
@@ -71529,7 +70915,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/caution/stand_clear,
@@ -71639,15 +71024,30 @@
 	icon_state = "darkpurple"
 	},
 /area/teleporter/quantum/science)
+"pSQ" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery";
+	location = "Kitchen"
+	},
+/obj/machinery/door/window/northleft{
+	dir = 4
+	},
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/kitchen)
 "pTd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/newscaster{
+	pixel_y = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/floodlight,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkgreenfull"
 	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
+/area/hydroponics)
 "pTh" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -71676,11 +71076,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "pTJ" = (
-/obj/item/radio/intercom{
-	pixel_y = 28
+/obj/structure/rack,
+/obj/item/weldingtool/largetank,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
 	},
+/obj/item/radio{
+	pixel_y = 6
+	},
+/obj/item/storage/toolbox/electrical,
+/obj/item/storage/belt/utility,
+/obj/item/extinguisher,
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 9;
 	icon_state = "yellow"
 	},
 /area/engine/mechanic_workshop)
@@ -71729,7 +71138,6 @@
 "pVm" = (
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/structure/cable/orange{
@@ -71798,6 +71206,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -71867,7 +71278,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -71888,17 +71298,17 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/theatre)
 "pXj" = (
-/obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/carpet/red,
-/area/chapel/main)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/black,
+/area/chapel/office)
 "pXp" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -71973,24 +71383,27 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/theatre)
 "pYu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "kitchen2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/door/window/westright{
+	dir = 2;
+	name = "Kitchen";
+	req_access_txt = "28"
 	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/carpet/green,
-/area/library)
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/crew_quarters/kitchen)
 "pYy" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -72004,15 +71417,9 @@
 /turf/simulated/wall/r_wall,
 /area/atmos)
 "pYG" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
+/obj/machinery/hydroponics/soil,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "pYL" = (
 /obj/effect/landmark/event/lightsout,
 /turf/simulated/floor/plasteel{
@@ -72147,12 +71554,12 @@
 	},
 /area/maintenance/fore)
 "qbU" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull";
+	tag = "icon-redfull (NORTHWEST)"
 	},
-/turf/simulated/floor/plating,
-/area/hydroponics)
+/area/crew_quarters/kitchen)
 "qct" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -72182,12 +71589,14 @@
 /turf/simulated/wall/r_wall,
 /area/engine/engineering)
 "qcL" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table/wood,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/library)
 "qcR" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -72230,6 +71639,27 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/engineering)
+"qea" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id_tag = "kitchen1"
+	},
+/obj/item/desk_bell{
+	pixel_x = 7;
+	pixel_y = 7;
+	anchored = 1
+	},
+/obj/machinery/door/window/westleft{
+	dir = 4;
+	name = "Kitchen";
+	req_access_txt = "28"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
 "qef" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
@@ -72246,17 +71676,11 @@
 	},
 /area/security/processing)
 "qel" = (
-/obj/machinery/camera{
-	c_tag = "Holodeck North"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/fitness)
+/turf/simulated/floor/wood,
+/area/library)
 "qeq" = (
 /turf/simulated/mineral/ancient/outer,
 /area/assembly/robotics)
@@ -72320,14 +71744,12 @@
 	},
 /area/engine/gravitygenerator)
 "qeU" = (
-/obj/machinery/cooker/deepfryer,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/plating/asteroid/ancient,
+/area/maintenance/port)
 "qeX" = (
 /obj/item/reagent_containers/food/drinks/bottle/patron,
 /obj/structure/table/wood,
@@ -72341,16 +71763,25 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "qfa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/structure/table,
-/obj/machinery/kitchen_machine/microwave,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding4"
+	},
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding2"
+	},
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding8"
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
+	icon_state = "asteroid"
 	},
-/area/crew_quarters/kitchen)
+/area/hydroponics)
 "qfg" = (
 /obj/machinery/door/airlock/medical{
 	name = "Brig Medical Bay";
@@ -72362,43 +71793,37 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whiteredfull"
 	},
 /area/security/medbay)
 "qfr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/light,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
 	},
-/obj/effect/landmark/start/chef,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "qft" = (
-/obj/structure/disposalpipe/segment{
+/obj/item/twohanded/required/kirbyplants,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
+"qfx" = (
+/obj/item/twohanded/required/kirbyplants,
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/library)
-"qfx" = (
-/obj/machinery/disposal,
-/obj/machinery/newscaster{
-	pixel_x = 28;
-	name = "east bump";
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/carpet/cyan,
+/area/crew_quarters/fitness)
 "qfX" = (
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -24
 	},
 /obj/structure/cable/orange{
@@ -72419,8 +71844,7 @@
 	dir = 4
 	},
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -72434,15 +71858,12 @@
 	},
 /area/ai_monitored/storage/eva)
 "qgJ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/machinery/door/airlock/atmos{
 	name = "Service Atmospherics Checkpoint";
 	req_access = list(24)
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/port2)
 "qgP" = (
@@ -72489,15 +71910,10 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/fore)
-"qhw" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/carpet/green,
-/area/library)
 "qhP" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
@@ -72526,9 +71942,7 @@
 /obj/item/book/manual/barman_recipes,
 /obj/item/lighter/zippo,
 /obj/structure/table/wood,
-/obj/structure/sign/barsign{
-	pixel_y = 32
-	},
+/obj/item/lighter/zippo,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "qiV" = (
@@ -72707,18 +72121,11 @@
 	},
 /area/toxins/mixing)
 "qlB" = (
-/obj/machinery/computer/HolodeckControl{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 9
-	},
-/obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+	dir = 1;
+	icon_state = "chapel"
 	},
-/area/crew_quarters/fitness)
+/area/chapel/main)
 "qlI" = (
 /obj/effect/spawner/random_barrier/wall_probably,
 /turf/simulated/floor/plating{
@@ -72830,8 +72237,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -72845,20 +72251,12 @@
 	},
 /area/assembly/chargebay)
 "qnk" = (
-/obj/structure/sign/poster/random{
-	name = "random official poster";
-	pixel_x = null;
-	pixel_y = -32;
-	random_basetype = /obj/structure/sign/poster/official
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 9
 	},
-/obj/structure/chair/stool,
-/obj/effect/landmark/start/civilian,
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
@@ -72905,13 +72303,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint2)
 "qnV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull"
+	icon_state = "dark"
 	},
-/area/crew_quarters/sleep)
+/area/library)
 "qob" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -73069,15 +72467,14 @@
 	},
 /area/maintenance/asmaint5)
 "qqe" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
+/obj/machinery/kitchen_machine/grill,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "cafeteria"
 	},
-/area/library)
+/area/crew_quarters/kitchen)
 "qqj" = (
 /obj/structure/girder,
 /obj/item/stack/sheet/metal,
@@ -73092,13 +72489,13 @@
 	},
 /area/medical/reception)
 "qqo" = (
-/obj/structure/chair/stool/bar{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
+	icon_state = "dark"
 	},
-/area/crew_quarters/bar)
+/area/hydroponics)
 "qqu" = (
 /obj/structure/cable/orange{
 	icon_state = "1-4"
@@ -73109,15 +72506,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "qqD" = (
-/mob/living/simple_animal/crab{
-	desc = "The local trainer hired to keep the crew in shape by aggressively snipping at them.";
-	name = "Crabohydrates"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/crew_quarters/fitness)
+/obj/structure/dresser,
+/turf/simulated/floor/wood,
+/area/crew_quarters/cabin4)
 "qqL" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -73132,11 +72523,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/orange{
 	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	tag = "icon-pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -73211,8 +72603,7 @@
 "qsR" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -73263,9 +72654,7 @@
 	dir = 4
 	},
 /obj/structure/rack,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/theatre)
 "qtF" = (
 /obj/structure/cable{
@@ -73383,16 +72772,11 @@
 /turf/simulated/floor/grass,
 /area/hallway/secondary/exit)
 "qwO" = (
-/obj/structure/table,
-/obj/structure/railing{
-	dir = 10
-	},
-/obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "chapel"
 	},
-/area/crew_quarters/fitness)
+/area/chapel/main)
 "qxj" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
@@ -73403,7 +72787,6 @@
 "qxn" = (
 /obj/machinery/newscaster{
 	pixel_x = 28;
-	name = "east bump";
 	dir = 8
 	},
 /obj/machinery/r_n_d/circuit_imprinter,
@@ -73412,16 +72795,11 @@
 	},
 /area/toxins/lab)
 "qxu" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/machinery/vending/dinnerware,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/carpet/green,
+/area/library)
 "qxB" = (
 /obj/machinery/conveyor/auto,
 /obj/machinery/light/small{
@@ -73431,9 +72809,6 @@
 /area/maintenance/disposal/external/southwest)
 "qxG" = (
 /obj/machinery/atmospherics/binary/valve/open,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/port2)
@@ -73551,8 +72926,7 @@
 "qAH" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -73616,8 +72990,7 @@
 "qBz" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -73694,7 +73067,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/simulated/floor/engine,
@@ -73730,7 +73102,6 @@
 "qCO" = (
 /obj/machinery/newscaster{
 	pixel_y = -28;
-	name = "south bump";
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -73739,17 +73110,17 @@
 	},
 /area/hallway/primary/starboard/north)
 "qCQ" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+/obj/machinery/button/windowtint{
+	anchored = 1;
+	id = "library";
+	pixel_y = 26
 	},
-/area/crew_quarters/fitness)
+/turf/simulated/floor/wood,
+/area/library)
 "qCT" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -73833,13 +73204,11 @@
 	},
 /area/security/podbay)
 "qFp" = (
-/obj/structure/table,
-/obj/item/kitchen/rollingpin,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "qFq" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -73866,21 +73235,10 @@
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology)
 "qFX" = (
-/obj/machinery/kitchen_machine/grill,
-/obj/machinery/requests_console{
-	department = "Kitchen";
-	departmentType = 2;
-	name = "Kitchen Requests Console";
-	pixel_x = 30
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/kitchen)
+/obj/structure/punching_bag,
+/turf/simulated/floor/carpet/cyan,
+/area/crew_quarters/fitness)
 "qGb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/camera{
 	c_tag = "Service Atmospherics Checkpoint";
 	dir = 5
@@ -73926,16 +73284,9 @@
 /turf/space,
 /area/hallway/spacebridge/sercom)
 "qGP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/fitness)
+/obj/machinery/light/small,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "qGQ" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/starboardsolar)
@@ -73991,8 +73342,7 @@
 /area/maintenance/electrical_shop)
 "qHH" = (
 /obj/item/radio/intercom{
-	pixel_x = 28;
-	name = "custom placement"
+	pixel_x = 28
 	},
 /obj/machinery/camera{
 	c_tag = "Detective's Office";
@@ -74486,8 +73836,7 @@
 	pixel_y = 25
 	},
 /obj/item/radio/intercom{
-	pixel_x = 28;
-	name = "custom placement"
+	pixel_x = 28
 	},
 /obj/item/radio/intercom/private{
 	pixel_x = 28;
@@ -74532,8 +73881,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -74541,14 +73889,13 @@
 	},
 /area/hallway/primary/port/east)
 "qTM" = (
-/obj/machinery/door/window/eastright{
-	dir = 8
+/obj/structure/chair/sofa/right{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "redyellowfull"
 	},
-/area/crew_quarters/fitness)
+/area/crew_quarters/bar)
 "qUd" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -74582,16 +73929,11 @@
 /turf/space,
 /area/solar/starboardaux)
 "qVc" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/newscaster{
+	pixel_y = 28
 	},
-/obj/structure/urinal{
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
+/turf/simulated/floor/carpet/black,
+/area/chapel/office)
 "qVi" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/shuttle,
@@ -74610,15 +73952,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint2)
 "qVt" = (
-/obj/structure/closet/masks,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -28
 	},
+/obj/structure/bed,
+/obj/item/bedsheet/blue,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "grimy"
 	},
-/area/crew_quarters/fitness)
+/area/crew_quarters/cabin1)
 "qVA" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -74706,10 +74049,17 @@
 /turf/simulated/wall,
 /area/maintenance/fore)
 "qXA" = (
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/structure/table/wood/fancy/black,
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/item/kitchen/utensil/fork,
+/turf/simulated/floor/plasteel{
+	icon_state = "redyellowfull"
+	},
 /area/crew_quarters/bar)
 "qXV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
@@ -74784,17 +74134,12 @@
 /mob/living/simple_animal/mouse/hamster/Representative,
 /turf/simulated/floor/wood,
 /area/ntrep)
-"qZk" = (
-/obj/machinery/computer/cryopod{
-	pixel_x = -32
+"qZf" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull"
-	},
-/area/crew_quarters/sleep)
+/turf/simulated/floor/carpet/green,
+/area/library)
 "qZp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -74828,11 +74173,18 @@
 	},
 /area/maintenance/asmaint5)
 "ran" = (
-/obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/door/airlock/public/glass{
+	req_access_txt = "35";
+	name = "Garden"
 	},
-/area/chapel/main)
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "asteroid"
+	},
+/area/hydroponics)
 "rao" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -74848,7 +74200,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/stripes/asteroid/end,
@@ -74877,13 +74228,14 @@
 	},
 /area/hallway/spacebridge/cargocom)
 "rbj" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
-	},
 /obj/machinery/light_switch{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/unary/cold_sink/freezer{
+	current_temperature = 80;
+	on = 1;
+	dir = 8
 	},
 /turf/simulated/floor/plasteel/dark/telecomms,
 /area/toxins/server)
@@ -74940,8 +74292,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -75019,14 +74370,15 @@
 	},
 /area/medical/morgue)
 "rds" = (
-/obj/structure/chair/sofa/pew/left{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "chapel"
+/obj/item/radio/intercom{
+	pixel_x = 28
 	},
-/area/chapel/main)
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/toilet)
 "rdM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -75136,8 +74488,7 @@
 /area/maintenance/engineering)
 "rgu" = (
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel{
@@ -75208,6 +74559,14 @@
 	name = "Central Access"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -75231,14 +74590,24 @@
 	},
 /area/hallway/primary/port/north)
 "rim" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
+/obj/machinery/cryopod{
+	dir = 2
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 24
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "whitegreen"
 	},
-/area/hydroponics)
+/area/crew_quarters/sleep)
 "riF" = (
 /obj/machinery/flasher{
 	id = "Cell 3";
@@ -75290,8 +74659,7 @@
 /area/medical/patients_rooms)
 "rjy" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -75299,23 +74667,10 @@
 	},
 /area/toxins/hallway)
 "rjM" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/eastleft{
-	base_state = "right";
-	icon_state = "right";
-	name = "Kitchen";
-	req_access = list(28)
-	},
-/obj/machinery/door/window/eastleft{
-	base_state = "right";
-	icon_state = "right";
-	name = "Kitchen";
-	req_access = list(35);
-	dir = 8
-	},
+/obj/structure/table,
+/obj/item/storage/firstaid/o2,
 /turf/simulated/floor/plasteel,
-/area/crew_quarters/kitchen)
+/area/crew_quarters/fitness)
 "rjY" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -75343,22 +74698,29 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "rkr" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/mint,
-/obj/item/eftpos,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/area/crew_quarters/kitchen)
+/obj/machinery/disposal,
+/turf/simulated/floor/plasteel{
+	icon_state = "redyellowfull"
+	},
+/area/crew_quarters/bar)
 "rkt" = (
-/obj/structure/table,
-/obj/machinery/kitchen_machine/microwave,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/area/crew_quarters/kitchen)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "asteroid"
+	},
+/area/hydroponics)
 "rkK" = (
 /obj/effect/landmark/start/engineer,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -75371,6 +74733,18 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"rle" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
 "rll" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -75422,25 +74796,32 @@
 "rlB" = (
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
 /area/turret_protected/aisat_interior)
 "rlI" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
-"rlM" = (
-/obj/structure/cable{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/port/south)
+"rlM" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/port2)
@@ -75471,8 +74852,7 @@
 "rmL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/item/radio/intercom{
-	pixel_x = -28;
-	name = "custom placement"
+	pixel_x = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
@@ -75599,8 +74979,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -75614,9 +74993,7 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
-	cell_type = 25000;
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -75687,14 +75064,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint5)
 "rqe" = (
-/obj/structure/table,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
-/obj/machinery/photocopier/faxmachine{
-	department = "Chief Medical Officer's Office"
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -75715,18 +75091,24 @@
 	},
 /area/medical/surgery/south)
 "rqJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/event/lightsout,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/area/crew_quarters/bar)
+/turf/simulated/floor/carpet/green,
+/area/library)
 "rqP" = (
-/obj/structure/closet/coffin,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/table/wood,
+/obj/item/camera_film,
+/obj/item/camera_film,
+/obj/machinery/door/window/westright{
+	dir = 2;
+	name = "Front Desk";
+	req_access = list(37)
 	},
-/area/chapel/main)
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/library)
 "rrp" = (
 /obj/effect/turf_decal/bot_white{
 	color = "#009dff"
@@ -75781,15 +75163,13 @@
 "rsj" = (
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -75830,7 +75210,6 @@
 "rtt" = (
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/stripes/asteroid/end{
@@ -75880,7 +75259,6 @@
 /obj/structure/closet/l3closet/scientist,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -76005,7 +75383,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
@@ -76136,34 +75514,40 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/southwest)
 "rzI" = (
-/obj/structure/railing{
-	dir = 8
+/obj/structure/toilet{
+	pixel_y = 6
 	},
-/obj/structure/chair{
-	dir = 8
+/obj/machinery/door_control{
+	id = "fb2";
+	name = "Privacy Bolts";
+	normaldoorcontrol = 1;
+	pixel_x = 24;
+	specialfunctions = 4
 	},
-/obj/structure/fans/tiny/invisible,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
-"rzK" = (
-/obj/machinery/door/window/westright{
-	name = "Hydroponics Desk";
-	req_access = list(35);
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/westright{
-	name = "Hydroponics Desk"
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/toilet)
+"rzK" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/item/desk_bell{
-	pixel_x = 7;
-	pixel_y = 7;
-	anchored = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "neutralcorner"
 	},
-/area/hydroponics)
+/area/hallway/primary/port/south)
 "rAi" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -76182,8 +75566,7 @@
 "rAD" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -76224,15 +75607,13 @@
 /turf/simulated/floor/plating/airless,
 /area/maintenance/disposal/east)
 "rBv" = (
-/obj/structure/chair/office/dark{
-	dir = 8
+/obj/structure/cable/orange{
+	icon_state = "1-4"
 	},
-/obj/effect/landmark/start/botanist,
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "whitegreenfull"
 	},
-/area/hydroponics)
+/area/crew_quarters/sleep)
 "rBB" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Port Asteroid Maintenance";
@@ -76263,12 +75644,14 @@
 /turf/simulated/wall,
 /area/hallway/primary/starboard/south)
 "rBT" = (
-/obj/effect/landmark/start/botanist,
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "whitegreenfull"
 	},
-/area/hydroponics)
+/area/crew_quarters/sleep)
 "rBV" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24;
@@ -76366,24 +75749,27 @@
 	},
 /area/security/lobby)
 "rDn" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/smartfridge/secure{
-	name = "\improper Kitchen Delivery SmartFridge";
-	req_one_access = list(28,35)
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/structure/chair/stool{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/crew_quarters/kitchen)
+/area/crew_quarters/fitness)
+"rDt" = (
+/obj/machinery/door/airlock/glass{
+	name = "Library"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/library)
 "rEg" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+/obj/machinery/camera/autoname{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "rEm" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24;
@@ -76498,8 +75884,7 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
@@ -76512,20 +75897,17 @@
 	},
 /area/hallway/spacebridge/cargocom)
 "rGC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/carpet/red,
-/area/chapel/main)
-"rHd" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
+/area/hydroponics)
+"rHd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -76551,9 +75933,6 @@
 	dir = 8;
 	level = 2
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -76562,7 +75941,6 @@
 /area/maintenance/port2)
 "rHo" = (
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -24
 	},
 /obj/structure/cable/orange,
@@ -76631,8 +76009,7 @@
 /area/maintenance/disposal)
 "rIO" = (
 /obj/item/radio/intercom{
-	pixel_x = -28;
-	name = "custom placement"
+	pixel_x = -28
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -76662,8 +76039,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -76726,22 +76102,17 @@
 /turf/simulated/floor/plasteel,
 /area/security/lobby)
 "rKX" = (
-/obj/structure/window/reinforced,
+/obj/machinery/light{
+	dir = 4
+	},
 /obj/machinery/slot_machine,
-/obj/machinery/camera{
-	c_tag = "Bar East";
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "rLb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -76751,11 +76122,7 @@
 	},
 /area/hallway/primary/starboard/south)
 "rLk" = (
-/obj/structure/chair/comfy/black{
-	dir = 1
-	},
-/obj/effect/landmark/start/civilian,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/carpet/orange,
 /area/crew_quarters/bar)
 "rLp" = (
 /obj/structure/table,
@@ -76795,6 +76162,9 @@
 	dir = 8;
 	icon_state = "pipe-j2"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -76816,6 +76186,16 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/starboard/south)
+"rMH" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/chili,
+/obj/item/seeds/grape,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkgreenfull"
+	},
+/area/hydroponics)
 "rMP" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -76849,9 +76229,22 @@
 	},
 /area/hallway/primary/aft/east)
 "rNg" = (
-/obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/keycard_auth{
 	pixel_x = -24
+	},
+/obj/structure/closet/secure_closet/CMO,
+/obj/item/megaphone,
+/obj/item/cartridge/medical{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/item/cartridge/medical{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/cartridge/medical,
+/obj/item/cartridge/chemistry{
+	pixel_y = 2
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -76894,8 +76287,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -76921,28 +76313,17 @@
 	},
 /area/medical/cmo)
 "rOX" = (
-/obj/structure/closet/secure_closet/CMO,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/cartridge/chemistry{
-	pixel_y = 2
+/obj/structure/table,
+/obj/machinery/photocopier/faxmachine/longrange{
+	department = "Chief Medical Officer's Office"
 	},
-/obj/item/cartridge/medical,
-/obj/item/cartridge/medical{
-	pixel_x = 6;
-	pixel_y = 3
-	},
-/obj/item/cartridge/medical{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/obj/item/megaphone,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkblue"
@@ -77143,12 +76524,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint2)
 "rSr" = (
-/obj/structure/chair/comfy/black{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/effect/landmark/start/civilian,
-/turf/simulated/floor/carpet/green,
-/area/library)
+/turf/simulated/floor/plasteel{
+	icon_state = "redyellowfull"
+	},
+/area/crew_quarters/bar)
 "rSu" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
@@ -77167,8 +76550,7 @@
 "rSN" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/structure/dresser,
 /turf/simulated/floor/plasteel{
@@ -77245,7 +76627,6 @@
 "rUB" = (
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -77284,37 +76665,17 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/port/north)
 "rVw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/window/westright{
-	name = "Hydroponics Desk";
-	req_access = list(35);
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/westright{
-	name = "Hydroponics Desk"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/hydroponics)
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/crew_quarters/sleep)
 "rVx" = (
 /obj/structure/cable/orange{
 	icon_state = "2-4"
@@ -77325,8 +76686,7 @@
 /area/maintenance/fore2)
 "rVC" = (
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -77366,8 +76726,7 @@
 "rWf" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -77398,21 +76757,13 @@
 	},
 /area/medical/chemistry)
 "rWQ" = (
-/obj/machinery/hydroponics/constructable,
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkgreenfull"
+	icon_state = "whitegreenfull"
 	},
-/area/hydroponics)
+/area/crew_quarters/sleep)
 "rXn" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating/airless,
@@ -77425,8 +76776,9 @@
 	},
 /area/security/medbay)
 "rXV" = (
-/turf/simulated/mineral/ancient,
-/area/engine/mechanic_workshop/expedition)
+/obj/structure/sign/custodian,
+/turf/simulated/wall,
+/area/space)
 "rXW" = (
 /obj/structure/showcase{
 	density = 0;
@@ -77485,12 +76837,16 @@
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "rYB" = (
-/obj/structure/railing{
-	dir = 1
+/obj/machinery/door/airlock{
+	name = "Bathroom"
 	},
-/obj/structure/fans/tiny/invisible,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/toilet)
 "rYV" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -77534,16 +76890,9 @@
 	},
 /area/security/brig)
 "rZo" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
+/obj/effect/spawner/window,
+/turf/simulated/floor/plating,
+/area/hydroponics)
 "rZw" = (
 /obj/machinery/power/grounding_rod{
 	anchored = 1
@@ -77567,23 +76916,30 @@
 /turf/simulated/wall,
 /area/hallway/secondary/entry/north)
 "sab" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/item/radio/intercom{
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkgreenfull"
-	},
-/area/hydroponics)
-"saj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/hydroponics)
+/area/chapel/office)
+"saj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitegreenfull"
+	},
+/area/crew_quarters/sleep)
 "sak" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 4
@@ -77601,7 +76957,6 @@
 "sat" = (
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -77637,25 +76992,11 @@
 	},
 /area/hallway/secondary/entry/north)
 "saT" = (
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/full,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
 /obj/item/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = -29
+	pixel_x = 28
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "sbg" = (
 /obj/structure/barricade/wooden,
 /turf/simulated/floor/plating{
@@ -77735,17 +77076,16 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/starboard/south)
 "sco" = (
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+/obj/effect/landmark/start/mime,
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
 	},
-/area/hallway/primary/port/south)
+/area/mimeoffice)
 "scE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -77758,7 +77098,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -77806,21 +77145,11 @@
 	},
 /area/hallway/primary/starboard/north)
 "scR" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/stripes/asteroid/end{
-	dir = 4
-	},
-/obj/structure/cable/orange{
-	icon_state = "0-4"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/library)
+/area/maintenance/gambling_den2)
 "scS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -77875,8 +77204,7 @@
 /area/hallway/primary/starboard/south)
 "sdN" = (
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/wood,
 /area/ntrep)
@@ -77994,7 +77322,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /mob/living/simple_animal/pet/cat/Runtime,
@@ -78022,12 +77349,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/external/southeast)
 "sfH" = (
-/obj/structure/chair/wood/wings{
-	dir = 1
+/obj/structure/table,
+/obj/item/destTagger,
+/obj/item/stack/packageWrap,
+/obj/item/book/manual/hydroponics_pod_people,
+/obj/item/book/manual/hydroponics_pod_people,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkgreenfull"
 	},
-/obj/effect/landmark/start/chaplain,
-/turf/simulated/floor/carpet/black,
-/area/chapel/office)
+/area/hydroponics)
 "sfZ" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -78082,8 +77413,7 @@
 "sgE" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -78187,8 +77517,7 @@
 /obj/item/clothing/glasses/meson,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -78306,7 +77635,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -78388,8 +77716,7 @@
 "smf" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -78480,24 +77807,22 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/aft/west)
 "snQ" = (
-/obj/machinery/light,
-/obj/item/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = -29
+/obj/machinery/cryopod{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitegreen"
+	},
+/area/crew_quarters/sleep)
+"snW" = (
+/obj/structure/chair/office/light{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/hydroponics)
-"snW" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/effect/landmark/start/civilian,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
 "snX" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -78530,11 +77855,11 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "soz" = (
-/obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkgreen"
+/obj/item/radio/intercom{
+	pixel_x = -28
 	},
-/area/hydroponics)
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "spf" = (
 /obj/effect/spawner/random_spawners/blood_maybe,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -78573,7 +77898,6 @@
 "squ" = (
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/structure/cable,
@@ -78607,13 +77931,13 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/port2)
 "srV" = (
@@ -78815,10 +78139,10 @@
 	},
 /area/chapel/main)
 "sup" = (
-/obj/structure/chair/office/dark,
-/obj/effect/landmark/start/civilian,
-/turf/simulated/floor/wood,
-/area/library)
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/crew_quarters/kitchen)
 "suP" = (
 /obj/structure/girder,
 /obj/effect/spawner/window/reinforced,
@@ -78944,8 +78268,7 @@
 /obj/machinery/light_switch{
 	dir = 4;
 	pixel_x = -4;
-	pixel_y = -32;
-	name = "custom placement"
+	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -79050,6 +78373,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/engine,
 /area/toxins/test_chamber)
+"sAH" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/maintenance/port)
 "sAI" = (
 /obj/structure/sign/security{
 	pixel_x = 32
@@ -79096,14 +78431,13 @@
 /turf/simulated/wall/r_wall,
 /area/medical/virology)
 "sBU" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "whitegreenfull"
 	},
-/area/hydroponics)
+/area/crew_quarters/sleep)
 "sBV" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -79153,14 +78487,26 @@
 	},
 /area/storage/primary)
 "sCU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "kitchen2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/item/desk_bell{
+	pixel_x = 7;
+	pixel_y = 7;
+	anchored = 1
 	},
-/turf/simulated/floor/wood,
-/area/library)
+/obj/machinery/door/window/westright{
+	dir = 2;
+	name = "Kitchen";
+	req_access_txt = "28"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/crew_quarters/kitchen)
 "sCV" = (
 /obj/item/radio/beacon,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -79171,6 +78517,14 @@
 	},
 /turf/simulated/floor/engine,
 /area/toxins/explab_chamber)
+"sDe" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/security/medbay)
 "sDk" = (
 /obj/machinery/conveyor/auto{
 	dir = 8
@@ -79287,36 +78641,23 @@
 	},
 /area/engine/engineering)
 "sFq" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "kitchen1"
-	},
-/obj/machinery/door/window/northleft{
-	name = "Kitchen Pick-Up";
-	req_access = list(28)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/crew_quarters/kitchen)
+/area/crew_quarters/fitness)
 "sFr" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/northleft{
-	name = "Kitchen Pick-Up";
-	req_access = list(28)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "kitchen1"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/machinery/door/firedoor,
-/obj/item/desk_bell{
-	pixel_x = 7;
-	pixel_y = 7;
-	anchored = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/kitchen)
+/area/library)
 "sFF" = (
 /obj/effect/landmark/event/lightsout,
 /turf/simulated/floor/transparent/glass/reinforced{
@@ -79330,11 +78671,12 @@
 	},
 /area/security/permabrig)
 "sFW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/chem_master/condimaster,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkgreenfull"
 	},
-/turf/simulated/floor/carpet/black,
-/area/chapel/office)
+/area/hydroponics)
 "sGf" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -79363,25 +78705,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/external/east)
 "sGz" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/northleft{
-	name = "Kitchen Pick-Up";
-	req_access = list(28)
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "kitchen1"
-	},
-/turf/simulated/floor/plasteel,
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/kitchenspike,
+/turf/simulated/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "sGH" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escape"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/hallway/primary/port/east)
+/mob/living/simple_animal/mouse/rat/irish/Remi,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/crew_quarters/kitchen)
 "sGZ" = (
 /obj/structure/table,
 /obj/item/stock_parts/cell/high/plus,
@@ -79409,8 +78745,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -79426,7 +78761,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/stripes/end{
@@ -79556,23 +78890,29 @@
 	},
 /area/hallway/spacebridge/sercom)
 "sLi" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -32
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/effect/landmark/start/botanist,
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding8"
+	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "asteroid"
 	},
-/area/hallway/primary/port/south)
+/area/hydroponics)
 "sLH" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 2
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -79593,21 +78933,29 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/orange{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/orange{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/fore/west)
 "sMp" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/obj/structure/cable/orange{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
 /area/maintenance/gambling_den2)
 "sME" = (
 /obj/machinery/light{
@@ -79677,8 +79025,7 @@
 /area/assembly/robotics)
 "sOx" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -79703,7 +79050,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
@@ -79717,7 +79063,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/newscaster{
 	dir = 4;
-	name = "west bump";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -79784,8 +79129,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	pixel_x = -28;
-	name = "custom placement"
+	pixel_x = -28
 	},
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel{
@@ -79833,7 +79177,6 @@
 /area/storage/primary)
 "sSj" = (
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -24
 	},
 /obj/structure/cable/orange{
@@ -79911,7 +79254,7 @@
 /area/maintenance/apmaint2)
 "sTp" = (
 /obj/structure/table,
-/obj/machinery/photocopier/faxmachine{
+/obj/machinery/photocopier/faxmachine/longrange{
 	department = "Research Director's Office"
 	},
 /turf/simulated/floor/plasteel{
@@ -79944,7 +79287,13 @@
 	dir = 4
 	},
 /obj/structure/closet/crate,
-/turf/simulated/floor/plating/asteroid/ancient,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
 /area/maintenance/gambling_den2)
 "sUG" = (
 /obj/structure/grille/broken,
@@ -80035,11 +79384,15 @@
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "sWh" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/door_control{
+	id = "kitchen2";
+	name = "Privacy Shutters";
+	pixel_y = 24
 	},
-/turf/simulated/floor/wood,
-/area/library)
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
 "sWr" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -80056,9 +79409,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/southwest)
-"sXj" = (
-/turf/simulated/wall/r_wall,
-/area/maintenance/engineering)
 "sXp" = (
 /obj/structure/closet/crate/freezer,
 /obj/effect/turf_decal/bot,
@@ -80068,13 +79418,12 @@
 	},
 /area/medical/virology)
 "sXs" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/door/airlock/maintenance{
+	name = "Hydroponics";
+	req_access_txt = "35"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet/green,
-/area/library)
+/turf/simulated/floor/plating,
+/area/hydroponics)
 "sXz" = (
 /obj/machinery/computer/med_data{
 	dir = 1
@@ -80093,14 +79442,13 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "sXR" = (
-/obj/structure/railing/corner{
+/obj/structure/chair/sofa/pew/right{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "chapel"
 	},
-/area/crew_quarters/fitness)
+/area/chapel/main)
 "sXY" = (
 /obj/structure/morgue,
 /obj/effect/decal/warning_stripes/south,
@@ -80139,10 +79487,10 @@
 	},
 /area/medical/morgue)
 "sYH" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
+/obj/structure/chair/comfy/black{
+	dir = 8
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/green,
 /area/library)
 "sZd" = (
 /obj/machinery/hologram/holopad,
@@ -80180,8 +79528,13 @@
 /turf/simulated/wall,
 /area/hallway/primary/fore)
 "sZE" = (
-/turf/simulated/mineral/ancient,
-/area/crew_quarters/cabin4)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/bot/left,
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/atmos)
 "sZL" = (
 /obj/machinery/camera{
 	c_tag = "Medbay South";
@@ -80208,8 +79561,7 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/machinery/door_control{
 	desc = "A remote control-switch to lock down the prison wing's blast doors";
@@ -80253,8 +79605,7 @@
 /area/maintenance/fore2)
 "tbf" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -80305,11 +79656,10 @@
 	},
 /area/hallway/secondary/entry/south)
 "tcg" = (
-/obj/structure/urinal{
-	pixel_x = 32
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/locker)
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/machinery/light,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/cabin2)
 "tcm" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 2;
@@ -80358,15 +79708,13 @@
 /turf/simulated/wall,
 /area/turret_protected/aisat_interior)
 "tcM" = (
-/obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+/obj/machinery/door/airlock/freezer{
+	name = "Freezer";
+	req_access_txt = "28"
 	},
-/obj/structure/closet/coffin,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel/freezer,
+/area/hydroponics)
 "tcN" = (
 /obj/structure/closet/firecloset/full,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -80404,8 +79752,7 @@
 "tdP" = (
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -80486,11 +79833,9 @@
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "tfK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/black,
-/area/chapel/office)
+/obj/structure/closet/lasertag/blue,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "tfR" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel{
@@ -80499,22 +79844,16 @@
 	},
 /area/hallway/secondary/exit)
 "tfU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/sign/poster/random{
+	name = "random official poster";
+	pixel_y = 32;
+	random_basetype = /obj/structure/sign/poster/official
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/disposalpipe/junction{
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/port/south)
+/turf/simulated/floor/carpet/cyan,
+/area/crew_quarters/fitness)
 "tga" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowcorners"
@@ -80582,36 +79921,24 @@
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "thZ" = (
-/obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+/obj/structure/chair/stool/bar{
+	dir = 4
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escape"
-	},
-/area/hallway/primary/port/east)
+/obj/effect/landmark/start/civilian,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/bar)
 "til" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
 /turf/simulated/floor/plating,
-/area/crew_quarters/fitness)
+/area/hallway/primary/port/south)
 "tim" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/carpet/green,
-/area/library)
+/area/crew_quarters/kitchen)
 "tir" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -80663,15 +79990,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/mechanic_workshop/expedition)
-"tiH" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/fitness)
 "tiI" = (
 /obj/structure/cable/orange{
 	icon_state = "2-8"
@@ -80788,12 +80106,10 @@
 	},
 /area/toxins/lab)
 "tjO" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/locker)
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/cabin2)
 "tjS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -80869,7 +80185,6 @@
 	dir = 5
 	},
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -24
 	},
 /obj/structure/cable/orange{
@@ -80913,11 +80228,12 @@
 	},
 /area/medical/medbay)
 "tly" = (
-/obj/machinery/kitchen_machine/oven,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/crew_quarters/kitchen)
+/obj/structure/chair/stool,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "tlJ" = (
 /obj/structure/grille/broken,
 /obj/structure/disposalpipe/segment{
@@ -80926,9 +80242,15 @@
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/starboard)
 "tma" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/kitchen)
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/crew_quarters/fitness)
 "tmq" = (
 /obj/item/storage/box/syringes,
 /obj/structure/rack,
@@ -81054,12 +80376,10 @@
 /obj/item/reagent_containers/food/snacks/pie,
 /obj/machinery/light_switch{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/wood,
 /area/clownoffice)
@@ -81161,13 +80481,10 @@
 	},
 /area/atmos)
 "tqj" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet/red,
-/area/chapel/main)
+/obj/structure/table,
+/obj/item/kitchen/knife,
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/kitchen)
 "tqy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 4
@@ -81202,6 +80519,9 @@
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -81232,9 +80552,13 @@
 	},
 /area/hallway/primary/fore)
 "trp" = (
-/obj/effect/landmark/start/civilian,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/green,
+/area/library)
 "trx" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -81298,8 +80622,7 @@
 "ttC" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bottle/ether,
@@ -81317,7 +80640,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -81328,6 +80650,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -81370,7 +80695,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/simulated/floor/engine,
@@ -81401,8 +80725,13 @@
 /area/maintenance/atmospherics)
 "tvd" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/sortjunction/reversed{
+	dir = 8;
+	name = "disposal pipe - Hydroponics";
+	sortType = 21
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -81431,10 +80760,9 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 2;
-	name = "disposal pipe - Kitchen";
-	sortType = 20
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -81473,8 +80801,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/engine{
 	slowdown = -0.3
@@ -81487,23 +80814,15 @@
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/fpmaint)
 "twA" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/hallway/primary/port/south)
 "twM" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/fyellow{
@@ -81591,8 +80910,7 @@
 /obj/item/stack/packageWrap,
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
@@ -81604,28 +80922,28 @@
 	},
 /area/toxins/lab)
 "tyR" = (
-/obj/machinery/biogenerator,
-/obj/machinery/requests_console{
-	department = "Hydroponics";
-	departmentType = 2;
-	name = "Hydroponics Requests Console";
-	pixel_y = 30
+/obj/machinery/smartfridge/secure{
+	name = "\improper Kitchen Delivery SmartFridge";
+	req_one_access_txt = "28;35"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "darkgreenfull"
+	icon_state = "neutralfull"
 	},
 /area/hydroponics)
 "tzb" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance";
-	req_access = list(12)
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/library)
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/office)
 "tzh" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -81672,10 +80990,6 @@
 	},
 /area/maintenance/gambling_den2)
 "tzH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
@@ -81699,12 +81013,19 @@
 "tzR" = (
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange,
 /turf/simulated/floor/plating/airless,
 /area/toxins/test_area)
+"tAc" = (
+/obj/structure/chair/sofa/right{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "redyellowfull"
+	},
+/area/crew_quarters/bar)
 "tAX" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Walkway"
@@ -81781,7 +81102,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -81798,12 +81118,11 @@
 	},
 /area/engine/gravitygenerator)
 "tCy" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	name = "north bump"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/turf/simulated/floor/carpet/black,
-/area/chapel/office)
+/turf/simulated/floor/carpet/green,
+/area/library)
 "tCE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -81821,14 +81140,9 @@
 	},
 /area/toxins/launch)
 "tCX" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/green,
-/area/library)
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/carpet/black,
+/area/chapel/office)
 "tDj" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/light/small{
@@ -81984,8 +81298,7 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -82010,8 +81323,7 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -82039,12 +81351,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "tIo" = (
-/obj/structure/chair/office/dark{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
 	},
-/obj/effect/landmark/start/civilian,
-/turf/simulated/floor/wood,
-/area/library)
+/area/maintenance/port2)
 "tIt" = (
 /obj/machinery/status_display{
 	layer = 4
@@ -82067,6 +81379,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/south)
+"tIQ" = (
+/obj/machinery/computer/security/telescreen/entertainment,
+/turf/simulated/mineral/ancient,
+/area/library)
 "tIY" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -82282,14 +81598,28 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowcorners"
 	},
-/area/maintenance/engineering)
+/area/engine/break_room)
 "tMQ" = (
 /turf/simulated/floor/carpet,
 /area/library)
+"tMS" = (
+/obj/machinery/ai_status_display,
+/turf/simulated/wall,
+/area/hydroponics)
 "tNt" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/carpet,
-/area/library)
+/obj/item/reagent_containers/glass/beaker,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
 "tNz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -82338,15 +81668,19 @@
 	},
 /area/medical/surgery/south)
 "tOx" = (
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 32
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/obj/machinery/computer/arcade,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
+"tOP" = (
+/obj/structure/table/wood,
+/obj/item/stack/sheet/wood{
+	amount = 30
+	},
+/obj/item/wrench,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/library)
 "tOU" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -82392,6 +81726,12 @@
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/maintenance/fpmaint)
 "tQa" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whiteblue"
@@ -82474,7 +81814,9 @@
 	pixel_x = -32
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/port2)
 "tSB" = (
@@ -82502,14 +81844,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/external/east)
 "tTE" = (
-/obj/machinery/door/morgue{
-	name = "Private Study";
-	req_access = list(37)
+/obj/structure/disposalpipe/segment,
+/obj/structure/table,
+/obj/item/storage/firstaid/brute,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/area/library)
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "tTK" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line,
@@ -82600,16 +81945,11 @@
 	},
 /area/hallway/secondary/entry/south)
 "tUU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/chair/stool/bar{
+/obj/structure/railing{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
-/area/crew_quarters/bar)
+/turf/simulated/floor/carpet/green,
+/area/library)
 "tVf" = (
 /obj/machinery/light,
 /obj/machinery/firealarm{
@@ -82618,6 +81958,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
@@ -82684,17 +82027,21 @@
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/fsmaint3)
 "tWL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/eastleft{
+	base_state = "right";
+	name = "Hydroponics";
+	req_access_txt = "35"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/port/east)
+/turf/simulated/floor/plating,
+/area/hydroponics)
 "tXb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -82708,23 +82055,21 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/orange{
-	icon_state = "1-8"
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
 	},
-/turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/gambling_den2)
 "tXy" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -82759,7 +82104,6 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -24
 	},
 /obj/structure/disposalpipe/segment{
@@ -82782,7 +82126,6 @@
 "tXO" = (
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -82794,8 +82137,17 @@
 /turf/simulated/mineral/ancient,
 /area/crew_quarters/arcade)
 "tXX" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/start/civilian,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -2;
+	pixel_y = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
@@ -82827,9 +82179,6 @@
 	icon_state = "dark"
 	},
 /area/quartermaster/office)
-"tYO" = (
-/turf/simulated/floor/wood,
-/area/crew_quarters/cabin1)
 "tYP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -82847,10 +82196,9 @@
 	pixel_x = 32;
 	pixel_y = -32
 	},
-/obj/structure/disposalpipe/sortjunction{
+/obj/structure/disposalpipe/segment{
 	dir = 2;
-	name = "disposal pipe - Bar";
-	sortType = 19
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -82888,8 +82236,7 @@
 /area/hallway/primary/aft/west)
 "tZa" = (
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/unary/cold_sink/freezer,
 /turf/simulated/floor/plasteel{
@@ -83001,8 +82348,7 @@
 "ube" = (
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -83012,6 +82358,19 @@
 	icon_state = "dark"
 	},
 /area/bridge)
+"ubs" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/port/south)
 "ubW" = (
 /obj/item/radio/intercom{
 	dir = 8;
@@ -83033,8 +82392,7 @@
 "uch" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -83050,10 +82408,15 @@
 	icon_state = "dark"
 	},
 /area/hallway/primary/aft/west)
+"ucW" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/library)
 "udb" = (
 /obj/machinery/newscaster{
 	pixel_y = -28;
-	name = "south bump";
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -83158,7 +82521,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/maintenance/engineering)
+/area/engine/break_room)
 "ugj" = (
 /obj/machinery/light{
 	dir = 8
@@ -83173,21 +82536,13 @@
 /turf/simulated/wall,
 /area/hallway/primary/aft/west)
 "ugC" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
 	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/hallway/primary/port/south)
 "ugQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -83233,7 +82588,6 @@
 "uhj" = (
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/structure/cable/orange{
@@ -83247,7 +82601,7 @@
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/chapel/main)
+/area/hydroponics)
 "uhk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -83256,15 +82610,19 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/central)
 "uhm" = (
-/obj/structure/chair{
-	dir = 8
+/obj/machinery/door_control{
+	id = "fb1";
+	name = "Privacy Bolts";
+	normaldoorcontrol = 1;
+	pixel_x = 24;
+	specialfunctions = 4
 	},
-/obj/structure/railing{
-	dir = 9
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/structure/fans/tiny/invisible,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/toilet)
 "uhB" = (
 /obj/machinery/light/small,
 /obj/machinery/embedded_controller/radio/airlock/access_controller{
@@ -83304,7 +82662,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/simulated/floor/plasteel{
@@ -83331,20 +82688,9 @@
 	},
 /area/security/podbay)
 "uhX" = (
-/obj/machinery/camera{
-	c_tag = "Service Asteroid Hallway 6";
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24;
-	name = "custom placement"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/port/south)
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/carpet,
+/area/library)
 "uii" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -83409,8 +82755,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -83450,17 +82795,12 @@
 	},
 /area/medical/virology)
 "ujV" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
-/obj/structure/window/reinforced,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	icon_state = "cafeteria"
 	},
-/area/library)
+/area/crew_quarters/kitchen)
 "ujX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random_spawners/oil_maybe,
@@ -83518,8 +82858,7 @@
 /area/maintenance/starboard)
 "ukE" = (
 /obj/item/radio/intercom{
-	pixel_x = -28;
-	name = "custom placement"
+	pixel_x = -28
 	},
 /turf/simulated/floor/wood,
 /area/blueshield)
@@ -83566,8 +82905,7 @@
 "ulG" = (
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -83636,8 +82974,7 @@
 /area/hallway/primary/aft/west)
 "uoB" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel{
@@ -83674,12 +83011,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint3)
 "upz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -83694,11 +83031,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "uqv" = (
-/obj/structure/chair/stool,
+/obj/effect/landmark/start/civilian,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
+	icon_state = "neutralfull"
 	},
-/area/medical/medbreak)
+/area/storage/primary)
 "uqz" = (
 /turf/simulated/wall,
 /area/security/main)
@@ -83745,18 +83082,27 @@
 	dir = 4
 	},
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/engine{
 	slowdown = -0.3
 	},
 /area/hallway/spacebridge/engmed)
 "uqU" = (
-/obj/effect/spawner/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/crew_quarters/bar)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/port/south)
 "urz" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/spacebridge/dockmed)
@@ -83952,10 +83298,14 @@
 /turf/simulated/floor/plasteel/white,
 /area/toxins/xenobiology)
 "uvg" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/plating,
-/area/maintenance/port)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "redyellowfull"
+	},
+/area/crew_quarters/bar)
 "uvp" = (
 /obj/machinery/camera{
 	c_tag = "SM East";
@@ -84010,7 +83360,6 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
@@ -84032,8 +83381,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light_switch{
 	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/structure/closet/l3closet/scientist,
 /turf/simulated/floor/plasteel{
@@ -84083,7 +83431,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/item/toy/figure/atmos,
@@ -84132,9 +83479,6 @@
 	},
 /area/medical/medbay)
 "uyK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /mob/living/simple_animal/mouse/rat,
@@ -84183,9 +83527,19 @@
 	},
 /area/security/armory)
 "uAD" = (
-/obj/structure/chair/office/dark,
-/turf/simulated/floor/carpet,
-/area/library)
+/obj/item/kitchen/rollingpin,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/bottle/cream,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
 "uAT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -84305,17 +83659,16 @@
 	},
 /area/maintenance/asmaint5)
 "uCO" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/machinery/newscaster{
+	pixel_y = -28;
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/chair/stool,
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
+	icon_state = "redfull";
+	tag = "icon-redfull (NORTHWEST)"
 	},
-/area/crew_quarters/bar)
+/area/crew_quarters/kitchen)
 "uCP" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
@@ -84331,18 +83684,23 @@
 /turf/simulated/floor/plating/airless,
 /area/maintenance/disposal/external/southeast)
 "uDr" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/chair/comfy/brown,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
+"uDu" = (
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 8;
 	icon_state = "neutralcorner"
 	},
-/area/crew_quarters/fitness)
-"uDu" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/hallway/primary/port/south)
 "uDv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -84380,10 +83738,15 @@
 	},
 /area/medical/virology)
 "uEn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/hydroponics)
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet/crate/can,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "escape"
+	},
+/area/space)
 "uEu" = (
 /obj/structure/cable/orange{
 	icon_state = "2-4"
@@ -84445,24 +83808,21 @@
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint2)
 "uFT" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck,
+/turf/simulated/floor/carpet/purple,
 /area/crew_quarters/bar)
 "uFW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/light_switch{
 	dir = 8;
-	icon_state = "neutralfull"
+	pixel_x = 24
 	},
-/area/hallway/primary/port/south)
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
 "uGb" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -84488,6 +83848,18 @@
 "uGJ" = (
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/atmospherics)
+"uHd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "escape"
+	},
+/area/space)
 "uHm" = (
 /turf/simulated/wall,
 /area/crew_quarters/sleep/secondary)
@@ -84523,8 +83895,7 @@
 "uHJ" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel/white,
 /area/toxins/xenobiology)
@@ -84543,20 +83914,22 @@
 /obj/item/storage/box/masks{
 	pixel_y = 5
 	},
+/obj/item/storage/box/gloves,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
 /area/medical/medbreak)
 "uIm" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/item/clothing/head/kitty,
-/obj/item/clothing/under/maid,
-/obj/item/clothing/suit/browntrenchcoat,
-/obj/machinery/light{
-	on = 1
+/obj/structure/disposalpipe/junction{
+	dir = 1
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/cabin1)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "uIo" = (
 /obj/machinery/chem_master,
 /turf/simulated/floor/plasteel{
@@ -84677,7 +84050,6 @@
 "uKT" = (
 /obj/machinery/newscaster{
 	pixel_x = -28;
-	name = "west bump";
 	dir = 4
 	},
 /obj/structure/table,
@@ -84774,7 +84146,6 @@
 /obj/item/stack/cable_coil,
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/item/multitool,
@@ -84808,12 +84179,11 @@
 	},
 /area/civilian/barber)
 "uNz" = (
-/obj/structure/extinguisher_cabinet{
-	name = "custom placement";
-	pixel_y = 28
-	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -84838,28 +84208,39 @@
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "uNO" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/structure/chair/sofa/corp/corner{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
-/area/crew_quarters/bar)
+/turf/simulated/floor/carpet,
+/area/hallway/primary/port/east)
 "uNT" = (
-/obj/structure/chair/comfy/black,
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
+/obj/structure/chair/sofa/corp{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
-/area/crew_quarters/bar)
+/turf/simulated/floor/carpet,
+/area/hallway/primary/port/east)
 "uNU" = (
-/obj/machinery/ai_status_display,
-/turf/simulated/wall,
-/area/crew_quarters/fitness)
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/eastleft{
+	base_state = "right";
+	icon_state = "right";
+	name = "Hydroponics";
+	req_access_txt = "35";
+	dir = 2
+	},
+/obj/machinery/door/window/eastleft{
+	base_state = "right";
+	icon_state = "right";
+	name = "Kitchen";
+	req_access_txt = "28";
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hydroponics)
 "uOe" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Aft Asteroid Maintenance";
@@ -84884,20 +84265,8 @@
 	},
 /area/maintenance/starboard)
 "uOq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/noticeboard{
-	pixel_y = 32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
@@ -84920,29 +84289,12 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "uOH" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -28
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/cabin3)
-"uPd" = (
-/obj/machinery/door_control{
-	desiredstate = 1;
-	id = "cabin3";
-	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
-	specialfunctions = 4;
-	pixel_x = 26
-	},
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/grown/poppy/geranium,
-/obj/item/radio/intercom{
-	pixel_x = 26;
-	pixel_y = 28
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/cabin3)
+/obj/machinery/vending/clothing,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "uPi" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -85001,7 +84353,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/stripes/asteroid/end,
@@ -85235,20 +84586,9 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
 "uVq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/port/south)
+/obj/structure/chair/sofa/corp/left,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "uVv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -85340,8 +84680,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -85468,15 +84807,17 @@
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "uZG" = (
-/obj/effect/landmark/event/lightsout,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/hydroponics/constructable,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/red,
-/area/chapel/main)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/hydroponics)
 "vaa" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -85487,8 +84828,7 @@
 "vap" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/engine{
@@ -85496,12 +84836,12 @@
 	},
 /area/hallway/spacebridge/servsci)
 "var" = (
-/obj/machinery/newscaster{
-	pixel_y = 28;
-	name = "north bump"
+/obj/structure/flora/ausbushes/grassybush,
+/obj/machinery/camera/autoname{
+	dir = 8
 	},
-/turf/simulated/floor/carpet/red,
-/area/chapel/main)
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "vax" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor/engine{
@@ -85515,8 +84855,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -85580,8 +84919,7 @@
 /area/medical/cloning)
 "vcx" = (
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/structure/filingcabinet/chestdrawer/autopsy,
 /turf/simulated/floor/plasteel{
@@ -85597,14 +84935,12 @@
 /turf/simulated/floor/plating,
 /area/medical/virology)
 "vcK" = (
-/obj/machinery/cryopod{
-	dir = 2
-	},
+/obj/structure/closet/wardrobe/xenos,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitegreen"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "vdj" = (
 /turf/simulated/floor/plating,
 /area/maintenance/perma)
@@ -85630,7 +84966,6 @@
 "vdF" = (
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/structure/cable/orange{
@@ -85645,7 +84980,6 @@
 /area/medical/virology)
 "vdN" = (
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/stripes/end{
@@ -85782,6 +85116,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -85828,27 +85163,21 @@
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/gambling_den2)
 "viX" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/library)
 "vjb" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry/south)
 "vjw" = (
-/obj/machinery/door/airlock/freezer{
-	name = "Freezer";
-	req_access = list(28)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "vjx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -85875,8 +85204,7 @@
 /obj/machinery/cell_charger,
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/item/flashlight,
 /turf/simulated/floor/plasteel{
@@ -85890,47 +85218,30 @@
 /turf/simulated/floor/plating,
 /area/security/processing)
 "vkc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/fore/west)
+"vki" = (
 /obj/structure/railing{
-	dir = 5
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/crew_quarters/fitness)
-"vki" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock{
-	name = "Bar Access";
-	req_access = list(25)
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "vkl" = (
 /turf/simulated/wall,
 /area/hallway/primary/aft/west)
 "vkG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/obj/structure/sign/barsign,
+/turf/simulated/wall,
 /area/crew_quarters/bar)
 "vkJ" = (
 /turf/simulated/wall,
@@ -85951,17 +85262,10 @@
 	},
 /area/gateway)
 "vls" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/carpet,
-/area/crew_quarters/bar)
+/area/hallway/primary/port/east)
 "vlu" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -86013,18 +85317,12 @@
 /turf/space,
 /area/turret_protected/aisat_interior/secondary)
 "vmp" = (
-/obj/item/radio/intercom{
-	name = "custom placement";
-	pixel_x = 28
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
-/obj/structure/chair/stool/bar{
-	dir = 1
-	},
-/obj/effect/landmark/start/civilian,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
-/area/crew_quarters/bar)
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "vms" = (
 /obj/machinery/vending/medical{
 	req_access = list(63)
@@ -86039,8 +85337,7 @@
 	dir = 4
 	},
 /obj/machinery/newscaster{
-	pixel_y = 28;
-	name = "north bump"
+	pixel_y = 32
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -86057,11 +85354,6 @@
 	},
 /area/hallway/secondary/entry/south)
 "vng" = (
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 24;
-	name = "east bump"
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
@@ -86115,16 +85407,23 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/starboard/south)
 "voC" = (
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -26
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding8"
 	},
-/obj/structure/cable/orange,
-/obj/effect/turf_decal/stripes/asteroid/end{
-	dir = 1
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding4"
 	},
-/turf/simulated/floor/plating/asteroid/ancient,
-/area/crew_quarters/fitness)
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding1"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "asteroid"
+	},
+/area/hydroponics)
 "voE" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel{
@@ -86133,20 +85432,9 @@
 	},
 /area/toxins/misc_lab)
 "voH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
-/area/crew_quarters/bar)
+/obj/structure/flora/ausbushes/leafybush,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "vpg" = (
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/fore)
@@ -86235,8 +85523,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/machinery/quantumpad/cere/arrivals_cargo{
 	name = "quantum pad"
@@ -86246,6 +85533,12 @@
 	icon_state = "darkyellowfull"
 	},
 /area/teleporter/quantum/docking)
+"vqK" = (
+/obj/structure/chair/sofa/pew/right{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/red,
+/area/chapel/main)
 "vrl" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -86386,8 +85679,7 @@
 /area/mimeoffice)
 "vtz" = (
 /obj/machinery/newscaster{
-	pixel_y = 28;
-	name = "north bump"
+	pixel_y = 32
 	},
 /obj/structure/closet/wardrobe/robotics_black,
 /turf/simulated/floor/plasteel{
@@ -86438,11 +85730,13 @@
 /area/maintenance/port)
 "vuE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/carpet/black,
+/area/chapel/office)
 "vuF" = (
 /obj/structure/chair/sofa/corp{
 	dir = 1
@@ -86451,12 +85745,19 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "vuG" = (
-/obj/structure/chair{
-	dir = 8
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
-/obj/effect/landmark/start/civilian,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	name = "disposal pipe - Library";
+	sortType = 16
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "vuM" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -86582,9 +85883,10 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/electrical_shop)
 "vxd" = (
-/obj/structure/bonfire,
-/turf/simulated/floor/carpet/green,
-/area/library)
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/rack,
+/turf/simulated/floor/plating/asteroid/ancient,
+/area/maintenance/port)
 "vxp" = (
 /obj/effect/spawner/random_spawners/oil_maybe,
 /turf/simulated/floor/plating,
@@ -86592,8 +85894,7 @@
 "vxC" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/engine{
@@ -86756,7 +86057,6 @@
 /obj/machinery/light,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/simulated/floor/plasteel{
@@ -86847,14 +86147,14 @@
 	},
 /area/toxins/misc_lab)
 "vDw" = (
-/obj/structure/chair/comfy/black{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/turf/simulated/floor/carpet/green,
-/area/library)
+/area/hallway/primary/port/south)
 "vDy" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/orange{
@@ -86867,13 +86167,13 @@
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/starboard)
 "vDL" = (
-/obj/machinery/sleeper{
-	dir = 1
-	},
 /obj/machinery/camera{
 	c_tag = "Medbay North";
 	dir = 1;
 	network = list("SS13","CMO")
+	},
+/obj/machinery/sleeper{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
@@ -86905,16 +86205,12 @@
 /turf/simulated/floor/plasteel,
 /area/security/processing)
 "vDZ" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+/obj/structure/window/basic{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
+/obj/structure/closet/lasertag/red,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "vEm" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Storage";
@@ -86925,6 +86221,20 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
+"vEn" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen/invisible,
+/obj/item/stack/packageWrap,
+/obj/item/destTagger,
+/obj/item/toy/figure/librarian,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/library)
 "vEt" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -86953,9 +86263,13 @@
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
 "vEG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "vEY" = (
 /obj/machinery/gateway{
 	dir = 4
@@ -87029,8 +86343,7 @@
 "vFP" = (
 /obj/machinery/iv_drip,
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -87100,6 +86413,14 @@
 	icon_state = "dark"
 	},
 /area/engine/mechanic_workshop/hangar)
+"vHE" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/crew_quarters/fitness)
 "vHF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -87127,8 +86448,7 @@
 /area/toxins/hallway)
 "vIu" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
@@ -87136,15 +86456,21 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/magistrateoffice)
 "vIx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet/green,
-/area/library)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/kitchen_machine/oven,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
 "vIG" = (
 /obj/structure/chair/comfy{
 	dir = 8
@@ -87195,7 +86521,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /turf/simulated/floor/engine{
@@ -87216,10 +86541,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint2)
 "vKi" = (
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
+/turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "vKO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -87289,15 +86614,22 @@
 	},
 /area/gateway)
 "vLI" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+/obj/structure/cable/orange{
+	icon_state = "1-4"
 	},
-/area/hallway/primary/port/east)
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/port/south)
 "vLR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -87335,6 +86667,16 @@
 	icon_state = "dark"
 	},
 /area/quartermaster/office)
+"vLX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/closet/walllocker/emerglocker/south,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "vault"
+	},
+/area/engine/mechanic_workshop/hangar)
 "vMg" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -87342,6 +86684,17 @@
 	icon_state = "darkpurple"
 	},
 /area/assembly/robotics)
+"vMl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/hydroponics)
 "vMA" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -87355,12 +86708,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "vMO" = (
-/obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/simulated/floor/carpet/red,
-/area/chapel/main)
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/port/north)
 "vMR" = (
 /obj/machinery/light{
 	dir = 1
@@ -87445,11 +86801,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/starboard)
-"vOI" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/crew_quarters/cabin4)
 "vPg" = (
 /obj/effect/landmark/ninja_teleport,
 /turf/simulated/floor/plating{
@@ -87461,8 +86812,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	pixel_x = -28;
-	name = "custom placement"
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -87472,8 +86822,7 @@
 "vPx" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /obj/item/storage/fancy/donut_box,
 /turf/simulated/floor/plasteel{
@@ -87555,8 +86904,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -87589,6 +86937,13 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/air,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_y = 32
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/port/north)
 "vRj" = (
@@ -87630,8 +86985,7 @@
 	dir = 4
 	},
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/structure/rack,
 /obj/item/clothing/under/plasmaman{
@@ -87766,8 +87120,7 @@
 "vSG" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -87841,21 +87194,21 @@
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "vUv" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/crew_quarters/sleep)
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/red,
+/turf/simulated/floor/wood,
+/area/crew_quarters/cabin4)
 "vUJ" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/storage/primary)
 "vUN" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
+/obj/machinery/gibber,
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/kitchen)
 "vUO" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -87882,8 +87235,7 @@
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/engine,
 /area/toxins/misc_lab)
@@ -87913,7 +87265,6 @@
 "vWb" = (
 /obj/machinery/newscaster{
 	pixel_y = -28;
-	name = "south bump";
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -88005,9 +87356,11 @@
 	},
 /area/maintenance/asmaint5)
 "vXx" = (
-/obj/structure/sign/custodian,
-/turf/simulated/mineral/ancient,
-/area/hallway/primary/port/south)
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/green,
+/area/library)
 "vXQ" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -88049,6 +87402,14 @@
 	},
 /area/maintenance/gambling_den2)
 "vYn" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/sortjunction/reversed{
+	dir = 8;
+	name = "disposal pipe - Bar";
+	sortType = 19
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -88215,10 +87576,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/south)
+"wbP" = (
+/obj/structure/cable/orange{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/carpet/red,
+/area/chapel/main)
 "wbT" = (
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/toxins,
@@ -88279,6 +87645,15 @@
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
+"weW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "wfd" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
@@ -88317,16 +87692,9 @@
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "wfH" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/effect/decal/warning_stripes/yellow/partial,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/segment{
-	dir = 1;
+	dir = 2;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/wood,
@@ -88360,8 +87728,7 @@
 /area/medical/medbay)
 "wfW" = (
 /obj/item/radio/intercom{
-	pixel_y = 28;
-	name = "custom placement"
+	pixel_y = 28
 	},
 /obj/structure/closet/secure_closet/guncabinet{
 	anchored = 1;
@@ -88472,7 +87839,6 @@
 "whS" = (
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -88517,11 +87883,9 @@
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior)
 "wiQ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/red,
-/area/chapel/main)
+/obj/structure/chair/comfy/black,
+/turf/simulated/floor/carpet/green,
+/area/library)
 "wiT" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -88643,8 +88007,7 @@
 "wkP" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -88662,7 +88025,6 @@
 /area/maintenance/disposal/south)
 "wlC" = (
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -24
 	},
 /obj/structure/cable/orange,
@@ -88681,19 +88043,24 @@
 /turf/simulated/floor/engine,
 /area/medical/chemistry)
 "wmj" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/machinery/door/airlock{
+	name = "Chaplain's Office";
+	req_access_txt = "22"
 	},
-/obj/structure/cable/orange{
-	icon_state = "0-4"
-	},
-/obj/effect/turf_decal/stripes/asteroid/end{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
 /area/chapel/office)
 "wmp" = (
@@ -88780,21 +88147,25 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fore/west)
 "wnk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
+/obj/item/radio/intercom{
+	pixel_x = -26;
 	pixel_y = 28
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/area/crew_quarters/fitness)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 26
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/cabin2)
 "wnI" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1
@@ -88820,18 +88191,22 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/port/north)
-"woF" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
+"wot" = (
+/obj/structure/window/reinforced,
 /obj/machinery/slot_machine,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
+/obj/machinery/camera{
+	c_tag = "Bar East";
+	dir = 8
 	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/bar)
+"woF" = (
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = 32
+	},
+/obj/machinery/computer/arcade,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "woS" = (
 /obj/machinery/light/small{
@@ -88952,7 +88327,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 32
 	},
 /turf/simulated/floor/carpet/black,
@@ -89077,6 +88451,14 @@
 /obj/item/assembly/mousetrap/armed,
 /turf/simulated/floor/plating,
 /area/maintenance/fore2)
+"wrV" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "wsm" = (
 /obj/effect/spawner/random_spawners/fungus_probably,
 /turf/simulated/wall,
@@ -89163,25 +88545,10 @@
 /turf/space,
 /area/space/nearstation)
 "wui" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Holodeck South";
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/hallway/primary/port/south)
 "wuk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -89263,8 +88630,7 @@
 "wuE" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
@@ -89301,14 +88667,9 @@
 /turf/simulated/floor/plating,
 /area/hallway/spacebridge/comeng)
 "wvA" = (
-/obj/machinery/camera{
-	c_tag = "Chapel East";
-	dir = 9
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "wvJ" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Genetics Cloning";
@@ -89340,11 +88701,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot_red,
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 32
-	},
 /turf/simulated/floor/noslip,
 /area/medical/cloning)
 "wwg" = (
@@ -89444,10 +88800,6 @@
 /obj/machinery/computer/cloning{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "whiteblue"
@@ -89492,6 +88844,13 @@
 	icon_state = "dark"
 	},
 /area/engine/engine_smes)
+"wyA" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/start/civilian,
+/turf/simulated/floor/wood,
+/area/library)
 "wyK" = (
 /obj/structure/cable/orange{
 	icon_state = "1-4"
@@ -89569,17 +88928,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/south)
 "wzp" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
-/area/crew_quarters/bar)
+/turf/simulated/floor/transparent/glass/reinforced,
+/area/maintenance/port)
 "wzC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -89652,8 +89008,7 @@
 /area/maintenance/port2)
 "wAO" = (
 /obj/item/radio/intercom{
-	pixel_x = -28;
-	name = "custom placement"
+	pixel_x = -28
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-25"
@@ -89666,8 +89021,7 @@
 "wAQ" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1;
@@ -89702,8 +89056,7 @@
 "wBA" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
@@ -89793,6 +89146,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/computer/podtracker{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "yellow"
@@ -89811,7 +89167,6 @@
 "wDL" = (
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "west bump";
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/stripes/asteroid/end{
@@ -89861,11 +89216,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/external/southeast)
 "wEs" = (
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkgreen"
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
-/area/hydroponics)
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/fitness)
 "wEt" = (
 /obj/machinery/computer/merch{
 	dir = 1
@@ -89889,11 +89244,16 @@
 	},
 /area/maintenance/fore2)
 "wET" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/carpet/red,
-/area/chapel/main)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/start/botanist,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/hydroponics)
 "wEY" = (
 /obj/effect/spawner/random_spawners/wall_rusted_maybe,
 /turf/simulated/wall,
@@ -89901,8 +89261,7 @@
 "wFa" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/item/radio/intercom{
-	pixel_x = 28;
-	name = "custom placement"
+	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -89949,7 +89308,6 @@
 "wGg" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/simulated/floor/plasteel{
@@ -89989,6 +89347,11 @@
 "wGA" = (
 /obj/structure/bed/dogbed/pet,
 /mob/living/simple_animal/goose/Scientist,
+/obj/machinery/atmospherics/unary/cold_sink/freezer{
+	current_temperature = 80;
+	on = 1;
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurplefull"
@@ -90112,11 +89475,16 @@
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/engineering)
 "wJD" = (
-/obj/machinery/shower{
-	dir = 8
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 24
 	},
-/turf/simulated/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/black,
+/area/chapel/office)
 "wJN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -90172,8 +89540,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -90186,7 +89553,6 @@
 "wKY" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -90257,6 +89623,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/maintenance/port)
 "wMb" = (
@@ -90337,17 +89704,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "wNd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/mob/living/simple_animal/hostile/killertomato{
-	desc = "Прирученный ботаниками томат-убийца. Не подпускать к Сане.";
-	faction = list("plants","neutral","hostile");
-	name = "Витамин"
+/obj/machinery/cryopod{
+	dir = 2
+	},
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "whitegreen"
 	},
-/area/hydroponics)
+/area/crew_quarters/sleep)
 "wNf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -90380,21 +89747,15 @@
 	icon_state = "darkblue"
 	},
 /area/gateway)
-"wOe" = (
-/obj/machinery/door/window/eastright{
-	dir = 8;
-	pixel_x = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/crew_quarters/fitness)
 "wOh" = (
 /obj/machinery/camera{
 	c_tag = "Service Asteroid Hallway 4";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -90402,8 +89763,7 @@
 /area/hallway/primary/port/south)
 "wOn" = (
 /obj/item/radio/intercom{
-	pixel_y = -28;
-	name = "custom placement"
+	pixel_y = -28
 	},
 /obj/structure/bed/roller,
 /obj/effect/turf_decal/bot,
@@ -90418,8 +89778,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -90435,8 +89794,14 @@
 	},
 /area/medical/medbay)
 "wPh" = (
-/obj/structure/closet/firecloset/full,
-/turf/simulated/floor/plating/asteroid/ancient,
+/obj/structure/disposalpipe/sortjunction/reversed{
+	dir = 1;
+	name = "disposal pipe - Kitchen";
+	sortType = 20
+	},
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
 /area/maintenance/gambling_den2)
 "wPk" = (
 /obj/structure/bed/roller,
@@ -90550,12 +89915,11 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/starboard/south)
 "wQM" = (
-/obj/machinery/door/morgue{
-	name = "Confession Room";
-	req_access = list(22)
+/obj/machinery/hydroponics/constructable,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plasteel,
-/area/chapel/main)
+/area/hydroponics)
 "wQS" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -90566,11 +89930,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "wQW" = (
-/obj/machinery/disposal,
-/obj/effect/turf_decal/bot_white,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
+/obj/structure/table/wood/fancy/black,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -90628,15 +89988,13 @@
 /obj/structure/cable/orange{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	name = "disposal pipe - Kitchen";
+	sortType = 20
 	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -90658,9 +90016,14 @@
 	},
 /area/hallway/primary/starboard/north)
 "wSt" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/crew_quarters/sleep)
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/cabin2)
 "wSu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -90767,12 +90130,10 @@
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior)
 "wVc" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance";
-	req_access = list(12)
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/gambling_den2)
+/obj/structure/chair/wood/wings,
+/obj/effect/landmark/start/chaplain,
+/turf/simulated/floor/carpet/black,
+/area/chapel/office)
 "wVh" = (
 /obj/structure/table/wood,
 /obj/item/camera,
@@ -90786,6 +90147,12 @@
 /mob/living/carbon/human/lesser/monkey/punpun{
 	icon = 'icons/mob/monkey.dmi';
 	icon_state = "punpun1"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -90801,6 +90168,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable/orange{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -90867,8 +90237,7 @@
 "wWW" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -90895,6 +90264,10 @@
 "wXJ" = (
 /obj/machinery/reagentgrinder,
 /obj/structure/table/wood,
+/obj/item/radio/intercom{
+	dir = 0;
+	pixel_x = -28
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "wXW" = (
@@ -90986,7 +90359,7 @@
 	pixel_y = -4
 	},
 /turf/simulated/floor/plating,
-/area/crew_quarters/fitness)
+/area/hallway/primary/port/south)
 "wZv" = (
 /turf/simulated/wall,
 /area/medical/paramedic)
@@ -91007,8 +90380,7 @@
 "wZF" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/structure/reagent_dispensers/oil,
 /turf/simulated/floor/plasteel{
@@ -91089,8 +90461,7 @@
 /area/toxins/xenobiology)
 "xau" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/wood,
 /area/civilian/vacantoffice)
@@ -91100,7 +90471,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "north bump";
 	pixel_y = 24
 	},
 /turf/simulated/floor/wood,
@@ -91172,13 +90542,6 @@
 "xbO" = (
 /turf/simulated/mineral/ancient/outer,
 /area/mine/unexplored/cere/engineering)
-"xbX" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/cabin3)
 "xcc" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -91225,8 +90588,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -91254,8 +90616,7 @@
 "xdo" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -91284,7 +90645,6 @@
 /area/engine/supermatter)
 "xdw" = (
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -24
 	},
 /obj/structure/cable/orange,
@@ -91436,7 +90796,7 @@
 	dir = 6;
 	icon_state = "darkyellow"
 	},
-/area/maintenance/engineering)
+/area/engine/engineering)
 "xhk" = (
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/courtroom)
@@ -91483,7 +90843,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/machinery/clonepod,
@@ -91623,10 +90982,16 @@
 	},
 /area/hallway/primary/aft/west)
 "xlg" = (
-/obj/structure/chair/office/dark,
-/obj/effect/landmark/start/librarian,
-/turf/simulated/floor/carpet,
-/area/library)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
 "xlt" = (
 /obj/effect/landmark/event/lightsout,
 /turf/simulated/floor/plasteel{
@@ -91641,8 +91006,7 @@
 "xlV" = (
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/item/reagent_containers/food/drinks/flask/barflask,
 /obj/item/clothing/head/that{
@@ -91674,13 +91038,14 @@
 /turf/simulated/floor/wood,
 /area/maintenance/gambling_den2)
 "xmQ" = (
-/obj/structure/table,
-/obj/item/taperecorder,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
+/obj/item/radio/intercom{
+	pixel_x = -28
 	},
-/area/crew_quarters/bar)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/green,
+/area/library)
 "xmT" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/simulated/floor/plating,
@@ -91841,6 +91206,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/gambling_den2)
 "xrn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "xro" = (
@@ -91906,13 +91279,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/north)
 "xsh" = (
-/obj/structure/cable/orange{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/maintenance/gambling_den2)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/carpet/green,
+/area/library)
 "xsF" = (
 /obj/structure/sign/science{
 	pixel_y = -32
@@ -91998,8 +91367,7 @@
 	dir = 4
 	},
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -92131,14 +91499,9 @@
 	},
 /area/turret_protected/ai)
 "xxw" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
-	icon_state = "whitered"
+	dir = 4;
+	icon_state = "whiteredfull"
 	},
 /area/security/medbay)
 "xxR" = (
@@ -92156,21 +91519,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/south)
 "xxW" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/seed_extractor,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "darkgreenfull"
 	},
-/area/hallway/primary/port/south)
+/area/hydroponics)
 "xyf" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -92218,8 +91572,7 @@
 "xyC" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /obj/structure/closet/emcloset,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -92285,9 +91638,7 @@
 /area/medical/patients_rooms)
 "xzi" = (
 /obj/structure/chair/comfy/black,
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
+/obj/effect/landmark/start/civilian,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "xzk" = (
@@ -92339,8 +91690,7 @@
 /area/engine/mechanic_workshop/hangar)
 "xzJ" = (
 /obj/machinery/alarm{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /obj/machinery/light{
 	dir = 1
@@ -92397,8 +91747,7 @@
 "xAL" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -92441,17 +91790,9 @@
 	},
 /area/maintenance/starboard)
 "xBb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/fitness)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/library)
 "xBq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -92501,16 +91842,21 @@
 	},
 /area/hallway/primary/port/east)
 "xCv" = (
-/obj/structure/table/wood,
-/obj/machinery/camera{
-	c_tag = "Library West";
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id_tag = "kitchen1"
 	},
-/obj/structure/window/reinforced,
+/obj/machinery/door/window/westright{
+	dir = 4;
+	name = "Kitchen";
+	req_access_txt = "28"
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	icon_state = "cafeteria"
 	},
-/area/library)
+/area/crew_quarters/kitchen)
 "xCz" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -92591,6 +91937,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/structure/table,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -92629,8 +91976,7 @@
 /obj/machinery/shieldwallgen,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -92652,8 +91998,7 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -92700,7 +92045,6 @@
 "xGg" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel/white,
@@ -92765,6 +92109,7 @@
 /area/space)
 "xHo" = (
 /obj/machinery/light/small,
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/port)
 "xHH" = (
@@ -92781,15 +92126,30 @@
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "xIG" = (
-/obj/machinery/light,
-/obj/structure/chair/sofa/pew/left{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/eastleft{
+	base_state = "right";
+	name = "Kitchen";
+	req_access_txt = "28";
+	dir = 1
+	},
+/obj/machinery/door/window/eastleft{
+	base_state = "right";
+	name = "Hydroponics";
+	req_access_txt = "35";
+	dir = 2
+	},
+/obj/machinery/door/firedoor,
+/obj/item/desk_bell{
+	pixel_x = 7;
+	pixel_y = 7;
+	anchored = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "chapel"
+	icon_state = "neutralfull"
 	},
-/area/chapel/main)
+/area/hydroponics)
 "xIH" = (
 /obj/machinery/light{
 	dir = 4
@@ -92960,6 +92320,11 @@
 /obj/effect/spawner/random_spawners/grille_maybe,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint5)
+"xMu" = (
+/obj/structure/chair/office/dark,
+/obj/effect/landmark/start/civilian,
+/turf/simulated/floor/wood,
+/area/library)
 "xMv" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -92993,14 +92358,11 @@
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/mine/unexplored/cere/command)
 "xNq" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-y"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
-/area/crew_quarters/bar)
+/turf/simulated/floor/wood,
+/area/library)
 "xNt" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -93031,22 +92393,27 @@
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "xNP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/kitchen_machine/oven,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
+	icon_state = "cafeteria"
 	},
-/area/crew_quarters/bar)
+/area/crew_quarters/kitchen)
 "xOt" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
+/obj/structure/table/wood,
+/obj/item/storage/fancy/cigarettes/cigpack_robust{
+	pixel_x = 7;
+	pixel_y = -2
 	},
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/carpet/orange,
 /area/crew_quarters/bar)
 "xOD" = (
 /obj/structure/girder,
@@ -93072,8 +92439,7 @@
 "xOY" = (
 /obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -93177,14 +92543,24 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/miningdock)
 "xRU" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/library,
-/obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/carpet,
-/area/library)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Kitchen";
+	req_access_txt = "28"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id_tag = "kitchen1"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
 "xRX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door_control{
@@ -93205,20 +92581,11 @@
 	},
 /area/hallway/primary/starboard/south)
 "xSj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/hallway/primary/port/south)
 "xSk" = (
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange,
@@ -93245,8 +92612,7 @@
 "xSC" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	name = "west bump"
+	pixel_x = -24
 	},
 /obj/machinery/camera{
 	c_tag = "Magistrate's Office";
@@ -93276,8 +92642,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/northwest)
 "xSR" = (
-/obj/structure/table/wood,
-/obj/item/candle,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
@@ -93451,13 +92818,14 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/starboard/north)
 "xWp" = (
-/obj/structure/railing,
-/obj/structure/fans/tiny/invisible,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+/obj/machinery/door/airlock/public{
+	name = "Chapel - Library"
 	},
-/area/crew_quarters/fitness)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/library)
 "xWt" = (
 /obj/structure/sink{
 	dir = 4;
@@ -93465,8 +92833,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -93545,14 +92912,24 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "xYi" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 28;
+	name = "custom placement"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	dir = 4;
+	icon_state = "redcorner"
 	},
-/area/crew_quarters/cabin4)
+/area/hallway/primary/fore/west)
 "xYq" = (
 /obj/machinery/door/airlock/hatch{
 	name = "AI Satellite Secondary Antechamber";
@@ -93690,7 +93067,7 @@
 	name = "Port Asteroid Maintenance";
 	req_access = list(12)
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/carpet/green,
 /area/maintenance/port)
 "xZI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -93720,6 +93097,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -93731,8 +93111,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	name = "north bump"
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -93802,9 +93181,6 @@
 /area/medical/paramedic)
 "ycg" = (
 /obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/orange{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -93815,15 +93191,16 @@
 	},
 /area/maintenance/gambling_den2)
 "ycy" = (
-/obj/structure/table/wood,
-/obj/item/camera_film,
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
-/area/library)
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
 "ycG" = (
 /obj/machinery/power/solar{
 	name = "Fore Solar Array"
@@ -93915,7 +93292,6 @@
 "yet" = (
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange,
@@ -93953,6 +93329,19 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"yeK" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -26
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitered"
+	},
+/area/security/medbay)
 "yfb" = (
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -94010,8 +93399,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -94028,7 +93416,6 @@
 /area/maintenance/disposal/southwest)
 "ygF" = (
 /obj/machinery/power/apc{
-	name = "south bump";
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -94110,7 +93497,6 @@
 "yhM" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 32
 	},
 /turf/simulated/floor/wood,
@@ -94306,15 +93692,26 @@
 	},
 /obj/item/assembly/mousetrap/armed,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/orange{
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "yll" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/fitness)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/port/south)
 "ylz" = (
 /obj/machinery/light/small,
 /obj/machinery/conveyor/auto/ccw{
@@ -94327,6 +93724,14 @@
 /obj/item/clothing/head/cone,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
+"ylV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/library)
 "ylX" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
@@ -105308,8 +104713,8 @@ xaR
 xaR
 xaR
 kiO
+jee
 rWC
-pXy
 pXy
 pXy
 vtY
@@ -105564,11 +104969,11 @@ uCK
 nIV
 uCK
 vvt
-uvg
-kfs
-pXy
-vtY
-vtY
+cGw
+cGw
+gat
+bXj
+bXj
 vtY
 vtY
 vtY
@@ -105805,7 +105210,7 @@ yli
 pTp
 pTp
 xyf
-jvx
+sAH
 xyf
 fuE
 xyf
@@ -105821,11 +105226,11 @@ uCK
 uCK
 bWE
 pXy
-vtY
-vtY
-vtY
-vtY
-vtY
+cGw
+vVZ
+xCz
+iNg
+bXj
 vtY
 vtY
 vtY
@@ -106058,11 +105463,11 @@ yfx
 pXy
 pXy
 pXy
-cUx
+eCI
 vtY
 lkL
 jee
-iWO
+cUx
 vtY
 pXy
 usD
@@ -106078,11 +105483,11 @@ vtY
 okh
 okh
 vtY
-vtY
-vtY
-vtY
-vtY
-vtY
+bXj
+baG
+feI
+tzb
+bXj
 vtY
 vtY
 bWr
@@ -106315,11 +105720,11 @@ elJ
 pXy
 usD
 xZC
-liJ
+jee
 vtY
 vtY
 cWr
-liJ
+cUx
 bMX
 pXy
 vtY
@@ -106331,15 +105736,15 @@ vtY
 vtY
 wjO
 bVj
-vtY
-vtY
-vtY
-vtY
-vtY
-vtY
-vtY
-vtY
-vtY
+cGw
+cGw
+bXj
+bXj
+bXj
+sab
+jvt
+jEG
+bXj
 vtY
 bWr
 bWr
@@ -106576,27 +105981,27 @@ mup
 vtY
 vtY
 tXA
-itU
+cUx
 ijF
-sNu
-bYI
-eNk
-eJJ
 vtY
 vtY
-rNT
-rNT
-rNT
-rNT
-rNT
-rNT
-rNT
-rNT
-uNh
-uNh
-uNh
-uNh
 vtY
+vtY
+vtY
+vtY
+vtY
+vtY
+vtY
+cGw
+miy
+ocA
+kFg
+iUc
+bXj
+eNP
+bXj
+bXj
+bXj
 vtY
 bWr
 amo
@@ -106829,30 +106234,30 @@ elJ
 wGX
 vtY
 vtY
-bMY
-bMY
-sZE
-ksj
-kzf
-kzf
-pEA
-pEA
-bNV
-ddD
-ddD
-ddD
-rNT
-bTZ
-bUH
-jvt
+vtY
+vtY
+vtY
+vtY
+oir
+aEe
+aEe
+aEe
+aEe
+aEe
+vtY
+vtY
+vtY
+vtY
+vtY
+cGw
 qVc
-get
+lqz
 jtD
-aqx
+lqz
 vuE
 hTD
-vEG
-vDZ
+bXj
+vtY
 vtY
 vtY
 iHn
@@ -107086,30 +106491,30 @@ elJ
 pXy
 vtY
 vtY
-sZE
-ltL
-guA
-kzf
-omX
-uOH
-bNV
-dau
-kbu
-ddD
-fRn
-piO
-rNT
-bUb
-egI
-jxe
-bUc
-bUc
+aEe
+aEe
+aEe
+aEe
+aEe
+aEe
+gCW
+nKe
+gcz
+aEe
+vtY
+vtY
+vtY
+vtY
+vtY
+cGw
+gJG
+wVc
 gLo
-rNT
+oRA
 jxe
 ikv
-bUc
-ltD
+bXj
+vtY
 vtY
 vtY
 bWr
@@ -107343,30 +106748,30 @@ elJ
 pXy
 vtY
 vtY
-bMY
-mSG
-xYi
-kzf
-bLC
-xbX
-bNV
-bOV
-bWO
-ddD
-nWJ
-uIm
-rNT
-bUb
-pTd
-rNT
-guo
-rNT
-pjj
-rNT
-bUc
-bUc
-epa
-bUc
+gfH
+qxu
+gfH
+ybP
+gfH
+xmQ
+bHZ
+bHZ
+bHZ
+aEe
+vtY
+aEe
+aEe
+aEe
+vtY
+cGw
+lqz
+beQ
+bGL
+lqz
+pXj
+tCX
+bXj
+vtY
 vtY
 vtY
 bWr
@@ -107597,33 +107002,33 @@ vtY
 vtY
 ePb
 yfx
+xjQ
 pXy
 vtY
-vtY
-bMY
-bLA
-vOI
-kzf
-uPd
-aJj
-bNV
-nEt
-oLF
-ddD
-tYO
-bzq
-rNT
-bUc
-pTd
-rNT
+gfH
+ybP
+gfH
+ybP
+gfH
+ybP
+bHZ
+wyA
+bHZ
+aEe
+aEe
+aEe
+dVo
+aEe
+aEe
+cGw
 meI
-rNT
+lqz
 pEF
-rNT
+bbf
+cpK
 wJD
-wJD
-wJD
-wJD
+bXj
+vtY
 vtY
 vtY
 cbc
@@ -107631,9 +107036,9 @@ rww
 cbc
 uJr
 uJr
-uJr
-uJr
-uJr
+cUs
+cOm
+bGE
 uJr
 aXn
 aXn
@@ -107853,43 +107258,43 @@ tIM
 xaR
 tIM
 kiO
-yfx
-xjQ
-pXy
-kWu
-bMY
-bMY
-ntl
-kzf
-kzf
-diy
-bNV
-jFJ
-bNV
-ddD
-bSn
-ddD
-rNT
-qdP
+vuG
+oCa
+uCK
+aEe
+cbf
+ybP
+jeC
+ybP
+cbf
+ybP
+aia
+bPi
+bHZ
+aEe
+wiQ
+vXx
+tUU
+aBK
 bgR
+bGq
+fFN
+fFN
+fFN
+cGw
+wmj
+cGw
+cGw
 rNT
 rNT
 rNT
-rNT
-rNT
-rNT
-rNT
-rNT
-rNT
-rNT
-kWu
-kWu
+gZm
 wYS
-kWu
+gHw
 uJr
 cCD
 cQz
-cUs
+sco
 agn
 uJr
 aXn
@@ -108109,45 +107514,45 @@ gLV
 xyf
 pTp
 xyf
-xyf
+gFA
 wRW
 jRE
-voC
-kWu
-bGo
-aCZ
-cFF
-nDt
-fQK
-bOY
-bOY
-bOY
-bQe
-bRd
-tiH
-oFD
-nKJ
+xaR
+bct
+gIp
+fXY
+gIp
+hAp
+gIp
+bbJ
+bZm
+bSn
+ybP
+kap
+gGV
+gIp
+gIp
 gIp
 xBb
 xWp
-pDn
-pDn
-pDn
-pDn
-pDn
-pDn
-pDn
-pDn
-pDn
-pDn
-rYB
+jil
+jil
+jil
+jil
+weW
+bYT
+bUN
+uNh
+uNh
+uNh
+rNT
 fcB
 cbd
 vtw
 veO
 fuU
 fLH
-cOm
+bNh
 uJr
 aXn
 aXn
@@ -108366,38 +107771,38 @@ vtY
 vtY
 vtY
 vtY
-vtY
-eCI
-jAn
+qeU
+dSe
+eAw
 eCI
 xZG
-cFF
-cFF
-cFF
-bKn
-qqD
-jQO
-jQO
-iUc
-jQO
-jQO
-fpN
-jQO
-lpW
-bUe
-bLF
-xWp
-pDn
-pDn
-pDn
-pDn
-pDn
-pDn
-pDn
-pDn
-pDn
-pDn
-rYB
+ybP
+rqJ
+xsh
+pwh
+lKl
+trp
+bGD
+gIp
+gIp
+rDt
+loQ
+bHZ
+sYH
+bHZ
+bHZ
+aEe
+kZz
+xkn
+jaM
+bUf
+xkn
+bYT
+bUN
+pgy
+bTZ
+eAq
+rNT
 kjs
 cbe
 cbT
@@ -108601,7 +108006,7 @@ bav
 nLm
 occ
 wkb
-occ
+oMz
 oMz
 cMX
 pqY
@@ -108625,37 +108030,37 @@ vtY
 vtY
 vtY
 vtY
-jAn
-eCI
-bEM
-cFF
-cFF
-cFF
-bKq
-bLD
-aTT
-aTT
-aTT
-aTT
-aTT
-kpd
-qVt
-pwt
+eAw
+vxd
+aEe
+gso
+bOV
+gfH
+bHZ
+esU
+bZN
+bbh
+inc
+ybP
+aEe
+ocC
+bHZ
+nHL
 bAe
 mfT
-xWp
-pDn
-pDn
-pDn
-tpw
-pDn
-pDn
-tpw
-pDn
-pDn
-pDn
-rYB
-ghX
+aEe
+wrV
+xkn
+esG
+xkn
+xkn
+bYT
+bUN
+oDb
+bUc
+hxD
+nVS
+yll
 wui
 ezu
 ezu
@@ -108858,7 +108263,7 @@ bav
 bax
 vSC
 nxr
-occ
+wzp
 oMD
 cMX
 eES
@@ -108868,52 +108273,52 @@ eES
 cMT
 faP
 yfx
-pXy
-vtY
+bkU
+ocv
 ngi
-vtY
-vtY
-vtY
-vtY
-pXy
-vtY
-vtY
-vtY
-vtY
-vtY
-vtY
-jAn
+ocv
+ocv
+ocv
+ocv
+bkU
+ocv
+ocv
+ocv
+ocv
+ocv
+ocv
+eAw
 xHo
-fxA
-fxA
-fxA
-fxA
-bEM
-wnk
-bNb
-nVj
-wOe
-bPa
-gGR
-fIN
-ovY
-bEM
+aEe
+aEe
+aEe
+aEe
+qcL
+fbj
+gPH
+nXv
+lKl
+lKl
+iTE
+viX
+bsI
+pdd
 fhb
 bLF
-xWp
-pDn
-pDn
-pDn
-pDn
-pDn
-pDn
-pDn
-pDn
-pDn
-pDn
+aEe
+bYT
+bVS
+cqu
+bVS
+bVS
+bYT
+bUN
+nZm
+rds
+bZi
 rYB
-cFF
-cbf
+vLI
+wui
 qAv
 pbh
 pDz
@@ -109125,7 +108530,7 @@ tgq
 cMT
 faP
 yfx
-pXy
+bkU
 uaG
 bnF
 boG
@@ -109138,38 +108543,38 @@ brA
 xIM
 sME
 fNq
-vtY
-oar
-fxA
-fxA
-lhc
-qZk
+ocv
+eAw
+aEe
+aEe
 cIX
-bEM
-jGS
-bNb
-bvX
-fMY
-fMY
-efU
-jQO
-bOX
-bEM
+bQj
+aEe
+oeB
+tMQ
+hxX
+bUg
+tCy
+fQK
+aEe
+qCQ
+xNq
+bHZ
 qel
-bLF
-xWp
-pDn
-pDn
-pDn
-pDn
-pDn
-pDn
-pDn
-pDn
-pDn
-pDn
-rYB
-cFF
+ikx
+aEe
+bgV
+vqK
+bVS
+bVS
+edM
+dcZ
+bUN
+grX
+rNT
+mQk
+qdP
+cbn
 twA
 ntr
 fEU
@@ -109382,7 +108787,7 @@ hOx
 cMT
 bjm
 yfx
-pXy
+bkU
 cYl
 bnG
 boH
@@ -109395,39 +108800,39 @@ jTQ
 vSk
 tqy
 wAQ
-vtY
+ocv
 eAw
+aEe
 bWG
-fxA
-vcK
-aCC
 cIX
-nhR
-jyO
-uDr
-bvX
-fMY
-fMY
-efU
-jQO
-ezW
-cGx
-iFh
-gVy
-pgy
+bGx
+aEe
+cFe
+tMQ
+lPd
+bbh
+ybP
+oGU
+bZf
+bHZ
+aia
+dQo
+bPi
+gcz
+aEe
 pzN
-pzN
-drZ
-dVo
+qwO
+bVS
+bVS
 qlB
 qwO
-dVo
+bUN
 uhm
+rNT
 rzI
-rzI
-kUt
-cFF
-cbg
+rNT
+yll
+wui
 qAv
 qAv
 tcu
@@ -109626,7 +109031,7 @@ hUU
 aXn
 mJl
 nHK
-bzj
+baz
 uSv
 uSv
 uSv
@@ -109639,50 +109044,50 @@ gKp
 cMT
 faP
 yfx
-pXy
+bkU
 rFZ
 sBV
-sSi
+uqv
 sSi
 sSi
 sSi
 cHx
 sSi
-sSi
+uqv
 vTq
 lsD
 mdH
 ngi
 eAw
-eoD
-fxA
-lUg
-okw
-aAG
-fQG
-aeV
-bNb
-vkc
-bQh
-eMW
-bRg
-jQO
-jGq
-bEM
-bUf
-bLF
-ikx
-jQO
-ikx
-sXR
-gGt
+aEe
+tOP
+ucW
+ylV
+aEe
+uhX
+aHL
+jyO
+bbh
+ybP
+bSn
+bZf
+bHZ
+xMu
+oOW
+bPi
+knU
+aEe
 eJK
 sXR
-qTM
-snW
-cFF
-cFF
-trp
+bVS
+bVS
+eJK
+sXR
+bUN
+rNT
+rNT
+rNT
+rNT
 yll
 ugC
 vRt
@@ -109883,7 +109288,7 @@ jHY
 mJl
 uLy
 vQR
-bzj
+baz
 ozh
 bbC
 fpS
@@ -109896,7 +109301,7 @@ bhA
 cMT
 faP
 yfx
-pXy
+bkU
 iqZ
 sBY
 bqh
@@ -109909,38 +109314,38 @@ vwc
 byk
 vtO
 mdH
-vtY
+ocv
 eAw
-ccx
-fxA
-vcK
+aEe
+jpE
+bbi
 qnV
-cIX
+aEe
 nhR
-bLF
-bNb
-vuG
-vuG
-cFF
-bRh
+tMQ
+rqP
+neU
+qZf
+ybP
+bZf
+bHZ
+aia
+bPi
+rUL
+gcz
+aEe
+hxE
 jQO
-nJA
-bEM
-bUg
-bLF
-jQO
-jQO
-jQO
-jQO
-jQO
-jQO
-bYw
-qCQ
+wbP
+bVS
+qlB
+qwO
+bUN
+kUt
+hYG
 uDu
-uDu
-uDu
-uDu
-uDu
+bRi
+nHr
 hOX
 jUa
 wjD
@@ -110141,19 +109546,19 @@ pvQ
 bwe
 lWb
 baz
-bwe
-bwe
-bwe
-bwe
-bdR
+bzj
+bzj
+bzj
+gRW
+bbC
 cMT
 wdJ
-dSI
-eES
+nNT
+eLI
 cMT
 faP
 yfx
-pXy
+bkU
 bmf
 sCh
 kgc
@@ -110166,38 +109571,38 @@ bxj
 byl
 xLq
 wBA
-vtY
+ocv
 mQB
-eCI
-fxA
-vcK
-lWg
-fYA
-bEM
+aEe
+vEn
+bUb
+sFr
+cTQ
+bfI
 fXh
-bNb
-cFF
-cFF
-rlI
-lHB
-pas
-bSS
-bEM
 iMc
-gzr
-pwh
+ccY
+jeC
+cbg
+aEe
+bgY
+frV
+bHZ
+bHZ
+bHZ
+aEe
 bVL
 mfG
 jnh
 ddb
-bXV
-bYx
-qGP
+sug
+hth
+bUN
 jjq
-jIh
 xSj
-jjq
-jjq
+xSj
+xSj
+bbI
 cbh
 til
 jif
@@ -110396,13 +109801,13 @@ lQq
 uSv
 uSv
 uSv
-uSv
-uSv
+dcz
+nIx
 bbb
 uSv
 uSv
 uSv
-ezi
+uSv
 cMT
 lVP
 bgP
@@ -110425,39 +109830,39 @@ dcW
 bkU
 nQA
 pcw
-ddd
-fxA
-wSt
-vUv
-wSt
-cGx
-eDz
-pwt
-bNc
-pwt
-bEM
-bEM
-bEM
-bEM
-cGx
-bEM
-bEM
-bEM
-bEM
-bEM
-bEM
-pwt
-bXW
-iHF
-pwt
-bEM
-bEM
-bEM
-uNU
-bEM
-bEM
-bEM
-bEM
+aEe
+aEe
+aEe
+aEe
+aEe
+aEe
+aEe
+ptU
+eJA
+ptU
+bLI
+aEe
+aEe
+aEe
+cau
+tIQ
+aEe
+aEe
+bVO
+bWn
+ghc
+egI
+bWn
+mNp
+bUN
+mCM
+mCM
+mCM
+mCM
+aBs
+jGu
+lZN
+lZN
 vkJ
 dND
 dND
@@ -110613,7 +110018,7 @@ vZd
 aGP
 bkF
 tzH
-bIT
+bkF
 nJL
 cHB
 dCr
@@ -110653,13 +110058,13 @@ mwr
 naF
 aYY
 bYu
-ivx
+dmV
 nTs
-qan
-bym
+vMO
+ohY
 ozV
 tdP
-pbO
+qan
 rEm
 qan
 dlC
@@ -110676,45 +110081,45 @@ qan
 woi
 uKa
 woi
-ovP
+qan
 bym
 flS
 qan
 qan
 tau
-qan
+jZb
 xZS
-gqA
-bUM
-gqA
-wOh
-bLG
-gqA
-gqA
-gqA
-nHr
-bRj
-bSf
-gqA
-gqA
-sLi
-bUM
-rhT
-gqA
-jmF
-gqA
-gqA
-bLG
-ibR
-gqA
-sco
-bSf
 bZX
-gqA
+ltD
+bZX
+wOh
+bZX
+bZX
+rlI
+bZX
+bZX
 bRj
-uhX
-bUM
+bZX
+bZX
+bZX
+bZX
+ltD
+rhT
+pus
+bZX
+ubs
+oeY
+bZX
+bZX
+bZX
+bZX
+bZX
+bZX
+bZX
+rzK
 gqA
+bUM
+bUe
 nzt
 gVT
 gVT
@@ -110869,8 +110274,8 @@ izZ
 aal
 aal
 aal
-lBB
-dpu
+aal
+aal
 hcr
 awq
 eHx
@@ -110910,13 +110315,13 @@ mQF
 nMl
 xsS
 wVG
-tPf
-tPf
+bgZ
+gLy
 tPf
 tPf
 oqj
 tPf
-pbQ
+tPf
 tPf
 tSq
 pVT
@@ -110945,13 +110350,13 @@ mCM
 mCM
 mCM
 mCM
-jWw
-ecG
 mCM
+ecG
+bfK
 mCM
 mGM
 mCM
-uFW
+mCM
 mCM
 mCM
 mCM
@@ -110960,15 +110365,15 @@ fne
 mCM
 mCM
 oKK
+vDw
 mCM
-jWw
-lDZ
+mCM
 ecG
 mCM
-uFW
 mCM
 mCM
 mCM
+guo
 mGM
 mCM
 mCM
@@ -111125,9 +110530,9 @@ szD
 wLH
 sKJ
 bLy
-aal
+yeK
 blg
-aHL
+aal
 oam
 uii
 gFp
@@ -111167,7 +110572,7 @@ mQU
 qpb
 aZb
 nAt
-xlY
+pGu
 vZo
 xlY
 xlY
@@ -111205,27 +110610,27 @@ oUG
 gFn
 oUG
 btN
-oUG
+jmF
 emo
 oUG
-xxW
-tfU
 oUG
-ohY
+oUG
+oUG
+oUG
 oUG
 dAW
-oUG
+uqU
 oUG
 wrh
 mnn
 bXY
-nSj
+bZe
 vhE
 bZe
-uVq
-gso
+bZe
+bIa
 bQF
-uyf
+iHF
 mnu
 uyf
 uyf
@@ -111382,8 +110787,8 @@ aoY
 qGo
 wNf
 xxw
-aal
-aal
+sDe
+lBB
 aal
 oam
 pYL
@@ -111424,23 +110829,23 @@ lAN
 leM
 aZa
 gPw
-btd
-btd
-btd
-btd
-btd
-btd
-btd
-btd
-uQa
-qbU
-lJR
-lJR
-lJR
-rzK
+bEM
+bEM
+pwt
+pwt
+bEM
+bEM
+bEM
+bEM
+pwt
+pwt
+bEM
+fGN
+fGN
 rVw
-btd
-btd
+rVw
+fGN
+fGN
 teX
 bqk
 klG
@@ -111459,28 +110864,28 @@ aZZ
 aZZ
 aZZ
 aZZ
-bGq
-bGq
-bGq
-bGq
-bGq
-bGq
+nZp
+uEn
 bPf
-bQj
-gBw
-bGq
-bGq
-mNp
-bVO
-bWn
+uHd
+bPf
+bPf
+bPf
+bPf
+baF
+nWU
+rXV
+tMS
+btd
+lJR
 kek
 hIh
-bWn
-bUN
-bZg
-bZf
-vXx
-gHw
+lJR
+tWL
+cMy
+lJR
+uQa
+eud
 bZj
 lZN
 lZN
@@ -111681,23 +111086,23 @@ hen
 nbL
 nmy
 nBj
-btd
-nVS
-ocA
-oir
-oAm
-oQS
-pdc
-bsI
-bfI
-bgS
-bjs
-biB
+bEM
+pDn
+pDn
+pDn
+pDn
+pDn
+pDn
+pDn
+pDn
+pDn
+pDn
+fGN
 rim
 rBv
 sBU
 bmj
-btd
+fGN
 boJ
 rLN
 brO
@@ -111715,29 +111120,29 @@ aZZ
 ebx
 bIb
 iYU
-aZZ
-bGx
-bJx
-bGq
+oAm
+baF
+baF
+iFh
 xRU
 mGj
 xCv
-ybP
+qea
 bQk
-gfH
-jeC
-gfH
-bUN
-bYT
-bYT
-bVS
-ocv
-jil
+baF
+get
+bYx
+btd
+pTd
+prN
+biB
+bCj
+gGt
 lXf
-bZg
-lxm
+snW
+prN
 cCB
-gHw
+btd
 bZZ
 caq
 bZF
@@ -111938,23 +111343,23 @@ hen
 mIh
 nmK
 nBP
-nHL
-eRz
-hxP
-bbh
-bbf
-bbf
-cFe
-prN
-prN
-bgT
-dbs
-dbs
-dbs
+bEM
+pDn
+pDn
+pDn
+pDn
+pDn
+pDn
+pDn
+pDn
+pDn
+pDn
+fGN
+hxe
 dbs
 rWQ
 snQ
-btd
+rVw
 boJ
 iDw
 xCt
@@ -111971,30 +111376,30 @@ xLi
 aZZ
 xzi
 wSz
-bJy
-aZZ
-jpE
+dWM
+wmR
+baF
 obz
-tTE
-tMQ
-jPS
-lPd
-oDb
+mrt
+dcF
+mrt
+mrt
+mrt
 bQl
-ybP
-ybP
-gfH
-bUN
+baF
+baF
+baF
+btd
 bWm
-rds
-cqu
-oLT
-bYa
-xIG
-bZg
-bZg
-gHw
-gHw
+prN
+biB
+bCj
+prN
+prN
+prN
+prN
+nSj
+btd
 cac
 caL
 caL
@@ -112195,23 +111600,23 @@ hen
 mIh
 nok
 nCB
-btd
-nWO
-bbg
-jAF
-uEn
-nNT
-pdd
-bfJ
-bhJ
-gFA
-qtZ
+bEM
+pDn
+pDn
+pDn
+tpw
+pDn
+pDn
+tpw
+pDn
+pDn
+pDn
 fGN
 wNd
-qtZ
-jCi
-bmk
-cTQ
+bgS
+rWQ
+snQ
+rVw
 boQ
 mNL
 qmn
@@ -112229,29 +111634,29 @@ aZZ
 bGz
 wSz
 dWM
-aZZ
-bLI
+qGP
+baF
 qqe
-bGq
+mrt
 cjJ
 xlg
 myn
-ybP
-bQk
-oGU
-ybP
+jWw
+mrt
+dNs
+nsX
 bSU
-bUN
-sug
-hth
-bVS
-oLT
-sug
-hth
-iNg
-bZi
-aXn
-aXn
+btd
+oQS
+prN
+wQM
+uZG
+kAT
+wQM
+wQM
+biB
+bld
+ueB
 aXn
 aXn
 aXn
@@ -112452,23 +111857,23 @@ kGi
 gyI
 noU
 djF
-nIx
-nWU
+bEM
+pDn
+pDn
+pDn
+pDn
+pDn
+pDn
+pDn
+pDn
+pDn
+pDn
+fGN
 hxe
-jGu
-grX
-bdX
-btd
-bfK
-dbI
-bgV
-bld
-bld
-bld
-bld
-sab
-prN
-lJR
+dbs
+rWQ
+snQ
+rVw
 boJ
 iDw
 wMK
@@ -112486,29 +111891,29 @@ aZZ
 wmR
 fEG
 fZP
-aZZ
-bGq
-bGq
-bGq
-fHT
+bWL
+baF
+hoq
+mrt
+mrt
 uAD
 fFg
-ybP
-bQk
-ybP
-ybP
-gfH
-bUN
+aVG
+mrt
+pxi
+mrt
+ozW
+btd
 bVR
-rds
-bVS
+prN
+biB
 oLT
 bYa
-rds
-bZg
-goW
-aXn
-aXn
+biB
+biB
+biB
+bld
+ueB
 aXn
 aXn
 aXn
@@ -112709,23 +112114,23 @@ wAL
 aYC
 aZd
 wAL
-ueB
-nXv
-bbi
-bbI
-bct
-dZs
-btd
-tyR
-gQb
-fFN
-biB
-kAT
-biB
+bEM
+pDn
+pDn
+pDn
+pDn
+pDn
+pDn
+pDn
+pDn
+pDn
+pDn
+fGN
+ibR
 rBT
 saj
 bmk
-cTQ
+fGN
 boJ
 iDw
 brM
@@ -112736,36 +112141,36 @@ aZZ
 aZZ
 aZZ
 aZZ
-cMy
+aZZ
 hGj
 aZZ
 aZZ
 bGB
 bGB
 bJA
-aZZ
-bLH
+bGB
+baF
 bNg
-bOd
-tMQ
+mrt
+mrt
 tNt
 ujV
-ybP
-gat
-ybP
-qhw
-bSU
-bUN
+dOy
+saK
+mrt
+mrt
+cTD
+btd
 bVN
-hth
-bVS
-uZG
-sug
-hth
+prN
 wQM
-knU
-aXn
-aXn
+uZG
+biB
+wQM
+wQM
+biB
+bld
+ueB
 aXn
 aXn
 aXn
@@ -112966,23 +112371,23 @@ wAL
 ncn
 nqf
 wAL
-ueB
-nXW
-bbj
-bbJ
+kWu
+pwt
+pwt
+pwt
 bcu
-bdh
-btd
-beQ
-mcu
-dUr
-bld
-bld
-bld
-bld
-bld
-prN
-uQa
+pwt
+pwt
+bcu
+pwt
+pwt
+pwt
+fGN
+fGN
+nWO
+lxm
+fGN
+fGN
 kNt
 iDw
 brM
@@ -112993,41 +112398,41 @@ wXJ
 biv
 dda
 xlV
-wmR
+bdR
 dcE
 wQW
 drp
-ddn
+bjr
 bjr
 qHW
-aZZ
-geR
+aqx
+baF
 ofT
-bNh
-dTL
+mrt
+mrt
 ycy
 nqJ
-inc
-bQk
-ybP
-ybP
-gfH
-bUN
-bYT
-bVS
-bVS
-oLT
-bVS
-bYT
-bXj
-bZl
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
+nEJ
+mrt
+mrt
+mrt
+qfr
+btd
+ezi
+prN
+wQM
+uZG
+biB
+wQM
+wQM
+biB
+pbQ
+ueB
+btd
+btd
+btd
+btd
+btd
 hUU
 hUU
 bhO
@@ -113222,69 +112627,69 @@ hUU
 wAL
 ncn
 nqf
-wAL
+kWu
 hjP
-baG
+cFF
 bbk
-mNA
+nNM
 bcv
 bdZ
-btd
-bfL
-gQb
-ltb
-biB
-biB
-biB
-biB
-biB
+cbl
+bcv
+bbk
+bbk
+nFC
+qft
+pFS
+wEs
+oSE
 soz
-btd
+bEM
 boJ
 ttU
 tWj
-aZZ
-eud
+bjn
+wmR
 wfH
 bxo
-vUN
-bxo
-bxo
+wmR
+wmR
+wmR
 cCp
 lao
 kIL
-wSz
 ddn
 bjr
-qHW
-aZZ
-bGD
-ybP
-bRi
-ybP
-ybP
-ybP
+bjr
+pIg
+qTM
+baF
+fDm
+mrt
+mrt
+xNP
+biT
 bPj
 nTU
-oGU
-ybP
-gfH
-bUN
-var
-xkn
-esG
+mrt
+mrt
+mrt
+xIG
+biB
+biB
+biB
 bEy
-xkn
-bVS
-bXj
+eRz
+bjs
+mJb
 mJb
 bZJ
-lqz
+rMH
 nnP
 hit
 cFH
 oIV
-bXj
+btd
 aXn
 hUU
 hUU
@@ -113479,24 +112884,24 @@ hUU
 gyI
 aJT
 nqf
-wAL
-wAL
-uzY
-uzY
+kWu
+uVq
+cFF
+cFF
 vjw
-baF
-baF
-btd
-dcz
-bfO
-bgY
+cFF
+cFF
+cFF
+cFF
+cFF
+cFF
 bhK
 jgT
-wEs
+cFF
 wEs
 oSE
 bmm
-btd
+bEM
 qTa
 iDw
 iZC
@@ -113504,46 +112909,46 @@ aZZ
 uNz
 lIP
 bxp
-dcS
+wmR
+gVy
 fEG
 ime
-wmR
 wVx
-kIL
 wSz
+ddn
 bjr
-fso
+bjr
 bJz
-aZZ
-bGE
-ybP
+bAv
+baF
+uFW
 tim
-lKl
+tim
 vIx
 biT
-sXs
 bQm
-ybP
-ybP
-bSU
-bUN
-vMO
-xkn
-jaM
+bQm
+mrt
+mrt
+mrt
+uNU
+biB
+biB
+biB
 bCj
-xkn
-bVS
-bXj
-bZm
-tfK
-bGL
-gww
-ihR
-bXj
-bXj
-bXj
-bXj
-bXj
+bJx
+ltb
+biB
+biB
+frK
+biB
+biB
+biB
+qqo
+bfO
+btd
+aXn
+aXn
 hUU
 hUU
 bhO
@@ -113736,71 +113141,71 @@ hUU
 wAL
 ncn
 nqf
-wAL
-wAL
-uzY
-baH
+kWu
+kWu
+bLG
+oeP
 okR
-bbK
-baF
-baF
+cFF
+vHE
+nqD
 peP
-baF
-qcL
-baF
-baF
+bXW
+cFF
+tly
+nMN
 rjM
 rDn
-baF
-baF
-baF
+oSE
+vmp
+bEM
 qbB
 dyv
 lQY
 aZZ
+bjn
 aZZ
-vki
+bKu
 aZZ
-qXA
-wSz
+jcC
 vVE
 wUz
 iKY
-aBK
 wSz
+ddn
 bjr
-xSR
+bjr
 bJB
-aZZ
-bGq
-dmV
+bAv
+baF
+baF
 drd
-bGq
-bGq
-bGq
-bGq
-loQ
-ybP
-ybP
-gfH
-bUN
-pXj
-nEJ
-bWL
+mrt
+cQc
+mrt
+aIh
+mrt
+mrt
+mrt
+mrt
+tyR
+prN
+prN
+biB
 rGC
-tqj
+qtZ
 wET
 mdP
-gLy
-dOy
-jkW
-cau
+qtZ
+qtZ
+qtZ
+qtZ
 hQl
-bXj
-vVZ
-xCz
-iTE
-bXj
+iJY
+bfO
+btd
+aXn
+aXn
 aXn
 hUU
 bhO
@@ -113995,69 +113400,69 @@ ncn
 nqf
 gyI
 wAL
-uzY
-odU
-okR
-oAs
+tfU
+oeP
+pGC
+cFF
 ePs
-baF
+ptB
 ptB
 bNz
-bgZ
-tly
+cFF
+bYy
 nMN
-mrt
-mrt
-blf
-baF
-eAq
+bjz
+rDn
+oSE
+eVx
+bEM
 thL
 iDw
 brN
-bjn
+jCi
 uNO
-dcF
+bjn
 iFe
-ddn
+bjr
 mso
 ddn
 ddn
-mso
-tUU
+dUr
+ddn
 elh
 bjr
-bAv
+bjr
 fTK
-aZZ
-bHZ
-bHZ
-ccY
+aHR
+bjr
+baF
+baF
 sWh
-nKe
-gcz
-bGq
-bGq
-gfH
-jeC
-gfH
-bUN
+jPS
+mrt
+mrt
+rle
+ogl
+kyB
+nvT
+btd
 gIq
 gEA
-bVS
+xxW
 oZA
-wiQ
-bYT
-bXj
-hxX
+prN
+ltb
+vMl
+prN
 sFW
 gQv
 sfH
-lqz
+oSt
 fGv
-xCz
-xCz
-eNP
-bXj
+bLH
+btd
+aXn
+aXn
 aXn
 hUU
 bhO
@@ -114252,69 +113657,69 @@ ncn
 nqf
 lxX
 wAL
-uzY
+odU
 oeP
 olB
 bGI
 tma
-baF
+ptK
 ptK
 pFC
 bha
-pxi
-aIh
-mrt
-pxi
-mrt
+aHw
+tTE
+bSf
+iKI
+ihR
 sFq
 pzM
-thL
+lXg
 jfr
-brO
-uqU
+brM
+rZl
 uNT
 vkG
-qQJ
-qQJ
-rqJ
-qQJ
-qQJ
-qQJ
-xNq
+iFe
+bjr
+kwn
 bjr
 bjr
-tXX
-bKu
-aZZ
-vDw
-ybP
+gBw
+bjr
+bjr
+bXV
+bjr
+qHW
+bjr
+bjr
+bjr
 aiR
 abL
-bHZ
-bHZ
-sYH
-aEe
-aEe
-aEe
-bZg
-bZg
+epa
+uCO
+uzY
+uzY
+nnc
+baF
+baF
+btd
 rZo
-bYT
-bYT
-fSi
-bYT
+rZo
+rZo
+rZo
+rZo
 ran
-bXj
-tCy
-kyB
-hAp
-eLI
-miy
-bXj
-pPy
-gCW
-gCP
-bXj
+jAF
+rZo
+rZo
+rZo
+rZo
+btd
+biB
+prN
+btd
+aXn
+aXn
 aXn
 hUU
 bhO
@@ -114509,69 +113914,69 @@ ncy
 nrT
 nCP
 wAL
-uzY
-oeY
+oCY
+oeP
 ony
-ogl
+cFF
 mNR
-baF
+vki
 ptQ
 lAJ
-qeU
+cFF
 bhN
 biG
 bjz
-saK
-mrt
-sFr
-pzM
+fHT
+cFF
+cFF
+pwt
 thL
 iEo
-lZD
+brM
+rZl
+lDZ
 aZZ
-aZZ
-uOq
-bjr
-tXX
+ntl
+onO
+mNA
+mBb
 bAv
-xSR
-fso
+fcD
+tAc
 bjr
-xNP
-qQJ
-qQJ
-wzp
-voH
-aZZ
-dds
-rSr
+uBQ
+onO
+qHW
+nXn
+bjr
+bjr
 bRP
 sup
-bPi
-rUL
-tIo
-aEe
-sbn
-sbn
-bZg
-rqP
+hxP
+sup
+uzY
+peW
+ogl
+sGz
+sGz
+btd
 fQI
-bYT
-bYT
-fSi
+bOd
 pYG
-bZg
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
-bXj
+att
+pYG
+pPy
+rkt
+bJy
+voH
+pYG
+bYC
+btd
+sXs
 emk
-bXj
-bXj
-bXj
+btd
+aXn
+aXn
 hUU
 hUU
 bhO
@@ -114766,22 +114171,22 @@ gyI
 pFa
 upz
 wAL
-uzY
+kWu
 ofc
-onH
-oCa
-oRA
-peW
-ptU
-pFS
-qfa
-rkt
+ghX
+cFF
+cFF
+cFF
+cFF
+cFF
+cFF
+cFF
 qFp
-rkr
-dNs
-mrt
-sGz
-pzM
+cFF
+cFF
+cFF
+cFF
+bHF
 thL
 vYn
 dyf
@@ -114789,44 +114194,44 @@ enj
 buG
 anS
 xrn
-fso
+dty
 kNx
-bAv
+kLc
 tXX
-kwn
+qXA
 ghB
-nnc
-onO
-uBQ
+dty
+dds
+dty
 qnk
-aZZ
-vxd
-oGU
+bjr
+bjr
+bjr
 pYu
-aia
-dQo
-bPi
-gcz
-aEe
-sbn
-sbn
-bZg
-rqP
-fQI
-bYT
-gNI
-fSi
-bZg
-bZg
-sbn
-sbn
-sbn
-sbn
-sbn
-sbn
-bXj
-nXn
-bXj
+fup
+bYw
+qbU
+uzY
+gzr
+ogl
+ogl
+jMh
+btd
+dkg
+jDX
+eXL
+pYG
+bYC
+pPy
+rkt
+pYG
+bIT
+wvA
+jDX
+ueB
+wph
+wph
+wph
 aXn
 hUU
 hUU
@@ -115023,67 +114428,67 @@ wAL
 ncn
 nDu
 lAO
-nZm
+kWu
 nSS
 opP
-oCY
-oSt
-baF
-pus
-mrt
-qfr
-iJY
-mrt
-pxi
-pGu
-ljD
+cFF
+cFF
+cFF
+cFF
+cFF
+cFF
+cFF
+cFF
+cFF
+cFF
+cFF
 aTh
-sGH
-vLI
+bEM
+thL
 ikB
 jWv
-rZl
+buH
 buH
 vls
 noZ
-dty
+qQJ
 ing
 bGf
-cCp
+pjj
 aas
-cCp
-cCp
-cCp
-uCO
-phF
-aZZ
-ybP
+goW
+qQJ
+uvg
+qQJ
+qQJ
+xSR
+qQJ
 rSr
 bRP
-sup
-oOW
-bPi
-tIo
-aEe
-sbn
-sbn
-bZg
+nLa
+phF
+bbK
+uzY
+baH
+blf
+nnV
+ogl
 tcM
 jDX
-bYT
-bYT
-fSi
-bZg
-sbn
-sbn
-sbn
-sbn
-sbn
-sbn
-sbn
-wmj
+bfL
+voC
+sLi
+niJ
+nXW
+gQb
+gww
+qfa
+voH
+bZl
+ueB
+wph
 caw
-bZt
+caw
 aXn
 hUU
 cdb
@@ -115280,66 +114685,66 @@ wAL
 wAL
 nDx
 nCP
-baF
-baF
-eVx
-baF
-baF
-baF
+kWu
+kWu
+kWu
+kWu
+eRp
+kWu
 ljI
-pGC
-qfx
-qxu
 qFX
-ozW
+qfx
+qFX
+qFX
+vDZ
 rEg
 saT
-baF
-thZ
+tfK
+bEM
 thL
 iDw
 iEH
-aZZ
+rZl
 euQ
-mQk
+aZZ
 bxs
 bjr
-onO
+uOq
 bjr
-wmR
-xrn
-gPH
-xrn
-wmR
+bjr
+bjr
+bjr
+bjr
+kzY
 iXQ
 mrF
-aZZ
-tCX
-ybP
+lZD
+bjr
+lZD
 sCU
 fup
-bHZ
-bHZ
-bHZ
-aEe
-sbn
-sbn
-bZg
-rqP
-fQI
-bYT
-bYT
+sGH
+fup
+uzY
+geR
+ogl
+oAs
+ogl
+ueB
+mcu
+jDX
+ovP
 fSi
-bZg
-sbn
-sbn
-sbn
-sbn
-sbn
-sbn
-sbn
-cbl
-caw
+bYC
+agm
+bgT
+pYG
+pYG
+bdh
+pYG
+ueB
+wEB
+fRn
 aXn
 aXn
 hUU
@@ -115542,61 +114947,61 @@ kxf
 opV
 fzp
 aYC
-baF
-baF
-baF
-baF
-baF
-baF
-baF
-baF
-baF
-baF
-gyI
+kWu
+kWu
+kWu
+kWu
+kWu
+kWu
+kWu
+kWu
+kWu
+kWu
+kWu
 tiv
 gio
-tWL
-uqU
-xmQ
-aHw
+iEH
+rZl
+rZl
+bjn
 bjr
-bjr
-qqo
 klX
-wmR
-nsX
+klX
+klX
+thZ
+rLk
 cVy
 rLk
 jpO
 uFT
-tXX
-aZZ
-nFC
-bHZ
-qft
+bbj
+lZD
+bjr
+rkr
+baF
 hQg
 ail
 png
-eJA
-aEe
-sbn
-sbn
-bZg
-rqP
+uzY
+tqj
+kfs
+vUN
+bWl
+ueB
 bYC
 wvA
-bYT
-fSi
+vEG
+gCP
 bZg
-sbn
-sbn
-sbn
-sbn
-sbn
-sbn
-sbn
-cbn
-caw
+dbI
+pYG
+bdh
+var
+jDX
+bdh
+ueB
+wph
+jAd
 aXn
 hUU
 hUU
@@ -115797,11 +115202,11 @@ nJy
 ncn
 ncn
 ncn
-nrT
-oTZ
+fze
+tIo
 oTZ
 uyK
-oTZ
+tIo
 qgJ
 qxG
 qGb
@@ -115813,46 +115218,46 @@ gyI
 boJ
 tvd
 tXb
-bjn
+rZl
 iSG
-vmp
-esU
+aZZ
+aZZ
 tOx
 woF
 rKX
-wmR
+wot
 aET
 xOt
-xrn
+onH
 fkt
 fkt
 fkt
+dcS
 fkt
-aEe
-aEe
-tzb
-aEe
-aEe
-aEe
-aEe
-aEe
-sbn
-sbn
-bZg
-bZg
-bZg
-bUN
-bUN
+fkt
+uzY
+uzY
+gNI
+pSQ
+uzY
+uzY
+uzY
+uzY
+uzY
+ueB
+ueB
+ueB
+ueB
 hhz
-bZg
-sbn
-sbn
-sbn
-sbn
-sbn
-sbn
-sbn
-cbn
+ueB
+ueB
+ueB
+ueB
+ueB
+ueB
+ueB
+ueB
+wph
 hoU
 mic
 hUU
@@ -116068,7 +115473,7 @@ hhi
 srC
 tSz
 mIQ
-rLN
+drZ
 tXy
 aZZ
 aZZ
@@ -116077,20 +115482,20 @@ aZZ
 fkt
 fkt
 fkt
-wVc
+fkt
 fkt
 fkt
 fkt
 fkt
 gtv
 ogY
-wph
-wph
+oIf
 scR
-cQc
-jAd
+scR
+scR
+pbO
 wPh
-xOD
+eoU
 sbn
 sbn
 sbn
@@ -116109,7 +115514,7 @@ lHd
 lHd
 vRn
 ycg
-xsh
+wph
 xtR
 aXn
 hUU
@@ -116344,10 +115749,10 @@ wAq
 wpF
 kPA
 tXm
-gRW
-sMp
-wAq
 wpF
+sMp
+jkW
+jIh
 wpF
 wpF
 wAq
@@ -116433,24 +115838,24 @@ rNK
 rNK
 rNK
 rNK
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-bHF
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -116603,7 +116008,7 @@ cxW
 shL
 sbn
 eiK
-sbn
+scR
 sUE
 viL
 gtv
@@ -116690,24 +116095,24 @@ rNK
 rNK
 rNK
 rNK
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -116947,24 +116352,24 @@ rNK
 rNK
 rNK
 rNK
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -117204,24 +116609,24 @@ rNK
 rNK
 rNK
 rNK
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -117461,24 +116866,24 @@ rNK
 rNK
 rNK
 rNK
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -117570,8 +116975,8 @@ aUv
 dhC
 piY
 irR
-bWx
-aWJ
+cGE
+vkc
 pAA
 unc
 mtU
@@ -117718,24 +117123,24 @@ rNK
 rNK
 rNK
 rNK
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -117828,7 +117233,7 @@ dhN
 pMu
 iqQ
 bWx
-aWJ
+cCK
 gGF
 gFu
 xYY
@@ -117975,24 +117380,24 @@ rNK
 rNK
 rNK
 rNK
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -118232,24 +117637,24 @@ rNK
 rNK
 rNK
 rNK
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -118337,12 +117742,12 @@ cFN
 aSK
 cFN
 ogL
-agm
+ogL
 ogL
 dlH
 dsL
 dOM
-rwD
+aWJ
 gGF
 gGF
 gGF
@@ -118489,24 +117894,24 @@ rNK
 rNK
 rNK
 rNK
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -118584,22 +117989,22 @@ aIa
 aiN
 aKb
 wrU
-vrQ
-fZJ
-gfP
-aKm
-cxU
-aPc
 lxM
+ovY
+aPc
+aKm
 aSL
-cww
-vrQ
-vrQ
-vrQ
-bLx
+aSL
+aSL
+aSL
+avS
+ksj
+ksj
+ksj
+ksj
 wBG
 chV
-rwD
+aWJ
 dzk
 gHl
 jpP
@@ -118746,24 +118151,24 @@ rNK
 rNK
 rNK
 rNK
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -118828,7 +118233,7 @@ aTz
 aTz
 afd
 abW
-nZp
+ivS
 dXH
 lVB
 uVA
@@ -118845,14 +118250,14 @@ aiN
 aiN
 aiN
 aiN
-kXu
-kXu
-kXu
-kXu
-kXu
-kXu
-kXu
-kXu
+aSL
+cxU
+qVt
+ddD
+bbg
+kzf
+omX
+cPA
 dlK
 dsN
 mTQ
@@ -119003,24 +118408,24 @@ rNK
 rNK
 rNK
 rNK
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -119102,18 +118507,18 @@ chc
 hIk
 coV
 cDO
-kXu
-kXu
-kXu
-kXu
-kXu
-kXu
-kXu
-kXu
-ice
+aSL
+lhc
+cGx
+ddD
+qSK
+kzf
+phM
+eMW
+kzf
 wBG
 chV
-rwD
+aWJ
 dzk
 gJa
 gIG
@@ -119260,24 +118665,24 @@ rNK
 rNK
 rNK
 rNK
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -119359,18 +118764,18 @@ fBl
 fBl
 acD
 dko
-kXu
-kXu
-kXu
-kXu
-kXu
-kXu
-kXu
-kXu
-gZm
+aSL
+aPf
+cPz
+ddD
+qSK
+kzf
+lUg
+nWJ
+kzf
 wBG
 chV
-rwD
+aWJ
 dzk
 gJd
 gIG
@@ -119517,24 +118922,24 @@ rNK
 rNK
 rNK
 rNK
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -119616,18 +119021,18 @@ aqC
 aqC
 muK
 aOS
-kXu
-kXu
-kXu
-kXu
-kXu
-kXu
-kXu
-ice
-gZm
+aSL
+cCC
+ddD
+ddD
+qSK
+kzf
+kzf
+nEt
+kzf
 wBG
 chV
-rwD
+aWJ
 dzk
 gJx
 gIG
@@ -119774,24 +119179,24 @@ rNK
 rNK
 rNK
 rNK
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -119873,18 +119278,18 @@ rGm
 aqC
 jHW
 aOT
-kXu
-kXu
-kXu
-kXu
-kXu
-kXu
-kXu
-ice
-ice
+aSL
+aTT
+eDz
+aUc
+gfP
+bhJ
+bKq
+itU
+kzf
 dsP
 dIS
-rwD
+aWJ
 dzk
 gJK
 gIG
@@ -120031,24 +119436,24 @@ rNK
 rNK
 rNK
 rNK
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -120128,20 +119533,20 @@ ksl
 ksl
 npt
 aqC
-aqC
+ezW
 fQm
-avS
-avS
-avS
-avS
-avS
-avS
-avS
-avS
-avS
+pEA
+bNV
+bNV
+uDr
+ltL
+bLD
+bMY
+bMY
+bMY
 wBG
 chV
-rwD
+aWJ
 aWu
 gJT
 ixb
@@ -120288,24 +119693,24 @@ rNK
 rNK
 rNK
 rNK
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -120385,20 +119790,20 @@ aKd
 aDh
 gnE
 cjB
-aNQ
-qSK
+vKi
 hSA
-aqC
+bNV
+wnk
 aSb
-aSO
-aqC
 aUc
-aqC
+pas
+aUc
+aPK
 chS
-aqC
+bMY
 awO
 ymg
-rwD
+aWJ
 dzk
 gLu
 gIG
@@ -120545,24 +119950,24 @@ rNK
 rNK
 rNK
 rNK
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -120643,16 +120048,16 @@ aKe
 lFk
 cEQ
 naP
-cGD
 nkc
-aqC
-jVe
-aqC
-aqC
-aUb
-aqC
+bNV
+aAG
+bNV
+bNV
+eRV
+bMY
+bMY
 aDz
-aqC
+bMY
 eBB
 aVP
 aWh
@@ -120802,24 +120207,24 @@ rNK
 rNK
 rNK
 rNK
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -120900,16 +120305,16 @@ aKf
 aLU
 cEQ
 naP
-cGD
 hSA
-aqC
+bNV
+bGo
+tjO
+bNV
+eRV
+bMY
+qqD
 chT
-aPf
-fLI
-chT
-chT
-chT
-aqC
+bMY
 wBG
 hWs
 hSH
@@ -121029,7 +120434,7 @@ koR
 prS
 flc
 wAG
-wAG
+bOX
 xGg
 uXg
 ktF
@@ -121059,24 +120464,24 @@ rNK
 rNK
 rNK
 rNK
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -121157,16 +120562,16 @@ aDO
 oFu
 cEQ
 vKi
-qSK
 hSA
-aqC
+bNV
+wSt
 tcg
-nyG
-tjO
-phM
+bNV
+eRV
+bMY
 aTF
 diM
-aqC
+bMY
 chz
 hWs
 rwD
@@ -121316,24 +120721,24 @@ rNK
 rNK
 rNK
 rNK
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -121413,17 +120818,17 @@ usr
 usr
 aLV
 cjM
-qSK
-csf
+fYA
 aqC
-aqC
-aqC
-aqC
+bNV
+cww
+jVe
+bNV
 eRV
-cPz
-aqC
-aqC
-aqC
+bMY
+vUv
+nVj
+bMY
 dtn
 hWs
 rwD
@@ -121573,24 +120978,24 @@ rNK
 rNK
 rNK
 rNK
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -121668,20 +121073,20 @@ uHm
 bQZ
 eZn
 cdc
-chi
-ghC
-aPK
-aPK
-aPK
-aRi
-aJe
-cGw
-aPK
-cPA
-cTD
-buJ
-dlL
-dts
+diy
+cEQ
+vKi
+qSK
+bNV
+bNV
+bNV
+bNV
+eRV
+bMY
+bMY
+bMY
+bMY
+wBG
 oTb
 rwD
 cXk
@@ -121830,24 +121235,24 @@ rNK
 rNK
 rNK
 rNK
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -121925,22 +121330,22 @@ uHm
 bRm
 cKp
 gGB
-adm
-qSK
-qSK
-qSK
-qSK
+chi
+ghC
+bWO
+bRg
+bRg
 bnV
-cEQ
-kJd
-cGD
-cPH
-qSK
-lBJ
+uIm
+bPa
+okw
+aSO
+gGR
+bLC
 dlT
 dtA
-hWs
-rwD
+bRh
+bNb
 fIg
 gNk
 gNk
@@ -122182,19 +121587,19 @@ uHm
 bRn
 aKl
 gGB
-abW
-abW
-abW
-hYG
-abW
-abW
+uOH
+qSK
+qSK
+qSK
+qSK
+buJ
 cEQ
-oFu
-cLN
-cPI
+kJd
+cGD
+cPH
 qSK
-qSK
-dmb
+lBJ
+dmg
 dtF
 dPq
 krD
@@ -122439,19 +121844,19 @@ uHm
 niC
 cKp
 gGB
-abW
-abW
-abW
-abW
-abW
-abW
-cCC
-cGB
-cGD
-cPM
-cTH
-diS
-aqC
+avS
+avS
+avS
+gZD
+avS
+avS
+cEQ
+oFu
+cLN
+cPI
+qSK
+qSK
+dmb
 dtZ
 dPt
 eIH
@@ -122700,16 +122105,16 @@ abW
 abW
 abW
 abW
-abW
-abW
+avS
+bRd
 cCJ
 xEb
-cGD
+dau
 cPW
 cTJ
 aqC
-dmg
-wBG
+aKp
+xYi
 hWs
 eAF
 fIg
@@ -122957,15 +122362,15 @@ abW
 abW
 abW
 abW
-abW
-abW
-cCK
+avS
+nJA
+cGD
 cGD
 cGD
 cGD
 cGD
 aqC
-lGk
+pfp
 wBG
 hWs
 eAo
@@ -123214,10 +122619,10 @@ abW
 abW
 abW
 abW
-abW
-abW
+avS
+fQG
+vcK
 cCL
-cGE
 cLO
 cQi
 cTK
@@ -123471,8 +122876,8 @@ abW
 abW
 abW
 abW
-abW
-abW
+avS
+avS
 avS
 avS
 gZD
@@ -123535,8 +122940,8 @@ ajz
 bDR
 bFa
 lvF
-bIi
-bIi
+aJj
+oFD
 qpd
 bQx
 tqg
@@ -123792,8 +123197,8 @@ rYW
 bDR
 bFb
 bGM
-bJI
-bJI
+sZE
+lpW
 yjY
 bIi
 bIi
@@ -125596,7 +125001,7 @@ eQG
 jqb
 eQG
 cQl
-bIi
+lHB
 bPx
 bJI
 bJI
@@ -126627,12 +126032,12 @@ bNu
 cQB
 bPA
 iTF
-bRv
+dAk
 bSs
-bTc
-bTc
+dAk
+dAk
 bTD
-bTc
+dAk
 deD
 bWa
 bIF
@@ -131245,11 +130650,11 @@ tHo
 tBG
 grW
 bHh
-bID
+bnS
 cMb
-bHD
+nOF
 orc
-mJM
+bNx
 bOG
 bPM
 bPI
@@ -131502,11 +130907,11 @@ fUR
 fBn
 bFB
 bHi
-bIG
+guA
 cMb
-bHD
+nOF
 cTg
-mJM
+bNx
 bOH
 bPN
 hKY
@@ -131759,11 +131164,11 @@ bDb
 wwR
 wwR
 bHj
-bIG
+guA
 cMb
-bHD
+nOF
 cTg
-mJM
+bNx
 bND
 bND
 bQM
@@ -132015,12 +131420,12 @@ rHt
 cjr
 bEm
 irh
-nVW
-nVW
+bIG
+guA
 cMb
-bHD
+nOF
 cTg
-mJM
+aCZ
 nVW
 nVW
 cFD
@@ -132263,21 +131668,21 @@ jUK
 bsj
 aYJ
 pQY
-sXj
+bwi
 bFu
 ufT
-bEl
-bEl
+rHt
+rHt
 bHD
 tMJ
-nVW
-nVW
-nVW
-nVW
+bIG
+bIG
+bIG
+guA
 bPF
 beU
 xgr
-nVW
+guA
 nVW
 nVW
 bQN
@@ -132520,21 +131925,21 @@ nJm
 rxW
 btK
 bvi
-sXj
+bwi
 djQ
 glW
 jiO
 bRs
 bRs
 cxf
+bIG
 nVW
 nVW
-nVW
-nVW
-nVW
-nVW
-nVW
-nVW
+guA
+guA
+guA
+guA
+guA
 nVW
 nVW
 bND
@@ -132777,14 +132182,14 @@ bgf
 cWM
 uLa
 bvj
-sXj
-sXj
+bwi
+bwi
 gBj
-nVW
-nVW
-nVW
-nVW
-nVW
+bIG
+bIG
+bIG
+bIG
+bIG
 nVW
 nVW
 nVW
@@ -141302,7 +140707,7 @@ afX
 afX
 afX
 tti
-hxE
+jvZ
 dax
 fID
 jAN
@@ -141567,7 +140972,7 @@ jvZ
 ueH
 dLJ
 krX
-bOj
+afX
 vRX
 nff
 xeL
@@ -141822,9 +141227,9 @@ bQJ
 ueH
 jvZ
 bQJ
-fSQ
-bOj
-bOj
+vLX
+afX
+afX
 vRX
 cdG
 hJt
@@ -142075,12 +141480,12 @@ uEU
 tga
 wLr
 wLr
-edM
 jOT
-jEG
+bUH
+wLr
 wLr
 hYF
-bOj
+afX
 yev
 qZT
 qfX
@@ -142331,10 +141736,10 @@ mHq
 lzO
 bWR
 djo
-viX
-dkg
 djo
 djo
+bdX
+bfJ
 ioJ
 ohN
 djo
@@ -142846,10 +142251,10 @@ iJa
 cnL
 djo
 cOO
+pdc
 mBq
 mTc
 ddE
-aVG
 tVf
 djo
 lXb
@@ -143103,10 +142508,10 @@ qlb
 aZc
 djo
 wDs
+pdc
 mTc
 mBq
 ddB
-frV
 flF
 djo
 aXn
@@ -143361,9 +142766,9 @@ bDW
 rdl
 aWr
 hBe
+fso
 nPH
-nPH
-nPH
+ljD
 fDL
 pvo
 hIi
@@ -143608,7 +143013,7 @@ rNK
 rNK
 hUU
 aXn
-rXV
+xvx
 bue
 bue
 hiN
@@ -143617,7 +143022,7 @@ bue
 owE
 ioJ
 laC
-aLH
+dTL
 blL
 jTp
 aLH
@@ -143842,7 +143247,7 @@ uhF
 oOe
 ddo
 tKE
-uqv
+tKE
 cTf
 bME
 evM
@@ -143865,21 +143270,21 @@ rNK
 rNK
 hUU
 aXn
-rXV
 xvx
 xvx
 xvx
 xvx
 xvx
-rXV
-kZz
-kZz
-kZz
+xvx
+xvx
 djo
 djo
 djo
-kZz
-kZz
+djo
+djo
+djo
+djo
+djo
 wHA
 xCO
 xdy
@@ -144131,7 +143536,7 @@ aXn
 aXn
 aXn
 aXn
-aXn
+dZs
 cdT
 aXn
 jpk
@@ -152048,7 +151453,7 @@ oNH
 bno
 xTb
 xTb
-vFQ
+bzq
 ogB
 vFQ
 dCT

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -9267,7 +9267,6 @@
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 2;
 	name = "disposal pipe - Library";
-	sort_type_txt = "16";
 	sortType = 16
 	},
 /turf/simulated/floor/carpet/green,
@@ -17232,7 +17231,6 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
 	name = "disposal pipe - Chapel";
-	sort_type_txt = "17";
 	sortType = 17
 	},
 /turf/simulated/floor/carpet/green,

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -1531,6 +1531,9 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
+/obj/structure/cable/orange{
+	icon_state = "2-8"
+	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -1614,24 +1617,24 @@
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
 "alg" = (
-/obj/machinery/door/window/brigdoor/southleft{
-	dir = 1;
-	req_access = list(63)
-	},
 /obj/structure/cable/orange{
 	icon_state = "1-2"
+	},
+/obj/structure/cable/orange{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/orange{
+	icon_state = "2-8"
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
 "alh" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
-/obj/structure/closet/emcloset,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/camera{
 	c_tag = "Brig Labor Camp Airlock North";
 	dir = 8
@@ -2270,20 +2273,23 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/northeast)
 "aok" = (
-/obj/structure/cable/orange{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable/orange{
-	icon_state = "2-8"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/security/prisonershuttle)
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/secondary/entry/south)
 "aol" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
 "aom" = (
@@ -35777,9 +35783,6 @@
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
 "dqb" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -44695,6 +44698,15 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/engineering)
+"fZA" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
+	},
+/area/hallway/secondary/entry/south)
 "fZJ" = (
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -47090,6 +47102,15 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/hor)
+"gTA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/entry/south)
 "gTD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -50569,13 +50590,13 @@
 	},
 /area/security/warden)
 "ijl" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "trade_dock";
-	locked = 1;
-	name = "External airlock"
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/hallway/secondary/entry/south)
 "ijr" = (
 /obj/effect/turf_decal/stripes/line{
@@ -52949,7 +52970,9 @@
 	name = "port bay 2";
 	width = 5
 	},
-/turf/space,
+/turf/space{
+	icon_state = "black"
+	},
 /area/space)
 "jgl" = (
 /obj/machinery/camera{
@@ -53417,13 +53440,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "jpz" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/red/corner,
-/turf/simulated/floor/plasteel{
-	icon_state = "arrival"
+/obj/machinery/door/airlock/external{
+	id_tag = "trade_dock";
+	locked = 1;
+	name = "External airlock"
 	},
-/area/hallway/secondary/entry/south)
+/obj/structure/fans/tiny,
+/turf/simulated/floor/plating,
+/area/space)
 "jpC" = (
 /obj/structure/rack,
 /obj/structure/disposalpipe/segment{
@@ -55334,15 +55358,14 @@
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
 "jYp" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external{
+	id_tag = "trade_dock";
+	locked = 1;
+	name = "External airlock"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/secondary/entry/south)
+/turf/simulated/floor/plating,
+/area/space)
 "jYU" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
@@ -58269,11 +58292,8 @@
 /area/maintenance/disposal/westalt)
 "leg" = (
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -59132,6 +59152,20 @@
 	icon_state = "dark"
 	},
 /area/hydroponics)
+"lte" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 7;
+	height = 15;
+	id = "trade_dock";
+	name = "port bay 4";
+	width = 18;
+	dheight = 1
+	},
+/turf/space{
+	icon_state = "black"
+	},
+/area/space)
 "ltk" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -61215,6 +61249,16 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/solar/starboard)
+"mlg" = (
+/obj/machinery/door/window/brigdoor/southleft{
+	dir = 1;
+	req_access = list(63)
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/security/prisonershuttle)
 "mlu" = (
 /obj/structure/closet/crate,
 /obj/structure/disposalpipe/segment{
@@ -78293,11 +78337,19 @@
 	},
 /area/medical/virology)
 "syJ" = (
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
 	},
-/area/hallway/secondary/entry/south)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/camera{
+	c_tag = "Brig Labor Camp Airlock North";
+	dir = 8
+	},
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plasteel,
+/area/security/prisonershuttle)
 "szl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -78689,12 +78741,6 @@
 "sGg" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
-	},
-/obj/structure/cable/orange{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/orange{
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
@@ -83062,7 +83108,9 @@
 	name = "port bay 3";
 	width = 5
 	},
-/turf/space,
+/turf/space{
+	icon_state = "black"
+	},
 /area/space)
 "uqR" = (
 /obj/structure/cable{
@@ -92097,16 +92145,12 @@
 	},
 /area/maintenance/apmaint2)
 "xGW" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 4;
-	height = 11;
-	id = "trade_dock";
-	name = "port bay 4";
-	width = 9
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/red/corner,
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
 	},
-/turf/space,
-/area/space)
+/area/hallway/secondary/entry/south)
 "xHo" = (
 /obj/machinery/light/small,
 /obj/structure/closet/emcloset,
@@ -106140,16 +106184,16 @@ rNK
 rNK
 rNK
 rNK
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
 xEp
 xEp
 xEp
@@ -106397,16 +106441,16 @@ rNK
 rNK
 rNK
 rNK
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
 xEp
 xEp
 xEp
@@ -106654,16 +106698,16 @@ rNK
 rNK
 rNK
 rNK
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
 xEp
 xEp
 xEp
@@ -106911,16 +106955,16 @@ rNK
 rNK
 rNK
 rNK
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
-jqn
 xEp
 xEp
 xEp
@@ -107168,7 +107212,6 @@ rNK
 rNK
 rNK
 rNK
-rNK
 jqn
 jqn
 jqn
@@ -107178,6 +107221,7 @@ jqn
 dqu
 jqn
 jqn
+rNK
 rNK
 rNK
 awE
@@ -107424,8 +107468,7 @@ rNK
 rNK
 rNK
 rNK
-rNK
-pVD
+nZp
 pVD
 arV
 mZH
@@ -107434,6 +107477,7 @@ cdL
 arV
 mZH
 arV
+pVD
 pVD
 pVD
 pVD
@@ -107681,8 +107725,7 @@ rNK
 rNK
 rNK
 rNK
-rNK
-pVD
+nZp
 aWm
 wFn
 mFT
@@ -107690,8 +107733,9 @@ qyS
 ale
 qyS
 mFT
-qyS
+wFn
 aoZ
+dqa
 dqa
 arV
 yfX
@@ -107938,16 +107982,16 @@ rNK
 rNK
 rNK
 cRv
-cRv
-pVD
+ivS
 doB
 ajA
 dpg
 qMd
+mlg
 alg
 sGg
 akC
-aok
+sGg
 apa
 vKV
 gYc
@@ -108195,12 +108239,12 @@ rNK
 rNK
 rNK
 cRv
-abW
-pVD
+ivS
 pPl
 ajB
 alW
 bTR
+syJ
 alh
 dqb
 iHo
@@ -129179,7 +129223,7 @@ rNK
 rNK
 rNK
 rNK
-rNK
+aZi
 rNK
 rNK
 rNK
@@ -130713,7 +130757,7 @@ rNK
 rNK
 rNK
 rNK
-aZi
+rNK
 rNK
 rNK
 rNK
@@ -130966,21 +131010,21 @@ rNK
 rNK
 xcc
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
 rNK
 rNK
@@ -131219,25 +131263,25 @@ dai
 mmF
 tYX
 uwf
-rNK
-rNK
+lzH
+lzH
 xcc
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
 rNK
 rNK
@@ -131476,25 +131520,25 @@ jqW
 koo
 spQ
 sHm
-lzH
-lzH
+rNK
+rNK
 xcc
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
 rNK
 rNK
@@ -131735,23 +131779,23 @@ spQ
 sHm
 rNK
 rNK
-xcc
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
 rNK
 rNK
@@ -131990,25 +132034,25 @@ tbP
 tuh
 spQ
 sHm
+nZp
+nZp
+nZp
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
 rNK
 rNK
@@ -132245,27 +132289,27 @@ hNb
 pLr
 gUa
 tuh
-spQ
+aok
+leg
+ijl
+xGW
 sHm
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+nZp
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
 rNK
 rNK
@@ -132502,27 +132546,27 @@ rAB
 mQN
 aIb
 ebV
-leg
-sHm
-sHm
-sHm
-sHm
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+eWu
+dbg
+dbg
+xQX
+uXr
+jYp
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
 rNK
 rNK
@@ -132759,27 +132803,27 @@ kQz
 pLr
 akn
 tWq
-spQ
-syJ
-jYp
-hDf
-sHm
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+eWu
+dbg
+dbg
+xQX
+uXr
+jpz
+lte
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
 rNK
 rNK
@@ -133018,25 +133062,25 @@ ewv
 tWq
 eWu
 dbg
-eWu
-jpz
+dbg
+rFJ
 sHm
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+nZp
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
 rNK
 rNK
@@ -133275,25 +133319,25 @@ mWg
 tWq
 eWu
 dbg
-eWu
-xQX
-ijl
-xGW
+gTA
+fZA
+sHm
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
 rNK
 rNK
@@ -133533,24 +133577,24 @@ tWq
 eWu
 dbg
 eWu
-rFJ
+vjb
 sHm
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
 rNK
 rNK
@@ -133793,21 +133837,21 @@ eWu
 hDf
 yjW
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
 rNK
 rNK
@@ -134050,21 +134094,21 @@ ckQ
 vjb
 sHm
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
 rNK
 rNK
@@ -134307,21 +134351,21 @@ cjs
 vjb
 sHm
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
 rNK
 rNK
@@ -138675,16 +138719,16 @@ jdC
 lqQ
 cJA
 xMQ
-rNK
-rNK
+jqn
+jqn
 uqP
-rNK
-rNK
-rNK
-rNK
+jqn
+jqn
+jqn
+jqn
 jfW
-rNK
-rNK
+jqn
+jqn
 rNK
 rNK
 rNK
@@ -138932,16 +138976,16 @@ pKz
 heH
 jUc
 uTr
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
 rNK
 rNK
@@ -139189,16 +139233,16 @@ pMv
 haH
 pjX
 xMQ
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
 rNK
 rNK
@@ -139446,16 +139490,16 @@ wpW
 kyQ
 oba
 xMQ
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
 rNK
 rNK
@@ -139703,16 +139747,16 @@ ckp
 djw
 hJY
 xMQ
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
 rNK
 rNK
@@ -139960,16 +140004,16 @@ opl
 djw
 hJY
 xMQ
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
 rNK
 rNK
@@ -140217,16 +140261,16 @@ ckq
 djw
 fEC
 xMQ
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
 jqn
 jqn
@@ -140474,16 +140518,16 @@ ckr
 ckW
 lXp
 xMQ
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
 jqn
 jqn
@@ -140731,16 +140775,16 @@ vMR
 djw
 hJY
 xMQ
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
 jqn
 jqn
@@ -140988,16 +141032,16 @@ kqg
 djw
 hJY
 csG
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
 jqn
 jqn
@@ -141245,11 +141289,11 @@ dkc
 djw
 hJY
 csG
-rNK
-rNK
-rNK
-rNK
-rNK
+jqn
+jqn
+jqn
+jqn
+jqn
 rNK
 rNK
 rNK

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -1125,7 +1125,7 @@
 	},
 /obj/machinery/door/airlock/public/glass{
 	name = "Kitchen";
-	req_access_txt = "28"
+	req_access = list(28)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -20234,7 +20234,7 @@
 /obj/machinery/door/window/westright{
 	dir = 4;
 	name = "Kitchen";
-	req_access_txt = "28"
+	req_access = list(28)
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
@@ -20827,7 +20827,7 @@
 /obj/machinery/door/window/westleft{
 	dir = 2;
 	name = "Kitchen";
-	req_access_txt = "28"
+	req_access = list(28)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redfull";
@@ -30333,7 +30333,7 @@
 	base_state = "right";
 	icon_state = "right";
 	name = "Hydroponics";
-	req_access_txt = "35"
+	req_access = list(35)
 	},
 /obj/item/desk_bell{
 	pixel_x = 7;
@@ -33721,7 +33721,7 @@
 "dcS" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Bar";
-	req_access_txt = "12"
+	req_access = list(12)
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41487,7 +41487,7 @@
 "eNP" = (
 /obj/machinery/door/airlock{
 	name = "Crematorium";
-	req_access_txt = "27"
+	req_access = list(27)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -41651,7 +41651,7 @@
 "eRp" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Port Asteroid Maintenance";
-	req_access_txt = "12"
+	req_access = list(12)
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port2)
@@ -44747,7 +44747,7 @@
 "gat" = (
 /obj/machinery/door/airlock{
 	name = "Crematorium";
-	req_access_txt = "27"
+	req_access = list(27)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -46805,7 +46805,7 @@
 "gNI" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Kitchen";
-	req_access_txt = "28"
+	req_access = list(28)
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49302,7 +49302,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "Hydroponics";
-	req_access_txt = "35"
+	req_access = list(35)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -53998,7 +53998,7 @@
 /area/engine/supermatter)
 "jAF" = (
 /obj/machinery/door/airlock/public/glass{
-	req_access_txt = "35";
+	req_access = list(35);
 	name = "Garden"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -55699,7 +55699,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "Hydroponics";
-	req_access_txt = "35"
+	req_access = list(35)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -62193,7 +62193,7 @@
 /obj/machinery/door/window/westleft{
 	dir = 4;
 	name = "Kitchen";
-	req_access_txt = "28"
+	req_access = list(28)
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -63949,7 +63949,7 @@
 "nnc" = (
 /obj/machinery/door/airlock/freezer{
 	name = "Freezer";
-	req_access_txt = "28"
+	req_access = list(28)
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel/freezer,
@@ -71439,7 +71439,7 @@
 /obj/machinery/door/window/westright{
 	dir = 2;
 	name = "Kitchen";
-	req_access_txt = "28"
+	req_access = list(28)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -71698,7 +71698,7 @@
 /obj/machinery/door/window/westleft{
 	dir = 4;
 	name = "Kitchen";
-	req_access_txt = "28"
+	req_access = list(28)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -74218,7 +74218,7 @@
 /area/maintenance/asmaint5)
 "ran" = (
 /obj/machinery/door/airlock/public/glass{
-	req_access_txt = "35";
+	req_access = list(35);
 	name = "Garden"
 	},
 /obj/machinery/door/firedoor,
@@ -78553,7 +78553,7 @@
 /obj/machinery/door/window/westright{
 	dir = 2;
 	name = "Kitchen";
-	req_access_txt = "28"
+	req_access = list(28)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -79466,7 +79466,7 @@
 "sXs" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Hydroponics";
-	req_access_txt = "35"
+	req_access = list(35)
 	},
 /turf/simulated/floor/plating,
 /area/hydroponics)
@@ -79756,7 +79756,7 @@
 "tcM" = (
 /obj/machinery/door/airlock/freezer{
 	name = "Freezer";
-	req_access_txt = "28"
+	req_access = list(28)
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel/freezer,
@@ -82078,7 +82078,7 @@
 /obj/machinery/door/window/eastleft{
 	base_state = "right";
 	name = "Hydroponics";
-	req_access_txt = "35"
+	req_access = list(35)
 	},
 /turf/simulated/floor/plating,
 /area/hydroponics)
@@ -84273,14 +84273,14 @@
 	base_state = "right";
 	icon_state = "right";
 	name = "Hydroponics";
-	req_access_txt = "35";
+	req_access = list(35);
 	dir = 2
 	},
 /obj/machinery/door/window/eastleft{
 	base_state = "right";
 	icon_state = "right";
 	name = "Kitchen";
-	req_access_txt = "28";
+	req_access = list(28);
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
@@ -88093,7 +88093,7 @@
 "wmj" = (
 /obj/machinery/door/airlock{
 	name = "Chaplain's Office";
-	req_access_txt = "22"
+	req_access = list(22)
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -91899,7 +91899,7 @@
 /obj/machinery/door/window/westright{
 	dir = 4;
 	name = "Kitchen";
-	req_access_txt = "28"
+	req_access = list(28)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -92174,13 +92174,13 @@
 /obj/machinery/door/window/eastleft{
 	base_state = "right";
 	name = "Kitchen";
-	req_access_txt = "28";
+	req_access = list(28);
 	dir = 1
 	},
 /obj/machinery/door/window/eastleft{
 	base_state = "right";
 	name = "Hydroponics";
-	req_access_txt = "35";
+	req_access = list(35);
 	dir = 2
 	},
 /obj/machinery/door/firedoor,
@@ -92595,7 +92595,7 @@
 	},
 /obj/machinery/door/airlock/public/glass{
 	name = "Kitchen";
-	req_access_txt = "28"
+	req_access = list(28)
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 8;

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -10010,7 +10010,6 @@
 /area/civilian/barber)
 "beQ" = (
 /obj/structure/table/wood,
-/obj/structure/table/wood,
 /obj/item/eftpos,
 /turf/simulated/floor/carpet/black,
 /area/chapel/office)
@@ -18134,7 +18133,6 @@
 	dir = 4
 	},
 /obj/structure/table/wood,
-/obj/structure/table/wood,
 /obj/item/candle,
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
@@ -18161,7 +18159,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/table/wood,
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/condiment/saltshaker{
 	pixel_x = -2;

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -47817,7 +47817,7 @@
 "hhz" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Hydroponics Garden";
-	req_one_access_txt = "35;28"
+	req_one_access = list(35,28)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80970,7 +80970,7 @@
 "tyR" = (
 /obj/machinery/smartfridge/secure{
 	name = "\improper Kitchen Delivery SmartFridge";
-	req_one_access_txt = "28;35"
+	req_one_access = list(28,35)
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -1621,18 +1621,12 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable/orange{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/orange{
 	icon_state = "2-8"
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
 "alh" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/camera{
@@ -15567,11 +15561,6 @@
 	},
 /obj/item/radio/intercom{
 	pixel_y = 28
-	},
-/obj/machinery/door/window/southleft{
-	name = "Public Fridge";
-	req_access = list(33);
-	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -35784,6 +35773,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
 "dqe" = (
@@ -40535,6 +40527,15 @@
 	},
 /turf/simulated/wall,
 /area/hydroponics)
+"eui" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/orange{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/security/prisonershuttle)
 "eux" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -89390,11 +89391,6 @@
 "wGA" = (
 /obj/structure/bed/dogbed/pet,
 /mob/living/simple_animal/goose/Scientist,
-/obj/machinery/atmospherics/unary/cold_sink/freezer{
-	current_temperature = 80;
-	on = 1;
-	dir = 8
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurplefull"
@@ -107984,7 +107980,7 @@ dpg
 qMd
 mlg
 alg
-sGg
+eui
 akC
 sGg
 apa

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -4196,6 +4196,13 @@
 /obj/machinery/computer/communications,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
+"ayy" = (
+/obj/structure/closet/secure_closet/miner,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/quartermaster/miningdock)
 "ayz" = (
 /obj/structure/table/wood,
 /obj/item/storage/lockbox/medal,
@@ -5120,10 +5127,7 @@
 "aFa" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/landmark/start/shaft_miner,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "brown"
-	},
+/turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "aFb" = (
 /obj/structure/closet/secure_closet/miner,
@@ -5257,6 +5261,13 @@
 /obj/machinery/ai_status_display,
 /turf/simulated/wall,
 /area/crew_quarters/captain)
+"aGm" = (
+/obj/structure/closet/secure_closet/miner,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purple"
+	},
+/area/quartermaster/miningdock)
 "aGq" = (
 /obj/machinery/status_display{
 	layer = 4
@@ -5307,9 +5318,12 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/miningdock)
 "aGC" = (
-/obj/structure/closet/secure_closet/miner,
-/turf/simulated/floor/plasteel,
-/area/quartermaster/miningdock)
+/obj/effect/landmark/start/doctor,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whiteblue"
+	},
+/area/medical/medbay)
 "aGH" = (
 /obj/structure/table,
 /obj/item/storage/box/evidence,
@@ -10029,6 +10043,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/landmark/start/engineer,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkyellow"
@@ -14887,6 +14902,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/effect/landmark/start/trainee_engineer,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkyellowcorners"
@@ -14977,7 +14993,10 @@
 /obj/machinery/computer/security/mining{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purple"
+	},
 /area/quartermaster/miningdock)
 "bye" = (
 /obj/structure/closet/emcloset,
@@ -16443,6 +16462,12 @@
 	icon_state = "dark"
 	},
 /area/engine/break_room)
+"bEn" = (
+/obj/effect/landmark/start/atmospheric,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/atmos)
 "bEq" = (
 /obj/machinery/camera{
 	c_tag = "Chief Medical Officer's Office";
@@ -17184,7 +17209,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bGA" = (
-/obj/structure/closet/secure_closet/miner,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -20146,6 +20170,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/effect/landmark/start/engineer,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkyellow"
@@ -20193,6 +20218,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/effect/landmark/start/warden,
 /turf/simulated/floor/plasteel,
 /area/security/processing)
 "bQg" = (
@@ -23230,7 +23256,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/landmark/start/shaft_miner,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "cbQ" = (
@@ -24465,6 +24490,7 @@
 	pixel_y = 28
 	},
 /obj/structure/chair/office/light,
+/obj/effect/landmark/start/security_officer,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -33317,6 +33343,13 @@
 	icon_state = "browncorner"
 	},
 /area/quartermaster/office)
+"cYj" = (
+/obj/effect/landmark/start/intern,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whiteblue"
+	},
+/area/medical/cmostore)
 "cYl" = (
 /obj/machinery/requests_console{
 	department = "Tool Storage";
@@ -48650,6 +48683,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
+"hxw" = (
+/obj/structure/closet/secure_closet/personal/mining,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purple"
+	},
+/area/quartermaster/miningdock)
 "hxD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -48963,6 +49003,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/landmark/start/intern,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -49632,6 +49673,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/effect/landmark/start/scientist,
 /turf/simulated/floor/plasteel/white,
 /area/toxins/lab)
 "hPZ" = (
@@ -53176,10 +53218,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "jkV" = (
-/obj/effect/landmark/start/shaft_miner,
-/obj/effect/landmark/start/shaft_miner,
-/turf/simulated/floor/plasteel,
-/area/quartermaster/miningdock)
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/engineer,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/engine/break_room)
 "jkW" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -53905,6 +53949,13 @@
 	icon_state = "grimy"
 	},
 /area/library)
+"jyU" = (
+/obj/structure/closet/secure_closet/miner,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "purple"
+	},
+/area/quartermaster/miningdock)
 "jyW" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/orange{
@@ -55300,11 +55351,18 @@
 	icon_state = "purplefull"
 	},
 /area/assembly/robotics)
+"jWN" = (
+/obj/effect/landmark/start/cargo_technician,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/quartermaster/office)
 "jWP" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/start/roboticist,
 /turf/simulated/floor/plasteel/white,
 /area/assembly/robotics)
 "jWR" = (
@@ -61972,6 +62030,7 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/start/doctor,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -63090,6 +63149,12 @@
 	slowdown = -0.3
 	},
 /area/hallway/spacebridge/medcargo)
+"mWR" = (
+/obj/effect/landmark/start/engineer,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/engine/engineering)
 "mXg" = (
 /obj/effect/spawner/random_spawners/wall_rusted_probably,
 /turf/simulated/wall,
@@ -64922,7 +64987,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/structure/closet/secure_closet/miner,
+/obj/structure/closet/secure_closet/personal/mining,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "purple"
@@ -68262,6 +68327,7 @@
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
+/obj/effect/landmark/start/engineer,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -70628,6 +70694,14 @@
 	dir = 8
 	},
 /area/atmos)
+"pKh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/landmark/start/atmospheric,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/atmos/break_room)
 "pKj" = (
 /obj/structure/table,
 /obj/machinery/light,
@@ -75999,6 +76073,7 @@
 /area/medical/surgery/north)
 "rHt" = (
 /obj/structure/chair/stool,
+/obj/effect/landmark/start/trainee_engineer,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -76108,7 +76183,7 @@
 	},
 /area/quartermaster/office)
 "rJZ" = (
-/obj/structure/closet/secure_closet/miner,
+/obj/structure/closet/secure_closet/personal/mining,
 /turf/simulated/floor/plating,
 /area/quartermaster/miningdock)
 "rKo" = (
@@ -78760,6 +78835,24 @@
 	icon_state = "white"
 	},
 /area/crew_quarters/kitchen)
+"sGL" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/landmark/start/intern,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/medbay)
 "sGZ" = (
 /obj/structure/table,
 /obj/item/stock_parts/cell/high/plus,
@@ -81176,6 +81269,7 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/start/scientist,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurple"
@@ -83003,6 +83097,7 @@
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/asmaint5)
 "uob" = (
+/obj/effect/landmark/start/atmospheric,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -84232,12 +84327,11 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "uNE" = (
-/obj/structure/closet/secure_closet/miner,
+/obj/effect/landmark/start/botanist,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "purple"
+	icon_state = "dark"
 	},
-/area/quartermaster/miningdock)
+/area/hydroponics)
 "uNN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -87566,9 +87660,9 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/aft/west)
 "waW" = (
-/obj/effect/landmark/start/shaft_miner,
+/obj/structure/closet/secure_closet/miner,
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 8;
 	icon_state = "brown"
 	},
 /area/quartermaster/miningdock)
@@ -89953,6 +90047,13 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/hallway/primary/starboard/south)
+"wQB" = (
+/obj/structure/closet/secure_closet/personal/mining,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "brown"
+	},
+/area/quartermaster/miningdock)
 "wQM" = (
 /obj/machinery/hydroponics/constructable,
 /turf/simulated/floor/plasteel{
@@ -112187,7 +112288,7 @@ bGB
 baF
 bNg
 mrt
-mrt
+pxi
 tNt
 ujV
 dOy
@@ -112964,11 +113065,11 @@ biT
 bQm
 bQm
 mrt
-mrt
+pxi
 mrt
 uNU
 biB
-biB
+uNE
 biB
 bCj
 bJx
@@ -124772,7 +124873,7 @@ xxR
 xeI
 mYI
 mYI
-bDX
+pKh
 bGQ
 bIq
 bJK
@@ -125299,7 +125400,7 @@ bOu
 bIi
 uka
 whf
-bIi
+bEn
 bIi
 bUV
 deA
@@ -130944,7 +131045,7 @@ bFB
 bHi
 guA
 cMb
-nOF
+mWR
 cTg
 bNx
 bOH
@@ -131451,7 +131552,7 @@ cJf
 cJg
 bCa
 evi
-rHt
+jkV
 cjr
 bEm
 irh
@@ -131706,7 +131807,7 @@ pQY
 bwi
 bFu
 ufT
-rHt
+jkV
 rHt
 bHD
 tMJ
@@ -142692,7 +142793,7 @@ svX
 brt
 svX
 aHp
-hZJ
+jWN
 aJC
 grY
 eJa
@@ -143528,10 +143629,10 @@ bJf
 tXL
 bIQ
 lkE
-dBO
+xdT
 dBO
 mGR
-xGc
+sGL
 dBy
 dBO
 bHp
@@ -144060,7 +144161,7 @@ vRA
 gtC
 wKw
 rTQ
-wvp
+rox
 iIM
 yfZ
 vHH
@@ -144298,7 +144399,7 @@ dBO
 bvI
 cKk
 lSt
-nqG
+aGC
 sEV
 wOn
 udk
@@ -144828,7 +144929,7 @@ aMC
 bZQ
 uhF
 jDW
-jDW
+cYj
 jDW
 jDW
 tmq
@@ -145785,7 +145886,7 @@ cnm
 scI
 any
 aQC
-hZJ
+jWN
 hZJ
 aTs
 any
@@ -147061,7 +147162,7 @@ rzh
 rzh
 iss
 aGy
-aCo
+wPN
 aCo
 aGs
 kFK
@@ -147568,9 +147669,9 @@ lCC
 alc
 alc
 alc
-alc
-alc
-alc
+uHx
+uHx
+uHx
 uHx
 uHx
 uKL
@@ -147824,12 +147925,12 @@ rzh
 lCC
 lCC
 alc
-alc
-alc
-alc
-alc
+uHx
 uHx
 yjb
+waW
+jyU
+waW
 nFn
 bGA
 ijr
@@ -148081,16 +148182,16 @@ rNK
 rNK
 lCC
 alc
-alc
-alc
-alc
-alc
 uHx
-waW
-jkV
-moU
+wQB
+aIB
+aIB
+aIB
+aIB
+iLv
 oRC
 moU
+oRC
 iKV
 sik
 uKL
@@ -148338,16 +148439,16 @@ rNK
 rNK
 lCC
 alc
-alc
-alc
-alc
-alc
 uHx
-uNE
-aGC
+hxw
+iLv
+iLv
+iLv
+iLv
+iLv
 iLv
 iWP
-aIB
+iLv
 cbP
 raW
 ciR
@@ -148595,16 +148696,16 @@ rzh
 rzh
 lCC
 alc
-alc
-alc
-alc
-alc
 uHx
+wQB
+aIB
+aIB
+aIB
 aFa
+aHv
+aHv
+aHv
 aJG
-aHv
-aHv
-aHv
 cbQ
 cfD
 uKL
@@ -148852,12 +148953,12 @@ rzh
 lCC
 lCC
 alc
-alc
-alc
-alc
-alc
+uHx
 uHx
 aFb
+ayy
+aGm
+ayy
 byd
 xHH
 cum
@@ -149110,11 +149211,11 @@ lCC
 alc
 alc
 alc
-alc
-alc
-alc
 uHx
 uHx
+uHx
+uHx
+uKL
 iss
 bGF
 iss


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Вторая посылка фиксов для карту Фаррагус. 
Changelog: 
СЕРВИС:
Перелопатил весь сервисный отдел(На место ботаники/поваров -> фитнес, на фитнес -> библия и церковь, на библия и церковь -> ботаники/повары)
Кабинки переехали во вторые дормы
Вернули смес сервис отделу
Фикс бухломата в стенке

Очищены кастомные название многих fire alarm, intercom, apc и другие настенные предметы от имён вроде "west bump" "custom placement"
Механика обновлена и стала удобнее
Фикс стыковки шаттла торговцев
Фикс шаттлов каторги и гаммы( теперь они больше не "целуют" друг-друга)
Чуть больше место для бригмеда
Убран лишний автолат у карго
Добавлено ещё скрабберов, помпов, ригов и ящиков для атмоса
Добавлен комп для контроля большими скрабберами в атмосе
Вернулись во многих местах гостевые пропуски
Фикс серверной(забыли фризер)
Зарядник в комнате отдыха медбея
Фикс боди сканнеров в медбее(пропажа иконок)
Поменялась расстановка вещей у СМО
Все факсы теперь могут написать на ЦК
Вернули сумки химикам с масками
Душ в рнд

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Фикс

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
См. MapDiffBot2