### PR TITLE
Fix: Убирание лава-пруфа после лодки

### DIFF
--- a/code/game/turfs/simulated/floor/lava.dm
+++ b/code/game/turfs/simulated/floor/lava.dm
@@ -61,10 +61,10 @@
 /turf/simulated/floor/plating/lava/proc/burn_stuff(AM)
 	. = 0
 
-	if(find_safeties())
+	if(locate(/obj/vehicle/lavaboat) in src.contents)
 		return FALSE
 
-	if(locate(/obj/vehicle/lavaboat) in src.contents)
+	if(find_safeties())
 		return FALSE
 
 	var/thing_to_check = src

--- a/code/game/turfs/simulated/floor/lava.dm
+++ b/code/game/turfs/simulated/floor/lava.dm
@@ -64,6 +64,9 @@
 	if(find_safeties())
 		return FALSE
 
+	if(locate(/obj/vehicle/lavaboat) in src.contents)
+		return FALSE
+
 	var/thing_to_check = src
 	if(AM)
 		thing_to_check = list(AM)

--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -181,19 +181,6 @@
 			last_message_time = world.time
 		return FALSE
 
-/obj/vehicle/lavaboat/Destroy()
-	for(var/mob/living/M in buckled_mobs)
-		M.weather_immunities -= "lava"
-	return ..()
-
-/obj/vehicle/lavaboat/user_buckle_mob(mob/living/M, mob/user)
-	M.weather_immunities |= "lava"
-	return ..()
-
-/obj/vehicle/lavaboat/unbuckle_mob(mob/living/buckled_mob, force)
-	. = ..()
-	buckled_mob.weather_immunities -= "lava"
-
 /obj/item/oar
 	name = "oar"
 	icon = 'icons/obj/vehicles.dmi'


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Меняет систему защиты от лавы от лодок. Вместо выдачи иммуна пристегнотому, оно делает тайл с лавой "Безопасным", что фиксит баг когда оно убирало пруф от лавы если человек его имел ещё до лодки.
Да, замена одного костыля другим.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багфикс, репорт - https://discord.com/channels/617003227182792704/1092408576846352485
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->