### PR TITLE
Fix: Dormitories area

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -6074,7 +6074,7 @@
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "aRH" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -15502,7 +15502,7 @@
 	dir = 4;
 	icon_state = "neutralcorner"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "bOj" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -20399,7 +20399,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "barber"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "cjZ" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -24927,7 +24927,7 @@
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "cDj" = (
 /obj/machinery/light{
 	dir = 4
@@ -25474,7 +25474,7 @@
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "cFi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -25483,7 +25483,7 @@
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "cFj" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -25493,18 +25493,15 @@
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "cFl" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "cFn" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -25513,7 +25510,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "cFs" = (
 /obj/machinery/camera{
 	c_tag = "Dorm Hallway West";
@@ -25524,7 +25521,7 @@
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "cFv" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -25534,10 +25531,13 @@
 	},
 /area/crew_quarters/fitness)
 "cFw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "cFy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -44038,7 +44038,7 @@
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "ecU" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -46196,7 +46196,7 @@
 	dir = 8;
 	icon_state = "neutral"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "eCO" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -47881,7 +47881,7 @@
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "eVB" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/warning_stripes/east,
@@ -49087,7 +49087,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "barber"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "fjF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -51321,7 +51321,7 @@
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "fMS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -55197,7 +55197,7 @@
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "gHQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
@@ -59631,7 +59631,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "hIc" = (
 /obj/structure/delta_statue/n,
 /turf/simulated/floor/plasteel{
@@ -59852,7 +59852,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "hKL" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -60113,7 +60113,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "hOi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -61291,7 +61291,7 @@
 	dir = 8;
 	icon_state = "arrival"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "ido" = (
 /obj/effect/decal/cleanable/crayon{
 	color = "#cc3300"
@@ -61375,7 +61375,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "ies" = (
 /mob/living/simple_animal/mouse/gray,
 /turf/simulated/floor/plating,
@@ -61498,7 +61498,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "igE" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 26;
@@ -62216,7 +62216,7 @@
 	dir = 4;
 	icon_state = "neutral"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "inV" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -64242,14 +64242,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/aisat_interior)
-"iMK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/sleep)
 "iNf" = (
 /obj/machinery/requests_console{
 	department = "Engineering";
@@ -65300,7 +65292,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "jaQ" = (
 /obj/machinery/vending/coffee,
 /obj/structure/window/reinforced{
@@ -67505,6 +67497,9 @@
 	dir = 1
 	},
 /obj/effect/landmark/join_late_cryo,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -73019,9 +73014,17 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint3)
 "kYQ" = (
+/obj/machinery/cryopod/right,
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -26
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "freezerfloor"
 	},
 /area/crew_quarters/sleep)
 "kYS" = (
@@ -81231,7 +81234,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "mTh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -82172,7 +82175,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "barber"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "ndu" = (
 /obj/structure/table/wood,
 /obj/item/folder/red{
@@ -88790,7 +88793,7 @@
 	dir = 1;
 	icon_state = "neutral"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "oEY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/structure/window/plasmareinforced{
@@ -89675,7 +89678,7 @@
 	dir = 4;
 	icon_state = "neutralcorner"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "oPR" = (
 /obj/structure/rack/gunrack,
 /obj/effect/decal/warning_stripes/red/hollow,
@@ -91670,7 +91673,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "poq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -94425,7 +94428,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "pRj" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -94692,11 +94695,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "pVL" = (
 /obj/machinery/disposal,
 /obj/effect/decal/warning_stripes/red,
@@ -94935,7 +94941,7 @@
 	dir = 4;
 	icon_state = "neutralcorner"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "pXD" = (
 /obj/structure/table/reinforced,
 /obj/item/wrench,
@@ -100541,12 +100547,6 @@
 	icon_state = "darkred"
 	},
 /area/security/permabrig)
-"rja" = (
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/sleep)
 "rjs" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -106719,7 +106719,7 @@
 	dir = 1;
 	icon_state = "neutral"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "sEZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -111097,19 +111097,6 @@
 	icon_state = "darkred"
 	},
 /area/security/securearmory)
-"tHZ" = (
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -26
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/sleep)
 "tIb" = (
 /obj/machinery/camera{
 	c_tag = "Paramedic's Office";
@@ -114463,7 +114450,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "uuD" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8;
@@ -119294,7 +119281,7 @@
 	dir = 8;
 	icon_state = "arrival"
 	},
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "vAb" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -119992,7 +119979,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/crew_quarters/sleep)
+/area/crew_quarters/locker)
 "vHi" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/recharge_station,
@@ -122350,22 +122337,6 @@
 	icon_state = "whitepurplefull"
 	},
 /area/medical/research/restroom)
-"wlH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/crew_quarters/sleep)
 "wlX" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
@@ -126398,9 +126369,15 @@
 /turf/simulated/floor/plasteel,
 /area/teleporter)
 "xhV" = (
+/obj/machinery/door/airlock/glass{
+	name = "Cabin"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "freezerfloor"
 	},
 /area/crew_quarters/sleep)
 "xik" = (
@@ -129589,12 +129566,12 @@
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
 "xOP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/effect/landmark/join_late_cryo,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "freezerfloor"
 	},
 /area/crew_quarters/sleep)
 "xOX" = (
@@ -178849,7 +178826,7 @@ cnP
 cjY
 ndq
 fjD
-vsF
+cnP
 jww
 egu
 vdX
@@ -179106,7 +179083,7 @@ cnP
 icS
 vAa
 icS
-vsF
+cnP
 onT
 onT
 jfE
@@ -179363,7 +179340,7 @@ eMg
 fMN
 eCs
 gHO
-vsF
+cnP
 dWT
 eXS
 fvV
@@ -179877,7 +179854,7 @@ gRQ
 bOh
 inS
 jaP
-vsF
+cnP
 kzW
 fTd
 xmh
@@ -180903,7 +180880,7 @@ cyM
 bEd
 cDo
 aRG
-pVy
+iFR
 cFj
 pts
 fif
@@ -181160,7 +181137,7 @@ cDo
 cDo
 cDo
 ecO
-wlH
+tUh
 cFs
 pts
 pts
@@ -181416,9 +181393,9 @@ jQn
 cyO
 ghY
 gnf
-rja
-pVy
-kYQ
+dVM
+iFR
+ctj
 lov
 ycU
 kBM
@@ -181931,8 +181908,8 @@ fLD
 gjh
 gnf
 oPP
-pVy
-tHZ
+iFR
+nRC
 lov
 lNM
 ovP
@@ -182444,14 +182421,14 @@ iBC
 cyS
 iBC
 ojx
-xhV
-pVy
-cFw
+tbb
+iFR
+nRC
 ojx
 iBC
 gJy
 iBC
-iBC
+kYQ
 vsF
 crX
 xfR
@@ -182701,13 +182678,13 @@ fsK
 fsK
 fsK
 cVX
-xhV
+tbb
 pVy
 cFw
-cVX
-fsK
-fsK
-fsK
+xhV
+xOP
+xOP
+xOP
 jAl
 vsF
 gYg
@@ -182958,9 +182935,9 @@ xWJ
 xWJ
 xWJ
 ojx
-xOP
+fre
 pom
-iMK
+fvU
 ojx
 fRN
 xWJ

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -73014,14 +73014,9 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint3)
 "kYQ" = (
-/obj/machinery/cryopod/right,
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -26
-	},
+/obj/effect/landmark/join_late_cryo,
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -100547,6 +100542,20 @@
 	icon_state = "darkred"
 	},
 /area/security/permabrig)
