### PR TITLE
fix: no more repeated bombs for guardian

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/types/bomb.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/bomb.dm
@@ -49,6 +49,8 @@
 	if(istype(A, /obj/machinery/disposal)) // Have no idea why they just destroy themselves
 		to_chat(src, "<span class='warning'>Бомбы не мусор! Нельзя минировать мусорки!</span>")
 		return FALSE
+	if(istype(A, /obj/item/guardian_bomb)) //No multibombing
+		return FALSE
 	return TRUE
 
 /obj/item/guardian_bomb

--- a/code/game/gamemodes/miniantags/guardian/types/bomb.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/bomb.dm
@@ -49,7 +49,7 @@
 	if(istype(A, /obj/machinery/disposal)) // Have no idea why they just destroy themselves
 		to_chat(src, "<span class='warning'>Бомбы не мусор! Нельзя минировать мусорки!</span>")
 		return FALSE
-	if(istype(A, /obj/item/guardian_bomb)) //No multibombing
+	if(istype(A, /obj/item/guardian_bomb)) //No multibombing, beware of infinite bombs if you dare removing this
 		return FALSE
 	return TRUE
 

--- a/code/game/gamemodes/miniantags/guardian/types/bomb.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/bomb.dm
@@ -49,7 +49,7 @@
 	if(istype(A, /obj/machinery/disposal)) // Have no idea why they just destroy themselves
 		to_chat(src, "<span class='warning'>Бомбы не мусор! Нельзя минировать мусорки!</span>")
 		return FALSE
-	if(istype(A, /obj/item/guardian_bomb)) //No multibombing, beware of infinite bombs if you dare removing this
+	if(istype(A, /obj/item/guardian_bomb)) //No multibombing, be aware of infinite bombs if you dare removing this
 		return FALSE
 	return TRUE
 

--- a/code/game/gamemodes/miniantags/guardian/types/bomb.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/bomb.dm
@@ -22,7 +22,7 @@
 	if(get_dist(get_turf(src), get_turf(A)) > 3)
 		to_chat(src, "<span class='danger'>Слишком далеко от [A] чтобы скрыть это как бомбу.</span>")
 		return
-	if(istype(A, /obj/) && can_plant(A))
+	if(isobj(A) && can_plant(A))
 		if(bomb_cooldown <= world.time && !stat)
 			var/obj/item/guardian_bomb/B = new /obj/item/guardian_bomb(get_turf(A))
 			add_attack_logs(src, A, "booby trapped (summoner: [summoner])")


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление ошибки "бесконечных бомб" защитника-подрывника.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Сам механизм установки/подрыва бомбы сломан при n > 1, где n - число бомб.
https://discord.com/channels/617003227182792704/1101226187486937238/1101226187486937238
## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
Теперь нельзя установить новую бомбу поверх старой, если та не закончила свое действие или не была взорвана.