### PR TITLE
Fix: carbon_lose_organ_signal

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -653,7 +653,7 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 
 		// Let's non-specially remove all non-vital organs
 		// What could possibly go wrong
-		var/obj/item/I = O.remove(H)
+		var/obj/item/I = O.remove(H, TRUE)
 		// Make this support stuff that turns into items when removed
 		I.forceMove(src)
 		missing_organs += I

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -61,7 +61,8 @@
 		M.internal_organs -= src
 		if(M.internal_organs_slot[slot] == src)
 			M.internal_organs_slot.Remove(slot)
-			SEND_SIGNAL(src, COMSIG_CARBON_LOSE_ORGAN)
+			if(!special)
+				SEND_SIGNAL(src, COMSIG_CARBON_LOSE_ORGAN)
 		if(vital && !special)
 			if(M.stat != DEAD)//safety check!
 				M.death()

--- a/code/modules/surgery/organs/subtypes/diona.dm
+++ b/code/modules/surgery/organs/subtypes/diona.dm
@@ -97,7 +97,7 @@
 
 /datum/action/item_action/organ_action/diona_brain_evacuation/IsAvailable()
 	. = ..()
-	if(owner.mind.suicided)
+	if((!owner.mind) || owner.mind.suicided)
 		return FALSE
 
 


### PR DESCRIPTION
## Описание
Теперь при удалении органа необычным способом (special = TRUE), не отсылается сигнал.
Клонерка теперь в начале своей работы вынимает органы со special TRUE.
Затрагивает только дион, фикся приколы с кучей нимф тогда, когда их быть не должно.

Так же пофикшен минорный рантайм при отсутствии майнда у куклы.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

