### PR TITLE
Ниндзя: Различные QoL изменения и фиксы

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -704,7 +704,6 @@
 
 // This item actions have their own charges/cooldown system like spell procholders, but without all the unnecessary magic stuff
 /datum/action/item_action/advanced
-	check_flags = 0
 	var/recharge_text_color = "#FFFFFF"
 	var/charge_type = ADV_ACTION_TYPE_RECHARGE //can be recharge, toggle, toggle_recharge or charges, see description in the defines file
 	var/charge_max = 100 //recharge time in deciseconds if charge_type = "recharge" or "toggle_recharge", alternatively counts as starting charges if charge_type = "charges"
@@ -719,11 +718,14 @@
 	var/coold_overlay_icon = 'icons/mob/screen_white.dmi'
 	var/coold_overlay_icon_state = "template"
 	var/no_count = FALSE  // This means that the action is charged but unavailable due to something else
+	var/wait_time = 2 SECONDS // Prevents spamming the button. Only for "charges" type actions
+	var/last_use_time = null
 
 /datum/action/item_action/advanced/New()
 	. = ..()
 	still_recharging_msg = "<span class='notice'>[name] is still recharging.</span>"
 	icon_state_disabled = background_icon_state
+	last_use_time = world.time
 	if(charge_type == ADV_ACTION_TYPE_CHARGES)
 		UpdateButtonIcon()
 		add_charges_overlay()
@@ -773,6 +775,7 @@
 			start_recharge()
 		if(ADV_ACTION_TYPE_CHARGES)
 			charge_counter--
+			last_use_time = world.time
 			UpdateButtonIcon()
 			add_charges_overlay()
 
@@ -782,7 +785,8 @@
  * ignore_ready - Are we ignoring the "action_ready" flag? Usefull when u call this check indirrectly.
  */
 /datum/action/item_action/advanced/IsAvailable(show_message = FALSE, ignore_ready = FALSE)
-	. = ..()
+	if(!..())
+		return FALSE
 	switch(charge_type)
 		if(ADV_ACTION_TYPE_RECHARGE)
 			if(charge_counter < charge_max)
@@ -797,6 +801,10 @@
 					to_chat(owner, still_recharging_msg)
 				return FALSE
 		if(ADV_ACTION_TYPE_CHARGES)
+			if(world.time < last_use_time + wait_time)
+				if(show_message)
+					to_chat(owner, "<span class='notice'>[name] is already being used.</span>")
+				return FALSE
 			if(!charge_counter)
 				if(show_message)
 					to_chat(owner, "<span class='notice'>[name] has no charges left.</span>")

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -803,7 +803,7 @@
 		if(ADV_ACTION_TYPE_CHARGES)
 			if(world.time < last_use_time + wait_time)
 				if(show_message)
-					to_chat(owner, "<span class='notice'>[name] is already being used.</span>")
+					to_chat(owner, "<span class='warning'>[name] is already being used.</span>")
 				return FALSE
 			if(!charge_counter)
 				if(show_message)

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1013,9 +1013,9 @@ GLOBAL_LIST_EMPTY(all_objectives)
 				killer.assigned_targets.Add("[steal_objective.steal_target]")
 				killer.add_objective(steal_objective)
 				//Ну и банальное - Выживи
-				var/datum/objective/survive/survive_objective = new
-				survive_objective.owner = newtraitormind
-				killer.add_objective(survive_objective)
+				var/datum/objective/escape/escape_objective = new
+				escape_objective.owner = newtraitormind
+				killer.add_objective(escape_objective)
 			killer.greet()	// Вот теперь здороваемся!
 			killer.update_traitor_icons_added()	// Фикс худа, а то порой те кому выпал хиджак при ниндзя - получали замену целек, но не худа
 
@@ -1178,7 +1178,11 @@ GLOBAL_LIST_EMPTY(all_objectives)
 		if(player.current)
 			if(ismindshielded(player.current))
 				possible_changelings -= player
+				continue
 			if(player.current.dna.species.name in temp_gameMode.protected_species)
+				possible_changelings -= player
+				continue
+			if(player.assigned_role in temp_gameMode.protected_jobs)
 				possible_changelings -= player
 	if(possible_changelings.len)
 		var/changeling_num = max(1, round((SSticker.mode.num_players_started())/(config.traitor_scaling))+1)
@@ -1216,7 +1220,11 @@ GLOBAL_LIST_EMPTY(all_objectives)
 		if(player.current)
 			if(ismindshielded(player.current))
 				possible_vampires -= player
+				continue
 			if(player.current.dna.species.name in temp_gameMode.protected_species)
