### PR TITLE
fix: Properly Working Bottler

### DIFF
--- a/code/modules/food_and_drinks/drinks/bottler/bottler_recipes.dm
+++ b/code/modules/food_and_drinks/drinks/bottler/bottler_recipes.dm
@@ -35,14 +35,6 @@ There is no excuse to do this wrong now that there is an example for you. --Fals
 					/obj/item/reagent_containers/food/snacks/grown/apple)
 	result = "apple-pocalypse"
 
-/datum/bottler_recipe/Berry_Banned
-	name = "Berry Banned"
-	description = "Reason for ban: Excessive Flavor."
-	ingredients = list(/obj/item/reagent_containers/food/snacks/grown/berries,
-					/obj/item/reagent_containers/food/snacks/grown/berries,
-					/obj/item/reagent_containers/food/snacks/grown/berries)
-	result = "berry_banned"
-
 /datum/bottler_recipe/Berry_Banned2
 	name = "Berry Banned"
 	description = "Reason for ban: Excessive Flavor."
@@ -50,6 +42,14 @@ There is no excuse to do this wrong now that there is an example for you. --Fals
 					/obj/item/reagent_containers/food/snacks/grown/berries/poison,
 					/obj/item/reagent_containers/food/snacks/grown/berries/poison)
 	result = "berry_banned2"
+
+/datum/bottler_recipe/Berry_Banned
+	name = "Berry Banned"
+	description = "Reason for ban: Excessive Flavor."
+	ingredients = list(/obj/item/reagent_containers/food/snacks/grown/berries,
+					/obj/item/reagent_containers/food/snacks/grown/berries,
+					/obj/item/reagent_containers/food/snacks/grown/berries)
+	result = "berry_banned"
 
 /datum/bottler_recipe/Blackeye_Brew
 	name = "Blackeye Brew"

--- a/code/modules/food_and_drinks/drinks/bottler/bottler_recipes.dm
+++ b/code/modules/food_and_drinks/drinks/bottler/bottler_recipes.dm
@@ -35,7 +35,7 @@ There is no excuse to do this wrong now that there is an example for you. --Fals
 					/obj/item/reagent_containers/food/snacks/grown/apple)
 	result = "apple-pocalypse"
 
-/datum/bottler_recipe/Berry_Banned2
+/datum/bottler_recipe/Berry_Banned2 // Berry_Banned2 must be first in recipes list, before Berry_Banned, since we are using poison berries specifically
 	name = "Berry Banned"
 	description = "Reason for ban: Excessive Flavor."
 	ingredients = list(/obj/item/reagent_containers/food/snacks/grown/berries/poison,


### PR DESCRIPTION
## Описание
<!-- -->
Мегафикс, перемещающий рецепт с ядовитыми ягодами выше по списку. Позволяет создавать реагент berry_banned2 (в конце двойка). Ранее всегда создавался только напиток berry_banned, независимо от типа ягод.

## Ссылка на предложение/Причина создания ПР
<!--  -->
Восстанавливаем доступность рецепта.
