### PR TITLE
fix: infinity stacks for mecha reactor

### DIFF
--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -399,16 +399,16 @@
 		if(result)
 			send_byjax(chassis.occupant,"exosuit.browser","\ref[src]",get_equip_info())
 
-/obj/item/mecha_parts/mecha_equipment/generator/proc/load_fuel(var/obj/item/I)
+/obj/item/mecha_parts/mecha_equipment/generator/proc/load_fuel(obj/item/I)
 	if(istype(I) && (fuel_type in I.materials))
 		if(istype(I, /obj/item/stack/sheet))
 			var/obj/item/stack/sheet/P = I
-			var/to_load = max(max_fuel - P.amount*P.perunit,0)
+			var/to_load = max(max_fuel - fuel_amount, 0)
 			if(to_load)
 				var/units = min(max(round(to_load / P.perunit),1),P.amount)
 				if(units)
 					var/added_fuel = units * P.perunit
-					fuel_amount += added_fuel
+					fuel_amount = min(fuel_amount + added_fuel, max_fuel)
 					P.use(units)
 					occupant_message("[units] unit\s of [fuel_name] successfully loaded.")
 					return added_fuel


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Сейчас логика загрузки стаков ресурсов в реакторы мехов не учитывает текущую загруженность реактора (в других способах пополнения это учитывается), но слишком рано проверяет колво энергии от стака.
От этого 2 проблемы: нельзя загрузить стак по 50 ресурса, просто оставив лишние, что неудобно. Но зато можно бесконечно подкладывать стаки меньшим числом, например по 25 урана и оно будет переходить максимум.
Исправляем эти проблемы, заменяя одну проверку на другую.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
В т.ч. закрывает багрепорт: https://discord.com/channels/617003227182792704/1095150660032397452
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
