### PR TITLE
fix: Wands and Staves Open Crates Properly

### DIFF
--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -143,9 +143,8 @@
 	D.open()
 
 /obj/item/projectile/magic/door/proc/OpenCloset(var/obj/structure/closet/C)
-	if(istype(C, /obj/structure/closet/secure_closet))
-		var/obj/structure/closet/secure_closet/SC = C
-		SC.locked = FALSE
+	if(C?.locked)
+		C.locked = FALSE
 	C.open()
 
 /obj/item/projectile/magic/change


### PR DESCRIPTION
## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->В данный момент снаряд волшебной палочки и посоха открытия дверей, сработает только на закрытые шкафы, но не на ящики, из-за неверной проверки. Исправляем это недоразумение.

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
Магия должна открывать любые закрытые контейнеры одного типа
