### PR TITLE
FIX: Team Fortress 220

### DIFF
--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -94,6 +94,7 @@
 		toggle_light()
 
 /obj/item/clothing/head/helmet/space/plasmaman/equipped(mob/living/carbon/human/user, slot)
+	..()
 	if(HUDType && slot == slot_head)
 		var/datum/atom_hud/H = GLOB.huds[HUDType]
 		H.add_hud_to(user)


### PR DESCRIPTION
возвращает иконки экшенов лампочки и шлемаков плазмачам

## Ссылка на предложение/Причина создания ПР
я говнокодер и новым свойством шапкам сломал старые функции
