### PR TITLE
FIX: Невосполнение шейкера сервисного юнита при кормлении куклы

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -44,15 +44,36 @@
 			else
 				to_chat(user, "<span class='warning'>[C]'s face is obscured, so[C.p_they()] cant eat.</span>")
 			return FALSE
+
+		var/list/transfer_data = reagents.get_transferred_reagents(C, amount_per_transfer_from_this)
 		if(C.eat(src, user))
 			if(isrobot(user)) //Cyborg modules that include drinks automatically refill themselves, but drain the borg's cell
-				var/mob/living/silicon/robot/borg = user
-				borg.cell.use(30)
-				var/refill = reagents.get_master_reagent_id()
-				if(refill in GLOB.drinks) // Only synthesize drinks
-					addtimer(CALLBACK(reagents, /datum/reagents.proc/add_reagent, refill, bitesize), 600)
+				if(length(transfer_data))
+					SynthesizeDrinkFromTransfer(M, user, transfer_data)
 			return TRUE
 	return FALSE
+
+/obj/item/reagent_containers/food/drinks/proc/SynthesizeDrinkFromTransfer(obj/target, mob/user, list/transfer_data)
+
+	var/list/ids_data = list()
+	var/trans = 0
+
+	transfer_data &= GLOB.drinks
+
+	for(var/thing in transfer_data)
+		var/datum/reagent/R = thing
+		ids_data[initial(R.id)] = transfer_data[R]
+		trans += transfer_data[R]
+
+	if(isrobot(user) && length(ids_data)) //Cyborg modules that include drinks automatically refill themselves, but drain the borg's cell
+		var/mob/living/silicon/robot/bro = user
+		var/chargeAmount = max(30,4*trans)
+		bro.cell.use(chargeAmount)
+		to_chat(user, "<span class='notice'>Now synthesizing [trans] units of cocktail...</span>")
+		addtimer(CALLBACK(reagents, /datum/reagents.proc/add_reagent_list, ids_data), 300)
+		addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat, user, "<span class='notice'>Cyborg [src] refilled.</span>"), 300)
+	else
+		reagents.add_reagent_list(ids_data)
 
 /obj/item/reagent_containers/food/drinks/MouseDrop(atom/over_object) //CHUG! CHUG! CHUG!
 	if(!iscarbon(over_object))
@@ -95,27 +116,12 @@
 			to_chat(user, "<span class='warning'> [target] is full.</span>")
 			return FALSE
 
-		var/list/transfer_data
-		var/list/ids_data = list()
-		if(isrobot(user))
-			transfer_data = reagents.get_transferred_reagents(target, amount_per_transfer_from_this)
-
 		var/trans = reagents.trans_to(target, amount_per_transfer_from_this)
+
+		if(isrobot(user))
+			SynthesizeDrinkFromTransfer(target, user, reagents)
+
 		to_chat(user, "<span class='notice'> You transfer [trans] units of the solution to [target].</span>")
-
-		transfer_data &= GLOB.drinks
-
-		for(var/thing in transfer_data)
-			var/datum/reagent/R = thing
-			ids_data[initial(R.id)] = transfer_data[R]
-
-		if(isrobot(user) && ids_data) //Cyborg modules that include drinks automatically refill themselves, but drain the borg's cell
-			var/mob/living/silicon/robot/bro = user
-			var/chargeAmount = max(30,4*trans)
-			bro.cell.use(chargeAmount)
-			to_chat(user, "<span class='notice'>Now synthesizing [trans] units of cocktail...</span>")
-			addtimer(CALLBACK(reagents, /datum/reagents.proc/add_reagent_list, ids_data), 300)
-			addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat, user, "<span class='notice'>Cyborg [src] refilled.</span>"), 300)
 
 	else if(target.is_drainable()) //A dispenser. Transfer FROM it TO us.
 		if(!is_refillable())

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -65,15 +65,18 @@
 		ids_data[initial(R.id)] = transfer_data[R]
 		trans += transfer_data[R]
 
