### PR TITLE
Удаление стандартных модулей для КА из РНД

### DIFF
--- a/code/modules/research/designs/mining_designs.dm
+++ b/code/modules/research/designs/mining_designs.dm
@@ -71,36 +71,6 @@
 	build_path = /obj/item/borg/upgrade/modkit/trigger_guard
 	category = list("Mining")
 
-/datum/design/damage_mod
-	name = "Kinetic Accelerator Damage Mod"
-	desc = "A device which allows kinetic accelerators to deal more damage."
-	id = "damagemod"
-	req_tech = list("materials" = 5, "powerstorage" = 4, "engineering" = 4, "magnets" = 4, "combat" = 3)
-	build_type = PROTOLATHE | MECHFAB
-	materials = list(MAT_METAL = 2000, MAT_GLASS = 1500, MAT_GOLD = 1500, MAT_URANIUM = 1000)
-	build_path = /obj/item/borg/upgrade/modkit/damage
-	category = list("Mining", "Cyborg Upgrade Modules")
-
-/datum/design/cooldown_mod
-	name = "Kinetic Accelerator Cooldown Mod"
-	desc = "A device which decreases the cooldown of a Kinetic Accelerator."
-	id = "cooldownmod"
-	req_tech = list("materials" = 5, "powerstorage" = 4, "engineering" = 4, "magnets" = 4, "combat" = 3)
-	build_type = PROTOLATHE | MECHFAB
-	materials = list(MAT_METAL = 2000, MAT_GLASS = 1500, MAT_GOLD = 1500, MAT_URANIUM = 1000)
-	build_path = /obj/item/borg/upgrade/modkit/cooldown
-	category = list("Mining", "Cyborg Upgrade Modules")
-
-/datum/design/range_mod
-	name = "Kinetic Accelerator Range Mod"
-	desc = "A device which allows kinetic accelerators to fire at a further range."
-	id = "rangemod"
-	req_tech = list("materials" = 5, "powerstorage" = 4, "engineering" = 4, "magnets" = 4, "combat" = 3)
-	build_type = PROTOLATHE | MECHFAB
-	materials = list(MAT_METAL = 2000, MAT_GLASS = 1500, MAT_GOLD = 1500, MAT_URANIUM = 1000)
-	build_path = /obj/item/borg/upgrade/modkit/range
-	category = list("Mining", "Cyborg Upgrade Modules")
-
 /datum/design/hyperaccelerator
 	name = "Kinetic Accelerator Mining AoE Mod"
 	desc = "A modification kit for Kinetic Accelerators which causes it to fire AoE blasts that destroy rock."


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
В рнд больше нельзя создать стандартные модули для КА(Урон, дальность, скорость). Остальные модули не тронуты.

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1085982173041004564


## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
