### PR TITLE
Fix: Map: двойной автомат в дормах дельты

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -3684,9 +3684,9 @@
 	dir = 1;
 	pixel_y = -25
 	},
-/mob/living/simple_animal/pet/cat/birman/Crusher,
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/blood/gibs/robot,
+/mob/living/simple_animal/pet/cat/birman/Crusher,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
@@ -3698,15 +3698,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/mob/living/simple_animal/mouse/brown{
-	desc = "Главный помощник архитектора станции.";
-	real_name = "Инспектор Мышь"
-	},
 /obj/effect/decal/cleanable/dirt{
 	layer = 2.1
 	},
 /obj/machinery/light/small{
 	dir = 8
+	},
+/mob/living/simple_animal/mouse/brown{
+	desc = "Главный помощник архитектора станции.";
+	real_name = "Инспектор Мышь"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -16394,11 +16394,6 @@
 /turf/simulated/floor/engine,
 /area/engine/controlroom)
 "bRK" = (
-/mob/living/simple_animal/bot/cleanbot{
-	name = "D.E.N";
-	on = 0;
-	real_name = "D.E.N"
-	},
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
@@ -16410,6 +16405,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/mob/living/simple_animal/bot/cleanbot{
+	name = "D.E.N";
+	on = 0;
+	real_name = "D.E.N"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -18852,7 +18852,7 @@
 	input_tag = "co2_in";
 	name = "Carbon Dioxide Supply Control";
 	output_tag = "co2_out";
-	sensors = list("co2_sensor"="Tank")
+	sensors = list("co2_sensor" = "Tank")
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -21807,12 +21807,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.1
+	},
 /mob/living/simple_animal/mouse/brown{
 	desc = "Главный помощник архитектора станции.";
 	real_name = "Инспектор Мышь"
-	},
-/obj/effect/decal/cleanable/dirt{
-	layer = 2.1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -32339,7 +32339,7 @@
 	frequency = 1443;
 	level = 3;
 	name = "Distribution and Waste Monitor";
-	sensors = list("mair_in_meter"="Mixed Air In","air_sensor"="Mixed Air Supply Tank","mair_out_meter"="Mixed Air Out","dloop_atm_meter"="Distribution Loop","wloop_atm_meter"="Waste Loop")
+	sensors = list("mair_in_meter" = "Mixed Air In", "air_sensor" = "Mixed Air Supply Tank", "mair_out_meter" = "Mixed Air Out", "dloop_atm_meter" = "Distribution Loop", "wloop_atm_meter" = "Waste Loop")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -37883,7 +37883,7 @@
 	input_tag = "o2_in";
 	name = "Oxygen Supply Control";
 	output_tag = "o2_out";
-	sensors = list("o2_sensor"="Tank")
+	sensors = list("o2_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
@@ -41141,7 +41141,7 @@
 	input_tag = "n2_in";
 	name = "Nitrogen Supply Control";
 	output_tag = "n2_out";
-	sensors = list("n2_sensor"="Tank")
+	sensors = list("n2_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
@@ -46301,13 +46301,13 @@
 "eEb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor{
-	armor = list("melee"=60,"bullet"=70,"laser"=70,"energy"=70,"bomb"=40,"bio"=100,"rad"=100,"fire"=70,"acid"=100);
+	armor = list("melee" = 60, "bullet" = 70, "laser" = 70, "energy" = 70, "bomb" = 40, "bio" = 100, "rad" = 100, "fire" = 70, "acid" = 100);
 	dir = 2;
 	name = "Secure Armory";
 	req_one_access = list(1)
 	},
 /obj/machinery/door/window/brigdoor{
-	armor = list("melee"=60,"bullet"=70,"laser"=70,"energy"=70,"bomb"=40,"bio"=100,"rad"=100,"fire"=70,"acid"=100);
+	armor = list("melee" = 60, "bullet" = 70, "laser" = 70, "energy" = 70, "bomb" = 40, "bio" = 100, "rad" = 100, "fire" = 70, "acid" = 100);
 	dir = 1;
 	name = "Secure Armory";
 	req_one_access = list(3)
@@ -47049,7 +47049,7 @@
 	name = "Mixed Air Supply Control";
 	output_tag = "air_out";
 	pressure_setting = 2000;
-	sensors = list("air_sensor"="Tank")
+	sensors = list("air_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
@@ -53424,8 +53424,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/mob/living/simple_animal/possum/Poppy,
 /obj/structure/bed/dogbed/pet,
+/mob/living/simple_animal/possum/Poppy,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "gmO" = (
@@ -61896,7 +61896,7 @@
 	input_tag = "tox_in";
 	name = "Toxin Supply Control";
 	output_tag = "tox_out";
-	sensors = list("tox_sensor"="Tank")
+	sensors = list("tox_sensor" = "Tank")
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -65868,8 +65868,8 @@
 	},
 /area/hallway/primary/port)
 "jiK" = (
-/mob/living/simple_animal/pet/dog/brittany/Psycho,
 /obj/structure/bed/dogbed/pet,
+/mob/living/simple_animal/pet/dog/brittany/Psycho,
 /turf/simulated/floor/carpet,
 /area/medical/psych)
 "jiL" = (
@@ -68079,7 +68079,7 @@
 /area/security/lobby)
 "jIc" = (
 /obj/machinery/camera{
-	armor = list("melee"=50,"bullet"=20,"laser"=20,"energy"=20,"bomb"=100,"bio"=0,"rad"=0,"fire"=90,"acid"=50);
+	armor = list("melee" = 50, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 100, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 50);
 	c_tag = "Research Toxins Test Chamber North";
 	network = list("Toxins","Research","SS13")
 	},
@@ -69625,7 +69625,7 @@
 	},
 /obj/machinery/computer/general_air_control{
 	name = "Tank Monitor";
-	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous Oxide","mix_sensor"="Gas Mix Tank")
+	sensors = list("n2_sensor" = "Nitrogen", "o2_sensor" = "Oxygen", "co2_sensor" = "Carbon Dioxide", "tox_sensor" = "Toxins", "n2o_sensor" = "Nitrous Oxide", "mix_sensor" = "Gas Mix Tank")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -74364,7 +74364,7 @@
 	input_tag = "n2o_in";
 	name = "Nitrous Oxide Supply Control";
 	output_tag = "n2o_out";
-	sensors = list("n2o_sensor"="Tank")
+	sensors = list("n2o_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
@@ -79037,12 +79037,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.1
+	},
 /mob/living/simple_animal/mouse/brown{
 	desc = "Главный помощник архитектора станции.";
 	real_name = "Инспектор Мышь"
-	},
-/obj/effect/decal/cleanable/dirt{
-	layer = 2.1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -81450,7 +81450,7 @@
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/door/window/brigdoor/northleft{
-	armor = list("melee"=85,"bullet"=20,"laser"=0,"energy"=0,"bomb"=60,"bio"=100,"rad"=100,"fire"=99,"acid"=100);
+	armor = list("melee" = 85, "bullet" = 20, "laser" = 0, "energy" = 0, "bomb" = 60, "bio" = 100, "rad" = 100, "fire" = 99, "acid" = 100);
 	damage_deflection = 21
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
@@ -85521,7 +85521,7 @@
 /area/crew_quarters/locker)
 "nRD" = (
 /obj/machinery/vending/dinnerware{
-	products = list(/obj/item/storage/bag/tray=1,/obj/item/kitchen/utensil/fork=2,/obj/item/kitchen/knife=0,/obj/item/kitchen/rollingpin=0,/obj/item/kitchen/sushimat=1,/obj/item/reagent_containers/food/drinks/drinkingglass=2,/obj/item/clothing/suit/chef/classic=1,/obj/item/storage/belt/chef=0,/obj/item/reagent_containers/food/condiment/pack/ketchup=1,/obj/item/reagent_containers/food/condiment/pack/hotsauce=0,/obj/item/reagent_containers/food/condiment/saltshaker=1,/obj/item/reagent_containers/food/condiment/peppermill=2,/obj/item/whetstone=1,/obj/item/mixing_bowl=3,/obj/item/kitchen/mould/bear=1,/obj/item/kitchen/mould/worm=0,/obj/item/kitchen/mould/bean=0,/obj/item/kitchen/mould/ball=1,/obj/item/kitchen/mould/cane=1,/obj/item/kitchen/mould/cash=0,/obj/item/kitchen/mould/coin=0,/obj/item/kitchen/mould/loli=1,/obj/item/kitchen/cutter=0,/obj/item/eftpos=1)
+	products = list(/obj/item/storage/bag/tray = 1, /obj/item/kitchen/utensil/fork = 2, /obj/item/kitchen/knife = 0, /obj/item/kitchen/rollingpin = 0, /obj/item/kitchen/sushimat = 1, /obj/item/reagent_containers/food/drinks/drinkingglass = 2, /obj/item/clothing/suit/chef/classic = 1, /obj/item/storage/belt/chef = 0, /obj/item/reagent_containers/food/condiment/pack/ketchup = 1, /obj/item/reagent_containers/food/condiment/pack/hotsauce = 0, /obj/item/reagent_containers/food/condiment/saltshaker = 1, /obj/item/reagent_containers/food/condiment/peppermill = 2, /obj/item/whetstone = 1, /obj/item/mixing_bowl = 3, /obj/item/kitchen/mould/bear = 1, /obj/item/kitchen/mould/worm = 0, /obj/item/kitchen/mould/bean = 0, /obj/item/kitchen/mould/ball = 1, /obj/item/kitchen/mould/cane = 1, /obj/item/kitchen/mould/cash = 0, /obj/item/kitchen/mould/coin = 0, /obj/item/kitchen/mould/loli = 1, /obj/item/kitchen/cutter = 0, /obj/item/eftpos = 1)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "tranquillite"
@@ -85532,7 +85532,7 @@
 	input_tag = "mix_in";
 	name = "Gas Mix Tank Control";
 	output_tag = "mix_out";
-	sensors = list("mix_sensor"="Tank")
+	sensors = list("mix_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
@@ -88837,7 +88837,7 @@
 "oFK" = (
 /obj/item/radio/beacon,
 /obj/machinery/camera{
-	armor = list("melee"=50,"bullet"=20,"laser"=20,"energy"=20,"bomb"=100,"bio"=0,"rad"=0,"fire"=90,"acid"=50);
+	armor = list("melee" = 50, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 100, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 50);
 	c_tag = "Research Toxins Test Chamber East";
 	dir = 4;
 	network = list("Toxins","Research","SS13")
@@ -93310,8 +93310,8 @@
 	},
 /area/medical/sleeper)
 "pFF" = (
-/mob/living/simple_animal/mouse/hamster/Representative,
 /obj/structure/bed/dogbed/pet,
+/mob/living/simple_animal/mouse/hamster/Representative,
 /turf/simulated/floor/wood,
 /area/ntrep)
 "pFI" = (
@@ -97145,8 +97145,8 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/mob/living/simple_animal/pet/slugcat/monk,
 /obj/structure/bed/dogbed/pet,
+/mob/living/simple_animal/pet/slugcat/monk,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple";
@@ -102360,7 +102360,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	armor = list("melee"=50,"bullet"=20,"laser"=20,"energy"=20,"bomb"=100,"bio"=0,"rad"=0,"fire"=90,"acid"=50);
+	armor = list("melee" = 50, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 100, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 50);
 	c_tag = "Research Toxins Test Chamber West";
 	dir = 4;
 	network = list("Toxins","Research","SS13")
@@ -108033,8 +108033,8 @@
 /turf/simulated/floor/carpet,
 /area/lawoffice)
 "sWz" = (
-/mob/living/simple_animal/mouse/white,
 /obj/effect/landmark/tiles/damageturf,
+/mob/living/simple_animal/mouse/white,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
 "sWE" = (
@@ -109430,7 +109430,6 @@
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "tno" = (
-/obj/machinery/vending/coffee,
 /obj/machinery/vending/coffee,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -117549,7 +117548,7 @@
 /obj/machinery/computer/general_air_control{
 	frequency = 1222;
 	name = "Bomb Mix Monitor";
-	sensors = list("burn_sensor"="Burn Mix")
+	sensors = list("burn_sensor" = "Burn Mix")
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
@@ -120465,7 +120464,7 @@
 /area/maintenance/consarea_virology)
 "vOV" = (
 /obj/machinery/camera{
-	armor = list("melee"=50,"bullet"=20,"laser"=20,"energy"=20,"bomb"=100,"bio"=0,"rad"=0,"fire"=90,"acid"=50);
+	armor = list("melee" = 50, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 100, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 50);
 	c_tag = "Research Toxins Test Chamber South";
 	dir = 1;
 	network = list("Toxins","Research","SS13")
@@ -124602,8 +124601,8 @@
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
-/mob/living/simple_animal/pet/dog/bullterrier/Genn,
 /obj/structure/bed/dogbed/pet,
+/mob/living/simple_animal/pet/dog/bullterrier/Genn,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Удаляет один из автоматов на одном тайле
P.S. все кроме 109434 строки mapmerge сделал

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
баг репорт - https://discord.com/channels/617003227182792704/1090232871169556541/1090232871169556541

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
было
![image](https://user-images.githubusercontent.com/74877393/228230759-a0b12c71-cf15-4d93-8fdf-abab2767e9b2.png)

стало
![image](https://user-images.githubusercontent.com/74877393/228230818-f40d3dfd-8382-46bf-ae3e-452207cbe65a.png)
