### PR TITLE
Fix: Spacepods paralax dir

### DIFF
--- a/code/game/area/ss13_areas.dm
+++ b/code/game/area/ss13_areas.dm
@@ -70,14 +70,13 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	dynamic_lighting = DYNAMIC_LIGHTING_FORCED
 	parallax_movedir = NORTH
 	sound_environment = SOUND_ENVIRONMENT_ROOM
-
-/area/shuttle/arrival
+/*
+/area/shuttle/arrival //dont have this, but at once...
 	name = "\improper Arrival Shuttle"
-	parallax_movedir = EAST
 
 /area/shuttle/arrival/pre_game
 	icon_state = "shuttle2"
-
+*/
 /area/shuttle/arrival/station
 	icon_state = "shuttle"
 
@@ -103,13 +102,11 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "\improper Escape Pod Three"
 	icon_state = "shuttle"
 	nad_allowed = TRUE
-	parallax_movedir = EAST
 
 /area/shuttle/pod_4
 	name = "\improper Escape Pod Four"
 	icon_state = "shuttle"
 	nad_allowed = TRUE
-	parallax_movedir = EAST
 
 /area/shuttle/escape_pod1
 	name = "\improper Escape Pod One"
@@ -247,7 +244,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/shuttle/administration
 	name = "\improper Nanotrasen Vessel"
 	icon_state = "shuttlered"
-	parallax_movedir = EAST
+	parallax_movedir = WEST
 
 /area/shuttle/administration/centcom
 	name = "\improper Nanotrasen Vessel Centcom"
@@ -387,7 +384,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 
 /area/shuttle/trade/sol
 	name = "Sol Freighter"
-	parallax_movedir = EAST
+	parallax_movedir = WEST
 
 /area/shuttle/freegolem
 	name = "Free Golem Ship"


### PR DESCRIPTION
## Описание
После изменения подов все они направлены на север, но два из них летят на восток. Так же изменено направление шаттла торговцев и адмнистрации на запад. Убраны в комментарий 2 неиспользуемые зоны шаттлов прибытия.(однажды...)

## Ссылка на предложение/Причина создания ПР
Минорный фикс

## Демонстрация изменений
Поды
![Безымянный](https://user-images.githubusercontent.com/110329212/230725669-8caf136f-5f44-4fba-b90e-b4798137a321.png)
Торговцы
![Безымянный](https://user-images.githubusercontent.com/110329212/230725696-429f7bc0-84aa-46bc-af2c-4cf406c71140.png)
Администрация
![Безымянный](https://user-images.githubusercontent.com/110329212/230725809-42759344-87c1-4c30-944d-3413bfa5abf3.png)

