### PR TITLE
Fix: Docking/Shuttle airlocks force close

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -280,8 +280,8 @@
 	if(density)
 		add_attack_logs(user, src, "emagged ([locked ? "bolted" : "not bolted"])")
 		flick("door_spark", src)
-		sleep(6)
-		open()
+		spawn(6)
+			open()
 		emagged = 1
 		return 1
 
@@ -289,8 +289,8 @@
 	if(!density)
 		return
 	flick("door_spark", src)
-	sleep(6) //The cmag doesn't automatically open doors. It inverts access, not provides it!
-	ADD_TRAIT(src, TRAIT_CMAGGED, CMAGGED)
+	spawn(6) //The cmag doesn't automatically open doors. It inverts access, not provides it!
+		ADD_TRAIT(src, TRAIT_CMAGGED, CMAGGED)
 	return TRUE
 
 //Proc for inverting access on cmagged doors."canopen" should always return the OPPOSITE of the normal result.
@@ -354,10 +354,10 @@
 	operating = TRUE
 	do_animate("opening")
 	set_opacity(0)
-	sleep(5)
-	density = FALSE
-	sleep(5)
-	layer = initial(layer)
+	spawn(5)
+		density = FALSE
+	spawn(5)
+		layer = initial(layer)
 	update_icon()
 	set_opacity(0)
 	operating = FALSE
@@ -384,9 +384,9 @@
 
 	do_animate("closing")
 	layer = closingLayer
-	sleep(5)
-	density = TRUE
-	sleep(5)
+	spawn(5)
+		density = TRUE
+	spawn(5)
 	update_icon()
 	if(visible && !glass)
 		set_opacity(1)
@@ -401,7 +401,7 @@
 
 /obj/machinery/door/proc/CheckForMobs()
 	if(locate(/mob/living) in get_turf(src))
-		sleep(1)
+		spawn(1)
 		open()
 
 /obj/machinery/door/proc/crush()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -399,6 +399,14 @@
 		crush()
 	return TRUE
 
+/obj/machinery/door/proc/force_close() //for shuttles
+	safe = FALSE
+	unlock()
+	close()
+	lock()
+	spawn(1)
+		safe = TRUE
+
 /obj/machinery/door/proc/CheckForMobs()
 	if(locate(/mob/living) in get_turf(src))
 		spawn(1)

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -22,15 +22,12 @@
 	. = ..()
 	if(!.)
 		return
-	INVOKE_ASYNC(src, .proc/close, 0, 1)
+	INVOKE_ASYNC(src, .proc/force_close, 0, 1)
 	// Close any nearby airlocks as well
 	for(var/obj/machinery/door/airlock/D in orange(1, src))
-		INVOKE_ASYNC(D, .proc/close, 0, 1)
-
-/obj/machinery/door/airlock/onShuttleMove()
-	. = ..()
+		INVOKE_ASYNC(D, .proc/force_close, 0, 1)
 	if(id_tag == "s_docking_airlock")
-		INVOKE_ASYNC(src, .proc/lock)
+		INVOKE_ASYNC(src, .proc/force_close)
 
 /mob/onShuttleMove(turf/oldT, turf/T1, rotation)
     if(!move_on_shuttle)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -586,10 +586,7 @@
 	for(var/obj/machinery/door/airlock/A in GLOB.airlocks)
 		if(A.id_tag == S0.id)
 			spawn(-1)
-				A.safe = FALSE
-				A.close()
-				A.lock()
-				A.safe = TRUE
+				A.force_close()
 
 /obj/docking_port/mobile/proc/unlockPortDoors(obj/docking_port/stationary/S1)
 	if(!istype(S1))
@@ -600,7 +597,6 @@
 			spawn(-1)
 				if(A.locked)
 					A.unlock()
-					A.safe = TRUE //just in case something gone wrong
 
 /obj/docking_port/mobile/proc/roadkill(list/L0, list/L1, dir)
 	var/list/hurt_mobs = list()

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -586,8 +586,10 @@
 	for(var/obj/machinery/door/airlock/A in GLOB.airlocks)
 		if(A.id_tag == S0.id)
 			spawn(-1)
+				A.safe = FALSE
 				A.close()
 				A.lock()
+				A.safe = TRUE
 
 /obj/docking_port/mobile/proc/unlockPortDoors(obj/docking_port/stationary/S1)
 	if(!istype(S1))
@@ -598,6 +600,7 @@
 			spawn(-1)
 				if(A.locked)
 					A.unlock()
+					A.safe = TRUE //just in case something gone wrong
 
 /obj/docking_port/mobile/proc/roadkill(list/L0, list/L1, dir)
 	var/list/hurt_mobs = list()


### PR DESCRIPTION
## Описание
Добавляет новый прок ```force_close``` и заменяет им ```close``` для дверей шаттлов и стыковочных портов. 
Таким образом шансы случайно выпасть с шаттлов и подов сводятся к нулю.
Заменяет ```sleep``` на ```spawn``` в door.dm

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1087309060006760458