### PR TITLE
fix: Runechat improvements

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -223,8 +223,6 @@
 	#define COMPONENT_MOVABLE_BLOCK_PRE_MOVE (1<<0)
 ///from base of atom/movable/Moved(): (/atom, dir)
 #define COMSIG_MOVABLE_MOVED "movable_moved"
-///fomr base of atom/movable/Moved(): (/atom, dir)
-#define COMSIG_MOVABLE_HOLDER_MOVED "movable_holder_moved"
 ///from base of atom/movable/Cross(): (/atom/movable)
 #define COMSIG_MOVABLE_CROSS "movable_cross"
 ///from base of atom/movable/Crossed(): (/atom/movable)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -203,7 +203,7 @@
 		return
 
 	if(.)
-		Moved(oldloc, direct)
+		Moved(oldloc, direct, FALSE)
 
 	last_move = direct
 	src.move_speed = world.time - src.l_move_time
@@ -279,7 +279,7 @@
 		if(old_z != dest_z)
 			onTransitZ(old_z, dest_z)
 
-	Moved(old_loc, NONE)
+	Moved(old_loc, NONE, TRUE)
 
 	return 1
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -301,8 +301,6 @@
 	if(client)
 		reset_perspective(destination)
 	update_canmove() //if the mob was asleep inside a container and then got forceMoved out we need to make them fall.
-	update_runechat_msg_location()
-
 
 //Called whenever an object moves and by mobs when they attempt to move themselves through space
 //And when an object or action applies a force on src, see newtonian_move() below

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -215,8 +215,6 @@
 // Called after a successful Move(). By this point, we've already moved
 /atom/movable/proc/Moved(atom/OldLoc, Dir, Forced = FALSE)
 	SEND_SIGNAL(src, COMSIG_MOVABLE_MOVED, OldLoc, Dir, Forced)
-	for(var/atom/movable/atom in contents)
-		SEND_SIGNAL(atom, COMSIG_MOVABLE_HOLDER_MOVED, OldLoc, Dir, Forced)
 	if(!inertia_moving)
 		inertia_next_move = world.time + inertia_move_delay
 		newtonian_move(Dir)

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -148,7 +148,7 @@
 
 		// Create map text message
 		if (client?.prefs.toggles2 & PREFTOGGLE_2_RUNECHAT) // can_hear is checked up there on L99
-			create_chat_message(speaker.runechat_msg_location, message_clean, FALSE, italics)
+			create_chat_message(speaker, message_clean, FALSE, italics)
 
 		var/effect = SOUND_EFFECT_NONE
 		if(isrobot(speaker))

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -286,8 +286,3 @@
 	if((src_object in view(src)) && get_dist(src_object, src) <= user.client.view)
 		return STATUS_INTERACTIVE	// interactive (green visibility)
 	return user.shared_living_ui_distance()
-
-
-/obj/item/mmi/forceMove(atom/destination)
-	. = ..()
-	brainmob?.update_runechat_msg_location()

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -108,11 +108,3 @@ I'm using this for Stat to give it a more nifty interface to work with
 
 /mob/living/carbon/brain/can_hear()
 	. = TRUE
-
-/mob/living/carbon/brain/update_runechat_msg_location()
-	if(ismecha(loc))
-		runechat_msg_location = loc
-	else if(container)
-		runechat_msg_location = container
-	else
-		runechat_msg_location = src

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1942,12 +1942,6 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 /mob/living/carbon/human/get_runechat_color()
    return dna.species.get_species_runechat_color(src)
 
-/mob/living/carbon/human/update_runechat_msg_location()
-	if(ismecha(loc))
-		runechat_msg_location = loc
-	else
-		runechat_msg_location = src
-
 /mob/living/carbon/human/limb_attack_self()
 	var/obj/item/organ/external/arm = hand ? get_organ(BODY_ZONE_L_ARM) : get_organ(BODY_ZONE_R_ARM)
 	if(arm)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1309,7 +1309,7 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 	//This communication is imperfect because the holopad "filters" voices and is only designed to connect to the master only.
 	var/rendered = "<i><span class='game say'>Relayed Speech: <span class='name'>[name_used]</span> [message]</span></i>"
 	if(client?.prefs.toggles2 & PREFTOGGLE_2_RUNECHAT)
