### PR TITLE
fix: attach_self in gravidash action

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -496,7 +496,7 @@
 	name = "Gravity jump"
 	desc = "Directs a pulse of gravity in front of the user, pulling them forward rapidly."
 
-/datum/action/item_action/gravity_jump/Trigger()
+/datum/action/item_action/gravity_jump/Trigger(attack_self = FALSE)
 	. = ..()
 	if(!.)
 		return FALSE


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Когда добавляли наследование способности прыжка у гравиботинок решили не убирать attack_self. Из-за этого при каждом клике на способности с гравиботинками мы пытаемся переключить их режим. Я не считаю что это нормально ведь рядом есть своя способность для переключения, отдельно.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Лучше убрать переключение:
![image](https://user-images.githubusercontent.com/120549107/235606434-866bdfcb-35c0-4c09-afcc-bba1709ab967.png)

<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->