### PR TITLE
fix: Fix cable restrains color

### DIFF
--- a/code/game/objects/items/stacks/stack_recipe.dm
+++ b/code/game/objects/items/stacks/stack_recipe.dm
@@ -35,8 +35,27 @@
 
 /datum/stack_recipe/cable_restraints
 /datum/stack_recipe/cable_restraints/post_build(obj/item/stack/S, obj/result)
-	if(istype(result, /obj/item/restraints/handcuffs/cable))
-		result.color = S.color
+	var/obj/item/restraints/handcuffs/cable/cable_restraints = result
+	if(istype(cable_restraints))
+		var/color = "white"
+
+		switch(S.color)
+			if(WIRE_COLOR_BLUE)
+				color = "blue"
+			if(WIRE_COLOR_CYAN)
+				color = "cyan"
+			if(WIRE_COLOR_GREEN)
+				color = "green"
+			if(WIRE_COLOR_ORANGE)
+				color = "orange"
+			if(WIRE_COLOR_PINK)
+				color = "pink"
+			if(WIRE_COLOR_RED)
+				color = "red"
+			if(WIRE_COLOR_YELLOW)
+				color = "yellow"
+
+		cable_restraints.icon_state = "cuff_[color]"
 	..()
 
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -476,7 +476,7 @@ By design, d1 is the smallest direction and d2 is the highest
 // Definitions
 ////////////////////////////////
 
-GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restraints", /obj/item/restraints/handcuffs/cable, 15)))
+GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe/cable_restraints("cable restraints", /obj/item/restraints/handcuffs/cable, 15)))
 
 /obj/item/stack/cable_coil
 	name = "cable coil"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
При крафте стяжек из кабелей из-за неправильно указанного рецепта не применялся цвет кабеля. Данный PR исправляет и улучшает это это, используя существующие в билде спрайты.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багфикс
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
![image](https://user-images.githubusercontent.com/5000549/232215026-f6212efa-0d4c-4764-8c63-e1f04d75e8a0.png)

<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
