### PR TITLE
Fix: double crates and closets for syndi spawners

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/syndiedepot.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndiedepot.dmm
@@ -147,6 +147,7 @@
 	on = 1
 	},
 /obj/effect/spawner/random_spawners/syndicate/loot,
+/obj/structure/closet/secure_closet/syndicate/depot,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -343,6 +344,7 @@
 /area/syndicate_depot/core)
 "bc" = (
 /obj/effect/spawner/random_spawners/syndicate/loot/level2,
+/obj/structure/closet/secure_closet/syndicate/depot,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -374,6 +376,7 @@
 	on = 1
 	},
 /obj/effect/spawner/random_spawners/syndicate/loot/level2,
+/obj/structure/closet/secure_closet/syndicate/depot,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -420,6 +423,7 @@
 	dir = 8
 	},
 /obj/effect/spawner/random_spawners/syndicate/loot,
+/obj/structure/closet/secure_closet/syndicate/depot,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -429,6 +433,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/random_spawners/syndicate/loot,
+/obj/structure/closet/secure_closet/syndicate/depot,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -796,6 +801,7 @@
 "cm" = (
 /obj/effect/spawner/random_spawners/syndicate/loot/level4,
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/closet/secure_closet/syndicate/depot/armory,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -806,12 +812,14 @@
 	on = 1
 	},
 /obj/effect/spawner/random_spawners/syndicate/loot/level4,
+/obj/structure/closet/secure_closet/syndicate/depot/armory,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/syndicate_depot/core)
 "co" = (
 /obj/effect/spawner/random_spawners/syndicate/loot/level4,
+/obj/structure/closet/secure_closet/syndicate/depot/armory,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -1109,6 +1117,7 @@
 	dir = 8
 	},
 /obj/effect/spawner/random_spawners/syndicate/loot/level2,
+/obj/structure/closet/secure_closet/syndicate/depot,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -1158,6 +1167,20 @@
 	gpstag = "ERR#UNKWN"
 	},
 /turf/simulated/wall/mineral/plastitanium/nodiagonal,
+/area/syndicate_depot/core)
+"nG" = (
+/obj/effect/spawner/random_spawners/syndicate/loot/level3,
+/obj/structure/closet/secure_closet/syndicate/depot,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/syndicate_depot/core)
+"UV" = (
+/obj/effect/spawner/random_spawners/syndicate/loot,
+/obj/structure/closet/secure_closet/syndicate/depot,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/syndicate_depot/core)
 
 (1,1,1) = {"
@@ -1800,7 +1823,7 @@ bv
 at
 aF
 ch
-aB
+UV
 at
 cM
 af
@@ -2048,7 +2071,7 @@ at
 aE
 at
 at
-aB
+UV
 aD
 aD
 bA
@@ -2056,7 +2079,7 @@ bJ
 bV
 aD
 aD
-bE
+nG
 cN
 aD
 cY
@@ -2107,7 +2130,7 @@ aD
 aD
 aD
 aD
-bE
+nG
 at
 aD
 aD
@@ -2415,7 +2438,7 @@ ck
 cy
 cK
 bY
-bE
+nG
 aD
 aD
 aE
@@ -2466,7 +2489,7 @@ cl
 cz
 aD
 cQ
-bE
+nG
 aD
 aD
 at
@@ -2502,7 +2525,7 @@ af
 at
 aw
 aD
-aB
+UV
 at
 aD
 aD
@@ -2553,7 +2576,7 @@ aq
 at
 aw
 aD
-aB
+UV
 at
 aD
 aD
@@ -2720,7 +2743,7 @@ aE
 aD
 cy
 aD
-bE
+nG
 at
 aD
 bv
@@ -2771,7 +2794,7 @@ at
 aD
 cD
 aD
-bE
+nG
 at
 aL
 aD
@@ -2908,7 +2931,7 @@ af
 af
 af
 at
-aB
+UV
 aD
 aK
 aR

--- a/code/game/objects/effects/spawners/random_spawners.dm
+++ b/code/game/objects/effects/spawners/random_spawners.dm
@@ -224,7 +224,6 @@
 /obj/effect/spawner/random_spawners/syndicate/loot
 	name = "common loot"
 	icon_state = "common"
-	spawn_inside = /obj/structure/closet/secure_closet/syndicate/depot
 	// Loot schema: costumes, toys, useless gimmick items
 	result = list(/datum/nothing = 13,
 		/obj/item/storage/toolbox/syndicate = 1,
@@ -316,7 +315,6 @@
 /obj/effect/spawner/random_spawners/syndicate/loot/level4
 	name = "armory loot"
 	icon_state = "armory"
-	spawn_inside = /obj/structure/closet/secure_closet/syndicate/depot/armory
 	// Loot schema: high-power weapons (m90, esword, ebow, revolver), devices that negate depot challenges (thermal glasses, chameleon device), explosives
 	result = list(/obj/item/gun/projectile/automatic/c20r = 1,
 		/obj/item/gun/projectile/automatic/m90 = 1,


### PR DESCRIPTION
Ввиду того, что Тайпан и депот синдиката используют одни и те же спавнеры для контрабанды произошел конфликт, при котором на Тайпане начали спавнится ящики депота.
Решение - выпилить из кода спавнера ящики и добавить их на депот вручную.