+				possible_vampires -= player
+				continue
+			if(player.assigned_role in temp_gameMode.protected_jobs)
 				possible_vampires -= player
 	if(possible_vampires.len)
 		var/vampires_num = max(1, round((SSticker.mode.num_players_started())/(config.traitor_scaling))+1)

--- a/code/game/gamemodes/spaceninja/ninja/machinery/ninja_mindscan_machine.dm
+++ b/code/game/gamemodes/spaceninja/ninja/machinery/ninja_mindscan_machine.dm
@@ -143,9 +143,9 @@
 	objective.scanned_occupants.Add("[occupant.mind]")
 	if(objective.target == occupant.mind || objective.scanned_occupants.len >= objective.scans_to_win)
 		objective.completed = TRUE
-		atom_say("Пациенту известна ценная информация! Данные переданы клану! Отличная работа [ninja]!")
+		atom_say("Пациенту известна ценная информация! Данные переданы клану! Отличная работа, [ninja]!")
 	else
-		atom_say("Пациенту не известна требуемая клану информация! И всё же были получены ценные обрывки информации... Продолжайте поиски!")
+		atom_say("Пациенту неизвестна требуемая клану информация! И всё же были получены ценные обрывки информации... Продолжайте поиски!")
 
 /obj/machinery/ninja_mindscan_machine/proc/take_occupant(var/mob/living/carbon/possible_occupant)
 	if(occupant)

--- a/code/game/gamemodes/spaceninja/ninja/machinery/ninja_mindscan_machine.dm
+++ b/code/game/gamemodes/spaceninja/ninja/machinery/ninja_mindscan_machine.dm
@@ -123,29 +123,29 @@
 	if(!occupant)
 		return
 	if(occupant.stat == DEAD)
-		atom_say("ERROR! Occupant is DEAD! Aborting!")
+		atom_say("ОШИБКА! Пациент МЁРТВ! Отмена сканирования!")
 		return
 	if("[occupant.mind]" in objective.scanned_occupants)
-		atom_say("ERROR! Occupant was already scanned before! Aborting!")
+		atom_say("ОШИБКА! Пациент уже сканировался ранее! Отмена сканирования!")
 		return
 	if(!(occupant.mind.assigned_role in objective.possible_roles))
-		atom_say("ERROR! Occupant's job is not on the list! Aborting!")
+		atom_say("ОШИБКА! Профессия пациент не сопадает с требуемыми кланом. Отмена сканирования!")
 		return
-	atom_say("Mind Scan initiated!")
+	atom_say("Сканирование разума начато!")
 	sleep(30)
-	atom_say("Analyzing nerve pattern for [occupant.real_name]")
+	atom_say("Анализ нервной системы пациента: [occupant.real_name]")
 	sleep(30)
 	atom_say("[rand(1, 50)]%")
 	sleep(50)
 	atom_say("[rand(51, 99)]%")
 	sleep(30)
-	atom_say("Mind Scan - Task completed!")
+	atom_say("Сканирование разума - Задача завершена!")
 	objective.scanned_occupants.Add("[occupant.mind]")
 	if(objective.target == occupant.mind || objective.scanned_occupants.len >= objective.scans_to_win)
 		objective.completed = TRUE
-		atom_say("Occupant knows valuable information! Info has been transferred to the clan! Well done [ninja]!")
+		atom_say("Пациенту известна ценная информация! Данные переданы клану! Отличная работа [ninja]!")
 	else
-		atom_say("Occupant does not know the information requested by the Clan! Still some information was usefull... Search more!")
+		atom_say("Пациенту не известна требуемая клану информация! И всё же были получены ценные обрывки информации... Продолжайте поиски!")
 
 /obj/machinery/ninja_mindscan_machine/proc/take_occupant(var/mob/living/carbon/possible_occupant)
 	if(occupant)

--- a/code/game/gamemodes/spaceninja/ninja/suit/ninja_equipment_actions/ninja_healing_chems.dm
+++ b/code/game/gamemodes/spaceninja/ninja/suit/ninja_equipment_actions/ninja_healing_chems.dm
@@ -17,10 +17,9 @@
 	if(ninjacost(0,N_HEAL))
 		return
 	var/mob/living/carbon/human/ninja = affecting
-	if(alert(ninja, "Вы уверены что хотите ввести себе эксперементальную лечащую сыворотку? Реагент не стабилен и может вызывать редкие парадоксы времени и пространства!",,"Да","Нет") == "Нет")
-		return
 	ninja.reagents.add_reagent("chiyurizine", 25)	//The 25 dose is important. Reagent won't work if you add less. And it will overdose if you add 30 or more
 	to_chat(ninja, span_notice("Реагенты успешно введены в пользователя."))
