### PR TITLE
feat: stamina loss for BS tomatos

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -110,7 +110,7 @@
 // Various gene procs
 /obj/item/reagent_containers/food/snacks/grown/attack_self(mob/user)
 	if(seed && seed.get_gene(/datum/plant_gene/trait/squash))
-		squash(user)
+		squash(user, user)
 	..()
 
 /obj/item/reagent_containers/food/snacks/grown/throw_impact(atom/hit_atom)

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -308,14 +308,19 @@
 	origin_tech = list("bluespace" = 5)
 	dangerous = TRUE
 
-/datum/plant_gene/trait/teleport/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
+/datum/plant_gene/trait/teleport/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target, mob/thrower)
 	if(isliving(target))
+		var/mob/living/living_target = target
+		if(thrower == living_target && !do_after(living_target, 1 SECONDS, target = living_target))
+			to_chat(target, "<span class='notice'>You need to hold still to squash [G.name].</span>")
+			return
 		var/teleport_radius = max(round(G.seed.potency / 10), 1)
-		var/turf/T = get_turf(target)
+		var/turf/T = get_turf(living_target)
 		new /obj/effect/decal/cleanable/molten_object(T) //Leave a pile of goo behind for dramatic effect...
 		add_attack_logs(target, T, "teleport squash [G](max radius: [teleport_radius])")
 		do_teleport(target, T, teleport_radius)
-		target.investigate_log("teleported from [COORD(T)] to [COORD(target)], squashing [G](max radius: [teleport_radius])", INVESTIGATE_BOTANY)
+		living_target.adjustStaminaLoss(33)
+		living_target.investigate_log("teleported from [COORD(T)] to [COORD(living_target)], squashing [G](max radius: [teleport_radius])", INVESTIGATE_BOTANY)
 
 /datum/plant_gene/trait/teleport/on_slip(obj/item/reagent_containers/food/snacks/grown/G, mob/living/carbon/C)
 	var/teleport_radius = max(round(G.seed.potency / 10), 1)

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -319,7 +319,8 @@
 		new /obj/effect/decal/cleanable/molten_object(T) //Leave a pile of goo behind for dramatic effect...
 		add_attack_logs(target, T, "teleport squash [G](max radius: [teleport_radius])")
 		do_teleport(target, T, teleport_radius)
-		living_target.adjustStaminaLoss(33)
+		if(thrower == living_target)
+			living_target.adjustStaminaLoss(33)
 		living_target.investigate_log("teleported from [COORD(T)] to [COORD(living_target)], squashing [G](max radius: [teleport_radius])", INVESTIGATE_BOTANY)
 
 /datum/plant_gene/trait/teleport/on_slip(obj/item/reagent_containers/food/snacks/grown/G, mob/living/carbon/C)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет задержку между нажатием и телепортом БС овощей если активировать в руках.
Добавляет стаминоурон при использовании в руке БС овощей, как и с БС кристаллами.

*Известные проблемы:*
Если не стоять на месте, то фрукт просто пропадёт. Но наверное это к лучшему, ибо после него оставляется `splat_type`.

## Ссылка на предложение/Причина создания ПР
[Ссылка](https://discord.com/channels/617003227182792704/755125334097133628/1068514437360783450)

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
