### PR TITLE
fix: Fix photocopier having fax icon

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/ussp_laboratory.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/ussp_laboratory.dmm
@@ -2246,7 +2246,6 @@
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/photocopier{
-	icon_state = "fax";
 	layer = 3.5;
 	pixel_y = 8
 	},


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Фотокопир имел иконку факса, что приводило к визуальным глитчам при его работе.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багфикс https://discord.com/channels/617003227182792704/1092864547200700556/1092864547200700556
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->