### PR TITLE
FIX: Blob smoke

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -117,12 +117,12 @@
 	var/turf/location = get_turf(src)
 
 	// Create the reagents to put into the air
-	create_reagents(200)
+	create_reagents(350)
 
 	if(overmind && overmind.blob_reagent_datum)
-		reagents.add_reagent(overmind.blob_reagent_datum.id, 200)
+		reagents.add_reagent(overmind.blob_reagent_datum.id, 350)
 	else
-		reagents.add_reagent("spore", 200)
+		reagents.add_reagent("spore", 350)
 
 	// Setup up the smoke spreader and start it.
 	S.set_up(reagents, location, TRUE)


### PR DESCRIPTION
При переделке дыма Димачом оказалось, что бывшие 8 юнитов вещества превратились в 3-5. Да, были проведены тесты для выяснения сколько юнитов выделяется. Небольшой фикс теперь будет выделять стабильно 8 юнитов в тело будущей еды блоба и вернет у него отобранную когда-то ранее силу.

<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Исправление прошлогодного насрал с дымом. Одного из. Дым настолько говно, что надо выделять чуть ли не в 50 раз больше реагентов. Пиздец.

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
