### PR TITLE
fix: fruit wine runtime

### DIFF
--- a/code/_globalvars/lists/reagents.dm
+++ b/code/_globalvars/lists/reagents.dm
@@ -46,7 +46,7 @@ GLOBAL_LIST_INIT(blocked_chems, list("polonium", "initropidril", "concentrated_i
 							"syndicate_nanites", "ripping_tendrils", "boiling_oil",
 							"envenomed_filaments", "lexorin_jelly", "kinetic",
 							"cryogenic_liquid", "dark_matter", "b_sorium",
-							"reagent", "life","dragonsbreath", "nanocalcium", "bungotoxin"))
+							"reagent", "life","dragonsbreath", "nanocalcium", "bungotoxin", "fruit_wine"))
 
 GLOBAL_LIST_INIT(safe_chem_list, list("antihol", "charcoal", "epinephrine", "insulin", "teporone","silver_sulfadiazine", "salbutamol",
 									  "omnizine", "stimulants", "synaptizine", "potass_iodide", "oculine", "mannitol", "styptic_powder",

--- a/code/game/objects/items/random_items.dm
+++ b/code/game/objects/items/random_items.dm
@@ -92,13 +92,13 @@
 
 /obj/item/reagent_containers/food/drinks/bottle/random_drink/Initialize()
 	. = ..()
-	var/datum/reagent/R
-	if (prob(50 * length(special_drinks) / (length(special_drinks) + length(GLOB.drinks))))
-		R = pick(special_drinks)
+	var/datum/reagent/reagent
+	if(prob(50 * length(special_drinks) / (length(special_drinks) + length(GLOB.drinks))))
+		reagent = pick(special_drinks)
 	else
-		R = pick(GLOB.drinks)
-
-	var/datum/reagent/reagent = R
+		reagent = pick(GLOB.drinks)
+		if(initial(reagent.id) in GLOB.blocked_chems)
+			reagent = pick(special_drinks)
 
 	reagents.add_reagent(initial(reagent.id), volume)
 	name = "unlabelled bottle"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Недавно сделали, чтобы в GLOB.drinks были все возможные напитки. На кибериаде, что у нас используется для тестов, есть шкаф со случайными напитками, которое берёт как раз из drinks. Фруктовое вино нельзя добавлять без предварительной data(оттого что оно особенное) и оно рантаймит, к тому же в этом шкафу мог появиться щитспавновый алкоголь. Поэтому добавляем вино в заблокированные реагенты и делаем так, чтобы они не появлялись в этом шкафу.
Сейчас эти заблокированные реагенты используются только для убирания из другого со случайными реагентами.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Крестики - плохо. Пример: https://github.com/ss220-space/Paradise/actions/runs/4589975904/jobs/8105221899
Щитспавновый алкоголь на кибериаде стартом - тоже нехорошо.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
