### PR TITLE
Fix: robohands fear not legushki.

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/frog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/frog.dm
@@ -59,26 +59,32 @@
 	icon_living = "rare_frog"
 	icon_dead = "rare_frog_dead"
 	icon_resting = "rare_frog"
-	var/toxin_per_touch = 5
+	var/toxin_per_touch = 2.5
 	var/toxin_type = "toxin"
 	gold_core_spawnable = HOSTILE_SPAWN
 	holder_type = /obj/item/holder/frog/toxic
 
 /mob/living/simple_animal/frog/toxic/attack_hand(mob/living/carbon/human/H as mob)
-	if(!istype(H.gloves, /obj/item/clothing/gloves))
-		to_chat(H, "<span class='warning'>Дотронувшись до [src.name], ваша кожа начинает чесаться!</span>")
-		toxin_affect(H)
-		if(H.a_intent == INTENT_DISARM || H.a_intent == INTENT_HARM)
-			..()
-	else
-		..()
+	if(ishuman(H))
+		if(!istype(H.gloves, /obj/item/clothing/gloves))
+			for(var/obj/item/organ/external/A in H.bodyparts)
+				if(!A.is_robotic())
+					if((A.body_part == HAND_LEFT) || (A.body_part == HAND_RIGHT))
+						to_chat(H, "<span class='warning'>Дотронувшись до [src.name], ваша кожа начинает чесаться!</span>")
+						toxin_affect(H)
+						if(H.a_intent == INTENT_DISARM || H.a_intent == INTENT_HARM)
+							..()
+	..()
 
 /mob/living/simple_animal/frog/toxic/Crossed(AM as mob|obj, oldloc)
 	if(ishuman(AM))
 		var/mob/living/carbon/human/H = AM
 		if(!istype(H.shoes, /obj/item/clothing/shoes))
-			toxin_affect(H)
-			to_chat(H, "<span class='warning'>Ваши ступни начинают чесаться!</span>")
+			for(var/obj/item/organ/external/F in H.bodyparts)
+				if(!F.is_robotic())
+					if((F.body_part == FOOT_LEFT) || (F.body_part == FOOT_RIGHT))
+						toxin_affect(H)
+						to_chat(H, "<span class='warning'>Ваши ступни начинают чесаться!</span>")
 	..()
 
 /mob/living/simple_animal/frog/toxic/proc/toxin_affect(mob/living/carbon/human/M as mob)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Во-первых, даёт возможность носить ядовитых лягушек персонажам с двумя робо-ладонями без перчаток, во-вторых, даёт возможность безвредно ходить через ядовитых лягушек босиком персонажам с двумя робо-стопами. В-третьих, при наступании органическими ногами/попытке взять органическими руками ядовитую лягуху человек травится не на 5и токсинов, а на 2,5и за каждую органическую руку(при подборе)/ногу(при наступании).<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на баг-репорт
https://discord.com/channels/617003227182792704/1101901929073877012<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
