### PR TITLE
TWEAK: Хрупкие кости воксов

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -24,6 +24,10 @@
 
 #define SPLINT_LIFE 2000 //number of steps splints stay on
 
+//BONE DEFINE
+
+#define FRAGILITY(A) (ishuman(A) ? A.dna.species.bonefragility : 1)
+
 
 //Pulse levels, very simplified
 #define PULSE_NONE		0	//so !M.pulse checks would be possible

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -59,6 +59,7 @@
 	var/stamina_mod = 1
 	var/stun_mod = 1	 // If a species is more/less impacated by stuns/weakens/paralysis
 	var/speed_mod = 0	// this affects the race's speed. positive numbers make it move slower, negative numbers make it move faster
+	var/bonefragility = 1 // higher numbers - higher chances to break bones
 	var/blood_damage_type = OXY //What type of damage does this species take if it's low on blood?
 	var/total_health = 100
 	var/punchdamagelow = 0       //lowest possible punch damage

--- a/code/modules/mob/living/carbon/human/species/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/vox.dm
@@ -17,7 +17,7 @@
 	smell.<br/><br/>Most humans will never meet a Vox raider, instead learning of this insular species through \
 	dealing with their traders and merchants; those that do rarely enjoy the experience."
 
-	brute_mod = 1.2 //20% more brute damage. Fragile bird bones.
+	bonefragility = 1.2 //20% more chance to break bones. Fragile bird bones.
 
 	breathid = "n2"
 

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -426,7 +426,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 //Updates brute_damn and burn_damn from wound damages. Updates BLEEDING status.
 /obj/item/organ/external/proc/check_fracture(damage)
 	if(config.bones_can_break && brute_dam + burn_dam + damage > min_broken_damage && !is_robotic())
-		if(prob(damage))
+		if(prob(damage * FRAGILITY(owner)))
 			fracture()
 			add_attack_logs(owner, null, "Suffered fracture to [src](Damage: [damage], Organ HP: [max_damage - (brute_dam + burn_dam) ])")
 


### PR DESCRIPTION
Заменяет брутмод воксов на новый параметр хрупкости костей, который призван увеличить шанс сломать кости, получая меньше актуального урона. По итогу мы просто убираем из переменной брутмод, шанс слома костей остался тот же.

<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1098322343027290305

## Демонстрация изменений
Выставили значение на 10000, каждый второй удар батоном по рукам всегда ломает кость, а значит переменная работает, а значит выставляем на 1.2 и радуемся жизни.
![image](https://user-images.githubusercontent.com/114731039/233288731-828eb9a5-9de5-4d79-8fcf-1accc18920e1.png)

