### PR TITLE
FEAT: Гачи пояс

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -17167,7 +17167,7 @@
 	},
 /obj/machinery/light/small,
 /obj/structure/closet/crate,
-/obj/item/storage/belt/champion,
+/obj/item/storage/belt/champion/wrestling/true,
 /obj/item/stack/sheet/mineral/gold,
 /obj/item/stack/sheet/mineral/gold,
 /turf/simulated/floor/plasteel{

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -59177,7 +59177,7 @@
 /obj/structure/closet/crate{
 	name = "Silver Crate"
 	},
-/obj/item/storage/belt/champion,
+/obj/item/storage/belt/champion/wrestling/true,
 /obj/item/stack/sheet/mineral/gold{
 	pixel_y = 2
 	},

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -20187,7 +20187,7 @@
 	name = "west station intercom (General)";
 	pixel_x = -28
 	},
-/obj/item/storage/belt/champion,
+/obj/item/storage/belt/champion/wrestling/true,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "vault"

--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -205,8 +205,8 @@ GLOBAL_LIST_INIT(potential_theft_objectives_collect, subtypesof(/datum/theft_obj
 	name = "золотой кубок"
 
 /datum/theft_objective/hard/belt_champion
-	typepath = /obj/item/storage/belt/champion
-	name = "чемпионский пояс"
+	typepath = /obj/item/storage/belt/champion/wrestling/true
+	name = "пояс Истинного Чемпиона"
 
 /datum/theft_objective/hard/unica
 	typepath = /obj/item/gun/projectile/revolver/mateba

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -324,9 +324,7 @@
 	item_state = "champion"
 	materials = list(MAT_GOLD=400)
 	storage_slots = 1
-	can_hold = list(
-		"/obj/item/clothing/mask/luchador"
-		)
+	can_hold = list("/obj/item/clothing/mask")
 
 /obj/item/storage/belt/military
 	name = "military belt"

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -210,13 +210,17 @@
 	name = "Wrestling Belt"
 	var/datum/martial_art/wrestling/style = new
 
+/obj/item/storage/belt/champion/wrestling/true
+	name = "Пояс Истинного Чемпиона"
+	desc = "Вы - лучший! и Вы это знаете!"
+
 /obj/item/storage/belt/champion/wrestling/equipped(mob/user, slot)
 	if(!ishuman(user))
 		return
 	if(slot == slot_belt)
 		var/mob/living/carbon/human/H = user
 		style.teach(H,1)
-		to_chat(user, "<span class='sciradio'>You have an urge to flex your muscles and get into a fight. You have the knowledge of a thousand wrestlers before you. You can remember more by using the Recall teaching verb in the wrestling tab.</span>")
+		to_chat(user, "<span class='sciradio'>You have an urge to flex your muscles and get into a fight. You have the knowledge of a thousand wrestlers before you. You can remember more by using the show info verb in the martial arts tab.</span>")
 	return
 
 /obj/item/storage/belt/champion/wrestling/dropped(mob/user)

--- a/code/modules/martial_arts/wrestling.dm
+++ b/code/modules/martial_arts/wrestling.dm
@@ -1,6 +1,6 @@
 /datum/martial_art/wrestling
 	name = "Wrestling"
-	help_verb = /mob/living/carbon/human/proc/wrestling_help
+	has_explaination_verb = TRUE
 
 //	combo refence since wrestling uses a different format to sleeping carp and plasma fist.
 //	Clinch "G"
@@ -57,12 +57,8 @@
 	D.apply_damage(10, STAMINA, affecting, armor_block)
 	return 1
 
-/mob/living/carbon/human/proc/wrestling_help()
-	set name = "Recall Teachings"
-	set desc = "Remember how to wrestle."
-	set category = "Wrestling"
-
+/datum/martial_art/wrestling/give_explaination(user = usr)
 	to_chat(usr, "<b><i>You flex your muscles and have a revelation...</i></b>")
-	to_chat(usr, "<span class='notice'>Clinch</span>: Grab. Passively gives you a chance to immediately aggressively grab someone. Not always successful.")
+	to_chat(usr, "<span class='notice'>Clinch</span>: Grab. Passively gives you a 50% chance to immediately aggressively grab someone.")
 	to_chat(usr, "<span class='notice'>Suplex</span>: Disarm someone you are grabbing. Suplexes your target to the floor. Greatly injures them and leaves both you and your target on the floor.")
-	to_chat(usr, "<span class='notice'>Advanced grab</span>: Grab. Passively causes stamina damage when grabbing someone.")
+	to_chat(usr, "<span class='notice'>Advanced grab</span>: Grab. Passively causes 10 stamina damage when grabbing someone.")


### PR DESCRIPTION

## Описание
Заменяет в хранилище нюки на всех станциях пояс чемпиона на пояс Истинного Чемпиона, дающий боевое искусство рестлинга. Заменил цель вора на спиздить пояс чемпиона на новый пояс, сделал рабочую вкладку Martial arts с подсказками для рестлинга. Пояс теперь может вмещать все маски.

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1093824342804135937

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
