### PR TITLE
feat: Add admin verb for debugging incorrect fire overlay issue

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -166,6 +166,7 @@ GLOBAL_LIST_INIT(admin_verbs_debug, list(
 	/client/proc/map_template_upload,
 	/client/proc/view_runtimes,
 	/client/proc/admin_serialize,
+	/client/proc/check_fire_overlay,
 	/client/proc/jump_to_ruin,
 	/client/proc/toggle_medal_disable,
 	/client/proc/uid_log,

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -789,6 +789,21 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 	else
 		alert("Invalid mob")
 
+/client/proc/check_fire_overlay()
+	set category = "Debug"
+	set name = "Check fire overlay"
+
+	if(!check_rights(R_DEBUG))
+		return
+
+	if(!SSticker)
+		alert("Wait until the game starts")
+		return
+
+	var/message = "Значение GLOB.fire_overlay.icon = '[GLOB.fire_overlay.icon]', должно быть 'icons/goonstation/effects/fire.dmi', [GLOB.fire_overlay.icon == 'icons/goonstation/effects/fire.dmi'? "СОВПАДАЕТ" : "НЕ СОВПАДАЕТ"]. Значение GLOB.fire_overlay.icon_state = \"[GLOB.fire_overlay.icon_state]\", должно быть \"fire\", [GLOB.fire_overlay.icon_state == "fire"? "СОВПАДАЕТ" : "НЕ СОВПАДАЕТ"]."
+	message_admins("[message] Если в раунде предметы горят чем попало, но не огнем, то сообщите разработчикам в Discord в канал #обучающий-и-тестовый-полигон текст этого сообщения.")
+	log_admin(message)
+
 /client/proc/view_runtimes()
 	set category = "Debug"
 	set name = "View Runtimes"


### PR DESCRIPTION
## Описание
Данный PR добавляет debug-педаль с информацией для отладки бага, при котором предметы горят не спрайтом огня, а каким попало.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1090663512575066163/1090663512575066163
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
![image](https://user-images.githubusercontent.com/5000549/228941712-09d5bce1-b7a2-4434-8ea2-9b403b3c7336.png)
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
