### PR TITLE
fix: Checking Weight No More

### DIFF
--- a/code/game/gamemodes/clockwork/clockwork_items.dm
+++ b/code/game/gamemodes/clockwork/clockwork_items.dm
@@ -206,6 +206,7 @@
 	desc = "A razor-sharp spear made of brass. It thrums with barely-contained energy."
 	icon = 'icons/obj/clockwork.dmi'
 	icon_state = "ratvarian_spear0"
+	slot_flags = SLOT_BACK
 	force = 12
 	force_unwielded = 12
 	force_wielded = 20

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -674,7 +674,7 @@
 
 			if(!H.w_uniform && !nojumpsuit && (!O || !(O.status & ORGAN_ROBOT)))
 				if(!disable_warning)
-					to_chat(H, "<span class='alert'>Вам нужен комбинезон перед тем как вы сможете прикрепить [name].</span>")
+					to_chat(H, "<span class='alert'>Вам нужен комбинезон перед тем как вы сможете прикрепить [I].</span>")
 				return FALSE
 			if(!(I.slot_flags & SLOT_BELT))
 				return
@@ -696,7 +696,7 @@
 
 			if(!H.w_uniform && !nojumpsuit && (!O || !(O.status & ORGAN_ROBOT)))
 				if(!disable_warning)
-					to_chat(H, "<span class='alert'>Вам нужен комбинезон перед тем как вы сможете прикрепить [name].</span>")
+					to_chat(H, "<span class='alert'>Вам нужен комбинезон перед тем как вы сможете прикрепить [I].</span>")
 				return FALSE
 			if(!(I.slot_flags & SLOT_ID))
 				return FALSE
@@ -708,7 +708,7 @@
 
 			if(!H.w_uniform && !nojumpsuit && (!O || !(O.status & ORGAN_ROBOT)))
 				if(!disable_warning)
-					to_chat(H, "<span class='alert'>Вам нужен комбинезон перед тем как вы сможете прикрепить [name].</span>")
+					to_chat(H, "<span class='alert'>Вам нужен комбинезон перед тем как вы сможете прикрепить [I].</span>")
 				return FALSE
 			if(!(I.slot_flags & SLOT_PDA))
 				return FALSE
@@ -722,7 +722,7 @@
 
 			if(!H.w_uniform && !nojumpsuit && (!O || !(O.status & ORGAN_ROBOT)))
 				if(!disable_warning)
-					to_chat(H, "<span class='alert'>Вам нужен комбинезон перед тем как вы сможете прикрепить [name].</span>")
+					to_chat(H, "<span class='alert'>Вам нужен комбинезон перед тем как вы сможете прикрепить [I].</span>")
 				return FALSE
 			if(I.slot_flags & SLOT_DENYPOCKET)
 				return
@@ -737,7 +737,7 @@
 
 			if(!H.w_uniform && !nojumpsuit && (!O || !(O.status & ORGAN_ROBOT)))
 				if(!disable_warning)
-					to_chat(H, "<span class='alert'>Вам нужен комбинезон перед тем как вы сможете прикрепить [name].</span>")
+					to_chat(H, "<span class='alert'>Вам нужен комбинезон перед тем как вы сможете прикрепить [I].</span>")
 				return FALSE
 			if(I.slot_flags & SLOT_DENYPOCKET)
 				return FALSE
@@ -751,15 +751,11 @@
 				return FALSE
 			if(!H.wear_suit)
 				if(!disable_warning)
-					to_chat(H, "<span class='alert'>Вам нужен костюм перед тем как вы сможете прикрепить [name].</span>")
+					to_chat(H, "<span class='alert'>Вам нужен костюм перед тем как вы сможете прикрепить [I].</span>")
 				return FALSE
 			if(!H.wear_suit.allowed)
 				if(!disable_warning)
 					to_chat(H, "Вы как-то достали костюм без хранения разрешенных предметов. Прекратите это.")
-				return FALSE
-			if(I.w_class > WEIGHT_CLASS_BULKY)
-				if(!disable_warning)
-					to_chat(H, "[name] слишком большой, чтобы прикрепить.")
 				return FALSE
 			if(istype(I, /obj/item/pda) || istype(I, /obj/item/pen) || is_type_in_list(I, H.wear_suit.allowed))
 				return TRUE
@@ -777,7 +773,7 @@
 		if(slot_tie)
 			if(!H.w_uniform)
 				if(!disable_warning)
-					to_chat(H, "<span class='warning'>Вам нужен комбинезон перед тем как вы сможете прикрепить [name].</span>")
+					to_chat(H, "<span class='warning'>Вам нужен комбинезон перед тем как вы сможете прикрепить [I].</span>")
 				return FALSE
 			var/obj/item/clothing/under/uniform = H.w_uniform
 			if(uniform.accessories.len && !uniform.can_attach_accessory(H))


### PR DESCRIPTION
## Описание
<!--  -->
Убирает проверку на вес у предметов, помещаемых в слот костюма. Данная проверка не нужна, потому что все предметы, которые можно поместить в данный слот, уже определены заранее, у каждого из костюмов.

Также теперь в текстовом сообщении выводится ошибка с названием предмета, а не гуманоида, который им оперировал.

## Ссылка на предложение/Причина создания ПР
<!--  -->
Исправляем невозможность положить молот/копьё Ратвара в слот кирасы/робы. Плюс копьё Ратвара можно носить на спине, как и все остальные копья.
