### PR TITLE
fix: Fix buckled mobs pulling stop

### DIFF
--- a/code/datums/spells/rod_form.dm
+++ b/code/datums/spells/rod_form.dm
@@ -37,7 +37,7 @@
 /obj/effect/immovablerod/wizard/Move()
 	if(get_dist(start_turf, get_turf(src)) >= max_distance)
 		qdel(src)
-	..()
+	. = ..()
 
 /obj/effect/immovablerod/wizard/Destroy()
 	if(wizard)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -58,6 +58,10 @@
 	return
 
 /atom/movable/proc/start_pulling(atom/movable/AM, state, force = pull_force, show_message = FALSE)
+	var/mob/M = AM
+	if(ismob(M) && M.buckled)
+		AM = M.buckled
+
 	if(QDELETED(AM))
 		return FALSE
 	if(!(AM.can_be_pulled(src, state, force)))
@@ -80,11 +84,12 @@
 		AM.pulledby.stop_pulling() //an object can't be pulled by two mobs at once.
 	pulling = AM
 	AM.pulledby = src
-	if(ismob(AM))
-		var/mob/M = AM
-		add_attack_logs(src, M, "passively grabbed", ATKLOG_ALMOSTALL)
+
+	var/mob/pulled_mob = ismob(AM) ? AM : buckled_mobs[1]
+	if(ismob(pulled_mob))
+		add_attack_logs(src, pulled_mob, "passively grabbed", ATKLOG_ALMOSTALL)
 		if(show_message)
-			visible_message("<span class='warning'>[src] схватил[genderize_ru(src.gender,"","а","о","и")] [M]!</span>")
+			visible_message("<span class='warning'>[src] схватил[genderize_ru(src.gender,"","а","о","и")] [pulled_mob]!</span>")
 	return TRUE
 
 /atom/movable/proc/stop_pulling()

--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -109,7 +109,7 @@
 		return ..()
 
 /mob/living/simple_animal/hostile/guardian/Move() //Returns to summoner if they move out of range
-	..()
+	. = ..()
 	snapback()
 
 /mob/living/simple_animal/hostile/guardian/death(gibbed)

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -213,7 +213,7 @@
 	return
 
 /obj/item/pipe/Move()
-	..()
+	. = ..()
 	if(is_bent_pipe() \
 		&& (src.dir in GLOB.cardinal))
 		src.dir = src.dir|turn(src.dir, 90)

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -25,7 +25,7 @@
 
 /obj/machinery/shield/Move()
 	var/turf/T = loc
-	..()
+	. = ..()
 	move_update_air(T)
 
 /obj/machinery/shield/CanPass(atom/movable/mover, turf/target, height)

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -68,6 +68,9 @@
 	if(M.pulledby)
 		if(buckle_prevents_pull)
 			M.pulledby.stop_pulling()
+		else
+			M.pulledby.pulling = src
+			M.pulledby = null
 
 	for(var/obj/item/grab/G in M.grabbed_by)
 		qdel(G)

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -188,7 +188,7 @@
 
 /obj/structure/foamedmetal/Move()
 	var/turf/T = loc
-	..()
+	. = ..()
 	move_update_air(T)
 
 /obj/structure/foamedmetal/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)

--- a/code/game/objects/effects/effect_system/effects_sparks.dm
+++ b/code/game/objects/effects/effect_system/effects_sparks.dm
@@ -38,7 +38,7 @@
 	return ..()
 
 /obj/effect/particle_effect/sparks/Move()
-	..()
+	. = ..()
 	var/turf/T = loc
 	if(isturf(T))
 		T.hotspot_expose(hotspottemp,100)

--- a/code/game/objects/effects/effect_system/effects_water.dm
+++ b/code/game/objects/effects/effect_system/effects_water.dm
@@ -14,7 +14,7 @@
 		return 0
 	if(newloc.density)
 		return 0
-	.=..()
+	. = ..()
 
 /obj/effect/particle_effect/water/Bump(atom/A)
 	if(reagents)

--- a/code/game/objects/items/shooting_range.dm
+++ b/code/game/objects/items/shooting_range.dm
@@ -18,7 +18,7 @@
 	return ..() // delete target
 
 /obj/item/target/Move()
-	..()
+	. = ..()
 	// After target moves, check for nearby stakes. If associated, move to target
 	for(var/obj/structure/target_stake/M in view(3, src))
 		if(M.density == 0 && M.pinned_target == src)

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -232,7 +232,7 @@
 		nadeassembly.HasProximity(AM)
 
 /obj/item/grenade/chem_grenade/Move() // prox sensors and infrared care about this
-	..()
+	. = ..()
 	if(nadeassembly)
 		nadeassembly.process_movement()
 

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -150,7 +150,7 @@
 		return 1
 
 /obj/item/reagent_containers/spray/mister/Move()
