### PR TITLE
Fix Map: Cerestation

### DIFF
--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -1127,6 +1127,7 @@
 	name = "Kitchen";
 	req_access = list(28)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -10022,6 +10023,7 @@
 "beQ" = (
 /obj/structure/table/wood,
 /obj/item/eftpos,
+/obj/item/lighter/zippo/black,
 /turf/simulated/floor/carpet/black,
 /area/chapel/office)
 "beR" = (
@@ -18168,6 +18170,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bJB" = (
@@ -18813,7 +18816,8 @@
 /obj/item/grown/log,
 /obj/item/grown/log,
 /obj/item/grown/log,
-/obj/item/hatchet,
+/obj/item/grown/log,
+/obj/item/storage/box/matches,
 /turf/simulated/floor/wood,
 /area/library)
 "bLG" = (
@@ -19916,7 +19920,7 @@
 	dir = 4;
 	icon_state = "escape"
 	},
-/area/space)
+/area/hallway/primary/port/south)
 "bPi" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/wood,
@@ -22257,6 +22261,9 @@
 /obj/structure/cable/orange{
 	icon_state = "2-8"
 	},
+/obj/structure/cable/orange{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bWP" = (
@@ -22627,7 +22634,7 @@
 /obj/item/mop,
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/plating,
-/area/space)
+/area/hallway/primary/port/south)
 "bYy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22874,10 +22881,8 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/port/south)
 "bZJ" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/smartfridge,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkgreenfull"
@@ -25280,6 +25285,12 @@
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry/south)
+"clO" = (
+/obj/machinery/status_display{
+	layer = 4
+	},
+/turf/simulated/wall,
+/area/crew_quarters/locker/locker_toilet)
 "clQ" = (
 /obj/machinery/sparker{
 	id = "mixingsparker";
@@ -38935,6 +38946,23 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/fore/west)
+"dNb" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/door_control{
+	desiredstate = 1;
+	id = "toilet2";
+	name = "Toilet Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_y = -25;
+	specialfunctions = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/locker/locker_toilet)
 "dNg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -39957,6 +39985,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/carpet/red,
 /area/chapel/main)
 "ehk" = (
@@ -40352,11 +40381,6 @@
 /obj/item/tank/internals/oxygen,
 /obj/item/clothing/shoes/magboots,
 /obj/effect/decal/warning_stripes/red/hollow,
-/obj/machinery/camera{
-	c_tag = "Brig Pilot Office";
-	dir = 4;
-	network = list("SS13","Security")
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -40961,6 +40985,15 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/maintenance/atmospherics)
+"eBt" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/locker/locker_toilet)
 "eBB" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -41548,6 +41581,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/carpet/black,
 /area/chapel/office)
 "eNS" = (
@@ -43336,6 +43370,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/main)
+"fyT" = (
+/obj/structure/sink{
+	pixel_y = 24
+	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/locker/locker_toilet)
 "fyY" = (
 /obj/structure/railing{
 	dir = 4;
@@ -44964,6 +45005,13 @@
 	icon_state = "darkredcorners"
 	},
 /area/security/prison/cell_block/A)
+"geb" = (
+/obj/machinery/door/airlock{
+	id_tag = "toilet1";
+	name = "Toilet"
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/locker/locker_toilet)
 "gen" = (
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "bridge";
@@ -44985,7 +45033,7 @@
 	pixel_x = 11
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/hallway/primary/port/south)
 "geD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -45113,6 +45161,7 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/carpet/red,
 /area/chapel/main)
 "ghv" = (
@@ -45145,8 +45194,15 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/orange{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "ghF" = (
@@ -45525,6 +45581,12 @@
 /obj/effect/spawner/lootdrop/crate_spawner,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/port)
+"grE" = (
+/obj/structure/urinal{
+	pixel_y = 28
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/locker/locker_toilet)
 "grJ" = (
 /obj/machinery/light/small,
 /obj/effect/turf_decal/stripes/asteroid/end{
@@ -45890,6 +45952,13 @@
 	},
 /turf/simulated/floor/engine,
 /area/medical/chemistry)
+"gxz" = (
+/obj/machinery/vending/hydronutrients,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkgreenfull"
+	},
+/area/hydroponics)
 "gxB" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -50891,6 +50960,9 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/engine/mechanic_workshop)
+"ioK" = (
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/locker/locker_toilet)
 "ioO" = (
 /obj/structure/closet/firecloset/full,
 /obj/item/pickaxe,
@@ -52456,6 +52528,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/wood,
 /area/library)
 "iTF" = (
@@ -53390,12 +53463,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/port/south)
-"jmY" = (
-/obj/machinery/conveyor/auto{
-	dir = 8
-	},
-/turf/simulated/floor/plating/airless,
-/area/space/nearstation)
 "jnf" = (
 /obj/structure/closet/secure_closet/security,
 /obj/machinery/light,
@@ -54700,6 +54767,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/aft/west)
+"jKi" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/locker/locker_toilet)
 "jKs" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -54823,6 +54906,13 @@
 	dir = 1
 	},
 /area/crew_quarters/heads/hop)
+"jNj" = (
+/obj/machinery/door/airlock{
+	id_tag = "toilet2";
+	name = "Toilet"
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/locker/locker_toilet)
 "jND" = (
 /obj/effect/spawner/window/reinforced/polarized{
 	id = "Magistrate"
@@ -65999,7 +66089,7 @@
 	name = "Broom Closet"
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/hallway/primary/port/south)
 "nXn" = (
 /obj/effect/landmark/event/lightsout,
 /turf/simulated/floor/plasteel{
@@ -66395,7 +66485,9 @@
 	},
 /area/gateway)
 "odU" = (
-/obj/machinery/camera/autoname,
+/obj/machinery/camera{
+	c_tag = "Fitness Room North"
+	},
 /turf/simulated/floor/carpet/cyan,
 /area/crew_quarters/fitness)
 "odZ" = (
@@ -68856,6 +68948,13 @@
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/aft/east)
+"paE" = (
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/locker/locker_toilet)
 "paK" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 4
@@ -69152,6 +69251,18 @@
 	icon_state = "dark"
 	},
 /area/security/podbay)
+"pgb" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/locker/locker_toilet)
 "pgy" = (
 /obj/structure/curtain/open/shower,
 /obj/machinery/alarm{
@@ -70927,6 +71038,10 @@
 /area/hallway/secondary/entry)
 "pMx" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/camera{
+	c_tag = "Brig Hangar";
+	network = list("SS13","Security")
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -71414,9 +71529,6 @@
 /obj/item/stack/ore/gold,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
-"pWB" = (
-/turf/simulated/mineral/ancient/outer,
-/area/space/nearstation)
 "pWE" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -71490,6 +71602,13 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/asmaint5)
+"pXS" = (
+/obj/structure/urinal{
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/locker/locker_toilet)
 "pXX" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -72750,6 +72869,23 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/starboard)
+"qsB" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/door_control{
+	desiredstate = 1;
+	id = "toilet1";
+	name = "Toilet Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_y = -25;
+	specialfunctions = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/locker/locker_toilet)
 "qsC" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -75936,10 +76072,12 @@
 	name = "Library"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/wood,
 /area/library)
 "rEg" = (
-/obj/machinery/camera/autoname{
+/obj/machinery/camera{
+	c_tag = "Fitness Room South";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
@@ -76362,10 +76500,10 @@
 	},
 /area/hallway/primary/starboard/south)
 "rMH" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/chili,
-/obj/item/seeds/grape,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkgreenfull"
@@ -76953,7 +77091,7 @@
 "rXV" = (
 /obj/structure/sign/custodian,
 /turf/simulated/wall,
-/area/space)
+/area/hallway/primary/port/south)
 "rXW" = (
 /obj/structure/showcase{
 	density = 0;
@@ -77218,11 +77356,11 @@
 /turf/space,
 /area/space/nearstation)
 "sbL" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -79704,10 +79842,6 @@
 	},
 /obj/structure/cable/orange{
 	icon_state = "4-8"
-	},
-/obj/machinery/camera{
-	c_tag = "Command Asteroid Hall 2";
-	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -82233,6 +82367,9 @@
 	name = "Hydroponics";
 	req_access = list(35)
 	},
