### PR TITLE
Фикс трейтов пеплоходцев

### DIFF
--- a/code/modules/mob/living/carbon/human/species/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/unathi.dm
@@ -149,7 +149,7 @@
 	default_language = "Sinta'unathi"
 
 	speed_mod = -0.80
-	species_traits = list(NOGUNS)
+	species_traits = list(NOGUNS, LIPS, PIERCEIMMUNE)
 
 	has_organ = list(
 		"heart" =    /obj/item/organ/internal/heart/unathi,


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Теперь у пеплоходцев есть те же трейты, что и унатхов, в добавок к невозможности стрелять

## Ссылка на предложение/Причина создания ПР
Пеплоходцы это бывшие унатхи, у них должны быть такие же трейты
