### PR TITLE
Fix: returning 3-round burst firing to burst disabler and correcting names on pod equip.

### DIFF
--- a/code/modules/research/designs/spacepod_designs.dm
+++ b/code/modules/research/designs/spacepod_designs.dm
@@ -93,8 +93,8 @@
 
 /datum/design/pod_gun_taser
 	construction_time = 200
-	name = "Spacepod Equipment (Taser)"
-	desc = "Allows for the construction of a spacepod mounted taser."
+	name = "Spacepod Equipment (Disabler)"
+	desc = "Allows for the construction of a spacepod mounted disabler."
 	id = "podgun_taser"
 	build_type = PODFAB
 	req_tech = list("materials" = 2, "combat" = 2)
@@ -105,8 +105,8 @@
 
 /datum/design/pod_gun_btaser
 	construction_time = 200
-	name = "Spacepod Equipment (Burst Taser)"
-	desc = "Allows for the construction of a spacepod mounted taser. This is the burst-fire model."
+	name = "Spacepod Equipment (Burst Disabler)"
+	desc = "Allows for the construction of a spacepod mounted disabler. This is the burst-fire model."
 	id = "podgun_btaser"
 	build_type = PODFAB
 	req_tech = list("materials" = 3, "combat" = 3)
@@ -141,8 +141,8 @@
 
 /datum/design/pod_mining_laser_basic
 	construction_time = 200
-	name = "Basic Mining Laser"
-	desc = "Allows for the construction of a weak mining laser"
+	name = "Spacepod Equipment (Kinetic Accelerator)"
+	desc = "Allows for the construction of a kinetic accelerator"
 	id = "pod_mining_laser_basic"
 	req_tech = list("materials" = 3, "powerstorage" = 2, "engineering" = 2, "magnets" = 3, "combat" = 2)
 	build_type = PODFAB
@@ -152,8 +152,8 @@
 
 /datum/design/pod_mining_laser
 	construction_time = 200
-	name = "Mining Laser"
-	desc = "Allows for the construction of a mining laser."
+	name = "Spacepod Equipment (Industrial Kinetic Accelerator)"
+	desc = "Allows for the construction of a industrial kinetic accelerator."
 	id = "pod_mining_laser"
 	req_tech = list("materials" = 6, "powerstorage" = 6, "engineering" = 5, "magnets" = 6, "combat" = 4)
 	build_type = PODFAB

--- a/code/modules/spacepods/equipment.dm
+++ b/code/modules/spacepods/equipment.dm
@@ -90,7 +90,7 @@
 
 /obj/item/spacepod_equipment/weaponry/taser
 	name = "disabler system"
-	desc = "A weak taser system for space pods, fires disabler beams."
+	desc = "A weak disabler system for space pods, fires disabler beams."
 	icon_state = "weapon_taser"
 	projectile_type = /obj/item/projectile/beam/disabler
 	shot_cost = 800
@@ -99,12 +99,12 @@
 	harmful = FALSE
 
 /obj/item/spacepod_equipment/weaponry/burst_taser
-	name = "burst taser system"
-	desc = "A weak taser system for space pods, this one fires 3 at a time."
+	name = "burst disabler system"
+	desc = "A weak disabler system for space pods, this one fires 3 round burst at a time."
 	icon_state = "weapon_burst_taser"
 	projectile_type = /obj/item/projectile/beam/disabler
-	shot_cost = 800
-	shots_per = 2
+	shot_cost = 1200
+	shots_per = 3
 	fire_sound = 'sound/weapons/taser.ogg'
 	fire_delay = 30
 	harmful = FALSE
@@ -129,8 +129,8 @@
 
 // MINING LASERS
 /obj/item/spacepod_equipment/weaponry/mining_laser_basic
-	name = "weak mining laser system"
-	desc = "A weak mining laser system for space pods, fires bursts of energy that cut through rock."
+	name = "kinetic accelerator system"
+	desc = "A kinetic accelerator system for space pods, fires bursts of kinetic force that cut through rock."
 	icon = 'icons/goonstation/pods/ship.dmi'
 	icon_state = "pod_taser"
 	projectile_type = /obj/item/projectile/kinetic/pod
@@ -139,8 +139,8 @@
 	fire_sound = 'sound/weapons/kenetic_accel.ogg'
 
 /obj/item/spacepod_equipment/weaponry/mining_laser
-	name = "mining laser system"
-	desc = "A mining laser system for space pods, fires bursts of energy that cut through rock."
+	name = "industrial kinetic accelerator system"
+	desc = "A industrial kinetic accelerator system for space pods, fires heavy bursts of kinetic force that cut through rock."
 	icon = 'icons/goonstation/pods/ship.dmi'
 	icon_state = "pod_m_laser"
 	projectile_type = /obj/item/projectile/kinetic/pod/regular


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Возвращает по ошибке отобранную у бурстового лазера ... бурстовость. Наконец поправляет названия у пушек для пода и для них же в фабрикаторе, ссылаясь на их текущий функционал (Дисейблеры теперь дисейблеры, а не тазеры; КАшки теперь КАшки, а не "шахтёрские лазеры").<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на баг-репорт
https://discord.com/channels/617003227182792704/1092989645161242695<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
