### PR TITLE
Fix: successfull clearing users from bots USERlist.

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -441,12 +441,6 @@ Returns 1 if the chain up to the area contains the given typepath
 		A = A.loc
 	return 0
 
-// the on-close client verb
-// called when a browser popup window is closed after registering with proc/onclose()
-// if a valid atom reference is supplied, call the atom's Topic() with "close=1"
-// otherwise, just reset the client mob's machine var.
-
-
 // returns the turf located at the map edge in the specified direction relative to A
 // used for mass driver
 /proc/get_edge_target_turf(var/atom/A, var/direction)

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -831,10 +831,9 @@ Pass a positive integer as an argument to override a bot's default speed.
 	users |= M
 	var/dat = {"<meta charset="UTF-8">"}
 	dat += get_controls(M)
-	var/datum/browser/popup = new(M,window_id,window_name,350,600)
+	var/datum/browser/popup = new(M,window_id,window_name,350,600,src)
 	popup.set_content(dat)
 	popup.open()
-	onclose(M,window_id,ref=src)
 	return
 
 /mob/living/simple_animal/bot/proc/update_controls()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
### Проблема решена Кусием, за что ему огромное спасибо. 
Во-первых убирает из хелпера ненужную подсказку к удалённому коду, которая сбивает с толку. Во-вторых убирает дублирующийся браузерный прок в коде окошка ботов, который мешал полноценно проигрываться коду Топика ботов.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР
Проблему заметил сам, может с недели две-три назад. Теперь дошли руки. Боты записывали себе в список ЮЗЕРов любого игрока, который открыл окошко управления ботом, но из-за продублированого прока боты не выписывали людей из списка по закрытию окошка. В итоге у ИИшки, у гостов и даже и живых игроков в отличающемся секторе, выскакивало окошка мулбота каждый раз, когда кто-то провоцировал его обновление.<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