+/obj/item/seeds/grape,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/chili,
 /turf/simulated/floor/plating,
 /area/hydroponics)
 "tXb" = (
@@ -83749,6 +83886,13 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/aft/west)
+"uAZ" = (
+/obj/machinery/vending/hydroseeds,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkgreenfull"
+	},
+/area/hydroponics)
 "uBd" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreen"
@@ -83948,7 +84092,7 @@
 	dir = 4;
 	icon_state = "escape"
 	},
-/area/space)
+/area/hallway/primary/port/south)
 "uEu" = (
 /obj/structure/cable/orange{
 	icon_state = "2-4"
@@ -84061,7 +84205,7 @@
 	dir = 4;
 	icon_state = "escape"
 	},
-/area/space)
+/area/hallway/primary/port/south)
 "uHm" = (
 /turf/simulated/wall,
 /area/crew_quarters/sleep/secondary)
@@ -86896,6 +87040,15 @@
 	icon_state = "dark"
 	},
 /area/hydroponics)
+"vMn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/locker/locker_toilet)
 "vMA" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -87691,9 +87844,6 @@
 "waj" = (
 /turf/simulated/mineral/ancient,
 /area/maintenance/disposal)
-"wam" = (
-/turf/simulated/mineral/ancient/outer,
-/area/space)
 "was" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -88255,6 +88405,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -89609,6 +89760,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/starboard/south)
+"wIb" = (
+/obj/structure/cable/orange{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/locker/locker_toilet)
 "wIi" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -90074,13 +90235,8 @@
 	},
 /area/engine/engineering)
 "wQf" = (
-/obj/machinery/camera{
-	c_tag = "Morgue West";
-	network = list("SS13","CMO");
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/medical/virology)
+/turf/simulated/wall,
+/area/crew_quarters/locker/locker_toilet)
 "wQh" = (
 /obj/structure/cable/orange{
 	icon_state = "2-4"
@@ -93021,6 +93177,7 @@
 	name = "Chapel - Library"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -93827,6 +93984,19 @@
 	icon_state = "darkred"
 	},
 /area/security/warden)
+"yjU" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/light,
+/turf/simulated/floor/plasteel/freezer,
+/area/crew_quarters/locker/locker_toilet)
 "yjW" = (
 /obj/machinery/status_display{
 	layer = 4
@@ -101732,9 +101902,9 @@ rNK
 rNK
 rNK
 rNK
-pWB
-jmY
-wam
+csP
+pan
+csP
 rNK
 rNK
 rNK
@@ -111063,7 +111233,7 @@ aZZ
 aZZ
 aZZ
 aZZ
-nZp
+lZN
 uEn
 bPf
 uHd
@@ -112804,7 +112974,7 @@ cNO
 cTo
 dcM
 xla
-drB
+sbL
 dKM
 aWJ
 dxD
@@ -113575,7 +113745,7 @@ cNO
 cTo
 deZ
 xla
-sbL
+drG
 dKM
 aWJ
 lpq
@@ -113649,10 +113819,10 @@ gIq
 gEA
 xxW
 oZA
-prN
+gxz
 ltb
 vMl
-prN
+uAZ
 sFW
 gQv
 sfH
@@ -121787,7 +121957,7 @@ bRn
 aKl
 gGB
 uOH
-qSK
+eRV
 qSK
 qSK
 qSK
@@ -122043,12 +122213,12 @@ uHm
 niC
 cKp
 gGB
-avS
-avS
-avS
-gZD
-avS
-avS
+wQf
+jKi
+wQf
+clO
+wQf
+aqC
 cEQ
 oFu
 cLN
@@ -122300,11 +122470,11 @@ uHm
 niC
 aKl
 gGB
-abW
-abW
-abW
-abW
-avS
+fyT
+pgb
+jNj
+dNb
+wQf
 bRd
 cCJ
 xEb
@@ -122556,12 +122726,12 @@ bCy
 uHm
 niC
 aKj
-gGB
-abW
-abW
-abW
-abW
-avS
+uHm
+paE
+yjU
+wQf
+wQf
+wQf
 nJA
 cGD
 cGD
@@ -122813,12 +122983,12 @@ qEz
 uHm
 aJk
 aKl
-gGB
-abW
-abW
-abW
-abW
-avS
+uHm
+ioK
+vMn
+geb
+qsB
+wQf
 fQG
 vcK
 cCL
@@ -123070,12 +123240,12 @@ aHc
 uHm
 aJl
 cKp
-gGB
-abW
-abW
-abW
-abW
-avS
+uHm
+pXS
+eBt
+wQf
+wQf
+wQf
 avS
 avS
 avS
@@ -123327,10 +123497,10 @@ bCL
 uHm
 aJm
 aKl
-gGB
-abW
-abW
-abW
+uHm
+grE
+wIb
+wQf
 abW
 abW
 abW
@@ -123585,9 +123755,9 @@ gGB
 uHm
 gGB
 gGB
-abW
-abW
-abW
+wQf
+wQf
+wQf
 abW
 abW
 bAK
@@ -147795,7 +147965,7 @@ bni
 rRG
 dAi
 szL
-wQf
+bil
 bpL
 tNU
 uhQ

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -34,6 +34,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -402,9 +403,6 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/head_of_security,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -1747,20 +1745,11 @@
 "alz" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/item/weldingtool,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/north)
 "alA" = (
 /obj/machinery/light/small{
 	dir = 1
-	},
-/obj/structure/disposalpipe/sortjunction/reversed{
-	dir = 8;
-	name = "disposal pipe - Custodials";
-	sortType = 22
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/north)
@@ -1783,11 +1772,6 @@
 "alL" = (
 /obj/structure/girder,
 /obj/structure/grille,
-/obj/structure/disposalpipe/sortjunction/reversed{
-	dir = 8;
-	name = "disposal pipe - HoS Office";
-	sortType = 7
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/north)
 "alM" = (
@@ -1796,11 +1780,6 @@
 	},
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb,
-/obj/structure/disposalpipe/sortjunction/reversed{
-	dir = 8;
-	name = "disposal pipe - HoP Office";
-	sortType = 15
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/north)
 "alP" = (
@@ -2004,8 +1983,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/north)
@@ -2019,7 +1997,11 @@
 /obj/structure/cable/orange{
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/junction,
+/obj/structure/disposalpipe/sortjunction/reversed{
+	dir = 8;
+	name = "disposal pipe - Custodials";
+	sortType = 22
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/north)
 "amW" = (
@@ -2032,7 +2014,11 @@
 	},
 /area/security/execution)
 "amX" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/sortjunction/reversed{
+	dir = 8;
+	name = "disposal pipe - HoP Office";
+	sortType = 15
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/north)
 "amZ" = (
@@ -2061,8 +2047,8 @@
 "anm" = (
 /obj/structure/girder,
 /obj/structure/grille,
-/obj/structure/disposalpipe/junction{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/north)
@@ -2075,7 +2061,8 @@
 /area/quartermaster/qm)
 "anr" = (
 /obj/structure/disposalpipe/junction{
-	dir = 1
+	dir = 8;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/north)
@@ -4698,6 +4685,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -5407,15 +5395,16 @@
 /obj/structure/cable/orange{
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	sortType = 18;
+	name = "disposal pipe - Captain's Office"
 	},
 /turf/simulated/floor/carpet/black,
 /area/bridge)
@@ -5431,6 +5420,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/carpet/black,
 /area/bridge)
@@ -5629,12 +5622,6 @@
 "aIZ" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
-	},
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -6886,11 +6873,11 @@
 	icon_state = "4-8"
 	},
 /obj/structure/chair/comfy/blue,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/landmark/start/nanotrasen_rep,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -7064,9 +7051,6 @@
 	},
 /obj/structure/table/wood,
 /obj/item/pen,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -7077,11 +7061,8 @@
 "aRk" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -9159,6 +9140,9 @@
 /area/chapel/office)
 "bbg" = (
 /obj/structure/table,
+/obj/machinery/vending/wallmed{
+	pixel_x = -28
+	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bbh" = (
@@ -10961,11 +10945,8 @@
 	},
 /area/medical/cmo)
 "bib" = (
-/obj/structure/disposalpipe/sortjunction/reversed{
-	dir = 8;
-	name = "disposal pipe - CMO Office";
-	sortType = 10
-	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/north)
 "bie" = (
@@ -12289,9 +12270,6 @@
 /obj/structure/cable/orange{
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fore2)
 "bnQ" = (
@@ -12563,9 +12541,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -13013,10 +12988,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -13032,10 +13004,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/disposalpipe/junction,
 /obj/structure/cable/orange{
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -13420,6 +13392,9 @@
 	dir = 9
 	},
 /obj/machinery/meter,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "bsb" = (
@@ -13913,6 +13888,7 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitebluecorner"
@@ -14485,6 +14461,12 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkyellowfull"
@@ -14496,6 +14478,9 @@
 	id_tag = "engineeringlockdown";
 	layer = 2.6;
 	name = "Emergency Lockdown Blastdoor"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/atmos/break_room)
@@ -14516,6 +14501,12 @@
 	req_one_access = list(32)
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkyellowfull"
@@ -15282,6 +15273,9 @@
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/machinery/vending/wallmed{
+	pixel_y = 28
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "red"
@@ -15434,8 +15428,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/sortjunction/reversed{
+	dir = 4;
+	name = "disposal pipe - CMO Office";
+	sortType = 10
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -15928,6 +15924,9 @@
 	network = list("SS13","CE")
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/vending/wallmed{
+	pixel_x = -28
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -16671,6 +16670,9 @@
 	amount = 50
 	},
 /obj/item/stack/sheet/glass/fifty,
+/obj/machinery/vending/wallmed{
+	pixel_y = 28
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow";
 	dir = 1
@@ -16731,6 +16733,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow";
 	dir = 8
@@ -16751,6 +16757,9 @@
 /area/hallway/primary/port/north)
 "bFi" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -17081,14 +17090,13 @@
 	},
 /area/medical/medbay)
 "bFK" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 2;
-	name = "disposal pipe - Chemistry";
-	sortType = 11
-	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -17159,6 +17167,7 @@
 "bFU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whiteblue"
@@ -17321,9 +17330,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -17331,6 +17337,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -17351,9 +17360,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -17361,6 +17367,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -17375,9 +17384,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -17386,6 +17392,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -17399,14 +17408,14 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
@@ -17441,9 +17450,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -17522,6 +17530,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/start/engineer,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -17577,9 +17586,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -17593,9 +17599,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -17613,7 +17616,8 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -17889,6 +17893,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -17911,6 +17918,7 @@
 	},
 /obj/item/storage/box/lights/mixed,
 /obj/item/storage/box/lights/mixed,
+/obj/item/clothing/gloves/color/yellow,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -18257,9 +18265,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-y"
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -18293,7 +18301,10 @@
 /obj/item/stack/sheet/rglass{
 	amount = 50
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -18419,6 +18430,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -18435,7 +18447,6 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -18480,6 +18491,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -18876,7 +18890,6 @@
 	},
 /obj/structure/closet/secure_closet/atmos_personal,
 /obj/item/pickaxe/mini,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -18968,7 +18981,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
@@ -18999,6 +19015,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
@@ -19009,6 +19028,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "darkyellow"
@@ -19042,7 +19062,6 @@
 /area/engine/engineering)
 "bMh" = (
 /obj/structure/rack,
-/obj/structure/disposalpipe/segment,
 /obj/item/rpd,
 /obj/item/rpd,
 /obj/item/storage/briefcase/inflatable,
@@ -19057,7 +19076,6 @@
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
-/obj/structure/disposalpipe/segment,
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
@@ -19355,7 +19373,7 @@
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
-	dir = 1
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -19395,11 +19413,12 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/computer/monitor{
-	dir = 4
-	},
 /obj/machinery/light_switch{
 	pixel_y = 24
+	},
+/obj/machinery/computer/monitor{
+	dir = 8;
+	name = "Main Power Monitoring Computer"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/chiefs_office)
@@ -19432,6 +19451,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkyellowfull"
@@ -19457,7 +19477,6 @@
 /area/engine/engine_smes)
 "bNB" = (
 /obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/engine/engine_smes)
 "bNC" = (
@@ -19487,6 +19506,10 @@
 	},
 /obj/structure/cable/orange{
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -19560,6 +19583,10 @@
 /area/maintenance/gambling_den2)
 "bOo" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow";
 	dir = 8
@@ -19567,6 +19594,9 @@
 /area/atmos)
 "bOp" = (
 /obj/structure/chair/stool/bar{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -19577,6 +19607,9 @@
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes,
 /obj/item/lighter,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -19588,6 +19621,9 @@
 /obj/structure/chair/stool/bar{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -19597,6 +19633,9 @@
 	pixel_y = 32
 	},
 /obj/structure/closet/radiation,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -19604,6 +19643,10 @@
 "bOt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -19623,6 +19666,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "darkyellow"
@@ -19636,6 +19683,9 @@
 	pixel_y = 24
 	},
 /obj/item/twohanded/required/kirbyplants,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow";
 	dir = 1
@@ -19645,10 +19695,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/computer/monitor,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow";
 	dir = 1
@@ -19663,7 +19712,7 @@
 	pixel_y = 32
 	},
 /obj/structure/disposalpipe/trunk{
-	dir = 4
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow";
@@ -19680,9 +19729,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/suit_storage_unit/engine,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow";
 	dir = 1
@@ -19693,10 +19739,6 @@
 	icon_state = "4-8"
 	},
 /obj/structure/table,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/item/tank/jetpack/carbondioxide{
 	pixel_x = -3;
 	pixel_y = 3
@@ -19712,7 +19754,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/suit_storage_unit/engine,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow";
 	dir = 1
@@ -19809,9 +19850,12 @@
 	},
 /area/engine/engine_smes)
 "bOH" = (
-/obj/machinery/computer/monitor,
 /obj/structure/cable{
 	icon_state = "0-8"
+	},
+/obj/machinery/computer/monitor{
+	dir = 8;
+	name = "Main Power Monitoring Computer"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -20122,24 +20166,29 @@
 	},
 /area/engine/engine_smes)
 "bPI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/engine/engine_smes)
