### PR TITLE
FIX: правильная цена за призовые билеты

### DIFF
--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -29,7 +29,7 @@ RSF
 			list("Dice Pack", 50, /obj/item/storage/pill_bottle/dice),
 			list("Cigarette", 50, /obj/item/clothing/mask/cigarette/menthol),
 			list("Deck of cards", 50, /obj/item/deck/cards),
-			list("Prize ticket", 500, /obj/item/stack/tickets/five)
+			list("Prize ticket", 250, /obj/item/stack/tickets/five)
 		)
 		update_desc()
 


### PR DESCRIPTION
Я не понял под чем я был когда сказал 50 а поставил 100, исправляю.

## Описание
Делает цену билета в 50 энергии а не 100

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1087700013943099392

## Демонстрация изменений

