### PR TITLE
fix: Mecha Facing Check

### DIFF
--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -146,9 +146,8 @@
 	return
 
 //Converts an angle (degrees) into an ss13 direction
-/proc/angle2dir(degree)
-	var/list/dirs = list(NORTH, NORTHEAST, EAST, SOUTHEAST, SOUTH, SOUTHWEST, WEST, NORTHWEST)
-	return dirs[1 + round(8 + degree * 8 / 360, 1) % 8]
+GLOBAL_LIST_INIT(modulo_angle_to_dir, list(NORTH,NORTHEAST,EAST,SOUTHEAST,SOUTH,SOUTHWEST,WEST,NORTHWEST))
+#define angle2dir(X) (GLOB.modulo_angle_to_dir[round((((X%360)+382.5)%360)/45)+1])
 
 /proc/angle2dir_cardinal(angle)
 	switch(round(angle, 0.1))
@@ -162,18 +161,26 @@
 			return WEST
 
 //returns the north-zero clockwise angle in degrees, given a direction
-
-/proc/dir2angle(var/D)
+/proc/dir2angle(D)
 	switch(D)
-		if(NORTH)		return 0
-		if(SOUTH)		return 180
-		if(EAST)		return 90
-		if(WEST)		return 270
-		if(NORTHEAST)	return 45
-		if(SOUTHEAST)	return 135
-		if(NORTHWEST)	return 315
-		if(SOUTHWEST)	return 225
-		else			return null
+		if(NORTH)
+			return 0
+		if(SOUTH)
+			return 180
+		if(EAST)
+			return 90
+		if(WEST)
+			return 270
+		if(NORTHEAST)
+			return 45
+		if(SOUTHEAST)
+			return 135
+		if(NORTHWEST)
+			return 315
+		if(SOUTHWEST)
+			return 225
+		else
+			return null
 
 //Returns the angle in english
 /proc/angle2text(var/degree)

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -146,16 +146,9 @@
 	return
 
 //Converts an angle (degrees) into an ss13 direction
-/proc/angle2dir(var/degree)
-	degree = ((degree+22.5)%365)
-	if(degree < 45)		return NORTH
-	if(degree < 90)		return NORTHEAST
-	if(degree < 135)	return EAST
-	if(degree < 180)	return SOUTHEAST
-	if(degree < 225)	return SOUTH
-	if(degree < 270)	return SOUTHWEST
-	if(degree < 315)	return WEST
-	return NORTH|WEST
+/proc/angle2dir(degree)
+	var/list/dirs = list(NORTH, NORTHEAST, EAST, SOUTHEAST, SOUTH, SOUTHWEST, WEST, NORTHWEST)
+	return dirs[1 + round(8 + degree * 8 / 360, 1) % 8]
 
 /proc/angle2dir_cardinal(angle)
 	switch(round(angle, 0.1))

--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -86,16 +86,10 @@
  * * target - target we want to check
  */
 /obj/item/mecha_parts/mecha_equipment/proc/is_faced_target(atom/target)
+	if(!chassis || !target)
+		return FALSE
 	var/dir_to_target = get_dir(chassis, target)
-	switch(chassis.dir)
-		if(NORTH)
-			return dir_to_target == NORTH || dir_to_target == NORTHEAST || dir_to_target == NORTHWEST
-		if(SOUTH)
-			return dir_to_target == SOUTH || dir_to_target == SOUTHEAST || dir_to_target == SOUTHWEST
-		if(EAST, NORTHEAST, SOUTHEAST)
-			return dir_to_target == EAST || dir_to_target == NORTHEAST || dir_to_target == SOUTHEAST
-		if(WEST, NORTHWEST, SOUTHWEST)
-			return dir_to_target == WEST || dir_to_target == NORTHWEST || dir_to_target == SOUTHWEST
+	return dir_to_target == chassis.dir || dir_to_target == get_clockwise_dir(chassis.dir) || dir_to_target == get_anticlockwise_dir(chassis.dir)
 
 /obj/item/mecha_parts/mecha_equipment/proc/action(atom/target)
 	return 0

--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -86,7 +86,16 @@
  * * target - target we want to check
  */
 /obj/item/mecha_parts/mecha_equipment/proc/is_faced_target(atom/target)
-	return get_dir(chassis, target) & chassis.dir
+	var/dir_to_target = get_dir(chassis, target)
+	switch(chassis.dir)
+		if(NORTH)
+			return dir_to_target == NORTH || dir_to_target == NORTHEAST || dir_to_target == NORTHWEST
+		if(SOUTH)
+			return dir_to_target == SOUTH || dir_to_target == SOUTHEAST || dir_to_target == SOUTHWEST
+		if(EAST, NORTHEAST, SOUTHEAST)
+			return dir_to_target == EAST || dir_to_target == NORTHEAST || dir_to_target == SOUTHEAST
+		if(WEST, NORTHWEST, SOUTHWEST)
+			return dir_to_target == WEST || dir_to_target == NORTHWEST || dir_to_target == SOUTHWEST
 
 /obj/item/mecha_parts/mecha_equipment/proc/action(atom/target)
 	return 0

--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -79,6 +79,15 @@
 		return 0
 	return 1
 
