### PR TITLE
fix: all donuts have initial icon

### DIFF
--- a/code/modules/food_and_drinks/food/foods/baked_goods.dm
+++ b/code/modules/food_and_drinks/food/foods/baked_goods.dm
@@ -480,6 +480,9 @@
 		filling_color = "#FF69B4"
 	. = ..()
 
+/obj/item/reagent_containers/food/snacks/donut/update_icon()
+	return
+
 /obj/item/reagent_containers/food/snacks/donut/sprinkles
 	name = "frosted donut"
 	icon_state = "donut2"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Из-за того что все реагент контейнеры теперь обновляют иконки при создании, пончики, которые с 30% шансом становятся с посыпкой, всегда имели базовую иконку.  Поэтому перегружаем апдейт, чтобы иконки были в порядке. Чинит иконки только самих пончиков.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Без розовых пончиков мир становится тусклее.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
