### PR TITLE
Tweak: Clockwork patch (Cogscarab, Marauder, Beacon)

### DIFF
--- a/code/_onclick/hud/_defines.dm
+++ b/code/_onclick/hud/_defines.dm
@@ -115,7 +115,7 @@
 #define ui_alien_health "EAST-1:28,CENTER-1:15" //aliens have the health display where humans have the pressure damage indicator.
 
 //aliens
-#define ui_cogscarab_timer "EAST-1:28,CENTER-3:11" //where the nutrition should be.
+#define ui_cogscarab_timer "EAST-1:27,CENTER+0:16" //Under health tab
 
 //constructs
 #define ui_construct_pull "EAST-1:28,SOUTH+1:10" //above the zone_sel icon

--- a/code/_onclick/hud/cogscarab.dm
+++ b/code/_onclick/hud/cogscarab.dm
@@ -1,5 +1,10 @@
 /obj/screen/wind_up_timer
-	name = "wind up timer"
+	name = "Windup"
 	icon = 'icons/mob/screen_gen.dmi'
 	icon_state = "windup_display-1"
 	screen_loc = ui_cogscarab_timer
+
+/obj/screen/wind_up_timer/examine(mob/user, infix, suffix)
+	. = ..()
+	var/mob/living/silicon/robot/cogscarab/cog = user
+	. += "<span class='notice'>Windup time: [cog.wind_up_timer].</span><BR>"

--- a/code/game/gamemodes/clockwork/clockwork_mob.dm
+++ b/code/game/gamemodes/clockwork/clockwork_mob.dm
@@ -46,10 +46,10 @@
 	SSticker.mode.remove_clocker(mind, FALSE)
 
 /mob/living/simple_animal/hostile/clockwork/marauder/AttackingTarget()
-	if(a_intent == INTENT_HELP && isliving(target) && !isclocker(target)) // yes i know, it's not a disarm
+	if(a_intent == INTENT_DISARM && isliving(target) && !isclocker(target))
 		var/mob/living/L = target
 		playsound(loc, 'sound/weapons/clash.ogg', 50, TRUE)
-		L.adjustStaminaLoss(20)
+		L.adjustStaminaLoss(25)
 		src.do_attack_animation(target)
 		target.visible_message("<span class='danger'>[src] hits [target] with flat of the sword!</span>", \
 						"<span class='userdanger'>[src] hits you with flat of the sword!</span>")
@@ -99,6 +99,31 @@
 			playsound(src, "ricochet", 50, TRUE)
 		return TRUE
 	return FALSE
+
+/mob/living/simple_animal/hostile/clockwork/marauder/a_intent_change(input as text)
+	set name = "a-intent"
+	set hidden = 1
+	if(can_change_intents)
+		switch(input)
+			if(INTENT_HELP,INTENT_DISARM,INTENT_HARM)
+				a_intent = input
+			if("right")
+				if(a_intent == INTENT_HELP)
+					a_intent = INTENT_DISARM
+				else if(a_intent == INTENT_DISARM)
+					a_intent = INTENT_HARM
+				else if(a_intent == INTENT_HARM)
+					a_intent = INTENT_HELP
+			if("left")
+				if(a_intent == INTENT_HELP)
+					a_intent = INTENT_HARM
+				else if(a_intent == INTENT_DISARM)
+					a_intent = INTENT_HELP
+				else if(a_intent == INTENT_HARM)
+					a_intent = INTENT_DISARM
+		if(hud_used && hud_used.action_intent)
+			hud_used.action_intent.icon_state = "[a_intent]"
+
 
 /*MOUSE*/
 /mob/living/simple_animal/mouse/clockwork

--- a/code/game/gamemodes/clockwork/clockwork_structures.dm
+++ b/code/game/gamemodes/clockwork/clockwork_structures.dm
@@ -97,7 +97,7 @@
 	name = "herald's beacon"
 	desc = "An imposing spire formed of brass. It somewhat pulsates."
 	icon_state = "beacon"
-	max_integrity = 750 // A very important one
+	max_integrity = 250 // A very important one
 	death_message = "<span class='danger'>The beacon crumbles and falls in parts to the ground relaesing it's power!</span>"
 	death_sound = 'sound/effects/creepyshriek.ogg'
 	var/heal_delay = 6 SECONDS

--- a/code/game/gamemodes/clockwork/cogscarab.dm
+++ b/code/game/gamemodes/clockwork/cogscarab.dm
@@ -85,8 +85,8 @@
 	if(hud_used)
 		var/datum/hud/hud = hud_used
 		if(!hud.wind_up_timer)
-			hud.wind_up_timer = new /obj/screen()
-			hud.static_inventory += hud.wind_up_timer
+			hud.wind_up_timer = new /obj/screen/wind_up_timer()
+			hud.infodisplay += hud.wind_up_timer
 			hud.show_hud(hud.hud_version)
 
 /mob/living/silicon/robot/cogscarab/Life(seconds, times_fired)
@@ -176,7 +176,7 @@
 /mob/living/silicon/robot/cogscarab/update_stat(reason = "none given", should_log = FALSE)
 	if(status_flags & GODMODE)
 		return ..()
-	if(health <= -maxHealth && stat != DEAD)
+	if(health <= 0 && stat != DEAD)
 		ghostize(TRUE)
 		gib()
 		log_debug("died of damage, trigger reason: [reason]")


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Fix: худ таймера для скарабея. Раньше не показывал потому что....
Fix: Марадёр теперь имеет третий правильный интент: дизарм. Раньше он мог стаминить через хелп интент, но теперь через дизарм интент.(Если хочет потыкать на хелп кого-то)
Tweak: Увеличивает урон стамина марадёра 20>25
Tweak: Здоровье маяка уменьшилось 750>250 (Даже 250 довольно крупная цифра для столь малой постройки)
Tweak: Нерфим скрытный баф скарабеев а именно максимум хп. Для смерти скарабея требовалось изначально понизить его здоровье до минус макс его хп т.е. не 35, а до 70 (-35). Теперь как и надо было 35.


## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Фиксы плюс пару баланс изменений.

Часть игроков была запутана тем, что марадёр наносил стамин урон на хелп интенте. И его мало кто использует. Данный баланс (+5 стамина) должен побудить игроков выбирать мирный путь нежели через резню.

Здоровье маяка было слишком большим. А поломка его занимало долгое время. Он даже крупнее чем портал ратвара что абсурдно. Теперь имеет здоровье как остальные многие постройки(в районе 200 пунктов)

Скарабей не боевой и данный скрытый баф не входил в план. Это не твик а больше как фикс ошибки.