### PR TITLE
Tweak: reduce nukeops challenge mode shuttle delay

### DIFF
--- a/code/modules/shuttle/syndicate.dm
+++ b/code/modules/shuttle/syndicate.dm
@@ -1,4 +1,4 @@
-#define SYNDICATE_CHALLENGE_TIMER 12000 //20 minutes
+#define SYNDICATE_CHALLENGE_TIMER 13 MINUTES
 
 /obj/machinery/computer/shuttle/syndicate
 	name = "syndicate shuttle terminal"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

После фикса таймера шаттла нюкопсов у станции оказалось дополнительно 7 минут на подготовку, возвращаем баланс на место