-	if(isrobot(user) && length(ids_data)) //Cyborg modules that include drinks automatically refill themselves, but drain the borg's cell
-		var/mob/living/silicon/robot/bro = user
-		var/chargeAmount = max(30,4*trans)
-		bro.cell.use(chargeAmount)
-		to_chat(user, "<span class='notice'>Now synthesizing [trans] units of cocktail...</span>")
-		addtimer(CALLBACK(reagents, /datum/reagents.proc/add_reagent_list, ids_data), 300)
-		addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat, user, "<span class='notice'>Cyborg [src] refilled.</span>"), 300)
+	if(length(ids_data))
+		if(isrobot(user)) //Cyborg modules that include drinks automatically refill themselves, but drain the borg's cell
+			var/mob/living/silicon/robot/bro = user
+			var/chargeAmount = max(30,4*trans)
+			bro.cell.use(chargeAmount)
+			to_chat(user, "<span class='notice'>Now synthesizing [trans] units of cocktail...</span>")
+			addtimer(CALLBACK(reagents, /datum/reagents.proc/add_reagent_list, ids_data), 300)
+			addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat, user, "<span class='notice'>Cyborg [src] refilled.</span>"), 300)
+		else
+			reagents.add_reagent_list(ids_data)
 	else
-		reagents.add_reagent_list(ids_data)
+		return
 
 /obj/item/reagent_containers/food/drinks/MouseDrop(atom/over_object) //CHUG! CHUG! CHUG!
 	if(!iscarbon(over_object))

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -116,10 +116,11 @@
 			to_chat(user, "<span class='warning'> [target] is full.</span>")
 			return FALSE
 
+		var/list/transfer_data = reagents.get_transferred_reagents(target, amount_per_transfer_from_this)
 		var/trans = reagents.trans_to(target, amount_per_transfer_from_this)
 
 		if(isrobot(user))
-			SynthesizeDrinkFromTransfer(target, user, reagents)
+			SynthesizeDrinkFromTransfer(user, transfer_data)
 
 		to_chat(user, "<span class='notice'> You transfer [trans] units of the solution to [target].</span>")
 

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -49,11 +49,11 @@
 		if(C.eat(src, user))
 			if(isrobot(user)) //Cyborg modules that include drinks automatically refill themselves, but drain the borg's cell
 				if(length(transfer_data))
-					SynthesizeDrinkFromTransfer(M, user, transfer_data)
+					SynthesizeDrinkFromTransfer(user, transfer_data)
 			return TRUE
 	return FALSE
 
-/obj/item/reagent_containers/food/drinks/proc/SynthesizeDrinkFromTransfer(obj/target, mob/user, list/transfer_data)
+/obj/item/reagent_containers/food/drinks/proc/SynthesizeDrinkFromTransfer(mob/user, list/transfer_data)
 
 	var/list/ids_data = list()
 	var/trans = 0

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -71,8 +71,8 @@
 			var/chargeAmount = max(30,4*trans)
 			bro.cell.use(chargeAmount)
 			to_chat(user, "<span class='notice'>Now synthesizing [trans] units of cocktail...</span>")
-			addtimer(CALLBACK(reagents, /datum/reagents.proc/add_reagent_list, ids_data), 300)
-			addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat, user, "<span class='notice'>Cyborg [src] refilled.</span>"), 300)
+			addtimer(CALLBACK(reagents, /datum/reagents.proc/add_reagent_list, ids_data), 30 SECONDS)
+			addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat, user, "<span class='notice'>Cyborg [src] refilled.</span>"), 30 SECONDS)
 		else
 			reagents.add_reagent_list(ids_data)
 	else


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправляет невозможность регенерации напитков шейкера сервисного борга при вскармливании.
Задал такую же логику, как и при пополнении контейнеров содержимим из шейкера.

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

Не учли в реворке сервисного борга эту особенность. Из-за этого изначальная задумка с регенерацией напитков не работала, т.к метод пополнения не был обновлен.

Технические особенности:
При пополнении реагентов шло обращение на поиск строки в списке GLOB.drinks (typepath'ов), в результате чего при вскармливании всегда не было возможности пополнить реагенты в шейкере сервисного юнита.

https://github.com/ss220-space/Paradise/pull/2390