### PR TITLE
fix: Morph Open Vent Range Fix

### DIFF
--- a/code/game/gamemodes/miniantags/morph/spells/open_vent.dm
+++ b/code/game/gamemodes/miniantags/morph/spells/open_vent.dm
@@ -8,13 +8,15 @@
 	allowed_type = /obj/machinery/atmospherics/unary
 
 /obj/effect/proc_holder/spell/targeted/click/morph_spell/open_vent/valid_target(target, user)
+	. = ..()
+	if(!.)
+		return FALSE
 	if(istype(target, /obj/machinery/atmospherics/unary/vent_scrubber))
 		var/obj/machinery/atmospherics/unary/vent_scrubber/S = target
 		return S.welded
 	else if(istype(target, /obj/machinery/atmospherics/unary/vent_pump))
 		var/obj/machinery/atmospherics/unary/vent_scrubber/V = target
 		return V.welded
-	return FALSE
 
 /obj/effect/proc_holder/spell/targeted/click/morph_spell/open_vent/cast(list/targets, mob/living/simple_animal/hostile/morph/user)
 	if(!length(targets))

--- a/code/game/gamemodes/miniantags/morph/spells/open_vent.dm
+++ b/code/game/gamemodes/miniantags/morph/spells/open_vent.dm
@@ -8,8 +8,7 @@
 	allowed_type = /obj/machinery/atmospherics/unary
 
 /obj/effect/proc_holder/spell/targeted/click/morph_spell/open_vent/valid_target(target, user)
-	. = ..()
-	if(!.)
+	if(!..())
 		return FALSE
 	if(istype(target, /obj/machinery/atmospherics/unary/vent_scrubber))
 		var/obj/machinery/atmospherics/unary/vent_scrubber/S = target
@@ -17,6 +16,8 @@
 	else if(istype(target, /obj/machinery/atmospherics/unary/vent_pump))
 		var/obj/machinery/atmospherics/unary/vent_scrubber/V = target
 		return V.welded
+	else
+		return FALSE
 
 /obj/effect/proc_holder/spell/targeted/click/morph_spell/open_vent/cast(list/targets, mob/living/simple_animal/hostile/morph/user)
 	if(!length(targets))

--- a/code/game/gamemodes/miniantags/morph/spells/open_vent.dm
+++ b/code/game/gamemodes/miniantags/morph/spells/open_vent.dm
@@ -13,11 +13,10 @@
 	if(istype(target, /obj/machinery/atmospherics/unary/vent_scrubber))
 		var/obj/machinery/atmospherics/unary/vent_scrubber/S = target
 		return S.welded
-	else if(istype(target, /obj/machinery/atmospherics/unary/vent_pump))
+	if(istype(target, /obj/machinery/atmospherics/unary/vent_pump))
 		var/obj/machinery/atmospherics/unary/vent_scrubber/V = target
 		return V.welded
-	else
-		return FALSE
+	return FALSE
 
 /obj/effect/proc_holder/spell/targeted/click/morph_spell/open_vent/cast(list/targets, mob/living/simple_animal/hostile/morph/user)
 	if(!length(targets))


### PR DESCRIPTION
## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
У морфа, из-за отсутствия наследования, не проверяется расстояние до вентиляционной решетки при касте способности "Вскрытие вентиляции". Исправляем возможность применять умение через весь экран

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->Фиксим баги