-	..()
+	. = ..()
 	if(loc != tank.loc)
 		loc = tank.loc
 
@@ -241,7 +241,7 @@
 	return
 
 /obj/item/extinguisher/mini/nozzle/Move()
-	..()
+	. = ..()
 	if(tank && loc != tank.loc)
 		loc = tank
 	return

--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -62,7 +62,7 @@
 
 /obj/structure/alien/resin/Move()
 	var/turf/T = loc
-	..()
+	. = ..()
 	move_update_air(T)
 
 /obj/structure/alien/resin/CanAtmosPass()

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -108,7 +108,7 @@
 	var/turf/T = loc
 	for(var/obj/structure/cable/C in T)
 		C.deconstruct()
-	..()
+	. = ..()
 
 /obj/structure/lattice/catwalk/deconstruct()
 	var/turf/T = loc

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -172,7 +172,7 @@
 	handle_layer()
 
 /obj/structure/railing/Move(newloc, direct, movetime)
-	..()
+	. = ..()
 	handle_layer()
 
 /obj/structure/railing/proc/handle_layer()

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -29,7 +29,7 @@
 	qdel(src)
 
 /obj/structure/chair/Move(atom/newloc, direct)
-	..()
+	. = ..()
 	handle_rotation()
 
 /obj/structure/chair/buckle_mob(mob/living/M, force, check_loc)

--- a/code/game/objects/structures/tribune.dm
+++ b/code/game/objects/structures/tribune.dm
@@ -47,7 +47,7 @@
 	handle_layer()
 
 /obj/structure/tribune/Move(newloc, direct, movetime)
-	..()
+	. = ..()
 	handle_layer()
 
 /obj/structure/tribune/proc/handle_layer()

--- a/code/game/objects/structures/wryn.dm
+++ b/code/game/objects/structures/wryn.dm
@@ -35,7 +35,7 @@
 
 /obj/structure/wryn/wax/Move()
 	var/turf/T = loc
-	..()
+	. = ..()
 	move_update_air(T)
 
 /obj/structure/wryn/wax/CanAtmosPass()

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -92,7 +92,7 @@
 		holder.update_icon()
 
 /obj/item/assembly/prox_sensor/Move()
-	..()
+	. = ..()
 	sense()
 
 /obj/item/assembly/prox_sensor/holder_movement(user)

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -111,7 +111,7 @@ Gunshots/explosions/opening doors/less rare audio (done)
 	Show()
 
 /obj/effect/hallucination/simple/Move()
-	..()
+	. = ..()
 	Show()
 
 /obj/effect/hallucination/simple/Destroy()

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -56,7 +56,7 @@
 	desc = "That's Hudson. " +  unbearable_pun// I am not sorry for this.
 
 /mob/living/simple_animal/hostile/bear/Move()
-	..()
+	. = ..()
 	if(stat != DEAD)
 		if(loc && istype(loc,/turf/space))
 			icon_state = "[icon_living]"

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -483,8 +483,8 @@
 /mob/living/simple_animal/hostile/Move(atom/newloc, dir , step_x , step_y)
 	if(dodging && approaching_target && prob(dodge_prob) && moving_diagonally == 0 && isturf(loc) && isturf(newloc))
 		return dodge(newloc, dir)
-	else
-		return ..()
+
+	. = ..()
 
 /mob/living/simple_animal/hostile/proc/dodge(moving_to,move_direction)
 	//Assuming we move towards the target we want to swerve toward them to get closer

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -138,7 +138,7 @@ Difficulty: Medium
 /mob/living/simple_animal/hostile/megafauna/blood_drunk_miner/Move(atom/newloc)
 	if(dashing || (newloc && newloc.z == z && (islava(newloc) || ischasm(newloc)))) //we're not stupid!
 		return FALSE
-	return ..()
+	. = ..()
 
 /mob/living/simple_animal/hostile/megafauna/blood_drunk_miner/ex_act(severity)
 	if(dash())

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -452,7 +452,7 @@ Difficulty: Hard
 	if(charging)
 		new /obj/effect/temp_visual/decoy/fading(loc,src)
 		DestroySurroundings()
-	..()
+	. = ..()
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/Moved(atom/OldLoc, Dir, Forced = FALSE)
 	if(Dir)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -412,7 +412,7 @@ Difficulty: Medium
 
 /mob/living/simple_animal/hostile/megafauna/dragon/Move()
 	if(!swooping)
-		..()
+		. = ..()
 
 /mob/living/simple_animal/hostile/megafauna/dragon/Goto(target, delay, minimum_distance)
 	if(!swooping)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
@@ -140,21 +140,22 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 
 
 /mob/living/simple_animal/hostile/swarmer/ai/Move(atom/newloc)
