### PR TITLE
fix/feat: Fulton & Crates

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -6,11 +6,12 @@
 	almost anything into a trash can.
 */
 /atom/MouseDrop(atom/over)
+	. = TRUE
 	if(!usr || !over)
-		return
+		return FALSE
 	if(!(istype(over, /obj/screen) || (loc && loc == over.loc)))
 		if(!Adjacent(usr) || !over.Adjacent(usr)) // should stop you from dragging through windows
-			return
+			return FALSE
 
 	INVOKE_ASYNC(over, PROC_REF(MouseDrop_T), src, usr)
 

--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -38,6 +38,16 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 		beacon = A
 		to_chat(user, "You link the extraction pack to the beacon system.")
 
+/obj/item/extraction_pack/MouseDrop(atom/over)
+	if(!..())
+		return FALSE
+	if(!(loc == usr && loc.Adjacent(over)))
+		return FALSE
+	if(usr.stat || !ishuman(usr) || usr.incapacitated())
+		return FALSE
+	afterattack(over, usr, TRUE)
+	return TRUE
+
 /obj/item/extraction_pack/afterattack(atom/movable/A, mob/living/carbon/human/user, flag, params)
 	. = ..()
 	if(!beacon)


### PR DESCRIPTION
## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->Добавляем возможность активации фултона, при его перетаскивании на атом. Стандартная активация, через прок атаки, открывала ящик/шкаф и в итоге он отправлялся без содержимого.

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
Теперь фултоном можно отправлять закрытые шкафы или ящики

