### PR TITLE
fix: overlay of the fax with goal is offset

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -520,7 +520,7 @@
 /proc/print_command_report(text = "", title = "Central Command Update", add_to_records = TRUE, var/datum/station_goal/goal = null)
 	for(var/obj/machinery/computer/communications/C in GLOB.shuttle_caller_list)
 		if(!(C.stat & (BROKEN|NOPOWER)) && is_station_contact(C.z))
-			var/obj/item/paper/P = new /obj/item/paper(C.loc)
+			var/obj/item/paper/P = new (C.loc)
 			P.name = "paper- '[title]'"
 			P.info = text
 			P.update_icon()
@@ -531,8 +531,8 @@
 				var/stampvalue = "navcom"
 				var/image/stampoverlay = image('icons/obj/bureaucracy.dmi')
 				stampoverlay.icon_state = "paper_stamp-[stampvalue]"
-				stampoverlay.pixel_x = P.x
-				stampoverlay.pixel_y = P.y
+				stampoverlay.pixel_x = rand(-2, 0)
+				stampoverlay.pixel_y = rand(-1, 2)
 				P.stamped = list()
 				P.stamped += /obj/item/stamp/navcom
 				if(!P.ico)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Оверлей печати у факса с целью смещается на слишком большое расстояние (а именно на координаты самого факса).
Так быть не должно, смещаем настолько же, на сколько смещается например печать при  "злом факсе".
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
![Снимок экрана 2023-05-02 114024](https://user-images.githubusercontent.com/120549107/235624904-96a5444b-d47c-4376-8e08-32e19c57a4a3.png)

<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

