### PR TITLE
fix: Fix runechat loc null runtimes

### DIFF
--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -196,7 +196,7 @@
 	var/list/next_signal_targets = list(message_source)
 
 	var/atom/movable/message_loc = message_source
-	while(!isturf(message_loc.loc))
+	while(message_loc.loc && !isturf(message_loc.loc))
 		message_loc = message_loc.loc
 		next_signal_targets += message_loc
 	message.loc = message_loc

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -201,13 +201,11 @@
 		next_signal_targets += message_loc
 	message.loc = message_loc
 
-	for(var/previous_target in previous_signal_targets)
-		if(!(previous_target in next_signal_targets))
-			UnregisterSignal(previous_target, COMSIG_MOVABLE_MOVED)
+	for(var/obsolete_target in previous_signal_targets - next_signal_targets)
+		UnregisterSignal(obsolete_target, COMSIG_MOVABLE_MOVED)
 
-	for(var/next_target in next_signal_targets)
-		if(!(next_target in previous_signal_targets))
-			RegisterSignal(next_target, COMSIG_MOVABLE_MOVED, .proc/adjust_message_loc)
+	for(var/new_target in next_signal_targets - previous_signal_targets)
+		RegisterSignal(new_target, COMSIG_MOVABLE_MOVED, .proc/adjust_message_loc)
 
 	signal_targets = next_signal_targets
 

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -217,7 +217,7 @@
 			to_chat(src, "<span class='warning'>You feel your headset vibrate but can hear nothing from it!</span>")
 	else
 		to_chat(src, "[part_a][track || speaker_name][part_b][message]</span></span>")
-		if(client?.prefs.toggles2 & PREFTOGGLE_2_RUNECHAT && !istype(speaker, /mob/living/automatedannouncer))
+		if(client?.prefs.toggles2 & PREFTOGGLE_2_RUNECHAT)
 			create_chat_message(speaker, message_clean, TRUE, FALSE)
 		if(src != speaker || isrobot(src) || isAI(src))
 			var/effect = SOUND_EFFECT_RADIO


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Данный PR исправляет рантаймы рунчата для атомов, у которых в цепочке `loc` есть `null.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/734823601110515882/1094301562433712259
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
