### PR TITLE
Fix: #2545 blocking makeshift item equiping on makeshift mecha.

### DIFF
--- a/code/game/mecha/makeshift/makeshift_tools.dm
+++ b/code/game/mecha/makeshift/makeshift_tools.dm
@@ -6,8 +6,8 @@
 	drill_delay = 15
 
 /obj/item/mecha_parts/mecha_equipment/drill/makeshift/can_attach(obj/mecha/M as obj)
-	if(..())
-		if(istype(M, /obj/mecha/makeshift) || istype(M, /obj/mecha/combat/lockersyndie))
+	if(istype(M, /obj/mecha/makeshift) || istype(M, /obj/mecha/combat/lockersyndie))
+		if(M.equipment.len < M.max_equip)
 			return TRUE
 	return FALSE
 
@@ -18,7 +18,7 @@
 	dam_force = 10
 
 /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/makeshift/can_attach(obj/mecha/M as obj)
-	if(..())
-		if(istype(M, /obj/mecha/makeshift) || istype(M, /obj/mecha/combat/lockersyndie))
+	if(istype(M, /obj/mecha/makeshift) || istype(M, /obj/mecha/combat/lockersyndie))
+		if(M.equipment.len < M.max_equip)
 			return TRUE
 	return FALSE


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Исправляет созданный мною баг при котором самодельные модули для мехов не ставились на обычный локермех.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР
Не знаю что именно и где пошло не так (или наоборот так), но на тестах проблемы не было. На лайве проблема наследования проявилась и, собственно, мне и исправлять.<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
