### PR TITLE
fix: Jetpack fixes

### DIFF
--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -116,11 +116,11 @@
 	return TRUE
 
 /obj/machinery/portable_atmospherics/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/tank))
+	var/obj/item/tank/T = W
+	if(istype(T) && T.fillable)
 		if(!(stat & BROKEN))
 			if(!user.drop_item())
 				return
-			var/obj/item/tank/T = W
 			user.drop_item()
 			if(src.holding)
 				to_chat(user, "<span class='notice'>[holding ? "In one smooth motion you pop [holding] out of [src]'s connector and replace it with [T]" : "You insert [T] into [src]"].</span>")

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -159,6 +159,7 @@
 	volume = 1
 	slot_flags = null
 	gas_type = null
+	fillable = FALSE
 	var/datum/gas_mixture/temp_air_contents
 	var/obj/item/tank/internals/tank = null
 	var/mob/living/carbon/human/cur_user

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -83,6 +83,12 @@
 
 	return 1
 
+/obj/item/tank/jetpack/Moved(OldLoc, Dir, Forced)
+	var/mob/living/carbon/human/holder = loc
+	if(on && !(istype(loc) && holder.back == src))
+		turn_off()
+	..()
+
 /obj/item/tank/jetpack/improvised
 	name = "improvised jetpack"
 	desc = "A jetpack made from two air tanks, a fire extinguisher and some atmospherics equipment. It doesn't look like it can hold much."

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -173,6 +173,9 @@
 /obj/item/tank/jetpack/suit/attack_self()
 	return
 
+/obj/item/tank/jetpack/suit/examine(mob/user)
+	. = ..(user, show_contents_info = FALSE)
+
 /obj/item/tank/jetpack/suit/cycle(mob/user)
 	if(!istype(loc, req_suit_type))
 		to_chat(user, "<span class='warning'>[src] must be connected to a [req_suit_name]!</span>")

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -35,8 +35,12 @@
 		var/datum/action/A = X
 		A.UpdateButtonIcon()
 
-/obj/item/tank/jetpack/proc/cycle(mob/user)
+/obj/item/tank/jetpack/proc/cycle(mob/user, must_be_on_back = TRUE)
 	if(user.incapacitated())
+		return
+
+	if(must_be_on_back && src != user.back)
+		to_chat(user, "<span class='warning'>You need [src] to be on your back!</span>")
 		return
 
 	if(!on)
@@ -184,7 +188,7 @@
 	if(!istype(H.s_store, /obj/item/tank))
 		to_chat(user, "<span class='warning'>You need a tank in your suit storage!</span>")
 		return
-	..()
+	..(user, must_be_on_back = FALSE)
 
 /obj/item/tank/jetpack/suit/turn_on(mob/user)
 	if(!istype(loc, req_suit_type) || !ishuman(loc.loc) || loc.loc != user)

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -19,12 +19,6 @@
 			if("carbon dioxide")
 				air_contents.carbon_dioxide = ((6 * ONE_ATMOSPHERE) * volume / (R_IDEAL_GAS_EQUATION * T20C))
 
-/obj/item/tank/jetpack/on_mob_move(direction, mob/user)
-	if(on)
-		var/turf/T = get_step(src, GetOppositeDir(direction))
-		if(!has_gravity(T))
-			new /obj/effect/particle_effect/ion_trails(T, direction)
-
 /obj/item/tank/jetpack/ui_action_click(mob/user, actiontype)
 	if(actiontype == /datum/action/item_action/toggle_jetpack || actiontype == /datum/action/item_action/toggle_jetpack/ninja)
 		cycle(user)
@@ -65,7 +59,7 @@
 	stabilizers = FALSE
 	icon_state = initial(icon_state)
 
-/obj/item/tank/jetpack/proc/allow_thrust(num, mob/living/user)
+/obj/item/tank/jetpack/proc/allow_thrust(num, mob/living/user, should_leave_trail)
 	if(!on)
 		return 0
 	if((num < 0.005 || air_contents.total_moles() < num))
@@ -79,6 +73,10 @@
 
 	var/turf/T = get_turf(user)
 	T.assume_air(removed)
+
+	if(!has_gravity(T) && should_leave_trail)
+		new /obj/effect/particle_effect/ion_trails(T)
+
 	return 1
 
 /obj/item/tank/jetpack/improvised
@@ -89,7 +87,7 @@
 	volume = 20 //normal jetpacks have 70 volume
 	gas_type = null //it starts empty
 
-/obj/item/tank/jetpack/improvised/allow_thrust(num, mob/living/user)
+/obj/item/tank/jetpack/improvised/allow_thrust(num, mob/living/user, should_leave_trail)
 	if(rand(0, 250) == 0)
 		to_chat(user, "<span class='notice'>You feel your jetpack's engines cut out.</span>")
 		turn_off(user)
@@ -230,3 +228,6 @@
 	for(jetpack_action in actions)
 		jetpack_action.button_icon = 'icons/mob/actions/actions_ninja.dmi'
 		jetpack_action.background_icon_state = "background_green"
+
+/obj/item/tank/jetpack/suit/ninja/allow_thrust(num, mob/living/user, should_leave_trail)
+	. = ..(num, user, cur_user?.alpha != NINJA_ALPHA_INVISIBILITY && should_leave_trail)

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -72,8 +72,11 @@
 		C.internal = src
 	C.update_action_buttons_icon()
 
-/obj/item/tank/examine(mob/user)
+/obj/item/tank/examine(mob/user, show_contents_info = TRUE)
 	. = ..()
+
+	if(!show_contents_info)
+		return
 
 	var/obj/icon = src
 	if(istype(loc, /obj/item/assembly))

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -16,6 +16,7 @@
 	var/distribute_pressure = ONE_ATMOSPHERE
 	var/integrity = 3
 	var/volume = 70
+	var/fillable = TRUE
 
 /obj/item/tank/New()
 	..()

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -5,25 +5,29 @@
 	. += dna.species.movement_delay(src)
 
 /mob/living/carbon/human/Process_Spacemove(movement_dir = 0)
-
 	if(..())
 		return TRUE
 
-	//Do we have a working jetpack?
-	var/obj/item/tank/jetpack/thrust
+	var/jetpacks = list()
+
 	if(istype(back, /obj/item/tank/jetpack))
-		thrust = back
-	else if(istype(wear_suit, /obj/item/clothing/suit/space/hardsuit))
-		var/obj/item/clothing/suit/space/hardsuit/C = wear_suit
-		thrust = C.jetpack
-	else if(istype(wear_suit, /obj/item/clothing/suit/space/space_ninja))
-		var/obj/item/clothing/suit/space/space_ninja/C = wear_suit
-		thrust = C.jetpack
-	if(thrust)
-		if((movement_dir || thrust.stabilizers) && thrust.allow_thrust(0.01, src, should_leave_trail = movement_dir))
+		jetpacks += back
+
+	var/obj/item/clothing/suit/space/hardsuit/H = wear_suit
+	if(istype(H) && H.jetpack)
+		jetpacks += H.jetpack
+
+	var/obj/item/clothing/suit/space/space_ninja/SN = wear_suit
+	if(istype(SN) && SN.jetpack)
+		jetpacks += SN.jetpack
+
+	for(var/obj/item/tank/jetpack/jetpack in jetpacks)
+		if((movement_dir || jetpack.stabilizers) && jetpack.allow_thrust(0.01, src, should_leave_trail = movement_dir))
 			return TRUE
+
 	if(dna.species.spec_Process_Spacemove(src))
 		return TRUE
+
 	return FALSE
 
 /mob/living/carbon/human/mob_has_gravity()

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -20,7 +20,7 @@
 		var/obj/item/clothing/suit/space/space_ninja/C = wear_suit
 		thrust = C.jetpack
 	if(thrust)
-		if((movement_dir || thrust.stabilizers) && thrust.allow_thrust(0.01, src))
+		if((movement_dir || thrust.stabilizers) && thrust.allow_thrust(0.01, src, should_leave_trail = movement_dir))
 			return TRUE
 	if(dna.species.spec_Process_Spacemove(src))
 		return TRUE


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Данный PR исправляет следующие проблемы с джетпаками:
* Джетпаки, встроенные в риг, теперь корректно будут оставлять след. Включенный в руке джетпак, фактически не работающий вне слота спины, след оставлять не будет. Джетпак ниндзи в невидимости тоже будет без следа.
* У джетпак апгрейда убрана информация о газах и возможность интеракции с канистрами, так как эта механика запутывала. Газы из джетпак апгрейда не используются.
* Наспинные джетпаки нельзя включить, пока они не на спине, добавлена подсказка. До этого их можно было включить в руке и они даже иногда оставляли след работающего джетпака, это запутывало.
* Фиксит баг, при котором выключенный джетпак на спине не позволял использовать включенный джетпак в риге.
* Выключает джетпак, если он снят со стены.

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/734823601110515882/1093409783719133214 плюс другие обнаруженные по ходу проблемы.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