-"bPJ" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	sortType = 12;
+	name = "disposal pipe - Research"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/toxins/hallway)
+"bPJ" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "whitepurplecorner"
 	},
-/area/engine/engine_smes)
+/area/toxins/hallway)
 "bPK" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -20308,6 +20357,9 @@
 /area/atmos)
 "bQr" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow";
 	dir = 8
@@ -20456,9 +20508,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
@@ -20473,20 +20522,16 @@
 	name = "Engineering Delivery Chute"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/engine/engine_smes)
 "bQN" = (
-/obj/structure/disposaloutlet{
-	dir = 8
+/obj/machinery/vending/wallmed{
+	pixel_x = -28
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	icon_state = "darkblue"
 	},
-/turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/bridge)
 "bQP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -20710,6 +20755,7 @@
 /area/atmos/distribution)
 "bRy" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -20870,6 +20916,7 @@
 "bRS" = (
 /obj/structure/railing/corner,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet/black,
 /area/bridge)
 "bRZ" = (
@@ -20964,6 +21011,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkyellow"
@@ -20979,6 +21029,9 @@
 	req_access = list(24)
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkyellowfull"
@@ -21142,6 +21195,9 @@
 /obj/machinery/atmospherics/binary/volume_pump{
 	name = "Mix to Filter";
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -22770,12 +22826,12 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/computer/monitor{
-	dir = 8;
-	name = "Bridge Power Monitoring Computer"
-	},
 /obj/structure/cable/orange{
 	icon_state = "0-8"
+	},
+/obj/machinery/computer/monitor{
+	dir = 8;
+	name = "Command Power Monitoring Computer"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -24809,10 +24865,6 @@
 /obj/structure/cable/orange{
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -25441,10 +25493,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/white,
 /area/toxins/lab)
 "cmV" = (
@@ -25617,10 +25669,10 @@
 "cnU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/junction,
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/white,
 /area/toxins/lab)
 "cnV" = (
@@ -25671,9 +25723,9 @@
 /area/security/warden)
 "coi" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -25681,10 +25733,6 @@
 "coj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -25737,10 +25785,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/white,
 /area/toxins/lab)
 "coO" = (
@@ -26194,9 +26242,10 @@
 /obj/structure/cable/orange{
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/junction{
+/obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	icon_state = "pipe-j2"
+	sortType = 14;
+	name = "disposal pipe - Robotics"
 	},
 /turf/simulated/floor/plasteel/white,
 /area/toxins/hallway)
@@ -26206,14 +26255,13 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	tag = "icon-pipe-j1 (EAST)"
-	},
 /obj/structure/cable/orange{
 	icon_state = "1-8"
 	},
 /obj/effect/landmark/start/student_sientist,
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel/white,
 /area/toxins/hallway)
 "cqN" = (
@@ -26292,6 +26340,9 @@
 	},
 /area/toxins/hallway)
 "crx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurplefull"