-	if(newloc)
-		if(newloc.z == z) //so these actions are Z-specific
-			if(islava(newloc))
-				var/turf/simulated/floor/plating/lava/L = newloc
-				if(!L.is_safe())
-					StartAction(20)
-					new /obj/structure/lattice/catwalk/swarmer_catwalk(newloc)
-					return FALSE
+	if(!newloc)
+		return FALSE
 
-			if(ischasm(newloc) && !throwing)
-				throw_at(get_edge_target_turf(src, get_dir(src, newloc)), 7 , 3, src, FALSE) //my planet needs me
+	if(newloc.z == z) //so these actions are Z-specific
+		if(islava(newloc))
+			var/turf/simulated/floor/plating/lava/L = newloc
+			if(!L.is_safe())
+				StartAction(20)
+				new /obj/structure/lattice/catwalk/swarmer_catwalk(newloc)
 				return FALSE
 
-		return ..()
+		if(ischasm(newloc) && !throwing)
+			throw_at(get_edge_target_turf(src, get_dir(src, newloc)), 7 , 3, src, FALSE) //my planet needs me
+			return FALSE
 
+	. = ..()
 
 /mob/living/simple_animal/hostile/swarmer/ai/proc/StartAction(deci = 0)
 	stop_automated_movement = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/legionnaire.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/legionnaire.dm
@@ -115,7 +115,7 @@
 /mob/living/simple_animal/hostile/asteroid/elite/legionnaire/Move()
 	if(charging)
 		return FALSE
-	return ..()
+	. = ..()
 
 /mob/living/simple_animal/hostile/asteroid/elite/legionnaire/MiddleClickOn(atom/A)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/spaceworms.dm
+++ b/code/modules/mob/living/simple_animal/hostile/spaceworms.dm
@@ -223,7 +223,8 @@
 //Move all segments if one piece moves.
 /mob/living/simple_animal/hostile/spaceWorm/Move()
 	var/segmentNextPos = loc
-	if(..())
+	. = ..()
+	if(.)
 		if(previousWorm)
 			previousWorm.Move(segmentNextPos)
 		update_icon()

--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -69,7 +69,7 @@
 		if(client)
 			to_chat(src, "<span class='warning'>You cannot move, there are eyes on you!</span>")
 		return 0
-	return ..()
+	. = ..()
 
 /mob/living/simple_animal/hostile/statue/handle_automated_action()
 	if(!..())

--- a/code/modules/projectiles/guns/projectile/saw.dm
+++ b/code/modules/projectiles/guns/projectile/saw.dm
@@ -88,7 +88,7 @@
 	armour_penetration = 0
 
 /obj/item/projectile/bullet/saw/incen/Move()
-	..()
+	. = ..()
 	var/turf/location = get_turf(src)
 	if(location)
 		new /obj/effect/hotspot(location)

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -204,7 +204,7 @@
 	damage = 20
 
 /obj/item/projectile/bullet/incendiary/shell/Move()
-	..()
+	. = ..()
 	var/turf/location = get_turf(src)
 	if(location)
 		new /obj/effect/hotspot(location)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -174,7 +174,7 @@
 
 
 /obj/structure/reagent_dispensers/fueltank/Move()
-	..()
+	. = ..()
 	if(rig)
 		rig.process_movement()
 

--- a/code/modules/ruins/lavalandruin_code/puzzle.dm
+++ b/code/modules/ruins/lavalandruin_code/puzzle.dm
@@ -206,8 +206,8 @@
 /obj/structure/puzzle_element/Move(nloc, dir)
 	if(!isturf(nloc) ||  moving_diagonally || get_dist(get_step(src,dir),get_turf(source)) > 1)
 		return 0
-	else
-		return ..()
+
+	. = ..()
 
 /obj/structure/puzzle_element/proc/set_puzzle_icon()
 	cut_overlays()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Сейчас при некоторых неочевидных условиях некорректно стопается пулл.

* Например: пуллить моба, который прибаклен, находится по диагонали, а тянущий начнет движение по горизонтали. Например, как на картинке.
![image](https://user-images.githubusercontent.com/5000549/232116987-95c59585-1a57-4b69-a56a-e1661854eadc.png)

* Или же пуллить стул, который находится по диагонали от моба, а моб движется по вертикали от стула.

К тому же, пулл моба на каталке и пулл каталки с мобом приводят к разной скорости пулла, при том, что чаще те же парамедики пуллят моба, по которому легче кликнуть.

Данный PR исправляет эти проблемы. При пулле прибакленных мобов теперь пуллится будет то, к чему прибаклен моб. Также за счет прописывания `. = ..()` починилось диагональное движение некоторых предметов, которое не работало из-за того, что их оверрайднутый `Move` не возвращал правдивое значение.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багфикс https://discord.com/channels/617003227182792704/734823601110515882/1096458290994630666
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
