### PR TITLE
fix: Shadowling Handle Life

### DIFF
--- a/code/modules/mob/living/carbon/human/species/shadowling.dm
+++ b/code/modules/mob/living/carbon/human/species/shadowling.dm
@@ -49,7 +49,6 @@
 			H.adjustCloneLoss(-1)
 			H.SetWeakened(0)
 			H.SetStunned(0)
-	..()
 
 
 /datum/species/shadow/ling/lesser //Empowered thralls. Obvious, but powerful
@@ -81,4 +80,3 @@
 			H.adjustToxLoss(-5)
 			H.adjustBrainLoss(-25)
 			H.adjustCloneLoss(-1)
-	..()


### PR DESCRIPTION
## Описание
<!--  -->
Итак, почему данное наследование не нужно тенелингам. В данный момент прок `handle_life` делает всё что нужно у тенелинга, затем возвращается к обычной тени. У обычной тени происходит по сути всё то же самое, только вот у неё `lightamount  > 2`, тогда как у тенелингов урон начинает проходить лишь с 4 (`#define LIGHT_DAM_THRESHOLD 4`). Итого, урон из ниоткуда и непонятно зачем. Плюс ко всему те же алёрты создаются повторно:

![7uiFokz](https://user-images.githubusercontent.com/35403274/229394384-a7b74d76-2a80-47d9-960a-1430a1d34b54.png)


Далее идет наследование к самому первому проку, который наносит единицу брута после крита, если цель не дышит. Это нужно только всяким големам, которые иначе бы не умирали после крита. При наличии света, тенелинги продолжают получать урон от ожогов даже в критическом состоянии:

![8DRnF4l](https://user-images.githubusercontent.com/35403274/229394924-b7e6e1e6-9fc3-431c-b11b-d2fb223b45e4.png)

Подводя итоги, оба этих наследования не несут ничего, кроме ещё больших страданий тенелингам от света.



Вторая проблема касается низшего тенелинга. Он проходит весь цикл наследования (включая своего родителя, лул). Таким образом у него уже тройные дебаффы на свету. Не думаю что так было задумано.

![y2Lo4zr](https://user-images.githubusercontent.com/35403274/229395476-2c092e2c-744b-40d2-99de-6aa37dbb03f2.png)