@@ -26319,6 +26370,10 @@
 /obj/machinery/newscaster{
 	pixel_y = -28;
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -26359,10 +26414,14 @@
 /obj/structure/table/reinforced{
 	layer = 2.5
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/recharger{
 	pixel_x = 1;
 	pixel_y = 3
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	sortType = 8;
+	name = "disposal pipe - Security"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
@@ -26375,7 +26434,7 @@
 	pixel_y = -28
 	},
 /obj/structure/disposalpipe/trunk{
-	dir = 1
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
@@ -26904,8 +26963,9 @@
 "cuU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -27429,17 +27489,16 @@
 	name = "Research Delivery Chute"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/toxins/misc_lab)
 "cyt" = (
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
+/obj/structure/girder,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/maintenance/fore2)
+/area/maintenance/disposal/south)
 "cyx" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
@@ -27455,21 +27514,15 @@
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/hop)
 "cyG" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Bridge APC Access";
-	req_access = list(10)
+	req_access = list(19)
 	},
 /obj/structure/cable/orange{
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fore2)
@@ -27478,9 +27531,6 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -27507,12 +27557,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/chair/comfy/blue,
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
-	},
 /obj/effect/landmark/start/hop,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -27574,7 +27621,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/wall,
+/turf/simulated/floor/plating,
 /area/toxins/misc_lab)
 "czg" = (
 /turf/simulated/floor/plasteel{
@@ -27584,8 +27631,7 @@
 /area/bridge)
 "czj" = (
 /obj/structure/disposalpipe/junction{
-	dir = 1;
-	tag = "icon-pipe-j1 (EAST)"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -27783,6 +27829,9 @@
 	c_tag = "Research Eastern Wing";
 	dir = 1
 	},
+/obj/machinery/vending/wallmed{
+	pixel_y = -28
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
@@ -27806,10 +27855,6 @@
 	c_tag = "Cargo Desk";
 	dir = 6;
 	network = list("SS13","QM")
-	},
-/obj/machinery/status_display{
-	name = "cargo display";
-	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -27960,10 +28005,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
@@ -27975,9 +28016,6 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -28845,9 +28883,6 @@
 	dir = 8;
 	location = "Engineering"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/engine/engine_smes)
 "cFE" = (
@@ -29606,6 +29641,7 @@
 /area/hallway/primary/central)
 "cJa" = (
 /obj/structure/reagent_dispensers/water_cooler,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "whiteblue"
@@ -29628,6 +29664,9 @@
 	name = "Emergency Lockdown Blastdoor"
 	},
 /obj/effect/spawner/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/engine/break_room)
 "cJe" = (
@@ -31100,6 +31139,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
@@ -31309,6 +31351,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/structure/disposalpipe/sortjunction{
+	name = "disposal pipe - Engineering";
+	sortType = 4;
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkyellowcorners"
@@ -31369,6 +31416,9 @@
 /area/engine/chiefs_office)
 "cQp" = (
 /obj/structure/table,
+/obj/machinery/vending/wallmed{
+	pixel_x = -28
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "escape"
@@ -31473,9 +31523,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/sortjunction{
+	name = "disposal pipe - CE Office";
+	sortType = 5;
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/chiefs_office)
@@ -31550,6 +31601,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/engine/chiefs_office)
 "cQM" = (
@@ -32214,15 +32266,15 @@
 	},
 /area/crew_quarters/kitchen)
 "cTF" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/disposal/north)
+/area/maintenance/disposal/west)
 "cTJ" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -32981,6 +33033,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/engine/chiefs_office)
 "cWc" = (
@@ -33932,7 +33985,6 @@
 "ddw" = (
 /obj/structure/closet/secure_closet/atmos_personal,
 /obj/item/pickaxe/mini,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/light_switch{
 	dir = 8;
 	pixel_x = 24
@@ -34026,6 +34078,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -34833,7 +34886,8 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/computer/monitor{
-	dir = 8
+	dir = 8;
+	name = "Command Power Monitoring Computer"
 	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/maintenance/fore)
@@ -34922,6 +34976,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -28;
 	name = "custom placement"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
@@ -35148,6 +35205,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint3)
 "dla" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreen"
 	},
@@ -35351,6 +35411,9 @@
 /obj/item/storage/firstaid/o2{
 	pixel_x = 4;
 	pixel_y = 4
+	},
+/obj/machinery/vending/wallmed{
+	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/mechanic_workshop/expedition)
@@ -36531,7 +36594,6 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -36605,7 +36667,6 @@
 	c_tag = "Brig Main Hall Center";
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkredcorners"
@@ -37402,9 +37463,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -37512,9 +37570,6 @@
 	},
 /obj/structure/cable/orange{
 	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/machinery/button/windowtint{
 	dir = 4;
@@ -38178,6 +38233,7 @@
 	},
 /area/turret_protected/ai)
 "dBv" = (
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "whiteblue"
@@ -38478,6 +38534,14 @@
 /obj/item/multitool,
 /turf/simulated/floor/plating,
 /area/storage/tech)
+"dDj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/engine/engineering)
 "dDA" = (
 /obj/machinery/smartfridge/medbay,
 /obj/machinery/door/window/southleft{
@@ -38682,7 +38746,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/toxins/misc_lab)
 "dHQ" = (
 /obj/effect/spawner/airlock/e_to_w,
@@ -38707,11 +38771,12 @@
 	},
 /area/hallway/primary/aft/west)
 "dIF" = (
-/obj/machinery/computer/monitor{
-	dir = 4
-	},
 /obj/structure/cable/orange{
 	icon_state = "0-4"
+	},
+/obj/machinery/computer/monitor{
+	dir = 8;
+	name = "Security Power Monitoring Computer"
 	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/maintenance/fpmaint)
@@ -39202,6 +39267,16 @@
 	icon_state = "redcorner"
 	},
 /area/security/lobby)
+"dPD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/disposal/west)
 "dPP" = (
 /obj/machinery/computer/arcade{
 	dir = 4
@@ -39228,9 +39303,12 @@
 	},
 /area/hallway/primary/fore)
 "dQc" = (
-/obj/machinery/computer/monitor,
 /obj/structure/cable/orange{
 	icon_state = "0-2"
+	},
+/obj/machinery/computer/monitor{
+	dir = 8;
+	name = "Arrivals Power Monitoring Computer"
 	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/maintenance/asmaint5)
@@ -39297,6 +39375,19 @@
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint5)
+"dRg" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/sortjunction/reversed{
+	dir = 8;
+	name = "disposal pipe - CE Office";
+	sortType = 5
+	},
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/maintenance/starboard)
 "dRu" = (
 /obj/item/folder{
 	pixel_x = -4
@@ -39603,14 +39694,14 @@
 	},
 /area/maintenance/apmaint2)
 "dWg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurple"
 	},
-/turf/simulated/floor/plasteel/white,
-/area/toxins/hallway)
+/area/toxins/misc_lab)
 "dWr" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -40122,8 +40213,10 @@
 /area/maintenance/disposal/west)
 "ejF" = (
 /obj/effect/decal/cleanable/cobweb,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	sortType = 7;
+	name = "disposal pipe - HoS Office"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/west)
@@ -40291,14 +40384,18 @@
 	},
 /area/security/brig)
 "enf" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	sortType = 7;
+	name = "disposal pipe - HoS Office"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/security/brig)
 "enj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -40956,23 +41053,12 @@
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/apmaint2)
 "eBl" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "whiteblue"
 	},