-		create_chat_message(M.runechat_msg_location, message_clean, TRUE, FALSE)
+		create_chat_message(M, message_clean, TRUE, FALSE)
 	show_message(rendered, 2)
 
 /mob/living/silicon/ai/proc/malfhacked(obj/machinery/power/apc/apc)
@@ -1459,10 +1459,3 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 
 	SEND_SIGNAL(src, COMSIG_MOB_UPDATE_SIGHT)
 	sync_lighting_plane_alpha()
-
-
-/mob/living/silicon/ai/update_runechat_msg_location()
-	if(istype(loc, /obj/item/aicard) || ismecha(loc))
-		runechat_msg_location = loc
-	else
-		runechat_msg_location = src

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -555,10 +555,3 @@
 	flashlight_on = FALSE
 	set_light(0)
 	card.set_light(0)
-
-
-/mob/living/silicon/pai/update_runechat_msg_location()
-	if(istype(loc, /obj/item/paicard))
-		runechat_msg_location = loc
-	else
-		runechat_msg_location = src

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -63,9 +63,3 @@
 /mob/living/simple_animal/shade/sword/Initialize(mapload)
 	.=..()
 	status_flags |= GODMODE
-
-/mob/living/simple_animal/shade/update_runechat_msg_location()
-	if(istype(loc, /obj/item/soulstone))
-		runechat_msg_location = loc
-	else
-		runechat_msg_location = src

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -33,8 +33,6 @@
 	input_focus = src
 	reset_perspective(src)
 	prepare_huds()
-	runechat_msg_location = src
-	update_runechat_msg_location()
 	. = ..()
 
 /atom/proc/prepare_huds()
@@ -1502,13 +1500,6 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 		blood_state = BLOOD_STATE_NOT_BLOODY
 		update_inv_shoes()
 	update_icons()	//apply the now updated overlays to the mob
-
-
-/**
- * Updates the mob's runechat maptext display location.
- */
-/mob/proc/update_runechat_msg_location()
-	return
 
 ///Makes a call in the context of a different usr. Use sparingly
 /world/proc/invoke_callback_with_usr(mob/user_mob, datum/callback/invoked_callback, ...)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -205,9 +205,5 @@
 
 	var/obj/effect/proc_holder/ranged_ability //Any ranged ability the mob has, as a click override
 
-
-	/// The location our runechat message should appear. Should be src by default.
-	var/atom/runechat_msg_location
-
 	/// The datum receiving keyboard input. parent mob by default.
 	var/datum/input_focus = null


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Сейчас рунчат работает неконсистентно. Для каждого рунчата выбирается атом (либо сам моб, либо меха), который показывает рунчат. Это приводит к нежелательным последствиям:
* рунчат исчезает, если моб с рунчатом закрывается в шкафу;
* исчезает, если мышь с рунчатом берется мобом;
* рунчат моба в мехе не такого же цвета, как рунчат моба вне меха;
* рунчат остается в мехе, если моб выйдет из него (см. скриншот);
![image](https://user-images.githubusercontent.com/5000549/229502844-d60e32ab-b03e-4def-bf26-bd7a88b6baf1.png)
* и в других случаях.

Данный PR исправляет это, оптимальным образом динамически меняя атом рунчата.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багфикс.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
Рунчат мыши всегда в корректном месте. На гифке длительность рунчата увеличена в демонстрационных целях.
![runechat_improved](https://user-images.githubusercontent.com/5000549/229501193-4592c6a7-6fb2-4def-929f-ec676bd1de01.gif)