### PR TITLE
fix: Fix automated announcer runtiming

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -217,7 +217,7 @@
 			to_chat(src, "<span class='warning'>You feel your headset vibrate but can hear nothing from it!</span>")
 	else
 		to_chat(src, "[part_a][track || speaker_name][part_b][message]</span></span>")
-		if(client?.prefs.toggles2 & PREFTOGGLE_2_RUNECHAT)
+		if(client?.prefs.toggles2 & PREFTOGGLE_2_RUNECHAT && !istype(speaker, /mob/living/automatedannouncer))
 			create_chat_message(speaker, message_clean, TRUE, FALSE)
 		if(src != speaker || isrobot(src) || isAI(src))
 			var/effect = SOUND_EFFECT_RADIO

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -215,17 +215,8 @@
 	if(!can_hear())
 		if(prob(20))
 			to_chat(src, "<span class='warning'>You feel your headset vibrate but can hear nothing from it!</span>")
-	else if(track)
-		to_chat(src, "[part_a][track][part_b][message]</span></span>")
-		if(client?.prefs.toggles2 & PREFTOGGLE_2_RUNECHAT)
-			create_chat_message(speaker, message_clean, TRUE, FALSE)
-		if(src != speaker || isrobot(src) || isAI(src))
-			var/effect = SOUND_EFFECT_RADIO
-			if(isrobot(speaker))
-				effect = SOUND_EFFECT_RADIO_ROBOT
-			INVOKE_ASYNC(GLOBAL_PROC, /proc/tts_cast, src, src, message_tts, speaker.tts_seed, FALSE, effect, null, null, 'sound/effects/radio_chatter.ogg')
 	else
-		to_chat(src, "[part_a][speaker_name][part_b][message]</span></span>")
+		to_chat(src, "[part_a][track || speaker_name][part_b][message]</span></span>")
 		if(client?.prefs.toggles2 & PREFTOGGLE_2_RUNECHAT)
 			create_chat_message(speaker, message_clean, TRUE, FALSE)
 		if(src != speaker || isrobot(src) || isAI(src))


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Automated announcer при попытке создать рунчат выдавал ошибку в рантайме, так как является абстрактным и не привязан к реальным объектам в мире. Данный PR исправляет это.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/734823601110515882/1093550617038946394 багфикс
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