-/area/security/warden)
+/area/medical/medbay)
 "eBn" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -41434,9 +41520,8 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -42169,6 +42254,7 @@
 	dir = 0;
 	pixel_x = -28
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -42502,6 +42588,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
+"fhM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/atmos)
 "fhQ" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel{
@@ -43322,6 +43417,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet/black,
 /area/bridge)
 "fxQ" = (
@@ -43355,10 +43451,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -43524,6 +43616,7 @@
 /area/mine/unexplored/cere/orbiting)
 "fDw" = (
 /obj/structure/reagent_dispensers/watertank,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/west)
 "fDL" = (
@@ -43645,7 +43738,7 @@
 /obj/structure/cable/orange{
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/junction{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -44000,6 +44093,15 @@
 /obj/structure/sign/radiation,
 /turf/simulated/wall/r_wall/coated,
 /area/engine/supermatter)
+"fLs" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/atmos)
 "fLE" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -44069,7 +44171,10 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "purplecorner"
@@ -44522,6 +44627,7 @@
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "fTR" = (
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkyellow"
@@ -44531,6 +44637,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -44974,12 +45081,13 @@
 	},
 /area/hallway/secondary/exit)
 "gds" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	sortType = 24;
+	name = "disposal pipe - Brig Physician"
 	},
-/turf/simulated/mineral/ancient,
-/area/mine/unexplored/cere/medical)
+/turf/simulated/floor/plating,
+/area/maintenance/disposal/west)
 "gdM" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -45051,6 +45159,18 @@
 /obj/structure/kitchenspike,
 /turf/simulated/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
+"geW" = (
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "engineeringlockdown";
+	layer = 2.6;
+	name = "Emergency Lockdown Blastdoor"
+	},
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/engine/break_room)
 "gfd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/maintenance/external{
@@ -45429,6 +45549,10 @@
 /area/toxins/server)
 "gou" = (
 /obj/structure/reagent_dispensers/fueltank,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/west)
 "goF" = (
@@ -45448,9 +45572,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/west)
@@ -47012,9 +47136,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowcorners"
 	},
@@ -47910,11 +48031,12 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -48664,6 +48786,9 @@
 /area/engine/mechanic_workshop)
 "hvj" = (
 /obj/machinery/light/small,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/west)
 "hvH" = (
@@ -48684,6 +48809,9 @@
 /area/quartermaster/office)
 "hvQ" = (
 /obj/structure/girder,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/west)
 "hwc" = (
@@ -48747,6 +48875,10 @@
 "hwM" = (
 /obj/structure/girder,
 /obj/structure/grille,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/west)
 "hwZ" = (
@@ -48886,6 +49018,7 @@
 /area/security/permabrig)
 "hyO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -48967,6 +49100,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/visible/cyan,
+/obj/machinery/meter,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "hAl" = (
@@ -49425,7 +49559,9 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/structure/disposalpipe/trunk,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkyellow"
@@ -49609,9 +49745,6 @@
 	},
 /area/hallway/spacebridge/engmed)
 "hKY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkyellow"
@@ -50502,7 +50635,6 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -50704,6 +50836,15 @@
 	icon_state = "whitepurple"
 	},
 /area/toxins/mixing)
+"iir" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/atmos)
 "iiG" = (
 /obj/structure/table,
 /obj/item/storage/box/lights/mixed,
@@ -50711,6 +50852,7 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
+/obj/item/clothing/gloves/color/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -50897,7 +51039,10 @@
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/west)
 "imU" = (
@@ -51047,6 +51192,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "purple"
@@ -51058,6 +51207,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -51331,7 +51484,7 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 9
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/toxins/misc_lab)
 "ivS" = (
 /turf/simulated/wall,
@@ -51718,6 +51871,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -51925,6 +52079,9 @@
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
@@ -52314,9 +52471,9 @@
 	},
 /area/toxins/mixing)
 "iOw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
@@ -52487,6 +52644,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
 	},
@@ -52956,8 +53114,10 @@
 /obj/structure/cable/orange{
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/sortjunction/reversed{
+	dir = 8;
+	name = "disposal pipe - CMO Office";
+	sortType = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
@@ -53330,6 +53490,7 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "jkV" = (
@@ -53532,6 +53693,9 @@
 /obj/item/storage/firstaid/regular{
 	pixel_x = 4;
 	pixel_y = 4
+	},
+/obj/machinery/vending/wallmed{
+	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -54146,7 +54310,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/obj/machinery/meter,
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
@@ -54737,7 +54900,6 @@
 	name = "R&D Desk";
 	req_access = list(47)
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
@@ -54747,6 +54909,7 @@
 /obj/structure/cable/orange{
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/toxins/lab)
 "jJJ" = (
@@ -55333,7 +55496,9 @@
 /obj/structure/cable/orange{
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/south)
 "jUK" = (
@@ -56104,6 +56269,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
+"kiT" = (
+/obj/structure/disposalpipe/sortjunction/reversed{
+	dir = 2;
+	name = "disposal pipe - Atmospherics";
+	sortType = 6
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/atmos)
 "kjb" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -56235,6 +56410,15 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"kkQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/engine/engineering)
 "kla" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
@@ -56442,14 +56626,10 @@
 	},
 /area/medical/medbay)
 "kpG" = (
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
+/obj/effect/spawner/window/reinforced,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/toxins/misc_lab)
+/area/medical/medbay)
 "kpQ" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -58463,7 +58643,6 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -59578,6 +59757,10 @@
 	c_tag = "Docking Asteroid Hall 6";
 	dir = 4
 	},
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_x = -32
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "escape"
@@ -59689,12 +59872,12 @@
 	},
 /area/security/lobby)
 "lyT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/disposal/north)
+/area/toxins/hallway)
 "lze" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -59843,11 +60026,12 @@
 /obj/structure/cable/orange{
 	icon_state = "2-8"
 	},
-/obj/machinery/computer/monitor{
-	dir = 8
-	},
 /obj/structure/cable/orange{
 	icon_state = "0-8"
+	},
+/obj/machinery/computer/monitor{
+	dir = 8;
+	name = "Cargo Power Monitoring Computer"
 	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/maintenance/fsmaint3)
@@ -60271,6 +60455,18 @@
 	icon_state = "dark"
 	},
 /area/engine/mechanic_workshop/hangar)
+"lMC" = (
+/obj/effect/spawner/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "engineeringlockdown";
+	layer = 2.6;
+	name = "Emergency Lockdown Blastdoor"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/atmos/break_room)
 "lNe" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
@@ -60356,12 +60552,12 @@
 /area/library)
 "lPl" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
-	dir = 8;
-	name = "disposal pipe - QM Office";
-	sortType = 3
+	dir = 1;
+	name = "disposal pipe - CMO Office";
+	sortType = 10
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/disposal/north)
+/area/maintenance/disposal/east)
 "lPr" = (
 /obj/structure/chair{
 	dir = 8
@@ -61087,6 +61283,7 @@
 /area/maintenance/disposal/westalt)
 "mdx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet/black,
 /area/bridge)
 "mdH" = (
@@ -61333,6 +61530,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -61359,6 +61560,17 @@
 "mic" = (
 /turf/simulated/wall,
 /area/mine/unexplored/cere/civilian)
+"miw" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/start/engineer,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/engine/engine_smes)
 "mix" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -61379,10 +61591,9 @@
 /turf/simulated/floor/carpet/black,
 /area/chapel/office)
 "miG" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/east)
@@ -61582,7 +61793,10 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
@@ -62297,6 +62511,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -62561,6 +62778,7 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/toxins/lab)
 "mJk" = (
@@ -63158,7 +63376,8 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/storage/toolbox/mechanical,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
@@ -64624,6 +64843,27 @@
 	},
 /turf/space,
 /area/hallway/spacebridge/medcargo)
