### PR TITLE
fix: Mute people can show Emote Typing Indicator

### DIFF
--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -21,7 +21,7 @@ GLOBAL_LIST_EMPTY(typing_indicator)
 		var/image/I = GLOB.typing_indicator[bubble_icon]
 		I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
 
-	if(ishuman(src))
+	if(ishuman(src) && !me)
 		var/mob/living/carbon/human/H = src
 		if((MUTE in H.mutations) || H.silent)
 			overlays -= GLOB.typing_indicator[bubble_icon]


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

Немые теперь могут показывать свой Emote Typing Indicator.