### PR TITLE
fix: Fix non-simple mobs in pipes breathing turf air instead of pipe air

### DIFF
--- a/code/ATMOSPHERICS/pipes/pipe.dm
+++ b/code/ATMOSPHERICS/pipes/pipe.dm
@@ -65,6 +65,11 @@
 		return 0
 	return parent.air
 
+/obj/machinery/atmospherics/pipe/remove_air(amount)
+	if(!parent)
+		return 0
+	return parent.air.remove(amount)
+
 /obj/machinery/atmospherics/pipe/build_network(remove_deferral = FALSE)
 	if(!parent)
 		parent = new /datum/pipeline()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Сейчас гуманоидные мобы, находясь в трубах, дышат воздухом не из трубы, а из турфа. Данный PR исправляет это, добавляя отсутствующий метод, без которого дыхание фоллбэчится на дыхание из турфа.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багфикс https://discord.com/channels/617003227182792704/1091732120851972147/1091732120851972147
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->