### PR TITLE
Fix: pet holders devouring.

### DIFF
--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -35,9 +35,10 @@
 
 /obj/item/holder/attack(mob/living/target, mob/living/user, def_zone)
 	if(ishuman(user))	//eating holder
-		for(var/mob/M in src.contents)
-			if(devoured(M, user))
-				return TRUE
+		if(target == user)
+			for(var/mob/M in src.contents)
+				if(devoured(M, user))
+					return TRUE
 	. = ..()
 
 /obj/item/holder/proc/show_message(var/message, var/m_type)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Исправляет Пупсмомент, где у холдера питомцев не прописана проверка на то, что для прока пожирания целью должен быть именно юзер, так что при клике на любое существо срабатывал прок пожирания на том, кто кликал, что приводило к непониманиям. Теперь, по старой доброй схеме пожирания, жрать может только юзер и только кликая на себя.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на баг-репорт
https://discord.com/channels/617003227182792704/1097769266037669888<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
