### PR TITLE
Refactor: Shuttles not take space/lava/chasms with them on transit

### DIFF
--- a/_maps/map_files/generic/CentComm.dmm
+++ b/_maps/map_files/generic/CentComm.dmm
@@ -19446,6 +19446,10 @@
 	icon_state = "darkblue"
 	},
 /area/centcom/zone1)
+"kAJ" = (
+/obj/effect/baseturf_helper/lava_land/surface,
+/turf/simulated/floor/shuttle,
+/area/shuttle/siberia)
 "kAK" = (
 /obj/effect/turf_decal/stripes/corner{
 	do_not_delete_me = 1
@@ -45278,6 +45282,10 @@
 	icon_state = "dark"
 	},
 /area/shuttle/syndicate)
+"wDF" = (
+/obj/effect/baseturf_helper/lava_land/surface,
+/turf/simulated/floor/shuttle,
+/area/shuttle/mining)
 "wDS" = (
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
@@ -50921,7 +50929,7 @@ pwa
 dDb
 eeO
 lPy
-qDA
+wDF
 lPy
 hhM
 rYU
@@ -59147,7 +59155,7 @@ nVS
 maj
 sKg
 tbv
-tbv
+kAJ
 tbv
 qgA
 sgG


### PR DESCRIPTION
## Описание
Оригинальный ПР: https://github.com/ParadiseSS13/Paradise/pull/18194
Полы шаттлов более не будут спавнить космос и другие нежелательные турфы, если разрушены. Что-угодно, что будет находится на разрушенном тайле пола, будет проигнорировано для транфсера. Помимо этого шаттлы подлежат восстановлению от нежелательных турфов.