+"nwo" = (
+/obj/effect/decal/warning_stripes/yellow/partial{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/arrow{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purplefull"
+	},
+/area/hallway/primary/aft/west)
+"nwp" = (
+/obj/structure/disposalpipe/sortjunction/reversed{
+	dir = 1;
+	name = "disposal pipe - CE Office";
+	sortType = 5
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/disposal/east)
 "nwv" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel,
@@ -64916,13 +65156,11 @@
 /turf/simulated/floor/wood,
 /area/civilian/vacantoffice)
 "nBP" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	name = "disposal pipe - Hydroponics";
-	sortType = 21
-	},
 /obj/structure/cable/orange{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -64930,11 +65168,11 @@
 /area/maintenance/port2)
 "nCB" = (
 /obj/item/assembly/mousetrap/armed,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/orange{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -65717,9 +65955,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/structure/disposalpipe/junction{
+/obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 8;
-	icon_state = "pipe-j2"
+	name = "disposal pipe - RD Office";
+	sortType = 13
 	},
 /turf/simulated/floor/plasteel/white,
 /area/toxins/hallway)
@@ -66713,13 +66952,14 @@
 /obj/structure/cable/orange{
 	icon_state = "2-8"
 	},
-/obj/machinery/computer/monitor{
-	dir = 8
-	},
 /obj/structure/cable/orange{
 	icon_state = "0-2"
 	},
 /obj/effect/decal/cleanable/cobweb,
+/obj/machinery/computer/monitor{
+	dir = 8;
+	name = "Service Power Monitoring Computer"
+	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/maintenance/port)
 "oir" = (
@@ -66735,6 +66975,10 @@
 	},
 /area/library)
 "oiL" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "whitegreen"
@@ -67783,11 +68027,12 @@
 /turf/simulated/floor/plasteel/white,
 /area/toxins/xenobiology)
 "oEi" = (
-/obj/machinery/computer/monitor{
-	dir = 8
-	},
 /obj/structure/cable/orange{
 	icon_state = "0-2"
+	},
+/obj/machinery/computer/monitor{
+	dir = 8;
+	name = "Medical Power Monitoring Computer"
 	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/hallway/primary/starboard/north)
@@ -68523,8 +68768,12 @@
 	},
 /area/hallway/secondary/exit)
 "oTM" = (
-/obj/structure/disposalpipe/junction,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/sortjunction{
+	dir = 2;
+	sortType = 15;
+	name = "disposal pipe - HoP Office"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -69325,6 +69574,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/aft/west)
+"phA" = (
+/obj/structure/disposalpipe/junction{
+	dir = 2
+	},
+/turf/simulated/floor/plating/asteroid/ancient,
+/area/maintenance/starboard)
 "phD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -69906,11 +70161,11 @@
 /area/toxins/xenobiology)
 "prV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -70484,6 +70739,10 @@
 /area/atmos/break_room)
 "pCA" = (
 /obj/structure/grille,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/south)
 "pDl" = (
@@ -70676,13 +70935,13 @@
 	},
 /area/atmos)
 "pGZ" = (
-/obj/structure/disposalpipe/sortjunction/reversed{
-	dir = 8;
-	name = "disposal pipe - RD Office";
-	sortType = 13
+/obj/machinery/vending/wallmed{
+	pixel_y = -28
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/disposal/north)
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
+	},
+/area/hallway/secondary/entry/south)
 "pHb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -70863,6 +71122,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/landmark/start/atmospheric,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -70944,9 +71206,6 @@
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "pLC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkyellowcorners"
@@ -70985,6 +71244,10 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard/north)
+"pLU" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/disposal/east)
 "pMa" = (
 /obj/structure/cable/orange{
 	icon_state = "1-4"
@@ -71991,8 +72254,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -72814,9 +73076,10 @@
 /obj/structure/cable/orange{
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/junction{
+/obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	tag = "icon-pipe-j2"
+	sortType = 24;
+	name = "disposal pipe - Brig Physician"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -72949,6 +73212,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -73830,17 +74097,11 @@
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/gambling_den2)
 "qJQ" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/bridge)
+/area/security/brig)
 "qKe" = (
 /obj/structure/cable/orange{
 	icon_state = "1-4"
@@ -73889,7 +74150,10 @@
 	},
 /area/toxins/mixing)
 "qLs" = (
-/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/engineer,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -74076,6 +74340,13 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/north)
+"qQq" = (
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/disposal/west)
 "qQw" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer{
 	dir = 8;
@@ -74431,6 +74702,9 @@
 /obj/item/pen,
 /obj/item/storage/firstaid/regular,
 /obj/structure/table/glass,
+/obj/machinery/vending/wallmed{
+	pixel_y = 28
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -74749,9 +75023,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -75326,6 +75597,12 @@
 /obj/item/book/manual/supermatter_engine,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"roM" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/medbay)
 "rph" = (
 /obj/structure/disposalpipe/junction,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -76080,6 +76357,9 @@
 	c_tag = "Fitness Room South";
 	dir = 8
 	},
+/obj/machinery/vending/wallmed{
+	pixel_x = 28
+	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
 "rEm" = (
@@ -76336,10 +76616,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/computer/monitor{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/computer/monitor{
+	dir = 8;
+	name = "Satellite Power Monitoring Computer"
+	},
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior)
 "rJj" = (
@@ -76847,7 +77128,6 @@
 /area/crew_quarters/bar)
 "rSu" = (
 /obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
 	pixel_y = 28
 	},
 /obj/machinery/hologram/holopad{
@@ -77193,9 +77473,9 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -77794,6 +78074,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -77924,16 +78205,11 @@
 	},
 /area/toxins/hallway)
 "sjQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engine/engineering)
 "ske" = (
 /obj/structure/cable/orange{
 	icon_state = "2-8"
@@ -78519,6 +78795,13 @@
 	},
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/arrival/station)
+"sww" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/white,
+/area/toxins/lab)
 "swQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -80431,10 +80714,10 @@
 /obj/structure/chair/office/light{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -80946,6 +81229,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whiteblue"
@@ -82779,10 +83063,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -82790,6 +83070,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -83152,6 +83435,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -83298,6 +83584,10 @@
 /area/maintenance/asmaint5)
 "uob" = (
 /obj/effect/landmark/start/atmospheric,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -83593,8 +83883,10 @@
 /turf/simulated/floor/engine,
 /area/toxins/mixing)
 "utS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/sortjunction/reversed{
+	dir = 4;
+	name = "disposal pipe - RD Office";
+	sortType = 13
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/south)
@@ -83813,6 +84105,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluecorner"
 	},
@@ -83879,6 +84175,10 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
+"uAJ" = (
+/obj/effect/landmark/start/atmospheric,
+/turf/simulated/floor/plasteel,
+/area/atmos/control)
 "uAT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -85002,6 +85302,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -85214,6 +85517,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "whiteblue"
@@ -86902,6 +87206,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "whiteblue"
@@ -87978,6 +88283,7 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
 "wdK" = (
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkyellowcorners"
@@ -88320,6 +88626,19 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/port/north)
+"wkr" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/vending/wallmed{
+	pixel_x = -28
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/port/south)
 "wkx" = (
 /obj/machinery/door/airlock/public/glass{
 	autoclose = 0;
@@ -88470,6 +88789,10 @@
 	name = "Radiation Shutters Control";
 	pixel_y = 34;
 	req_access = list(10)
+	},
+/obj/machinery/camera{
+	c_tag = "SM South";
+	network = list("SS13","CE","engine")
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
@@ -89184,17 +89507,14 @@
 /turf/simulated/wall,
 /area/maintenance/port2)
 "wys" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 4;
+	icon_state = "darkredcorners"
 	},
-/area/engine/engine_smes)
+/area/security/brig)
 "wyA" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -89398,10 +89718,11 @@
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/maintenance/port)
 "wBr" = (
-/obj/machinery/computer/monitor{
-	dir = 1
-	},
 /obj/structure/cable/orange,
+/obj/machinery/computer/monitor{
+	dir = 8;
+	name = "Research Power Monitoring Computer"
+	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/maintenance/apmaint2)
 "wBA" = (
@@ -89644,9 +89965,7 @@
 	},
 /area/hallway/primary/aft/west)
 "wFA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurplecorner"
@@ -89925,8 +90244,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -90229,6 +90549,9 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -90985,10 +91308,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
-/obj/machinery/camera{
-	c_tag = "SM South";
-	network = list("SS13","CE","engine")
-	},
 /obj/machinery/power/apc{
 	cell_type = 25000;
 	dir = 1;
@@ -91329,10 +91648,9 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2"
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -91630,13 +91948,13 @@
 /turf/simulated/wall,
 /area/security/interrogation)
 "xsc" = (
-/obj/structure/disposalpipe/sortjunction/reversed{
-	dir = 8;
-	name = "disposal pipe - CE Office";
-	sortType = 5
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/disposal/north)
+/turf/simulated/floor/plasteel{
+	icon_state = "whiteblue"
+	},
+/area/medical/medbay)
 "xsh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet/green,
