### PR TITLE
FEAT: Мимдзюцу для мимов

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -220,7 +220,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "Contains two manuals to teach you advanced Mime skills. You will be able to shoot stunning bullets out of your fingers, and create large walls that can block an entire hallway!"
 	reference = "AM"
 	item = /obj/item/storage/box/syndie_kit/mimery
-	cost = 6
+	cost = 7
 	job = list("Mime")
 
 //Miner

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -279,6 +279,7 @@
 	..()
 	new /obj/item/spellbook/oneuse/mime/greaterwall(src)
 	new	/obj/item/spellbook/oneuse/mime/fingergun(src)
+	new /obj/item/mimejutsu_scroll(src)
 
 
 /obj/item/storage/box/syndie_kit/atmosn2ogrenades

--- a/code/modules/martial_arts/combos/mimejutsu/silent_palm.dm
+++ b/code/modules/martial_arts/combos/mimejutsu/silent_palm.dm
@@ -9,5 +9,5 @@
 						"<span class='userdanger'>[user] hovers [user.p_their()] palm over your face!</span>")
 
 		var/atom/throw_target = get_edge_target_turf(target, get_dir(target, get_step_away(target, user)))
-		target.throw_at(throw_target, 200, 4, user)
+		target.throw_at(throw_target, 4, 4, user)
 	return MARTIAL_COMBO_DONE_BASIC_HIT

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -107,8 +107,8 @@
 	var/armor_block = D.run_armor_check(affecting, "melee")
 
 	playsound(D.loc, attack.attack_sound, 25, 1, -1)
-	D.visible_message("<span class='danger'>[A] has [atk_verb]ed [D]!</span>", \
-								"<span class='userdanger'>[A] has [atk_verb]ed [D]!</span>")
+	D.visible_message("<span class='danger'>[A] has [atk_verb] [D]!</span>", \
+								"<span class='userdanger'>[A] has [atk_verb] [D]!</span>")
 
 	D.apply_damage(damage, BRUTE, affecting, armor_block)
 	objective_damage(A, D, damage, BRUTE)


### PR DESCRIPTION
Добавляет берет Мимдзюцу в набор продвинутых пантомим, который дает три прикольных приема ближнего боя.

Исправил "Ударилed" баг с БИ, теперь будут нормальные аттак логи.

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1093160174707015812

## Демонстрация изменений
Зашли за мима, получили аплинк, стоит теперь 7 ТК :suki:, в коробке теперь лежит берет-свиток обучающий мимдзюцу.