### PR TITLE
Fix: spacepod key path

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -51536,7 +51536,7 @@
 /obj/structure/closet/secure_closet/security,
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/light,
-/obj/item/spacepod_key{
+/obj/item/spacepod_equipment/key{
 	id = 100000
 	},
 /obj/item/spacepod_equipment/weaponry/laser,
@@ -82567,7 +82567,7 @@
 "njj" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/mug/hos,
-/obj/item/spacepod_key{
+/obj/item/spacepod_equipment/key{
 	id = 100000
 	},
 /obj/machinery/firealarm{

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -3168,7 +3168,7 @@
 /obj/structure/closet/secure_closet/hos,
 /obj/item/megaphone,
 /obj/item/reagent_containers/food/drinks/flask/barflask,
-/obj/item/spacepod_key{
+/obj/item/spacepod_equipment/key{
 	id = 100000
 	},
 /turf/simulated/floor/wood,
@@ -53625,7 +53625,7 @@
 "jnf" = (
 /obj/structure/closet/secure_closet/security,
 /obj/machinery/light,
-/obj/item/spacepod_key{
+/obj/item/spacepod_equipment/key{
 	id = 100000
 	},
 /obj/item/spacepod_equipment/weaponry/laser,

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -2954,7 +2954,7 @@
 	name = "west light switch";
 	pixel_x = -24
 	},
-/obj/item/spacepod_key{
+/obj/item/spacepod_equipment/key{
 	id = 100000
 	},
 /obj/item/gps,
@@ -95079,7 +95079,7 @@
 	pixel_y = 8
 	},
 /obj/item/stamp/hos,
-/obj/item/spacepod_key{
+/obj/item/spacepod_equipment/key{
 	id = 100000
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -252,7 +252,7 @@
 		/obj/item/clothing/accessory/medal/gold/captain,
 		/obj/item/clothing/gloves/color/black/krav_maga/sec,
 		/obj/item/clothing/gloves/color/black/forensics,
-		/obj/item/spacepod_key,
+		/obj/item/spacepod_equipment/key,
 		/obj/item/nullrod,
 		/obj/item/key,
 		/obj/item/door_remote,

--- a/code/modules/research/designs/spacepod_designs.dm
+++ b/code/modules/research/designs/spacepod_designs.dm
@@ -250,5 +250,5 @@
 	req_tech = list("materials" = 1) //The most basic kind of locking system
 	build_type = PODFAB
 	materials = list(MAT_METAL=500)
-	build_path = /obj/item/spacepod_key
+	build_path = /obj/item/spacepod_equipment/key
 	category = list("Pod_Parts")

--- a/code/modules/spacepods/equipment.dm
+++ b/code/modules/spacepods/equipment.dm
@@ -265,7 +265,7 @@ GLOBAL_LIST_EMPTY(pod_trackers)
 	id = ++id_source
 
 // The key
-/obj/item/spacepod_key
+/obj/item/spacepod_equipment/key
 	name = "spacepod key"
 	desc = "A key for a spacepod lock."
 	icon_state = "podkey"
@@ -274,8 +274,8 @@ GLOBAL_LIST_EMPTY(pod_trackers)
 
 // Key - Lock Interactions
 /obj/item/spacepod_equipment/lock/keyed/attackby(obj/item/I as obj, mob/user as mob, params)
-	if(istype(I, /obj/item/spacepod_key))
-		var/obj/item/spacepod_key/key = I
+	if(istype(I, /obj/item/spacepod_equipment/key))
+		var/obj/item/spacepod_equipment/key/key = I
 		if(!key.id)
 			key.id = id
 			to_chat(user, "<span class='notice'>You grind the blank key to fit the lock.</span>")

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -371,8 +371,8 @@
 			add_equipment(user, W, "lock_system")
 			return
 
-	else if(istype(W, /obj/item/spacepod_key) && istype(equipment_system.lock_system, /obj/item/spacepod_equipment/lock/keyed))
-		var/obj/item/spacepod_key/key = W
+	else if(istype(W, /obj/item/spacepod_equipment/key) && istype(equipment_system.lock_system, /obj/item/spacepod_equipment/lock/keyed))
+		var/obj/item/spacepod_equipment/key/key = W
 		if(key.id == equipment_system.lock_system.id)
 			lock_pod()
 			return


### PR DESCRIPTION
## Описание
Из-за https://github.com/ss220-space/Paradise/pull/2626 потерялся спрайт ключей от подов, а дело в том, что ключ не имел пути оборудования пода. Теперь его ```icon``` указан в родителе ```/obj/item/spacepod_equipment```

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1094707044075966624
