### PR TITLE
fix: Clothing Slot Weight

### DIFF
--- a/code/game/gamemodes/clockwork/clockwork_items.dm
+++ b/code/game/gamemodes/clockwork/clockwork_items.dm
@@ -218,6 +218,7 @@
 	attack_verb = list("stabbed", "poked", "slashed")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	w_class = WEIGHT_CLASS_HUGE
+	ignore_weight_equipped = TRUE
 	needs_permit = TRUE
 
 /obj/item/twohanded/ratvarian_spear/Initialize(mapload)
@@ -367,6 +368,7 @@
 	throwforce = 30
 	throw_range = 7
 	w_class = WEIGHT_CLASS_HUGE
+	ignore_weight_equipped = TRUE
 	needs_permit = TRUE
 
 /obj/item/twohanded/clock_hammer/Initialize(mapload)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -27,6 +27,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 	var/throwhitsound
 	var/stealthy_audio = FALSE //Whether or not we use stealthy audio levels for this item's attack sounds
 	var/w_class = WEIGHT_CLASS_NORMAL
+	var/ignore_weight_equipped = FALSE // used to make item fit equipment slot, ignoring weight restrictions
 	var/slot_flags = 0		//This is used to determine on which slots an item can fit.
 	pass_flags = PASSTABLE
 	pressure_resistance = 4

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -757,6 +757,10 @@
 				if(!disable_warning)
 					to_chat(H, "Вы как-то достали костюм без хранения разрешенных предметов. Прекратите это.")
 				return FALSE
+			if(I.w_class > WEIGHT_CLASS_BULKY && !I.ignore_weight_equipped)
+				if(!disable_warning)
+					to_chat(H, "[I] слишком большой, чтобы прикрепить.")
+				return FALSE
 			if(istype(I, /obj/item/pda) || istype(I, /obj/item/pen) || is_type_in_list(I, H.wear_suit.allowed))
 				return TRUE
 			return FALSE


### PR DESCRIPTION
## Описание
<!-- -->
Более элегантное решение проблемы, позволяющее любому предмету игнорировать ограничения веса, для помещения в слот одежды, для любого костюма.

## Ссылка на предложение/Причина создания ПР
<!--  -->
Возвращаются запреты на огромное оружие в слотах костюмов, которые я упустил из виду в этом PR:
https://github.com/ss220-space/Paradise/pull/2610