+/**
+ * Proc that checks if the target of the mecha is in front of it
+ *
+ * Arguments
+ * * target - target we want to check
+ */
+/obj/item/mecha_parts/mecha_equipment/proc/is_faced_target(atom/target)
+	return get_dir(chassis, target) & chassis.dir
+
 /obj/item/mecha_parts/mecha_equipment/proc/action(atom/target)
 	return 0
 

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -306,6 +306,8 @@
 		return
 	if(mode)
 		return analyze_reagents(target)
+	if(!is_faced_target(target))
+		return FALSE
 	if(!syringes.len)
 		occupant_message("<span class=\"alert\">No syringes loaded.</span>")
 		return

--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -16,6 +16,8 @@
 /obj/item/mecha_parts/mecha_equipment/teleporter/action(atom/target)
 	if(!action_checks(target) || !is_teleport_allowed(loc.z))
 		return
+	if(!is_faced_target(target))
+		return FALSE
 	var/turf/T = get_turf(target)
 	if(T)
 		chassis.use_power(energy_drain)
@@ -46,6 +48,8 @@
 /obj/item/mecha_parts/mecha_equipment/wormhole_generator/action(atom/target)
 	if(!action_checks(target) || !is_teleport_allowed(loc.z))
 		return
+	if(!is_faced_target(target))
+		return FALSE
 	var/list/theareas = get_areas_in_range(100, chassis)
 	if(!theareas.len)
 		return
@@ -97,6 +101,8 @@
 /obj/item/mecha_parts/mecha_equipment/gravcatapult/action(atom/movable/target)
 	if(!action_checks(target))
 		return
+	if(!is_faced_target(target))
+		return FALSE
 	if(cooldown_timer > world.time)
 		occupant_message("<span class='warning'>[src] is still recharging.</span>")
 		return

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -28,6 +28,8 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/action(target, params)
 	if(!action_checks(target))
 		return 0
+	if(!is_faced_target(target))
+		return FALSE
 
 	var/turf/curloc = get_turf(chassis)
 	var/turf/targloc = get_turf(target)
@@ -240,6 +242,7 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic
 	name = "General Ballisic Weapon"
 	size = 2
+
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/action_checks(atom/target)
 	if(..())
 		if(projectiles > 0)
@@ -354,6 +357,8 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/action(target, params)
 	if(!action_checks(target))
 		return
+	if(!is_faced_target(target))
+		return FALSE
 	var/obj/item/missile/M = new projectile(chassis.loc)
 	M.primed = 1
 	playsound(chassis, fire_sound, 50, 1)
@@ -412,6 +417,8 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flashbang/action(target, params)
 	if(!action_checks(target))
 		return
+	if(!is_faced_target(target))
+		return FALSE
 	var/obj/item/grenade/flashbang/F = new projectile(chassis.loc)
 	playsound(chassis, fire_sound, 50, 1)
 	F.throw_at(target, missile_range, missile_speed)
@@ -457,6 +464,8 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/banana_mortar/action(target, params)
 	if(!action_checks(target))
 		return
+	if(!is_faced_target(target))
+		return FALSE
 	var/obj/item/grown/bananapeel/B = new projectile(chassis.loc)
 	playsound(chassis, fire_sound, 60, 1)
 	B.throw_at(target, missile_range, missile_speed)
@@ -484,6 +493,8 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/mousetrap_mortar/action(target, params)
 	if(!action_checks(target))
 		return
+	if(!is_faced_target(target))
+		return FALSE
 	var/obj/item/assembly/mousetrap/M = new projectile(chassis.loc)
 	M.secured = 1
 	playsound(chassis, fire_sound, 60, 1)
@@ -514,6 +525,8 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/bola/action(target, params)
 	if(!action_checks(target))
 		return
+	if(!is_faced_target(target))
+		return FALSE
 	var/obj/item/restraints/legcuffs/bola/M = new projectile(chassis.loc)
 	playsound(chassis, fire_sound, 50, 1)
 	M.throw_at(target, missile_range, missile_speed)


### PR DESCRIPTION
## Описание
<!--  -->
В данный момент мехи могут использовать различное оборудование на цели позади себя, во время движения по диагонали. Добавил проверку, которая будет сверять направление меха и вектора до цели, у всего оборудования, где это важно.

NW--N--NE
W--------E
SW--S--SE

Двигаясь по горизонтали или по вертикали, мех может стрелять только по трём направлениям, например, двигаясь на восток (E), мех может стрелять только на восток (E) / северо-восток (NE) / юго-восток (SE).

Двигаясь по любой диагонали, мех может стрелять по двум дополнительным направлениям, например, двигаясь на юго-восток (SE), мех может стрелять не только на юго-восток (SE) / восток (E) / юг (S), но и на северо-восток (NE) + юго-запад (SW).

## Ссылка на предложение/Причина создания ПР
<!-- -->Мех не должен стрелять себе за спину

## Демонстрация проблемы
<!-- -->
Вот так было раньше, при движении, по диагонали, на юго-запад, к примеру:

![dreamseeker_f5xonfl27z](https://user-images.githubusercontent.com/35403274/235943287-ffe41460-04da-426a-8ebb-4e12b5e327f9.gif)


