### PR TITLE
fix: Ratvarian Clothing Slot

### DIFF
--- a/code/game/gamemodes/clockwork/clockwork_items.dm
+++ b/code/game/gamemodes/clockwork/clockwork_items.dm
@@ -206,6 +206,7 @@
 	desc = "A razor-sharp spear made of brass. It thrums with barely-contained energy."
 	icon = 'icons/obj/clockwork.dmi'
 	icon_state = "ratvarian_spear0"
+	slot_flags = SLOT_BACK
 	force = 12
 	force_unwielded = 12
 	force_wielded = 20

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -758,8 +758,10 @@
 					to_chat(H, "Вы как-то достали костюм без хранения разрешенных предметов. Прекратите это.")
 				return FALSE
 			if(I.w_class > WEIGHT_CLASS_BULKY)
+				if(isclocker(H) && (istype(I, /obj/item/twohanded/ratvarian_spear) || istype(I, /obj/item/twohanded/clock_hammer)))
+					return TRUE
 				if(!disable_warning)
-					to_chat(H, "[name] слишком большой, чтобы прикрепить.")
+					to_chat(H, "[I] слишком большой, чтобы прикрепить.")
 				return FALSE
 			if(istype(I, /obj/item/pda) || istype(I, /obj/item/pen) || is_type_in_list(I, H.wear_suit.allowed))
 				return TRUE


### PR DESCRIPTION
## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
По какой-то неведомой причине есть дополнительная проверка того, какой размер у предмета, помещённого в слот костюма. Тогда как все предметы которые туда могут быть помещены и так фиксированы списком у каждого костюма.

## Ссылка на предложение/Причина создания ПР
Костыльный фикс позволяющий носить копьё и молот Ратвара в слоте костюма, поскольку они обладают гигантским размером.
