### PR TITLE
fix: Fix weapon cooldown starting too late because of sleep()

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -37,25 +37,24 @@
 		return 0
 
 	for(var/i=1 to get_shot_amount())
-		var/obj/item/projectile/A = new projectile(curloc)
-		A.firer = chassis.occupant
-		A.original = target
-		A.current = curloc
+		spawn((i - 1) * projectile_delay)
+			var/obj/item/projectile/A = new projectile(curloc)
+			A.firer = chassis.occupant
+			A.original = target
+			A.current = curloc
 
-		var/spread = 0
-		if(variance)
-			if(randomspread)
-				spread = round((rand() - 0.5) * variance)
-			else
-				spread = round((i / projectiles_per_shot - 0.5) * variance)
-		A.preparePixelProjectile(target, targloc, chassis.occupant, params, spread)
+			var/spread = 0
+			if(variance)
+				if(randomspread)
+					spread = round((rand() - 0.5) * variance)
+				else
+					spread = round((i / projectiles_per_shot - 0.5) * variance)
+			A.preparePixelProjectile(target, targloc, chassis.occupant, params, spread)
 
-		chassis.use_power(energy_drain)
-		projectiles--
-		A.fire()
-		playsound(chassis, fire_sound, 50, 1)
-
-		sleep(max(0, projectile_delay))
+			chassis.use_power(energy_drain)
+			projectiles--
+			A.fire()
+			playsound(chassis, fire_sound, 50, 1)
 	log_message("Fired from [name], targeting [target].")
 	add_attack_logs(chassis.occupant, target, "fired a [src]")
 	start_cooldown()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
В проке стрельбы оружием мехов из-за синхронного `sleep` кулдаун с блокировкой оружия начинался слишком поздно, давая игроку возможность пустить дополнительные очереди в это временное окно. Данный PR исправляет это.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/734823601110515882/1093599855642943648
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
