### PR TITLE
fix: Fix engineer jumskirts names

### DIFF
--- a/code/modules/clothing/under/jobs/engineering.dm
+++ b/code/modules/clothing/under/jobs/engineering.dm
@@ -49,7 +49,7 @@
 	item_color = "trainee"
 
 /obj/item/clothing/under/rank/engineer/trainee/skirt
-	name = "engineer trainee jumpsuit"
+	name = "engineer trainee jumpskirt"
 	icon_state = "traineef_s"
 	item_color = "traineef"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
@@ -60,7 +60,7 @@
 	item_color = "eng_ass"
 
 /obj/item/clothing/under/rank/engineer/trainee/assistant/skirt
-	name = "engineer assistant jumpsuit"
+	name = "engineer assistant jumpskirt"
 	icon_state = "eng_ass_f_s"
 	item_color = "eng_ass_f"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Из-за того, что название джампскиртов дублировало название джампсьютов, в вендомате неверно отображалось количество оставшихся предметов. Данный PR исправляет это.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багфикс
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
До фикса:
![jumpskirts_bug](https://user-images.githubusercontent.com/5000549/232330349-ba6d17bc-a67f-4c23-8f42-221df205ab87.gif)
После фикса:
![jumpskirts_fixed](https://user-images.githubusercontent.com/5000549/232330643-640eae90-925e-434e-a8a4-b26df122f39b.gif)
<!-- Здесь вы 

можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