+	atom_say("Spider-OS напоминает вам, вы можете отслеживать количество реагента в крови с помощью встроенных сканеров.")
 	add_attack_logs(ninja, null, "Activated healing chems.")
 	for(var/datum/action/item_action/advanced/ninja/ninjaheal/ninja_action in actions)
 		ninja_action.use_action()

--- a/code/game/gamemodes/spaceninja/ninja/suit/ninja_equipment_actions/ninja_spirit_form.dm
+++ b/code/game/gamemodes/spaceninja/ninja/suit/ninja_equipment_actions/ninja_spirit_form.dm
@@ -4,7 +4,7 @@
 	Which allows passing almost through anything, at the cost of a big passive increase to energy consumption. \
 	Also all restraining effects like handcuffs will drop off from you! \
 	Remember that this module is still a prototipe and won't make you invincible! Passively encrease suit energy consumption."
-	check_flags = AB_CHECK_CONSCIOUS
+	check_flags = AB_CHECK_LYING | AB_CHECK_CONSCIOUS
 	charge_type = ADV_ACTION_TYPE_TOGGLE_RECHARGE
 	charge_max = 25 SECONDS
 	use_itemicon = FALSE

--- a/code/game/gamemodes/spaceninja/ninja/suit/suit_SpiderOS.dm
+++ b/code/game/gamemodes/spaceninja/ninja/suit/suit_SpiderOS.dm
@@ -6,6 +6,7 @@
 /datum/action/item_action/advanced/ninja/SpiderOS
 	name = "SpiderOS"
 	desc = "Your personal integrated suit AI that will help you configure yourself for the upcoming mission!"
+	check_flags = NONE
 	charge_type = ADV_ACTION_TYPE_TOGGLE
 	use_itemicon = FALSE
 	icon_icon = 'icons/mob/actions/actions_ninja.dmi'
@@ -176,7 +177,7 @@
 				return
 			switch(SSshuttle.moveShuttle(shuttle_controller.shuttleId, destination, TRUE, usr))
 				if(0)
-					atom_say("Shuttle departing!")
+					atom_say("Шаттл отправляется!")
 					usr.create_log(MISC_LOG, "remotedly used [shuttle_controller] to call the [shuttle_controller.shuttleId] shuttle")
 					if(!shuttle_controller.moved)
 						shuttle_controller.moved = TRUE

--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -12,7 +12,7 @@
 	config_tag = "vampire"
 	restricted_jobs = list("AI", "Cyborg")
 	protected_jobs = list("Security Officer", "Security Cadet", "Warden", "Detective", "Head of Security", "Captain", "Blueshield", "Nanotrasen Representative", "Security Pod Pilot", "Magistrate", "Chaplain", "Brig Physician", "Internal Affairs Agent", "Nanotrasen Navy Officer", "Nanotrasen Navy Field Officer", "Special Operations Officer", "Supreme Commander", "Syndicate Officer")
-	protected_species = list("Machine")
+	protected_species = list("Machine", "Голем")
 	required_players = 15
 	required_enemies = 1
 	recommended_enemies = 4

--- a/code/modules/events/ninja.dm
+++ b/code/modules/events/ninja.dm
@@ -15,6 +15,12 @@
 
 /datum/event/space_ninja/start()
 	processing = 0 //so it won't fire again in next tick
+	var/list/check_list = GLOB.player_list
+	for(var/mob/new_player/lobby_player in check_list)
+		check_list -= lobby_player
+	if(length(check_list) < 25)
+		message_admins("Space Ninja event failed to start. Not enough players.")
+		return
 	if(!get_ninja())
 		message_admins("Space Ninja event failed to find players. Retrying in 30s.")
 		addtimer(CALLBACK(src, .proc/get_ninja), 5 SECONDS)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
* Adv_action-ы теперь реально учитывают состояние игрока запрещая их юзать.(До этого изменения оказывается можно было юзать абилки лёжа, в стане и т.д...)
* Теперь у Adv_action-ов типа "charges" есть небольшой скрытый кулдаун, дабы предотвратить случайный спам и трату большего, чем надо, количества зарядов способностей.
* Ужесточила проверки при доспавне генокрадов и вампиров для целей ниндзя. Больше никаких вампиров священников или големов...
* Локализовала atom_say костюма и устройств ниндзя
* Лечащий коктейль больше не высвечивает окно подтверждения. Это не нужно так как его типу экшнов добавлен маленький кд.
* При активации лечащего коктейля костюм напоминает ниндзя через atom_say о том, чтобы он следил за реагентом в крови.
* Форму духа больше нельзя прожать лёжа. (Спасёт новеньких от панического клика абилки в стане. Убьёт стареньких пока они лежат на стеклянном столе ими же разбитом :P)
* Мидраунд ивент на ниндзя теперь требует минимум 25 активных человек на станции для активации.

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Баги и неудобства - плохо.
