### PR TITLE
fix: Remove confusing hands overlay

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -396,7 +396,7 @@
 	object_overlays.Cut()
 
 /obj/screen/inventory/proc/add_overlays()
-	if(!hud?.mymob || !slot_id)
+	if(!hud?.mymob || !slot_id || slot_id == slot_l_hand || slot_id == slot_r_hand)
 		return
 
 	var/mob/user = hud.mymob

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -396,24 +396,25 @@
 	object_overlays.Cut()
 
 /obj/screen/inventory/proc/add_overlays()
+	if(!hud?.mymob || !slot_id)
+		return
+
 	var/mob/user = hud.mymob
+	var/obj/item/holding = user.get_active_hand()
 
-	if(hud && user && slot_id)
-		var/obj/item/holding = user.get_active_hand()
+	if(!holding || user.get_item_by_slot(slot_id))
+		return
 
-		if(!holding || user.get_item_by_slot(slot_id))
-			return
+	var/image/item_overlay = image(holding)
+	item_overlay.alpha = 92
 
-		var/image/item_overlay = image(holding)
-		item_overlay.alpha = 92
+	if(!user.advanced_can_equip(holding, slot_id, disable_warning = TRUE))
+		item_overlay.color = "#ff0000"
+	else
+		item_overlay.color = "#00ff00"
 
-		if(!user.advanced_can_equip(holding, slot_id, disable_warning = TRUE))
-			item_overlay.color = "#ff0000"
-		else
-			item_overlay.color = "#00ff00"
-
-		object_overlays += item_overlay
-		add_overlay(object_overlays)
+	object_overlays += item_overlay
+	add_overlay(object_overlays)
 
 /obj/screen/inventory/Click(location, control, params)
 	// At this point in client Click() code we have passed the 1/10 sec check and little else


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Сейчас, если в активной руке есть предмет и навестись на пустую ячейку инвентаря, то появится зеленый/красный оверлей, если можно/нельзя положить предмет в слот соответственно. При клике на слот с зеленым оверлеем предмет кладется в этот слот.

Этот же зеленый оверлей появляется, если навестись на пустую неактивную руку, но по клику происходит смена руки. Это поведение неожиданно и нелогично. Данный PR убирает этот оверлей для рук.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багфикс
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
До фикса:
![image](https://user-images.githubusercontent.com/5000549/231127835-bc2fdf9e-280e-4e69-bb93-a5e5e8135848.png)
После фикса:
![image](https://user-images.githubusercontent.com/5000549/231128103-61f9cb1a-9804-4539-b191-181f8ec547c8.png)
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