+"rja" = (
+/obj/machinery/cryopod/right,
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -26
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/crew_quarters/sleep)
 "rjs" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -129565,15 +129574,6 @@
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
-"xOP" = (
-/obj/effect/landmark/join_late_cryo,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/crew_quarters/sleep)
 "xOX" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Staff Room";
@@ -178566,10 +178566,10 @@ xDf
 vSD
 jrh
 cnP
-xZu
-xZu
-xZu
-xZu
+cnP
+cnP
+cnP
+cnP
 daS
 xWh
 rpb
@@ -182428,7 +182428,7 @@ ojx
 iBC
 gJy
 iBC
-kYQ
+rja
 vsF
 crX
 xfR
@@ -182682,9 +182682,9 @@ tbb
 pVy
 cFw
 xhV
-xOP
-xOP
-xOP
+kYQ
+kYQ
+kYQ
 jAl
 vsF
 gYg


### PR DESCRIPTION
## Описание
Перепланировка зоны крио в дормах.
Зона дорм, а именно ```qrew_quaters/sleep``` внесена в список исключения ивента радиации, поэтому при текущем её расположении на Дельте весь коридор у кабинок защищён, хоть и является ответвлением центрального. 

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1091977534805135451

## Демонстрация изменений
Теперь коридор будет в другой зоне, в связи с чем АЦП переезжает в комнату.
![Безымянный](https://user-images.githubusercontent.com/110329212/230707092-7585239d-df79-45e4-9e53-7367b5a1cd46.png)

