### PR TITLE
fix: Force ninja to drop all highrisk items before self gib

### DIFF
--- a/code/__HELPERS/atoms.dm
+++ b/code/__HELPERS/atoms.dm
@@ -18,3 +18,33 @@
 		processing_list += checked_atom.contents
 		if(istype(checked_atom, type))
 			. += checked_atom
+
+/// Forces atom to drop all the important items while dereferencing them from their
+/// containers both ways. To be used to preserve important items before mob gib/self-gib.
+/atom/proc/drop_ungibbable_items()
+	for(var/atom/movable/I in contents)
+		if(!is_type_in_list(I, GLOB.ungibbable_items_types))
+			if(length(I.contents))
+				I.drop_ungibbable_items()
+			continue
+
+		var/mob/holder_mob = I.loc
+		if(istype(holder_mob))
+			holder_mob.unEquip(I)
+			continue
+
+		I.forceMove(get_turf(I))
+		for(var/var_name in vars)
+			// Item may be referenced in some properties of container.
+			// E.g. holsters.
+			if(vars[var_name] == I)
+				vars[var_name] = null
+			// Item may be referenced in some list properties of container.
+			// E.g. medals.
+			else if(I in vars[var_name])
+				vars[var_name] -= I
+		for(var/var_name in I.vars)
+			// Item may reference container in some properties.
+			// E.g. medals.
+			if(I.vars[var_name] == src)
+				I.vars[var_name] = null

--- a/code/game/gamemodes/spaceninja/ninja/suit/ninja_equipment_actions/ninja_autodust.dm
+++ b/code/game/gamemodes/spaceninja/ninja/suit/ninja_equipment_actions/ninja_autodust.dm
@@ -51,9 +51,7 @@
 																												[span_revenwarning("Стихли все звуки. \n \
 																																	Вокруг мёртвая Тишина. \n \
 																																	Пепел сакуры... \n")]"))
-	for(var/obj/item/I in ninja.contents)
-		if(I == src)
-			continue
-		if(I.flags & NODROP)
-			qdel(I)
+
+	ninja.drop_ungibbable_items()
+
 	ninja.dust()

--- a/code/game/gamemodes/spaceninja/ninja/suit/ninja_equipment_actions/ninja_autodust.dm
+++ b/code/game/gamemodes/spaceninja/ninja/suit/ninja_equipment_actions/ninja_autodust.dm
@@ -47,10 +47,14 @@
 		return
 	var/mob/living/carbon/human/ninja = affecting
 	add_attack_logs(ninja, ninja, "Self-dusted")
-	ninja.visible_message(span_warning("[ninja] мгновенно сгорает в ослепительной вспышке!"),span_reallybig("Программа [span_warning("\"Автораспыления\"")] активирована!</span>\n \
-																												[span_revenwarning("Стихли все звуки. \n \
-																																	Вокруг мёртвая Тишина. \n \
-																																	Пепел сакуры... \n")]"))
+	ninja.visible_message(
+		span_warning("[ninja] мгновенно сгорает в ослепительной вспышке!"),
+		span_reallybig(
+			"Программа [span_warning("\"Автораспыления\"")] активирована!</span>\n\
+			[span_revenwarning("Стихли все звуки,\n\
+								Исчезли раздумия.\n\
+								Мир прощай бренный...\n")]")
+	)
 
 	ninja.drop_ungibbable_items()
 

--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -7,12 +7,31 @@ GLOBAL_LIST_INIT(potential_theft_objectives_hard, subtypesof(/datum/theft_object
 GLOBAL_LIST_INIT(potential_theft_objectives_medium, subtypesof(/datum/theft_objective/medium))
 GLOBAL_LIST_INIT(potential_theft_objectives_collect, subtypesof(/datum/theft_objective/collect) - /datum/theft_objective/collect/number - /datum/theft_objective/collect/number/name)
 
+GLOBAL_LIST_INIT(ungibbable_items_types, get_ungibbable_items_types())
+
 #define THEFT_FLAG_HIGHRISK 0
 #define THEFT_FLAG_UNIQUE 	1
 #define THEFT_FLAG_HARD 	2
 #define THEFT_FLAG_MEDIUM 	3
 #define THEFT_FLAG_COLLECT 	4
 
+/proc/get_ungibbable_items_types()
+	var/types = list()
+
+	// Highrisk items
+	for(var/highrisk_objective_type in subtypesof(/datum/theft_objective/highrisk))
+		var/datum/theft_objective/highrisk_objective = highrisk_objective_type
+		types += initial(highrisk_objective.typepath)
+
+	// Cash objective
+	types += /obj/item/stack/spacecash
+
+	// Brains
+	types += /obj/item/mmi/robotic_brain // Robotic and positronic
+	types += /obj/item/organ/internal/brain // Regular brains
+	types += /mob/living/simple_animal/diona // Possible diona brains
+
+	return types
 
 /datum/objective/proc/get_theft_list_objectives(var/type_theft_flag)
 	switch(type_theft_flag)

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -54,7 +54,7 @@
 	icon = null
 	invisibility = 101
 	dust_animation()
-	QDEL_IN(src, 15)
+	QDEL_IN(src, 0)
 	return TRUE
 
 /mob/living/carbon/human/dust_animation()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Сейчас при авто-гибе ниндзи все хайрисковые предметы и мозги исчезают вместе с ним. Данный PR исправляет это.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1093884983036366848/1093904240805679188
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
![highrisk_drop](https://user-images.githubusercontent.com/5000549/230648141-72e934c6-f782-45ff-afac-b1d6244d8630.gif)
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
