### PR TITLE
FEAT: Антиголь для КПБ

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -1189,6 +1189,22 @@
 	update_flags |= M.adjustBrainLoss(-3, FALSE)
 	return ..() | update_flags
 
+//Coolant: Antihol
+/datum/reagent/medicine/coolant
+	name = "Coolant"
+	id = "coolant"
+	description = "Fixes speech bugs"
+	reagent_state = LIQUID
+	color = "#0af0f0"
+	process_flags = SYNTHETIC
+	taste_description = "error"
+
+/datum/reagent/medicine/coolant/on_mob_life(mob/living/M)
+	var/update_flags = STATUS_UPDATE_NONE
+	M.SetSlur(0)
+	M.AdjustDrunk(-4)
+	M.reagents.remove_all_type(/datum/reagent/consumable/ethanol/synthanol, 8, 0, 1)
+	return ..() | update_flags
 
 
 //Trek-Chems. DO NOT USE THES OUTSIDE OF BOTANY OR FOR VERY SPECIFIC PURPOSES. NEVER GIVE A RECIPE UNDER ANY CIRCUMSTANCES//

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -266,6 +266,15 @@
 	mix_message = "A minty and refreshing smell drifts from the effervescent mixture."
 	mix_sound = 'sound/goonstation/misc/drinkfizz.ogg'
 
+/datum/chemical_reaction/coolant
+	name = "Coolant"
+	id = "coolant"
+	result = "coolant"
+	required_reagents = list("cryostylane" = 1, "liquid_solder" = 1)
+	result_amount = 2
+	mix_message = "You swear you saw a blue cat.. nevermind"
+	mix_sound = 'sound/goonstation/misc/drinkfizz.ogg'
+
 /datum/chemical_reaction/teporone
 	name = "Teporone"
 	id = "teporone"


### PR DESCRIPTION
Добавляет аналог антиголя для КПБ Coolant, делается из жидкого солдата и криостилана.

## Описание
аналог антиголя

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1092196524378837093

## Демонстрация изменений
зашли за КПБ, скрафтили, выпили, смотрим на VV строчку Drunk, если падает - значит все нормально(наверное). Но так как она падает, значит все работает.
