### PR TITLE
FIX: Mecha directional protection fix + ADD: take_damage attack direction

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -104,7 +104,7 @@
 /obj/attacked_by(obj/item/I, mob/living/user)
 	if(I.force)
 		user.visible_message("<span class='danger'>[user] has hit [src] with [I]!</span>", "<span class='danger'>You hit [src] with [I]!</span>")
-	take_damage(I.force, I.damtype, "melee", 1)
+	take_damage(I.force, I.damtype, "melee", 1, get_dir(src, user))
 
 /mob/living/attacked_by(obj/item/I, mob/living/user, def_zone)
 	send_item_attack_message(I, user)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Корректирует работу защиты мехов, позволяя работать бонусу/уменьшению атаки для орудий ближнего боя, также вводит расчёт угла атаки по объектам (для потомков)

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
В данный момент защита мехов против орудий ближнего боя работает некорректно, принимая со всех сторон один и тот же урон. Причём для атак дальнего боя и метательных атак защита отрабатывает корректно, давая лицевую/боковую защиту и уязвимость со стороны спины.

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
https://media.discordapp.net/attachments/734823601110515882/1103417691735339068/13_.gif?width=672&height=676