@@ -92017,11 +92335,11 @@
 	location = "Research Division"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/structure/disposalpipe/segment{
-	dir = 4;
+	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/insulated,
 /turf/simulated/floor/plating,
 /area/toxins/misc_lab)
 "xzA" = (
@@ -92639,6 +92957,7 @@
 /area/maintenance/atmospherics)
 "xLP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkblue"
@@ -92780,6 +93099,8 @@
 	dir = 2;
 	id_tag = "RnDShutters"
 	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/toxins/lab)
 "xON" = (
@@ -93223,9 +93544,10 @@
 /turf/simulated/wall,
 /area/hallway/primary/fore/east)
 "xXg" = (
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
+/obj/structure/disposalpipe/sortjunction/reversed{
+	dir = 8;
+	name = "disposal pipe - Captain's Office";
+	sortType = 18
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/north)
@@ -93906,6 +94228,17 @@
 "yii" = (
 /turf/simulated/mineral/ancient/outer,
 /area/hallway/primary/central)
+"yin" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/atmos/distribution)
 "yiw" = (
 /obj/machinery/door/airlock/external{
 	name = "Arrival Airlock";
@@ -105523,9 +105856,9 @@ foL
 nxA
 abW
 gnu
-ehn
-don
-don
+gds
+dom
+qQq
 don
 fiK
 fiK
@@ -106296,7 +106629,7 @@ doo
 dCV
 emn
 fFc
-yja
+cTF
 hvQ
 gnu
 cRv
@@ -106553,7 +106886,7 @@ tiJ
 dCV
 epq
 fFq
-yja
+dPD
 hwM
 gnu
 cRv
@@ -109515,7 +109848,7 @@ cen
 cen
 cTh
 pCA
-mkA
+cyt
 utS
 mna
 fYO
@@ -110468,7 +110801,7 @@ rlI
 bZX
 bZX
 bRj
-bZX
+wkr
 bZX
 bZX
 bZX
@@ -112177,19 +112510,19 @@ drA
 fRS
 dsy
 qts
-dpu
-dpu
+qJQ
+qJQ
 eZS
-dpu
-dpu
-dpu
-dpu
-dpu
-dpu
-dpu
-dpu
-dpu
-tZS
+qJQ
+qJQ
+qJQ
+qJQ
+qJQ
+qJQ
+qJQ
+qJQ
+qJQ
+enf
 dpu
 dpu
 dpu
@@ -112436,8 +112769,8 @@ yfX
 qeE
 dtp
 dtP
-cgi
-cgi
+wys
+wys
 rZn
 cgi
 cgi
@@ -114374,9 +114707,9 @@ sNo
 obg
 tRr
 mUu
-uMr
-lxD
-rBW
+xOL
+lyT
+bPI
 vBA
 uwd
 ctb
@@ -114504,7 +114837,7 @@ ctn
 bUL
 ccI
 ijk
-eBl
+aMN
 coi
 crT
 cxQ
@@ -114623,16 +114956,16 @@ wiE
 wiE
 tIt
 iqk
-xEd
+jTe
 shR
-meh
+nwo
 mJg
 aBP
 aaj
-tRr
+sww
 wFA
 xOL
-sjC
+bPJ
 cqL
 mof
 iNK
@@ -114889,7 +115222,7 @@ prV
 cmU
 cnU
 coK
-dWg
+cpB
 cqM
 dka
 uwd
@@ -115411,9 +115744,9 @@ cul
 rup
 uxx
 cuU
-wwg
-wwg
-wwg
+dWg
+dWg
+dWg
 iqA
 czb
 wwg
@@ -116699,7 +117032,7 @@ nej
 vey
 vWk
 ivR
-kpG
+pon
 pon
 rSk
 nSK
@@ -116955,7 +117288,7 @@ xPU
 pzF
 pzF
 pzF
-xIa
+xPU
 cen
 kji
 czK
@@ -119622,7 +119955,7 @@ rNK
 shU
 shU
 alz
-cTF
+aEw
 wVI
 abW
 abW
@@ -120135,7 +120468,7 @@ rNK
 rNK
 rNK
 tDn
-xsc
+akA
 amV
 jPj
 aoD
@@ -120392,7 +120725,7 @@ rNK
 rNK
 rNK
 tDn
-pGZ
+akA
 amX
 mZi
 hXe
@@ -120649,7 +120982,7 @@ rNK
 rNK
 rNK
 tDn
-lPl
+bib
 xXg
 pQH
 aEw
@@ -120907,7 +121240,7 @@ rNK
 rNK
 tDn
 bib
-mZi
+eqN
 apO
 azD
 wVI
@@ -121419,9 +121752,9 @@ jqn
 jqn
 jqn
 cAD
-akA
+wVI
 alM
-pQH
+eqN
 apP
 wVI
 abW
@@ -121677,7 +122010,7 @@ jqn
 ajP
 akA
 akA
-lyT
+akA
 anr
 pQH
 lEz
@@ -123824,11 +124157,11 @@ bDR
 bFc
 mhV
 fTT
-bIi
+bIm
 bKC
-bIi
-bIi
-bIi
+bIm
+kiT
+iir
 bNq
 bIi
 bQt
@@ -124080,7 +124413,7 @@ job
 bDR
 bFd
 uds
-bIm
+bIi
 ddw
 bKD
 bLR
@@ -124787,7 +125120,7 @@ abW
 abW
 aiN
 csz
-cyt
+vrQ
 nuE
 nuE
 btv
@@ -124841,7 +125174,7 @@ bqn
 brV
 bgc
 plG
-bwk
+lMC
 bxt
 tyb
 kpV
@@ -125044,7 +125377,7 @@ abW
 abW
 aiN
 vrQ
-sRh
+vrQ
 nuE
 bqF
 cGM
@@ -125116,7 +125449,7 @@ bNs
 bOt
 ddN
 fTT
-nAg
+fLs
 bOo
 ded
 del
@@ -125366,7 +125699,7 @@ nGm
 bFi
 bGR
 bIr
-eQG
+uAJ
 jqb
 eQG
 cQl
@@ -125374,7 +125707,7 @@ lHB
 bPx
 bJI
 bJI
-bJI
+fhM
 lRU
 nqw
 bIi
@@ -126329,7 +126662,7 @@ ubW
 ckI
 xYZ
 aPg
-qJQ
+cyR
 cBf
 xYZ
 xYZ
@@ -126916,7 +127249,7 @@ cQD
 cQK
 cWa
 bRx
-bQw
+yin
 bTG
 deo
 bTF
@@ -127103,7 +127436,7 @@ aPj
 cyR
 bpg
 tpA
-aTH
+bQN
 aNY
 brs
 aUE
@@ -129477,13 +129810,13 @@ bCX
 bhd
 bFo
 fyH
-enf
+bJN
 eKU
-qLs
+dDj
 bMh
 bNB
 bOA
-kRw
+miw
 bQI
 bRG
 bND
@@ -129740,8 +130073,8 @@ qLs
 bMi
 bNB
 bOB
-bPJ
-wys
+kRw
+bQI
 xRE
 bSz
 bTl
@@ -129993,12 +130326,12 @@ fPv
 bHe
 iiG
 jRi
-nOF
+dDj
 bMj
 bNx
 bOC
 bPK
-sjQ
+bQI
 bRI
 bND
 bTm
@@ -130249,8 +130582,8 @@ bhd
 bFy
 bHe
 wNm
-nOF
-nOF
+mWR
+dDj
 bMk
 bNC
 bOD
@@ -130507,7 +130840,7 @@ bFz
 bHe
 nOF
 nOF
-nOF
+dDj
 eWS
 bNx
 bOE
@@ -130754,17 +131087,17 @@ aYJ
 aYJ
 bwi
 bwi
-bwi
-bwi
-bwi
 bBW
+bwi
+bwi
+bwi
 bwi
 bhd
 bFA
 bHg
 fTR
 wdK
-nOF
+kkQ
 huN
 bNx
 bOF
@@ -131020,13 +131353,13 @@ tBG
 grW
 bHh
 bnS
-cMb
+sjQ
 nOF
 orc
 bNx
 bOG
 bPM
-bPI
+bPG
 bRL
 bND
 bND
@@ -131523,7 +131856,7 @@ jMD
 bsh
 iXV
 jbr
-cJd
+geW
 bxI
 byJ
 vis
@@ -132054,7 +132387,7 @@ xgr
 guA
 nVW
 nVW
-bQN
+bND
 bND
 nVW
 mkk
@@ -132311,8 +132644,8 @@ guA
 guA
 nVW
 nVW
-bND
-bND
+nVW
+nVW
 nVW
 aKI
 mkk
@@ -137500,7 +137833,7 @@ rFt
 cjx
 gqK
 cjs
-vjb
+pGZ
 sHm
 rNK
 rNK
@@ -141800,12 +142133,12 @@ bia
 sPB
 bps
 bqK
-dBO
+roM
 btP
 cJa
-bIQ
+kpG
 dBv
-ovq
+eBl
 bzP
 dBO
 dBe
@@ -141824,7 +142157,7 @@ rKw
 rKw
 rkl
 nlS
-gds
+aZM
 aZM
 aZM
 aZM
@@ -143915,7 +144248,7 @@ kWx
 cdT
 cdT
 cdT
-jpk
+cdT
 cdT
 cdT
 cdT
@@ -145603,7 +145936,7 @@ rNK
 ayP
 woa
 fgS
-any
+hVN
 cAo
 hZJ
 urZ
@@ -145655,7 +145988,7 @@ ddr
 vUg
 nqG
 tLf
-bJf
+xsc
 epP
 epP
 epP
@@ -145912,7 +146245,7 @@ cPm
 vUg
 nqG
 tLf
-bJf
+xsc
 epP
 uAb
 oVC
@@ -146169,7 +146502,7 @@ bkO
 lFM
 lAp
 tLf
-bJf
+xsc
 epP
 tZa
 vbD
@@ -147730,9 +148063,9 @@ iFv
 cFA
 bNL
 mqf
-sWr
+dRg
 iOw
-vDE
+phA
 vDE
 vDE
 vDE
@@ -152614,7 +152947,7 @@ aUA
 hUN
 dQj
 dQj
-xiQ
+dQj
 xiQ
 xiQ
 rNK
@@ -152869,9 +153202,9 @@ vbl
 xcF
 pyz
 lCV
+pLU
 kZm
 dQj
-rNK
 rNK
 fMl
 rNK
@@ -153125,12 +153458,12 @@ wTp
 wrc
 eUU
 fwe
+eUU
 rlw
 dNV
 dQj
 dQj
 dQj
-rNK
 rNK
 rNK
 rNK
@@ -153383,11 +153716,11 @@ eag
 bXX
 gZc
 exL
+lPl
 dtf
 gRM
 rBn
 aGx
-wdb
 wdb
 wdb
 lzH
@@ -153641,10 +153974,10 @@ dQj
 xtF
 xtF
 xtF
+xtF
 dQj
 dQj
 dQj
-sbG
 sbG
 sbG
 rNK
@@ -153889,8 +154222,8 @@ rNK
 rNK
 rNK
 rNK
-rNK
 dQj
+xtF
 miG
 iDa
 kZw
@@ -154146,9 +154479,9 @@ wdb
 wdb
 wdb
 wdb
-wdb
 ycO
 gRM
+nwp
 cSD
 hUs
 dQj
@@ -154403,7 +154736,7 @@ sbG
 sbG
 sbG
 sbG
-sbG
+dQj
 dQj
 dQj
 dQj

--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -38,13 +38,15 @@ GLOBAL_LIST_INIT(scarySounds, list('sound/weapons/thudswoosh.ogg','sound/weapons
 
 //If you don't want to fuck up disposals, add to this list, and don't change the order.
 //If you insist on changing the order, you'll have to change every sort junction to reflect the new order. --Pete
+//keep the number comments so it would be easy for you and others to set correct sortype -Beeb
 
-GLOBAL_LIST_INIT(TAGGERLOCATIONS, list("Disposals",
-	"Cargo Bay", "QM Office", "Engineering", "CE Office",
-	"Atmospherics", "HoS Office", "Security", "Medbay",
-	"CMO Office", "Chemistry", "Research", "RD Office",
-	"Robotics", "HoP Office", "Library", "Chapel", "Captain's Office",
-	"Bar", "Kitchen", "Hydroponics", "Janitor Closet","Genetics","Brig Physician", "Morgue"))
+GLOBAL_LIST_INIT(TAGGERLOCATIONS, list("Disposals", //1
+	"Cargo Bay", "QM Office", "Engineering", "CE Office", //2, 3, 4, 5
+	"Atmospherics", "HoS Office", "Security", "Medbay", //6, 7, 8, 9
+	"CMO Office", "Chemistry", "Research", "RD Office", //10, 11, 12 ,13
+	"Robotics", "HoP Office", "Library", "Chapel", //14, 15, 16, 17
+	"Captain's Office", "Bar", "Kitchen", "Hydroponics", //18, 19, 20, 21
+	"Janitor Closet","Genetics","Brig Physician", "Morgue")) //22, 23, 24, 25
 
 GLOBAL_LIST_INIT(hit_appends, list("-OOF", "-ACK", "-UGH", "-HRNK", "-HURGH", "-GLORF"))
 

--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -390,6 +390,16 @@
 			return TRUE
 	return ..()
 
+/turf/simulated/mineral/ancient/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+	for(var/turf/T in range(1, src))
+		var/area/A = get_area(T)
+		if(isspaceturf(T) || (!isonshuttle && (istype(A, /area/shuttle) || istype(A, /area/space))) || (isonshuttle && !istype(A, /area/shuttle)))
+			to_chat(S, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
+			S.target = null
+			return TRUE
+	return ..()
+
+
 /obj/structure/window/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	var/isonshuttle = istype(get_area(src), /area/shuttle)
 	for(var/turf/T in range(1, src))

--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -391,6 +391,7 @@
 	return ..()
 
 /turf/simulated/mineral/ancient/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+	var/isonshuttle = istype(loc, /area/shuttle)
 	for(var/turf/T in range(1, src))
 		var/area/A = get_area(T)
 		if(isspaceturf(T) || (!isonshuttle && (istype(A, /area/shuttle) || istype(A, /area/space))) || (isonshuttle && !istype(A, /area/shuttle)))

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -178,6 +178,27 @@
 	else
 		return attack_hand(user)
 
+
+/turf/simulated/mineral/ancient/burn_down()
+	return
+
+/turf/simulated/mineral/ancient/rpd_act()
+	return
+
+/turf/simulated/mineral/ancient/acid_act(acidpwr, acid_volume)
+	return
+
+/turf/simulated/mineral/ancient/ex_act(severity)
+	switch(severity)
+		if(3)
+			return
+		if(2)
+			if(prob(75))
+				gets_drilled(null, 1)
+		if(1)
+			gets_drilled(null, 1)
+	return TRUE
+
 /turf/simulated/mineral/ancient/outer
 	name = "cold ancient rock"
 	desc = "A rare and dense asteroid rock that appears to be resistant to everything except diamond and sonic tools! Can not be used to create portals to hell."
@@ -199,6 +220,9 @@
 		to_chat(user, "<span class='notice'>Only a diamond tools or a sonic jackhammer can break this rock.</span>")
 		return
 	return ..()
+
+/turf/simulated/mineral/ancient/outer/ex_act(severity)
+	return
 
 /turf/simulated/mineral/random
 	var/mineralSpawnChanceList = list(/turf/simulated/mineral/uranium = 5, /turf/simulated/mineral/diamond = 1, /turf/simulated/mineral/gold = 10,


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Fix: Дубликация камер
Add: Туалет во дормах возле команд отдела
Fix: на западе одна схема труб была без питания и мусор не долетал до карго. Теперь долетает.
Remove: Отобрали топорик из библии, поменяли на спички.
Add: Вернули зиппо святоще
Add: Холодильник ботаникам И раздатчики семян, вещей
Fix: КОСМОС ЗОНЫ возле кухни и в уборочной мелкой.
Add: Пожарные двери в некоторых местах
Fix: Свармеры и многие другие вещи больше не смогут легко сломать камни
Tweak: Разобрал все КОМАНДНЫЕ мусорные трубы. Раньше посылали в теха мостика(что тупо). Теперь личная посылка каждому главу :)
Add: Наномады на стенке по станции

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Фиксы
