### PR TITLE
fix: Clothing Slot Weight Limit

### DIFF
--- a/code/game/gamemodes/clockwork/clockwork_items.dm
+++ b/code/game/gamemodes/clockwork/clockwork_items.dm
@@ -644,6 +644,9 @@
 	flags_inv = HIDEJUMPSUIT
 	magical = TRUE
 
+/obj/item/clothing/suit/hooded/clockrobe/bypass_weight_check(obj/item/I)
+	return TRUE
+
 /obj/item/clothing/suit/hooded/clockrobe/Initialize(mapload)
 	. = ..()
 	enchants = GLOB.robe_spells
@@ -743,6 +746,9 @@
 	var/reflect_uses = 3
 	var/normal_armor
 	var/harden_armor = list("melee" = 80, "bullet" = 60, "laser" = 50, "energy" = 50, "bomb" = 100, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100)
+
+/obj/item/clothing/suit/armor/clockwork/bypass_weight_check(obj/item/I)
+	return TRUE
 
 /obj/item/clothing/suit/armor/clockwork/Initialize(mapload)
 	. = ..()

--- a/code/game/gamemodes/clockwork/clockwork_items.dm
+++ b/code/game/gamemodes/clockwork/clockwork_items.dm
@@ -644,7 +644,7 @@
 	flags_inv = HIDEJUMPSUIT
 	magical = TRUE
 
-/obj/item/clothing/suit/hooded/clockrobe/bypass_weight_check(obj/item/I)
+/obj/item/clothing/suit/hooded/clockrobe/can_store_weighted()
 	return TRUE
 
 /obj/item/clothing/suit/hooded/clockrobe/Initialize(mapload)
@@ -747,7 +747,7 @@
 	var/normal_armor
 	var/harden_armor = list("melee" = 80, "bullet" = 60, "laser" = 50, "energy" = 50, "bomb" = 100, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100)
 
-/obj/item/clothing/suit/armor/clockwork/bypass_weight_check(obj/item/I)
+/obj/item/clothing/suit/armor/clockwork/can_store_weighted()
 	return TRUE
 
 /obj/item/clothing/suit/armor/clockwork/Initialize(mapload)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -637,9 +637,9 @@ BLIND     // can't see anything
 		to_chat(user, "<span class='notice'>You attempt to button up the velcro on \the [src], before promptly realising how foolish you are.</span>")
 
 // Proc used to check if suit storage is limited by item weight
-// Allows any suit to bypass weight check when equipping item into suit storage by calling this proc and returning TRUE
-/obj/item/clothing/suit/proc/bypass_weight_check(obj/item/I)
-	if(I.w_class > WEIGHT_CLASS_BULKY)
+// Allows any suit to have their own weight limit for items that can be equipped into suit storage
+/obj/item/clothing/suit/proc/can_store_weighted(obj/item/I, item_weight = WEIGHT_CLASS_BULKY)
+	if(I.w_class > item_weight)
 		return FALSE
 	return TRUE
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -639,9 +639,7 @@ BLIND     // can't see anything
 // Proc used to check if suit storage is limited by item weight
 // Allows any suit to have their own weight limit for items that can be equipped into suit storage
 /obj/item/clothing/suit/proc/can_store_weighted(obj/item/I, item_weight = WEIGHT_CLASS_BULKY)
-	if(I.w_class > item_weight)
-		return FALSE
-	return TRUE
+	return I.w_class <= item_weight
 
 /obj/item/clothing/suit/equipped(var/mob/living/carbon/human/user, var/slot) //Handle tail-hiding on a by-species basis.
 	..()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -636,6 +636,13 @@ BLIND     // can't see anything
 	else
 		to_chat(user, "<span class='notice'>You attempt to button up the velcro on \the [src], before promptly realising how foolish you are.</span>")
 
+// Proc used to check if suit storage is limited by item weight
+// Allows any suit to bypass weight check when equipping item into suit storage by calling this proc and returning TRUE
+/obj/item/clothing/suit/proc/bypass_weight_check(obj/item/I)
+	if(I.w_class > WEIGHT_CLASS_BULKY)
+		return FALSE
+	return TRUE
+
 /obj/item/clothing/suit/equipped(var/mob/living/carbon/human/user, var/slot) //Handle tail-hiding on a by-species basis.
 	..()
 	if(ishuman(user) && hide_tail_by_species && slot == slot_wear_suit)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -759,7 +759,7 @@
 				return FALSE
 			if(!H.wear_suit.can_store_weighted(I))
 				if(!disable_warning)
-					to_chat(H, "[I] слишком большой, чтобы прикрепить.")
+					to_chat(H, "Размер [I] слишком большой, чтобы прикрепить.")
 				return FALSE
 			if(istype(I, /obj/item/pda) || istype(I, /obj/item/pen) || is_type_in_list(I, H.wear_suit.allowed))
 				return TRUE

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -757,7 +757,7 @@
 				if(!disable_warning)
 					to_chat(H, "Вы как-то достали костюм без хранения разрешенных предметов. Прекратите это.")
 				return FALSE
-			if(!H.wear_suit.bypass_weight_check(I))
+			if(!H.wear_suit.can_store_weighted(I))
 				if(!disable_warning)
 					to_chat(H, "[I] слишком большой, чтобы прикрепить.")
 				return FALSE

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -757,6 +757,10 @@
 				if(!disable_warning)
 					to_chat(H, "Вы как-то достали костюм без хранения разрешенных предметов. Прекратите это.")
 				return FALSE
+			if(!H.wear_suit.bypass_weight_check(I))
+				if(!disable_warning)
+					to_chat(H, "[I] слишком большой, чтобы прикрепить.")
+				return FALSE
 			if(istype(I, /obj/item/pda) || istype(I, /obj/item/pen) || is_type_in_list(I, H.wear_suit.allowed))
 				return TRUE
 			return FALSE


### PR DESCRIPTION
## Описание
<!-- -->
Более элегантное решение проблемы, позволяющее любому костюму, при необходимости, устанавливать свои ограничения по максимальному весу, для предметов, помещаемых в слот одежды

## Ссылка на предложение/Причина создания ПР
<!--  -->
Возвращаются запреты на огромное оружие в слотах костюмов, которые я упустил из виду в этом PR:
https://github.com/ss220-space/Paradise/pull/2610
