### PR TITLE
Feat: Cere improvement

### DIFF
--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -40,13 +40,17 @@
 	},
 /area/toxins/lab)
 "aan" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	on = 0;
+	pixel_x = -6;
+	pixel_y = 14
 	},
-/obj/machinery/dnaforensics,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/item/storage/fancy/cigarettes/dromedaryco,
+/obj/item/clothing/glasses/sunglasses,
+/turf/simulated/floor/carpet{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "carpet6-2"
 	},
 /area/security/detectives_office)
 "aas" = (
@@ -650,8 +654,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
@@ -682,10 +687,9 @@
 	},
 /area/security/permabrig)
 "aeK" = (
-/obj/machinery/alarm{
-	pixel_y = 24
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
-/obj/structure/closet/secure_closet/injection,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -792,6 +796,7 @@
 /obj/structure/chair/comfy{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "afO" = (
@@ -828,6 +833,7 @@
 /obj/structure/table,
 /obj/item/dice/d20,
 /obj/item/instrument/harmonica,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -939,6 +945,21 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/starboard)
+"ahd" = (
+/obj/effect/decal/warning_stripes/northeast,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/closet/secure_closet/hos,
+/obj/item/megaphone,
+/obj/item/reagent_containers/food/drinks/flask/barflask,
+/obj/item/spacepod_equipment/key{
+	id = 100000
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/security/hos)
 "ahj" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/fingerless,
@@ -986,10 +1007,6 @@
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "ahK" = (
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "brigpsych"
-	},
 /obj/machinery/computer/operating{
 	dir = 4
 	},
@@ -1047,6 +1064,13 @@
 	tag = "icon-redfull (NORTHWEST)"
 	},
 /area/crew_quarters/kitchen)
+"aiw" = (
+/obj/machinery/vending/cigarette/free,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "darkred"
+	},
+/area/security/brig)
 "aiF" = (
 /obj/structure/chair/comfy{
 	dir = 1
@@ -1158,9 +1182,17 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/recharger{
+	pixel_x = 1;
+	pixel_y = 3
+	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/main)
 "ajz" = (
@@ -1174,7 +1206,9 @@
 /obj/structure/cable/orange{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
 /area/security/prisonershuttle)
 "ajB" = (
 /obj/machinery/light{
@@ -1201,16 +1235,13 @@
 	},
 /area/turret_protected/ai)
 "ajH" = (
-/obj/structure/curtain/black,
-/obj/structure/bed,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/engine,
 /area/security/execution)
 "ajI" = (
+/obj/item/pickaxe,
+/obj/item/pickaxe,
 /obj/structure/rack,
-/obj/item/shovel,
-/obj/item/shovel,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/mine/unexplored/cere/command)
 "ajJ" = (
@@ -1312,16 +1343,10 @@
 	},
 /area/security/permabrig)
 "aka" = (
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/execution)
+/area/space)
 "akc" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -1511,19 +1536,24 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
 /area/security/prisonershuttle)
 "akD" = (
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -24
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/security/execution)
 "akE" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -1550,10 +1580,10 @@
 	},
 /area/security/permabrig)
 "akK" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -1600,16 +1630,26 @@
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
 "ali" = (
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -24
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/security/execution)
 "alj" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -1623,8 +1663,13 @@
 	},
 /area/maintenance/fsmaint4)
 "all" = (
-/obj/machinery/ai_status_display,
-/turf/simulated/wall/r_wall,
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/security/execution)
 "aln" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1635,6 +1680,21 @@
 	icon_state = "floorgrime"
 	},
 /area/security/permabrig)
+"alo" = (
+/obj/machinery/computer/security/wooden_tv{
+	network = list("SS13","Research Outpost","Mining Outpost");
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/obj/structure/table/wood,
+/obj/machinery/button/windowtint{
+	dir = 4;
+	id = "Detective";
+	pixel_x = 32;
+	req_access = list(4)
+	},
+/turf/simulated/floor/carpet,
+/area/security/detectives_office)
 "alp" = (
 /obj/machinery/light/small,
 /obj/machinery/cryopod{
@@ -1648,11 +1708,11 @@
 /obj/structure/cable/orange{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/security/permabrig)
@@ -1868,28 +1928,20 @@
 	},
 /area/turret_protected/aisat_interior/secondary)
 "amM" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
+/obj/item/radio/intercom{
+	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/security/execution)
 "amN" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -1942,10 +1994,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/north)
 "amW" = (
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/light/small{
+/obj/machinery/atmospherics/binary/valve/digital{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -1982,8 +2034,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/north)
 "ane" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/computer/card/minor/hos{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
 /turf/simulated/floor/wood,
 /area/security/hos)
@@ -2127,8 +2183,6 @@
 /obj/structure/cable/orange{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/flasher_button{
 	id = "permaflash2";
 	name = "Prison Cell 2 Flasher";
@@ -2147,6 +2201,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
 	},
@@ -2204,12 +2264,6 @@
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
 "aom" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching Prison Wing holding areas.";
-	name = "Prison Monitor";
-	network = list("Prison");
-	pixel_x = -32
-	},
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
 	},
@@ -2297,34 +2351,29 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
 /area/security/prisonershuttle)
 "apb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
 /area/security/prisonershuttle)
-"apc" = (
-/obj/structure/table,
-/obj/item/storage/box/prisoner,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/security/prisonlockers)
 "ape" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 5
 	},
-/obj/machinery/light_switch{
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
 /area/security/prisonlockers)
 "apf" = (
 /obj/machinery/door/airlock/security/glass{
@@ -2338,7 +2387,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
 /area/security/prisonlockers)
 "apg" = (
 /obj/structure/chair/office/dark,
@@ -2361,7 +2412,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "darkredfull"
+	icon_state = "dark"
 	},
 /area/security/permabrig)
 "apk" = (
@@ -2404,22 +2455,11 @@
 	},
 /area/hallway/secondary/entry/north)
 "apA" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/clothing/glasses/sunglasses/blindfold,
-/obj/item/taperecorder,
-/obj/item/storage/fancy/cigarettes/cigpack_robust,
-/obj/item/lighter,
+/obj/item/flag/species,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/execution)
+/area/space)
 "apI" = (
 /obj/structure/cable/orange{
 	icon_state = "2-4"
@@ -2518,6 +2558,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior/secondary)
+"aqh" = (
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "darkred"
+	},
+/area/security/brig)
 "aqk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2612,27 +2658,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/northeast)
 "aqY" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Prisoner Lockers";
-	req_access = list(63)
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/orange{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/security/prisonlockers)
+/area/security/permabrig)
 "ara" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/security/prisonlockers)
-"arb" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/structure/table,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/under/color/orange/prison,
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
 "arc" = (
@@ -2658,13 +2692,11 @@
 /area/maintenance/disposal/northeast)
 "arp" = (
 /obj/structure/cable/orange{
-	icon_state = "0-2"
+	icon_state = "1-8"
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 24
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
 	},
-/turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
 "ars" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -2776,17 +2808,20 @@
 /turf/simulated/floor/plating,
 /area/security/prisonershuttle)
 "arW" = (
-/obj/structure/table,
-/obj/item/storage/box/prisoner,
-/obj/machinery/light,
-/turf/simulated/floor/plasteel,
-/area/security/prisonlockers)
+/obj/structure/chair/comfy/red,
+/obj/effect/landmark/start/head_of_security,
+/obj/effect/decal/warning_stripes/red/hollow,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "asa" = (
-/obj/structure/table,
-/obj/item/clothing/shoes/orange,
-/obj/item/clothing/under/color/orange/prison,
-/turf/simulated/floor/plasteel,
-/area/security/prisonlockers)
+/obj/structure/chair/comfy/black,
+/obj/effect/decal/warning_stripes/red/hollow,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "asc" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Prison Wing";
@@ -2801,8 +2836,8 @@
 	},
 /area/security/permabrig)
 "asu" = (
-/obj/machinery/ai_status_display,
-/turf/simulated/wall/r_wall,
+/obj/machinery/photocopier,
+/turf/simulated/floor/wood,
 /area/security/hos)
 "asv" = (
 /obj/structure/curtain,
@@ -2941,14 +2976,28 @@
 /turf/simulated/floor/plating,
 /area/security/hos)
 "ata" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/disposalpipe/segment,
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
 	},
+/turf/simulated/floor/wood,
 /area/security/hos)
 "atc" = (
-/turf/simulated/floor/wood,
+/obj/structure/table/wood,
+/obj/item/paper_bin/nanotrasen,
+/obj/item/flashlight/lamp/green{
+	on = 0;
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/item/pen/multi,
+/obj/item/toy/figure/hos{
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
 /area/security/hos)
 "atg" = (
 /obj/structure/rack,
@@ -2970,9 +3019,8 @@
 	},
 /area/hallway/primary/starboard/south)
 "atr" = (
-/obj/structure/table,
-/obj/item/restraints/handcuffs,
-/turf/simulated/floor/plasteel,
+/obj/machinery/ai_status_display,
+/turf/simulated/wall/r_wall,
 /area/security/prisonlockers)
 "att" = (
 /obj/structure/flora/ausbushes/fullgrass,
@@ -2984,6 +3032,14 @@
 /obj/effect/spawner/lootdrop/maintenance/double,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
+"aty" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/security/hos)
 "atB" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -3121,52 +3177,20 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkredfull"
 	},
 /area/security/brig)
 "aum" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_y = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Brig Main Hall West 1"
-	},
+/obj/structure/table/reinforced,
+/obj/item/flashlight/lamp,
+/obj/item/toy/figure/secofficer,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkredcorners"
+	icon_state = "dark"
 	},
-/area/security/brig)
-"aup" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkredcorners"
-	},
-/area/security/brig)
+/area/space)
 "auq" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 24
 	},
 /obj/structure/cable/orange{
 	icon_state = "0-4"
@@ -3178,8 +3202,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkredcorners"
+	icon_state = "dark"
 	},
 /area/security/brig)
 "auF" = (
@@ -3193,8 +3216,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkredcorners"
+	icon_state = "darkredfull"
 	},
 /area/security/brig)
 "auG" = (
@@ -3332,6 +3354,9 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -3568,22 +3593,12 @@
 	icon_state = "dark"
 	},
 /area/security/brig)
-"awu" = (
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
-	},
-/area/security/brig)
 "awv" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "awD" = (
@@ -3601,21 +3616,27 @@
 /turf/simulated/floor/plating,
 /area/security/brig)
 "awF" = (
-/obj/structure/chair{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_y = 10
+	},
+/obj/item/pen{
+	pixel_y = 9
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	icon_state = "dark"
 	},
-/area/security/hos)
+/area/space)
 "awG" = (
-/obj/structure/table/wood,
-/obj/item/stamp/hos,
-/obj/effect/spawner/lootdrop/officetoys,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/structure/table/reinforced,
+/obj/item/folder/red{
+	pixel_y = 3
 	},
-/area/security/hos)
+/obj/item/storage/fancy/donut_box,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "awH" = (
 /obj/structure/railing{
 	dir = 8
@@ -3644,14 +3665,13 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "awP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/chair/comfy/black{
-	dir = 8
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -3790,7 +3810,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/closet/bombcloset,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -3809,14 +3828,11 @@
 	},
 /area/turret_protected/aisat_interior)
 "axV" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/machinery/door_control{
 	desc = "A remote control-switch to lock down the prison wing's blast doors";
 	id = "Prison Gate";
 	name = "Prison Wing Lockdown";
-	pixel_x = 1;
+	pixel_x = -8;
 	pixel_y = -28;
 	req_access = list(2)
 	},
@@ -3824,21 +3840,18 @@
 	id = "hosofficedoor";
 	name = "Office Door";
 	normaldoorcontrol = 1;
-	pixel_x = 11;
+	pixel_x = 10;
 	pixel_y = -28;
 	req_access = list(58)
 	},
-/obj/machinery/door_control{
-	id = "Secure Gate";
-	name = "Brig Lockdown";
-	pixel_x = -9;
-	pixel_y = -28;
-	req_access = list(2)
+/obj/machinery/button/windowtint{
+	dir = 1;
+	id = "hos";
+	pixel_x = 1;
+	pixel_y = -27
 	},
-/mob/living/simple_animal/hostile/retaliate/araneus,
-/obj/structure/bed/dogbed{
-	desc = "A comfy-looking spider bed. You can even strap your pet in, just in case the gravity turns off.";
-	name = "spider bed"
+/obj/machinery/computer/prisoner{
+	req_access = list(2)
 	},
 /turf/simulated/floor/wood,
 /area/security/hos)
@@ -4088,19 +4101,18 @@
 /turf/simulated/wall,
 /area/security/hos)
 "azX" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
 /obj/item/radio/intercom{
 	pixel_y = -28
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/bed/dogbed{
+	desc = "A comfy-looking spider bed. You can even strap your pet in, just in case the gravity turns off.";
+	name = "spider bed"
 	},
+/mob/living/simple_animal/hostile/retaliate/araneus,
+/turf/simulated/floor/wood,
 /area/security/hos)
 "azY" = (
 /obj/machinery/light,
-/obj/machinery/photocopier,
 /turf/simulated/floor/wood,
 /area/security/hos)
 "aAb" = (
@@ -4111,15 +4123,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/plasteel,
-/area/security/processing)
-"aAe" = (
-/obj/machinery/computer/security{
-	dir = 1;
-	network = list("SS13","Research Outpost","Mining Outpost")
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "redcorner"
 	},
-/turf/simulated/floor/wood,
-/area/security/hos)
+/area/security/processing)
 "aAg" = (
 /obj/machinery/conveyor/auto{
 	dir = 4
@@ -4187,6 +4195,12 @@
 	icon_state = "dark"
 	},
 /area/security/evidence)
+"aAF" = (
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "redcorner"
+	},
+/area/security/main)
 "aAG" = (
 /obj/machinery/door_control{
 	desiredstate = 1;
@@ -4205,18 +4219,10 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/cabin2)
 "aAJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "darkredfull"
 	},
-/obj/structure/chair/comfy/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/red/hollow,
-/turf/simulated/floor/plasteel,
-/area/security/main)
+/area/space)
 "aAS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4296,7 +4302,10 @@
 /obj/item/gun/energy/laser/practice,
 /obj/machinery/recharger,
 /obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "red"
+	},
 /area/security/range)
 "aBI" = (
 /obj/structure/cable{
@@ -4468,11 +4477,9 @@
 /turf/simulated/wall,
 /area/engine/engineering)
 "aDa" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	dir = 4;
+	icon_state = "red"
 	},
 /area/security/main)
 "aDc" = (
@@ -4484,7 +4491,10 @@
 "aDe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "red"
+	},
 /area/security/range)
 "aDh" = (
 /obj/structure/chair/sofa/corp/right{
@@ -4633,24 +4643,43 @@
 "aEi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
-	},
+/turf/simulated/floor/plasteel,
 /area/security/seceqstorage)
 "aEj" = (
 /turf/simulated/floor/grass,
 /area/hallway/spacebridge/scidock)
 "aEk" = (
+/obj/structure/table/reinforced,
+/obj/item/radio{
+	pixel_x = -4
+	},
+/obj/item/radio{
+	pixel_x = 4
+	},
+/obj/item/radio{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/radio{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/main)
 "aEq" = (
 /obj/structure/target_stake,
 /obj/machinery/magnetic_module,
-/turf/simulated/floor/plasteel,
+/obj/effect/decal/warning_stripes/red/hollow,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull";
+	tag = "icon-redfull (NORTHWEST)"
+	},
 /area/security/range)
 "aEs" = (
 /obj/effect/spawner/airlock/w_to_e,
@@ -4860,6 +4889,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/computer/med_data{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitered"
@@ -4915,10 +4947,7 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
-	},
+/turf/simulated/floor/plasteel,
 /area/security/seceqstorage)
 "aGX" = (
 /obj/effect/spawner/window/reinforced,
@@ -5155,7 +5184,10 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "red"
+	},
 /area/security/processing)
 "aIR" = (
 /obj/structure/disposaloutlet,
@@ -5166,7 +5198,7 @@
 /area/maintenance/disposal/northwest)
 "aIX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -5185,10 +5217,6 @@
 "aJb" = (
 /obj/machinery/light{
 	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
 	},
 /obj/machinery/flasher/portable,
 /obj/effect/decal/warning_stripes/red/hollow,
@@ -5496,9 +5524,14 @@
 	dir = 1;
 	pixel_y = 24
 	},
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_x = 1;
+	pixel_y = 3
+	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/main)
 "aLs" = (
@@ -5629,14 +5662,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
-"aLZ" = (
-/obj/item/vending_refill/cola,
-/obj/item/multitool,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/security/permabrig)
 "aMc" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
@@ -5734,17 +5759,6 @@
 	icon_state = "dark"
 	},
 /area/security/warden)
-"aMS" = (
-/obj/machinery/suit_storage_unit/security,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
-	},
-/area/security/armory)
 "aMX" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -5866,7 +5880,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "red"
+	},
 /area/security/lobby)
 "aNK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5998,6 +6015,9 @@
 	},
 /area/security/warden)
 "aOI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
 	},
@@ -6009,6 +6029,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -6037,14 +6060,14 @@
 /obj/item/clothing/suit/armor/riot,
 /obj/item/shield/riot,
 /obj/item/clothing/head/helmet/riot,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/area/security/armory)
-"aOO" = (
-/obj/machinery/suit_storage_unit/security,
-/obj/structure/window/reinforced,
+/obj/machinery/door/window{
+	dir = 1;
+	name = "Secure Armory";
+	req_access = list(1)
+	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -6286,19 +6309,20 @@
 	dir = 4;
 	icon_state = "pipe-y"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
-	},
+/turf/simulated/floor/plasteel,
 /area/security/lobby)
 "aPW" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/lobby)
 "aPX" = (
+/obj/structure/chair{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/lobby)
 "aPY" = (
@@ -6309,13 +6333,14 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/lobby)
 "aQc" = (
 /obj/structure/disposalpipe/junction,
 /turf/simulated/floor/plasteel{
-	dir = 8
+	dir = 8;
+	icon_state = "redcorner"
 	},
 /area/security/lobby)
 "aQj" = (
@@ -6420,7 +6445,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "aRc" = (
@@ -6436,7 +6461,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "aRe" = (
@@ -6630,7 +6655,10 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "red"
+	},
 /area/security/range)
 "aSo" = (
 /obj/structure/closet/crate,
@@ -6647,7 +6675,10 @@
 /obj/machinery/light_switch{
 	pixel_y = 24
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "red"
+	},
 /area/security/range)
 "aSz" = (
 /obj/machinery/ai_status_display,
@@ -6816,7 +6847,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "red"
+	},
 /area/security/range)
 "aTh" = (
 /obj/machinery/atm{
@@ -6901,8 +6935,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
 "aTF" = (
@@ -7033,7 +7067,8 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1
+	dir = 4;
+	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
 "aUx" = (
@@ -7205,8 +7240,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "aVz" = (
@@ -7395,13 +7430,16 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "aWm" = (
 /obj/machinery/computer/prisoner{
 	req_access = list(2)
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = 31
 	},
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
@@ -8257,7 +8295,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
 /area/security/main)
 "bav" = (
 /turf/simulated/wall/r_wall,
@@ -8406,7 +8449,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "red"
+	},
 /area/security/range)
 "baV" = (
 /obj/machinery/light/small,
@@ -8422,7 +8468,14 @@
 /area/hallway/primary/port/north)
 "bbe" = (
 /obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
+/obj/machinery/door/window/brigdoor{
+	name = "Security Reception";
+	req_access = list(1)
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "red"
+	},
 /area/security/range)
 "bbf" = (
 /obj/machinery/firealarm{
@@ -9062,16 +9115,15 @@
 	},
 /area/medical/research/restroom)
 "bed" = (
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
 /area/security/main)
 "bei" = (
 /obj/machinery/light{
@@ -9260,7 +9312,10 @@
 /area/hallway/secondary/garden)
 "beS" = (
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "red"
+	},
 /area/security/range)
 "beT" = (
 /obj/machinery/door/airlock/maintenance{
@@ -9775,7 +9830,10 @@
 "bgv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "red"
+	},
 /area/security/range)
 "bgw" = (
 /obj/structure/cable/orange{
@@ -11256,12 +11314,11 @@
 	c_tag = "Brig Briefing Room West";
 	dir = 1
 	},
-/obj/structure/chair{
-	dir = 4
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/main)
 "bnM" = (
@@ -11308,29 +11365,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/cmo)
-"bof" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "redcorner"
-	},
-/area/security/main)
 "bog" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
-	},
+/turf/simulated/floor/plasteel,
 /area/security/main)
 "bol" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/machinery/vending/security,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	dir = 6;
+	icon_state = "red"
 	},
 /area/security/main)
 "bom" = (
@@ -11346,6 +11391,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -11380,7 +11428,10 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "red"
+	},
 /area/security/range)
 "box" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -11477,24 +11528,14 @@
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "boM" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Office";
-	req_access = list(63)
+/obj/structure/chair{
+	dir = 1
 	},
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/effect/landmark/start/security_officer,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/brigstaff)
+/area/space)
 "boN" = (
 /obj/structure/cable/orange{
 	icon_state = "1-4"
@@ -12076,7 +12117,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkredfull"
 	},
 /area/security/brig)
 "bqZ" = (
@@ -12562,10 +12603,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "red"
-	},
+/turf/simulated/floor/plasteel,
 /area/security/seceqstorage)
 "bsN" = (
 /obj/machinery/door/airlock/security/glass{
@@ -12576,10 +12614,7 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
-	},
+/turf/simulated/floor/plasteel,
 /area/security/seceqstorage)
 "bsO" = (
 /obj/structure/table/reinforced,
@@ -12593,7 +12628,10 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "red"
+	},
 /area/security/range)
 "bsP" = (
 /obj/machinery/syndicatebomb/training,
@@ -12601,7 +12639,10 @@
 /obj/item/radio/intercom{
 	pixel_y = -28
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 0;
+	icon_state = "red"
+	},
 /area/security/range)
 "bsQ" = (
 /obj/machinery/light{
@@ -12610,7 +12651,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "bsR" = (
@@ -12637,7 +12678,10 @@
 /area/security/warden)
 "bsW" = (
 /obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "red"
+	},
 /area/security/range)
 "btd" = (
 /turf/simulated/wall,
@@ -12884,7 +12928,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "red"
+	},
 /area/security/range)
 "btY" = (
 /obj/machinery/light{
@@ -13827,7 +13874,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	dir = 4;
 	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
@@ -14070,6 +14117,11 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/maintenance/disposal/external/southeast)
+"byO" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "red"
+	},
+/area/security/lobby)
 "byS" = (
 /obj/item/radio/intercom{
 	pixel_y = 28
@@ -14413,7 +14465,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	pixel_y = 28
+	pixel_y = 23
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -15319,7 +15371,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "bEC" = (
@@ -16267,6 +16319,19 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"bHn" = (
+/obj/structure/table/reinforced,
+/obj/item/flashlight/seclite{
+	pixel_y = -3
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_robust{
+	pixel_y = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/security/brig)
 "bHp" = (
 /obj/machinery/shower{
 	dir = 1
@@ -16603,7 +16668,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/landmark/event/lightsout,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
 /area/security/processing)
 "bIT" = (
 /obj/structure/flora/ausbushes/ppflowers,
@@ -16618,6 +16685,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/effect/landmark/start/security_officer,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "red"
@@ -16918,8 +16986,8 @@
 "bKg" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	dir = 8;
+	icon_state = "red"
 	},
 /area/security/lobby)
 "bKp" = (
@@ -16929,13 +16997,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/landmark/event/lightsout,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
 /area/security/seceqstorage)
 "bKr" = (
 /obj/structure/cable/orange{
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
 /area/security/seceqstorage)
 "bKt" = (
 /obj/effect/landmark/start/security_officer,
@@ -17050,6 +17122,12 @@
 	req_access = list(1)
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters{
+	dir = 8;
+	id_tag = "ArmorySec";
+	layer = 5;
+	name = "Armory Security Shutters"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -17108,6 +17186,13 @@
 	id = "Secure Armory";
 	name = "Secure Armory Shutter Control";
 	pixel_x = 12;
+	pixel_y = 28;
+	req_access = list(3)
+	},
+/obj/machinery/door_control{
+	id = "ArmorySec";
+	name = "Armory Security Window Control";
+	pixel_x = -10;
 	pixel_y = 28;
 	req_access = list(3)
 	},
@@ -17338,6 +17423,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/carpet/green,
 /area/library)
+"bLL" = (
+/turf/simulated/floor/carpet{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "carpet7-3"
+	},
+/area/security/detectives_office)
 "bLO" = (
 /obj/machinery/door/window/eastright{
 	dir = 1;
@@ -18207,7 +18298,9 @@
 /area/quartermaster/storage)
 "bOR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
 /area/security/hos)
 "bOV" = (
 /obj/machinery/light/small{
@@ -18447,12 +18540,11 @@
 	},
 /area/engine/engine_smes)
 "bPO" = (
-/obj/structure/closet/secure_closet/detective,
-/obj/item/flash,
-/obj/item/restraints/handcuffs,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/item/twohanded/required/kirbyplants,
+/obj/machinery/light{
+	dir = 4
 	},
+/turf/simulated/floor/wood,
 /area/security/detectives_office)
 "bPR" = (
 /obj/structure/chair/office/dark{
@@ -18489,7 +18581,10 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "red"
+	},
 /area/security/processing)
 "bQg" = (
 /obj/machinery/hologram/holopad,
@@ -18705,12 +18800,15 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel,
-/area/security/processing)
-"bQQ" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "redcorner"
+	},
+/area/security/processing)
+"bQQ" = (
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "red"
 	},
 /area/security/seceqstorage)
 "bQT" = (
@@ -19252,6 +19350,13 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
+"bSV" = (
+/obj/machinery/vending/security,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkred"
+	},
+/area/security/brig)
 "bSW" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
@@ -19528,6 +19633,9 @@
 /area/medical/virology)
 "bTO" = (
 /obj/structure/chair,
+/obj/structure/sign/redcross{
+	pixel_x = -32
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "red"
@@ -19561,15 +19669,18 @@
 	},
 /area/security/seceqstorage)
 "bTX" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
 /obj/machinery/recharger/wallcharger{
 	pixel_y = -25
 	},
 /obj/machinery/recharger/wallcharger{
 	pixel_y = -36
 	},
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/storage/fancy/donut_box,
+/obj/item/hand_labeler,
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
@@ -19732,22 +19843,6 @@
 	pixel_x = 6;
 	pixel_y = -6
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/ammo_box/magazine/enforcer,
-/obj/item/ammo_box/magazine/enforcer{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/ammo_box/magazine/enforcer{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/ammo_box/magazine/enforcer{
-	pixel_x = -6;
-	pixel_y = 6
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
@@ -19766,39 +19861,33 @@
 	},
 /area/engine/mechanic_workshop/hangar)
 "bUK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/structure/closet/secure_closet/guncabinet{
+	anchored = 1;
+	name = "Rubber Bullets";
+	req_access = list(1)
 	},
-/obj/structure/closet/secure_closet/security,
-/obj/machinery/camera{
-	c_tag = "Brig Security Equipment Lockers";
-	dir = 1
+/obj/item/ammo_box/magazine/enforcer{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/ammo_box/magazine/enforcer,
+/obj/item/ammo_box/magazine/enforcer{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/ammo_box/magazine/enforcer{
+	pixel_x = -6;
+	pixel_y = 6
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red"
+	dir = 1
 	},
 /area/security/seceqstorage)
 "bUL" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/closet/secure_closet/guncabinet{
 	anchored = 1;
 	name = "Tasers and Dominators";
 	req_access = list(1)
-	},
-/obj/item/gun/energy/gun/advtaser,
-/obj/item/gun/energy/gun/advtaser{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/gun/advtaser{
-	pixel_x = 3;
-	pixel_y = -3
 	},
 /obj/item/gun/energy/dominator/sibyl,
 /obj/item/gun/energy/dominator/sibyl,
@@ -19839,7 +19928,7 @@
 	},
 /area/hallway/primary/fore)
 "bUP" = (
-/obj/machinery/vending/security,
+/obj/machinery/vending/clothing/departament/security,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "red"
@@ -19907,7 +19996,9 @@
 /turf/simulated/floor/wood,
 /area/maintenance/gambling_den2)
 "bVd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -19949,13 +20040,7 @@
 	},
 /area/maintenance/starboard)
 "bVp" = (
-/obj/machinery/suit_storage_unit/security,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
@@ -20402,7 +20487,6 @@
 	specialfunctions = 4
 	},
 /obj/machinery/button/windowtint{
-	anchored = 1;
 	id = "privateroom";
 	pixel_y = -36
 	},
@@ -20871,8 +20955,7 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
 "bYO" = (
@@ -21617,24 +21700,14 @@
 /turf/simulated/floor/plating,
 /area/security/warden)
 "ccJ" = (
-/obj/structure/table/reinforced{
-	layer = 2.5
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	name = "Secure Armory";
-	req_access = list(1)
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 2;
-	name = "Secure Armory";
-	req_access = list(3)
-	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "floorgrime"
 	},
-/area/security/warden)
+/area/security/permabrig)
 "ccK" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel{
@@ -21672,26 +21745,16 @@
 /obj/structure/window/reinforced,
 /obj/item/clothing/suit/armor/bulletproof,
 /obj/item/clothing/head/helmet/alt,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
 	},
 /area/security/armory)
 "ccO" = (
-/obj/item/gun/energy/disabler{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/disabler,
-/obj/item/gun/energy/disabler{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/structure/rack/gunrack,
+/obj/structure/closet/l3closet/security,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
@@ -21792,6 +21855,12 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"cds" = (
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "redcorner"
+	},
+/area/security/main)
 "cdv" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 6";
@@ -21808,8 +21877,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "redcorner"
+	dir = 1
 	},
 /area/security/prison/cell_block/A)
 "cdx" = (
@@ -22086,8 +22154,14 @@
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/asmaint5)
 "ceL" = (
-/turf/simulated/mineral/ancient,
-/area/security/processing)
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/landmark/start/security_officer,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkredfull"
+	},
+/area/space)
 "ceO" = (
 /obj/structure/chair{
 	dir = 8
@@ -22350,7 +22424,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "cgj" = (
@@ -22426,6 +22500,9 @@
 /area/security/warden)
 "cgE" = (
 /obj/machinery/photocopier,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 31
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkred"
@@ -22503,11 +22580,14 @@
 	},
 /area/security/armory)
 "cgX" = (
-/obj/structure/holohoop{
-	dir = 8
+/obj/structure/chair{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/security/permabrig)
+/obj/effect/landmark/start/security_cadet,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "cgZ" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -22571,8 +22651,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "chC" = (
@@ -23201,6 +23281,9 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "ckB" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = 31
+	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "red"
@@ -23647,6 +23730,19 @@
 	icon_state = "dark"
 	},
 /area/security/warden)
+"cnX" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-4"
+	},
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/security/detectives_office)
 "cnZ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -23703,6 +23799,7 @@
 	},
 /area/security/warden)
 "con" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -24344,10 +24441,6 @@
 /area/security/warden)
 "crV" = (
 /obj/machinery/suit_storage_unit/security,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
@@ -24540,7 +24633,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "ctB" = (
@@ -24705,7 +24798,8 @@
 /turf/simulated/floor/plasteel/white,
 /area/toxins/hallway)
 "cuJ" = (
-/obj/machinery/hologram/holopad,
+/obj/structure/table,
+/obj/item/restraints/handcuffs,
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
 "cuQ" = (
@@ -24879,15 +24973,14 @@
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology)
 "cvY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/security/glass,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/brig)
+/area/security/reception)
 "cwf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24918,7 +25011,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/lobby)
 "cwk" = (
@@ -24993,13 +25086,11 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/wood,
 /area/security/hos)
 "cxb" = (
-/obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/grass,
+/obj/structure/railing,
+/turf/simulated/floor/plasteel,
 /area/security/lobby)
 "cxc" = (
 /obj/structure/cable/orange{
@@ -25012,7 +25103,7 @@
 /obj/structure/cable/orange,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "cxd" = (
@@ -25550,7 +25641,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 4;
+	icon_state = "darkredcorners"
 	},
 /area/security/prison/cell_block/A)
 "cAs" = (
@@ -25560,7 +25652,7 @@
 /obj/effect/landmark/event/lightsout,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "cAx" = (
@@ -25578,7 +25670,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "cAC" = (
@@ -25634,7 +25726,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "cBb" = (
@@ -25643,7 +25735,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "cBe" = (
@@ -25696,11 +25788,8 @@
 /area/space/nearstation)
 "cBy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/security/permabrig)
+/turf/simulated/wall/r_wall,
+/area/security/hos)
 "cBz" = (
 /obj/structure/table/reinforced,
 /obj/item/gavelhammer,
@@ -25800,7 +25889,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/lobby)
 "cBP" = (
@@ -25847,15 +25936,12 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
-/obj/machinery/door_timer/cell_4{
-	pixel_y = -32
-	},
+/obj/machinery/door_timer/cell_4,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "cBV" = (
@@ -25870,8 +25956,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "cBY" = (
@@ -25916,20 +26001,15 @@
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "cCh" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance";
-	req_access = list(63);
-	security_level = 1
+/obj/structure/chair{
+	dir = 1
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Secure Gate";
-	name = "Security Blast Door";
-	opacity = 0
+/obj/effect/landmark/start/security_cadet,
+/obj/effect/landmark/start/security_cadet,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/fore2)
+/area/space)
 "cCi" = (
 /obj/structure/table,
 /obj/machinery/cell_charger{
@@ -26034,10 +26114,10 @@
 	},
 /area/bridge)
 "cDb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -26147,6 +26227,7 @@
 	dir = 8
 	},
 /obj/structure/table,
+/obj/item/storage/fancy/donut_box,
 /turf/simulated/floor/plasteel,
 /area/security/processing)
 "cEi" = (
@@ -26220,8 +26301,8 @@
 "cEP" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/lobby)
 "cEQ" = (
@@ -26250,10 +26331,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
-	},
+/turf/simulated/floor/plasteel,
 /area/security/lobby)
 "cEZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -26308,14 +26386,14 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	pixel_y = -28
+	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	dir = 10;
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "cFh" = (
@@ -26361,8 +26439,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "cFm" = (
@@ -26373,7 +26450,7 @@
 	icon_state = "2-8"
 	},
 /obj/item/radio/intercom{
-	pixel_y = -28
+	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -26382,8 +26459,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "cFq" = (
@@ -26411,8 +26487,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "cFu" = (
@@ -26476,8 +26551,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "cFD" = (
@@ -26536,7 +26610,7 @@
 	icon_state = "2-8"
 	},
 /obj/item/radio/intercom{
-	pixel_y = -28
+	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -26548,8 +26622,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "cFY" = (
@@ -26561,8 +26634,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "cFZ" = (
@@ -26584,8 +26656,8 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	dir = 6;
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "cGb" = (
@@ -26658,11 +26730,9 @@
 /area/crew_quarters/locker)
 "cGp" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 1
+	dir = 4;
+	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
 "cGq" = (
@@ -26802,10 +26872,10 @@
 /turf/simulated/floor/plasteel,
 /area/engine/mechanic_workshop/expedition)
 "cHh" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "red"
 	},
-/turf/simulated/floor/plasteel,
 /area/security/processing)
 "cHi" = (
 /obj/machinery/light_switch{
@@ -26814,8 +26884,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	dir = 8;
+	icon_state = "red"
 	},
 /area/security/lobby)
 "cHj" = (
@@ -26854,8 +26924,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "cHC" = (
@@ -27545,6 +27621,9 @@
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitered"
@@ -27643,8 +27722,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	dir = 8;
+	icon_state = "red"
 	},
 /area/security/lobby)
 "cLu" = (
@@ -27688,7 +27767,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/lobby)
 "cLD" = (
@@ -27780,17 +27859,6 @@
 	icon_state = "darkblue"
 	},
 /area/bridge)
-"cMc" = (
-/obj/machinery/camera{
-	c_tag = "Brig Staff Room";
-	dir = 4;
-	network = list("SS13","Security")
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "redcorner"
-	},
-/area/security/brigstaff)
 "cMg" = (
 /obj/structure/cable/orange{
 	icon_state = "0-2"
@@ -27852,14 +27920,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/port)
-"cMx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
-	},
-/area/security/brig)
 "cMy" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -27930,18 +27990,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/bed,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/item/bedsheet/yellow,
-/obj/machinery/flasher{
-	id = "permaflash3";
-	pixel_x = 28
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floorgrime"
-	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/engine,
 /area/security/permabrig)
 "cMS" = (
 /obj/structure/sign/securearea{
@@ -28140,6 +28191,9 @@
 /turf/space,
 /area/hallway/spacebridge/engmed)
 "cNv" = (
+/obj/machinery/light_switch{
+	pixel_y = 24
+	},
 /obj/machinery/papershredder,
 /turf/simulated/floor/wood,
 /area/security/hos)
@@ -28159,7 +28213,7 @@
 "cNG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkredfull"
 	},
 /area/security/prison/cell_block/A)
 "cNH" = (
@@ -28170,7 +28224,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkredcorners"
 	},
 /area/security/prison/cell_block/A)
 "cNJ" = (
@@ -28206,6 +28260,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
@@ -28215,8 +28270,8 @@
 	},
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	dir = 9;
+	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
 "cNW" = (
@@ -28253,13 +28308,14 @@
 	},
 /area/security/prison/cell_block/A)
 "cOl" = (
-/obj/structure/cable/orange{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plasteel{
+/obj/structure/chair{
 	dir = 1
 	},
-/area/security/prison/cell_block/A)
+/obj/effect/landmark/start/security_cadet,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkredfull"
+	},
+/area/space)
 "cOm" = (
 /obj/effect/landmark/start/mime,
 /turf/simulated/floor/plasteel{
@@ -28314,7 +28370,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/effect/landmark/start/security_officer,
 /turf/simulated/floor/plasteel,
 /area/security/range)
 "cOv" = (
@@ -28375,22 +28430,11 @@
 	},
 /area/medical/surgery/north)
 "cOI" = (
-/obj/structure/cable/orange{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Secure Gate";
-	name = "Security Blast Door";
-	opacity = 0
-	},
-/obj/structure/cable/orange{
-	icon_state = "2-8"
-	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/security/prison/cell_block/A)
+/obj/structure/table,
+/obj/item/taperecorder,
+/obj/item/clothing/glasses/sunglasses/blindfold,
+/turf/simulated/floor/engine,
+/area/security/execution)
 "cOL" = (
 /obj/machinery/optable,
 /turf/simulated/floor/plasteel{
@@ -29296,7 +29340,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	dir = 4;
 	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
@@ -29338,8 +29382,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "cTn" = (
@@ -29358,7 +29401,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	dir = 4;
 	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
@@ -29367,6 +29410,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
+	dir = 1;
 	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
@@ -29374,8 +29418,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1
 	},
@@ -29398,8 +29444,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "cTD" = (
@@ -29511,6 +29556,14 @@
 	icon_state = "darkblue"
 	},
 /area/bridge)
+"cUf" = (
+/obj/structure/chair/comfy/red,
+/obj/effect/landmark/start/head_of_security,
+/obj/effect/decal/warning_stripes/red/hollow,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/brig)
 "cUg" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Central Asteroid Maintenance";
@@ -30072,16 +30125,9 @@
 /turf/simulated/floor/carpet/orange,
 /area/crew_quarters/bar)
 "cVO" = (
-/obj/structure/table,
-/obj/item/clothing/shoes/orange,
-/obj/item/clothing/under/color/orange/prison,
-/obj/machinery/alarm{
-	pixel_y = 24
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
 "cVP" = (
 /obj/machinery/flasher{
@@ -30481,13 +30527,12 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	dir = 8;
+	icon_state = "red"
 	},
 /area/security/lobby)
 "cYo" = (
 /obj/structure/flora/ausbushes/brflowers,
-/obj/structure/railing,
 /turf/simulated/floor/grass,
 /area/security/lobby)
 "cYq" = (
@@ -30498,11 +30543,9 @@
 /turf/simulated/floor/wood,
 /area/medical/psych)
 "cYs" = (
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/structure/rack,
-/turf/simulated/floor/plating/asteroid/ancient,
-/area/mine/unexplored/cere/command)
+/obj/structure/chair/e_chair,
+/turf/simulated/floor/engine,
+/area/security/execution)
 "cYu" = (
 /obj/machinery/camera{
 	c_tag = "Clown's Office";
@@ -30571,8 +30614,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "redcorner"
+	dir = 1
 	},
 /area/security/prison/cell_block/A)
 "cZu" = (
@@ -30684,9 +30726,12 @@
 	},
 /area/engine/mechanic_workshop/hangar)
 "daG" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = 31
+	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkredcorners"
+	dir = 5;
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "daS" = (
@@ -30899,8 +30944,11 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/security_officer,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "ddn" = (
@@ -30944,8 +30992,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "redcorner"
+	dir = 1
 	},
 /area/security/prison/cell_block/A)
 "ddr" = (
@@ -31124,13 +31171,14 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/mug/sec,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
 /area/security/main)
 "ddV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
@@ -31440,7 +31488,7 @@
 /obj/item/bedsheet/orange,
 /obj/structure/bed,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
 "dfc" = (
@@ -31450,13 +31498,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door_timer/cell_1{
-	pixel_y = -32
-	},
+/obj/machinery/door_timer/cell_1,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "dfg" = (
@@ -31471,8 +31516,8 @@
 /obj/structure/table,
 /obj/item/flashlight/lamp,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "redcorner"
+	dir = 10;
+	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
 "dfI" = (
@@ -31522,18 +31567,6 @@
 	icon_state = "dark"
 	},
 /area/turret_protected/aisat_interior)
-"dgf" = (
-/obj/structure/chair,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/effect/landmark/start/security_officer,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
-	},
-/area/security/brigstaff)
 "dgg" = (
 /turf/simulated/floor/wood,
 /area/clownoffice)
@@ -31564,12 +31597,6 @@
 	icon_state = "darkblue"
 	},
 /area/medical/cmo)
-"dgF" = (
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "redcorner"
-	},
-/area/security/prison/cell_block/A)
 "dgN" = (
 /obj/effect/spawner/random_spawners/grille_often,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -31587,13 +31614,12 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
 "dgZ" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
 "dha" = (
@@ -31649,7 +31675,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
 "dhC" = (
@@ -31666,7 +31692,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
 "dhH" = (
@@ -31679,7 +31705,8 @@
 /obj/item/bedsheet/brown,
 /obj/structure/bed,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	dir = 6;
+	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
 "dif" = (
@@ -31905,9 +31932,11 @@
 	},
 /area/engine/break_room)
 "djS" = (
-/obj/machinery/ai_status_display,
-/turf/simulated/wall/r_wall,
-/area/security/prisonlockers)
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkred"
+	},
+/area/security/brig)
 "dka" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -32079,12 +32108,12 @@
 	},
 /area/teleporter/quantum/cargo)
 "dkI" = (
-/obj/machinery/vending/coffee,
+/obj/structure/chair/comfy/black,
+/obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "dark"
 	},
-/area/security/brigstaff)
+/area/security/brig)
 "dkK" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
@@ -32171,19 +32200,19 @@
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/maintenance/fpmaint)
 "dlh" = (
-/obj/structure/railing/corner{
-	dir = 4;
-	pixel_y = 11
-	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/railing{
+	dir = 4;
+	pixel_y = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
 /area/security/lobby)
 "dlj" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "neutral"
-	},
+/obj/structure/railing,
+/obj/structure/flora/ausbushes/leafybush,
+/turf/simulated/floor/grass,
 /area/security/lobby)
 "dlk" = (
 /obj/machinery/sleeper,
@@ -32208,9 +32237,9 @@
 /obj/structure/cable/orange{
 	icon_state = "2-4"
 	},
-/obj/structure/railing/corner{
-	dir = 1;
-	pixel_y = 11
+/obj/structure/railing{
+	dir = 8;
+	pixel_y = 10
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -32229,7 +32258,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/lobby)
 "dls" = (
@@ -32273,9 +32302,7 @@
 /turf/simulated/floor/plating,
 /area/security/prison/cell_block/A)
 "dlv" = (
-/obj/machinery/door_timer/cell_2{
-	pixel_y = -32
-	},
+/obj/machinery/door_timer/cell_2,
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
@@ -32286,8 +32313,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "dlC" = (
@@ -32334,9 +32360,6 @@
 	req_access = list(63)
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -32630,11 +32653,11 @@
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
 "doE" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating/asteroid/ancient,
-/area/mine/unexplored/cere/command)
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/cigarettes/cigpack_robust,
+/obj/item/lighter,
+/turf/simulated/floor/engine,
+/area/security/execution)
 "doH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -32659,10 +32682,8 @@
 	},
 /area/maintenance/fpmaint)
 "doM" = (
-/obj/structure/chair/e_chair,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/obj/machinery/atmospherics/unary/outlet_injector/on,
+/turf/simulated/floor/engine,
 /area/security/execution)
 "doO" = (
 /obj/machinery/door/airlock/maintenance{
@@ -32678,9 +32699,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "doR" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/engine,
 /area/security/execution)
 "doZ" = (
 /obj/machinery/light{
@@ -32709,21 +32729,16 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
 /area/security/prisonershuttle)
 "dph" = (
-/obj/machinery/door/airlock/security{
-	aiControlDisabled = 1;
-	name = "Deluxe Prisoner 'Transfer' Lounge";
-	req_access = list(1);
-	security_level = 1
-	},
-/obj/structure/fans/tiny,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/execution)
+/obj/structure/rack,
+/obj/item/shovel,
+/obj/item/shovel,
+/turf/simulated/floor/plating/asteroid/ancient,
+/area/mine/unexplored/cere/command)
 "dpl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
@@ -32759,16 +32774,14 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	dir = 9;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "dpM" = (
 /obj/structure/holohoop{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "dpO" = (
@@ -32787,7 +32800,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "dpP" = (
@@ -32817,7 +32830,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "dqa" = (
@@ -32872,6 +32885,10 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/railing/corner{
+	dir = 4;
+	pixel_y = 11
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutral"
@@ -32894,16 +32911,8 @@
 	},
 /area/space)
 "dqw" = (
-/obj/structure/table,
-/obj/item/storage/box/bodybags,
-/obj/item/assembly/signaler{
-	code = 6;
-	frequency = 1445
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/execution)
+/turf/simulated/wall/r_wall,
+/area/security/prisonershuttle)
 "dqz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -32989,6 +32998,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/railing/corner{
+	dir = 1;
+	pixel_y = 11
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutral"
@@ -33061,8 +33074,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "drw" = (
@@ -33078,26 +33091,11 @@
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
 "drz" = (
-/obj/machinery/door/airlock/security{
-	aiControlDisabled = 1;
-	name = "Prisoner 'Transfer' Lounge";
-	req_access = list(1);
-	security_level = 1
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/execution)
+/turf/simulated/floor/plating/asteroid/ancient,
+/area/mine/unexplored/cere/command)
 "drA" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -33128,8 +33126,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "drC" = (
@@ -33161,8 +33159,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "drL" = (
@@ -33180,8 +33178,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "drR" = (
@@ -33246,8 +33244,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "dsi" = (
@@ -33264,8 +33262,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "dsm" = (
@@ -33283,8 +33281,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "dsu" = (
@@ -33307,8 +33305,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "dsw" = (
@@ -33322,8 +33320,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "dsy" = (
@@ -33331,8 +33329,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkredcorners"
+	icon_state = "dark"
 	},
 /area/security/brig)
 "dsD" = (
@@ -33350,8 +33347,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "dsL" = (
@@ -33367,8 +33364,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "dsN" = (
@@ -33387,8 +33384,8 @@
 	sortType = 22
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "dsO" = (
@@ -33406,8 +33403,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "dsY" = (
@@ -33441,8 +33438,8 @@
 "dtj" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	dir = 10;
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "dtl" = (
@@ -33452,8 +33449,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	icon_state = "dark"
 	},
 /area/security/brig)
 "dtn" = (
@@ -33471,8 +33467,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "dtp" = (
@@ -33480,13 +33476,12 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkredcorners"
 	},
 /area/security/brig)
 "dtr" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "dty" = (
@@ -33507,8 +33502,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "dtF" = (
@@ -33522,8 +33517,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "dtH" = (
@@ -33552,9 +33547,12 @@
 	c_tag = "Brig Main Hall Center";
 	dir = 8
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "dtZ" = (
@@ -33568,8 +33566,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "dub" = (
@@ -33644,14 +33642,18 @@
 	},
 /area/maintenance/asmaint5)
 "dun" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/effect/decal/warning_stripes/south{
+	pixel_y = 7
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/area/security/brig)
+/obj/structure/window/reinforced{
+	color = "red"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/engine,
+/area/security/execution)
 "duo" = (
 /turf/simulated/floor/engine{
 	slowdown = -0.3
@@ -33664,10 +33666,7 @@
 "duu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
-	},
+/turf/simulated/floor/plasteel,
 /area/security/main)
 "duB" = (
 /obj/machinery/light{
@@ -33740,8 +33739,8 @@
 /area/security/permabrig)
 "duQ" = (
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	dir = 8;
+	icon_state = "red"
 	},
 /area/security/main)
 "dvc" = (
@@ -33839,6 +33838,9 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -33847,7 +33849,8 @@
 /obj/vehicle/secway,
 /obj/effect/turf_decal/delivery/red,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 10;
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "dvM" = (
@@ -33900,13 +33903,22 @@
 /obj/item/radio/intercom{
 	pixel_y = -28
 	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/main)
 "dvY" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/sop_legal{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/item/megaphone,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/main)
 "dwa" = (
@@ -33966,13 +33978,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/northwest)
 "dwm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/effect/decal/warning_stripes/south{
+	pixel_y = 7
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/door/window/brigdoor{
+	dir = 2;
+	name = "Execution Access";
+	req_access = list(1)
 	},
-/area/security/armory)
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/engine,
+/area/security/execution)
 "dww" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -34172,16 +34188,24 @@
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/fore)
-"dxD" = (
-/turf/simulated/wall,
-/area/security/detectives_office)
 "dxE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/courtroom)
 "dxG" = (
-/obj/machinery/ai_status_display,
-/turf/simulated/wall,
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen/multi{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/turf/simulated/floor/carpet{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "carpet14-10"
+	},
 /area/security/detectives_office)
 "dxK" = (
 /obj/structure/cable/orange{
@@ -34199,17 +34223,32 @@
 	},
 /area/hallway/secondary/entry/north)
 "dxN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/closet/secure_closet/guncabinet{
+	anchored = 1;
+	name = "Tasers";
+	req_access = list(1)
 	},
-/obj/structure/closet/secure_closet/security,
+/obj/item/gun/energy/gun/advtaser{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/gun/advtaser{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/gun/energy/gun/advtaser,
 /turf/simulated/floor/plasteel{
-	icon_state = "red"
+	dir = 1
 	},
 /area/security/seceqstorage)
 "dxP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/stack/tape_roll,
+/obj/item/stack/tape_roll{
+	pixel_y = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
@@ -34329,6 +34368,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -34340,6 +34382,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -34384,10 +34427,12 @@
 	},
 /area/hallway/primary/fore)
 "dyJ" = (
-/obj/machinery/computer/security/wooden_tv{
-	network = list("SS13","Research Outpost","Mining Outpost")
+/obj/structure/table/wood,
+/obj/machinery/recharger{
+	pixel_x = 1;
+	pixel_y = 3
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/security/detectives_office)
 "dyK" = (
 /obj/structure/window/reinforced{
@@ -35232,6 +35277,19 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft/west)
+"dBZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkredcorners"
+	},
+/area/security/brig)
 "dCc" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/sign/explosives,
@@ -35393,8 +35451,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/computer/arcade,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
 "dDj" = (
@@ -35935,14 +35992,18 @@
 /turf/simulated/floor/plasteel/freezer,
 /area/crew_quarters/locker/locker_toilet)
 "dNf" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/orange{
-	icon_state = "4-8"
+/obj/effect/decal/warning_stripes/south{
+	pixel_y = 7
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/area/security/brig)
+/obj/structure/window/reinforced{
+	color = "red"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/engine,
+/area/security/execution)
 "dNg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -36341,7 +36402,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "dSe" = (
@@ -36358,7 +36419,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 4;
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "dSs" = (
@@ -36490,11 +36552,18 @@
 	},
 /area/crew_quarters/bar)
 "dUJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/door/firedoor,
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/security{
+	aiControlDisabled = 1;
+	name = "Deluxe Prisoner 'Transfer' Lounge";
+	req_access = list(1);
+	security_level = 1
 	},
-/turf/simulated/floor/plasteel,
-/area/security/seceqstorage)
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/execution)
 "dUO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -36624,7 +36693,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/main)
 "dXP" = (
@@ -36635,12 +36704,14 @@
 /area/maintenance/gambling_den2)
 "dXQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+	dir = 5
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "floorgrime"
+	},
 /area/security/permabrig)
 "dXV" = (
 /turf/simulated/wall/r_wall,
@@ -36938,15 +37009,10 @@
 	},
 /area/hallway/primary/fore/east)
 "efs" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
 	},
-/obj/machinery/camera{
-	c_tag = "Brig Prisoner Lockers"
-	},
-/obj/effect/decal/warning_stripes/red/hollow,
-/turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
 "efv" = (
 /obj/structure/cable/orange{
@@ -37062,10 +37128,9 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/structure/chair{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
 	},
-/turf/simulated/floor/plasteel,
 /area/security/main)
 "ehn" = (
 /obj/structure/disposalpipe/segment{
@@ -37195,7 +37260,6 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
@@ -37296,12 +37360,17 @@
 	},
 /area/medical/virology)
 "elc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
-/area/security/permabrig)
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
+	},
+/obj/item/wrench,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/execution)
 "elh" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
@@ -37379,9 +37448,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/port/south)
-"emw" = (
-/turf/simulated/mineral/ancient,
-/area/security/detectives_office)
 "emA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -37400,8 +37466,8 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkredcorners"
+	dir = 1;
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "ena" = (
@@ -37577,8 +37643,10 @@
 /turf/simulated/wall,
 /area/medical/cloning)
 "epY" = (
-/turf/simulated/mineral/ancient/outer,
-/area/security/processing)
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/execution)
 "equ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -37691,14 +37759,6 @@
 /obj/effect/landmark/event/blobstart,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"etG" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/security/detectives_office)
 "etI" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating{
@@ -37731,7 +37791,9 @@
 /obj/structure/cable/orange{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
 /area/security/prisonershuttle)
 "eux" = (
 /obj/structure/closet/emcloset,
@@ -37766,16 +37828,10 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "evg" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -24
-	},
 /obj/structure/cable/orange{
-	icon_state = "0-4"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/turf/simulated/floor/wood,
 /area/security/detectives_office)
 "evi" = (
 /obj/structure/table/reinforced,
@@ -37784,6 +37840,17 @@
 	icon_state = "dark"
 	},
 /area/engine/break_room)
+"evp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/security/permabrig)
 "evA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -38093,8 +38160,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "eBF" = (
@@ -38120,6 +38187,15 @@
 	slowdown = -0.3
 	},
 /area/hallway/spacebridge/comeng)
+"eCx" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = 31
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkred"
+	},
+/area/security/warden)
 "eCB" = (
 /obj/machinery/status_display{
 	layer = 4
@@ -38127,15 +38203,12 @@
 /turf/simulated/wall,
 /area/medical/paramedic)
 "eCE" = (
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "brigpsych"
-	},
+/obj/structure/closet/secure_closet/injection,
+/obj/effect/decal/warning_stripes/red,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whiteredfull"
+	icon_state = "dark"
 	},
-/area/security/medbay)
+/area/security/execution)
 "eCI" = (
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -38393,14 +38466,15 @@
 	},
 /area/hallway/spacebridge/engmed)
 "eHx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable/orange{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkredcorners"
 	},
-/area/security/brig)
+/area/security/reception)
 "eHy" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -38807,7 +38881,7 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
 "eQt" = (
@@ -39043,14 +39117,12 @@
 /turf/simulated/wall,
 /area/crew_quarters/captain)
 "eTs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 4;
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "eTA" = (
@@ -39281,8 +39353,8 @@
 /area/quartermaster/office)
 "eWZ" = (
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkredcorners"
+	dir = 8;
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "eXH" = (
@@ -39406,13 +39478,9 @@
 	},
 /area/medical/genetics)
 "eZS" = (
-/obj/item/radio/intercom{
-	dir = 0;
-	pixel_x = -28
-	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkredfull"
 	},
 /area/security/brig)
 "eZV" = (
@@ -39653,6 +39721,11 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"fep" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/security/lobby)
 "fet" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -39683,8 +39756,8 @@
 	},
 /obj/machinery/disposal,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "redcorner"
+	dir = 10;
+	icon_state = "red"
 	},
 /area/security/main)
 "ffc" = (
@@ -39791,20 +39864,15 @@
 	},
 /area/medical/research/restroom)
 "fiD" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -24
+/obj/structure/chair{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
+/obj/effect/landmark/start/security_cadet,
+/obj/effect/landmark/start/security_cadet,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	icon_state = "dark"
 	},
-/area/security/brigstaff)
+/area/security/brig)
 "fiK" = (
 /turf/simulated/mineral/ancient/outer,
 /area/maintenance/disposal/west)
@@ -40490,13 +40558,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/central)
-"fvV" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/obj/effect/landmark/start/detective,
-/turf/simulated/floor/carpet,
-/area/security/detectives_office)
 "fwd" = (
 /obj/effect/decal/cleanable/crayon,
 /turf/simulated/floor/wood,
@@ -40722,10 +40783,6 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
-/obj/structure/table/reinforced,
-/obj/item/pen,
-/obj/item/flashlight/lamp,
-/obj/item/toy/figure/secofficer,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -40830,6 +40887,12 @@
 	icon_state = "browncorner"
 	},
 /area/quartermaster/office)
+"fDb" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/simulated/floor/wood/fancy/cherry,
+/area/lawoffice)
 "fDg" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -41058,10 +41121,13 @@
 	},
 /area/hallway/spacebridge/servsci)
 "fFH" = (
-/obj/structure/chair{
-	dir = 4
+/obj/structure/chair/comfy/brown{
+	dir = 4;
+	layer = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
 /area/security/main)
 "fFN" = (
 /obj/effect/spawner/window/reinforced/polarized{
@@ -41680,12 +41746,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/carpet/green,
 /area/library)
-"fRa" = (
-/obj/structure/plasticflaps{
-	name = "Officer Batonga's Home"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/primary/fore/west)
 "fRn" = (
 /obj/item/plant_analyzer,
 /turf/simulated/floor/plating,
@@ -41697,18 +41757,13 @@
 /turf/simulated/wall,
 /area/hallway/primary/fore/west)
 "fRz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/holohoop{
+	dir = 8
 	},
-/obj/item/storage/fancy/donut_box,
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
 	},
-/turf/simulated/floor/plasteel,
-/area/security/main)
+/area/security/permabrig)
 "fRK" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -41801,6 +41856,16 @@
 /obj/effect/spawner/random_spawners/blood_often,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/starboard)
+"fSz" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	initialize_directions = 11
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/plasteel,
+/area/security/permabrig)
 "fSQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41826,7 +41891,7 @@
 	pixel_x = 26
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	dir = 1
 	},
 /area/security/prison/cell_block/A)
 "fTe" = (
@@ -41959,15 +42024,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/south)
-"fVG" = (
-/obj/structure/cable/orange{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/window/reinforced/polarized{
-	id = "Detective"
-	},
-/turf/simulated/floor/plating,
-/area/security/detectives_office)
 "fVX" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -42272,15 +42328,27 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkredcorners"
+	icon_state = "dark"
 	},
 /area/security/brig)
 "gby" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/security/permabrig)
+/obj/machinery/door/airlock/security{
+	aiControlDisabled = 1;
+	name = "Prisoner 'Transfer' Lounge";
+	req_access = list(1);
+	security_level = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/execution)
 "gbF" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -42304,12 +42372,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/atmospherics)
 "gce" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/red,
-/area/security/hos)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/execution)
 "gch" = (
 /turf/simulated/wall,
 /area/ntrep)
@@ -42346,15 +42418,11 @@
 /turf/simulated/floor/wood,
 /area/library)
 "gcE" = (
-/obj/machinery/requests_console{
-	department = "Detective";
-	name = "Detective Requests Console";
-	pixel_y = -30
+/obj/structure/window/reinforced{
+	color = "red";
+	dir = 8
 	},
-/obj/machinery/photocopier,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/turf/simulated/floor/wood,
 /area/security/detectives_office)
 "gcN" = (
 /obj/machinery/hydroponics/constructable{
@@ -42421,8 +42489,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	icon_state = "dark"
 	},
 /area/security/prison/cell_block/A)
 "gdW" = (
@@ -42786,6 +42853,15 @@
 /obj/effect/landmark/ninja_teleport,
 /turf/simulated/floor/plating,
 /area/maintenance/electrical_shop)
+"gjR" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = 31
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkred"
+	},
+/area/security/brig)
 "gkc" = (
 /obj/structure/chair{
 	dir = 4
@@ -43138,7 +43214,7 @@
 "grV" = (
 /obj/effect/landmark/start/security_officer,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkredfull"
 	},
 /area/security/prison/cell_block/A)
 "grX" = (
@@ -43195,15 +43271,17 @@
 	},
 /area/maintenance/fsmaint3)
 "gtc" = (
-/obj/structure/table,
-/obj/machinery/newscaster/security_unit{
-	dir = 1;
-	pixel_y = -28
+/obj/machinery/power/apc{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	icon_state = "dark"
 	},
-/area/security/brigstaff)
+/area/security/execution)
 "gth" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -43507,8 +43585,8 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 5;
+	icon_state = "red"
 	},
 /area/security/lobby)
 "gyA" = (
@@ -43601,19 +43679,13 @@
 	name = "Cell 4 Locker"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
 "gAS" = (
 /obj/machinery/alarm{
 	pixel_y = 24
-	},
-/obj/machinery/computer/secure_data{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/security/hos)
@@ -43663,7 +43735,8 @@
 	req_access = list(63)
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "gBw" = (
@@ -43723,12 +43796,6 @@
 	pixel_x = 31;
 	pixel_y = 10;
 	specialfunctions = 4
-	},
-/obj/machinery/flasher_button{
-	id = "permaflash3";
-	name = "Prison Cell 3 Flasher";
-	pixel_x = 22;
-	pixel_y = 11
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -43915,6 +43982,9 @@
 	},
 /area/medical/research/restroom)
 "gEZ" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -44056,6 +44126,14 @@
 	slowdown = -0.3
 	},
 /area/hallway/spacebridge/scidock)
+"gGh" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
+/area/security/processing)
 "gGt" = (
 /obj/machinery/light{
 	dir = 8
@@ -44065,6 +44143,13 @@
 	icon_state = "darkgreenfull"
 	},
 /area/hydroponics)
+"gGw" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood,
+/area/security/detectives_office)
 "gGB" = (
 /turf/simulated/mineral/ancient/outer,
 /area/crew_quarters/sleep/secondary)
@@ -44213,6 +44298,24 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/janitor)
+"gJe" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = 31
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/security/lobby)
 "gJw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -44301,7 +44404,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
-/turf/space,
+/turf/simulated/floor/plating,
 /area/security/processing)
 "gKp" = (
 /obj/structure/table/wood,
@@ -44412,6 +44515,14 @@
 /obj/structure/rack,
 /obj/item/gun/energy/ionrifle,
 /obj/item/clothing/suit/armor/laserproof,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window{
+	dir = 1;
+	name = "Secure Armory";
+	req_access = list(1)
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -44466,7 +44577,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
 "gMK" = (
@@ -44868,9 +44979,6 @@
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/starboard)
 "gSZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "red"
@@ -44908,16 +45016,19 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/effect/landmark/start/security_officer,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
 /area/security/seceqstorage)
 "gTI" = (
-/obj/machinery/vending/cigarette,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+/obj/structure/table/reinforced,
+/obj/item/folder/red{
+	pixel_y = 3
 	},
-/area/security/brigstaff)
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/brig)
 "gTV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/power/apc{
@@ -45040,9 +45151,25 @@
 	},
 /area/hallway/spacebridge/servsci)
 "gVY" = (
-/obj/structure/railing,
-/turf/simulated/floor/plasteel,
-/area/security/lobby)
+/obj/machinery/light/small{
+	brightness_range = 6;
+	light_range = 8;
+	nightshift_light_range = 6;
+	throw_range = 6
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/morphine{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bottle/sulfonal{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/execution)
 "gWd" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -45056,7 +45183,10 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/security_officer,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "redcorner"
+	},
 /area/security/processing)
 "gWG" = (
 /obj/effect/landmark/start/coroner,
@@ -45130,10 +45260,13 @@
 	},
 /area/security/prisonershuttle)
 "gYq" = (
-/mob/living/simple_animal/pet/dog/security/detective,
-/obj/structure/bed/dogbed,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/flask/detflask,
+/obj/item/toy/figure/detective,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/carpet{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "carpet14-10"
 	},
 /area/security/detectives_office)
 "gYw" = (
@@ -45193,11 +45326,27 @@
 	},
 /area/toxins/misc_lab)
 "gYW" = (
-/obj/structure/railing/corner{
-	dir = 8
+/obj/structure/table,
+/obj/item/reagent_containers/food/pill/morphine{
+	pixel_x = 7;
+	pixel_y = 9
 	},
-/turf/simulated/floor/plasteel,
-/area/security/lobby)
+/obj/item/reagent_containers/food/pill/fakedeath{
+	pixel_x = -4;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/syringe{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/syringe/capulettium_plus{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/execution)
 "gYX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -45275,6 +45424,18 @@
 /obj/item/flag/nt,
 /turf/simulated/floor/wood,
 /area/blueshield)
+"gZS" = (
+/obj/structure/rack,
+/obj/item/camera_film,
+/obj/item/camera{
+	desc = "A one use - polaroid camera. 30 photos left.";
+	name = "detectives camera";
+	pictures_left = 30
+	},
+/obj/item/taperecorder,
+/obj/item/storage/briefcase,
+/turf/simulated/floor/wood,
+/area/security/detectives_office)
 "hab" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -45388,17 +45549,6 @@
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/wood,
 /area/blueshield)
-"hcb" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Equipment Storage";
-	req_access = list(1)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "red"
-	},
-/area/security/seceqstorage)
 "hcc" = (
 /turf/simulated/wall,
 /area/security/checkpoint2)
@@ -45465,6 +45615,12 @@
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/south)
+"hdO" = (
+/obj/machinery/dnaforensics,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/security/detectives_office)
 "hec" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -45569,19 +45725,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/paramedic)
-"hgd" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/cans/beer{
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/food/drinks/cans/beer{
-	pixel_x = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
-	},
-/area/security/brigstaff)
 "hgL" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel{
@@ -45659,6 +45802,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/ntrep)
+"hii" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/wood,
+/area/security/hos)
 "hit" = (
 /obj/item/honey_frame,
 /obj/item/honey_frame,
@@ -45676,6 +45824,12 @@
 	icon_state = "darkgreenfull"
 	},
 /area/hydroponics)
+"hiz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/railing/corner,
+/turf/simulated/floor/plasteel,
+/area/security/lobby)
 "hiI" = (
 /obj/structure/chair/sofa/corp{
 	dir = 8
@@ -45791,6 +45945,13 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay)
+"hlo" = (
+/obj/machinery/computer/secure_data{
+	dir = 4;
+	pixel_x = 3
+	},
+/turf/simulated/floor/wood,
+/area/security/detectives_office)
 "hlA" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -46028,7 +46189,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whiteredfull"
 	},
 /area/security/medbay)
 "hpD" = (
@@ -46473,11 +46635,20 @@
 	},
 /area/medical/morgue)
 "hxh" = (
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = -24
+/obj/structure/closet/secure_closet{
+	anchored = 1;
+	name = "Evidence Storage";
+	req_access = list(4)
 	},
-/obj/machinery/vending/cigarette/free,
+/obj/item/storage/box/bodybags,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/folder/red,
+/obj/item/folder/red,
+/obj/item/folder/red,
+/obj/structure/window/reinforced{
+	color = "red";
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -46510,7 +46681,7 @@
 /area/chapel/main)
 "hxL" = (
 /obj/machinery/camera{
-	c_tag = "Brig Head of Security's Office";
+	c_tag = "Brig Head of Security's Office south";
 	dir = 1
 	},
 /obj/machinery/requests_console{
@@ -46519,9 +46690,6 @@
 	departmentType = 5;
 	name = "Head of Security Requests Console";
 	pixel_y = -30
-	},
-/obj/machinery/computer/card/minor/hos{
-	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/security/hos)
@@ -46939,12 +47107,8 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/aft/west)
 "hEQ" = (
-/obj/structure/bed/dogbed,
-/mob/living/simple_animal/bot/secbot/beepsky{
-	name = "Officer Batonga"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/primary/fore/west)
+/turf/simulated/wall/r_wall,
+/area/security/detectives_office)
 "hEU" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Pods";
@@ -47250,9 +47414,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/atmospherics)
 "hIK" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
 	},
+/turf/simulated/floor/wood,
 /area/security/hos)
 "hIU" = (
 /obj/structure/cable/orange,
@@ -47338,9 +47503,16 @@
 	},
 /area/quartermaster/office)
 "hKH" = (
-/obj/structure/closet/l3closet/janitor,
-/turf/simulated/floor/plasteel,
-/area/janitor)
+/obj/structure/table,
+/obj/item/storage/box/bodybags,
+/obj/item/assembly/signaler{
+	code = 6;
+	frequency = 1445
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/execution)
 "hKW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -47383,8 +47555,8 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/lobby)
 "hMh" = (
@@ -47538,7 +47710,10 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/security_officer,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "red"
+	},
 /area/security/processing)
 "hOX" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -47767,7 +47942,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "hSp" = (
@@ -47916,7 +48091,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "hUx" = (
@@ -48306,7 +48481,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/lobby)
 "idg" = (
@@ -48725,12 +48900,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/external/southeast)
 "ilu" = (
-/obj/machinery/computer/med_data{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whiteredfull"
+	icon_state = "white"
 	},
 /area/security/medbay)
 "ilR" = (
@@ -48767,14 +48938,13 @@
 	},
 /area/engine/mechanic_workshop/hangar)
 "imu" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
+/obj/structure/closet/firecloset,
+/obj/item/crowbar/red,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkredcorners"
-	},
-/area/security/brig)
+/turf/simulated/floor/plating,
+/area/security/permabrig)
 "imE" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -48887,7 +49057,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/security_cadet,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
 /area/security/prisonershuttle)
 "ioE" = (
 /turf/simulated/floor/plasteel{
@@ -48941,10 +49113,18 @@
 /obj/machinery/suit_storage_unit/brigmed{
 	req_access = list(5)
 	},
-/obj/structure/window/reinforced,
 /obj/machinery/door/window/eastright{
+	dir = 2;
 	name = "Hardsuit storage";
 	req_access = list(5)
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 8;
+	id = "robo"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "robo"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -49017,8 +49197,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "iqY" = (
@@ -49089,8 +49269,8 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "irU" = (
@@ -49327,8 +49507,8 @@
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "ixg" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -49375,6 +49555,16 @@
 /obj/machinery/biogenerator,
 /turf/simulated/floor/grass,
 /area/hallway/secondary/garden)
+"iyo" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/security/hos)
 "iys" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -49835,21 +50025,11 @@
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall/coated,
 /area/engine/supermatter)
-"iGF" = (
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "redcorner"
-	},
-/area/security/brigstaff)
-"iGG" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/security/detectives_office)
+"iHa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/security/permabrig)
 "iHf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood/fancy/light,
@@ -50738,26 +50918,20 @@
 "iVJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/item/radio/intercom{
-	pixel_y = 28
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "iVY" = (
-/obj/structure/closet/secure_closet/hos,
-/obj/item/megaphone,
-/obj/item/reagent_containers/food/drinks/flask/barflask,
-/obj/machinery/camera{
-	c_tag = "HoS Bedroom";
-	network = list("SS13","Security")
+/obj/item/clothing/under/color/orange/prison,
+/obj/item/clothing/shoes/orange,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
 	},
-/obj/item/spacepod_equipment/key{
-	id = 100000
-	},
-/turf/simulated/floor/carpet/red,
-/area/security/hos)
+/area/security/permabrig)
 "iWv" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -51040,13 +51214,10 @@
 /turf/simulated/floor/carpet/red,
 /area/chapel/main)
 "jaN" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/execution)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/security/permabrig)
 "jaR" = (
 /obj/structure/sign/evac,
 /turf/simulated/wall,
@@ -51118,6 +51289,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
+"jdj" = (
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "darkred"
+	},
+/area/security/brig)
 "jdn" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -51552,13 +51730,11 @@
 	},
 /area/teleporter/quantum/security)
 "jjV" = (
-/obj/structure/closet/secure_closet/brigdoc{
-	req_access = list(2,5)
+/obj/structure/table/glass,
+/obj/item/reagent_containers/food/drinks/mug/sec,
+/obj/item/storage/fancy/donut_box{
+	pixel_y = -4
 	},
-/obj/item/storage/pill_bottle/patch_pack,
-/obj/item/storage/pill_bottle,
-/obj/item/storage/belt/medical,
-/obj/item/handheld_defibrillator,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "whitered"
@@ -51710,7 +51886,7 @@
 /obj/machinery/status_display{
 	layer = 4
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/security/detectives_office)
 "jmj" = (
 /turf/simulated/floor/engine{
@@ -51773,11 +51949,12 @@
 	},
 /area/atmos)
 "jnG" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10;
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -51805,6 +51982,15 @@
 "job" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/atmospherics)
+"joq" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkred"
+	},
+/area/security/brig)
 "jor" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
@@ -51895,8 +52081,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkredcorners"
+	dir = 8;
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "jpO" = (
@@ -51908,7 +52094,8 @@
 /turf/simulated/floor/carpet/purple,
 /area/crew_quarters/bar)
 "jpP" = (
-/turf/simulated/mineral/ancient,
+/obj/structure/closet/l3closet/janitor,
+/turf/simulated/floor/plasteel,
 /area/janitor)
 "jpT" = (
 /obj/structure/table,
@@ -52129,7 +52316,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "redcorner"
+	},
 /area/security/lobby)
 "jtJ" = (
 /obj/structure/disposaloutlet{
@@ -52180,8 +52370,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkredcorners"
+	dir = 8;
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "jva" = (
@@ -52257,7 +52447,7 @@
 	pixel_y = -36
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
 "jvt" = (
@@ -52366,6 +52556,12 @@
 	},
 /turf/simulated/floor/plasteel/airless/indestructible,
 /area/toxins/test_area)
+"jwx" = (
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "darkred"
+	},
+/area/security/brig)
 "jwB" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -53314,6 +53510,7 @@
 	},
 /area/maintenance/port)
 "jMg" = (
+/obj/machinery/computer/crew,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitered"
@@ -53346,7 +53543,6 @@
 /area/hallway/primary/fore)
 "jNy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/railing/corner,
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -53516,6 +53712,26 @@
 	icon_state = "darkpurple"
 	},
 /area/assembly/robotics)
+"jQC" = (
+/obj/structure/cable/orange{
+	icon_state = "0-2"
+	},
+/obj/structure/cable/orange{
+	icon_state = "2-8"
+	},
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "Detective"
+	},
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "open";
+	id_tag = "brig_detprivacy";
+	name = "Detective Privacy Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/security/detectives_office)
 "jQE" = (
 /obj/machinery/door/airlock/glass,
 /obj/structure/barricade/wooden,
@@ -53535,6 +53751,15 @@
 /obj/item/stack/sheet/metal,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/apmaint2)
+"jRt" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/brig)
 "jRz" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -53722,15 +53947,11 @@
 	},
 /area/assembly/chargebay)
 "jUI" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_x = 1;
-	pixel_y = 3
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/brig)
+/area/security/permabrig)
 "jUJ" = (
 /obj/structure/cable/orange{
 	icon_state = "1-8"
@@ -54005,10 +54226,18 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fore)
 "jYY" = (
-/obj/structure/bed,
-/obj/item/bedsheet/hos,
-/turf/simulated/floor/carpet/red,
-/area/security/hos)
+/obj/structure/cable/orange{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 24
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/simulated/floor/plasteel,
+/area/security/prisonlockers)
 "jZb" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
@@ -54086,15 +54315,13 @@
 	},
 /area/teleporter)
 "jZS" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/structure/closet/secure_closet/brig,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitered"
-	},
-/area/security/medbay)
+/obj/effect/decal/warning_stripes/red/hollow,
+/turf/simulated/floor/plasteel,
+/area/security/prisonlockers)
 "kac" = (
 /obj/effect/landmark/event/blobstart,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -54348,9 +54575,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint2)
 "kef" = (
-/obj/machinery/door_timer/cell_3{
-	pixel_y = -32
-	},
+/obj/machinery/door_timer/cell_3,
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
@@ -54358,8 +54583,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "kei" = (
@@ -54600,22 +54824,17 @@
 	},
 /area/toxins/xenobiology)
 "kia" = (
-/obj/structure/safe{
-	known_by = list("hos")
+/obj/structure/table,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/under/color/orange/prison,
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
-/obj/item/ammo_box/a357{
-	pixel_x = -9;
-	pixel_y = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/item/ammo_box/a357{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/ammo_box/a357,
-/obj/item/gun/projectile/revolver/mateba,
-/obj/item/clothing/accessory/holster,
-/turf/simulated/floor/carpet/red,
-/area/security/hos)
+/turf/simulated/floor/plasteel,
+/area/security/prisonlockers)
 "kic" = (
 /obj/structure/closet/wardrobe/grey,
 /turf/simulated/floor/shuttle,
@@ -54670,15 +54889,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/table/wood,
-/obj/item/paper_bin/nanotrasen,
-/obj/item/flashlight/lamp/green{
-	on = 0;
-	pixel_x = -3;
-	pixel_y = 8
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
-/obj/item/pen/multi,
-/obj/item/lighter/zippo/hos,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -55000,6 +55213,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology)
+"koS" = (
+/obj/machinery/light_switch{
+	pixel_y = 24
+	},
+/obj/machinery/camera{
+	c_tag = "Brig Main Hall West 1"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkred"
+	},
+/area/security/brig)
 "koT" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plating,
@@ -55084,6 +55309,16 @@
 	icon_state = "dark"
 	},
 /area/security/armory)
+"kqF" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 24
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/wood,
+/area/security/hos)
 "kqL" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/orange{
@@ -55578,7 +55813,7 @@
 	pixel_x = 26
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	dir = 1
 	},
 /area/security/prison/cell_block/A)
 "kyd" = (
@@ -55876,6 +56111,9 @@
 	},
 /turf/simulated/floor/wood,
 /area/blueshield)
+"kCz" = (
+/turf/simulated/wall/r_wall,
+/area/janitor)
 "kCM" = (
 /obj/machinery/conveyor/auto,
 /turf/simulated/floor/plating,
@@ -56162,6 +56400,12 @@
 	icon_state = "bot"
 	},
 /area/toxins/storage)
+"kHL" = (
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkredcorners"
+	},
+/area/security/brig)
 "kHT" = (
 /obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -56261,12 +56505,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "kKa" = (
-/obj/machinery/recharge_station,
+/obj/structure/table/reinforced,
+/obj/item/flashlight/lamp,
+/obj/item/toy/figure/secofficer,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "dark"
 	},
-/area/security/brigstaff)
+/area/security/brig)
 "kKh" = (
 /obj/machinery/camera{
 	c_tag = "Vault Interior";
@@ -56291,16 +56536,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/atmospherics)
 "kKK" = (
-/obj/structure/table/glass,
-/obj/item/storage/fancy/donut_box{
-	pixel_y = -4
+/obj/structure/closet/secure_closet/brig,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/item/reagent_containers/food/drinks/mug/sec,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitered"
+/obj/machinery/camera{
+	c_tag = "Brig Prisoner Lockers"
 	},
-/area/security/medbay)
+/obj/effect/decal/warning_stripes/red/hollow,
+/turf/simulated/floor/plasteel,
+/area/security/prisonlockers)
 "kKP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -56358,6 +56603,22 @@
 /obj/machinery/seed_extractor,
 /turf/simulated/floor/grass,
 /area/hallway/secondary/garden)
+"kMT" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/newscaster/security_unit{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -28
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 32
+	},
+/turf/simulated/floor/carpet{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "carpet13-5"
+	},
+/area/security/detectives_office)
 "kMZ" = (
 /obj/structure/cable/orange{
 	icon_state = "2-8"
@@ -56449,8 +56710,8 @@
 "kOX" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 5;
+	icon_state = "red"
 	},
 /area/security/lobby)
 "kPr" = (
@@ -56875,6 +57136,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -57354,15 +57616,12 @@
 "lfh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "red"
+	},
 /area/security/range)
 "lfz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/item/radio/intercom/locked/prison{
 	pixel_y = 25
 	},
@@ -57372,7 +57631,7 @@
 	network = list("Prison","SS13")
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "floorgrime"
+	icon_state = "dark"
 	},
 /area/security/permabrig)
 "lfB" = (
@@ -57392,8 +57651,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint2)
 "lfN" = (
-/turf/simulated/wall,
-/area/security/brigstaff)
+/obj/item/flag/species,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/brig)
 "lfX" = (
 /obj/machinery/suit_storage_unit/cmo/sec_storage,
 /obj/effect/turf_decal/bot,
@@ -57739,8 +58001,6 @@
 /obj/item/radio/intercom/locked/prison{
 	pixel_x = -25
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -57899,6 +58159,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/table,
+/obj/item/folder/red,
+/obj/item/pen,
 /turf/simulated/floor/plasteel,
 /area/security/processing)
 "log" = (
@@ -57944,15 +58206,9 @@
 /turf/simulated/floor/wood,
 /area/library)
 "lpb" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floorgrime"
-	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/engine,
 /area/security/permabrig)
 "lpg" = (
 /obj/machinery/light,
@@ -57979,18 +58235,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/ntrep)
-"lpq" = (
-/obj/structure/cable/orange{
-	icon_state = "0-2"
-	},
-/obj/structure/cable/orange{
-	icon_state = "2-8"
-	},
-/obj/effect/spawner/window/reinforced/polarized{
-	id = "Detective"
-	},
-/turf/simulated/floor/plating,
-/area/security/detectives_office)
 "lpF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -58197,20 +58441,14 @@
 	},
 /area/space)
 "ltg" = (
-/obj/machinery/power/apc{
-	pixel_y = -26
+/obj/structure/chair{
+	dir = 1
 	},
-/obj/structure/cable/orange{
-	icon_state = "0-8"
+/obj/effect/landmark/start/security_cadet,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/security/brigstaff)
+/area/security/brig)
 "ltk" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -58566,7 +58804,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/lobby)
 "lyT" = (
@@ -59179,14 +59417,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/fore2)
-"lKg" = (
-/obj/machinery/computer/med_data{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/security/detectives_office)
 "lKk" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -59201,13 +59431,6 @@
 /turf/simulated/floor/grass,
 /area/hallway/spacebridge/scidock)
 "lKW" = (
-/obj/structure/table/wood,
-/obj/machinery/photocopier/faxmachine/longrange{
-	department = "Head of Security's Office"
-	},
-/obj/machinery/light_switch{
-	pixel_y = 24
-	},
 /turf/simulated/floor/wood,
 /area/security/hos)
 "lKX" = (
@@ -59325,7 +59548,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/lobby)
 "lNA" = (
@@ -59433,9 +59656,6 @@
 /turf/simulated/floor/plasteel/white,
 /area/toxins/hallway)
 "lPW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
@@ -59906,8 +60126,7 @@
 "lXO" = (
 /obj/structure/closet/secure_closet/guncabinet{
 	anchored = 1;
-	name = "Magazines for SMG";
-	req_access = list(3)
+	name = "Magazines for SMG"
 	},
 /obj/item/ammo_box/magazine/wt550m9{
 	pixel_x = -4;
@@ -59929,6 +60148,9 @@
 /obj/item/ammo_box/magazine/wt550m9{
 	pixel_x = 6;
 	pixel_y = -6
+	},
+/obj/machinery/alarm{
+	pixel_y = 26
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -60206,8 +60428,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkredcorners"
 	},
 /area/security/brig)
 "mco" = (
@@ -60229,9 +60455,16 @@
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
 "mcE" = (
-/obj/machinery/photocopier,
+/obj/structure/table/reinforced,
+/obj/item/restraints/handcuffs{
+	pixel_y = -3
+	},
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs{
+	pixel_y = 3
+	},
 /turf/simulated/floor/plasteel{
-	dir = 1
+	icon_state = "red"
 	},
 /area/security/main)
 "mcI" = (
@@ -60347,8 +60580,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	dir = 1
 	},
 /area/security/prison/cell_block/A)
 "mey" = (
@@ -60470,27 +60702,18 @@
 	id_tag = "Secure Armory";
 	name = "Secure Armory Shutters"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/security/armory)
 "mgY" = (
-/obj/structure/cable/orange{
-	icon_state = "2-4"
-	},
+/obj/structure/table,
+/obj/item/storage/box/prisoner,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/brig)
+/turf/simulated/floor/plasteel,
+/area/security/prisonlockers)
 "mhe" = (
 /obj/structure/toilet{
 	dir = 4
@@ -60498,11 +60721,19 @@
 /turf/simulated/floor/plasteel/freezer,
 /area/medical/virology)
 "mhv" = (
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+/obj/structure/closet/secure_closet/brig,
+/obj/machinery/light{
+	dir = 1
 	},
-/area/security/prison/cell_block/A)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/red/hollow,
+/turf/simulated/floor/plasteel,
+/area/security/prisonlockers)
 "mhA" = (
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -60580,13 +60811,12 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
 /area/security/main)
 "miw" = (
 /obj/structure/cable/yellow{
@@ -60630,6 +60860,15 @@
 /obj/structure/barricade/wooden,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
+"mjn" = (
+/obj/structure/closet/secure_closet/detective,
+/obj/item/flash,
+/obj/item/restraints/handcuffs,
+/obj/item/storage/box/evidence,
+/obj/item/storage/box/evidence,
+/obj/item/hand_labeler,
+/turf/simulated/floor/wood,
+/area/security/detectives_office)
 "mjo" = (
 /turf/simulated/wall/r_wall,
 /area/toxins/launch)
@@ -60697,7 +60936,9 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
 /area/security/prisonershuttle)
 "mlu" = (
 /obj/structure/closet/crate,
@@ -60839,7 +61080,11 @@
 /area/hallway/spacebridge/comeng)
 "mnQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_y = -63
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -60963,24 +61208,17 @@
 /turf/simulated/floor/grass,
 /area/hallway/spacebridge/scidock)
 "mpQ" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Cell 3";
-	req_access = list(2);
-	security_level = 1
-	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "open";
 	id_tag = "Prison Gate";
 	name = "Prison Lockdown Blast Doors";
 	opacity = 0
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Storage";
+	req_access = list(63)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -61270,22 +61508,8 @@
 /area/hallway/secondary/entry)
 "mwR" = (
 /obj/structure/table/wood,
-/obj/item/radio{
-	pixel_x = 5
-	},
-/obj/machinery/button/windowtint{
-	dir = 1;
-	id = "hos";
-	pixel_x = -4;
-	pixel_y = -24
-	},
-/obj/machinery/keycard_auth{
-	pixel_x = 8;
-	pixel_y = -24
-	},
-/obj/item/toy/figure/hos,
-/obj/machinery/recharger{
-	pixel_y = 4
+/obj/machinery/photocopier/faxmachine/longrange{
+	department = "Head of Security's Office"
 	},
 /turf/simulated/floor/wood,
 /area/security/hos)
@@ -61707,6 +61931,12 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"mEm" = (
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/security/lobby)
 "mEq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall,
@@ -61744,6 +61974,7 @@
 	},
 /area/turret_protected/ai)
 "mFT" = (
+/obj/effect/decal/warning_stripes/red,
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
 "mFX" = (
@@ -61779,6 +62010,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/crew_quarters/kitchen)
+"mGu" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/simulated/floor/wood,
+/area/security/detectives_office)
 "mGB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/orange{
@@ -61963,9 +62200,9 @@
 /turf/simulated/mineral/ancient,
 /area/hallway/primary/port/north)
 "mJt" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
+/obj/structure/table,
+/obj/item/storage/box/prisoner,
+/obj/machinery/light,
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
 "mJJ" = (
@@ -62077,10 +62314,7 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
-	},
+/turf/simulated/floor/plasteel,
 /area/security/main)
 "mLq" = (
 /obj/structure/lattice,
@@ -62097,6 +62331,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior)
+"mLK" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "darkredfull"
+	},
+/area/security/prison/cell_block/A)
 "mLO" = (
 /obj/structure/cable/orange{
 	icon_state = "1-8"
@@ -62589,21 +62828,13 @@
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "mVK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
 /obj/machinery/newscaster/security_unit{
 	dir = 1;
 	pixel_y = -28
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
-	},
-/area/security/brig)
+/obj/structure/sign/poster,
+/turf/simulated/wall/r_wall,
+/area/security/reception)
 "mVN" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -62725,7 +62956,9 @@
 	},
 /obj/machinery/hologram/holopad,
 /obj/effect/landmark/start/security_officer,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
 /area/security/prisonershuttle)
 "mXW" = (
 /mob/living/simple_animal/mouse/white,
@@ -62854,6 +63087,13 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/spacebridge/sercom)
+"naK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/official/kill_syndicate{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plasteel,
+/area/security/range)
 "naP" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -62939,6 +63179,17 @@
 /obj/structure/sign/securearea,
 /turf/simulated/wall,
 /area/storage/tech)
+"ncZ" = (
+/obj/effect/landmark/start/detective,
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/carpet,
+/area/security/detectives_office)
 "ndd" = (
 /obj/structure/rack,
 /obj/structure/disposalpipe/segment{
@@ -63618,8 +63869,8 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkredcorners"
+	dir = 8;
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "noC" = (
@@ -63868,11 +64119,21 @@
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "nso" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/light_switch{
+	pixel_y = 24
 	},
-/turf/simulated/floor/carpet/red,
-/area/security/hos)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/plasteel,
+/area/security/prisonlockers)
 "nsF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -63956,6 +64217,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/clownoffice)
+"nts" = (
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "red"
+	},
+/area/security/processing)
 "ntV" = (
 /obj/effect/landmark/event/lightsout,
 /turf/simulated/floor/plasteel{
@@ -64026,9 +64293,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/turf/simulated/floor/wood,
 /area/security/detectives_office)
 "nvQ" = (
 /obj/structure/cable{
@@ -64120,13 +64385,6 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/paramedic)
-"nwu" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/landmark/start/security_cadet,
-/turf/simulated/floor/plasteel,
-/area/security/brigstaff)
 "nwv" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel,
@@ -64334,10 +64592,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/spacebridge/servsci)
-"nzD" = (
-/obj/effect/landmark/event/lightsout,
-/turf/simulated/floor/plasteel,
-/area/security/brigstaff)
 "nzK" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -64360,14 +64614,13 @@
 /area/solar/starboardaux)
 "nAb" = (
 /obj/structure/chair{
-	dir = 4
+	dir = 1
 	},
-/obj/machinery/light,
-/obj/effect/landmark/start/security_officer,
+/obj/effect/landmark/start/security_cadet,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	icon_state = "darkredfull"
 	},
-/area/security/brigstaff)
+/area/security/brig)
 "nAc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -64797,6 +65050,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/south)
+"nGL" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/wood/fancy/light,
+/area/crew_quarters/courtroom)
 "nHa" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -64835,18 +65094,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port/south)
-"nHy" = (
-/obj/machinery/computer/secure_data{
-	dir = 4
-	},
-/obj/machinery/button/windowtint{
-	dir = 4;
-	id = "Detective";
-	pixel_x = -24;
-	req_access = list(4)
-	},
-/turf/simulated/floor/carpet,
-/area/security/detectives_office)
 "nHE" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -65211,14 +65458,12 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
 "nNb" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/mug/hos,
-/obj/item/paper/monitorkey,
-/obj/item/paper/safe_code{
-	owner = "hos"
+/obj/item/vending_refill/cola,
+/obj/item/multitool,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
 	},
-/turf/simulated/floor/carpet/red,
-/area/security/hos)
+/area/security/permabrig)
 "nNd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
@@ -65294,16 +65539,18 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
 "nNY" = (
-/obj/item/restraints/handcuffs/pinkcuffs,
-/obj/item/clothing/accessory/cowboyshirt/pink/short_sleeved{
-	pixel_y = 6
+/obj/structure/table/wood,
+/obj/item/folder/red{
+	pixel_y = 3
 	},
-/obj/item/clothing/shoes/cowboy/pink{
-	pixel_x = 4;
-	pixel_y = -5
+/obj/item/stamp/hos,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/security/processing)
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/security/hos)
 "nOb" = (
 /obj/structure/cable/orange{
 	icon_state = "0-8"
@@ -65440,8 +65687,8 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/lobby)
 "nRb" = (
@@ -65555,7 +65802,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "nTL" = (
@@ -65628,6 +65875,17 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/cabin4)
+"nVO" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/photocopier,
+/turf/simulated/floor/carpet{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "carpet5-1"
+	},
+/area/security/detectives_office)
 "nVQ" = (
 /turf/simulated/mineral/ancient,
 /area/hallway/primary/starboard/south)
@@ -65934,16 +66192,10 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/fitness)
 "oac" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/filingcabinet/chestdrawer,
 /obj/structure/cable/orange{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/turf/simulated/floor/wood,
 /area/security/detectives_office)
 "oam" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -65952,8 +66204,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	pixel_y = -29
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "oaB" = (
@@ -66053,6 +66312,13 @@
 	icon_state = "darkbrown"
 	},
 /area/quartermaster/office)
+"obZ" = (
+/obj/machinery/suit_storage_unit/security/hos,
+/obj/effect/decal/warning_stripes/northwest,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/security/hos)
 "occ" = (
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/maintenance/port)
@@ -66075,8 +66341,8 @@
 /obj/structure/bed,
 /obj/item/bedsheet/blue,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 5;
+	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
 "ocw" = (
@@ -66181,11 +66447,22 @@
 	},
 /area/solar/port)
 "ofN" = (
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+/obj/structure/table/wood,
+/obj/item/toy/russian_revolver{
+	pixel_x = 6
 	},
-/area/security/brigstaff)
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	pixel_x = -6;
+	pixel_y = 18
+	},
+/obj/item/lighter/zippo/hos{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/security/hos)
 "ofT" = (
 /obj/structure/table/reinforced,
 /obj/machinery/processor{
@@ -66246,23 +66523,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/east)
 "ohf" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/vending/cigarette/free,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkredcorners"
+	icon_state = "grimy"
 	},
-/area/security/brig)
+/area/security/hos)
 "ohh" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 2
@@ -66485,6 +66750,14 @@
 /obj/effect/spawner/window/reinforced/polarized{
 	id = "Detective"
 	},
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "open";
+	id_tag = "brig_detprivacy";
+	name = "Detective Privacy Shutters";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
 "okt" = (
@@ -66686,7 +66959,7 @@
 "ooF" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkredfull"
 	},
 /area/security/prison/cell_block/A)
 "ooM" = (
@@ -66755,7 +67028,6 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/obj/structure/closet/secure_closet/brig/evidence,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -66813,14 +67085,14 @@
 	},
 /area/maintenance/port2)
 "oqb" = (
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "brigpsych"
+/obj/item/twohanded/required/kirbyplants,
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "grimy"
 	},
-/area/security/medbay)
+/area/security/hos)
 "oqj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -66897,6 +67169,12 @@
 	icon_state = "black"
 	},
 /area/space)
+"oqZ" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/security/lobby)
 "org" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -66950,13 +67228,6 @@
 "ory" = (
 /turf/simulated/wall/r_wall,
 /area/medical/psych)
-"orG" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkredcorners"
-	},
-/area/security/brig)
 "orJ" = (
 /obj/structure/chair/comfy/lime{
 	dir = 4
@@ -66965,12 +67236,8 @@
 /turf/simulated/floor/carpet,
 /area/medical/psych)
 "orL" = (
-/obj/item/clothing/shoes/orange,
-/obj/item/clothing/under/color/orange/prison,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
+/turf/simulated/floor/plating,
 /area/security/permabrig)
 "orR" = (
 /obj/structure/sign/poster/random{
@@ -67144,7 +67411,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "owe" = (
@@ -67288,6 +67555,7 @@
 /area/hallway/primary/starboard/south)
 "oyU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -67373,7 +67641,10 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "red"
+	},
 /area/security/range)
 "oBi" = (
 /obj/structure/cable{
@@ -67564,6 +67835,11 @@
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/hallway/primary/starboard/north)
+"oEo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/security/permabrig)
 "oEE" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -67612,13 +67888,50 @@
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/hallway/primary/fore/west)
 "oFn" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
 	},
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/item/clothing/accessory/holster{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/clothing/accessory/holster{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/clothing/accessory/holster{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/accessory/holster{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/accessory/holster,
+/obj/item/clothing/accessory/holster,
+/obj/item/clothing/accessory/holster{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/accessory/holster{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/accessory/holster{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/item/clothing/accessory/holster{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = 31
+	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 5;
+	icon_state = "red"
 	},
 /area/security/main)
 "oFu" = (
@@ -67667,22 +67980,29 @@
 	},
 /area/medical/medbay)
 "oGc" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/item/radio/intercom{
-	pixel_y = -28
+/obj/machinery/camera{
+	c_tag = "Brig Head of Security's Office east"
 	},
-/obj/effect/decal/warning_stripes/red/hollow,
-/turf/simulated/floor/plasteel,
-/area/security/prisonlockers)
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/item/radio/intercom{
+	pixel_y = 29
+	},
+/turf/simulated/floor/wood,
+/area/security/hos)
 "oGl" = (
 /turf/simulated/floor/plasteel{
 	dir = 8
 	},
 /area/security/lobby)
 "oGr" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/security/brigstaff)
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/landmark/start/security_officer,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/brig)
 "oGy" = (
 /obj/machinery/door/airlock/glass{
 	id = "IAA";
@@ -67745,9 +68065,9 @@
 	icon_state = "1-8"
 	},
 /obj/effect/landmark/start/detective,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/obj/structure/chair/office/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/wood,
 /area/security/detectives_office)
 "oIc" = (
 /obj/structure/cable{
@@ -67900,6 +68220,32 @@
 	icon_state = "dark"
 	},
 /area/engine/gravitygenerator)
+"oKT" = (
+/obj/structure/table/wood,
+/obj/machinery/keycard_auth{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/machinery/door_control{
+	id = "Secure Gate";
+	name = "Brig Lockdown";
+	pixel_x = 1;
+	pixel_y = -4;
+	req_access = list(2)
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/security/hos)
 "oLw" = (
 /obj/machinery/camera{
 	c_tag = "Robotics Surgery";
@@ -68162,7 +68508,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "oQa" = (
@@ -68208,7 +68554,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 4;
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "oQS" = (
@@ -68233,6 +68580,15 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/apmaint2)
+"oRe" = (
+/obj/structure/table,
+/obj/machinery/microscope{
+	pixel_y = 6
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/security/detectives_office)
 "oRA" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
@@ -68534,10 +68890,9 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/orange{
-	icon_state = "2-4"
+/turf/simulated/floor/plasteel{
+	icon_state = "redcorner"
 	},
-/turf/simulated/floor/plasteel,
 /area/security/processing)
 "oVX" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -68723,7 +69078,10 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/security_cadet,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "red"
+	},
 /area/security/processing)
 "oYe" = (
 /obj/effect/decal/warning_stripes/east,
@@ -68777,16 +69135,12 @@
 /turf/simulated/floor/plasteel/white,
 /area/toxins/lab)
 "oZm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/wood,
 /area/security/detectives_office)
 "oZn" = (
 /obj/structure/grille/broken,
@@ -69475,6 +69829,15 @@
 /obj/effect/spawner/window/shuttle,
 /turf/simulated/floor/plating,
 /area/shuttle/arrival/station)
+"pkA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel,
+/area/security/permabrig)
 "pkO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -69683,6 +70046,12 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/hallway/primary/aft/west)
+"poM" = (
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/security/brig)
 "poR" = (
 /obj/machinery/door/poddoor/multi_tile/two_tile_hor,
 /obj/structure/spacepoddoor{
@@ -69810,8 +70179,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkredcorners"
+	icon_state = "dark"
 	},
 /area/security/brig)
 "pqv" = (
@@ -70014,8 +70382,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "pus" = (
@@ -70052,6 +70419,16 @@
 /obj/item/stack/rods,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/engineering)
+"puU" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
+/area/security/processing)
 "pvl" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -70218,13 +70595,12 @@
 	},
 /area/crew_quarters/kitchen)
 "pxk" = (
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "redcorner"
+	},
 /area/security/main)
 "pxm" = (
 /obj/structure/sign/directions/science{
@@ -70297,13 +70673,19 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "pzk" = (
+/obj/machinery/autolathe/security,
+/obj/item/stack/sheet/metal{
+	amount = 10
+	},
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
 /obj/machinery/light_switch{
 	pixel_y = 24
 	},
-/obj/machinery/vending/security,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	dir = 9;
+	icon_state = "red"
 	},
 /area/security/main)
 "pzp" = (
@@ -70869,8 +71251,7 @@
 	},
 /obj/machinery/computer/arcade,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
 "pJd" = (
@@ -70897,13 +71278,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard/north)
-"pJg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/effect/landmark/start/security_cadet,
-/turf/simulated/floor/plasteel,
-/area/security/brigstaff)
 "pJm" = (
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
@@ -70948,7 +71322,8 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "pJK" = (
@@ -71183,14 +71558,22 @@
 	},
 /area/hallway/primary/starboard/north)
 "pOo" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/structure/safe{
+	known_by = list("hos")
 	},
-/obj/machinery/photocopier,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/item/gun/projectile/revolver/mateba,
+/obj/item/ammo_box/a357{
+	pixel_x = -9;
+	pixel_y = 9
 	},
-/area/security/brig)
+/obj/item/ammo_box/a357{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/ammo_box/a357,
+/obj/item/clothing/accessory/holster,
+/turf/simulated/floor/wood,
+/area/security/hos)
 "pOB" = (
 /obj/effect/landmark/event/lightsout,
 /turf/simulated/floor/plasteel{
@@ -71288,7 +71671,13 @@
 	},
 /area/hydroponics)
 "pPN" = (
-/turf/simulated/floor/carpet,
+/obj/structure/bed/dogbed{
+	pixel_x = 2
+	},
+/mob/living/simple_animal/pet/dog/security/detective{
+	pixel_x = 4
+	},
+/turf/simulated/floor/wood,
 /area/security/detectives_office)
 "pQa" = (
 /turf/simulated/floor/plasteel{
@@ -71297,18 +71686,12 @@
 	},
 /area/hallway/secondary/entry/north)
 "pQv" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/machinery/light{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/red/hollow,
-/turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
 "pQE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -71955,13 +72338,17 @@
 	},
 /area/hallway/primary/port/north)
 "qas" = (
-/obj/machinery/light,
-/obj/structure/chair{
+/obj/structure/table/reinforced,
+/obj/item/book/manual/security_space_law,
+/obj/item/folder/red{
+	pixel_y = 3
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/main)
 "qaC" = (
@@ -71992,7 +72379,9 @@
 /turf/simulated/floor/plasteel/white,
 /area/toxins/xenobiology)
 "qaK" = (
-/obj/machinery/suit_storage_unit/security/hos,
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
 /turf/simulated/floor/wood,
 /area/security/hos)
 "qaY" = (
@@ -72474,7 +72863,8 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 4;
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "qiy" = (
@@ -72501,6 +72891,12 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard/north)
+"qjg" = (
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "darkred"
+	},
+/area/security/prison/cell_block/A)
 "qjk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -72536,8 +72932,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 9;
+	icon_state = "red"
 	},
 /area/security/lobby)
 "qjG" = (
@@ -72871,7 +73267,7 @@
 	pixel_x = 26
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	dir = 1
 	},
 /area/security/prison/cell_block/A)
 "qng" = (
@@ -73166,10 +73562,11 @@
 	},
 /area/hallway/secondary/exit)
 "qqV" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/security/brigstaff)
+/obj/item/flag/sec,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/security/hos)
 "qrV" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 2";
@@ -73177,7 +73574,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
 "qsb" = (
@@ -73193,6 +73590,7 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/starboard/south)
 "qsf" = (
+/obj/effect/landmark/start/security_officer,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "red"
@@ -73302,7 +73700,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkredfull"
 	},
 /area/security/brig)
 "qtD" = (
@@ -73369,8 +73767,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "qvd" = (
@@ -73380,9 +73777,8 @@
 	},
 /area/maintenance/starboard)
 "qvm" = (
-/obj/structure/cable/orange{
-	icon_state = "1-8"
-	},
+/obj/structure/closet/secure_closet/brig,
+/obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
 "qvn" = (
@@ -73421,12 +73817,11 @@
 	},
 /area/chapel/main)
 "qwY" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/whiskey{
-	pixel_y = 18
+/obj/structure/bed,
+/obj/item/bedsheet/hos,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/obj/item/toy/russian_revolver,
-/turf/simulated/floor/carpet/red,
 /area/security/hos)
 "qwZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -73543,14 +73938,16 @@
 	},
 /area/hallway/spacebridge/servsci)
 "qzQ" = (
-/obj/structure/sign/poster/secret/yug0{
-	pixel_x = 32
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prisoner Lockers";
+	req_access = list(63)
 	},
-/turf/simulated/floor/carpet/red,
-/area/security/hos)
+/turf/simulated/floor/plasteel,
+/area/security/prisonlockers)
 "qzT" = (
 /obj/item/seeds/wheat/rice,
 /turf/simulated/floor/grass,
@@ -73738,6 +74135,7 @@
 /area/maintenance/disposal/external/southeast)
 "qCe" = (
 /turf/simulated/floor/plasteel{
+	dir = 10;
 	icon_state = "red"
 	},
 /area/security/seceqstorage)
@@ -73817,7 +74215,6 @@
 /area/hallway/primary/starboard/north)
 "qCQ" = (
 /obj/machinery/button/windowtint{
-	anchored = 1;
 	id = "library";
 	pixel_y = 26
 	},
@@ -74012,8 +74409,8 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/lobby)
 "qHa" = (
@@ -74022,10 +74419,7 @@
 	req_access = list(1)
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "red"
-	},
+/turf/simulated/floor/plasteel,
 /area/security/seceqstorage)
 "qHd" = (
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -74063,9 +74457,8 @@
 	c_tag = "Detective's Office";
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/obj/machinery/vending/cigarette/free,
+/turf/simulated/floor/wood,
 /area/security/detectives_office)
 "qHJ" = (
 /obj/structure/railing{
@@ -74189,6 +74582,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/starboard/north)
+"qJr" = (
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkred"
+	},
+/area/security/prison/cell_block/A)
 "qJw" = (
 /obj/structure/cable/orange{
 	icon_state = "1-4"
@@ -74205,16 +74604,9 @@
 	},
 /area/maintenance/port)
 "qJA" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/engine,
 /area/security/permabrig)
 "qJD" = (
 /obj/structure/cable/orange{
@@ -74346,7 +74738,9 @@
 /obj/structure/cable/orange{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
 /area/security/prisonershuttle)
 "qMi" = (
 /obj/structure/closet,
@@ -74388,6 +74782,16 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/cmostore)
+"qNi" = (
+/obj/machinery/requests_console{
+	name = "Detective Requests Console";
+	pixel_y = -30
+	},
+/turf/simulated/floor/carpet{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "carpet13-5"
+	},
+/area/security/detectives_office)
 "qNu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -74499,7 +74903,6 @@
 /area/medical/cmo)
 "qPs" = (
 /obj/machinery/door/airlock/security/glass{
-	id = "Detective";
 	name = "Detective";
 	req_access = list(4)
 	},
@@ -74510,9 +74913,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/turf/simulated/floor/wood,
 /area/security/detectives_office)
 "qPU" = (
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -74536,7 +74937,10 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "redcorner"
+	},
 /area/security/processing)
 "qQw" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer{
@@ -74602,12 +75006,16 @@
 	},
 /area/hallway/primary/fore/east)
 "qQZ" = (
-/obj/item/radio/intercom{
-	pixel_y = -30
+/obj/structure/closet/secure_closet/brigdoc{
+	req_access = list(2,5)
 	},
+/obj/item/storage/pill_bottle/patch_pack,
+/obj/item/storage/pill_bottle,
+/obj/item/storage/belt/medical,
+/obj/item/handheld_defibrillator,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 0;
+	dir = 5;
 	icon_state = "whitered"
 	},
 /area/security/medbay)
@@ -74901,9 +75309,12 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/main)
 "qYi" = (
@@ -74981,6 +75392,12 @@
 "qZp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/sign/poster/official/ion_rifle{
+	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -75132,11 +75549,6 @@
 /area/hallway/primary/port/north)
 "rcx" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3
-	},
-/obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -75310,8 +75722,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -75559,8 +75971,8 @@
 "rkD" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/lobby)
 "rll" = (
@@ -76002,13 +76414,9 @@
 	},
 /area/engine/chiefs_office)
 "rrF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "rrN" = (
 /obj/effect/turf_decal/stripes/line{
@@ -76109,12 +76517,12 @@
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/maintenance/apmaint2)
 "rtN" = (
-/obj/structure/chair{
-	dir = 4
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/main)
 "rtW" = (
@@ -76132,6 +76540,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint3)
+"rub" = (
+/obj/structure/window/reinforced{
+	color = "red";
+	dir = 8
+	},
+/obj/machinery/computer/med_data{
+	dir = 1;
+	pixel_x = 4
+	},
+/turf/simulated/floor/wood,
+/area/security/detectives_office)
 "rup" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -76313,8 +76732,6 @@
 	},
 /area/engine/mechanic_workshop/hangar)
 "rxu" = (
-/obj/machinery/door/airlock/security/glass,
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -76326,8 +76743,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "rxW" = (
@@ -76693,7 +77109,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/lobby)
 "rDn" = (
@@ -76714,12 +77130,10 @@
 /turf/simulated/floor/wood,
 /area/library)
 "rDY" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8;
-	on = 1
-	},
-/turf/simulated/floor/carpet/red,
-/area/security/hos)
+/obj/machinery/portable_atmospherics/canister/sleeping_agent,
+/obj/effect/decal/warning_stripes/northwestcorner,
+/turf/simulated/floor/engine,
+/area/security/permabrig)
 "rEg" = (
 /obj/machinery/camera{
 	c_tag = "Fitness Room South";
@@ -76730,6 +77144,11 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
+"rEl" = (
+/obj/structure/girder,
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/security/processing)
 "rEm" = (
 /obj/structure/extinguisher_cabinet{
 	name = "custom placement";
@@ -76746,12 +77165,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/orange{
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkredcorners"
+	icon_state = "dark"
 	},
 /area/security/brig)
 "rEy" = (
@@ -76795,6 +77210,10 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/fore2)
+"rEY" = (
+/obj/structure/sign/poster/official/spiders,
+/turf/simulated/wall/r_wall,
+/area/security/detectives_office)
 "rFb" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
@@ -76908,16 +77327,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/security/permabrig)
-"rHk" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/flask/detflask,
-/obj/structure/cable/orange{
-	icon_state = "1-4"
-	},
-/obj/item/toy/figure/detective,
-/obj/effect/spawner/lootdrop/officetoys,
-/turf/simulated/floor/carpet,
-/area/security/detectives_office)
 "rHn" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 8;
@@ -77133,7 +77542,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "red"
+	},
 /area/security/lobby)
 "rKX" = (
 /obj/machinery/light{
@@ -77446,17 +77858,19 @@
 /turf/simulated/wall,
 /area/maintenance/port2)
 "rQs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/spawner/window/reinforced,
 /obj/structure/cable/orange{
-	icon_state = "2-4"
+	icon_state = "1-2"
+	},
+/obj/structure/cable/orange,
+/obj/structure/cable/orange{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkredcorners"
 	},
-/area/security/brig)
+/area/security/reception)
 "rQv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall,
@@ -77513,11 +77927,10 @@
 	},
 /area/hallway/secondary/entry/north)
 "rQZ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	icon_state = "darkredfull"
 	},
-/turf/simulated/floor/plasteel,
-/area/security/brigstaff)
+/area/security/brig)
 "rRb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -78052,8 +78465,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkredcorners"
+	icon_state = "dark"
 	},
 /area/security/brig)
 "rZo" = (
@@ -78209,8 +78621,8 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "scd" = (
@@ -79289,6 +79701,19 @@
 	icon_state = "white"
 	},
 /area/crew_quarters/kitchen)
+"suq" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkredfull"
+	},
+/area/security/brig)
 "suu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -79330,6 +79755,21 @@
 	icon_state = "asteroidplating"
 	},
 /area/quartermaster/office)
+"svu" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/mug/hos,
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/obj/item/paper/safe_code{
+	owner = "hos"
+	},
+/obj/item/lighter/zippo/hos,
+/obj/item/paper/monitorkey,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/security/hos)
 "svX" = (
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
@@ -79506,11 +79946,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/camera{
-	c_tag = "Brig Labor Camp Airlock North";
-	dir = 8
-	},
-/obj/structure/closet/emcloset,
+/obj/machinery/suit_storage_unit/security,
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
 "szl" = (
@@ -79520,22 +79956,28 @@
 /turf/simulated/wall,
 /area/hallway/primary/fore)
 "szr" = (
-/obj/structure/dresser,
-/obj/structure/mirror{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/turf/simulated/floor/carpet/red,
-/area/security/hos)
-"szu" = (
-/obj/machinery/vending/clothing/departament/security,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "grimy"
 	},
-/area/security/brigstaff)
+/area/security/hos)
+"szu" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_y = 10
+	},
+/obj/item/pen{
+	pixel_y = 9
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/brig)
 "szD" = (
 /obj/machinery/bodyscanner{
 	dir = 4
@@ -79693,11 +80135,11 @@
 	},
 /area/storage/primary)
 "sBX" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -79797,6 +80239,10 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/port/north)
+"sEl" = (
+/obj/effect/decal/warning_stripes/red/hollow,
+/turf/simulated/floor/wood/fancy/light,
+/area/crew_quarters/courtroom)
 "sED" = (
 /obj/structure/chair/wood,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -80155,6 +80601,19 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/apmaint2)
+"sKm" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkred"
+	},
+/area/security/brig)
 "sKv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -80313,9 +80772,7 @@
 	dir = 8
 	},
 /obj/machinery/disposal,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/turf/simulated/floor/wood,
 /area/security/detectives_office)
 "sOD" = (
 /obj/structure/cable/orange{
@@ -80334,6 +80791,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -80388,6 +80846,16 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/asmaint5)
+"sPq" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkred"
+	},
+/area/security/brig)
 "sPB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/orange{
@@ -80471,11 +80939,8 @@
 	},
 /area/engine/engineering)
 "sQT" = (
-/obj/structure/chair/office/dark,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/officetoys,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -80555,7 +81020,8 @@
 	req_access = list(63)
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "sSq" = (
@@ -80731,7 +81197,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkredfull"
 	},
 /area/security/brig)
 "sVu" = (
@@ -80881,8 +81347,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "sZz" = (
@@ -80932,6 +81398,12 @@
 	pixel_y = -24;
 	req_access = list(2)
 	},
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching Prison Wing holding areas.";
+	name = "Prison Monitor";
+	network = list("Prison");
+	pixel_x = -32
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkredcorners"
@@ -80951,15 +81423,16 @@
 	},
 /area/hallway/primary/port/north)
 "tac" = (
-/obj/structure/cable/orange{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "grimy"
 	},
-/area/security/brig)
+/area/security/hos)
 "taz" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/mug/serv,
@@ -81554,7 +82027,8 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1
+	dir = 8;
+	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
 "tkg" = (
@@ -81583,8 +82057,7 @@
 	pixel_y = -36
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
 "tkr" = (
@@ -81629,9 +82102,7 @@
 	},
 /area/maintenance/starboard)
 "tll" = (
-/obj/structure/closet/secure_closet/bar{
-	req_access = list(25)
-	},
+/obj/structure/closet/secure_closet/bar,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "tlw" = (
@@ -81736,15 +82207,14 @@
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/apmaint2)
 "tnn" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Office";
-	req_access = list(63)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/area/security/brigstaff)
+/turf/simulated/floor/wood,
+/area/security/hos)
 "tnq" = (
 /turf/simulated/mineral/ancient,
 /area/hallway/primary/starboard/north)
@@ -82054,13 +82524,7 @@
 	},
 /area/medical/surgery/south)
 "ttS" = (
-/obj/structure/cable/orange{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/bodyscanner,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -82149,9 +82613,14 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_x = 1;
+	pixel_y = 3
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/main)
 "tuK" = (
@@ -82418,11 +82887,10 @@
 	},
 /area/chapel/office)
 "tze" = (
-/obj/structure/cable/orange{
-	icon_state = "0-4"
+/obj/structure/closet/secure_closet/security,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
 /area/security/reception)
 "tzh" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -82481,6 +82949,15 @@
 	icon_state = "redyellowfull"
 	},
 /area/crew_quarters/bar)
+"tAV" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/security/prison/cell_block/A)
 "tAX" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Walkway"
@@ -82848,6 +83325,14 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/fsmaint4)
+"tIl" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/effect/decal/warning_stripes/red/hollow,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/simulated/floor/plasteel,
+/area/security/prisonlockers)
 "tIo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -82937,6 +83422,9 @@
 	},
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/engineering)
+"tJC" = (
+/turf/simulated/wall,
+/area/security/brig)
 "tJO" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -83124,10 +83612,11 @@
 	},
 /area/quartermaster/qm)
 "tLk" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/effect/decal/warning_stripes/red/hollow,
-/turf/simulated/floor/plasteel,
-/area/security/prisonlockers)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/security/hos)
 "tLy" = (
 /obj/machinery/r_n_d/protolathe,
 /turf/simulated/floor/plasteel{
@@ -83201,10 +83690,15 @@
 	},
 /area/hallway/primary/aft/east)
 "tNC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/simulated/floor/carpet/red,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
 /area/security/hos)
 "tNT" = (
 /turf/simulated/wall,
@@ -83947,7 +84441,6 @@
 	dir = 4
 	},
 /obj/effect/landmark/event/lightsout,
-/obj/structure/closet/l3closet/virology,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -84022,6 +84515,16 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/port/south)
+"ubM" = (
+/obj/structure/window/reinforced{
+	color = "red";
+	dir = 1
+	},
+/obj/structure/morgue,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/security/detectives_office)
 "ubW" = (
 /obj/item/radio/intercom{
 	dir = 8;
@@ -84074,7 +84577,7 @@
 	},
 /obj/effect/landmark/start/civilian,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/lobby)
 "udb" = (
@@ -84330,8 +84833,8 @@
 /obj/item/bedsheet/purple,
 /obj/structure/bed,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
 "uhQ" = (
@@ -84444,9 +84947,12 @@
 	},
 /area/medical/virology)
 "ujR" = (
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	dir = 6;
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "ujU" = (
@@ -84836,12 +85342,10 @@
 /area/maintenance/port)
 "urf" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/firecloset,
-/obj/item/crowbar/red,
-/obj/machinery/light{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
 	},
-/turf/simulated/floor/plating,
 /area/security/permabrig)
 "urz" = (
 /turf/simulated/wall/r_wall,
@@ -85142,7 +85646,7 @@
 /obj/effect/landmark/start/security_cadet,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "uxx" = (
@@ -85305,6 +85809,12 @@
 /area/medical/cloning)
 "uAd" = (
 /obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "uAp" = (
@@ -85315,6 +85825,9 @@
 /area/maintenance/engineering)
 "uAv" = (
 /obj/structure/dispenser/oxygen,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
@@ -85442,8 +85955,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "uCu" = (
@@ -85625,6 +86144,11 @@
 	icon_state = "escape"
 	},
 /area/hallway/secondary/exit)
+"uFz" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
+/area/security/processing)
 "uFG" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Science SMES Access";
@@ -85636,17 +86160,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint2)
 "uFO" = (
+/obj/structure/cable/orange{
+	icon_state = "1-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 9
 	},
-/obj/machinery/door/airlock/command{
-	name = "Head of Security";
-	req_access = list(58)
+/obj/structure/chair/comfy/black{
+	dir = 8
 	},
-/obj/machinery/door/firedoor,
+/obj/effect/landmark/start/head_of_security,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -85671,6 +86197,15 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/port)
+"uGk" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/security/main)
 "uGx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -85807,7 +86342,6 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
@@ -85832,6 +86366,12 @@
 	},
 /turf/simulated/wall,
 /area/hallway/primary/central)
+"uJp" = (
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkred"
+	},
+/area/security/brig)
 "uJq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall,
@@ -85891,20 +86431,14 @@
 	},
 /area/maintenance/electrical_shop)
 "uKA" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/chair{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/item/radio/intercom{
+	pixel_x = -28
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkredcorners"
-	},
-/area/security/brig)
+/turf/simulated/floor/plasteel,
+/area/security/prisonershuttle)
 "uKE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -86172,16 +86706,15 @@
 /obj/machinery/vending/clothing,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
+"uOW" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel,
+/area/janitor)
 "uOX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "uPi" = (
@@ -86392,9 +86925,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/east)
 "uTo" = (
+/obj/structure/chair{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/lobby)
 "uTr" = (
@@ -86426,11 +86962,16 @@
 	},
 /area/teleporter)
 "uTV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/computer/security{
+	dir = 1;
+	network = list("SS13","Research Outpost","Mining Outpost")
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Head of Security's Desk";
+	departmentType = 5;
+	name = "Head of Security Requests Console";
+	pixel_x = 31
 	},
 /turf/simulated/floor/wood,
 /area/security/hos)
@@ -86448,14 +86989,8 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/starboard/south)
 "uUJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/carpet/red,
+/obj/machinery/ai_status_display,
+/turf/simulated/wall/r_wall,
 /area/security/hos)
 "uUL" = (
 /obj/machinery/light/small{
@@ -86608,12 +87143,19 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/south)
 "uXA" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/landmark/start/head_of_security,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -86669,30 +87211,15 @@
 /turf/simulated/wall/r_wall/coated,
 /area/engine/supermatter)
 "uYw" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "cell3";
-	name = "Permabrig Cell 3";
-	req_access = list(2);
-	security_level = 1
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/box/lights/mixed,
+/obj/item/stack/sheet/plasteel{
+	amount = 10
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Prison Gate";
-	name = "Prison Lockdown Blast Doors";
-	opacity = 0
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/light,
+/turf/simulated/floor/engine,
 /area/security/permabrig)
 "uYD" = (
 /obj/machinery/hologram/holopad,
@@ -86757,13 +87284,14 @@
 /turf/simulated/floor/plating,
 /area/toxins/rdoffice)
 "uZB" = (
-/obj/structure/table/reinforced,
-/obj/item/taperecorder,
-/obj/item/folder/red{
-	pixel_y = 3
+/obj/structure/cable/orange{
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/plasteel,
-/area/security/main)
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "hos"
+	},
+/turf/simulated/floor/plating,
+/area/security/hos)
 "uZG" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -86787,14 +87315,8 @@
 /obj/structure/cable/orange{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable/orange{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -86991,11 +87513,23 @@
 /turf/simulated/mineral/ancient,
 /area/hallway/primary/aft/east)
 "vev" = (
-/obj/machinery/computer/crew,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+/obj/structure/cable/orange{
+	icon_state = "2-4"
 	},
-/area/security/medbay)
+/obj/structure/cable/orange{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/command/glass{
+	id = "hos";
+	id_tag = "hosofficedoor";
+	name = "Head of Security";
+	req_access = list(58)
+	},
+/turf/simulated/floor/wood,
+/area/security/hos)
 "vey" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/simulated/floor/bluegrid{
@@ -87075,7 +87609,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/landmark/start/security_cadet,
 /turf/simulated/floor/plasteel,
 /area/security/range)
 "vhk" = (
@@ -87098,8 +87631,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "vhE" = (
@@ -87175,7 +87708,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/landmark/start/security_officer,
 /turf/simulated/floor/plasteel,
 /area/security/range)
 "vjw" = (
@@ -87295,7 +87827,11 @@
 	},
 /obj/machinery/hologram/holopad,
 /obj/effect/landmark/event/lightsout,
-/turf/simulated/floor/plasteel,
+/obj/structure/table/wood,
+/obj/item/storage/fancy/donut_box,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
 /area/security/main)
 "vlU" = (
 /obj/machinery/door/airlock/research{
@@ -87617,8 +88153,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	icon_state = "dark"
 	},
 /area/security/prison/cell_block/A)
 "vso" = (
@@ -87761,8 +88296,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkredcorners"
+	icon_state = "dark"
 	},
 /area/security/brig)
 "vtS" = (
@@ -87773,6 +88307,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
+"vtU" = (
+/obj/structure/window/reinforced{
+	color = "red";
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/security/detectives_office)
 "vtV" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/gloves,
@@ -88060,6 +88603,12 @@
 /obj/item/pickaxe,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/port)
+"vzg" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/security/lobby)
 "vzj" = (
 /obj/structure/showcase{
 	density = 0;
@@ -88633,6 +89182,12 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/aft/east)
+"vJu" = (
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "redcorner"
+	},
+/area/security/processing)
 "vJA" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -88694,7 +89249,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
 /area/security/prisonershuttle)
 "vKW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
@@ -89220,7 +89777,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "vRR" = (
@@ -89365,8 +89923,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
 "vTI" = (
@@ -89441,6 +89998,15 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/aft/west)
+"vVq" = (
+/obj/item/radio/intercom{
+	pixel_y = 22
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkred"
+	},
+/area/security/brig)
 "vVt" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/firealarm{
@@ -89555,10 +90121,14 @@
 	},
 /area/medical/medbreak)
 "vXd" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/security/brigstaff)
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/landmark/start/security_officer,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkredfull"
+	},
+/area/security/brig)
 "vXn" = (
 /turf/simulated/wall,
 /area/hallway/primary/starboard/south)
@@ -89658,14 +90228,14 @@
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
 "vZd" = (
-/obj/item/radio/intercom{
-	dir = 0;
-	pixel_x = 28
+/obj/structure/cable/orange{
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "hos"
 	},
-/area/security/brig)
+/turf/simulated/floor/plating,
+/area/security/hos)
 "vZe" = (
 /obj/effect/spawner/random_barrier/possibly_welded_airlock,
 /turf/simulated/floor/plating,
@@ -89990,12 +90560,11 @@
 /area/medical/medbay)
 "wfW" = (
 /obj/item/radio/intercom{
-	pixel_y = 28
+	pixel_y = 23
 	},
 /obj/structure/closet/secure_closet/guncabinet{
 	anchored = 1;
-	name = "Security SMG's";
-	req_access = list(3)
+	name = "Security SMG's"
 	},
 /obj/item/gun/projectile/automatic/wt550{
 	pixel_x = -3;
@@ -90199,18 +90768,14 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
-	},
+/turf/simulated/floor/plasteel,
 /area/security/lobby)
 "wjz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
 /area/security/main)
 "wjD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -91033,8 +91598,8 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	dir = 8;
+	icon_state = "red"
 	},
 /area/security/lobby)
 "wvp" = (
@@ -91161,6 +91726,23 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/engineering)
+"wxp" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkredfull"
+	},
+/area/security/brig)
 "wxv" = (
 /obj/machinery/computer/cloning{
 	dir = 1
@@ -91201,9 +91783,13 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
+/obj/item/radio/intercom{
+	pixel_x = 32;
+	pixel_y = -2
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "wyA" = (
@@ -91307,7 +91893,8 @@
 "wzW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whiteredfull"
 	},
 /area/security/medbay)
 "wAb" = (
@@ -91324,8 +91911,8 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "wAp" = (
@@ -91354,7 +91941,12 @@
 	},
 /area/security/processing)
 "wAA" = (
-/obj/item/flag/sec,
+/obj/machinery/computer/secure_data{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_x = 31
+	},
 /turf/simulated/floor/wood,
 /area/security/hos)
 "wAB" = (
@@ -91415,7 +92007,8 @@
 	},
 /obj/effect/landmark/start/brig_physician,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whiteredfull"
 	},
 /area/security/medbay)
 "wBc" = (
@@ -91439,6 +92032,20 @@
 	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/maintenance/apmaint2)
+"wBw" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_x = 1;
+	pixel_y = 3
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/security/brig)
 "wBA" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -91463,8 +92070,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "wBL" = (
@@ -91527,11 +92134,11 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/starboard/south)
 "wCT" = (
-/obj/machinery/vending/security,
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "grimy"
 	},
-/area/security/brig)
+/area/security/hos)
 "wCU" = (
 /obj/structure/cable/orange{
 	icon_state = "1-4"
@@ -91548,15 +92155,13 @@
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "wDr" = (
-/obj/structure/cable/orange,
-/obj/structure/cable/orange{
-	icon_state = "1-8"
-	},
-/obj/effect/spawner/window/reinforced,
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/photocopier,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/security/reception)
 "wDs" = (
 /obj/machinery/light{
@@ -91622,7 +92227,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whiteredfull"
 	},
 /area/security/medbay)
 "wEh" = (
@@ -91820,7 +92426,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "wGA" = (
@@ -92390,7 +92996,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "redcorner"
+	},
 /area/security/main)
 "wQW" = (
 /obj/structure/table/wood/fancy/black,
@@ -92447,6 +93056,12 @@
 "wRL" = (
 /turf/simulated/mineral/ancient,
 /area/maintenance/fsmaint4)
+"wRQ" = (
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkredcorners"
+	},
+/area/security/brig)
 "wSk" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -92490,6 +93105,14 @@
 /obj/structure/table/wood/fancy/black,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"wSG" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkred"
+	},
+/area/security/brig)
 "wSP" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -92796,8 +93419,8 @@
 	name = "Cell 3 Locker"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
 "wYt" = (
@@ -92844,11 +93467,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/falsewall/mineral_ancient{
-	icon_state = "rock_ancient";
-	pixel_x = -4;
-	pixel_y = -4
-	},
+/obj/structure/falsewall/mineral_ancient,
 /turf/simulated/floor/plating,
 /area/hallway/primary/port/south)
 "wZv" = (
@@ -92962,7 +93581,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "xas" = (
@@ -92979,13 +93598,11 @@
 /area/civilian/vacantoffice)
 "xax" = (
 /obj/structure/cable/orange{
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 24
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/turf/simulated/floor/wood,
 /area/security/hos)
 "xaD" = (
 /obj/machinery/light,
@@ -93015,6 +93632,11 @@
 	icon_state = "darkpurple"
 	},
 /area/teleporter/quantum/science)
+"xaL" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/security/detectives_office)
 "xaR" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating{
@@ -93413,12 +94035,17 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/structure/chair{
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
 	dir = 4
+	},
+/obj/machinery/recharger{
+	pixel_x = 1;
+	pixel_y = 3
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/security/main)
 "xjO" = (
@@ -93479,6 +94106,15 @@
 	icon_state = "dark"
 	},
 /area/toxins/lab)
+"xkM" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/security/processing)
 "xkQ" = (
 /obj/machinery/optable,
 /obj/machinery/shower{
@@ -93599,7 +94235,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "xnc" = (
@@ -93850,12 +94486,12 @@
 	},
 /area/engine/engineering)
 "xrM" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/effect/decal/warning_stripes/red/hollow,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
 /area/security/prisonlockers)
 "xrN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -94420,7 +95056,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "redcorner"
+	},
 /area/security/processing)
 "xBN" = (
 /obj/effect/turf_decal/stripes/line{
@@ -94723,9 +95361,6 @@
 	},
 /area/hallway/secondary/entry/south)
 "xHc" = (
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -94830,7 +95465,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+	dir = 10;
+	icon_state = "red"
 	},
 /area/security/lobby)
 "xIX" = (
@@ -95144,7 +95780,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "darkredfull"
+	icon_state = "dark"
 	},
 /area/security/permabrig)
 "xRE" = (
@@ -95415,17 +96051,14 @@
 	},
 /area/bridge)
 "xVM" = (
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
 /obj/structure/table,
 /obj/item/flashlight/lamp,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
 "xVV" = (
@@ -95451,6 +96084,19 @@
 	icon_state = "dark"
 	},
 /area/engine/break_room)
+"xWl" = (
+/obj/machinery/optable,
+/obj/item/scalpel,
+/obj/item/autopsy_scanner,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/machinery/camera{
+	c_tag = "Detective's Lab";
+	network = list("SS13","Security")
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/security/detectives_office)
 "xWp" = (
 /obj/machinery/door/airlock/public{
 	name = "Chapel - Library"
@@ -95496,7 +96142,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "xWB" = (
@@ -95515,7 +96161,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "xXg" = (
@@ -95579,8 +96226,8 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/primary/fore/west)
 "xYq" = (
@@ -95609,23 +96256,7 @@
 /turf/space,
 /area/security/armory)
 "xYR" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/structure/table/wood,
-/obj/item/clothing/glasses/sunglasses,
-/obj/item/storage/fancy/cigarettes/dromedaryco,
-/obj/item/camera{
-	desc = "A one use - polaroid camera. 30 photos left.";
-	name = "detectives camera";
-	pictures_left = 30
-	},
-/obj/item/flashlight/lamp/green{
-	on = 0;
-	pixel_x = -3;
-	pixel_y = 8
-	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/security/detectives_office)
 "xYT" = (
 /obj/structure/cable/orange{
@@ -95918,8 +96549,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkred"
 	},
 /area/security/brig)
 "ydE" = (
@@ -95946,6 +96580,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
+"ydJ" = (
+/obj/machinery/door/window/eastright{
+	dir = 8;
+	name = "Forensic laboratory";
+	req_access = list(4)
+	},
+/turf/simulated/floor/wood,
+/area/security/detectives_office)
 "yep" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -96190,9 +96832,7 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
-	},
+/turf/simulated/floor/plasteel,
 /area/security/lobby)
 "yiE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -96282,6 +96922,11 @@
 	},
 /area/atmos)
 "ykj" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/item/radio/intercom{
+	pixel_y = -28
+	},
+/obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
 "yks" = (
@@ -96326,8 +96971,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/landmark/start/security_officer,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
 /area/security/seceqstorage)
 "ylg" = (
 /obj/structure/cable/orange{
@@ -106011,7 +106657,7 @@ nGg
 nGg
 nGg
 nGg
-gLH
+nGg
 vZt
 abW
 abW
@@ -107544,7 +108190,7 @@ dgN
 eOW
 yhW
 xJa
-gLH
+nGg
 kRx
 kRx
 iDB
@@ -107807,8 +108453,8 @@ xhk
 iDB
 xhk
 xhk
-eiM
-xhk
+nGL
+sEl
 nGg
 rSI
 wmV
@@ -108049,10 +108695,10 @@ abE
 cRv
 cRv
 cRv
-epY
-epY
-epY
-epY
+cRv
+cRv
+cRv
+cRv
 goa
 jqr
 tuf
@@ -108306,9 +108952,9 @@ xEp
 xEp
 xEp
 xEp
-epY
-nNY
-kzg
+cRv
+abW
+rEl
 paR
 goa
 xkQ
@@ -108564,17 +109210,17 @@ xEp
 xEp
 xEp
 tYz
-ceL
-ceL
-paR
+tYz
+tYz
+tYz
 goa
 ahK
-eCE
-oqb
+xxw
+xxw
 mnQ
 cmY
 goa
-qjw
+uTo
 glD
 yaN
 lNp
@@ -108826,7 +109472,7 @@ mCZ
 hXE
 goa
 ipD
-vev
+xxw
 ilu
 hpx
 dOz
@@ -109084,14 +109730,14 @@ voa
 goa
 jMg
 wBa
-xxw
+ilu
 wDZ
 qQZ
 goa
-uTo
+mEm
 xNk
 xzA
-aPX
+byO
 jND
 cBD
 fXQ
@@ -109348,7 +109994,7 @@ bVX
 wjm
 nfr
 yaN
-aPX
+byO
 jND
 cBG
 amU
@@ -109597,12 +110243,12 @@ khd
 kzg
 goa
 jjV
-kKK
 jbA
-jZS
+jbA
+jbA
 qks
 goa
-uTo
+mEm
 cxe
 yaN
 aPW
@@ -110087,7 +110733,7 @@ rNK
 rNK
 rNK
 rNK
-nZp
+pVD
 pVD
 arV
 mZH
@@ -110344,7 +110990,7 @@ rNK
 rNK
 rNK
 rNK
-nZp
+pVD
 aWm
 wFn
 mFT
@@ -110354,10 +111000,10 @@ qyS
 mFT
 wFn
 aoZ
-dqa
+uKA
 dqa
 arV
-yfX
+jwx
 cDJ
 dtj
 wUX
@@ -110366,14 +111012,14 @@ aRK
 qcY
 wUX
 aGH
-nII
+nts
 oYd
-nII
+dxo
 bQb
 nII
 jHo
 tYz
-uTo
+mEm
 sxs
 yaN
 idf
@@ -110623,14 +111269,14 @@ aXo
 vHZ
 wUX
 osN
-nII
+vJu
 aWE
 jxh
 gWg
 nII
 nmn
 cfL
-uTo
+mEm
 sxs
 yaN
 ucY
@@ -110881,13 +111527,13 @@ uDS
 bZP
 dww
 xBF
-xBF
+puU
 bIS
 aAb
 aJQ
 mRX
 cfM
-uTo
+mEm
 jYI
 yaN
 rDk
@@ -111116,20 +111762,20 @@ rNK
 rNK
 cRv
 abW
-pVD
 mCL
 mCL
+dqw
 mCL
 mCL
+gby
 mCL
-drz
 mCL
 xQS
+qzQ
 xQS
-aqY
 xQS
-xQS
-aum
+koS
+bqV
 dtr
 hrN
 hrN
@@ -111137,9 +111783,9 @@ hrN
 hrN
 hrN
 nRr
-nII
-nII
-cHh
+vJu
+uFz
+gGh
 bQP
 bTP
 ccv
@@ -111147,7 +111793,7 @@ cfP
 rkD
 pXV
 sgH
-idf
+qBE
 oGy
 vFG
 cDi
@@ -111373,21 +112019,21 @@ vva
 vva
 cRv
 abW
-abW
 mCL
+cOI
 doR
-doR
+dun
 akD
 ali
 amM
-aka
 xQS
+jYY
 arp
-qvm
-tLk
+tIl
 xQS
-uKA
-dpu
+djS
+bqV
+dtr
 xrZ
 aAy
 pnf
@@ -111630,21 +112276,21 @@ cRv
 cRv
 cRv
 abW
-abW
 mCL
+cYs
 doM
-doR
+dwm
 akE
 alj
 amN
-jaN
-xQS
+mCL
+jZS
 xrM
 mJt
-arW
 xQS
-aup
-vQv
+djS
+bqY
+wSG
 xrZ
 juf
 bap
@@ -111653,7 +112299,7 @@ bnz
 aOn
 cHh
 hOF
-cHh
+xkM
 aIP
 nII
 wAt
@@ -111668,7 +112314,7 @@ cEC
 aUo
 wjS
 wjS
-vFG
+fDb
 dkp
 dpO
 dIS
@@ -111887,28 +112533,28 @@ cRv
 abW
 abW
 abW
-ivS
 mCL
+doE
 ajH
-doR
+dNf
 amW
-doR
+gce
 ixg
-dqw
-xQS
+mCL
+kia
 cVO
 ykj
-oGc
 xQS
-uKA
-dpu
+vVq
+bqV
+dtr
 xrZ
 xrZ
 xrZ
 xrZ
 xrZ
 bsG
-qej
+dxo
 usW
 qej
 dxo
@@ -112144,23 +112790,23 @@ abW
 abW
 abW
 ivS
-vva
 mCL
 mCL
-dph
 mCL
+mCL
+elc
 aeK
 ttS
-apA
-xQS
+mCL
+kKK
 efs
 cuJ
 atr
 djS
-uKA
-dpu
-dpu
-dpu
+bqV
+kHL
+wBw
+bHn
 vRQ
 dvH
 jgj
@@ -112173,7 +112819,7 @@ tYz
 tYz
 tYz
 gmC
-sxs
+gJe
 qBE
 idf
 qCk
@@ -112402,33 +113048,33 @@ vva
 abW
 ivS
 xNi
-doE
 vva
-vva
+drz
 mCL
+epY
 all
+gVY
 mCL
-mCL
-xQS
-apc
-ykj
-tLk
-xQS
+mgY
+cVO
+qvm
+gmC
+sPq
 auq
 dpu
 dpu
 dpu
 dpu
-dpu
-dpu
+kHL
+poM
 jpI
-imu
-gbq
-yfX
 dpu
+gbq
+poM
+poM
 gBt
 xXf
-dpu
+poM
 sSn
 sxs
 qBE
@@ -112661,25 +113307,25 @@ jKO
 vva
 vva
 vva
-vva
-rBH
-rNK
-rNK
-rNK
-xQS
+dUJ
+epY
+aeK
+gYW
+mCL
+mhv
 pQv
 ara
-asa
 xQS
+djS
 auF
 awq
 dpu
-dun
 dpu
 dpu
-vZd
-mgY
-tac
+dpu
+dpu
+dpu
+dpu
 jnG
 mbV
 eTs
@@ -112695,7 +113341,7 @@ cHi
 bKg
 cLt
 bKg
-bKg
+oqZ
 cYn
 wvi
 dqh
@@ -112877,14 +113523,14 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+aka
+aka
+aka
+aka
+aka
+aka
+aka
+aka
 rNK
 rNK
 rNK
@@ -112916,37 +113562,37 @@ vva
 rBH
 rBH
 vva
-vva
+dph
 ajI
-cYs
-rBH
-rNK
-rNK
-rNK
-xQS
+mCL
+eCE
+gtc
+hKH
+mCL
+nso
 ape
-arb
-tLk
+qvm
 xQS
-uKA
+djS
+bqV
 dpu
-lfN
-lfN
+dpu
+dkI
+dpu
 oGr
 oGr
-lfN
-boM
-lfN
-wCT
+dpu
+dpu
+dpu
 oam
-eHx
+gmC
 gop
 vXY
 tgN
 dAM
 aNG
 jNy
-cwk
+hiz
 cwk
 cBJ
 qHJ
@@ -113134,14 +113780,14 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+aka
+asa
+aka
+boM
+boM
+aka
+aka
+aka
 rNK
 rNK
 rNK
@@ -113177,23 +113823,23 @@ afd
 afd
 afd
 afd
-afd
+mCL
 afd
 afd
 xQS
 apf
 xQS
 xQS
-xQS
-uKA
+gjR
+bqV
 dpu
 lfN
 kKa
-iGF
-iGF
-cMc
+rQZ
+vXd
+oGr
 ltg
-lfN
+rQZ
 rcx
 ddm
 cvY
@@ -113202,7 +113848,7 @@ qSQ
 mZB
 sGy
 rKD
-gVY
+yaN
 cxb
 etJ
 dyV
@@ -113391,14 +114037,14 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+apA
+aum
+aAJ
+ceL
+boM
+cgX
+aAJ
+aka
 rNK
 rNK
 rNK
@@ -113441,17 +114087,17 @@ aom
 nFH
 sZS
 afd
-yfX
+djS
 bqV
 wpm
-lfN
+cUf
 szu
-pJg
-qqV
+rQZ
+dpu
 vXd
 fiD
-lfN
-jUI
+rQZ
+dpu
 ydA
 eHx
 tze
@@ -113459,8 +114105,8 @@ mAz
 lQX
 oCQ
 rKD
-gYW
-tJs
+yaN
+vzg
 tJs
 cBL
 cEH
@@ -113648,14 +114294,14 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+arW
+awF
+aAJ
+aka
+ceL
+cCh
+aAJ
+aka
 rNK
 rNK
 rNK
@@ -113698,17 +114344,17 @@ aou
 apg
 dxq
 afd
-yfX
+djS
 bqV
 dpu
 lfN
 gTI
 rQZ
-nzD
-nwu
+oGr
+vXd
 nAb
-lfN
-pOo
+rQZ
+dpu
 uCt
 rQs
 wDr
@@ -113718,7 +114364,7 @@ jvm
 gyj
 lyS
 lyS
-lyS
+fep
 cBN
 cEX
 cLA
@@ -113905,14 +114551,14 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+apA
+awG
+aAJ
+boM
+ceL
+cOl
+aAJ
+aka
 rNK
 rNK
 rNK
@@ -113955,16 +114601,16 @@ xRy
 aph
 mzA
 afd
-yfX
+djS
 bqY
 vQv
-lfN
+dpu
 dkI
-ofN
-dgf
-hgd
-gtc
-lfN
+dpu
+oGr
+oGr
+dpu
+dpu
 uCz
 cHB
 mVK
@@ -114162,14 +114808,14 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+aka
+asa
+aka
+boM
+boM
+aka
+aka
+aka
 rNK
 rNK
 rNK
@@ -114215,25 +114861,25 @@ asc
 pqs
 auG
 uii
-lfN
-lfN
-tnn
-lfN
-oGr
-oGr
-lfN
 dpu
 dpu
+dpu
+dpu
+dpu
+dpu
+dpu
+dpu
+dBZ
 uOX
-orG
+uOX
 juF
-yfX
+poM
 nop
-yfX
+poM
 pJG
+tAV
 eWZ
-dWr
-dWr
+eWZ
 cFf
 tnz
 ejj
@@ -114419,14 +115065,14 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+aka
+aka
+aka
+aka
+aka
+aka
+aka
+aka
 rNK
 rNK
 rNK
@@ -114476,19 +115122,19 @@ qJQ
 eZS
 qJQ
 qJQ
+eZS
 qJQ
 qJQ
+eZS
+jRt
 qJQ
-qJQ
-qJQ
-dNf
-qJQ
+eZS
 xdZ
 dpu
-dpu
+rQZ
 dpu
 gSF
-dWr
+mLK
 dWr
 grV
 cFt
@@ -114714,7 +115360,7 @@ adr
 adC
 alr
 afJ
-vdq
+aqY
 dQE
 mYJ
 afd
@@ -114726,22 +115372,22 @@ xNI
 afd
 afd
 afd
-yfX
+gjR
 qeE
 dtp
 dtP
 wys
-wys
+joq
 rZn
 cgi
 cgi
 hRW
 owb
-cgi
+sKm
 rEq
-cgi
+rEq
 xWw
-cgi
+rEq
 bEz
 hUv
 crd
@@ -114757,16 +115403,16 @@ xla
 aVy
 dKM
 aWJ
-ice
-cWq
+rEY
 hEQ
-iGj
-abW
-cRv
+hEQ
+hEQ
+hEQ
+hEQ
+hEQ
+hEQ
 cRv
 abE
-rNK
-rNK
 rNK
 rNK
 rNK
@@ -114971,23 +115617,23 @@ vdq
 adD
 aes
 afY
-aQL
-aQL
+ccJ
+dXQ
 ajN
 akf
 vNP
 alp
 afd
 rrF
+rrF
 qJA
 afd
-rNK
-gmC
+aiw
 yfX
 xMk
 dtr
 uqz
-uqz
+tJC
 rCG
 dvt
 rCG
@@ -114995,7 +115641,7 @@ uqz
 tNT
 tNT
 tNT
-hcb
+qHa
 qHa
 rJj
 oZD
@@ -115014,16 +115660,16 @@ dlt
 drB
 dKM
 ezS
-fRa
-cWq
-cWq
-iGj
-abW
+hEQ
+gZS
+mGu
+cnX
+ubM
+xaL
+hdO
+hEQ
 abW
 cRv
-abE
-rNK
-rNK
 rNK
 rNK
 rNK
@@ -115229,19 +115875,19 @@ hxj
 glG
 aga
 aiF
-rHj
+evp
 ajO
 adc
 vdq
 rHj
 afd
 lfz
-aQL
+rrF
+uYw
 afd
-rNK
-gmC
-yfX
-xMk
+bSV
+dpu
+wxp
 dtr
 uqz
 pzk
@@ -115271,16 +115917,16 @@ xla
 sbL
 dKM
 aWJ
-dxD
-dxD
-dxD
-dxD
-dxD
+hEQ
+mjn
+xYR
+gGw
+vtU
+xaL
+oRe
+hEQ
 abW
 cRv
-abE
-rNK
-rNK
 rNK
 rNK
 rNK
@@ -115494,10 +116140,10 @@ alt
 afd
 lpb
 cMR
+rDY
 afd
-rNK
-gmC
-yfX
+jdj
+wRQ
 xMk
 dtr
 uqz
@@ -115528,17 +116174,17 @@ goe
 drB
 haT
 aWJ
-fVG
+okm
 dyJ
-nHy
+xYR
 evg
 hxh
-ivS
+xaL
+xWl
+hEQ
+abW
 cRv
-abE
-abE
 rNK
-aZi
 rNK
 rNK
 hUU
@@ -115743,25 +116389,25 @@ gZj
 vdq
 agf
 vdq
-vdq
-vdq
-vNP
-vdq
+fSz
+iHa
+oEo
+pkA
 aQL
 afd
-uYw
 afd
 afd
 afd
 afd
-yfX
+afd
+djS
 xMk
-dtj
+uJp
 uqz
 xjK
 xHc
-fFH
-fFH
+xkf
+xkf
 qas
 tNT
 bAj
@@ -115774,7 +116420,7 @@ psM
 cnZ
 cHQ
 rJj
-eWZ
+qJr
 dWr
 cFT
 tnz
@@ -115787,15 +116433,15 @@ dKM
 aWJ
 okm
 pPN
-fvV
-etG
+xYR
+evg
 gcE
-ivS
+ydJ
+rub
+hEQ
+abW
 cRv
 cRv
-abE
-rNK
-rNK
 rNK
 rNK
 rNK
@@ -116001,24 +116647,24 @@ afd
 afd
 dEC
 bVd
-hxj
-hxj
+vdq
+vdq
 sBX
 dpM
 lmh
-dXQ
+vdq
 afd
 avn
 pVH
 riA
 vtR
-cBS
+suq
 dtr
 rCG
 rtN
 pxk
 fFH
-fFH
+aAF
 bnJ
 tNT
 aEh
@@ -116031,7 +116677,7 @@ cje
 cnV
 aOF
 ccG
-eWZ
+qJr
 cNG
 cFY
 lUn
@@ -116042,19 +116688,19 @@ xla
 drG
 dKM
 aWJ
-lpq
-rHk
+okm
 xYR
-etG
-lKg
-ivS
+xYR
+evg
+xYR
+xYR
+hlo
+hEQ
 abW
 cRv
-abE
+cRv
 rNK
-rNK
-rNK
-rNK
+aZi
 rNK
 hUU
 hUU
@@ -116270,13 +116916,13 @@ vNP
 vpG
 xmZ
 qJb
-cMx
+pqs
 jnZ
 duu
 bed
 ddU
 wjz
-bof
+duu
 bsM
 aEi
 bKp
@@ -116288,7 +116934,7 @@ aMM
 coh
 aOB
 cxE
-eWZ
+qJr
 cNH
 cGa
 xla
@@ -116299,17 +116945,17 @@ xla
 drG
 dMP
 aEV
-dxD
+jQC
 oac
-iGG
-etG
+xYR
+evg
 aan
-ivS
+bLL
+nVO
+hEQ
 abW
 cRv
-abE
-rNK
-rNK
+cRv
 rNK
 rNK
 hUU
@@ -116527,7 +117173,7 @@ afd
 afd
 xaq
 fKk
-awu
+dsy
 lVX
 mLm
 mis
@@ -116545,7 +117191,7 @@ aMN
 cnV
 crS
 cxO
-eWZ
+qJr
 cTm
 cGb
 vXQ
@@ -116561,14 +117207,14 @@ nvH
 oZm
 oHV
 gYq
-abW
+ncZ
+qNi
+hEQ
 abW
 cRv
-abE
 rNK
 rNK
-hUU
-hUU
+rNK
 hUU
 aXn
 aXn
@@ -116789,7 +117435,7 @@ rCG
 qYg
 wQS
 bau
-xkf
+cds
 dvX
 tNT
 bAk
@@ -116813,20 +117459,20 @@ dlu
 drL
 dNw
 eAo
-dxD
+hEQ
 sOx
 qHH
 bPO
 dxG
+alo
+kMT
+hEQ
 abW
 cRv
-cRv
-abE
+rNK
 rNK
 rNK
 hUU
-aXn
-aXn
 aXn
 aXn
 wAL
@@ -117041,20 +117687,20 @@ pVH
 mwt
 vtR
 cBS
-dtj
+uJp
 uqz
 ajt
 fzQ
-fRz
-uZB
+mCo
+xkf
 aEk
 bsL
 bAj
 bKt
 era
 dxP
-ccJ
-aDc
+rJj
+eCx
 reB
 coj
 crU
@@ -117071,18 +117717,18 @@ dsd
 bWx
 aWJ
 jmh
-dxD
-dxD
-emw
-emw
+hEQ
+hEQ
+hEQ
+hEQ
+hEQ
+hEQ
+hEQ
 abW
 cRv
-abE
-abE
 rNK
 rNK
 hUU
-aXn
 aXn
 aXn
 aXn
@@ -117302,13 +117948,13 @@ dtr
 uqz
 aLp
 fyS
-aAJ
+mCo
 xkf
 dvY
 tNT
 bAl
 bKt
-dUJ
+fEL
 lPW
 oZD
 aDc
@@ -117316,13 +117962,13 @@ dyA
 con
 aOI
 oZD
-eWZ
+dWr
 vTF
 dlt
 tmS
 lDw
 utC
-dgF
+dgZ
 cBP
 wAb
 bWx
@@ -117334,12 +117980,12 @@ pJd
 gGF
 gGF
 gGF
-abE
-rNK
+abW
+abW
+cRv
 rNK
 rNK
 hUU
-aXn
 aXn
 aXn
 aXn
@@ -117545,8 +118191,8 @@ aiM
 afd
 oic
 rHj
-rHj
-cgX
+fRz
+vNP
 vNP
 dqz
 vNP
@@ -117554,11 +118200,11 @@ rHj
 ard
 afd
 daG
-ohf
-daG
+xMk
+aqh
 uqz
 oFn
-qYg
+uGk
 mCo
 aDa
 bol
@@ -117591,12 +118237,12 @@ srB
 pfX
 sVi
 gGF
+abW
+cRv
 abE
 rNK
 rNK
-rNK
 hUU
-aXn
 aXn
 aXn
 aXn
@@ -117802,13 +118448,13 @@ aTz
 afd
 aTz
 aTz
-rHj
 aTz
-aTz
+afd
+afd
 afd
 afd
 twU
-mYJ
+uUJ
 fqh
 asY
 auH
@@ -117849,11 +118495,11 @@ mkz
 rKo
 gGF
 gGF
+abE
 rNK
 rNK
 rNK
 hUU
-aXn
 aXn
 aXn
 aXn
@@ -118060,13 +118706,13 @@ afd
 aTz
 aTz
 aTz
-aTz
-aTz
 afd
-vNP
 orL
-aLZ
-fqh
+iVY
+nNb
+orL
+cBy
+hii
 ata
 cxa
 hIK
@@ -118079,7 +118725,7 @@ bov
 bsO
 bBH
 bLb
-dwm
+ioE
 aIX
 sOL
 kVv
@@ -118109,7 +118755,7 @@ tzP
 rNK
 rNK
 rNK
-hUU
+rNK
 hUU
 aXn
 aXn
@@ -118317,16 +118963,16 @@ abW
 afd
 aTz
 aTz
-aTz
-aTz
 afd
+imu
+jaN
 urf
-gby
+adc
 cBy
-fqh
+kqF
 xax
 avc
-awF
+txK
 azY
 azW
 aSo
@@ -118347,7 +118993,7 @@ bBH
 cBb
 gdV
 cGh
-mhv
+cOh
 aTX
 aUt
 dgZ
@@ -118574,16 +119220,16 @@ abW
 abW
 afd
 aTz
-aTz
-aTz
 afd
-vNP
-elc
-fqh
+orL
+jUI
+orL
+adc
+uUJ
 asu
-atc
+txK
 kja
-awG
+txK
 mwR
 azW
 oAV
@@ -118832,9 +119478,9 @@ abW
 afd
 aTz
 aTz
-aTz
-aTz
-aTz
+afd
+afd
+afd
 afd
 fqh
 cNv
@@ -119090,12 +119736,12 @@ afd
 aTz
 aTz
 aTz
-aTz
-aTz
-aTz
+fqh
+fqh
+fqh
 fqh
 gAS
-atc
+txK
 uXA
 txK
 hxL
@@ -119113,7 +119759,7 @@ ioE
 aVT
 cjA
 ioE
-aOO
+crV
 bBH
 bsQ
 puj
@@ -119347,15 +119993,15 @@ afd
 aTz
 aTz
 aTz
-aTz
-aTz
-aTz
 fqh
+nNY
+txK
+uZB
 lKW
 atc
-uXA
+oKT
 sQT
-aAe
+lKW
 dbl
 lfh
 psy
@@ -119368,11 +120014,11 @@ aJb
 kqo
 uAv
 bVp
-aMS
+crV
 cov
 aOM
 bBH
-eWZ
+qJr
 qva
 xla
 uhO
@@ -119604,16 +120250,16 @@ afd
 aTz
 aTz
 aTz
-aTz
-aTz
-aTz
-aTz
 fqh
-fqh
+ofN
+szr
+vev
+aty
+iyo
 uFO
-fqh
-fqh
-fqh
+txK
+lKW
+azW
 wOD
 aEq
 wOD
@@ -119629,11 +120275,11 @@ bBH
 bBH
 bBH
 bBH
-eWZ
+qJr
 rxx
 aSH
 xVM
-cOl
+cOh
 aUv
 dhC
 piY
@@ -119861,18 +120507,18 @@ abW
 nKz
 afd
 afd
-afd
-afd
-aTz
-aTz
 fqh
+ohf
+tac
+vZd
+qaK
 wAA
 uTV
 ane
 qaK
-fqh
+azW
 aTc
-psy
+naK
 bgv
 wOD
 btX
@@ -119886,7 +120532,7 @@ xYM
 xYM
 xYM
 bBH
-eWZ
+qjg
 ujR
 aSI
 oct
@@ -120118,16 +120764,16 @@ dyn
 fsr
 vqk
 pcg
-lEz
-afd
-aTz
-aTz
 fqh
-iVY
-uUJ
-tNC
-qwY
+oqb
+tac
 fqh
+fqh
+fqh
+fqh
+fqh
+fqh
+azW
 swq
 swq
 oQa
@@ -120144,11 +120790,11 @@ bBH
 bBH
 bBH
 xla
-cCh
 xla
 xla
-cOI
-iww
+xla
+xla
+xla
 xla
 xla
 dsD
@@ -120375,16 +121021,16 @@ shU
 shU
 uhH
 fED
-wVI
-afd
-aTz
-aTz
 fqh
-szr
-rDY
-nso
-nNb
+oGc
+tnn
+lKW
+obZ
 fqh
+abW
+abW
+abW
+aiN
 kUn
 lRP
 hHg
@@ -120632,16 +121278,16 @@ akz
 and
 dpP
 lez
-lEz
-afd
-aTz
-aTz
 fqh
-jYY
-qzQ
-gce
-kia
+pOo
+tLk
+lKW
+ahd
 fqh
+abW
+abW
+abW
+aiN
 idr
 cgg
 xqz
@@ -120672,8 +121318,8 @@ dzk
 gHl
 jpP
 jpP
-jpP
-jpP
+uOW
+kCz
 cRv
 abE
 rNK
@@ -120889,16 +121535,16 @@ shU
 lEz
 anW
 aEw
-lEz
-afd
-aTz
-aTz
+fqh
+qqV
+txK
+wCT
 fqh
 fqh
-fqh
-fqh
-fqh
-fqh
+abW
+abW
+aiN
+aiN
 ooT
 heX
 aHe
@@ -120927,10 +121573,10 @@ mTQ
 nTL
 gzT
 rYt
-hKH
-hKH
+gIG
+gIG
 joE
-jpP
+kCz
 cRv
 cRv
 rNK
@@ -121146,14 +121792,14 @@ shU
 lEz
 wVI
 aEw
-lEz
-afd
-aTz
-aTz
-afd
-aTz
+fqh
+qwY
+tNC
+svu
+fqh
 abW
-rBH
+abW
+aiN
 bhn
 cgg
 lKe
@@ -121187,7 +121833,7 @@ gJa
 gIG
 iwW
 jpT
-jpP
+kCz
 abW
 cRv
 rNK
@@ -121403,11 +122049,11 @@ shU
 lEz
 anX
 aEw
-wVI
-abW
-afd
-afd
-afd
+fqh
+fqh
+fqh
+fqh
+fqh
 abW
 abW
 aiN
@@ -121444,7 +122090,7 @@ gJd
 gIG
 gIG
 jqP
-jpP
+kCz
 cRv
 cRv
 rNK
@@ -121701,7 +122347,7 @@ gJx
 gIG
 ixb
 jsi
-jpP
+kCz
 cRv
 abE
 rNK
@@ -122729,7 +123375,7 @@ gML
 hOn
 iAF
 jwW
-jpP
+kCz
 cRv
 rNK
 rNK
@@ -122985,8 +123631,8 @@ dzk
 dzk
 dzk
 dzk
-jpP
-jpP
+kCz
+kCz
 cRv
 cRv
 cRv

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -57,9 +57,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/wood,
 /obj/item/candle,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
 "aay" = (
 /obj/machinery/camera{
@@ -194,13 +192,6 @@
 /obj/item/tank/internals/emergency_oxygen,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/external/north)
-"abv" = (
-/obj/effect/decal/warning_stripes/southeast,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "rampbottom"
-	},
-/area/gateway)
 "abE" = (
 /turf/simulated/floor/plating/asteroid/ancient/airless,
 /area/mine/unexplored/cere/command)
@@ -445,6 +436,12 @@
 	icon_state = "bcircuit"
 	},
 /area/turret_protected/ai)
+"acK" = (
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "whitered"
+	},
+/area/hallway/primary/port/south)
 "acN" = (
 /obj/machinery/hydroponics/constructable{
 	desc = "These are connected with an irrigation tube. You see a little pipe connecting the trays.";
@@ -675,7 +672,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/east)
 "aeJ" = (
@@ -1566,6 +1563,15 @@
 	icon_state = "floorgrime"
 	},
 /area/security/permabrig)
+"akH" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkblue"
+	},
+/area/space)
 "akI" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -1749,7 +1755,7 @@
 /obj/effect/turf_decal/box,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "purplefull"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/west)
 "alz" = (
@@ -2594,9 +2600,7 @@
 	dir = 1;
 	pixel_y = -25
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "aqC" = (
 /turf/simulated/wall,
@@ -3235,7 +3239,9 @@
 /area/hallway/secondary/exit)
 "auL" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fore2)
 "auP" = (
@@ -4309,7 +4315,9 @@
 "aCb" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fore2)
 "aCg" = (
@@ -4655,6 +4663,15 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/crew_quarters/captain)
+"aER" = (
+/obj/machinery/gateway{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "vault"
+	},
+/area/space)
 "aES" = (
 /obj/machinery/light_switch{
 	dir = 1;
@@ -4686,14 +4703,12 @@
 	},
 /area/hallway/primary/fore/west)
 "aEZ" = (
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "darkblue"
+	icon_state = "dark"
 	},
-/area/gateway)
+/area/engine/gravitygenerator)
 "aFa" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/landmark/start/shaft_miner,
@@ -5032,9 +5047,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/civilian,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
 "aHZ" = (
 /obj/structure/table/wood,
@@ -5051,7 +5064,6 @@
 	},
 /area/maintenance/fore2)
 "aIb" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -5059,6 +5071,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -5661,8 +5674,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "yellowcorner"
+	dir = 7;
+	icon_state = "yellow"
 	},
 /area/hallway/primary/central)
 "aMM" = (
@@ -6293,8 +6306,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/exit)
 "aQl" = (
@@ -7144,7 +7156,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "browncorner"
+	dir = 4;
+	icon_state = "brown"
 	},
 /area/quartermaster/office)
 "aVt" = (
@@ -7203,8 +7216,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
+	dir = 1;
+	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
 "aVA" = (
@@ -7224,8 +7237,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
+	dir = 1;
+	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
 "aVC" = (
@@ -7233,12 +7246,6 @@
 /obj/item/storage/photo_album,
 /turf/simulated/floor/carpet/black,
 /area/crew_quarters/captain)
-"aVD" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/fore/east)
 "aVG" = (
 /obj/item/storage/box/donkpockets,
 /obj/structure/table/reinforced,
@@ -7327,7 +7334,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "browncorner"
+	dir = 4;
+	icon_state = "brown"
 	},
 /area/quartermaster/office)
 "aWh" = (
@@ -7417,11 +7425,17 @@
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "aWx" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/gateway{
+	dir = 5
 	},
-/area/engine/gravitygenerator)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "vault"
+	},
+/area/gateway)
 "aWz" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -7959,6 +7973,7 @@
 	dir = 1;
 	network = list("SS13","Security")
 	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plasteel,
 /area/engine/mechanic_workshop/expedition)
 "aZd" = (
@@ -8857,7 +8872,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "bluecorner"
+	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard/north)
 "bcT" = (
@@ -9231,7 +9246,9 @@
 /area/security/range)
 "beM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
 /area/crew_quarters/bar)
 "beN" = (
 /obj/machinery/light,
@@ -9416,7 +9433,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/civilian,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
 "bfA" = (
 /obj/structure/cable{
@@ -9434,6 +9451,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
+"bfF" = (
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/space)
 "bfI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9542,8 +9565,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "yellowcorner"
+	dir = 7;
+	icon_state = "yellow"
 	},
 /area/hallway/primary/central)
 "bgc" = (
@@ -9556,8 +9579,8 @@
 /obj/machinery/light,
 /obj/effect/landmark/event/lightsout,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "yellowcorner"
+	dir = 7;
+	icon_state = "yellow"
 	},
 /area/hallway/primary/central)
 "bge" = (
@@ -9569,8 +9592,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "yellowcorner"
+	dir = 7;
+	icon_state = "yellow"
 	},
 /area/hallway/primary/central)
 "bgf" = (
@@ -9584,8 +9607,8 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "yellowcorner"
+	dir = 7;
+	icon_state = "yellow"
 	},
 /area/hallway/primary/central)
 "bgi" = (
@@ -9593,7 +9616,10 @@
 	pixel_x = -32;
 	pixel_y = -32
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
 /area/hallway/primary/central)
 "bgj" = (
 /obj/structure/cable{
@@ -10144,8 +10170,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "bluecorner"
+	dir = 0;
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/north)
 "big" = (
@@ -10336,10 +10362,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bjr" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
+/obj/effect/decal/remains/mouse{
+	desc = "??????? ????,??????? ????????????? ??? ???????,????????? ???? ????. SQUEEK! ";
+	name = "SQUEEK!"
 	},
-/area/crew_quarters/bar)
+/turf/simulated/floor/plating/asteroid/ancient/airless,
+/area/crew_quarters/captain)
 "bjs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -10457,15 +10485,9 @@
 	},
 /area/medical/surgery/north)
 "bjM" = (
-/obj/machinery/gateway{
-	dir = 10
-	},
-/obj/effect/landmark/join_late_gateway,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "vault"
-	},
-/area/gateway)
+/obj/effect/decal/warning_stripes/northwest,
+/turf/simulated/floor/engine,
+/area/engine/gravitygenerator)
 "bjN" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
@@ -10609,8 +10631,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "bluecorner"
+	dir = 0;
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/north)
 "bkH" = (
@@ -11844,7 +11866,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "yellowcorner"
+	icon_state = "yellow"
 	},
 /area/hallway/primary/central)
 "bqq" = (
@@ -12181,6 +12203,19 @@
 	icon_state = "dark"
 	},
 /area/quartermaster/office)
+"brv" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_x = 32
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/dispenser/oxygen,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "brx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -13033,8 +13068,8 @@
 /area/hallway/primary/central)
 "buQ" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "yellowcorner"
+	dir = 7;
+	icon_state = "yellow"
 	},
 /area/hallway/primary/central)
 "buS" = (
@@ -13661,7 +13696,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
 /area/crew_quarters/bar)
 "bxp" = (
 /obj/structure/disposalpipe/segment{
@@ -13681,9 +13718,7 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bxt" = (
 /obj/structure/cable{
@@ -13826,7 +13861,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/starboard/south)
@@ -14174,6 +14208,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
+"bzF" = (
+/obj/structure/dispenser/oxygen,
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
+"bzJ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/primary/port/south)
 "bzK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -14449,9 +14500,7 @@
 "bAv" = (
 /obj/structure/table/wood,
 /obj/item/kitchen/utensil/fork,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
 "bAx" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -15840,12 +15889,28 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay)
+"bGb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Gravity Generator";
+	dir = 4;
+	network = list("SS13","CE")
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "bGf" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/chair/sofa/left,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
 "bGm" = (
 /obj/machinery/door/poddoor{
@@ -16328,6 +16393,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
+"bHP" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/grass,
+/area/hallway/secondary/entry/south)
 "bHR" = (
 /obj/structure/closet/paramedic,
 /obj/item/defibrillator/loaded,
@@ -16512,9 +16584,13 @@
 /turf/simulated/mineral/ancient,
 /area/engine/break_room)
 "bII" = (
-/obj/machinery/gravity_generator/main/station,
-/turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "bIK" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder,
@@ -16718,9 +16794,7 @@
 	},
 /obj/structure/table/wood,
 /obj/item/candle,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
 "bJA" = (
 /obj/machinery/door/airlock/glass{
@@ -16753,9 +16827,7 @@
 	pixel_x = 2;
 	pixel_y = 6
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
 "bJD" = (
 /obj/machinery/camera{
@@ -16866,16 +16938,13 @@
 	},
 /area/engine/engineering)
 "bJX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/gateway)
 "bJY" = (
 /obj/item/radio/intercom{
 	pixel_y = 28
@@ -17026,23 +17095,13 @@
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "bKS" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Gravity Generator";
-	dir = 4;
-	network = list("SS13","CE")
-	},
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/gateway)
 "bKV" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor{
@@ -17372,6 +17431,10 @@
 	icon_state = "dark"
 	},
 /area/atmos)
+"bLP" = (
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/engine,
+/area/engine/gravitygenerator)
 "bLQ" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -18265,7 +18328,7 @@
 "bPf" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "escape"
+	icon_state = "whitered"
 	},
 /area/hallway/primary/port/south)
 "bPi" = (
@@ -19264,6 +19327,19 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/port)
+"bSK" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "bST" = (
 /obj/machinery/door_control{
 	id = "CargoWarehouse";
@@ -19415,10 +19491,10 @@
 /turf/simulated/floor/plating,
 /area/engine/engine_smes)
 "bTn" = (
-/obj/machinery/power/emitter,
-/obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/turf/simulated/floor/plasteel{
+	icon_state = "brown"
+	},
+/area/quartermaster/office)
 "bTp" = (
 /obj/machinery/door/poddoor/multi_tile/two_tile_ver,
 /obj/structure/spacepoddoor{
@@ -19856,8 +19932,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
+	dir = 1;
+	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
 "bUP" = (
@@ -20313,8 +20389,10 @@
 /obj/structure/cable/orange{
 	icon_state = "2-8"
 	},
-/obj/effect/decal/cleanable/cobweb,
 /obj/structure/closet,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/maintenance/fore2)
 "bWl" = (
@@ -20687,9 +20765,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bXW" = (
 /obj/structure/railing{
@@ -22062,8 +22138,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "browncorner"
+	dir = 1;
+	icon_state = "brown"
 	},
 /area/hallway/primary/fore/east)
 "ceI" = (
@@ -22368,6 +22444,19 @@
 	slowdown = -0.3
 	},
 /area/hallway/spacebridge/servsci)
+"cgq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "cgr" = (
 /obj/structure/cable/orange{
 	icon_state = "1-4"
@@ -22679,7 +22768,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/east)
 "chY" = (
@@ -22700,7 +22789,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/east)
 "cia" = (
@@ -22715,7 +22804,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/east)
 "cib" = (
@@ -22730,7 +22819,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/east)
 "cic" = (
@@ -22820,12 +22909,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/miningdock)
-"ciV" = (
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "escape"
-	},
-/area/hallway/secondary/exit)
 "ciW" = (
 /obj/structure/railing{
 	dir = 1
@@ -22902,10 +22985,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -22984,8 +23063,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/entry)
 "cjJ" = (
@@ -23066,8 +23144,7 @@
 	dir = 5
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -23096,6 +23173,13 @@
 	icon_state = "bluered"
 	},
 /area/hallway/secondary/entry/south)
+"ckn" = (
+/obj/effect/decal/warning_stripes/northwest,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "rampbottom"
+	},
+/area/space)
 "cko" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23133,8 +23217,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/entry)
 "ckq" = (
@@ -23148,8 +23231,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/entry)
 "ckr" = (
@@ -23163,8 +23245,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/entry)
 "ckt" = (
@@ -23181,8 +23262,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/entry)
 "ckw" = (
@@ -23307,14 +23387,17 @@
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "whitepurple"
 	},
 /area/toxins/lab)
 "clk" = (
 /obj/effect/landmark/start/scientist,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "whitepurple"
 	},
 /area/toxins/lab)
 "cll" = (
@@ -23323,7 +23406,7 @@
 "clB" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry/south)
 "clH" = (
@@ -23332,7 +23415,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry/south)
 "clO" = (
@@ -23416,6 +23499,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fore)
+"cms" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "cmB" = (
 /obj/structure/cable/orange{
 	icon_state = "1-4"
@@ -23744,6 +23841,9 @@
 /area/toxins/storage)
 "coJ" = (
 /obj/structure/closet/crate,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/atmospherics)
 "coK" = (
@@ -24900,14 +25000,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4
-	},
 /obj/effect/decal/warning_stripes/arrow{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "purple"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
 /area/hallway/primary/aft/west)
 "cwh" = (
@@ -25482,8 +25580,8 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "yellowcorner"
+	dir = 7;
+	icon_state = "yellow"
 	},
 /area/hallway/primary/central)
 "czZ" = (
@@ -25924,13 +26022,28 @@
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "cCj" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "darkbluecorners"
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -28
 	},
-/area/gateway)
+/obj/structure/cable/orange{
+	icon_state = "0-4"
+	},
+/obj/machinery/camera{
+	c_tag = "Gravity Generator";
+	dir = 4;
+	network = list("SS13","CE")
+	},
+/obj/structure/closet/radiation,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/engine/gravitygenerator)
 "cCp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
 /area/crew_quarters/bar)
 "cCw" = (
 /turf/simulated/floor/engine,
@@ -26322,7 +26435,9 @@
 	pixel_x = 32;
 	pixel_y = -32
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowcorner"
+	},
 /area/hallway/primary/central)
 "cFk" = (
 /obj/machinery/ai_status_display,
@@ -27224,7 +27339,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "yellowcorner"
+	icon_state = "yellow"
 	},
 /area/hallway/primary/central)
 "cJn" = (
@@ -27347,7 +27462,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry)
 "cJC" = (
@@ -27434,7 +27549,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "yellowcorner"
+	icon_state = "yellow"
 	},
 /area/hallway/primary/central)
 "cJT" = (
@@ -27816,7 +27931,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "browncorner"
+	dir = 4;
+	icon_state = "brown"
 	},
 /area/quartermaster/office)
 "cMw" = (
@@ -28564,7 +28680,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "yellowcorner"
+	icon_state = "yellow"
 	},
 /area/hallway/primary/central)
 "cPT" = (
@@ -28708,8 +28824,7 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/exit)
 "cQy" = (
@@ -29090,8 +29205,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "browncorner"
+	dir = 1;
+	icon_state = "brown"
 	},
 /area/quartermaster/office)
 "cSD" = (
@@ -29107,8 +29222,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "browncorner"
+	dir = 1;
+	icon_state = "brown"
 	},
 /area/quartermaster/office)
 "cSF" = (
@@ -29120,8 +29235,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "browncorner"
+	dir = 1;
+	icon_state = "brown"
 	},
 /area/quartermaster/office)
 "cSG" = (
@@ -29133,8 +29248,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "browncorner"
+	dir = 1;
+	icon_state = "brown"
 	},
 /area/quartermaster/office)
 "cSH" = (
@@ -29146,7 +29261,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "browncorner"
+	dir = 5;
+	icon_state = "brown"
 	},
 /area/quartermaster/office)
 "cSJ" = (
@@ -29359,6 +29475,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/west)
+"cTG" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "cTN" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Port Asteroid Maintenance";
@@ -30038,18 +30169,6 @@
 	icon_state = "floorgrime"
 	},
 /area/security/permabrig)
-"cVS" = (
-/obj/machinery/gateway{
-	dir = 5
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "vault"
-	},
-/area/gateway)
 "cVX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30649,8 +30768,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/entry)
 "dbg" = (
@@ -30755,8 +30873,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "yellowcorner"
+	dir = 8;
+	icon_state = "yellow"
 	},
 /area/hallway/primary/central)
 "dcN" = (
@@ -30850,9 +30968,7 @@
 /obj/structure/chair/stool/bar{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "ddo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -30907,9 +31023,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "ddu" = (
 /obj/structure/extinguisher_cabinet{
@@ -31521,12 +31635,6 @@
 /obj/structure/closet/firecloset/full,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint2)
-"dhm" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/hallway/secondary/entry/north)
 "dhr" = (
 /obj/item/solar_assembly,
 /obj/item/stack/sheet/glass,
@@ -31667,11 +31775,17 @@
 	},
 /area/bridge)
 "djd" = (
-/obj/machinery/r_n_d/destructive_analyzer,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/extinguisher_cabinet{
+	name = "custom placement";
+	pixel_y = -27
 	},
-/area/toxins/lab)
+/obj/effect/decal/warning_stripes/yellow/partial{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "purple"
+	},
+/area/hallway/primary/aft/west)
 "djg" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -31865,8 +31979,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/entry)
 "dkd" = (
@@ -32157,18 +32270,10 @@
 	},
 /area/security/lobby)
 "dls" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/gateway)
 "dlt" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/orange,
@@ -32451,6 +32556,11 @@
 	},
 /turf/simulated/wall,
 /area/hallway/primary/fore)
+"dne" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/railing,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/entry/south)
 "dnA" = (
 /turf/simulated/wall,
 /area/hallway/spacebridge/cargocom)
@@ -32699,7 +32809,6 @@
 	},
 /area/hallway/primary/fore/west)
 "dpP" = (
-/obj/effect/decal/cleanable/cobweb,
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -32942,9 +33051,7 @@
 	dir = 0;
 	pixel_x = -28
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "drr" = (
 /obj/structure/cable{
@@ -33382,9 +33489,7 @@
 "dty" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "dtA" = (
 /obj/structure/disposalpipe/junction{
@@ -33577,8 +33682,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
+	dir = 1;
+	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
 "duF" = (
@@ -33620,8 +33725,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
+	dir = 1;
+	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
 "duK" = (
@@ -33775,8 +33880,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
+	dir = 1;
+	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
 "dvS" = (
@@ -33840,8 +33945,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
+	dir = 1;
+	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
 "dwg" = (
@@ -33858,8 +33963,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
+	dir = 1;
+	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
 "dwi" = (
@@ -33912,8 +34017,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
+	dir = 1;
+	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
 "dwV" = (
@@ -33933,8 +34038,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
+	dir = 1;
+	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
 "dxa" = (
@@ -33954,8 +34059,8 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
+	dir = 1;
+	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
 "dxf" = (
@@ -33988,8 +34093,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
+	dir = 1;
+	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
 "dxo" = (
@@ -34036,8 +34141,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
+	dir = 1;
+	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
 "dxw" = (
@@ -34058,8 +34163,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
+	dir = 1;
+	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
 "dxx" = (
@@ -34079,8 +34184,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
+	dir = 1;
+	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
 "dxE" = (
@@ -34299,8 +34404,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
+	dir = 1;
+	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
 "dyD" = (
@@ -34317,8 +34422,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
+	dir = 1;
+	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
 "dyJ" = (
@@ -34403,8 +34508,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
+	dir = 1;
+	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
 "dyY" = (
@@ -34495,8 +34600,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
+	dir = 1;
+	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
 "dzn" = (
@@ -34507,8 +34612,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
+	dir = 1;
+	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
 "dzo" = (
@@ -34520,8 +34625,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
+	dir = 1;
+	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
 "dzp" = (
@@ -34532,8 +34637,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
+	dir = 1;
+	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
 "dzq" = (
@@ -35070,8 +35175,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "browncorner"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
 /area/hallway/spacebridge/cargocom)
 "dBx" = (
@@ -35101,6 +35206,13 @@
 	icon_state = "white"
 	},
 /area/medical/medbay)
+"dBD" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/grass,
+/area/hallway/secondary/entry/south)
 "dBG" = (
 /obj/machinery/door/airlock{
 	name = "Bathroom"
@@ -35115,8 +35227,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "browncorner"
+	dir = 1;
+	icon_state = "brown"
 	},
 /area/hallway/primary/fore/east)
 "dBI" = (
@@ -35127,8 +35239,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "browncorner"
+	dir = 1;
+	icon_state = "brown"
 	},
 /area/hallway/primary/fore/east)
 "dBJ" = (
@@ -35140,8 +35252,8 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "browncorner"
+	dir = 1;
+	icon_state = "brown"
 	},
 /area/hallway/primary/fore/east)
 "dBL" = (
@@ -35227,8 +35339,8 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "browncorner"
+	dir = 1;
+	icon_state = "brown"
 	},
 /area/hallway/primary/fore/east)
 "dCA" = (
@@ -35239,8 +35351,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "browncorner"
+	dir = 1;
+	icon_state = "brown"
 	},
 /area/hallway/primary/fore/east)
 "dCC" = (
@@ -35268,7 +35380,10 @@
 /obj/structure/cable/orange{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "brown"
+	},
 /area/hallway/primary/fore/east)
 "dCF" = (
 /obj/machinery/hologram/holopad,
@@ -35404,7 +35519,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "bluecorner"
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/south)
 "dDI" = (
@@ -35419,8 +35534,8 @@
 	name = "Central Access"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "yellowcorner"
+	dir = 8;
+	icon_state = "yellow"
 	},
 /area/hallway/primary/central)
 "dEj" = (
@@ -35714,6 +35829,13 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/fore/west)
+"dKZ" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/entry/south)
 "dLb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -36198,11 +36320,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -36331,8 +36448,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/east)
 "dSv" = (
@@ -36442,9 +36558,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "dUJ" = (
 /obj/machinery/door/firedoor,
@@ -36475,7 +36589,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/east)
 "dUR" = (
@@ -36530,6 +36644,13 @@
 	icon_state = "dark"
 	},
 /area/security/prison/cell_block/A)
+"dWz" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "dWE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -36582,8 +36703,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
+"dXA" = (
+/obj/effect/decal/warning_stripes/southeast,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "rampbottom"
+	},
+/area/gateway)
 "dXO" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -36767,6 +36895,10 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -36891,6 +37023,13 @@
 /obj/machinery/recycler,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
+"eeA" = (
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "rampbottom"
+	},
+/area/space)
 "eeI" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/navbeacon{
@@ -36916,7 +37055,10 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "brown"
+	},
 /area/hallway/primary/fore/east)
 "efB" = (
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -36937,7 +37079,10 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "brown"
+	},
 /area/quartermaster/office)
 "ega" = (
 /obj/machinery/door/airlock/maintenance{
@@ -36969,9 +37114,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/civilian,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
 "egu" = (
 /obj/effect/landmark/join_late_cyborg,
@@ -37135,6 +37278,20 @@
 /obj/effect/spawner/random_barrier/wall_probably,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint3)
+"eiT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "ejh" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
@@ -37270,9 +37427,7 @@
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "ell" = (
 /obj/effect/spawner/window/reinforced,
@@ -37502,6 +37657,15 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/port)
+"eoO" = (
+/obj/machinery/gateway{
+	dir = 10
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "vault"
+	},
+/area/space)
 "eoU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -37615,10 +37779,9 @@
 	},
 /area/hallway/primary/port/north)
 "esB" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
+/obj/structure/railing,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/entry/south)
 "esG" = (
 /obj/structure/table/wood,
@@ -37831,6 +37994,23 @@
 	dir = 8
 	},
 /area/hallway/primary/fore/west)
+"ewS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "exF" = (
 /obj/structure/sign/directions/science{
 	pixel_x = 32;
@@ -38133,9 +38313,7 @@
 /obj/structure/table/wood,
 /obj/item/kitchen/utensil/fork,
 /obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
 "eDi" = (
 /obj/machinery/firealarm{
@@ -38254,8 +38432,8 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
+	dir = 1;
+	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
 "eGP" = (
@@ -38306,8 +38484,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "yellowcorner"
+	dir = 8;
+	icon_state = "yellow"
 	},
 /area/hallway/primary/central)
 "eHo" = (
@@ -38486,6 +38664,12 @@
 	icon_state = "brown"
 	},
 /area/engine/chiefs_office)
+"eKz" = (
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkbluecorners"
+	},
+/area/space)
 "eKU" = (
 /obj/effect/landmark/start/trainee_engineer,
 /obj/structure/cable{
@@ -38742,6 +38926,12 @@
 	icon_state = "dark"
 	},
 /area/crew_quarters/fitness)
+"ePy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/toxins/lab)
 "ePP" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -39400,7 +39590,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/east)
 "fae" = (
@@ -39531,9 +39721,7 @@
 	},
 /obj/structure/table/wood,
 /obj/item/candle,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
 "fcK" = (
 /obj/structure/cable{
@@ -39719,6 +39907,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
+"fhi" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/entry/south)
 "fhx" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
@@ -39845,6 +40046,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/south)
+"fko" = (
+/obj/structure/table,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "fkt" = (
 /turf/simulated/mineral/ancient,
 /area/crew_quarters/bar)
@@ -39965,6 +40172,14 @@
 /obj/machinery/papershredder,
 /turf/simulated/floor/wood,
 /area/library)
+"fmy" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/entry/south)
 "fmI" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -40120,10 +40335,13 @@
 	},
 /area/hallway/primary/fore/east)
 "fqu" = (
+/obj/effect/decal/warning_stripes/red/partial{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/gateway)
+/area/engine/gravitygenerator)
 "fqw" = (
 /turf/simulated/wall,
 /area/maintenance/starboard)
@@ -40144,10 +40362,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "frh" = (
-/obj/machinery/photocopier,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/structure/table,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/scanning_module,
+/obj/item/stock_parts/scanning_module{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/storage/belt/utility,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
@@ -40465,18 +40691,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/cable/orange{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
+	dir = 1;
+	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
 "fwt" = (
@@ -40681,7 +40904,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "brown"
+	},
 /area/hallway/primary/fore/east)
 "fAm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -40767,7 +40993,8 @@
 "fCV" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "browncorner"
+	dir = 4;
+	icon_state = "brown"
 	},
 /area/quartermaster/office)
 "fDb" = (
@@ -40818,6 +41045,17 @@
 	icon_state = "yellow"
 	},
 /area/engine/mechanic_workshop)
+"fEc" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "fEh" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/drinkingglass{
@@ -40905,7 +41143,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry)
 "fED" = (
@@ -40942,6 +41180,13 @@
 "fEL" = (
 /turf/simulated/floor/plasteel,
 /area/security/seceqstorage)
+"fEP" = (
+/obj/effect/decal/warning_stripes/north,
+/obj/structure/closet/secure_closet/exile,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "fEU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -41221,8 +41466,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/exit)
 "fJJ" = (
@@ -41309,8 +41553,8 @@
 	pixel_y = 40
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "browncorner"
+	dir = 1;
+	icon_state = "brown"
 	},
 /area/hallway/primary/fore/east)
 "fLH" = (
@@ -41462,7 +41706,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "bluecorner"
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/south)
 "fOe" = (
@@ -41808,7 +42052,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry/south)
 "fTG" = (
@@ -41836,9 +42080,7 @@
 /obj/structure/chair/sofa/right{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
 "fTL" = (
 /obj/effect/turf_decal/stripes/line{
@@ -41861,6 +42103,11 @@
 	icon_state = "dark"
 	},
 /area/atmos)
+"fTW" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/railing,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/entry/south)
 "fUp" = (
 /obj/machinery/door/airlock/security/glass{
 	id = "process";
@@ -42137,12 +42384,9 @@
 	},
 /area/maintenance/engineering)
 "fZA" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal,
+/obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry/south)
 "fZG" = (
@@ -42232,6 +42476,17 @@
 	icon_state = "dark"
 	},
 /area/security/execution)
+"gbD" = (
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/stock_parts/cell/high,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "gbF" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -42416,8 +42671,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/exit)
 "geF" = (
@@ -42643,6 +42897,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint4)
+"ghH" = (
+/turf/simulated/floor/plating,
+/area/space)
 "ghT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -42677,7 +42934,10 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "brown"
+	},
 /area/hallway/primary/fore/east)
 "giA" = (
 /obj/structure/cable{
@@ -42687,9 +42947,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/light{
 	dir = 8
 	},
 /obj/structure/disposalpipe/junction{
@@ -42741,8 +42998,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "browncorner"
+	dir = 10;
+	icon_state = "brown"
 	},
 /area/quartermaster/office)
 "gkV" = (
@@ -42773,7 +43030,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "browncorner"
+	dir = 6;
+	icon_state = "brown"
 	},
 /area/quartermaster/office)
 "glA" = (
@@ -42950,8 +43208,8 @@
 /area/maintenance/disposal/west)
 "goT" = (
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurplecorner"
+	dir = 1;
+	icon_state = "whitepurple"
 	},
 /area/toxins/lab)
 "goU" = (
@@ -42977,9 +43235,7 @@
 /obj/structure/chair/sofa/left{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
 "gpk" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -43201,8 +43457,7 @@
 /area/medical/cmostore)
 "gtE" = (
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/exit)
 "gtJ" = (
@@ -43225,6 +43480,16 @@
 /obj/effect/spawner/random_barrier/wall_probably,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint3)
+"gul" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/closet/l3closet/scientist,
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "guo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -43337,6 +43602,13 @@
 	icon_state = "wood-broken"
 	},
 /area/maintenance/starboard)
+"gvB" = (
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/entry/south)
 "gvF" = (
 /obj/structure/girder,
 /obj/item/stack/sheet/metal,
@@ -43520,9 +43792,6 @@
 /obj/effect/spawner/random_spawners/fungus_maybe,
 /turf/simulated/wall,
 /area/clownoffice/secret)
-"gzv" = (
-/turf/simulated/wall/r_wall,
-/area/engine/gravitygenerator)
 "gzT" = (
 /obj/structure/plasticflaps{
 	opacity = 1
@@ -43538,6 +43807,15 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/janitor)
+"gzZ" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "gAG" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -43620,9 +43898,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "gBy" = (
 /obj/machinery/light/small{
@@ -43642,6 +43918,20 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/fore/west)
+"gBE" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/machinery/vending/wallmed{
+	pixel_y = -28
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "gBM" = (
 /obj/machinery/chem_master,
 /turf/simulated/floor/plating,
@@ -43749,7 +44039,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "browncorner"
+	icon_state = "brown"
 	},
 /area/hallway/primary/fore/east)
 "gDR" = (
@@ -44540,6 +44830,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/gambling_den2)
+"gNP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/entry/south)
 "gNT" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -44858,31 +45157,21 @@
 	icon_state = "red"
 	},
 /area/security/seceqstorage)
-"gTy" = (
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id_tag = "stationawaygate";
-	name = "Gateway Access Shutters"
-	},
-/obj/machinery/door_control{
-	id = "stationawaygate";
-	name = "Gateway Shutters Access Control";
-	pixel_x = 24;
-	req_access = list(62)
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
 "gTA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/hallway/secondary/entry/south)
+/area/hallway/primary/fore)
 "gTD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -44936,14 +45225,14 @@
 	pixel_x = -32;
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -45279,9 +45568,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -45343,12 +45629,6 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry)
-"haN" = (
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "rampbottom"
-	},
-/area/gateway)
 "haT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -45715,6 +45995,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/dispenser/oxygen,
 /turf/simulated/floor/plasteel,
 /area/engine/mechanic_workshop/expedition)
 "hiU" = (
@@ -45733,7 +46014,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry/south)
 "hjb" = (
@@ -45769,8 +46050,8 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "yellowcorner"
+	dir = 8;
+	icon_state = "yellow"
 	},
 /area/hallway/primary/central)
 "hkx" = (
@@ -45993,13 +46274,23 @@
 	},
 /area/crew_quarters/kitchen)
 "hoP" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-4"
+	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/gateway)
+/area/engine/gravitygenerator)
 "hoU" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -46216,7 +46507,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "bluecorner"
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/north)
 "hsP" = (
@@ -46263,7 +46554,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "browncorner"
+	icon_state = "brown"
 	},
 /area/hallway/primary/fore/east)
 "htc" = (
@@ -46716,7 +47007,7 @@
 "hzz" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "bluecorner"
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/north)
 "hzL" = (
@@ -46912,11 +47203,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboardaux)
 "hDf" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-25"
-	},
+/obj/structure/table/holotable/wood,
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry/south)
 "hDL" = (
@@ -47208,6 +47497,20 @@
 /obj/machinery/slot_machine,
 /turf/simulated/floor/wood,
 /area/maintenance/gambling_den2)
+"hHD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable/orange{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "hHP" = (
 /obj/machinery/disposal,
 /obj/machinery/firealarm{
@@ -47259,22 +47562,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint5)
 "hIA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "darkbluecorners"
 	},
-/area/engine/gravitygenerator)
+/area/gateway)
 "hIC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -47356,7 +47648,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry)
 "hKc" = (
@@ -47828,9 +48120,6 @@
 	icon_state = "darkred"
 	},
 /area/security/brig)
-"hSp" = (
-/turf/simulated/wall/r_wall,
-/area/gateway)
 "hSA" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plasteel{
@@ -47947,7 +48236,7 @@
 	req_access = list(71)
 	},
 /turf/space,
-/area/security/podbay)
+/area/space)
 "hUg" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -48029,8 +48318,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/west)
 "hVj" = (
@@ -48540,7 +48828,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/east)
 "igu" = (
@@ -48675,6 +48963,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -48724,12 +49016,17 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "browncorner"
+	icon_state = "brown"
 	},
 /area/hallway/primary/fore/east)
 "ikc" = (
 /turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/captain)
+"ikd" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "ikv" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -48898,9 +49195,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "inP" = (
 /obj/structure/rack,
@@ -48930,6 +49225,14 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"iox" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "ioy" = (
 /obj/machinery/light/small,
 /obj/item/assembly/mousetrap/armed,
@@ -48971,7 +49274,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "bluecorner"
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/south)
 "ipv" = (
@@ -49259,9 +49562,23 @@
 	},
 /area/security/podbay)
 "iuR" = (
-/obj/machinery/vending/syndierobotics,
-/turf/simulated/wall,
-/area/maintenance/fsmaint3)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/primary/fore)
 "iuX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -49377,7 +49694,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/east)
 "iwW" = (
@@ -49389,6 +49706,14 @@
 /obj/effect/landmark/start/janitor,
 /turf/simulated/floor/plasteel,
 /area/janitor)
+"ixc" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "ixg" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -49592,23 +49917,6 @@
 	icon_state = "white"
 	},
 /area/toxins/mixing)
-"iBP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/engine/gravitygenerator)
 "iCf" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 1
@@ -49636,8 +49944,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "purplefull"
+	dir = 9;
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/west)
 "iCA" = (
@@ -49809,6 +50117,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -49817,13 +50129,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/area/crew_quarters/bar)
+/area/hallway/primary/fore)
 "iFh" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -50058,7 +50373,9 @@
 	pixel_x = -3;
 	pixel_y = -28
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "brown"
+	},
 /area/quartermaster/office)
 "iIV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -50093,13 +50410,10 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/starboard/south)
 "iJi" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/r_n_d/circuit_imprinter,
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "whitepurple"
+	icon_state = "dark"
 	},
 /area/toxins/lab)
 "iJk" = (
@@ -50183,7 +50497,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
 "iLv" = (
 /turf/simulated/floor/plasteel,
@@ -50317,12 +50631,23 @@
 	},
 /area/turret_protected/ai_upload)
 "iNr" = (
-/obj/structure/bed/dogbed,
-/mob/living/simple_animal/bot/secbot/beepsky{
-	name = "Officer Pipsqueak"
+/obj/structure/table,
+/obj/item/radio{
+	pixel_x = -6;
+	pixel_y = 4
 	},
-/turf/simulated/floor/plating,
-/area/hallway/secondary/entry/north)
+/obj/item/radio{
+	pixel_y = 6
+	},
+/obj/item/radio{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/radio,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "iNu" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Fore Asteroid Solars";
@@ -50373,12 +50698,16 @@
 	},
 /area/toxins/misc_lab)
 "iNO" = (
-/obj/machinery/gateway/centerstation,
-/obj/structure/cable/orange,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/gateway)
+/area/engine/gravitygenerator)
 "iNY" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -50429,8 +50758,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "iOM" = (
+/obj/structure/table/glass,
+/obj/item/disk/design_disk,
+/obj/item/disk/design_disk,
+/obj/item/disk/tech_disk,
+/obj/item/disk/tech_disk,
+/obj/item/folder/white,
 /obj/effect/turf_decal/stripes/line{
-	dir = 6
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -50513,6 +50848,12 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"iQn" = (
+/obj/effect/landmark/join_late_gateway,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "iQJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -50843,6 +51184,18 @@
 /obj/item/storage/fancy/cigarettes/cigpack_robustgold,
 /turf/simulated/floor/carpet/royalblack,
 /area/ntrep)
+"iWH" = (
+/obj/machinery/gateway{
+	dir = 1
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/space)
 "iWP" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/hologram/holopad,
@@ -50865,7 +51218,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "browncorner"
+	icon_state = "brown"
 	},
 /area/hallway/primary/fore/east)
 "iXc" = (
@@ -51127,8 +51480,8 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "yellowcorner"
+	dir = 6;
+	icon_state = "yellow"
 	},
 /area/hallway/primary/central)
 "jby" = (
@@ -51147,11 +51500,19 @@
 /obj/machinery/ai_status_display,
 /turf/simulated/wall,
 /area/teleporter/quantum/security)
+"jcu" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "jcC" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/paper_bin,
 /obj/item/pen,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
 "jcQ" = (
 /obj/machinery/door/airlock/external{
@@ -51706,7 +52067,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "bluecorner"
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/south)
 "jlk" = (
@@ -51785,8 +52146,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/east)
 "jmu" = (
@@ -51875,19 +52235,9 @@
 	},
 /area/security/brig)
 "jor" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/machinery/vending/wallmed{
-	pixel_y = -28
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
+/obj/effect/decal/warning_stripes/southeast,
+/turf/simulated/floor/engine,
+/area/engine/gravitygenerator)
 "joE" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -52265,21 +52615,18 @@
 	},
 /area/medical/morgue)
 "jvi" = (
-/obj/structure/cable{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/newscaster{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/hallway/secondary/entry/north)
+/area/hallway/primary/fore)
 "jvl" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -52408,6 +52755,20 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
+"jwf" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/machinery/vending/wallmed{
+	pixel_y = -28
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "jwg" = (
 /obj/machinery/door/window{
 	dir = 8;
@@ -52992,7 +53353,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
 /area/crew_quarters/bar)
 "jGj" = (
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -53007,7 +53370,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/port/south)
 "jGA" = (
@@ -53114,6 +53477,13 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/fpmaint)
+"jHT" = (
+/obj/machinery/floodlight,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/simulated/floor/plating,
+/area/engine/engine_smes)
 "jHW" = (
 /obj/structure/cable/orange{
 	icon_state = "2-8"
@@ -53266,6 +53636,13 @@
 /obj/structure/chair/office/dark,
 /turf/simulated/floor/carpet/royalblack,
 /area/ntrep)
+"jJV" = (
+/obj/structure/flora/rock/jungle,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/grass,
+/area/hallway/secondary/entry/south)
 "jJY" = (
 /obj/machinery/keycard_auth{
 	pixel_y = 24
@@ -53463,7 +53840,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "browncorner"
+	icon_state = "brown"
 	},
 /area/hallway/primary/fore/east)
 "jNZ" = (
@@ -53588,6 +53965,15 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"jQs" = (
+/obj/machinery/gateway{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/space)
 "jQz" = (
 /obj/structure/closet/secure_closet/roboticist,
 /obj/machinery/door_control{
@@ -53802,7 +54188,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry)
 "jUd" = (
@@ -54090,6 +54476,16 @@
 	icon_state = "vault"
 	},
 /area/security/nuke_storage)
+"jXO" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "jYI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -54267,6 +54663,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fore)
+"kaL" = (
+/turf/simulated/mineral/ancient/outer,
+/area/space)
 "kbd" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -54876,6 +55275,7 @@
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/atmospherics)
 "kjW" = (
@@ -54892,7 +55292,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "browncorner"
+	icon_state = "brown"
 	},
 /area/hallway/primary/fore/east)
 "kkv" = (
@@ -54930,12 +55330,41 @@
 	},
 /turf/space,
 /area/solar/port)
+"kkY" = (
+/obj/machinery/door/airlock/command{
+	name = "Gateway Access";
+	req_access = list(62)
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "kla" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
 /area/medical/morgue)
+"kle" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "klh" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -55167,8 +55596,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/entry)
 "kqo" = (
@@ -55422,13 +55850,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
-"ktM" = (
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "rampbottom"
-	},
-/area/gateway)
 "ktW" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -55448,8 +55869,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "bluecorner"
+	dir = 0;
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/north)
 "kuj" = (
@@ -55524,6 +55945,16 @@
 	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology)
+"kvt" = (
+/obj/machinery/gateway{
+	dir = 6
+	},
+/obj/effect/landmark/join_late_gateway,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "vault"
+	},
+/area/gateway)
 "kvO" = (
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel{
@@ -55570,9 +56001,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "kwq" = (
 /obj/structure/chair/stool/bar,
@@ -55634,6 +56063,21 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/carpet/orange,
 /area/engine/chiefs_office)
+"kxb" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/secondary/entry/north)
 "kxf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -55714,6 +56158,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/south)
+"kyi" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/entry/south)
 "kyB" = (
 /obj/machinery/computer/guestpass{
 	pixel_x = 30
@@ -55777,6 +56227,14 @@
 	icon_state = "yellow"
 	},
 /area/engine/mechanic_workshop)
+"kzw" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "kzz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -55864,7 +56322,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "browncorner"
+	icon_state = "brown"
 	},
 /area/hallway/primary/fore/east)
 "kAz" = (
@@ -55939,12 +56397,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "kBo" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/gateway{
+	dir = 1
 	},
-/area/engine/gravitygenerator)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/gateway)
 "kBz" = (
 /obj/structure/sink{
 	dir = 8;
@@ -55983,6 +56446,22 @@
 	icon_state = "dark"
 	},
 /area/atmos/distribution)
+"kCn" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
+/obj/item/multitool,
+/obj/item/multitool,
+/obj/item/multitool,
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "kCq" = (
 /obj/machinery/camera{
 	c_tag = "Blueshield's Office";
@@ -56238,8 +56717,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purplecorner"
+	dir = 10;
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/west)
 "kGG" = (
@@ -56361,7 +56840,7 @@
 "kIL" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/storage/fancy/cigcase,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
 "kIM" = (
 /obj/item/radio/intercom{
@@ -56494,6 +56973,15 @@
 /obj/machinery/seed_extractor,
 /turf/simulated/floor/grass,
 /area/hallway/secondary/garden)
+"kMH" = (
+/obj/machinery/gateway{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/space)
 "kMT" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/newscaster/security_unit{
@@ -56541,9 +57029,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "kNB" = (
 /obj/structure/rack,
@@ -56570,6 +57056,15 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/fore)
+"kNT" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "kOk" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -56605,6 +57100,23 @@
 	icon_state = "red"
 	},
 /area/security/lobby)
+"kPg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "kPr" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 4
@@ -56852,8 +57364,7 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/exit)
 "kSI" = (
@@ -56877,7 +57388,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "bluecorner"
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/south)
 "kSZ" = (
@@ -57081,7 +57592,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "browncorner"
+	icon_state = "brown"
 	},
 /area/hallway/primary/fore/east)
 "kVY" = (
@@ -57345,6 +57856,16 @@
 	icon_state = "asteroidplating"
 	},
 /area/security/processing)
+"lcQ" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/power/port_gen/pacman,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "lcR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -57512,6 +58033,13 @@
 	icon_state = "red"
 	},
 /area/security/range)
+"lfo" = (
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "rampbottom"
+	},
+/area/space)
 "lfz" = (
 /obj/item/radio/intercom/locked/prison{
 	pixel_y = 25
@@ -57686,6 +58214,12 @@
 /obj/structure/table/wood,
 /turf/simulated/floor/wood,
 /area/maintenance/gambling_den2)
+"lji" = (
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "rampbottom"
+	},
+/area/space)
 "ljp" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -57833,8 +58367,7 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/exit)
 "llH" = (
@@ -58037,7 +58570,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/east)
 "loa" = (
@@ -58236,7 +58769,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "bluecorner"
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/south)
 "lrS" = (
@@ -58443,6 +58976,16 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/starboard)
+"luI" = (
+/obj/structure/closet/l3closet/scientist,
+/obj/effect/decal/warning_stripes/southwest,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "luL" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = -32
@@ -58576,8 +59119,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/exit)
 "lwN" = (
@@ -58617,7 +59159,7 @@
 "lxo" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "browncorner"
+	icon_state = "brown"
 	},
 /area/hallway/primary/fore/east)
 "lxv" = (
@@ -58974,11 +59516,10 @@
 	},
 /area/hallway/primary/port/south)
 "lDt" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/structure/sign/science{
+	pixel_y = -32
 	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -59164,12 +59705,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/gambling_den2)
 "lHe" = (
-/obj/structure/closet/secure_closet/exile,
-/obj/effect/decal/warning_stripes/west,
+/obj/machinery/computer/station_alert,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_y = 33
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/gateway)
+/area/engine/gravitygenerator)
 "lHk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -59335,20 +59879,6 @@
 	},
 /turf/space,
 /area/hallway/spacebridge/dockmed)
-"lLd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/command{
-	name = "Gateway Access";
-	req_access = list(62)
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
 "lLO" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59365,7 +59895,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "browncorner"
+	icon_state = "brown"
 	},
 /area/hallway/primary/fore/east)
 "lLY" = (
@@ -59605,10 +60135,13 @@
 /area/medical/cloning)
 "lQT" = (
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "yellowcorner"
+	dir = 8;
+	icon_state = "yellow"
 	},
 /area/hallway/primary/central)
+"lQW" = (
+/turf/simulated/wall/r_wall,
+/area/space)
 "lQX" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/security_officer,
@@ -59639,6 +60172,25 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/spacebridge/sercom)
+"lRe" = (
+/obj/machinery/door/airlock/command{
+	name = "Gateway Access";
+	req_access = list(62)
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "lRI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -59810,8 +60362,8 @@
 	},
 /area/hallway/secondary/entry/south)
 "lTq" = (
-/turf/simulated/mineral/ancient/outer,
-/area/gateway)
+/turf/simulated/wall/r_wall,
+/area/engine/gravitygenerator)
 "lTw" = (
 /obj/machinery/door/airlock{
 	name = "Magistrate's Office";
@@ -59987,6 +60539,23 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/port/east)
+"lXj" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "lXo" = (
 /obj/machinery/computer/drone_control,
 /turf/simulated/floor/plating,
@@ -60002,7 +60571,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry)
 "lXM" = (
@@ -60139,9 +60708,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "lZE" = (
 /obj/item/radio/intercom{
@@ -60474,6 +61041,12 @@
 	dir = 1
 	},
 /area/security/prison/cell_block/A)
+"met" = (
+/obj/machinery/gateway/centerstation,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "mey" = (
 /obj/effect/spawner/random_spawners/cobweb_left_rare,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -60518,6 +61091,14 @@
 	icon_state = "barber"
 	},
 /area/civilian/barber)
+"mfw" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "mfA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -60642,22 +61223,9 @@
 	},
 /obj/effect/landmark/start/civilian,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/exit)
-"mhJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/hallway/secondary/entry/south)
 "mhV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -60688,6 +61256,15 @@
 "mic" = (
 /turf/simulated/wall,
 /area/mine/unexplored/cere/civilian)
+"mim" = (
+/obj/machinery/gateway{
+	density = 0
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/space)
 "mio" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
@@ -60839,6 +61416,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/east)
+"mlZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
+"mmi" = (
+/obj/machinery/gravity_generator/main/station,
+/turf/simulated/floor/plating,
+/area/space)
 "mmq" = (
 /obj/structure/dresser,
 /obj/machinery/newscaster{
@@ -61201,9 +61799,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/civilian,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "msD" = (
 /obj/structure/disposalpipe/segment{
@@ -61251,8 +61847,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/entry)
 "mtJ" = (
@@ -61282,8 +61877,7 @@
 	},
 /area/security/podbay)
 "mtW" = (
-/obj/machinery/r_n_d/protolathe,
-/obj/effect/turf_decal/stripes/line,
+/obj/machinery/computer/rdconsole/core,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -61393,8 +61987,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/entry)
 "mwR" = (
@@ -61426,6 +62019,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -61593,9 +62189,7 @@
 /area/hallway/secondary/entry/north)
 "mBb" = (
 /obj/structure/chair/sofa/right,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
 "mBg" = (
 /obj/structure/table,
@@ -62014,11 +62608,7 @@
 /turf/simulated/floor/grass,
 /area/hallway/spacebridge/scidock)
 "mIa" = (
-/obj/structure/extinguisher_cabinet{
-	name = "custom placement";
-	pixel_y = -28
-	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -62302,8 +62892,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/exit)
 "mNp" = (
@@ -62331,9 +62920,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/event/lightsout,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "mNL" = (
 /obj/structure/cable/orange{
@@ -62648,6 +63235,24 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/fore/west)
+"mTW" = (
+/obj/structure/table,
+/obj/item/radio{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/radio{
+	pixel_y = 6
+	},
+/obj/item/radio{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/radio,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "mTZ" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -62782,13 +63387,17 @@
 /turf/space,
 /area/hallway/spacebridge/cargocom)
 "mWJ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8;
+	on = 1
+	},
+/obj/effect/decal/warning_stripes/red/partial{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/gateway)
+/area/engine/gravitygenerator)
 "mWL" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -62815,13 +63424,15 @@
 	},
 /area/engine/engineering)
 "mXa" = (
-/obj/effect/decal/cleanable/cobweb,
 /obj/structure/closet,
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
 /obj/effect/spawner/lootdrop/maintenance/double,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/north)
 "mXg" = (
@@ -62899,17 +63510,15 @@
 	},
 /area/security/reception)
 "mZD" = (
-/obj/machinery/gateway{
-	dir = 1
+/obj/machinery/door/airlock/highsecurity{
+	name = "Gravity Generator Foyer";
+	req_access = list(10)
 	},
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
-	},
-/area/gateway)
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/engine/gravitygenerator)
 "mZG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -63396,21 +64005,10 @@
 /turf/simulated/floor/carpet,
 /area/library)
 "niz" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/belt/utility,
-/obj/item/storage/belt/utility,
-/obj/item/storage/belt/utility,
-/obj/item/multitool,
-/obj/item/multitool,
-/obj/item/multitool,
-/obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
+/obj/machinery/gravity_generator/main/station,
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/engine,
+/area/engine/gravitygenerator)
 "niC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -63471,8 +64069,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/exit)
 "njR" = (
@@ -63772,6 +64369,11 @@
 	icon_state = "dark"
 	},
 /area/maintenance/asmaint5)
+"noF" = (
+/obj/structure/railing,
+/obj/structure/sink/puddle,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/entry/south)
 "noO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -63808,10 +64410,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/southwest)
-"noZ" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/bar)
 "npb" = (
 /turf/simulated/wall,
 /area/assembly/robotics)
@@ -64090,9 +64688,7 @@
 	icon_state = "plant-21"
 	},
 /obj/structure/piano,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "ntr" = (
 /obj/machinery/door/firedoor,
@@ -64339,6 +64935,14 @@
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/maintenance/port)
 "nxx" = (
+/obj/structure/table,
+/obj/item/destTagger{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/stack/packageWrap,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
 /obj/structure/extinguisher_cabinet{
 	name = "custom placement";
 	pixel_x = 24
@@ -64372,7 +64976,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/east)
 "nyc" = (
@@ -65215,8 +65819,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/east)
 "nKz" = (
@@ -65538,17 +66141,30 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/mechanic_workshop)
+"nPM" = (
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "rampbottom"
+	},
+/area/space)
+"nQh" = (
+/obj/machinery/door/poddoor/shutters{
+	id_tag = "stationawaygate";
+	name = "Gateway Access Shutters"
+	},
+/turf/space,
+/area/gateway)
 "nQk" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/fore2)
 "nQr" = (
-/obj/machinery/light,
-/obj/structure/closet/radiation,
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "rampbottom"
 	},
-/area/engine/gravitygenerator)
+/area/gateway)
 "nQC" = (
 /obj/machinery/newscaster{
 	dir = 8;
@@ -65869,15 +66485,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
-"nWS" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
 "nWU" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Broom Closet"
@@ -65886,9 +66493,7 @@
 /area/hallway/primary/port/south)
 "nXn" = (
 /obj/effect/landmark/event/lightsout,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "nXv" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -66148,11 +66753,14 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry)
 "obg" = (
 /obj/machinery/hologram/holopad,
+/obj/structure/table,
+/obj/machinery/recharger,
+/obj/item/toy/figure/scientist,
 /turf/simulated/floor/plasteel/white,
 /area/toxins/lab)
 "obz" = (
@@ -66161,6 +66769,16 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
+"obF" = (
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	id_tag = "stationawaygate";
+	name = "Gateway Access Shutters"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "obL" = (
 /obj/machinery/light{
 	dir = 4
@@ -66271,13 +66889,10 @@
 /turf/simulated/wall,
 /area/maintenance/apmaint2)
 "odM" = (
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/gateway)
+/area/engine/gravitygenerator)
 "odZ" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
@@ -66581,8 +67196,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "browncorner"
+	dir = 1;
+	icon_state = "brown"
 	},
 /area/hallway/primary/fore/east)
 "ojy" = (
@@ -66765,6 +67380,9 @@
 	},
 /obj/item/storage/belt/utility,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -66819,11 +67437,11 @@
 /turf/simulated/floor/carpet/orange,
 /area/crew_quarters/bar)
 "onO" = (
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
+	dir = 8;
+	icon_state = "brown"
 	},
-/area/crew_quarters/bar)
+/area/quartermaster/office)
 "oow" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -66887,8 +67505,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/entry)
 "opo" = (
@@ -66945,7 +67562,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/east)
 "opI" = (
@@ -67218,6 +67835,11 @@
 	icon_state = "dark"
 	},
 /area/assembly/robotics)
+"ova" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "darkbluecorners"
+	},
+/area/gateway)
 "ovd" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -67470,6 +68092,15 @@
 /obj/item/stack/sheet/metal,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/atmospherics)
+"ozC" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "ozK" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -67578,6 +68209,14 @@
 "oBP" = (
 /turf/simulated/mineral/ancient/outer,
 /area/maintenance/apmaint)
+"oBY" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/engine/gravitygenerator)
 "oCa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -67888,6 +68527,18 @@
 	icon_state = "dark"
 	},
 /area/security/brig)
+"oGx" = (
+/obj/machinery/gateway{
+	dir = 5
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "vault"
+	},
+/area/space)
 "oGy" = (
 /obj/machinery/door/airlock/glass{
 	id = "IAA";
@@ -67997,15 +68648,14 @@
 	},
 /area/engine/engineering)
 "oIS" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/gateway{
+	dir = 8
 	},
-/obj/machinery/power/port_gen/pacman,
-/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "vault"
 	},
-/area/engine/gravitygenerator)
+/area/gateway)
 "oIV" = (
 /obj/structure/closet{
 	name = "Bee-keeping suits"
@@ -68091,20 +68741,17 @@
 	},
 /area/hallway/primary/port/south)
 "oKS" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/machinery/gateway{
+	dir = 9
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "vault"
 	},
-/area/engine/gravitygenerator)
+/area/gateway)
 "oKT" = (
 /obj/structure/table/wood,
 /obj/machinery/keycard_auth{
@@ -68197,8 +68844,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "browncorner"
+	dir = 1;
+	icon_state = "brown"
 	},
 /area/quartermaster/office)
 "oMx" = (
@@ -68246,8 +68893,7 @@
 	},
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/exit)
 "oNw" = (
@@ -68347,8 +68993,8 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "browncorner"
+	dir = 1;
+	icon_state = "brown"
 	},
 /area/hallway/primary/fore/east)
 "oOV" = (
@@ -68396,6 +69042,15 @@
 	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
+"oPM" = (
+/obj/machinery/gateway{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "vault"
+	},
+/area/space)
 "oQa" = (
 /obj/machinery/door/airlock/security{
 	name = "Firing Range";
@@ -68547,6 +69202,12 @@
 	},
 /turf/simulated/wall,
 /area/hallway/primary/central)
+"oSB" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "oSE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -68619,8 +69280,7 @@
 	},
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/exit)
 "oTM" = (
@@ -68845,17 +69505,9 @@
 /turf/simulated/floor/wood,
 /area/medical/psych)
 "oWJ" = (
-/obj/machinery/gateway{
-	dir = 9
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "vault"
-	},
-/area/gateway)
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/engine/gravitygenerator)
 "oWZ" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line,
@@ -69007,15 +69659,9 @@
 	},
 /area/maintenance/starboard)
 "oYM" = (
-/obj/machinery/gateway{
-	dir = 6
-	},
-/obj/effect/landmark/join_late_gateway,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "vault"
-	},
-/area/gateway)
+/obj/effect/decal/warning_stripes/northeast,
+/turf/simulated/floor/engine,
+/area/engine/gravitygenerator)
 "oYZ" = (
 /turf/simulated/floor/plasteel/white,
 /area/toxins/lab)
@@ -69104,8 +69750,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/east)
 "paE" = (
@@ -69155,6 +69800,23 @@
 /obj/structure/statue/bananium/clown/unique,
 /turf/simulated/floor/wood,
 /area/clownoffice)
+"pbs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "pbt" = (
 /obj/machinery/camera{
 	c_tag = "Research Director's Office";
@@ -69223,6 +69885,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/north)
+"pcn" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/entry/south)
 "pcI" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -69309,18 +69979,16 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/miningdock)
 "pdz" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
 /obj/structure/cable/orange{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 26
-	},
-/obj/structure/dispenser/oxygen,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/gateway)
+/area/engine/gravitygenerator)
 "pep" = (
 /obj/structure/table/wood,
 /obj/item/trash/liquidfood,
@@ -69643,9 +70311,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/wood,
 /obj/item/kitchen/utensil/fork,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
 "pjx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -69677,7 +70343,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry)
 "pkf" = (
@@ -69763,7 +70429,8 @@
 /area/maintenance/fore)
 "plG" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "yellowcorner"
+	dir = 10;
+	icon_state = "yellow"
 	},
 /area/hallway/primary/central)
 "plM" = (
@@ -69852,28 +70519,31 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/secondary/entry/north)
 "pnu" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/machinery/power/port_gen/pacman,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/gateway)
+/area/engine/gravitygenerator)
 "pnL" = (
 /obj/machinery/door/poddoor/multi_tile/two_tile_hor,
 /obj/structure/spacepoddoor{
@@ -70155,6 +70825,9 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment,
+/obj/structure/chair/office/light{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -70239,11 +70912,9 @@
 /turf/simulated/floor/plating,
 /area/library)
 "ptY" = (
-/obj/structure/table,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/engine,
+/area/engine/gravitygenerator)
 "pue" = (
 /obj/structure/cable/orange{
 	icon_state = "2-8"
@@ -70591,25 +71262,13 @@
 	},
 /area/hallway/spacebridge/servsci)
 "pzs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker/large{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/dropper,
-/obj/item/clothing/glasses/welding,
 /obj/machinery/computer/guestpass{
 	pixel_y = -28
 	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/r_n_d/protolathe,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple"
+	icon_state = "dark"
 	},
 /area/toxins/lab)
 "pzy" = (
@@ -71004,7 +71663,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry/south)
 "pHb" = (
@@ -71099,9 +71758,7 @@
 /obj/structure/chair/sofa/left{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
 "pIu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -71320,6 +71977,16 @@
 	icon_state = "darkyellowcorners"
 	},
 /area/engine/engine_smes)
+"pLD" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "blue"
+	},
+/area/hallway/primary/starboard/south)
 "pLL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -71775,7 +72442,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "bluecorner"
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/north)
 "pTp" = (
@@ -71785,6 +72452,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
+"pTE" = (
+/obj/structure/closet/secure_closet/exile,
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "pTJ" = (
 /obj/structure/rack,
 /obj/item/weldingtool/largetank,
@@ -71832,28 +72506,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "pUC" = (
-/obj/structure/table/glass,
-/obj/item/disk/design_disk,
-/obj/item/disk/design_disk,
-/obj/item/disk/tech_disk,
-/obj/item/disk/tech_disk,
-/obj/item/folder/white,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door_control{
-	id = "RnDShutters";
-	name = "Research Privacy Shutters";
-	pixel_y = 24;
-	req_access = list(47)
-	},
 /obj/machinery/camera{
 	c_tag = "Research and Development";
 	network = list("SS13","RD")
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/plasteel/white,
 /area/toxins/lab)
 "pVc" = (
 /obj/structure/disposalpipe/segment{
@@ -72233,6 +72890,13 @@
 	icon_state = "red"
 	},
 /area/security/main)
+"qau" = (
+/obj/machinery/gateway/centerstation,
+/obj/structure/cable/orange,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "qaC" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security SMES Access";
@@ -72267,15 +72931,9 @@
 /turf/simulated/floor/wood,
 /area/security/hos)
 "qaY" = (
-/obj/machinery/gateway{
-	density = 0
-	},
-/obj/effect/landmark/join_late_gateway,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
-	},
-/area/gateway)
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/engine,
+/area/engine/gravitygenerator)
 "qbf" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -72340,8 +72998,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/entry)
 "qcI" = (
@@ -72493,12 +73150,6 @@
 "qeq" = (
 /turf/simulated/mineral/ancient/outer,
 /area/assembly/robotics)
-"qet" = (
-/obj/structure/plasticflaps{
-	name = "Officer Pipsqueak's Home"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/secondary/entry/north)
 "qeE" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -72533,24 +73184,18 @@
 /turf/simulated/wall,
 /area/hallway/primary/starboard/south)
 "qeR" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Gravity Generator";
-	req_access = list(10)
+/obj/machinery/door/poddoor/shutters{
+	id_tag = "stationawaygate";
+	name = "Gateway Access Shutters"
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/door_control{
+	id = "stationawaygate";
+	name = "Gateway Shutters Access Control";
+	pixel_y = -32;
+	req_access = list(62)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/engine/gravitygenerator)
+/turf/space,
+/area/gateway)
 "qeU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -72724,6 +73369,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port2)
+"qij" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "qir" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -73178,9 +73834,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "qnt" = (
 /obj/structure/cable/orange{
@@ -73275,8 +73929,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
+	dir = 1;
+	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
 "qoU" = (
@@ -73379,7 +74033,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "bluecorner"
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/south)
 "qqd" = (
@@ -73758,6 +74412,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/port2)
+"qxL" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/entry/south)
 "qyx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -73882,8 +74545,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/east)
 "qAO" = (
@@ -73957,8 +74619,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "bluecorner"
+	dir = 0;
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/north)
 "qBE" = (
@@ -73968,20 +74630,22 @@
 /turf/simulated/floor/plasteel,
 /area/security/lobby)
 "qBG" = (
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/scanning_module{
-	pixel_x = 2;
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/stock_parts/scanning_module,
-/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/dropper,
+/obj/item/clothing/glasses/welding,
 /obj/structure/sign/poster/random{
 	name = "random official poster";
 	pixel_x = 32;
 	random_basetype = /obj/structure/sign/poster/official
 	},
-/obj/item/storage/belt/utility,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurple"
@@ -74004,8 +74668,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "bluecorner"
+	dir = 0;
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/north)
 "qBS" = (
@@ -74030,8 +74694,8 @@
 "qCq" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "bluecorner"
+	dir = 0;
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/north)
 "qCu" = (
@@ -74061,15 +74725,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Hangar";
-	req_access = list(18,70,71,48)
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Hangar";
+	req_access = list(18,70,71,48)
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/mechanic_workshop/hangar)
 "qCK" = (
@@ -74091,8 +74755,8 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "bluecorner"
+	dir = 0;
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/north)
 "qCQ" = (
@@ -74108,8 +74772,8 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "bluecorner"
+	dir = 0;
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/north)
 "qDo" = (
@@ -74367,16 +75031,13 @@
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology)
 "qHW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
+	icon_state = "dark"
 	},
-/area/crew_quarters/bar)
+/area/engine/gravitygenerator)
 "qIC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/turf_decal/stripes/line,
@@ -74693,7 +75354,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "bluecorner"
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/north)
 "qNK" = (
@@ -74846,9 +75507,7 @@
 /area/toxins/hallway)
 "qQJ" = (
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "qQM" = (
 /obj/structure/chair/comfy/black{
@@ -74877,8 +75536,8 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "browncorner"
+	dir = 1;
+	icon_state = "brown"
 	},
 /area/hallway/primary/fore/east)
 "qQZ" = (
@@ -75002,9 +75661,7 @@
 /obj/structure/chair/sofa/right{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
 "qUd" = (
 /obj/structure/cable/orange{
@@ -75154,9 +75811,7 @@
 	},
 /obj/structure/table/wood,
 /obj/item/kitchen/utensil/fork,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
 "qXV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
@@ -75395,6 +76050,19 @@
 	icon_state = "bcircuit"
 	},
 /area/turret_protected/ai_upload)
+"rbE" = (
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
+"rbP" = (
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkbluecorners"
+	},
+/area/space)
 "rbR" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -75437,9 +76105,6 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "rcz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	pixel_y = 28
 	},
@@ -75451,6 +76116,9 @@
 	},
 /obj/structure/cable/orange{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -75498,13 +76166,22 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "rdk" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
+	},
+/obj/effect/decal/warning_stripes/red/partial{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/gateway)
+/area/engine/gravitygenerator)
 "rdl" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Space Expedition Storage";
@@ -75606,9 +76283,11 @@
 	},
 /area/security/warden)
 "rfd" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "whitepurple"
+	icon_state = "dark"
 	},
 /area/toxins/lab)
 "rfj" = (
@@ -75693,6 +76372,18 @@
 /obj/effect/spawner/random_spawners/oil_maybe,
 /turf/simulated/floor/plating,
 /area/hallway/primary/fore)
+"rhH" = (
+/obj/machinery/gateway{
+	dir = 9
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "vault"
+	},
+/area/space)
 "rhQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -75796,9 +76487,10 @@
 /area/crew_quarters/fitness)
 "rjY" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "rampbottom"
 	},
-/area/engine/gravitygenerator)
+/area/gateway)
 "rki" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/machinery/camera{
@@ -75825,9 +76517,7 @@
 	dir = 8
 	},
 /obj/machinery/disposal,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "rkt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -75863,7 +76553,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/east)
 "rln" = (
@@ -76027,7 +76717,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "blue"
+	},
 /area/hallway/primary/starboard/south)
 "rnQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -76046,7 +76739,10 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "blue"
+	},
 /area/hallway/primary/starboard/south)
 "rnX" = (
 /obj/machinery/navbeacon{
@@ -76112,7 +76808,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry)
 "ron" = (
@@ -76454,8 +77150,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/exit)
 "rvc" = (
@@ -76508,15 +77203,18 @@
 /turf/simulated/floor/plasteel,
 /area/security/lobby)
 "rvM" = (
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id_tag = "stationawaygate";
-	name = "Gateway Access Shutters"
+/obj/machinery/door/airlock/highsecurity{
+	name = "Gravity Generator Foyer";
+	req_access = list(10)
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/door/firedoor,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
-/area/gateway)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/space,
+/area/engine/gravitygenerator)
 "rvX" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Bay SMES";
@@ -76622,6 +77320,13 @@
 	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
+"rxE" = (
+/obj/machinery/light,
+/obj/structure/closet/radiation,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "rxW" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -76646,8 +77351,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/exit)
 "ryD" = (
@@ -76761,7 +77465,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutralfull"
 	},
 /area/hallway/primary/port/south)
 "rAi" = (
@@ -77005,6 +77709,22 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/wood,
 /area/library)
+"rDF" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
+/obj/item/multitool,
+/obj/item/multitool,
+/obj/item/multitool,
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "rDY" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/effect/decal/warning_stripes/northwestcorner,
@@ -77065,7 +77785,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "bluecorner"
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/south)
 "rEC" = (
@@ -77075,6 +77795,13 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/port)
+"rEH" = (
+/obj/effect/decal/warning_stripes/southeast,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "rampbottom"
+	},
+/area/space)
 "rEI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -77136,8 +77863,9 @@
 /obj/effect/turf_decal/stripes/red/corner{
 	dir = 8
 	},
+/obj/machinery/vending/chinese,
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry/south)
 "rFR" = (
@@ -77576,7 +78304,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/east)
 "rNg" = (
@@ -77601,6 +78329,19 @@
 	icon_state = "darkblue"
 	},
 /area/medical/cmo)
+"rNj" = (
+/obj/structure/cable/orange{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 26
+	},
+/obj/structure/dispenser/oxygen,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "rNo" = (
 /obj/machinery/cooker/deepfryer,
 /obj/structure/window/reinforced{
@@ -77659,10 +78400,9 @@
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/arrow,
-/obj/effect/decal/warning_stripes/yellow/partial,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "purplecorner"
+	icon_state = "neutralfull"
 	},
 /area/hallway/primary/aft/west)
 "rOJ" = (
@@ -77935,9 +78675,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "rSu" = (
 /obj/machinery/vending/wallmed{
@@ -78201,8 +78939,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/east)
 "rWw" = (
@@ -78471,18 +79208,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /obj/structure/cable/orange{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
+	dir = 1;
+	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
 "sbL" = (
@@ -78688,7 +79425,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/east)
 "set" = (
@@ -78755,10 +79492,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
-	},
+/turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/south)
 "sfu" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -78952,24 +79686,6 @@
 "shU" = (
 /turf/simulated/mineral/ancient/outer,
 /area/maintenance/disposal/north)
-"shV" = (
-/obj/structure/table,
-/obj/item/radio{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/radio{
-	pixel_y = 6
-	},
-/obj/item/radio{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/radio,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
 "shZ" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical{
@@ -79138,8 +79854,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurple"
+	icon_state = "dark"
 	},
 /area/toxins/lab)
 "smj" = (
@@ -79174,9 +79889,31 @@
 /turf/simulated/floor/wood,
 /area/maintenance/asmaint5)
 "snb" = (
-/obj/machinery/computer/rdconsole/core,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "RnDShutters"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "researchlockdown";
+	layer = 2.6;
+	name = "Research Emergency Lockdown"
+	},
+/obj/machinery/autolathe,
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	id = "Autolathe";
+	name = "Autolathe Access";
+	req_access = list(47)
+	},
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
+/obj/item/stack/sheet/metal{
+	amount = 10
+	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "white"
 	},
 /area/toxins/lab)
 "snc" = (
@@ -79263,7 +80000,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "brown"
+	},
 /area/quartermaster/office)
 "soz" = (
 /obj/item/radio/intercom{
@@ -79383,14 +80123,13 @@
 	},
 /area/clownoffice/secret)
 "ssi" = (
-/obj/machinery/gateway{
-	dir = 8
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+	icon_state = "dark"
 	},
-/area/gateway)
+/area/engine/gravitygenerator)
 "ssn" = (
 /obj/structure/closet/secure_closet/captains,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -79568,8 +80307,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/east)
 "sug" = (
@@ -79807,7 +80545,10 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "brown"
+	},
 /area/quartermaster/office)
 "syI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -79831,6 +80572,13 @@
 /obj/machinery/suit_storage_unit/security,
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
+"szf" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/structure/flora/rock/jungle,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/entry/south)
 "szl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80101,8 +80849,7 @@
 "sDL" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/exit)
 "sEa" = (
@@ -80447,14 +81194,14 @@
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "sJs" = (
-/obj/structure/closet/radiation,
-/obj/structure/sign/electricshock{
-	pixel_y = -32
+/obj/machinery/gateway{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "vault"
 	},
-/area/engine/gravitygenerator)
+/area/gateway)
 "sJv" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -80470,13 +81217,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/west)
 "sJD" = (
-/obj/effect/turf_decal/loading_area/white{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
+/obj/effect/decal/warning_stripes/green,
+/turf/simulated/floor/engine,
+/area/engine/gravitygenerator)
 "sJS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80485,7 +81228,9 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/bartender,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
 /area/crew_quarters/bar)
 "sKh" = (
 /turf/simulated/floor/plating{
@@ -80630,6 +81375,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
@@ -80802,8 +81551,7 @@
 	},
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/exit)
 "sQn" = (
@@ -80857,9 +81605,7 @@
 	dir = 8;
 	pixel_x = 28
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "sRU" = (
 /obj/structure/lattice/catwalk,
@@ -81499,6 +82245,14 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/port/north)
+"tdV" = (
+/obj/effect/turf_decal/loading_area/white{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "tdX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -81608,8 +82362,7 @@
 "tfR" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/exit)
 "tga" = (
@@ -81894,7 +82647,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "bluecorner"
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/south)
 "tjT" = (
@@ -81952,19 +82705,15 @@
 	},
 /area/security/prison/cell_block/A)
 "tkr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/orange{
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/gateway)
+/area/engine/gravitygenerator)
 "tla" = (
 /obj/structure/lattice,
 /obj/item/storage/toolbox/electrical,
@@ -82496,8 +83245,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/east)
 "tuI" = (
@@ -82708,30 +83456,25 @@
 	name = "Science Requests Console";
 	pixel_x = -30
 	},
-/obj/machinery/r_n_d/circuit_imprinter,
-/obj/effect/turf_decal/stripes/line,
+/obj/machinery/r_n_d/destructive_analyzer,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/toxins/lab)
 "tyK" = (
-/obj/structure/table,
-/obj/item/destTagger{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/item/stack/packageWrap,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high,
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple"
+	icon_state = "dark"
 	},
 /area/toxins/lab)
 "tyO" = (
@@ -82836,9 +83579,7 @@
 /obj/structure/chair/sofa/right{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
 "tAX" = (
 /obj/machinery/door/airlock/public/glass{
@@ -82921,26 +83662,11 @@
 /turf/simulated/floor/plating,
 /area/toxins/lab)
 "tCc" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkblue"
 	},
-/area/engine/gravitygenerator)
+/area/gateway)
 "tCy" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -83059,6 +83785,18 @@
 	icon_state = "darkbrown"
 	},
 /area/quartermaster/office)
+"tEP" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/medical1{
+	req_access = list(5,62)
+	},
+/obj/effect/decal/warning_stripes/southeast,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "tEV" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -83140,7 +83878,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "bluecorner"
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/south)
 "tHo" = (
@@ -83164,8 +83902,11 @@
 /turf/simulated/floor/noslip,
 /area/medical/surgery/south)
 "tHv" = (
-/turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "tHB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -83560,7 +84301,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/east)
 "tNC" = (
@@ -83714,10 +84455,12 @@
 /turf/simulated/floor/plating,
 /area/hallway/spacebridge/engmed)
 "tRr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel/white,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/toxins/lab)
 "tRA" = (
 /turf/simulated/wall,
@@ -83995,6 +84738,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -84150,9 +84896,7 @@
 	pixel_x = -2;
 	pixel_y = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
 "tYn" = (
 /obj/structure/cable{
@@ -84266,8 +85010,8 @@
 	},
 /area/hallway/primary/port/east)
 "tZz" = (
-/turf/simulated/mineral/ancient/outer,
-/area/engine/gravitygenerator)
+/turf/simulated/wall/r_wall,
+/area/gateway)
 "tZQ" = (
 /obj/machinery/vending/medical,
 /turf/simulated/floor/plasteel{
@@ -84688,6 +85432,13 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"uhu" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/entry/south)
 "uhB" = (
 /obj/machinery/light/small,
 /obj/machinery/embedded_controller/radio/airlock/access_controller{
@@ -84786,6 +85537,21 @@
 	icon_state = "whitegreen"
 	},
 /area/medical/virology)
+"uiT" = (
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkblue"
+	},
+/area/space)
+"uja" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/entry/south)
 "ujr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -85320,6 +86086,15 @@
 	icon_state = "red"
 	},
 /area/security/processing)
+"ute" = (
+/obj/structure/closet/radiation,
+/obj/structure/sign/electricshock{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "utq" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/double,
@@ -85446,9 +86221,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "uvp" = (
 /obj/machinery/camera{
@@ -85515,9 +86288,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/machinery/recharger,
-/obj/item/toy/figure/scientist,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
@@ -85804,9 +86574,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "uBY" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -85982,8 +86750,8 @@
 	},
 /obj/structure/closet/crate/can,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "escape"
+	dir = 5;
+	icon_state = "whitered"
 	},
 /area/hallway/primary/port/south)
 "uEu" = (
@@ -86023,8 +86791,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/exit)
 "uFz" = (
@@ -86130,7 +86897,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "escape"
+	icon_state = "whitered"
 	},
 /area/hallway/primary/port/south)
 "uHm" = (
@@ -86357,8 +87124,7 @@
 	},
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/exit)
 "uKX" = (
@@ -86384,7 +87150,10 @@
 /obj/effect/landmark/event/lightsout,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "browncorner"
+	},
 /area/quartermaster/office)
 "uLy" = (
 /obj/effect/spawner/airlock/s_to_n,
@@ -86561,9 +87330,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "uOu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -86710,6 +87477,20 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"uRi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/command{
+	name = "Gateway Access";
+	req_access = list(62)
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "uRk" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Asteroid Hallway 1";
@@ -87142,7 +87923,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "bluecorner"
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/south)
 "uZl" = (
@@ -87244,7 +88025,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/east)
 "vaY" = (
@@ -87324,6 +88105,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
+"vcY" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "vda" = (
 /obj/structure/closet,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -87474,6 +88264,12 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
+"vgF" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "vgV" = (
 /obj/machinery/r_n_d/circuit_imprinter,
 /turf/simulated/floor/plasteel{
@@ -87581,8 +88377,11 @@
 /turf/simulated/floor/wood,
 /area/library)
 "vjb" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry/south)
 "vjg" = (
@@ -87660,8 +88459,8 @@
 	},
 /obj/machinery/vending/cart,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "browncorner"
+	dir = 9;
+	icon_state = "brown"
 	},
 /area/quartermaster/office)
 "vkG" = (
@@ -87678,14 +88477,13 @@
 /turf/simulated/floor/plasteel/white,
 /area/toxins/xenobiology)
 "vlj" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
+/obj/structure/sign/electricshock{
+	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/gateway)
+/area/engine/gravitygenerator)
 "vls" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -87913,8 +88711,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/exit)
 "vqi" = (
@@ -88140,6 +88937,13 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/mimeoffice)
+"vty" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/flora/grass/jungle,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/entry/south)
 "vtz" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -88238,11 +89042,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "vuM" = (
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
-	},
-/area/hallway/primary/starboard/south)
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/engine,
+/area/engine/gravitygenerator)
 "vuQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -88257,6 +89059,16 @@
 	icon_state = "white"
 	},
 /area/medical/cloning)
+"vuR" = (
+/obj/machinery/gateway{
+	density = 0
+	},
+/obj/effect/landmark/join_late_gateway,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/gateway)
 "vuY" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -88443,22 +89255,16 @@
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior/secondary)
 "vyv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/effect/decal/warning_stripes/red/partial{
+	dir = 4
 	},
 /obj/structure/cable/orange{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-8"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/gateway)
+/area/engine/gravitygenerator)
 "vyQ" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -88785,14 +89591,14 @@
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "vEY" = (
-/obj/machinery/gateway{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8;
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+	icon_state = "dark"
 	},
-/area/gateway)
+/area/engine/gravitygenerator)
 "vFg" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -88896,6 +89702,25 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft/west)
+"vGZ" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "Gravity Generator Room";
+	req_access = list(19,23)
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "vHl" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -88972,7 +89797,10 @@
 /obj/machinery/atm{
 	pixel_y = 32
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "brown"
+	},
 /area/quartermaster/office)
 "vHZ" = (
 /obj/structure/table,
@@ -89100,6 +89928,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
+"vKk" = (
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "yellow"
+	},
+/area/hallway/primary/central)
 "vKO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating{
@@ -89173,11 +90007,12 @@
 	},
 /area/toxins/launch)
 "vLE" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkbluecorners"
+	icon_state = "dark"
 	},
-/area/gateway)
+/area/engine/gravitygenerator)
 "vLI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -89302,8 +90137,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/entry)
 "vMS" = (
@@ -89338,7 +90172,7 @@
 "vNe" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "yellowcorner"
+	icon_state = "yellow"
 	},
 /area/hallway/primary/central)
 "vNu" = (
@@ -89382,6 +90216,14 @@
 "vNP" = (
 /turf/simulated/floor/plating,
 /area/security/permabrig)
+"vNU" = (
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "vOe" = (
 /obj/effect/spawner/random_spawners/fungus_maybe,
 /turf/simulated/wall,
@@ -89407,6 +90249,7 @@
 "vOv" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/starboard)
 "vPg" = (
@@ -89433,16 +90276,12 @@
 	},
 /area/bridge)
 "vPy" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
+/obj/machinery/gateway/centerstation,
+/obj/structure/cable,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/gateway)
 "vPD" = (
 /obj/machinery/floodlight{
 	light_power = 1
@@ -89450,22 +90289,14 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/north)
 "vPZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/structure/window/reinforced,
 /obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkblue"
 	},
-/area/engine/gravitygenerator)
+/area/gateway)
 "vQl" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -89719,7 +90550,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "brown"
+	},
 /area/quartermaster/office)
 "vSy" = (
 /obj/structure/table,
@@ -89890,7 +90724,7 @@
 "vVE" = (
 /obj/item/reagent_containers/glass/rag,
 /obj/structure/table/wood/fancy/black,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
 "vVG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -89916,8 +90750,8 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "yellowcorner"
+	dir = 7;
+	icon_state = "yellow"
 	},
 /area/hallway/primary/central)
 "vWk" = (
@@ -90350,16 +91184,12 @@
 	},
 /area/maintenance/gambling_den2)
 "weq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/storage/toolbox/mechanical,
 /obj/machinery/light,
 /obj/item/radio/intercom{
 	pixel_y = -28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
@@ -90417,7 +91247,9 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
 /area/crew_quarters/bar)
 "wfR" = (
 /obj/structure/cable/orange{
@@ -90786,6 +91618,11 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/engine,
 /area/medical/chemistry)
+"wme" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "darkbluecorners"
+	},
+/area/space)
 "wmj" = (
 /obj/machinery/door/airlock{
 	name = "Chaplain's Office";
@@ -91021,6 +91858,42 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/surgery/north)
+"wpw" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
+"wpx" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 26
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/closet/secure_closet/exile,
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "wpB" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -91096,8 +91969,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/entry)
 "wpX" = (
@@ -91162,9 +92034,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
 /obj/structure/extinguisher_cabinet{
 	name = "custom placement";
 	pixel_y = 28
@@ -91174,6 +92043,9 @@
 	},
 /obj/structure/cable/orange{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -91300,7 +92172,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "bluecorner"
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/south)
 "wsR" = (
@@ -92123,7 +92995,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "browncorner"
+	dir = 10;
+	icon_state = "brown"
 	},
 /area/quartermaster/office)
 "wEA" = (
@@ -92392,7 +93265,8 @@
 /obj/structure/table,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "browncorner"
+	dir = 4;
+	icon_state = "brown"
 	},
 /area/quartermaster/office)
 "wIP" = (
@@ -92506,7 +93380,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/east)
 "wLj" = (
@@ -92576,8 +93450,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/exit)
 "wMe" = (
@@ -92679,11 +93552,16 @@
 /turf/simulated/floor/plasteel,
 /area/security/lobby)
 "wOc" = (
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkblue"
+/obj/effect/decal/warning_stripes/red/partial{
+	dir = 4
 	},
-/area/gateway)
+/obj/structure/cable/orange{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/engine/gravitygenerator)
 "wOh" = (
 /obj/machinery/camera{
 	c_tag = "Service Asteroid Hallway 4";
@@ -92818,6 +93696,22 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"wQb" = (
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	id_tag = "stationawaygate";
+	name = "Gateway Access Shutters"
+	},
+/obj/machinery/door_control{
+	id = "stationawaygate";
+	name = "Gateway Shutters Access Control";
+	pixel_x = 24;
+	req_access = list(62)
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "wQf" = (
 /turf/simulated/wall,
 /area/crew_quarters/locker/locker_toilet)
@@ -92872,7 +93766,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
 "wQY" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -92939,8 +93833,8 @@
 /area/maintenance/gambling_den2)
 "wSq" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "bluecorner"
+	dir = 0;
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/north)
 "wSt" = (
@@ -92969,7 +93863,7 @@
 /area/engine/engineering)
 "wSz" = (
 /obj/structure/table/wood/fancy/black,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
 "wSG" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -92989,6 +93883,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior/secondary)
+"wSV" = (
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "wTg" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -93007,8 +93909,8 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "wTu" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
 /area/crew_quarters/bar)
 "wUc" = (
@@ -93050,6 +93952,16 @@
 	},
 /turf/simulated/wall,
 /area/turret_protected/aisat_interior)
+"wUs" = (
+/obj/machinery/gateway{
+	dir = 10
+	},
+/obj/effect/landmark/join_late_gateway,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "vault"
+	},
+/area/gateway)
 "wUv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -93065,7 +93977,7 @@
 	pixel_y = 7
 	},
 /obj/structure/table/wood/fancy/black,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
 "wUV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -93314,8 +94226,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "purplecorner"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/west)
 "wYO" = (
@@ -93676,6 +94587,20 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
 /area/civilian/vacantoffice)
+"xdW" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "xdZ" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
@@ -93723,6 +94648,15 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/cloning)
+"xeH" = (
+/obj/machinery/gateway{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "vault"
+	},
+/area/space)
 "xeI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -93775,6 +94709,14 @@
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/engineering)
+"xgy" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "xhk" = (
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/courtroom)
@@ -93829,6 +94771,12 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/cloning)
+"xia" = (
+/turf/simulated/floor/plasteel{
+	dir = 0;
+	icon_state = "blue"
+	},
+/area/hallway/primary/starboard/south)
 "xiv" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -93890,8 +94838,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escapecorner"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/exit)
 "xjK" = (
@@ -93947,29 +94894,36 @@
 /turf/simulated/wall/r_wall,
 /area/toxins/test_area)
 "xkt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
-"xkB" = (
-/obj/machinery/vending/snack,
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/starboard/south)
-"xkK" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable/orange{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
+	},
+/area/engine/gravitygenerator)
+"xkB" = (
+/obj/machinery/vending/snack,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "blue"
+	},
+/area/hallway/primary/starboard/south)
+"xkK" = (
+/obj/machinery/door_control{
+	id = "RnDShutters";
+	name = "Research Privacy Shutters";
+	pixel_y = 24;
+	req_access = list(47)
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple"
 	},
 /area/toxins/lab)
 "xkM" = (
@@ -94308,7 +95262,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "xro" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -94322,8 +95276,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escape"
+	icon_state = "bar"
 	},
 /area/hallway/secondary/entry)
 "xrs" = (
@@ -94392,14 +95345,12 @@
 /turf/simulated/floor/carpet/green,
 /area/library)
 "xsF" = (
-/obj/structure/sign/science{
-	pixel_y = -32
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "purple"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
 /area/hallway/primary/aft/west)
 "xsS" = (
@@ -94615,7 +95566,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "bluecorner"
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/south)
 "xyo" = (
@@ -94723,33 +95674,18 @@
 	},
 /area/hallway/primary/port/north)
 "xzp" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "RnDShutters"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "researchlockdown";
-	layer = 2.6;
-	name = "Research Emergency Lockdown"
-	},
-/obj/machinery/autolathe,
-/obj/machinery/door/window/brigdoor{
+/obj/machinery/firealarm{
 	dir = 1;
-	id = "Autolathe";
-	name = "Autolathe Access";
-	req_access = list(47)
+	pixel_y = -24
 	},
-/obj/item/stack/sheet/glass{
-	amount = 10
+/obj/effect/decal/warning_stripes/yellow/partial{
+	dir = 4
 	},
-/obj/item/stack/sheet/metal{
-	amount = 10
-	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 10;
+	icon_state = "purple"
 	},
-/area/toxins/lab)
+/area/hallway/primary/aft/west)
 "xzt" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
@@ -94850,7 +95786,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "bluecorner"
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/south)
 "xAU" = (
@@ -94987,7 +95923,7 @@
 /obj/effect/turf_decal/bot_white,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "purplefull"
+	icon_state = "purple"
 	},
 /area/hallway/primary/aft/west)
 "xCO" = (
@@ -95000,17 +95936,18 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "yellowcorner"
+	icon_state = "yellow"
 	},
 /area/hallway/primary/central)
 "xDp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA";
+	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -95085,6 +96022,15 @@
 	icon_state = "cafeteria"
 	},
 /area/toxins/rdoffice)
+"xEE" = (
+/obj/machinery/gateway{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/space)
 "xEJ" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/shieldwallgen,
@@ -95222,8 +96168,12 @@
 "xGW" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/red/corner,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry/south)
 "xHc" = (
@@ -95268,6 +96218,17 @@
 "xIa" = (
 /turf/simulated/wall,
 /area/toxins/xenobiology)
+"xIi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "xIu" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
@@ -95532,6 +96493,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/permabrig)
+"xNN" = (
+/obj/machinery/door/poddoor/shutters{
+	id_tag = "stationawaygate";
+	name = "Gateway Access Shutters"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "xNP" = (
 /obj/machinery/kitchen_machine/oven,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -95579,9 +96549,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/chair/sofa,
 /obj/effect/landmark/start/civilian,
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
 "xOY" = (
 /obj/machinery/light_switch{
@@ -95627,7 +96595,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/red/line,
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry/south)
 "xQY" = (
@@ -95751,9 +96719,7 @@
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redyellowfull"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "xSV" = (
 /obj/structure/cable/orange{
@@ -96348,6 +97314,14 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/gambling_den2)
+"ycm" = (
+/obj/effect/decal/warning_stripes/northwest,
+/obj/structure/closet/l3closet/scientist,
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "ycy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -96376,7 +97350,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "bluecorner"
+	icon_state = "blue"
 	},
 /area/hallway/primary/starboard/south)
 "ycO" = (
@@ -96399,8 +97373,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
+	dir = 1;
+	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
 "ydc" = (
@@ -96460,6 +97434,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint5)
+"yer" = (
+/obj/effect/turf_decal/bot_white,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "purple"
+	},
+/area/hallway/primary/aft/west)
 "yes" = (
 /turf/simulated/wall,
 /area/clownoffice)
@@ -96684,6 +97665,20 @@
 	icon_state = "dark"
 	},
 /area/atmos/distribution)
+"yir" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "yiw" = (
 /obj/machinery/door/airlock/external{
 	locked = 1;
@@ -96705,6 +97700,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/atmospherics)
+"yiI" = (
+/obj/effect/turf_decal/loading_area/white{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/space)
 "yiP" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
@@ -108164,7 +109167,7 @@ uCK
 mHL
 vtY
 vtY
-ccW
+uCK
 ccW
 ccW
 ccW
@@ -113287,10 +114290,10 @@ oeY
 bZX
 bZX
 bZX
-bZX
-bZX
-bZX
-bZX
+bzJ
+bzJ
+bzJ
+bzJ
 rzK
 gqA
 bUM
@@ -113575,7 +114578,7 @@ xEd
 xEd
 xEd
 vdZ
-hVP
+udN
 uRf
 fhQ
 bIk
@@ -113832,7 +114835,7 @@ rNY
 atE
 wiT
 kjJ
-hVP
+udN
 uRf
 fOJ
 bec
@@ -114036,8 +115039,8 @@ aZZ
 xKV
 aZZ
 aZZ
-aZZ
-aZZ
+bGB
+bGB
 aZZ
 lZN
 uEn
@@ -114046,7 +115049,7 @@ uHd
 bPf
 bPf
 bPf
-bPf
+acK
 baF
 nWU
 rXV
@@ -114089,7 +115092,7 @@ vkl
 vkl
 vGl
 xEd
-hVP
+udN
 uRf
 lVC
 fTe
@@ -115577,9 +116580,9 @@ bdR
 dcE
 wQW
 drp
-bjr
-bjr
-qHW
+wmR
+wmR
+kSA
 aqx
 baF
 ofT
@@ -115827,15 +116830,15 @@ bjn
 wmR
 wfH
 bxo
-wmR
-wmR
-wmR
+wTu
+wTu
+wTu
 cCp
 lao
 kIL
 mso
-bjr
-bjr
+wmR
+wmR
 pIg
 qTM
 baF
@@ -115888,9 +116891,9 @@ raH
 rob
 jGC
 xEd
-lDt
+hVP
+xzp
 uMr
-djd
 clj
 tyF
 smf
@@ -116091,8 +117094,8 @@ ime
 wVx
 wSz
 ddn
-bjr
-bjr
+wmR
+wmR
 bJz
 bAv
 baF
@@ -116146,11 +117149,11 @@ wiE
 wMV
 xEd
 xsF
-uMr
+mIa
 snb
 clk
 mtW
-oYZ
+rfd
 pzs
 uMr
 lxD
@@ -116348,8 +117351,8 @@ wUz
 iKY
 wSz
 ddn
-bjr
-bjr
+wmR
+wmR
 bJB
 eDb
 baF
@@ -116402,12 +117405,12 @@ taJ
 wiE
 ete
 ciB
-mIa
+xsF
+djd
 uMr
-pUC
 xkK
 iOM
-oYZ
+tRr
 tyK
 uMr
 lxD
@@ -116597,19 +117600,19 @@ brN
 jCi
 uNO
 bjn
-iFe
-bjr
+bxp
+wmR
 mso
 ddn
 ddn
 dUr
 ddn
 elh
-bjr
-bjr
+wmR
+wmR
 fTK
 aHR
-bjr
+wmR
 baF
 baF
 xHg
@@ -116659,11 +117662,11 @@ qbf
 uTv
 grQ
 xEd
-udN
-xzp
-rfd
+xsF
+lDt
+uMr
 goT
-oYZ
+pUC
 oYZ
 uwy
 uMr
@@ -116854,20 +117857,20 @@ brM
 qXX
 uNT
 vkG
-iFe
-bjr
+bxp
+wmR
 kwn
-bjr
-bjr
+wmR
+wmR
 gBw
-bjr
-bjr
+wmR
+wmR
 bXV
-bjr
-qHW
-bjr
-bjr
-bjr
+wmR
+kSA
+wmR
+wmR
+wmR
 aiR
 abL
 epa
@@ -116917,7 +117920,7 @@ nDp
 xWu
 xEd
 cwf
-uMr
+mIa
 bwu
 frh
 gqL
@@ -117112,19 +118115,19 @@ rZl
 lDZ
 aZZ
 ntl
-onO
+fEG
 mNA
 mBb
 bAv
 fcD
 tAc
-bjr
+wmR
 uBQ
-onO
-qHW
+fEG
+kSA
 nXn
-bjr
-bjr
+wmR
+wmR
 bRP
 sup
 hxP
@@ -117178,7 +118181,7 @@ meh
 tBX
 sNo
 obg
-tRr
+ePy
 axa
 xOL
 lyT
@@ -117271,7 +118274,7 @@ rNK
 rNK
 rNK
 nHN
-cRv
+rNK
 cRv
 abW
 abW
@@ -117379,9 +118382,9 @@ dty
 dds
 dty
 qnk
-bjr
-bjr
-bjr
+wmR
+wmR
+wmR
 pYu
 fup
 bYw
@@ -117528,7 +118531,7 @@ rNK
 rNK
 rNK
 nHN
-cRv
+rNK
 cRv
 abW
 abW
@@ -117625,7 +118628,7 @@ jWv
 buH
 buH
 vls
-noZ
+qQJ
 qQJ
 ing
 bGf
@@ -117883,18 +118886,18 @@ rZl
 euQ
 aZZ
 bxs
-bjr
+wmR
 uOq
-bjr
-bjr
-bjr
-bjr
-bjr
+wmR
+wmR
+wmR
+wmR
+wmR
 kzY
 iXQ
 mrF
 lZD
-bjr
+wmR
 lZD
 xiv
 fup
@@ -118151,7 +119154,7 @@ jpO
 sQg
 bbj
 lZD
-bjr
+wmR
 rkr
 baF
 hQg
@@ -118455,7 +119458,7 @@ vHF
 qWS
 bLp
 ifg
-xCH
+yer
 xWu
 xEd
 udN
@@ -127317,8 +128320,8 @@ abW
 abW
 abW
 abW
-aiN
-aiN
+kXu
+kXu
 fZJ
 mMb
 cbw
@@ -127574,7 +128577,7 @@ abW
 abW
 abW
 abW
-kXu
+abW
 kXu
 kXu
 kXu
@@ -127859,7 +128862,7 @@ pHp
 bAK
 xTc
 wUi
-bUO
+gTA
 ugQ
 xru
 aKp
@@ -128119,16 +129122,16 @@ vzX
 bUO
 ugQ
 xru
-hSp
-hSp
-hSp
-hSp
-hSp
-hSp
-hSp
-hSp
 lTq
-cRv
+lTq
+lTq
+lTq
+lTq
+lTq
+lTq
+lTq
+lTq
+lTq
 abE
 rNK
 lzH
@@ -128160,7 +129163,7 @@ cJm
 bqp
 vNe
 vNe
-buQ
+vKk
 bwk
 bxv
 byx
@@ -128376,17 +129379,17 @@ vzX
 bUO
 ugQ
 xru
-hSp
+lTq
 pdz
 hoP
 cCj
-haN
-abv
+oWJ
 odM
-fqu
+odM
+qHW
 vlj
 lTq
-abE
+lTq
 rNK
 lzH
 fph
@@ -128633,17 +129636,17 @@ vzX
 fwq
 dQk
 xDp
-lLd
+lTq
 vyv
 rdk
 wOc
 oWJ
 ssi
 bjM
-fqu
+vuM
 ptY
+odM
 lTq
-abE
 lzH
 lzH
 lWT
@@ -128888,8 +129891,8 @@ bAD
 fxB
 vzX
 sbC
-ugQ
-xru
+iFe
+jvi
 rvM
 tkr
 xkt
@@ -128899,8 +129902,8 @@ iNO
 qaY
 sJD
 niz
+odM
 lTq
-cRv
 rNK
 rNK
 aXD
@@ -129146,18 +130149,18 @@ cIp
 vzX
 qoS
 ugQ
-xru
-gTy
+xDp
+lTq
 fqu
 mWJ
-wOc
-cVS
+fqu
+oWJ
 vEY
 oYM
-fqu
+bLP
 jor
+odM
 lTq
-cRv
 rNK
 rNK
 aXD
@@ -129401,20 +130404,20 @@ cQJ
 cTW
 lqC
 uuv
-qoS
+iuR
 ugQ
 xru
-hSp
+lTq
 lHe
 pnu
 vLE
-haN
-ktM
-nWS
-fqu
-shV
+oWJ
+odM
+odM
+oBY
+vlj
 lTq
-cRv
+lTq
 rNK
 rNK
 rNK
@@ -129661,17 +130664,17 @@ aVS
 qoS
 ugQ
 eJS
-hSp
-hSp
-hSp
-hSp
-hSp
-hSp
-hSp
-hSp
-hSp
 lTq
-dhs
+lTq
+lTq
+lTq
+lTq
+lTq
+lTq
+lTq
+lTq
+lTq
+abE
 rNK
 rNK
 rNK
@@ -130401,8 +131404,8 @@ abW
 abW
 abW
 abW
-abW
-abW
+dxS
+bjr
 dxS
 eSk
 nQN
@@ -130658,8 +131661,8 @@ abW
 abW
 abW
 abW
-abW
-abW
+dxS
+dxS
 dxS
 cSQ
 aNM
@@ -133321,7 +134324,7 @@ bPK
 bQK
 bND
 bND
-bTn
+bUA
 bUA
 bUA
 bND
@@ -133578,7 +134581,7 @@ bPL
 pLC
 bRK
 bND
-jEh
+jHT
 jEh
 rZw
 bND
@@ -135419,7 +136422,7 @@ rrt
 hNb
 pLr
 gUa
-tuh
+qxL
 aok
 leg
 ijl
@@ -135677,9 +136680,9 @@ rAB
 mQN
 aIb
 ebV
+uja
+dbg
 eWu
-dbg
-dbg
 xQX
 uXr
 hzu
@@ -135934,9 +136937,9 @@ kQz
 pLr
 akn
 tWq
+uhu
+dKZ
 eWu
-dbg
-dbg
 xQX
 uXr
 jPp
@@ -136191,9 +137194,9 @@ qWI
 nFW
 ewv
 tWq
+dBD
+dne
 eWu
-dbg
-dbg
 rFJ
 sHm
 sHm
@@ -136448,9 +137451,9 @@ vRX
 cjE
 mWg
 tWq
+jJV
+noF
 eWu
-dbg
-gTA
 fZA
 sHm
 rNK
@@ -136704,9 +137707,9 @@ uCM
 wKu
 kAW
 uKe
-tWq
-eWu
-dbg
+fhi
+bHP
+fTW
 eWu
 vjb
 sHm
@@ -136961,8 +137964,8 @@ aUu
 grJ
 sHm
 wqU
-mhJ
-eWu
+tWq
+vty
 esB
 eWu
 hDf
@@ -137219,10 +138222,10 @@ tji
 sHm
 rcz
 mxo
-eWu
-dbg
+gvB
+szf
 ckQ
-vjb
+fmy
 sHm
 rNK
 jqn
@@ -137476,10 +138479,10 @@ tji
 iBp
 kFu
 iFb
-eWu
-dbg
+kyi
+gNP
 cjs
-vjb
+pcn
 sHm
 rNK
 jqn
@@ -138250,7 +139253,7 @@ bhm
 oWG
 kuZ
 cjs
-vjb
+dbg
 tjD
 rNK
 uSP
@@ -138507,7 +139510,7 @@ quK
 tWC
 ckm
 cjs
-vjb
+dbg
 tjD
 rNK
 uSP
@@ -138764,7 +139767,7 @@ tHB
 tWC
 kuZ
 cjs
-vjb
+dbg
 tjD
 rNK
 pkt
@@ -139021,7 +140024,7 @@ ezV
 uTR
 eoc
 cjs
-vjb
+dbg
 tjD
 rNK
 pkt
@@ -139278,7 +140281,7 @@ bmg
 tWC
 kuZ
 cjs
-vjb
+dbg
 tjD
 rNK
 pkt
@@ -139535,7 +140538,7 @@ tWC
 tWC
 vmW
 cjs
-vjb
+dbg
 tjD
 rNK
 uSP
@@ -139792,7 +140795,7 @@ gQP
 hcc
 omt
 cjs
-vjb
+dbg
 sHm
 rNK
 uSP
@@ -140027,17 +141030,17 @@ aXn
 aXn
 aXn
 aXn
-aXn
-aXn
-aXn
-aXn
-aXn
-aXn
-aXn
-aXn
-aXn
-aXn
-aXn
+tZz
+tZz
+tZz
+tZz
+tZz
+tZz
+tZz
+tZz
+tZz
+tZz
+tZz
 vpJ
 eST
 lJT
@@ -140049,7 +141052,7 @@ drE
 hcc
 fNi
 cjs
-vjb
+dbg
 sHm
 rNK
 rNK
@@ -140285,16 +141288,16 @@ aXn
 aXn
 aXn
 tZz
+wpx
+gul
+tEP
+ova
+rjY
+dXA
+vNU
+dls
+gzZ
 tZz
-tZz
-gzv
-gzv
-gzv
-tZz
-tZz
-aXn
-aXn
-aXn
 aXn
 eST
 eBn
@@ -140541,17 +141544,17 @@ aXn
 aXn
 aXn
 aXn
-gzv
+tZz
 dls
 bJX
 bKS
 tCc
 oKS
 oIS
+wUs
+dls
+gbD
 tZz
-aXn
-aXn
-aXn
 lXb
 eST
 ihT
@@ -140798,17 +141801,17 @@ cbU
 xbr
 hPZ
 aXn
-gzv
+tZz
 tHv
-tHv
-tHv
+lXj
+eiT
 vPZ
 kBo
 vPy
-gzv
-aXn
-aXn
-aXn
+vuR
+tdV
+kCn
+tZz
 lXb
 fka
 pXf
@@ -141055,17 +142058,17 @@ olv
 lvk
 diY
 aXn
-gzv
-tHv
-tHv
+tZz
+dWz
+yir
 bII
-iBP
+tCc
 aWx
 sJs
-gzv
-dhm
-diY
-aXn
+kvt
+dls
+jwf
+tZz
 vpJ
 vpJ
 wIS
@@ -141312,17 +142315,17 @@ oxv
 cbW
 crp
 oQP
-gzv
-tHv
-tHv
-tHv
+tZz
+bzF
+yir
+dls
 hIA
 rjY
 nQr
-gzv
-diY
+vcY
+dls
 iNr
-aXn
+tZz
 aXn
 rpW
 eST
@@ -141569,17 +142572,17 @@ jnV
 wPr
 wPr
 ecd
-gzv
-gzv
-gzv
-gzv
+tZz
+tZz
+lRe
+nQh
 qeR
-gzv
-gzv
-gzv
-qet
-wPr
-aXn
+tZz
+tZz
+tZz
+tZz
+tZz
+tZz
 aXn
 vpJ
 uOe
@@ -141827,13 +142830,13 @@ mBh
 hJd
 xMv
 jLv
-cJi
+kxb
 pno
 giA
 gZA
 xBq
 cJi
-jvi
+cJi
 bDc
 oow
 cJi
@@ -142287,20 +143290,20 @@ nGE
 qAO
 qNC
 rni
-vuM
+bmS
 seO
 bxN
 ipe
 tjS
 tGN
-bxN
+pLD
 dDG
 qqb
-bxN
-bxN
-bxN
+pLD
+pLD
+pLD
 wsO
-bxN
+pLD
 jlh
 xyk
 uZh
@@ -142546,7 +143549,7 @@ aZq
 rnv
 bmS
 bmS
-bmS
+xia
 vXn
 oGF
 tIP
@@ -146363,7 +147366,7 @@ iIK
 vkt
 gkc
 ayP
-aVD
+ojx
 fmI
 jho
 mAp
@@ -146618,9 +147621,9 @@ kda
 kda
 iIK
 vHL
-aov
+bTn
 ydF
-aVD
+ojx
 fmI
 fwV
 noO
@@ -146875,9 +147878,9 @@ iIX
 wnI
 cNc
 cSC
-aov
+bTn
 ydF
-aVD
+ojx
 eeI
 fxV
 fmI
@@ -146971,9 +147974,9 @@ gdn
 ccL
 vgt
 ruX
-ciV
+gtE
 sQj
-ciV
+gtE
 aQj
 lwE
 uKT
@@ -147132,7 +148135,7 @@ hZJ
 aGt
 hVN
 cSE
-aov
+bTn
 ayP
 dCE
 efv
@@ -147651,7 +148654,7 @@ syx
 efV
 sou
 vSw
-aov
+onO
 wEt
 alc
 rPi
@@ -150216,7 +151219,7 @@ rWb
 rWb
 rWb
 gRY
-iuR
+gRY
 hqL
 xaF
 rFn
@@ -154673,16 +155676,16 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+lQW
+lQW
+lQW
+lQW
+lQW
+lQW
+lQW
+lQW
+lQW
+lQW
 rNK
 rNK
 rNK
@@ -154930,16 +155933,16 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+lQW
+rNj
+xgy
+wme
+lji
+rEH
+wSV
+iQn
+kNT
+lQW
 rNK
 rNK
 rNK
@@ -155187,16 +156190,16 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+uRi
+pbs
+mfw
+uiT
+rhH
+xEE
+eoO
+ikd
+fko
+lQW
 rNK
 rNK
 rNK
@@ -155444,16 +156447,16 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+obF
+hHD
+cms
+akH
+iWH
+qau
+mim
+yiI
+rDF
+lQW
 rNK
 rNK
 rNK
@@ -155701,16 +156704,16 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+wQb
+ikd
+jcu
+uiT
+oGx
+jQs
+aER
+ikd
+gBE
+lQW
 rNK
 rNK
 rNK
@@ -155958,16 +156961,16 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+lQW
+pTE
+luI
+rbP
+lji
+eeA
+ozC
+ikd
+mTW
+lQW
 rNK
 rNK
 rNK
@@ -156215,29 +157218,29 @@ rNK
 rNK
 rNK
 rNK
+lQW
+lQW
+lQW
+lQW
+lQW
+lQW
+lQW
+lQW
+lQW
+lQW
 rNK
 rNK
 rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+lQW
+lQW
+lQW
+lQW
+lQW
+lQW
+lQW
 rNK
 rNK
 rNK
@@ -156488,13 +157491,13 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+lQW
+ikd
+oPM
+xEE
+eoO
+ikd
+lQW
 rNK
 rNK
 rNK
@@ -156745,13 +157748,13 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+lQW
+ikd
+kMH
+met
+mim
+yiI
+lQW
 rNK
 rNK
 rNK
@@ -157002,13 +158005,13 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+lQW
+lfo
+xeH
+jQs
+aER
+ckn
+lQW
 rNK
 rNK
 rNK
@@ -157259,13 +158262,13 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+lQW
+nPM
+bSK
+ixc
+jXO
+nPM
+lQW
 rNK
 rNK
 rNK
@@ -157516,13 +158519,13 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+lQW
+rbP
+bfF
+bfF
+bfF
+eKz
+lQW
 rNK
 rNK
 rNK
@@ -157773,13 +158776,13 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+lQW
+kzw
+oSB
+kle
+iox
+ycm
+lQW
 rNK
 rNK
 rNK
@@ -158030,13 +159033,13 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+lQW
+brv
+xdW
+xIi
+ikd
+fEP
+lQW
 rNK
 rNK
 rNK
@@ -158276,24 +159279,24 @@ rNK
 rNK
 rNK
 rNK
+kaL
+kaL
+kaL
+lQW
+lQW
+lQW
+kaL
+kaL
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+lQW
+lQW
+kkY
+xNN
+xNN
+lQW
+lQW
 rNK
 rNK
 rNK
@@ -158533,14 +159536,14 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+lQW
+cgq
+qij
+bGb
+wpw
+cTG
+lcQ
+kaL
 rNK
 rNK
 rNK
@@ -158790,14 +159793,14 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+lQW
+ghH
+ghH
+ghH
+kPg
+rbE
+fEc
+lQW
 rNK
 rNK
 rNK
@@ -159047,14 +160050,14 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+lQW
+ghH
+ghH
+mmi
+ewS
+vgF
+ute
+lQW
 rNK
 rNK
 rNK
@@ -159304,14 +160307,14 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+lQW
+ghH
+ghH
+ghH
+mlZ
+ikd
+rxE
+lQW
 rNK
 rNK
 rNK
@@ -159561,14 +160564,14 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
-rNK
+lQW
+lQW
+lQW
+lTq
+vGZ
+lQW
+lQW
+lQW
 rNK
 rNK
 rNK

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -1616,6 +1616,9 @@
 	c_tag = "Brig Labor Camp Airlock North";
 	dir = 8
 	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
 "ali" = (
@@ -2348,6 +2351,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/structure/cable/orange{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redfull"
 	},
@@ -2356,6 +2362,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redfull"
@@ -3180,14 +3189,14 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/orange{
-	icon_state = "0-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -4704,17 +4713,15 @@
 /turf/simulated/floor/carpet/black,
 /area/crew_quarters/captain)
 "aEV" = (
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "darkred"
 	},
-/area/hallway/primary/fore/west)
+/area/security/brig)
 "aEZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10370,8 +10377,12 @@
 /area/maintenance/port)
 "bjr" = (
 /obj/effect/decal/remains/mouse{
-	desc = "??????? ????,??????? ????????????? ??? ???????,????????? ???? ????. SQUEEK! ";
+	desc = "Останки Мыши, которая изжила себя, перестраивая эту станцию. SQUEEK! ";
 	name = "SQUEEK!"
+	},
+/obj/item/reagent_containers/food/snacks/cheesewedge{
+	pixel_x = -6;
+	pixel_y = 10
 	},
 /turf/simulated/floor/plating/asteroid/ancient/airless,
 /area/crew_quarters/captain)
@@ -16711,7 +16722,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "redcorner"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry/north)
 "bJo" = (
@@ -16920,7 +16931,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry/north)
 "bKd" = (
@@ -21160,7 +21171,9 @@
 /area/hallway/primary/port/south)
 "cac" = (
 /obj/structure/dispenser/oxygen,
-/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/port/south)
 "cak" = (
@@ -23092,7 +23105,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "bluered"
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry/south)
 "cko" = (
@@ -23117,8 +23130,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry/south)
 "ckp" = (
@@ -27331,8 +27344,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry/south)
 "cJy" = (
@@ -28928,8 +28941,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry/south)
 "cRQ" = (
@@ -32731,9 +32744,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
 "dqe" = (
@@ -32962,9 +32972,6 @@
 	},
 /area/hallway/primary/fore/west)
 "drw" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -37459,7 +37466,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "bluered"
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry/south)
 "eom" = (
@@ -37682,9 +37689,6 @@
 "eui" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
-	},
-/obj/structure/cable/orange{
-	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redfull"
@@ -39927,8 +39931,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry/south)
 "flS" = (
@@ -41422,24 +41426,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"fNi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
-	},
-/area/hallway/secondary/entry/south)
 "fNq" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1;
@@ -42444,10 +42430,12 @@
 /turf/simulated/floor/plating,
 /area/ntrep)
 "get" = (
-/obj/effect/decal/cleanable/cobweb,
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = 11
+	},
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/port/south)
@@ -43084,8 +43072,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry/south)
 "gqL" = (
@@ -46975,9 +46963,7 @@
 /area/maintenance/starboardaux)
 "hDf" = (
 /obj/structure/table/holotable/wood,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
+/turf/simulated/floor/carpet/royalblack,
 /area/hallway/secondary/entry/south)
 "hDL" = (
 /obj/structure/cable/orange{
@@ -48819,9 +48805,7 @@
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
+/turf/simulated/floor/carpet/royalblack,
 /area/hallway/secondary/entry/south)
 "ikM" = (
 /obj/item/gavelblock,
@@ -50067,8 +50051,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bluered"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry/south)
 "iHT" = (
@@ -53335,8 +53319,8 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry/south)
 "jJr" = (
@@ -55627,7 +55611,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "bluered"
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry/south)
 "kve" = (
@@ -57082,7 +57066,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry/north)
 "kUO" = (
@@ -62827,7 +62811,6 @@
 	dir = 1;
 	pixel_y = -28
 	},
-/obj/structure/sign/poster,
 /turf/simulated/wall/r_wall,
 /area/security/reception)
 "mVN" = (
@@ -62957,6 +62940,9 @@
 	},
 /obj/machinery/hologram/holopad,
 /obj/effect/landmark/start/security_officer,
+/obj/structure/cable/orange{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redfull"
 	},
@@ -63158,7 +63144,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/port2)
 "ncE" = (
@@ -66909,8 +66897,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry/south)
 "omG" = (
@@ -72662,7 +72650,9 @@
 	pixel_y = -32;
 	req_access = list(62)
 	},
-/turf/space,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/gateway)
 "qeU" = (
 /obj/structure/disposalpipe/segment{
@@ -76656,7 +76646,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/space,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/engine/gravitygenerator)
 "rvX" = (
 /obj/machinery/camera{
@@ -78418,7 +78410,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry/north)
 "rYs" = (
@@ -80912,6 +80904,9 @@
 	dir = 1;
 	pixel_y = 24
 	},
+/obj/structure/cable/orange{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -83263,7 +83258,9 @@
 	id_tag = "stationawaygate";
 	name = "Gateway Access Shutters"
 	},
-/turf/space,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/gateway)
 "tGD" = (
 /obj/machinery/door/poddoor/shutters{
@@ -87740,9 +87737,7 @@
 /obj/structure/chair/comfy/brown{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
+/turf/simulated/floor/carpet/royalblack,
 /area/hallway/secondary/entry/south)
 "vjg" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -87928,7 +87923,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "bluered"
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry/south)
 "vnl" = (
@@ -89292,9 +89287,6 @@
 "vKV" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
-	},
-/obj/structure/cable/orange{
-	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -114954,7 +114946,7 @@ dpu
 dpu
 dpu
 dBZ
-uOX
+aEV
 uOX
 juF
 poM
@@ -117028,7 +117020,7 @@ xla
 xla
 drG
 dMP
-aEV
+aWJ
 jQC
 oac
 xYR
@@ -140265,7 +140257,7 @@ chE
 rAi
 drE
 hcc
-fNi
+kuZ
 cjs
 dbg
 sHm

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -38187,15 +38187,6 @@
 	slowdown = -0.3
 	},
 /area/hallway/spacebridge/comeng)
-"eCx" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = 31
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkred"
-	},
-/area/security/warden)
 "eCB" = (
 /obj/machinery/status_display{
 	layer = 4
@@ -42853,15 +42844,6 @@
 /obj/effect/landmark/ninja_teleport,
 /turf/simulated/floor/plating,
 /area/maintenance/electrical_shop)
-"gjR" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = 31
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkred"
-	},
-/area/security/brig)
 "gkc" = (
 /obj/structure/chair{
 	dir = 4
@@ -47766,6 +47748,15 @@
 /obj/item/clothing/glasses/meson,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/north)
+"hQa" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/security/prison/cell_block/A)
 "hQg" = (
 /obj/structure/table,
 /obj/item/eftpos,
@@ -53528,6 +53519,14 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/central)
+"jNa" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/effect/decal/warning_stripes/red/hollow,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/simulated/floor/plasteel,
+/area/security/prisonlockers)
 "jNj" = (
 /obj/machinery/door/airlock{
 	id_tag = "toilet2";
@@ -63187,7 +63186,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "ndd" = (
@@ -77806,6 +77804,15 @@
 	icon_state = "dark"
 	},
 /area/medical/cmo)
+"rOS" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = 31
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkred"
+	},
+/area/security/brig)
 "rOX" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -80341,6 +80348,15 @@
 	icon_state = "dark"
 	},
 /area/library)
+"sFw" = (
+/obj/item/radio/intercom{
+	pixel_y = 22
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkred"
+	},
+/area/security/brig)
 "sFF" = (
 /obj/effect/landmark/event/lightsout,
 /turf/simulated/floor/transparent/glass/reinforced{
@@ -82949,15 +82965,6 @@
 	icon_state = "redyellowfull"
 	},
 /area/crew_quarters/bar)
-"tAV" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/security/prison/cell_block/A)
 "tAX" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Walkway"
@@ -83325,14 +83332,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/fsmaint4)
-"tIl" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/effect/decal/warning_stripes/red/hollow,
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/simulated/floor/plasteel,
-/area/security/prisonlockers)
 "tIo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -83778,6 +83777,15 @@
 	icon_state = "browncorner"
 	},
 /area/quartermaster/qm)
+"tPK" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = 31
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkred"
+	},
+/area/security/warden)
 "tPP" = (
 /obj/structure/chair/comfy/brown,
 /turf/simulated/floor/carpet,
@@ -89998,15 +90006,6 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/aft/west)
-"vVq" = (
-/obj/item/radio/intercom{
-	pixel_y = 22
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkred"
-	},
-/area/security/brig)
 "vVt" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/firealarm{
@@ -112029,7 +112028,7 @@ amM
 xQS
 jYY
 arp
-tIl
+jNa
 xQS
 djS
 bqV
@@ -112545,7 +112544,7 @@ kia
 cVO
 ykj
 xQS
-vVq
+sFw
 bqV
 dtr
 xrZ
@@ -113830,7 +113829,7 @@ xQS
 apf
 xQS
 xQS
-gjR
+rOS
 bqV
 dpu
 lfN
@@ -114877,7 +114876,7 @@ poM
 nop
 poM
 pJG
-tAV
+hQa
 eWZ
 eWZ
 cFf
@@ -115372,7 +115371,7 @@ xNI
 afd
 afd
 afd
-gjR
+rOS
 qeE
 dtp
 dtP
@@ -117700,7 +117699,7 @@ bKt
 era
 dxP
 rJj
-eCx
+tPK
 reB
 coj
 crU

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -1240,7 +1240,7 @@
 /obj/item/pickaxe,
 /obj/structure/rack,
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/mine/unexplored/cere/command)
+/area/security/execution)
 "ajJ" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "cell1";
@@ -1620,10 +1620,14 @@
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
 "alh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/orange{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
@@ -3976,11 +3980,11 @@
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/fsmaint4)
 "ayT" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	dir = 1;
 	icon_state = "vault"
 	},
 /area/engine/mechanic_workshop/hangar)
@@ -8504,6 +8508,7 @@
 	c_tag = "Rehabilitation Dome West 1";
 	dir = 4
 	},
+/obj/item/reagent_containers/glass/bucket/wooden,
 /turf/simulated/floor/grass,
 /area/hallway/secondary/garden)
 "bbo" = (
@@ -9588,12 +9593,6 @@
 /turf/simulated/floor/plasteel{
 	dir = 7;
 	icon_state = "yellow"
-	},
-/area/hallway/primary/central)
-"bgc" = (
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
 "bgd" = (
@@ -12879,10 +12878,7 @@
 	dir = 1;
 	icon_state = "pipe-j2"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutral"
-	},
+/turf/simulated/floor/plasteel,
 /area/hallway/primary/port/south)
 "btP" = (
 /obj/structure/cable/orange{
@@ -18291,7 +18287,7 @@
 "bPf" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitered"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "bPi" = (
@@ -22342,8 +22338,8 @@
 	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/east)
 "cfW" = (
@@ -26616,7 +26612,10 @@
 "cFZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/entry/south)
 "cGa" = (
 /obj/structure/cable/orange{
@@ -26973,7 +26972,7 @@
 /turf/simulated/floor/grass,
 /area/hallway/secondary/garden)
 "cHY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -31596,8 +31595,8 @@
 	},
 /area/solar/starboard)
 "dhs" = (
-/turf/simulated/floor/plating/asteroid/ancient/airless,
-/area/space)
+/turf/simulated/wall,
+/area/security/execution)
 "dht" = (
 /obj/effect/landmark/honk_squad,
 /turf/simulated/floor/shuttle,
@@ -32622,7 +32621,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/entry/south)
 "doL" = (
 /obj/structure/cable/orange{
@@ -32695,7 +32697,7 @@
 /obj/item/shovel,
 /obj/item/shovel,
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/mine/unexplored/cere/command)
+/area/security/execution)
 "dpl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
@@ -32796,12 +32798,8 @@
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
 "dqb" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
 "dqe" = (
@@ -33043,7 +33041,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/mine/unexplored/cere/command)
+/area/security/execution)
 "drA" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -35753,9 +35751,6 @@
 	},
 /area/quartermaster/office)
 "dKK" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkyellow"
@@ -37026,7 +37021,7 @@
 /area/maintenance/fsmaint3)
 "egm" = (
 /turf/simulated/wall/r_wall,
-/area/mine/unexplored/cere/medical)
+/area/hallway/primary/starboard/south)
 "egq" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -37410,10 +37405,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutral"
-	},
+/turf/simulated/floor/plasteel,
 /area/hallway/primary/port/south)
 "emA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -37470,7 +37462,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/entry/south)
 "enS" = (
 /obj/structure/cable/orange{
@@ -40628,7 +40623,10 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/hallway/primary/fore/east)
 "fxg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -41248,7 +41246,10 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/entry/south)
 "fHy" = (
 /obj/machinery/door/airlock/public/glass{
@@ -41867,15 +41868,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
-"fSQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "vault"
-	},
-/area/engine/mechanic_workshop/hangar)
 "fSS" = (
 /obj/machinery/treadmill_monitor{
 	id = "Cell 8";
@@ -42021,7 +42013,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/entry/south)
 "fVX" = (
 /obj/effect/spawner/window/reinforced,
@@ -42347,6 +42342,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -46368,8 +46366,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/east)
 "hsS" = (
@@ -50000,8 +49998,8 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/kitchen)
 "iFs" = (
-/turf/simulated/wall,
-/area/mine/unexplored/cere/research)
+/turf/simulated/floor/plating/asteroid/ancient,
+/area/security/execution)
 "iFv" = (
 /obj/structure/extinguisher_cabinet{
 	name = "custom placement";
@@ -51610,7 +51608,7 @@
 "jgj" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall,
-/area/security/processing)
+/area/security/brig)
 "jgl" = (
 /obj/machinery/camera{
 	c_tag = "Research Toxins Mixing East";
@@ -52036,10 +52034,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutral"
-	},
+/turf/simulated/floor/plasteel,
 /area/hallway/primary/port/south)
 "jng" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -52079,7 +52074,7 @@
 "jnR" = (
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whitered"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "jnV" = (
@@ -53547,7 +53542,7 @@
 "jKO" = (
 /obj/structure/mineral_door/iron,
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/mine/unexplored/cere/command)
+/area/security/execution)
 "jLd" = (
 /turf/simulated/floor/carpet/purple,
 /area/toxins/rdoffice)
@@ -54987,8 +54982,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/east)
 "kiO" = (
@@ -55782,7 +55777,10 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/entry/south)
 "kwd" = (
 /obj/item/assembly/mousetrap/armed,
@@ -56002,8 +56000,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/east)
 "kzq" = (
@@ -57257,8 +57255,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/east)
 "kVq" = (
@@ -58819,8 +58817,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/east)
 "lwE" = (
@@ -59266,7 +59264,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/entry/south)
 "lDZ" = (
 /obj/machinery/light,
@@ -60325,8 +60326,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/east)
 "lYt" = (
@@ -60636,8 +60637,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/east)
 "mcM" = (
@@ -60802,8 +60803,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/east)
 "mfG" = (
@@ -61277,8 +61278,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/spacebridge/medcargo)
 "moB" = (
@@ -62675,8 +62676,17 @@
 	},
 /area/storage/primary)
 "mPI" = (
-/turf/simulated/wall/r_wall,
-/area/mine/unexplored/cere/cargo)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/port/south)
 "mPT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -62959,9 +62969,14 @@
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology)
 "mVm" = (
-/obj/effect/spawner/random_spawners/wall_rusted_probably,
-/turf/simulated/wall,
-/area/mine/unexplored/cere/cargo)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/port/south)
 "mVA" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -64048,8 +64063,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/east)
 "noU" = (
@@ -64085,7 +64100,7 @@
 "npl" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "npq" = (
@@ -65222,7 +65237,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/entry/south)
 "nGL" = (
 /obj/machinery/light{
@@ -66291,7 +66309,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "nZm" = (
@@ -66308,8 +66326,16 @@
 /turf/simulated/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "nZp" = (
-/turf/simulated/wall,
-/area/space)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/port/south)
 "nZG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -68415,13 +68441,12 @@
 /obj/structure/table/wood,
 /obj/machinery/keycard_auth{
 	pixel_x = 1;
-	pixel_y = 9
+	pixel_y = 8
 	},
 /obj/machinery/door_control{
 	id = "Secure Gate";
 	name = "Brig Lockdown";
-	pixel_x = 1;
-	pixel_y = -4;
+	pixel_y = -3;
 	req_access = list(2)
 	},
 /obj/structure/cable/orange{
@@ -71483,9 +71508,6 @@
 	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
-"pJd" = (
-/turf/simulated/mineral/ancient,
-/area/security/podbay)
 "pJe" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -77254,9 +77276,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/southwest)
-"rBH" = (
-/turf/simulated/wall/r_wall,
-/area/mine/unexplored/cere/command)
 "rBO" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -82780,8 +82799,8 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutral"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
 /area/hallway/primary/port/north)
 "trc" = (
@@ -86485,7 +86504,7 @@
 /obj/structure/closet/crate/can,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whitered"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "uEu" = (
@@ -86636,7 +86655,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitered"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "uHm" = (
@@ -87224,7 +87243,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "uRn" = (
@@ -89733,11 +89752,12 @@
 	},
 /area/hallway/primary/port/south)
 "vLR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 4;
+	icon_state = "vault"
 	},
 /area/engine/mechanic_workshop/hangar)
 "vLS" = (
@@ -91527,7 +91547,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/mine/unexplored/cere/command)
+/area/security/execution)
 "woU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/bluespace_beacon,
@@ -92117,7 +92137,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/spacebridge/dockmed)
 "wxd" = (
@@ -92730,10 +92750,6 @@
 	icon_state = "bcircuit"
 	},
 /area/turret_protected/aisat_interior/secondary)
-"wEY" = (
-/obj/effect/spawner/random_spawners/wall_rusted_maybe,
-/turf/simulated/wall,
-/area/mine/unexplored/cere/research)
 "wFa" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/item/radio/intercom{
@@ -95008,7 +95024,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/entry/south)
 "xud" = (
 /obj/item/grown/bananapeel{
@@ -95416,10 +95435,6 @@
 	icon_state = "white"
 	},
 /area/medical/patients_rooms)
-"xAG" = (
-/obj/effect/spawner/random_spawners/wall_rusted_maybe,
-/turf/simulated/wall,
-/area/mine/unexplored/cere/engineering)
 "xAI" = (
 /obj/structure/window/reinforced,
 /obj/effect/decal/warning_stripes/west,
@@ -96097,7 +96112,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/mine/unexplored/cere/command)
+/area/security/execution)
 "xNk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -96334,7 +96349,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/hallway/secondary/entry/south)
 "xSC" = (
 /obj/machinery/firealarm{
@@ -106622,7 +106640,7 @@ sji
 dvS
 sji
 cRv
-ivS
+yhW
 bzh
 nxA
 nxA
@@ -110878,7 +110896,7 @@ cuy
 cvs
 vyU
 cxd
-iFs
+cen
 ccW
 ccW
 rWw
@@ -111136,7 +111154,7 @@ jiS
 sJg
 htc
 odu
-iFs
+cen
 ccW
 rWw
 rNK
@@ -111393,7 +111411,7 @@ jiS
 wsR
 cen
 dkC
-wEY
+odu
 ccW
 rWw
 rWw
@@ -111650,7 +111668,7 @@ jiS
 hkG
 czM
 sJg
-wEY
+odu
 ccW
 ccW
 rWw
@@ -111907,7 +111925,7 @@ lZz
 sJg
 kFc
 nLO
-iFs
+cen
 ccW
 ccW
 rWw
@@ -112252,10 +112270,10 @@ rNK
 rNK
 rNK
 cRv
-dqw
+abW
 mCL
 mCL
-dqw
+mCL
 mCL
 mCL
 gby
@@ -112517,7 +112535,7 @@ dun
 akD
 ali
 amM
-xQS
+mCL
 jYY
 arp
 jNa
@@ -113280,7 +113298,7 @@ cRv
 abW
 abW
 abW
-ivS
+dhs
 mCL
 mCL
 mCL
@@ -113537,9 +113555,9 @@ cRv
 abW
 vva
 abW
-ivS
+dhs
 xNi
-vva
+iFs
 drz
 mCL
 epY
@@ -113549,7 +113567,7 @@ mCL
 mgY
 cVO
 qvm
-gmC
+xQS
 sPq
 auq
 dpu
@@ -113795,9 +113813,9 @@ abW
 vva
 woS
 jKO
-vva
-vva
-vva
+iFs
+iFs
+iFs
 dUJ
 epY
 aeK
@@ -114050,9 +114068,9 @@ cRv
 abW
 adh
 vva
-rBH
-rBH
-vva
+mCL
+mCL
+iFs
 dph
 ajI
 mCL
@@ -114076,7 +114094,7 @@ dpu
 dpu
 dpu
 oam
-gmC
+gop
 gop
 vXY
 tgN
@@ -114314,12 +114332,12 @@ afd
 afd
 afd
 afd
-mCL
+afd
 afd
 afd
 xQS
 apf
-afd
+xQS
 xQS
 rOS
 bqV
@@ -114408,13 +114426,13 @@ bIa
 oUG
 oUG
 gFn
-oUG
+mPI
 btN
 jmF
 emo
-oUG
-oUG
-oUG
+mVm
+mVm
+nZp
 oUG
 oUG
 oUG
@@ -120013,7 +120031,7 @@ sFj
 kxI
 gGF
 gGF
-dhs
+abE
 rNK
 rNK
 rNK
@@ -120270,7 +120288,7 @@ iuy
 foN
 gGF
 abE
-dhs
+abE
 rNK
 rNK
 rNK
@@ -121552,8 +121570,8 @@ gGF
 gGF
 gGF
 gGF
-pJd
-pJd
+gGF
+gGF
 cRv
 rNK
 rNK
@@ -125512,7 +125530,7 @@ tuF
 izC
 ccW
 mHk
-wEY
+odu
 eBj
 wsR
 cdQ
@@ -125769,9 +125787,9 @@ rWf
 izC
 ccW
 ccW
-iFs
-wEY
-wEY
+cen
+odu
+odu
 czQ
 wsR
 hCC
@@ -126028,7 +126046,7 @@ ccW
 ccW
 ccW
 ccW
-iFs
+cen
 ccW
 ccW
 rfn
@@ -128270,7 +128288,7 @@ csk
 boY
 bqn
 brV
-bgc
+csk
 plG
 lMC
 bxt
@@ -133597,7 +133615,7 @@ apw
 xkY
 cDp
 cRv
-ivS
+cDp
 cRv
 cRv
 cRv
@@ -138043,12 +138061,12 @@ aXR
 aXR
 aXR
 aXR
-aYg
-xAG
-xAG
+mJM
+aKI
+aKI
 aXR
-aYg
-aYg
+mJM
+mJM
 aKI
 mkk
 mkk
@@ -138306,8 +138324,8 @@ aXR
 aXR
 aXR
 aXR
-xAG
-aYg
+aKI
+mJM
 aXR
 aXR
 aXR
@@ -143630,8 +143648,8 @@ alc
 rzh
 rzh
 ftx
-lCC
-lCC
+ftx
+ftx
 aRx
 aRx
 lCC
@@ -143741,8 +143759,8 @@ wbw
 ckt
 nqK
 jvZ
-ueH
-dLJ
+jvZ
+urT
 xYC
 afX
 xXq
@@ -143998,8 +144016,8 @@ dKK
 ueH
 rpR
 jvZ
-ayT
-fSQ
+ueH
+dLJ
 bJG
 afX
 xXq
@@ -144256,7 +144274,7 @@ bQJ
 bXw
 bQY
 vLR
-urT
+ayT
 eGP
 afX
 cCc
@@ -144502,7 +144520,7 @@ dmf
 afX
 afX
 afX
-bOj
+aXn
 afX
 afX
 afX
@@ -145691,8 +145709,8 @@ any
 hVN
 rLt
 any
-aRx
-wRL
+any
+qIF
 iIK
 iIK
 iIK
@@ -146226,7 +146244,7 @@ alc
 alc
 alc
 alc
-mPI
+rPi
 gRY
 ltQ
 lVT
@@ -146482,7 +146500,7 @@ mAp
 mAp
 mAp
 alc
-mPI
+rPi
 gsO
 kUP
 ltY
@@ -146739,7 +146757,7 @@ mAp
 dSG
 mAp
 alc
-mPI
+rPi
 gsO
 mQx
 luh
@@ -148302,7 +148320,7 @@ aZM
 aZM
 aZM
 aZM
-aZN
+fqw
 vHH
 iFS
 qpx
@@ -148559,7 +148577,7 @@ fMl
 aZM
 aZM
 aZM
-aZN
+fqw
 vHH
 kuE
 gFg
@@ -148816,7 +148834,7 @@ fMl
 fMl
 aZM
 aZM
-aZN
+fqw
 aKx
 kuE
 qqj
@@ -149330,7 +149348,7 @@ lwN
 fMl
 aZM
 aZM
-aZN
+fqw
 jEq
 kuE
 aKx
@@ -149416,7 +149434,7 @@ ckw
 aXn
 aXn
 aXn
-mic
+cdT
 pWu
 uut
 fJJ
@@ -150320,7 +150338,7 @@ wtU
 woa
 gFv
 eib
-rWb
+qIF
 rWb
 rWb
 rWb
@@ -150577,7 +150595,7 @@ iss
 iDV
 gFv
 ahj
-rWb
+qIF
 rWb
 rWb
 rWb
@@ -150615,7 +150633,7 @@ lzH
 lzH
 fMl
 aZM
-aZN
+fqw
 gSQ
 iFS
 fqw
@@ -150834,7 +150852,7 @@ aMq
 qsY
 aOl
 pLN
-rWb
+qIF
 rWb
 rWb
 rWb
@@ -150872,7 +150890,7 @@ lzH
 fMl
 fMl
 aZM
-aZN
+fqw
 xmU
 iFS
 itf
@@ -151091,7 +151109,7 @@ aMn
 glZ
 tKN
 sHS
-rWb
+qIF
 rWb
 rWb
 rWb
@@ -151348,7 +151366,7 @@ uKL
 eRg
 cqo
 cvp
-gRY
+any
 gRY
 gRY
 rWb
@@ -151605,7 +151623,7 @@ uKL
 any
 any
 any
-gRY
+any
 rWb
 rWb
 rWb
@@ -152126,7 +152144,7 @@ rFn
 eiP
 rFn
 rFn
-mVm
+nPE
 alc
 alc
 hFo
@@ -156022,11 +156040,11 @@ aZM
 fqw
 gMK
 bns
-nZp
+fqw
 jqn
 cKd
 jqn
-nZp
+fqw
 aZM
 aZM
 aZM
@@ -156303,7 +156321,7 @@ lCV
 pLU
 kZm
 dQj
-rNK
+fMl
 fMl
 rNK
 rNK

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -15995,7 +15995,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -312,7 +312,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "acb" = (
@@ -1369,7 +1369,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "akq" = (
@@ -1938,7 +1938,7 @@
 /area/security/execution)
 "amN" = (
 /obj/machinery/firealarm{
-	dir = 4;
+	dir = 8;
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
@@ -2463,7 +2463,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "apI" = (
@@ -2739,7 +2739,7 @@
 	icon_state = "plant-22"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "arC" = (
@@ -3011,8 +3011,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "atr" = (
@@ -3065,7 +3065,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/aft/west)
 "atJ" = (
@@ -3184,8 +3184,8 @@
 /obj/structure/cable/orange{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"
@@ -4268,10 +4268,7 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
+/turf/simulated/floor/plasteel,
 /area/hallway/primary/port/south)
 "aBA" = (
 /obj/machinery/status_display{
@@ -5100,7 +5097,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "aIg" = (
@@ -5684,8 +5681,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "aMC" = (
@@ -6332,7 +6328,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit)
 "aQl" = (
@@ -7375,7 +7372,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "aWi" = (
@@ -7524,7 +7521,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "aWL" = (
@@ -7701,8 +7698,8 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "aXs" = (
@@ -7911,8 +7908,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/turf_decal/caution/red,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/spacebridge/comeng)
 "aYQ" = (
@@ -7962,7 +7959,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "aZa" = (
@@ -7984,7 +7981,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "aZc" = (
@@ -8216,8 +8214,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "bam" = (
@@ -8268,7 +8266,7 @@
 "baq" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "bau" = (
@@ -8401,7 +8399,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "baP" = (
@@ -8740,7 +8738,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/turret_protected/aisat_interior)
 "bct" = (
@@ -8812,8 +8811,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "bcD" = (
@@ -8839,15 +8838,15 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "bcG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/turret_protected/aisat_interior)
 "bcH" = (
@@ -8887,7 +8886,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/north)
 "bcS" = (
@@ -8898,7 +8897,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/north)
 "bcT" = (
@@ -9114,7 +9113,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "bek" = (
@@ -9128,7 +9127,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "bel" = (
@@ -9147,7 +9146,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
 "bem" = (
@@ -9177,7 +9177,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
 "bep" = (
@@ -9190,7 +9191,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "bes" = (
@@ -9262,7 +9263,7 @@
 "beB" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/north)
 "beE" = (
@@ -9322,7 +9323,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "beY" = (
@@ -9670,7 +9671,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "bgl" = (
@@ -9785,7 +9786,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/north)
 "bgt" = (
@@ -9812,7 +9813,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/north)
 "bgv" = (
@@ -9838,7 +9839,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/north)
 "bgx" = (
@@ -9962,8 +9963,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "bhg" = (
@@ -10102,8 +10103,8 @@
 	name = "Central Access"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "bhW" = (
@@ -10391,7 +10392,7 @@
 	pixel_y = 10
 	},
 /turf/simulated/floor/plating/asteroid/ancient/airless,
-/area/crew_quarters/captain)
+/area/bridge)
 "bjs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -10582,7 +10583,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/turret_protected/aisat_interior)
 "bkk" = (
@@ -10613,8 +10615,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/turret_protected/aisat_interior)
 "bkp" = (
@@ -10785,8 +10787,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "blk" = (
@@ -10849,7 +10851,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "blw" = (
@@ -11090,12 +11092,20 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/hallway/primary/starboard/south)
+"bmQ" = (
+/obj/machinery/alarm{
+	pixel_y = 27
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "bmR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "bmS" = (
@@ -11496,15 +11506,6 @@
 	icon_state = "neutral"
 	},
 /area/storage/primary)
-"boJ" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/port/east)
 "boL" = (
 /obj/machinery/door/airlock/glass{
 	name = "Primary Tool Storage"
@@ -11536,7 +11537,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "boY" = (
@@ -11546,7 +11547,8 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
 "boZ" = (
@@ -11623,7 +11625,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
 /area/hallway/primary/central)
 "bpm" = (
 /obj/machinery/camera{
@@ -11637,7 +11642,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "bps" = (
@@ -12285,8 +12290,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "brN" = (
@@ -12297,8 +12301,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "brO" = (
@@ -12310,8 +12313,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "brT" = (
@@ -12332,8 +12334,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "brU" = (
@@ -12351,8 +12352,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "brV" = (
@@ -12365,7 +12365,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/hallway/primary/central)
 "brW" = (
 /obj/structure/cable{
@@ -12465,7 +12468,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
 /area/hallway/primary/central)
 "bsi" = (
 /obj/structure/cable{
@@ -12476,8 +12481,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "bsj" = (
@@ -12492,8 +12496,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "bsl" = (
@@ -12502,8 +12505,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "bso" = (
@@ -12515,8 +12517,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "bst" = (
@@ -12696,7 +12697,7 @@
 "bto" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "btp" = (
@@ -12879,7 +12880,8 @@
 	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "btP" = (
@@ -13015,7 +13017,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "buE" = (
@@ -13399,7 +13402,8 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/turret_protected/aisat_interior)
 "bvU" = (
@@ -13696,7 +13700,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "bxo" = (
@@ -13863,7 +13868,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "bxN" = (
@@ -13973,7 +13978,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "byn" = (
@@ -14674,7 +14679,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "bBF" = (
@@ -15002,8 +15008,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "bDh" = (
@@ -15378,8 +15384,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/turret_protected/aisat_interior)
 "bEL" = (
@@ -15529,7 +15535,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "bFi" = (
@@ -16403,7 +16409,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "bIb" = (
@@ -16725,7 +16732,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "bJo" = (
@@ -17382,6 +17389,9 @@
 /turf/simulated/floor/carpet/green,
 /area/library)
 "bLL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/carpet{
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "carpet7-3"
@@ -17690,7 +17700,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "bNf" = (
@@ -18665,7 +18675,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "bQG" = (
@@ -19247,8 +19258,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/turret_protected/aisat_interior)
 "bSD" = (
@@ -19659,7 +19670,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "bUf" = (
@@ -19855,7 +19866,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "bUN" = (
@@ -20734,7 +20745,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "bYa" = (
@@ -20794,7 +20806,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "bYw" = (
@@ -20986,7 +20998,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "bZf" = (
@@ -21145,7 +21158,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "bZZ" = (
@@ -21246,7 +21259,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/turret_protected/aisat_interior)
 "caL" = (
@@ -21289,8 +21303,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/turret_protected/aisat_interior)
 "caX" = (
@@ -21318,7 +21332,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "cbe" = (
@@ -21332,7 +21346,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "cbf" = (
@@ -21352,7 +21366,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "cbl" = (
@@ -21382,7 +21396,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "cbw" = (
@@ -22916,7 +22930,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "cjw" = (
@@ -22992,7 +23006,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry)
 "cjJ" = (
@@ -23139,7 +23154,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry)
 "ckq" = (
@@ -23153,7 +23169,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry)
 "ckr" = (
@@ -23167,7 +23184,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry)
 "ckt" = (
@@ -23184,7 +23202,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry)
 "ckw" = (
@@ -23328,7 +23347,7 @@
 "clB" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "clH" = (
@@ -23337,7 +23356,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "clO" = (
@@ -23403,7 +23422,10 @@
 	name = "Central Access"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "cmr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -23589,7 +23611,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/security/lobby)
 "cnJ" = (
 /obj/machinery/ai_status_display,
@@ -23947,7 +23972,10 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "cpQ" = (
 /obj/structure/closet/firecloset/full,
@@ -24388,6 +24416,12 @@
 "csh" = (
 /turf/simulated/wall,
 /area/hallway/spacebridge/comeng)
+"csk" = (
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
+	},
+/area/hallway/primary/central)
 "css" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/meson,
@@ -24489,7 +24523,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/security/lobby)
 "ctd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -24836,7 +24873,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "cvr" = (
@@ -24905,17 +24942,11 @@
 	},
 /area/security/reception)
 "cwf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/arrow{
-	dir = 4
-	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "dark"
 	},
-/area/hallway/primary/aft/west)
+/area/security/brig)
 "cwh" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -24941,7 +24972,10 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/security/lobby)
 "cwq" = (
 /obj/structure/sign/directions/evac{
@@ -25011,7 +25045,10 @@
 /area/security/hos)
 "cxb" = (
 /obj/structure/railing,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/security/lobby)
 "cxc" = (
 /obj/structure/cable/orange{
@@ -25049,7 +25086,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/security/lobby)
 "cxf" = (
 /obj/structure/table/reinforced,
@@ -25266,7 +25306,9 @@
 /area/maintenance/disposal/south)
 "cyx" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "cyI" = (
 /obj/structure/cable/orange{
@@ -25783,7 +25825,10 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/security/lobby)
 "cBL" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -25792,7 +25837,10 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/security/lobby)
 "cBM" = (
 /obj/structure/cable/orange{
@@ -25981,7 +26029,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "cCK" = (
@@ -25992,7 +26041,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "cCP" = (
@@ -26168,7 +26217,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "cEl" = (
@@ -26222,7 +26271,10 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/security/lobby)
 "cEP" = (
 /obj/structure/chair,
@@ -26361,10 +26413,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/obj/machinery/door_timer/cell_6{
-	pixel_x = 0;
-	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
@@ -27082,8 +27130,8 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 5;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "cIJ" = (
@@ -27095,7 +27143,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "cIL" = (
@@ -27104,7 +27152,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "cIO" = (
@@ -27237,8 +27285,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "cJm" = (
@@ -27276,8 +27324,8 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "cJq" = (
@@ -27289,7 +27337,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "cJr" = (
@@ -27370,7 +27418,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry)
 "cJC" = (
@@ -27446,8 +27494,8 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "cJP" = (
@@ -27469,7 +27517,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "cJU" = (
@@ -27488,7 +27536,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "cJX" = (
@@ -27508,8 +27556,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "cKd" = (
@@ -27684,7 +27732,10 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/security/lobby)
 "cLA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -28139,6 +28190,12 @@
 	},
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/theatre)
+"cNE" = (
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/entry/south)
 "cNG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
@@ -28732,7 +28789,8 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit)
 "cQy" = (
@@ -30089,7 +30147,8 @@
 /area/maintenance/fore)
 "cWn" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "cWq" = (
@@ -30162,8 +30221,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "cWO" = (
@@ -30183,8 +30241,7 @@
 /area/hallway/primary/fore/west)
 "cWQ" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "cWT" = (
@@ -30192,8 +30249,8 @@
 /area/hallway/spacebridge/engmed)
 "cWU" = (
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "cWX" = (
@@ -30236,7 +30293,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "cXk" = (
@@ -30269,8 +30326,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/turret_protected/aisat_interior)
 "cXC" = (
@@ -30327,7 +30384,8 @@
 /area/solar/auxstarboard)
 "cXU" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/turret_protected/aisat_interior)
 "cXW" = (
@@ -30352,7 +30410,7 @@
 /obj/effect/turf_decal/caution/red,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/spacebridge/comeng)
 "cYa" = (
@@ -30361,7 +30419,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "cYb" = (
@@ -30370,7 +30428,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "cYe" = (
@@ -30661,7 +30719,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry)
 "dbg" = (
@@ -30758,7 +30817,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "dcK" = (
@@ -31657,7 +31717,9 @@
 /area/hallway/secondary/entry/north)
 "diZ" = (
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
 /area/hallway/secondary/entry/south)
 "djc" = (
 /obj/structure/disposalpipe/segment,
@@ -31672,7 +31734,7 @@
 	name = "custom placement";
 	pixel_y = -27
 	},
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/decal/warning_stripes/arrow{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -31872,7 +31934,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry)
 "dkd" = (
@@ -32107,7 +32170,8 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/security/lobby)
 "dlj" = (
@@ -32144,7 +32208,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/security/lobby)
 "dlq" = (
@@ -32222,7 +32286,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "dlG" = (
@@ -32421,7 +32485,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "dmW" = (
@@ -32839,8 +32903,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/aft/west)
 "dqM" = (
@@ -32871,7 +32935,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "dra" = (
@@ -33082,7 +33146,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/spacebridge/engmed)
 "drU" = (
@@ -33658,7 +33722,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "dvi" = (
@@ -33677,7 +33741,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "dvt" = (
@@ -34107,7 +34171,7 @@
 "dxM" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "dxN" = (
@@ -34161,8 +34225,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "dyn" = (
@@ -34646,8 +34709,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+	dir = 1;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "dzU" = (
@@ -34668,8 +34731,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/spacebridge/engmed)
 "dzV" = (
@@ -34692,8 +34754,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+	dir = 1;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "dAd" = (
@@ -34763,8 +34825,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+	dir = 1;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "dAk" = (
@@ -34802,8 +34864,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+	dir = 1;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "dAv" = (
@@ -34811,8 +34873,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+	dir = 1;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "dAw" = (
@@ -34835,8 +34897,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+	dir = 1;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "dAD" = (
@@ -34856,8 +34918,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+	dir = 1;
+	icon_state = "neutral"
 	},
 /area/hallway/spacebridge/cargocom)
 "dAF" = (
@@ -34911,7 +34973,8 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "dAX" = (
@@ -35162,7 +35225,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/aft/west)
 "dBZ" = (
@@ -36026,7 +36089,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/aft/west)
 "dOk" = (
@@ -36383,7 +36446,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "dTd" = (
@@ -37348,7 +37411,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "emA" = (
@@ -37619,7 +37683,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "esB" = (
@@ -37714,7 +37778,8 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 10;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "evc" = (
@@ -37757,7 +37822,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "evG" = (
@@ -37774,7 +37839,7 @@
 /area/toxins/xenobiology)
 "evL" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "evM" = (
@@ -37817,13 +37882,13 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "ewM" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "ewR" = (
@@ -37832,7 +37897,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8
+	dir = 8;
+	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/fore/west)
 "exF" = (
@@ -37854,7 +37920,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8
+	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/fore/west)
 "exK" = (
@@ -37925,7 +37991,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "ezU" = (
@@ -37969,7 +38035,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "eAq" = (
@@ -37989,7 +38055,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "eAS" = (
@@ -38112,7 +38178,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "eCT" = (
@@ -38148,7 +38214,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "eDm" = (
@@ -38158,7 +38224,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "eDx" = (
@@ -38350,7 +38416,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/spacebridge/engmed)
 "eHx" = (
@@ -38393,7 +38459,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "eIL" = (
@@ -38411,7 +38477,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "eJa" = (
@@ -38477,7 +38543,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "eJU" = (
@@ -38560,6 +38626,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
+"eLJ" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/entry/south)
 "eLS" = (
 /obj/machinery/status_display{
 	layer = 4
@@ -38605,7 +38678,8 @@
 	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
 /area/hallway/primary/fore)
 "eMX" = (
@@ -38666,7 +38740,10 @@
 /area/maintenance/disposal/external/east)
 "eOf" = (
 /obj/structure/chair/sofa/corp,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "eOi" = (
 /obj/machinery/light/small,
@@ -38836,7 +38913,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "eRg" = (
@@ -38914,17 +38991,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
-"eRW" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/fore)
 "eSc" = (
 /obj/structure/sign/directions/engineering{
 	pixel_x = -32;
@@ -38946,7 +39012,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
 /area/hallway/primary/fore)
 "eSe" = (
 /obj/machinery/disposal/deliveryChute{
@@ -38993,18 +39061,6 @@
 	icon_state = "bot"
 	},
 /area/toxins/storage)
-"eTj" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/hallway/primary/fore)
 "eTm" = (
 /turf/simulated/wall,
 /area/crew_quarters/captain)
@@ -39020,7 +39076,7 @@
 "eTA" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/aft/west)
 "eTG" = (
@@ -39052,7 +39108,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
 /area/hallway/primary/fore)
 "eTT" = (
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -39076,7 +39134,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "eUs" = (
@@ -39138,7 +39196,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "eUS" = (
@@ -39173,7 +39231,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "eVY" = (
@@ -39186,8 +39244,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "eWu" = (
@@ -39220,7 +39278,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "eWL" = (
@@ -39267,8 +39325,8 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "eYr" = (
@@ -39305,7 +39363,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "eYX" = (
@@ -39332,7 +39390,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "eZs" = (
@@ -39387,7 +39445,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "eZW" = (
@@ -39528,7 +39586,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "fcD" = (
@@ -39553,8 +39611,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "fcO" = (
@@ -39696,7 +39753,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "fgu" = (
@@ -39942,7 +39999,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "flT" = (
@@ -40026,7 +40083,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/east)
 "fof" = (
@@ -40105,7 +40162,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/east)
 "fpL" = (
@@ -40130,7 +40187,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/east)
 "fqu" = (
@@ -40193,7 +40250,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/east)
 "frK" = (
@@ -40230,7 +40287,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/east)
 "fsl" = (
@@ -40313,7 +40370,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/east)
 "ftr" = (
@@ -40336,7 +40393,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/east)
 "fue" = (
@@ -40419,7 +40476,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/east)
 "fuU" = (
@@ -40538,6 +40595,15 @@
 	icon_state = "dark"
 	},
 /area/engine/break_room)
+"fwL" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/entry/south)
 "fwV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -40655,7 +40721,10 @@
 	pixel_y = 8
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/security/lobby)
 "fzc" = (
 /obj/structure/spacepoddoor{
@@ -40892,8 +40961,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "fEy" = (
@@ -40950,7 +41019,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry)
 "fED" = (
@@ -40981,7 +41050,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/north)
 "fEL" = (
@@ -41156,6 +41225,14 @@
 	icon_state = "dark"
 	},
 /area/turret_protected/ai_upload)
+"fGX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/hallway/primary/fore)
 "fHj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/public/glass{
@@ -41164,7 +41241,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "fHp" = (
@@ -41189,7 +41266,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/spacebridge/serveng)
 "fHA" = (
@@ -41229,8 +41306,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "fJd" = (
@@ -41266,7 +41343,8 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit)
 "fJJ" = (
@@ -41524,9 +41602,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
+"fOE" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/hallway/secondary/entry/south)
 "fOJ" = (
 /obj/structure/chair/comfy,
 /obj/effect/landmark/start/student_sientist,
@@ -41843,7 +41926,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "fTG" = (
@@ -42115,7 +42198,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry)
 "fYd" = (
@@ -42172,7 +42255,7 @@
 "fZA" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "fZG" = (
@@ -42454,7 +42537,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/exit)
 "geF" = (
@@ -42539,8 +42622,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/north)
 "gfD" = (
@@ -42733,8 +42816,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "giH" = (
@@ -42832,7 +42915,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/security/lobby)
 "glG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -43251,7 +43337,8 @@
 /area/medical/cmostore)
 "gtE" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit)
 "gtJ" = (
@@ -43618,7 +43705,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "gAX" = (
@@ -43770,7 +43857,8 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "gDr" = (
@@ -43973,7 +44061,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "gFu" = (
@@ -44145,8 +44234,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "gHw" = (
@@ -44376,7 +44465,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "gLj" = (
@@ -44652,7 +44741,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "gPa" = (
@@ -44800,7 +44890,7 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "gQP" = (
@@ -44876,6 +44966,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/fore)
@@ -44990,7 +45081,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "gUe" = (
@@ -45000,7 +45091,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "gUh" = (
@@ -45118,7 +45209,8 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "gXl" = (
@@ -45180,7 +45272,7 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/flask/detflask,
 /obj/item/toy/figure/detective,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet{
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "carpet14-10"
@@ -45316,16 +45408,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "gZD" = (
@@ -45399,7 +45487,10 @@
 "hbl" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/red/corner,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "hbo" = (
 /obj/structure/rack,
@@ -45589,8 +45680,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/spacebridge/dockmed)
 "heX" = (
@@ -45736,7 +45827,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing/corner,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
 /area/security/lobby)
 "hiI" = (
 /obj/structure/chair/sofa/corp{
@@ -45768,7 +45861,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "hjb" = (
@@ -46972,7 +47065,9 @@
 /area/maintenance/starboardaux)
 "hDf" = (
 /obj/structure/table/holotable/wood,
-/turf/simulated/floor/carpet/royalblack,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "hDL" = (
 /obj/structure/cable/orange{
@@ -47368,8 +47463,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "hJt" = (
@@ -47400,7 +47495,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry)
 "hKc" = (
@@ -47638,7 +47733,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "hPc" = (
@@ -47798,7 +47893,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "hRi" = (
@@ -47888,7 +47983,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "hSL" = (
@@ -48248,7 +48343,7 @@
 /obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "hYW" = (
@@ -48721,7 +48816,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "ijr" = (
@@ -48814,7 +48909,9 @@
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/royalblack,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "ikM" = (
 /obj/item/gavelblock,
@@ -49030,7 +49127,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "ipB" = (
@@ -49384,7 +49481,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "ivI" = (
@@ -49851,8 +49948,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "iES" = (
@@ -50030,7 +50126,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "iHG" = (
@@ -50060,8 +50157,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	dir = 1;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "iHT" = (
@@ -50111,7 +50208,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "iIK" = (
@@ -50749,7 +50846,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/aft/west)
 "iTA" = (
@@ -50918,7 +51015,7 @@
 /obj/effect/turf_decal/caution/red,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/spacebridge/dockmed)
 "iWx" = (
@@ -51041,7 +51138,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "iYg" = (
@@ -51108,7 +51205,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "iZr" = (
@@ -51129,8 +51226,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "iZX" = (
@@ -51191,7 +51287,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "jaM" = (
@@ -51374,6 +51471,15 @@
 	icon_state = "dark"
 	},
 /area/hallway/primary/starboard/south)
+"jet" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/security/lobby)
 "jew" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -51534,7 +51640,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/east)
 "jhp" = (
@@ -51672,7 +51778,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "jjr" = (
@@ -51899,8 +52005,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "jms" = (
@@ -51931,7 +52037,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "jng" = (
@@ -52175,7 +52282,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "jqX" = (
@@ -52396,7 +52503,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "jvl" = (
@@ -52848,7 +52955,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "jBV" = (
@@ -52882,7 +52989,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "jCw" = (
@@ -52944,8 +53052,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "jDh" = (
@@ -53127,8 +53234,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "jGA" = (
@@ -53465,8 +53571,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "jLz" = (
@@ -53488,7 +53594,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "jLV" = (
@@ -53562,7 +53669,10 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/security/lobby)
 "jND" = (
 /obj/effect/spawner/window/reinforced/polarized{
@@ -53926,7 +54036,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry)
 "jUd" = (
@@ -54056,8 +54166,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "jVQ" = (
@@ -54099,7 +54208,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "jWv" = (
@@ -54108,8 +54217,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "jWw" = (
@@ -54224,7 +54332,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/security/lobby)
 "jYU" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -54260,7 +54371,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "jZd" = (
@@ -54444,8 +54555,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/aft/west)
 "kcF" = (
@@ -54865,7 +54976,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "kix" = (
@@ -54960,7 +55071,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "kju" = (
@@ -55097,8 +55208,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "klX" = (
@@ -55221,8 +55331,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "koR" = (
@@ -55259,7 +55368,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "kpn" = (
@@ -55292,7 +55401,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry)
 "kqo" = (
@@ -55439,7 +55549,7 @@
 	pixel_y = -29
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "krX" = (
@@ -55654,7 +55764,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "kvU" = (
@@ -55827,7 +55937,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "kyB" = (
 /obj/machinery/computer/guestpass{
@@ -56048,7 +56161,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/aft/west)
 "kAZ" = (
@@ -56192,8 +56305,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "kDr" = (
@@ -56338,7 +56451,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "kFw" = (
@@ -56492,6 +56605,14 @@
 	icon_state = "bcircuit"
 	},
 /area/toxins/server_coldroom)
+"kIK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/hallway/primary/central)
 "kIL" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/storage/fancy/cigcase,
@@ -56659,7 +56780,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "kNw" = (
@@ -56787,8 +56908,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/aft/west)
 "kQG" = (
@@ -56855,7 +56976,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/north)
 "kRw" = (
@@ -56972,7 +57093,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/east)
 "kSG" = (
@@ -56984,7 +57105,8 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit)
 "kSI" = (
@@ -57054,8 +57176,8 @@
 "kUt" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	dir = 9;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "kUy" = (
@@ -57450,8 +57572,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "lcq" = (
@@ -57548,7 +57669,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "leh" = (
@@ -57609,7 +57730,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/spacebridge/sercom)
 "lfe" = (
@@ -57723,7 +57844,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/spacebridge/sercom)
 "lht" = (
@@ -57969,7 +58091,7 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/exit)
 "llH" = (
@@ -58154,7 +58276,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/spacebridge/comeng)
 "lnY" = (
@@ -58221,7 +58343,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/spacebridge/comeng)
 "loQ" = (
@@ -58360,7 +58483,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "lrO" = (
@@ -58507,7 +58630,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "ltL" = (
@@ -58584,8 +58707,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/aft/west)
 "lva" = (
@@ -58711,7 +58834,8 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit)
 "lwN" = (
@@ -59035,7 +59159,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "lCd" = (
@@ -59113,7 +59237,7 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "lDt" = (
@@ -59121,6 +59245,9 @@
 	pixel_y = -32
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/arrow{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -59762,8 +59889,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "lRc" = (
@@ -59842,8 +59968,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/north)
 "lSs" = (
@@ -59936,8 +60062,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 5;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "lTq" = (
@@ -59953,7 +60079,10 @@
 /area/lawoffice)
 "lTH" = (
 /obj/structure/closet/emcloset,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "lUn" = (
 /obj/machinery/door/window/brigdoor{
@@ -60114,8 +60243,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	dir = 1;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "lXo" = (
@@ -60133,7 +60262,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry)
 "lXJ" = (
@@ -60647,8 +60776,8 @@
 /obj/structure/fans/tiny,
 /obj/effect/turf_decal/caution/red,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/spacebridge/dockmed)
 "mfh" = (
@@ -60780,7 +60909,8 @@
 	},
 /obj/effect/landmark/start/civilian,
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit)
 "mhV" = (
@@ -60996,7 +61126,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "mmE" = (
 /obj/effect/turf_decal/stripes/line,
@@ -61069,7 +61202,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "mnu" = (
@@ -61085,7 +61219,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "mnz" = (
@@ -61214,7 +61349,10 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "mpB" = (
 /turf/simulated/wall/r_wall,
@@ -61299,7 +61437,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/aft/west)
 "mrh" = (
@@ -61374,7 +61512,8 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry)
 "mtJ" = (
@@ -61514,7 +61653,8 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry)
 "mwR" = (
@@ -61741,8 +61881,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "mBm" = (
@@ -62138,9 +62278,6 @@
 /turf/simulated/floor/grass,
 /area/hallway/spacebridge/scidock)
 "mIa" = (
-/obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "purple"
 	},
@@ -62190,7 +62327,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "mJb" = (
@@ -62230,7 +62367,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "mJM" = (
@@ -62422,7 +62559,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/exit)
 "mNp" = (
@@ -62861,7 +62998,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "mWm" = (
@@ -63098,7 +63235,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/spacebridge/sercom)
 "naK" = (
@@ -63217,8 +63354,8 @@
 /obj/structure/chair/comfy/brown{
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
@@ -63371,7 +63508,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/security/lobby)
 "nfC" = (
 /obj/structure/cable/orange{
@@ -63602,7 +63742,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit)
 "njR" = (
@@ -63713,7 +63854,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "nlI" = (
@@ -64420,8 +64561,8 @@
 /obj/effect/turf_decal/caution/red,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/spacebridge/medcargo)
 "nwI" = (
@@ -64431,8 +64572,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "nwJ" = (
@@ -64579,7 +64720,7 @@
 /obj/effect/turf_decal/caution/red,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/spacebridge/medcargo)
 "nzl" = (
@@ -64611,7 +64752,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/spacebridge/servsci)
 "nzK" = (
@@ -64688,7 +64829,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "nAT" = (
@@ -64752,8 +64894,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/port/south)
 "nCB" = (
@@ -65052,8 +65194,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/north)
 "nGw" = (
@@ -65124,7 +65266,10 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
 /area/hallway/primary/port/south)
 "nHE" = (
 /obj/structure/lattice/catwalk,
@@ -65165,7 +65310,10 @@
 /area/space/nearstation)
 "nIh" = (
 /obj/structure/chair/sofa/corp/right,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "nIq" = (
 /obj/machinery/vending/cola,
@@ -65821,7 +65969,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "nTC" = (
@@ -65839,7 +65987,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "nTU" = (
@@ -66266,8 +66414,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/north)
 "oba" = (
@@ -66285,7 +66433,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry)
 "obg" = (
@@ -66307,7 +66455,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/north)
 "obN" = (
@@ -66361,7 +66509,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "oct" = (
@@ -66449,7 +66597,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "ofc" = (
@@ -66588,6 +66736,17 @@
 	icon_state = "purple"
 	},
 /area/hallway/primary/aft/west)
+"ohF" = (
+/obj/effect/decal/warning_stripes/yellow/partial{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/arrow{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "purple"
+	},
+/area/hallway/primary/aft/west)
 "ohN" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Mechanic Workshop";
@@ -66626,7 +66785,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "oib" = (
@@ -66976,8 +67135,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "ooA" = (
@@ -66996,8 +67155,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "ooT" = (
@@ -67027,11 +67186,15 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry)
 "opo" = (
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/hallway/secondary/entry/south)
 "opB" = (
 /obj/machinery/door_control{
@@ -67303,8 +67466,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "otq" = (
@@ -67492,7 +67654,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "owN" = (
@@ -67637,7 +67799,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "ozW" = (
@@ -67699,7 +67861,7 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "oBJ" = (
@@ -67841,7 +68003,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "oDZ" = (
@@ -68017,8 +68179,18 @@
 /turf/simulated/floor/wood,
 /area/security/hos)
 "oGl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	dir = 8
+	dir = 8;
+	icon_state = "neutralfull"
 	},
 /area/security/lobby)
 "oGr" = (
@@ -68085,15 +68257,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "oHV" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/structure/cable/orange{
 	icon_state = "1-8"
 	},
 /obj/effect/landmark/start/detective,
 /obj/structure/chair/office/dark,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/security/detectives_office)
 "oIc" = (
@@ -68384,7 +68552,8 @@
 	},
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit)
 "oNw" = (
@@ -68756,7 +68925,8 @@
 	},
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit)
 "oTM" = (
@@ -68836,6 +69006,18 @@
 /area/maintenance/port2)
 "oUg" = (
 /obj/structure/chair/office/dark,
+/obj/machinery/door_control{
+	id = "stationawaygate";
+	name = "Gateway Shutters Access Control";
+	pixel_x = 28;
+	req_access = list(62)
+	},
+/obj/machinery/door_control{
+	id = "Exp_lockdown";
+	name = "Expedition Lockdown Control";
+	pixel_x = 38;
+	req_access = list(62)
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hop)
 "oUr" = (
@@ -68861,7 +69043,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "oUM" = (
@@ -69162,7 +69345,9 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/wood,
 /area/security/detectives_office)
 "oZn" = (
@@ -69387,7 +69572,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "pcR" = (
@@ -69426,7 +69612,10 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "pdv" = (
 /turf/simulated/floor/plasteel{
@@ -69810,7 +69999,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry)
 "pkf" = (
@@ -69924,8 +70113,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/aft/west)
 "pmS" = (
@@ -69997,8 +70186,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "pnu" = (
@@ -70115,7 +70304,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "ppj" = (
@@ -70439,7 +70628,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "puE" = (
@@ -70448,7 +70637,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "puO" = (
@@ -70755,7 +70944,7 @@
 /obj/effect/turf_decal/caution/red,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/spacebridge/servsci)
 "pzs" = (
@@ -71128,7 +71317,8 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "pGv" = (
@@ -71160,7 +71350,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "pHb" = (
@@ -71171,8 +71361,8 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 9;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/north)
 "pHf" = (
@@ -71211,7 +71401,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/north)
 "pHI" = (
@@ -71224,8 +71414,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "pHR" = (
@@ -71314,7 +71504,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/north)
 "pJm" = (
@@ -71350,7 +71540,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/north)
 "pJG" = (
@@ -71479,8 +71669,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "pLN" = (
@@ -71504,7 +71694,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/north)
 "pLU" = (
@@ -71593,7 +71783,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/north)
 "pOo" = (
@@ -71664,7 +71854,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/north)
 "pPl" = (
@@ -72001,12 +72191,22 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "pUC" = (
-/obj/machinery/camera{
-	c_tag = "Research and Development";
-	network = list("SS13","RD")
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel/white,
-/area/toxins/lab)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/door_timer/cell_6{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkred"
+	},
+/area/security/prison/cell_block/A)
 "pVc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -72217,7 +72417,10 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/security/lobby)
 "pXX" = (
 /obj/structure/cable/orange{
@@ -72368,7 +72571,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "qas" = (
@@ -72448,7 +72651,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "qbE" = (
@@ -72486,7 +72689,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry)
 "qcI" = (
@@ -72682,6 +72886,13 @@
 	pixel_y = -32;
 	req_access = list(62)
 	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Exp_lockdown";
+	name = "Expedition Lockdown";
+	opacity = 0
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -72839,7 +73050,7 @@
 	pixel_y = -40
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "qhP" = (
@@ -72904,8 +73115,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/north)
 "qjg" = (
@@ -73060,6 +73271,14 @@
 	icon_state = "whitered"
 	},
 /area/security/medbay)
+"qkA" = (
+/obj/structure/sign/electricshock{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/engine/gravitygenerator)
 "qkF" = (
 /obj/structure/fence{
 	dir = 4
@@ -73239,8 +73458,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "qmr" = (
@@ -73296,8 +73514,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "qni" = (
@@ -73441,7 +73658,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/turf_decal/caution/red,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/spacebridge/sercom)
 "qpd" = (
@@ -73735,7 +73953,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "qtO" = (
@@ -73906,7 +74125,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "qyP" = (
 /turf/simulated/floor/transparent/glass/reinforced{
@@ -74061,7 +74283,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/security/lobby)
 "qBl" = (
 /obj/structure/table/reinforced,
@@ -74192,7 +74417,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "qCD" = (
@@ -74282,7 +74507,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "qDY" = (
@@ -74314,7 +74539,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "qFb" = (
@@ -74488,7 +74714,10 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/security/lobby)
 "qHL" = (
 /obj/machinery/door/poddoor/preopen{
@@ -74527,8 +74756,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/north)
 "qID" = (
@@ -74859,7 +75088,10 @@
 	dir = 8;
 	pixel_y = 10
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/security/lobby)
 "qOp" = (
 /obj/structure/cable/orange{
@@ -75131,7 +75363,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "qTm" = (
@@ -75366,8 +75598,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/spacebridge/serveng)
 "qYD" = (
@@ -75593,7 +75824,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "rcB" = (
@@ -75833,7 +76064,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "rhr" = (
@@ -75865,7 +76096,7 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "rhV" = (
@@ -75882,7 +76113,8 @@
 	icon_state = "pipe-y"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "riA" = (
@@ -76062,7 +76294,8 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/turret_protected/aisat_interior)
 "rlI" = (
@@ -76081,7 +76314,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "rlM" = (
@@ -76123,8 +76356,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "rmR" = (
@@ -76251,8 +76484,8 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "roj" = (
@@ -76267,7 +76500,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry)
 "ron" = (
@@ -76615,7 +76848,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 9;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit)
 "rvc" = (
@@ -76644,8 +76878,8 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/aft/west)
 "rvD" = (
@@ -76665,7 +76899,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/security/lobby)
 "rvM" = (
 /obj/machinery/door/airlock/highsecurity{
@@ -76737,7 +76974,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "rwI" = (
@@ -76796,8 +77033,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "rym" = (
@@ -76811,7 +77047,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/exit)
 "ryD" = (
@@ -76923,10 +77159,7 @@
 /obj/structure/cable/orange{
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
+/turf/simulated/floor/plasteel,
 /area/hallway/primary/port/south)
 "rAi" = (
 /turf/simulated/floor/plasteel{
@@ -77204,7 +77437,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "rEq" = (
@@ -77309,7 +77542,7 @@
 	},
 /obj/machinery/vending/chinese,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "rFR" = (
@@ -77484,7 +77717,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "rIZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -77526,7 +77762,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "rJt" = (
@@ -77621,8 +77858,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "rLk" = (
@@ -77688,7 +77925,7 @@
 "rLW" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "rLZ" = (
@@ -77724,6 +77961,12 @@
 	icon_state = "brown"
 	},
 /area/quartermaster/miningdock)
+"rMt" = (
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/hallway/primary/port/south)
 "rMH" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -77833,19 +78076,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/aft/west)
 "rOq" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/arrow,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/hallway/primary/aft/west)
+/turf/simulated/floor/wood,
+/area/security/detectives_office)
 "rOJ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/orange,
@@ -77911,6 +78150,12 @@
 "rPi" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/fsmaint3)
+"rPK" = (
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "neutral"
+	},
+/area/hallway/primary/central)
 "rQf" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plasteel{
@@ -77986,7 +78231,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "rQZ" = (
@@ -78292,7 +78537,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "rVw" = (
@@ -78332,8 +78578,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "rVD" = (
@@ -78511,7 +78756,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "rZl" = (
 /turf/simulated/floor/carpet,
@@ -78762,7 +79010,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/north)
 "scR" = (
@@ -78839,8 +79087,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "sdN" = (
@@ -79057,7 +79305,10 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/security/lobby)
 "sgR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -79382,7 +79633,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "snx" = (
@@ -79478,8 +79730,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "sqc" = (
@@ -80092,6 +80343,12 @@
 /obj/effect/spawner/lootdrop/officetoys,
 /turf/simulated/floor/wood,
 /area/civilian/vacantoffice)
+"szK" = (
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/secondary/entry/south)
 "szL" = (
 /obj/machinery/iv_drip,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -80174,7 +80431,8 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "sBd" = (
@@ -80307,7 +80565,7 @@
 "sDL" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/exit)
 "sEa" = (
@@ -80323,7 +80581,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "sEl" = (
@@ -80786,7 +81044,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "sMp" = (
@@ -80827,7 +81085,10 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "sNo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -80904,8 +81165,8 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "sOU" = (
@@ -81017,7 +81278,8 @@
 	},
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit)
 "sQn" = (
@@ -81031,8 +81293,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "sQS" = (
@@ -81522,7 +81783,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "tac" = (
@@ -81616,7 +81877,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "tcg" = (
@@ -81694,7 +81955,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
 /area/hallway/primary/port/north)
 "tdA" = (
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -81708,7 +81972,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "tdX" = (
@@ -81792,7 +82056,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "tfi" = (
@@ -81820,7 +82084,8 @@
 "tfR" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit)
 "tga" = (
@@ -81886,8 +82151,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	dir = 1;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "thN" = (
@@ -81930,7 +82195,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "tiv" = (
@@ -81942,7 +82207,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "tiw" = (
@@ -81984,7 +82249,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "tiJ" = (
@@ -82007,7 +82272,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "tiL" = (
@@ -82016,7 +82281,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "tjb" = (
@@ -82029,7 +82294,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "tji" = (
@@ -82515,8 +82780,8 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "trc" = (
@@ -82826,7 +83091,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "twM" = (
@@ -83168,7 +83433,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/security/lobby)
 "tDj" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -83307,6 +83575,13 @@
 /obj/machinery/door/poddoor/shutters{
 	id_tag = "stationawaygate";
 	name = "Gateway Access Shutters"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Exp_lockdown";
+	name = "Expedition Lockdown";
+	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -83484,7 +83759,10 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/security/lobby)
 "tJt" = (
 /obj/machinery/light/small{
@@ -83515,7 +83793,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/spacebridge/servsci)
 "tJP" = (
@@ -83842,6 +84121,13 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/port/north)
+"tPB" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/port/south)
 "tPF" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -84101,7 +84387,9 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
 /area/hallway/primary/port/north)
 "tUG" = (
 /obj/item/stack/cable_coil{
@@ -84177,8 +84465,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "tWl" = (
@@ -84256,8 +84543,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "tXm" = (
@@ -84285,8 +84571,7 @@
 	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "tXA" = (
@@ -84409,8 +84694,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "tYX" = (
@@ -84438,8 +84722,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/aft/west)
 "tZa" = (
@@ -84467,8 +84751,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "tZz" = (
@@ -84493,7 +84776,10 @@
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/red/corner,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "uav" = (
 /obj/effect/turf_decal/stripes/asteroid/end{
@@ -84549,8 +84835,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/spacebridge/engmed)
 "uba" = (
@@ -84601,7 +84886,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "ubM" = (
@@ -84638,8 +84923,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "uct" = (
@@ -84675,8 +84959,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "udc" = (
@@ -84735,7 +85018,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/hallway/primary/starboard/south)
 "ueB" = (
 /turf/simulated/mineral/ancient,
@@ -84811,7 +85097,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "ugQ" = (
@@ -84835,8 +85121,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/north)
 "uha" = (
@@ -84963,11 +85249,11 @@
 /turf/simulated/floor/carpet,
 /area/library)
 "uii" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/area/security/brig)
+/turf/simulated/floor/wood,
+/area/security/detectives_office)
 "uir" = (
 /obj/structure/closet/firecloset/full,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -85102,7 +85388,10 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "uko" = (
 /obj/structure/cable/orange{
@@ -85200,7 +85489,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "umg" = (
@@ -85280,8 +85569,8 @@
 "uoi" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/aft/west)
 "uoB" = (
@@ -85420,7 +85709,8 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "uqX" = (
@@ -85666,6 +85956,12 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"uvE" = (
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/hallway/primary/fore/west)
 "uvT" = (
 /turf/simulated/mineral/ancient,
 /area/maintenance/electrical_shop)
@@ -85812,7 +86108,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "uyl" = (
@@ -86015,6 +86312,12 @@
 	icon_state = "whitegreen"
 	},
 /area/medical/virology)
+"uCb" = (
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/security/lobby)
 "uCi" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -86110,7 +86413,7 @@
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "uDv" = (
@@ -86227,7 +86530,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/exit)
 "uFz" = (
@@ -86478,7 +86781,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "uKb" = (
@@ -86503,7 +86806,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "uKs" = (
@@ -86532,8 +86835,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/turret_protected/aisat_interior)
 "uKF" = (
@@ -86560,7 +86863,8 @@
 	},
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/exit)
 "uKX" = (
@@ -86572,7 +86876,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "uLa" = (
@@ -87646,7 +87950,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/aft/west)
 "vfF" = (
@@ -87738,7 +88042,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "vib" = (
@@ -87795,7 +88100,9 @@
 /obj/structure/chair/comfy/brown{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/royalblack,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "vjg" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -87851,7 +88158,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "vki" = (
@@ -87890,13 +88197,11 @@
 /turf/simulated/floor/plasteel/white,
 /area/toxins/xenobiology)
 "vlj" = (
-/obj/structure/sign/electricshock{
-	pixel_y = -32
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/engine/gravitygenerator)
+/turf/simulated/floor/wood,
+/area/security/detectives_office)
 "vls" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -88137,7 +88442,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/exit)
 "vqi" = (
@@ -88390,8 +88695,8 @@
 	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "vtO" = (
@@ -88554,7 +88859,7 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "vvT" = (
@@ -88710,7 +89015,10 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/security/lobby)
 "vzj" = (
 /obj/structure/showcase{
@@ -88762,7 +89070,9 @@
 "vAr" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "vAD" = (
 /obj/structure/cable{
@@ -89115,7 +89425,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/aft/west)
 "vHl" = (
@@ -89396,10 +89706,11 @@
 /area/toxins/launch)
 "vLE" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
 	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/wrench,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -89418,7 +89729,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "vLR" = (
@@ -89514,7 +89825,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "vMR" = (
@@ -89528,7 +89839,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry)
 "vMS" = (
@@ -89868,9 +90180,6 @@
 "vRQ" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/vehicle/secway,
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkred"
@@ -89961,7 +90270,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/aft/west)
 "vSH" = (
@@ -90344,7 +90653,8 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "vZt" = (
@@ -90480,7 +90790,10 @@
 /obj/effect/turf_decal/stripes/red/corner{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "wbP" = (
 /obj/structure/cable/orange{
@@ -90674,7 +90987,7 @@
 "wgh" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "wgq" = (
@@ -90819,7 +91132,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
 /area/hallway/primary/aft/west)
 "wiV" = (
 /obj/structure/mirror{
@@ -90912,7 +91228,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "wkx" = (
@@ -90951,8 +91267,8 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "wkW" = (
@@ -91095,7 +91411,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "wmO" = (
 /obj/machinery/floodlight{
@@ -91178,7 +91497,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "wot" = (
@@ -91311,7 +91630,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry)
 "wpX" = (
@@ -91364,8 +91684,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "wqR" = (
@@ -91391,7 +91711,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "wrc" = (
@@ -91412,7 +91732,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "wrM" = (
@@ -91578,7 +91899,7 @@
 /area/space/nearstation)
 "wui" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "wuk" = (
@@ -91668,8 +91989,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "wvi" = (
@@ -92192,7 +92513,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "wCG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -92631,8 +92955,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "wIS" = (
@@ -92802,7 +93126,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/exit)
 "wMe" = (
@@ -92847,8 +93171,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "wMV" = (
@@ -92901,7 +93224,10 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/security_cadet,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/security/lobby)
 "wOc" = (
 /obj/effect/decal/warning_stripes/red/partial{
@@ -92925,7 +93251,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "wOn" = (
@@ -93378,8 +93704,8 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "wVS" = (
@@ -93610,8 +93936,8 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "xag" = (
@@ -93830,8 +94156,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "xcX" = (
@@ -93852,7 +94177,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore/west)
 "xdu" = (
@@ -94119,7 +94444,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/hallway/secondary/exit)
 "xjK" = (
@@ -94313,7 +94639,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "xmy" = (
@@ -94574,7 +94901,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/hallway/secondary/entry)
 "xrs" = (
@@ -94584,7 +94912,10 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "xru" = (
 /obj/structure/disposalpipe/segment{
@@ -94789,8 +95120,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "xwI" = (
@@ -94812,7 +95143,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "xwT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -94979,16 +95313,13 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/north)
 "xzp" = (
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
-	},
-/obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -95013,7 +95344,10 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/security/lobby)
 "xzG" = (
 /obj/item/radio/intercom{
@@ -95071,7 +95405,10 @@
 /obj/machinery/camera{
 	c_tag = "Docking Asteroid Hall 10"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "xAz" = (
 /obj/machinery/vending/medical,
@@ -95138,8 +95475,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "xBC" = (
@@ -95203,8 +95540,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/east)
 "xCv" = (
@@ -95259,7 +95595,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/fore)
 "xDv" = (
@@ -95481,7 +95817,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
+	dir = 10;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "xHc" = (
@@ -95559,7 +95896,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "xIM" = (
 /obj/machinery/camera{
@@ -95739,8 +96079,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/north)
 "xMI" = (
@@ -95765,7 +96105,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
 /area/security/lobby)
 "xNq" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -95891,7 +96234,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/red/line,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/south)
 "xQY" = (
@@ -95960,8 +96303,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/starboard/south)
 "xSj" = (
@@ -96514,7 +96857,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "xZX" = (
@@ -96549,6 +96892,16 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/atmospherics)
+"yaX" = (
+/obj/machinery/camera{
+	c_tag = "GateWay";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "rampbottom"
+	},
+/area/gateway)
 "ybb" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -96593,7 +96946,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "ybP" = (
@@ -96919,7 +97273,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
 "yhU" = (
@@ -97080,7 +97434,10 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/hallway/secondary/entry/south)
 "ykU" = (
 /obj/machinery/computer/guestpass{
@@ -97139,7 +97496,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/hallway/primary/port/south)
 "ylp" = (
@@ -109099,7 +109456,7 @@ uEk
 goa
 qjw
 nom
-oGl
+yaN
 xIV
 vFB
 qqy
@@ -109356,7 +109713,7 @@ cmY
 goa
 uTo
 glD
-yaN
+uCb
 lNp
 vFB
 ude
@@ -109613,7 +109970,7 @@ dOz
 goa
 uTo
 cnx
-yaN
+uCb
 aPX
 jND
 cBz
@@ -110127,7 +110484,7 @@ jai
 bVX
 wjm
 nfr
-yaN
+uCb
 byO
 jND
 cBG
@@ -110384,7 +110741,7 @@ qks
 goa
 mEm
 cxe
-yaN
+uCb
 aPW
 vFB
 mCr
@@ -110897,8 +111254,8 @@ bTO
 cco
 tYz
 hMg
-sxs
-yaN
+oGl
+uCb
 aPY
 dkp
 dkp
@@ -111154,8 +111511,8 @@ nII
 jHo
 tYz
 mEm
-sxs
-yaN
+oGl
+uCb
 idf
 qCk
 cBH
@@ -111396,7 +111753,7 @@ vKV
 gYc
 sSq
 aui
-dtr
+awv
 wUX
 opC
 aXo
@@ -111411,8 +111768,8 @@ nII
 nmn
 cfL
 mEm
-sxs
-yaN
+oGl
+uCb
 ucY
 qCk
 cBI
@@ -111669,7 +112026,7 @@ mRX
 cfM
 mEm
 jYI
-yaN
+uCb
 rDk
 qCk
 ddc
@@ -112440,7 +112797,7 @@ wAt
 tYz
 nQT
 sxs
-qBE
+jet
 ucY
 qCk
 hHc
@@ -112954,7 +113311,7 @@ tYz
 tYz
 gmC
 gJe
-qBE
+jet
 idf
 qCk
 aRT
@@ -113200,7 +113557,7 @@ dpu
 dpu
 dpu
 kHL
-poM
+xXf
 jpI
 dpu
 gbq
@@ -113211,7 +113568,7 @@ xXf
 poM
 sSn
 sxs
-qBE
+jet
 cwj
 dkp
 dkp
@@ -113298,10 +113655,10 @@ egI
 bWn
 mNp
 bUN
-mCM
-mCM
-mCM
-mCM
+rMt
+xSj
+xSj
+xSj
 aBs
 jGu
 lZN
@@ -113556,9 +113913,9 @@ bZX
 bZX
 bZX
 nCq
-nCq
-nCq
-nCq
+tPB
+tPB
+tPB
 rzK
 gqA
 bUM
@@ -113962,7 +114319,7 @@ afd
 afd
 xQS
 apf
-xQS
+afd
 xQS
 rOS
 bqV
@@ -113982,7 +114339,7 @@ qSQ
 mZB
 sGy
 rKD
-yaN
+uCb
 cxb
 etJ
 dyV
@@ -113995,13 +114352,13 @@ dlj
 dqG
 dKM
 exF
-evL
+uvE
 gDm
-evL
-evL
+uvE
+uvE
 jao
-evL
-evL
+uvE
+uvE
 sAI
 lhr
 lEI
@@ -114223,7 +114580,7 @@ sZS
 afd
 fMs
 kyU
-dpu
+cwf
 cUf
 szu
 rQZ
@@ -114546,7 +114903,7 @@ rBv
 sBU
 qKk
 fGN
-boJ
+thL
 rLN
 brO
 upi
@@ -114803,7 +115160,7 @@ dbs
 rWQ
 pYw
 rVw
-boJ
+thL
 iDw
 xCt
 oOg
@@ -114994,7 +115351,7 @@ bkA
 asc
 pqs
 auG
-uii
+dpu
 dpu
 dpu
 dpu
@@ -115271,7 +115628,7 @@ gSF
 mLK
 dWr
 grV
-cFt
+pUC
 cLE
 cNO
 cTo
@@ -115317,7 +115674,7 @@ dbs
 rWQ
 pYw
 rVw
-boJ
+thL
 iDw
 wMK
 oOg
@@ -115574,7 +115931,7 @@ rBT
 saj
 cPV
 fGN
-boJ
+thL
 iDw
 brM
 aZZ
@@ -116088,7 +116445,7 @@ wEs
 oSE
 soz
 bEM
-boJ
+thL
 ttU
 tWj
 bjn
@@ -116310,7 +116667,7 @@ haT
 aWJ
 okm
 dyJ
-xYR
+rOq
 evg
 hxh
 xaL
@@ -116567,7 +116924,7 @@ dKM
 aWJ
 okm
 pPN
-xYR
+uii
 evg
 gcE
 ydJ
@@ -116824,10 +117181,10 @@ dKM
 aWJ
 okm
 xYR
-xYR
+uii
 evg
 xYR
-xYR
+vlj
 hlo
 hEQ
 abW
@@ -116931,7 +117288,7 @@ xsF
 lDt
 uMr
 goT
-pUC
+oYZ
 oYZ
 uwy
 uMr
@@ -117081,7 +117438,7 @@ dMP
 aWJ
 jQC
 oac
-xYR
+uii
 evg
 aan
 bLL
@@ -117184,8 +117541,8 @@ qni
 nDp
 xWu
 xEd
-cwf
-mIa
+xsF
+ohF
 bwu
 frh
 gqL
@@ -117441,7 +117798,7 @@ dGr
 wiE
 dHU
 xEd
-rOq
+xsF
 meh
 tBX
 sNo
@@ -118110,7 +118467,7 @@ eAF
 gGF
 gGF
 gGF
-pJd
+gGF
 gGF
 gGF
 gGF
@@ -118658,7 +119015,7 @@ rHd
 gyI
 spx
 gyI
-boJ
+thL
 tvd
 tXb
 upO
@@ -126844,7 +127201,7 @@ diU
 tEV
 bEj
 ugQ
-xru
+fGX
 fVX
 abE
 abE
@@ -127101,7 +127458,7 @@ aKp
 aKp
 eGz
 ugQ
-xru
+fGX
 fVX
 abE
 abE
@@ -127358,7 +127715,7 @@ aKp
 kNR
 bUO
 ugQ
-xru
+fGX
 fVX
 abE
 abE
@@ -127615,7 +127972,7 @@ aKp
 bze
 bUO
 ugQ
-xru
+fGX
 fVX
 abE
 abE
@@ -127872,7 +128229,7 @@ nuE
 nuE
 duB
 oMx
-xru
+fGX
 fVX
 abE
 abE
@@ -127899,17 +128256,17 @@ aYG
 hVO
 bcz
 cIx
-lip
+rPK
 pLL
-rLW
-rLW
+csk
+csk
 bhT
-rLW
+csk
 cJp
-rLW
+csk
 blj
 cJO
-rLW
+csk
 boY
 bqn
 brV
@@ -128129,7 +128486,7 @@ xTc
 wUi
 gTA
 ugQ
-xru
+fGX
 aKp
 cRv
 cRv
@@ -128156,7 +128513,7 @@ fph
 fph
 wkN
 bdr
-bhe
+kIK
 cIC
 cJe
 iPa
@@ -128386,7 +128743,7 @@ fxB
 vzX
 bUO
 ugQ
-xru
+fGX
 lTq
 lTq
 lTq
@@ -128397,7 +128754,7 @@ lTq
 lTq
 lTq
 lTq
-abE
+lTq
 rNK
 lzH
 fph
@@ -128628,8 +128985,8 @@ abW
 abW
 abW
 abW
-abW
-abW
+aVS
+aVS
 bAK
 yaj
 oUg
@@ -128643,7 +129000,7 @@ fxB
 vzX
 bUO
 ugQ
-xru
+fGX
 lTq
 pdz
 hoP
@@ -128652,8 +129009,8 @@ oWJ
 odM
 odM
 qHW
-vlj
-lTq
+odM
+qkA
 lTq
 rNK
 lzH
@@ -128885,8 +129242,8 @@ abW
 abW
 abW
 abW
-abW
-abW
+aVS
+bjr
 bAK
 nuE
 nuE
@@ -129671,7 +130028,7 @@ lqC
 uuv
 iuR
 ugQ
-xru
+fGX
 lTq
 lHe
 pnu
@@ -129680,8 +130037,8 @@ oWJ
 odM
 odM
 xOW
-vlj
-lTq
+odM
+qkA
 lTq
 rNK
 rNK
@@ -129939,7 +130296,7 @@ lTq
 lTq
 lTq
 lTq
-abE
+lTq
 rNK
 rNK
 rNK
@@ -130669,8 +131026,8 @@ abW
 abW
 abW
 abW
-dxS
-bjr
+abW
+abW
 dxS
 eSk
 nQN
@@ -130699,7 +131056,7 @@ djc
 dmo
 dvR
 ugQ
-xru
+fGX
 aKp
 aKp
 aKp
@@ -130926,8 +131283,8 @@ abW
 abW
 abW
 abW
-dxS
-dxS
+abW
+abW
 dxS
 cSQ
 aNM
@@ -131984,7 +132341,7 @@ aVS
 aVS
 aVA
 vuY
-xru
+fGX
 aKp
 gXl
 jNw
@@ -132498,7 +132855,7 @@ abW
 aKp
 dxj
 vuY
-eRW
+eTQ
 aKp
 gXL
 gXL
@@ -133012,7 +133369,7 @@ abW
 aKp
 dxt
 dQg
-eTj
+eTQ
 fXC
 fXC
 fXC
@@ -134040,7 +134397,7 @@ dji
 dmA
 dyD
 vuY
-eRW
+eTQ
 fXV
 hbW
 hZh
@@ -134554,7 +134911,7 @@ djv
 dmA
 dwg
 vuY
-eRW
+eTQ
 gch
 gch
 gch
@@ -135068,7 +135425,7 @@ rUq
 dmH
 dyX
 lva
-eRW
+eTQ
 gcu
 hec
 ibP
@@ -135582,7 +135939,7 @@ aKp
 aKp
 dzn
 aVR
-eRW
+eTQ
 gen
 hhE
 ibP
@@ -136867,7 +137224,7 @@ dkd
 aKp
 dAj
 vuY
-xru
+fGX
 aKp
 hna
 ier
@@ -137124,7 +137481,7 @@ dkm
 aKp
 dAs
 vuY
-xru
+fGX
 aKp
 hna
 gXL
@@ -137381,7 +137738,7 @@ rLL
 aKp
 dAv
 vuY
-xru
+fGX
 aKp
 cmr
 ieC
@@ -138518,7 +138875,7 @@ bhm
 oWG
 kuZ
 cjs
-dbg
+fOE
 tjD
 rNK
 uSP
@@ -138775,7 +139132,7 @@ quK
 tWC
 ckm
 cjs
-dbg
+fOE
 tjD
 rNK
 uSP
@@ -139032,7 +139389,7 @@ tHB
 tWC
 kuZ
 cjs
-dbg
+fOE
 tjD
 rNK
 pkt
@@ -139289,7 +139646,7 @@ ezV
 uTR
 eoc
 cjs
-dbg
+fOE
 tjD
 rNK
 pkt
@@ -139546,7 +139903,7 @@ bmg
 tWC
 kuZ
 cjs
-dbg
+fOE
 tjD
 rNK
 pkt
@@ -139803,7 +140160,7 @@ tWC
 tWC
 vmW
 cjs
-dbg
+fOE
 tjD
 rNK
 uSP
@@ -140060,7 +140417,7 @@ gQP
 hcc
 omt
 cjs
-dbg
+fOE
 sHm
 rNK
 uSP
@@ -140317,7 +140674,7 @@ drE
 hcc
 kuZ
 cjs
-dbg
+fOE
 sHm
 rNK
 rNK
@@ -140557,7 +140914,7 @@ pRS
 jir
 fun
 sOU
-rjY
+yaX
 qTm
 anH
 dls
@@ -140810,7 +141167,7 @@ aXn
 aXn
 aXn
 tZz
-dls
+bmQ
 bJX
 bKS
 tCc
@@ -141604,25 +141961,25 @@ cko
 tUS
 diZ
 cmo
-diZ
+eLJ
 uap
 sNm
 cpM
-opo
+cNE
 xIH
 hbl
 ykM
 wbA
-opo
-opo
+cNE
+cNE
 xIH
-opo
-fHp
-opo
-opo
-opo
+cNE
+fwL
+cNE
+cNE
+cNE
 xIH
-opo
+szK
 xSy
 cyx
 sHm
@@ -149551,7 +149908,7 @@ ceQ
 lvj
 pdv
 cdT
-gtE
+jvl
 jvl
 jvl
 jvl

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -1343,10 +1343,8 @@
 	},
 /area/security/permabrig)
 "aka" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
+/turf/simulated/mineral/ancient,
+/area/janitor)
 "akc" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -2454,12 +2452,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/secondary/entry/north)
-"apA" = (
-/obj/item/flag/species,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "apI" = (
 /obj/structure/cable/orange{
 	icon_state = "2-4"
@@ -2807,21 +2799,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/prisonershuttle)
-"arW" = (
-/obj/structure/chair/comfy/red,
-/obj/effect/landmark/start/head_of_security,
-/obj/effect/decal/warning_stripes/red/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
-"asa" = (
-/obj/structure/chair/comfy/black,
-/obj/effect/decal/warning_stripes/red/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "asc" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Prison Wing";
@@ -3180,14 +3157,6 @@
 	icon_state = "darkredfull"
 	},
 /area/security/brig)
-"aum" = (
-/obj/structure/table/reinforced,
-/obj/item/flashlight/lamp,
-/obj/item/toy/figure/secofficer,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "auq" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -3615,28 +3584,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/brig)
-"awF" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	pixel_y = 10
-	},
-/obj/item/pen{
-	pixel_y = 9
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
-"awG" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/red{
-	pixel_y = 3
-	},
-/obj/item/storage/fancy/donut_box,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "awH" = (
 /obj/structure/railing{
 	dir = 8
@@ -4218,11 +4165,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/cabin2)
-"aAJ" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "darkredfull"
-	},
-/area/space)
 "aAS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11527,15 +11469,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
-"boM" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/landmark/start/security_officer,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "boN" = (
 /obj/structure/cable/orange{
 	icon_state = "1-4"
@@ -21938,7 +21871,7 @@
 /area/maintenance/auxsolarport)
 "cdL" = (
 /obj/machinery/ai_status_display,
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/security/prisonershuttle)
 "cdO" = (
 /obj/structure/closet,
@@ -22153,15 +22086,6 @@
 /obj/effect/spawner/lootdrop/crate_spawner,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/asmaint5)
-"ceL" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/landmark/start/security_officer,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkredfull"
-	},
-/area/space)
 "ceO" = (
 /obj/structure/chair{
 	dir = 8
@@ -22579,15 +22503,6 @@
 	icon_state = "vault"
 	},
 /area/security/armory)
-"cgX" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/landmark/start/security_cadet,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "cgZ" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -26000,16 +25915,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
-"cCh" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/landmark/start/security_cadet,
-/obj/effect/landmark/start/security_cadet,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "cCi" = (
 /obj/structure/table,
 /obj/machinery/cell_charger{
@@ -28307,15 +28212,6 @@
 	dir = 1
 	},
 /area/security/prison/cell_block/A)
-"cOl" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/landmark/start/security_cadet,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkredfull"
-	},
-/area/space)
 "cOm" = (
 /obj/effect/landmark/start/mime,
 /turf/simulated/floor/plasteel{
@@ -29558,7 +29454,6 @@
 /area/bridge)
 "cUf" = (
 /obj/structure/chair/comfy/red,
-/obj/effect/landmark/start/head_of_security,
 /obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -38461,10 +38356,7 @@
 /obj/structure/cable/orange{
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
-	},
+/turf/simulated/floor/plating,
 /area/security/reception)
 "eHy" = (
 /obj/effect/spawner/window/reinforced,
@@ -65681,9 +65573,6 @@
 "nQT" = (
 /obj/structure/chair,
 /obj/effect/landmark/start/civilian,
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "red"
@@ -67169,9 +67058,7 @@
 /area/space)
 "oqZ" = (
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutral"
-	},
+/turf/simulated/floor/plasteel,
 /area/security/lobby)
 "org" = (
 /obj/structure/chair/office/light{
@@ -72030,9 +71917,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/medical/chemistry)
-"pVD" = (
-/turf/simulated/wall,
-/area/security/prisonershuttle)
 "pVH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -74749,12 +74633,6 @@
 "qMy" = (
 /turf/simulated/floor/transparent/glass/reinforced/plasma,
 /area/engine/engineering)
-"qMQ" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/armory)
 "qMV" = (
 /obj/structure/cable/orange{
 	icon_state = "2-4"
@@ -77873,10 +77751,7 @@
 /obj/structure/cable/orange{
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
-	},
+/turf/simulated/floor/plating,
 /area/security/reception)
 "rQv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -86180,7 +86055,6 @@
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
-/obj/effect/landmark/start/head_of_security,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -87163,7 +87037,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/landmark/start/head_of_security,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -91148,12 +91021,6 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/surgery/north)
-"wpm" = (
-/obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/brig)
 "wpB" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -110732,8 +110599,8 @@ rNK
 rNK
 rNK
 rNK
-pVD
-pVD
+dqw
+dqw
 arV
 mZH
 arV
@@ -110741,10 +110608,10 @@ cdL
 arV
 mZH
 arV
-pVD
-pVD
-pVD
-pVD
+dqw
+dqw
+dqw
+dqw
 wEh
 anJ
 awp
@@ -110989,7 +110856,7 @@ rNK
 rNK
 rNK
 rNK
-pVD
+dqw
 aWm
 wFn
 mFT
@@ -111246,7 +111113,7 @@ rNK
 rNK
 rNK
 cRv
-ivS
+dqw
 doB
 ajA
 dpg
@@ -111503,7 +111370,7 @@ rNK
 rNK
 rNK
 cRv
-ivS
+dqw
 pPl
 ajB
 alW
@@ -111760,7 +111627,7 @@ rNK
 rNK
 rNK
 cRv
-abW
+dqw
 mCL
 mCL
 dqw
@@ -113522,14 +113389,14 @@ rNK
 rNK
 rNK
 rNK
-aka
-aka
-aka
-aka
-aka
-aka
-aka
-aka
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -113779,14 +113646,14 @@ rNK
 rNK
 rNK
 rNK
-aka
-asa
-aka
-boM
-boM
-aka
-aka
-aka
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -114036,14 +113903,14 @@ rNK
 rNK
 rNK
 rNK
-apA
-aum
-aAJ
-ceL
-boM
-cgX
-aAJ
-aka
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -114088,7 +113955,7 @@ sZS
 afd
 djS
 bqV
-wpm
+dpu
 cUf
 szu
 rQZ
@@ -114293,14 +114160,14 @@ rNK
 rNK
 rNK
 rNK
-arW
-awF
-aAJ
-aka
-ceL
-cCh
-aAJ
-aka
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -114550,14 +114417,14 @@ rNK
 rNK
 rNK
 rNK
-apA
-awG
-aAJ
-boM
-ceL
-cOl
-aAJ
-aka
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -114807,14 +114674,14 @@ rNK
 rNK
 rNK
 rNK
-aka
-asa
-aka
-boM
-boM
-aka
-aka
-aka
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -115064,14 +114931,14 @@ rNK
 rNK
 rNK
 rNK
-aka
-aka
-aka
-aka
-aka
-aka
-aka
-aka
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -118435,16 +118302,16 @@ lzH
 rNK
 rNK
 cRv
+cRv
 abW
 abW
 abW
 abW
 abW
 abW
-abW
+afd
 afd
 aTz
-afd
 aTz
 aTz
 aTz
@@ -118691,17 +118558,17 @@ rNK
 lzH
 rNK
 rNK
-cRv
-cRv
-cRv
-cRv
+rNK
 cRv
 cRv
 cRv
 cRv
 abW
+abW
 afd
 afd
+afd
+aTz
 aTz
 aTz
 aTz
@@ -118952,14 +118819,14 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
 cRv
 cRv
-abW
-abW
 afd
+aTz
+aTz
+aTz
+aTz
+aTz
 aTz
 aTz
 afd
@@ -119210,14 +119077,14 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
 cRv
-abW
-abW
-abW
 afd
+aTz
+aTz
+aTz
+aTz
+aTz
+aTz
 aTz
 afd
 orL
@@ -119238,7 +119105,7 @@ bbe
 aBG
 bBH
 lXO
-qMQ
+ioE
 bVm
 ccN
 cgL
@@ -119467,14 +119334,14 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
 cRv
 cRv
-cRv
-abW
 afd
+aTz
+aTz
+aTz
+aTz
+aTz
 aTz
 aTz
 afd
@@ -119725,13 +119592,13 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
 cRv
-abW
 afd
+aTz
+aTz
+aTz
+aTz
+aTz
 aTz
 aTz
 aTz
@@ -119982,13 +119849,13 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
-rNK
 cRv
-abW
+cRv
 afd
+afd
+aTz
+aTz
+aTz
 aTz
 aTz
 aTz
@@ -120240,11 +120107,11 @@ rNK
 rNK
 rNK
 rNK
-rNK
-rNK
-rNK
 cRv
-abW
+cRv
+cRv
+afd
+afd
 afd
 aTz
 aTz
@@ -120499,10 +120366,10 @@ rNK
 rNK
 rNK
 rNK
-rNK
 cRv
 cRv
-abW
+cRv
+cRv
 nKz
 afd
 afd
@@ -121060,8 +120927,8 @@ gGF
 gGF
 gGF
 gGF
-gGF
-gGF
+pJd
+pJd
 cRv
 rNK
 rNK
@@ -121318,7 +121185,7 @@ gHl
 jpP
 jpP
 uOW
-kCz
+aka
 cRv
 abE
 rNK
@@ -121575,7 +121442,7 @@ rYt
 gIG
 gIG
 joE
-kCz
+aka
 cRv
 cRv
 rNK
@@ -121832,7 +121699,7 @@ gJa
 gIG
 iwW
 jpT
-kCz
+aka
 abW
 cRv
 rNK
@@ -122089,7 +121956,7 @@ gJd
 gIG
 gIG
 jqP
-kCz
+aka
 cRv
 cRv
 rNK
@@ -122346,7 +122213,7 @@ gJx
 gIG
 ixb
 jsi
-kCz
+aka
 cRv
 abE
 rNK

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -535,6 +535,9 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "greencorner"
@@ -771,6 +774,9 @@
 "afD" = (
 /obj/machinery/computer/library,
 /obj/structure/table,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
@@ -1535,6 +1541,10 @@
 	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/camera{
+	c_tag = "ExterminateRoom";
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -1612,10 +1622,6 @@
 "alh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/camera{
-	c_tag = "Brig Labor Camp Airlock North";
-	dir = 8
-	},
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
@@ -15989,7 +15995,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
@@ -16097,9 +16103,6 @@
 "bGQ" = (
 /obj/structure/cable{
 	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -17485,11 +17488,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
@@ -18124,14 +18122,10 @@
 	output_level = 90000
 	},
 /obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/power/smes/engineering{
-	input_level = 200000;
-	output_level = 190000
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -18147,7 +18141,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -18162,11 +18156,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -18181,11 +18175,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/structure/sign/electricshock{
 	pixel_y = 32
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -34090,6 +34084,12 @@
 	pixel_x = -7;
 	pixel_y = 5
 	},
+/obj/machinery/door_control{
+	id = "brig_detprivacy";
+	name = "Detective Privacy Shutters Control";
+	pixel_x = 31;
+	pixel_y = 1
+	},
 /turf/simulated/floor/carpet{
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "carpet14-10"
@@ -41368,6 +41368,15 @@
 "fMl" = (
 /turf/simulated/mineral/ancient/outer,
 /area/mine/unexplored/cere/medical)
+"fMs" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkred"
+	},
+/area/security/brig)
 "fMz" = (
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -52356,6 +52365,9 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -53506,6 +53518,9 @@
 /area/maintenance/port)
 "jMg" = (
 /obj/machinery/computer/crew,
+/obj/machinery/camera{
+	c_tag = "BrigMedical"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitered"
@@ -55844,6 +55859,20 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry)
+"kyU" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkredfull"
+	},
+/area/security/brig)
 "kzf" = (
 /turf/simulated/wall,
 /area/crew_quarters/cabin3)
@@ -62000,6 +62029,9 @@
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/wood,
 /area/security/detectives_office)
 "mGB" = (
@@ -67027,6 +67059,9 @@
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "EvidenceRoom"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -79465,6 +79500,20 @@
 	icon_state = "dark"
 	},
 /area/medical/morgue)
+"sqh" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/brig)
 "squ" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -79985,6 +80034,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/suit_storage_unit/security,
+/obj/machinery/camera{
+	c_tag = "Brig Labor Camp Airlock North";
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
 "szl" = (
@@ -87338,6 +87391,14 @@
 	icon_state = "dark"
 	},
 /area/hydroponics)
+"uZO" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/security/detectives_office)
 "vaa" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -114163,8 +114224,8 @@ aom
 nFH
 sZS
 afd
-djS
-bqV
+fMs
+kyU
 dpu
 cUf
 szu
@@ -114678,7 +114739,7 @@ aph
 mzA
 afd
 djS
-bqY
+sqh
 vQv
 dpu
 dkI
@@ -115741,7 +115802,7 @@ gZS
 mGu
 cnX
 ubM
-xaL
+uZO
 hdO
 hEQ
 abW

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -436,12 +436,6 @@
 	icon_state = "bcircuit"
 	},
 /area/turret_protected/ai)
-"acK" = (
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "whitered"
-	},
-/area/hallway/primary/port/south)
 "acN" = (
 /obj/machinery/hydroponics/constructable{
 	desc = "These are connected with an irrigation tube. You see a little pipe connecting the trays.";
@@ -1563,15 +1557,6 @@
 	icon_state = "floorgrime"
 	},
 /area/security/permabrig)
-"akH" = (
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkblue"
-	},
-/area/space)
 "akI" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -2113,6 +2098,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/northeast)
+"anH" = (
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "anI" = (
 /obj/machinery/light{
 	dir = 1
@@ -2726,6 +2719,14 @@
 	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology)
+"ary" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/entry/south)
 "arC" = (
 /obj/machinery/conveyor/counterclockwise{
 	dir = 6;
@@ -3066,6 +3067,20 @@
 	icon_state = "bcircuit"
 	},
 /area/turret_protected/aisat_interior/secondary)
+"atM" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "atT" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -3993,6 +4008,13 @@
 "azu" = (
 /turf/simulated/wall,
 /area/security/range)
+"azB" = (
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/entry/south)
 "azD" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -4663,15 +4685,6 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/crew_quarters/captain)
-"aER" = (
-/obj/machinery/gateway{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "vault"
-	},
-/area/space)
 "aES" = (
 /obj/machinery/light_switch{
 	dir = 1;
@@ -9451,12 +9464,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
-"bfF" = (
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkblue"
-	},
-/area/space)
 "bfI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -12203,19 +12210,6 @@
 	icon_state = "dark"
 	},
 /area/quartermaster/office)
-"brv" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_x = 32
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/dispenser/oxygen,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "brx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -14208,23 +14202,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
-"bzF" = (
-/obj/structure/dispenser/oxygen,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
-"bzJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/hallway/primary/port/south)
 "bzK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -15889,24 +15866,6 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay)
-"bGb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Gravity Generator";
-	dir = 4;
-	network = list("SS13","CE")
-	},
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "bGf" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/chair/sofa/left,
@@ -16393,13 +16352,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
-"bHP" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/grass,
-/area/hallway/secondary/entry/south)
 "bHR" = (
 /obj/structure/closet/paramedic,
 /obj/item/defibrillator/loaded,
@@ -17431,10 +17383,6 @@
 	icon_state = "dark"
 	},
 /area/atmos)
-"bLP" = (
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/engine,
-/area/engine/gravitygenerator)
 "bLQ" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -19327,19 +19275,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/port)
-"bSK" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "bST" = (
 /obj/machinery/door_control{
 	id = "CargoWarehouse";
@@ -22444,19 +22379,6 @@
 	slowdown = -0.3
 	},
 /area/hallway/spacebridge/servsci)
-"cgq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "cgr" = (
 /obj/structure/cable/orange{
 	icon_state = "1-4"
@@ -23173,13 +23095,6 @@
 	icon_state = "bluered"
 	},
 /area/hallway/secondary/entry/south)
-"ckn" = (
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "rampbottom"
-	},
-/area/space)
 "cko" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23499,20 +23414,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fore)
-"cms" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "cmB" = (
 /obj/structure/cable/orange{
 	icon_state = "1-4"
@@ -29475,21 +29376,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/west)
-"cTG" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "cTN" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Port Asteroid Maintenance";
@@ -32556,11 +32442,6 @@
 	},
 /turf/simulated/wall,
 /area/hallway/primary/fore)
-"dne" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/railing,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/entry/south)
 "dnA" = (
 /turf/simulated/wall,
 /area/hallway/spacebridge/cargocom)
@@ -35206,13 +35087,6 @@
 	icon_state = "white"
 	},
 /area/medical/medbay)
-"dBD" = (
-/obj/structure/flora/ausbushes/sunnybush,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/grass,
-/area/hallway/secondary/entry/south)
 "dBG" = (
 /obj/machinery/door/airlock{
 	name = "Bathroom"
@@ -35829,13 +35703,6 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/fore/west)
-"dKZ" = (
-/obj/structure/railing{
-	dir = 10
-	},
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/entry/south)
 "dLb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -36165,6 +36032,20 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/apmaint2)
+"dOn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "dOt" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -36644,13 +36525,6 @@
 	icon_state = "dark"
 	},
 /area/security/prison/cell_block/A)
-"dWz" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
 "dWE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -36705,13 +36579,6 @@
 	},
 /turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
-"dXA" = (
-/obj/effect/decal/warning_stripes/southeast,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "rampbottom"
-	},
-/area/gateway)
 "dXO" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -37023,13 +36890,6 @@
 /obj/machinery/recycler,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"eeA" = (
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "rampbottom"
-	},
-/area/space)
 "eeI" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/navbeacon{
@@ -37278,20 +37138,6 @@
 /obj/effect/spawner/random_barrier/wall_probably,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint3)
-"eiT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
 "ejh" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
@@ -37657,15 +37503,6 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/port)
-"eoO" = (
-/obj/machinery/gateway{
-	dir = 10
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "vault"
-	},
-/area/space)
 "eoU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -37994,23 +37831,6 @@
 	dir = 8
 	},
 /area/hallway/primary/fore/west)
-"ewS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "exF" = (
 /obj/structure/sign/directions/science{
 	pixel_x = 32;
@@ -38605,6 +38425,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
+"eJw" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/entry/south)
 "eJA" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Library"
@@ -38664,12 +38491,6 @@
 	icon_state = "brown"
 	},
 /area/engine/chiefs_office)
-"eKz" = (
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkbluecorners"
-	},
-/area/space)
 "eKU" = (
 /obj/effect/landmark/start/trainee_engineer,
 /obj/structure/cable{
@@ -38926,12 +38747,6 @@
 	icon_state = "dark"
 	},
 /area/crew_quarters/fitness)
-"ePy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/white,
-/area/toxins/lab)
 "ePP" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -39748,6 +39563,13 @@
 /obj/effect/landmark/join_late,
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
+"fcQ" = (
+/obj/machinery/floodlight,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/simulated/floor/plating,
+/area/engine/engine_smes)
 "fdD" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -39907,19 +39729,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
-"fhi" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/hallway/secondary/entry/south)
 "fhx" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
@@ -40046,12 +39855,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/south)
-"fko" = (
-/obj/structure/table,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "fkt" = (
 /turf/simulated/mineral/ancient,
 /area/crew_quarters/bar)
@@ -40172,14 +39975,6 @@
 /obj/machinery/papershredder,
 /turf/simulated/floor/wood,
 /area/library)
-"fmy" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/hallway/secondary/entry/south)
 "fmI" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -40558,6 +40353,18 @@
 "ful" = (
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai_upload)
+"fun" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/medical1{
+	req_access = list(5,62)
+	},
+/obj/effect/decal/warning_stripes/southeast,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "fup" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "redfull";
@@ -40818,6 +40625,13 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"fyR" = (
+/obj/effect/turf_decal/bot_white,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "purple"
+	},
+/area/hallway/primary/aft/west)
 "fyS" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -41045,17 +40859,6 @@
 	icon_state = "yellow"
 	},
 /area/engine/mechanic_workshop)
-"fEc" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "fEh" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/drinkingglass{
@@ -41180,13 +40983,6 @@
 "fEL" = (
 /turf/simulated/floor/plasteel,
 /area/security/seceqstorage)
-"fEP" = (
-/obj/effect/decal/warning_stripes/north,
-/obj/structure/closet/secure_closet/exile,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "fEU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -42103,11 +41899,6 @@
 	icon_state = "dark"
 	},
 /area/atmos)
-"fTW" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/railing,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/entry/south)
 "fUp" = (
 /obj/machinery/door/airlock/security/glass{
 	id = "process";
@@ -42447,6 +42238,12 @@
 	icon_state = "white"
 	},
 /area/medical/chemistry)
+"gbe" = (
+/turf/simulated/floor/plasteel{
+	dir = 0;
+	icon_state = "blue"
+	},
+/area/hallway/primary/starboard/south)
 "gbq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -42476,17 +42273,6 @@
 	icon_state = "dark"
 	},
 /area/security/execution)
-"gbD" = (
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/obj/item/stock_parts/cell/high,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
 "gbF" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -42897,9 +42683,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint4)
-"ghH" = (
-/turf/simulated/floor/plating,
-/area/space)
 "ghT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -43101,6 +42884,15 @@
 "gnu" = (
 /turf/simulated/mineral/ancient,
 /area/maintenance/disposal/west)
+"gnA" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "gnE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -43300,6 +43092,11 @@
 /obj/effect/landmark/event/lightsout,
 /turf/simulated/floor/plasteel/white,
 /area/toxins/lab)
+"gqO" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/railing,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/entry/south)
 "grs" = (
 /obj/item/stack/sheet/metal,
 /obj/effect/spawner/lootdrop/crate_spawner,
@@ -43480,16 +43277,6 @@
 /obj/effect/spawner/random_barrier/wall_probably,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint3)
-"gul" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/closet/l3closet/scientist,
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
 "guo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -43602,13 +43389,6 @@
 	icon_state = "wood-broken"
 	},
 /area/maintenance/starboard)
-"gvB" = (
-/obj/structure/railing{
-	dir = 5
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/entry/south)
 "gvF" = (
 /obj/structure/girder,
 /obj/item/stack/sheet/metal,
@@ -43807,15 +43587,6 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/janitor)
-"gzZ" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
 "gAG" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -43918,20 +43689,6 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/fore/west)
-"gBE" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/machinery/vending/wallmed{
-	pixel_y = -28
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "gBM" = (
 /obj/machinery/chem_master,
 /turf/simulated/floor/plating,
@@ -44830,15 +44587,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/gambling_den2)
-"gNP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/hallway/secondary/entry/south)
 "gNT" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -44862,6 +44610,15 @@
 	icon_state = "darkpurple"
 	},
 /area/assembly/robotics)
+"gOd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/entry/south)
 "gOp" = (
 /obj/structure/table,
 /obj/item/phone,
@@ -47129,6 +46886,20 @@
 /obj/effect/landmark/start/mechanic,
 /turf/simulated/floor/plasteel,
 /area/engine/mechanic_workshop)
+"hBi" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/machinery/vending/wallmed{
+	pixel_y = -28
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "hBk" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -47497,20 +47268,6 @@
 /obj/machinery/slot_machine,
 /turf/simulated/floor/wood,
 /area/maintenance/gambling_den2)
-"hHD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/structure/cable/orange{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "hHP" = (
 /obj/machinery/disposal,
 /obj/machinery/firealarm{
@@ -49022,11 +48779,6 @@
 "ikc" = (
 /turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/captain)
-"ikd" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "ikv" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -49063,6 +48815,14 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/port)
+"ikK" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/entry/south)
 "ikM" = (
 /obj/item/gavelblock,
 /obj/item/gavelhammer,
@@ -49225,14 +48985,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"iox" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "ioy" = (
 /obj/machinery/light/small,
 /obj/item/assembly/mousetrap/armed,
@@ -49528,6 +49280,25 @@
 /obj/structure/closet/firecloset/full,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/fsmaint4)
+"itP" = (
+/obj/machinery/door/airlock/command{
+	name = "Gateway Access";
+	req_access = list(62)
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "itW" = (
 /obj/machinery/power/smes,
 /obj/structure/cable/orange{
@@ -49706,14 +49477,6 @@
 /obj/effect/landmark/start/janitor,
 /turf/simulated/floor/plasteel,
 /area/janitor)
-"ixc" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "ixg" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -50848,12 +50611,6 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
-"iQn" = (
-/obj/effect/landmark/join_late_gateway,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "iQJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -51184,18 +50941,6 @@
 /obj/item/storage/fancy/cigarettes/cigpack_robustgold,
 /turf/simulated/floor/carpet/royalblack,
 /area/ntrep)
-"iWH" = (
-/obj/machinery/gateway{
-	dir = 1
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
-	},
-/area/space)
 "iWP" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/hologram/holopad,
@@ -51395,6 +51140,17 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/port/east)
+"iZX" = (
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/stock_parts/cell/high,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "iZY" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/double,
@@ -51500,14 +51256,6 @@
 /obj/machinery/ai_status_display,
 /turf/simulated/wall,
 /area/teleporter/quantum/security)
-"jcu" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "jcC" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/paper_bin,
@@ -51856,6 +51604,16 @@
 	icon_state = "dark"
 	},
 /area/chapel/main)
+"jir" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/closet/l3closet/scientist,
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "jix" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -52137,6 +51895,21 @@
 	slowdown = -0.3
 	},
 /area/hallway/spacebridge/engmed)
+"jmk" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/secondary/entry/north)
 "jms" = (
 /obj/machinery/light_switch{
 	dir = 1;
@@ -52203,6 +51976,12 @@
 	icon_state = "dark"
 	},
 /area/security/brig)
+"jnR" = (
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "whitered"
+	},
+/area/hallway/primary/port/south)
 "jnV" = (
 /obj/machinery/status_display{
 	layer = 4
@@ -52755,20 +52534,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
-"jwf" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/machinery/vending/wallmed{
-	pixel_y = -28
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
 "jwg" = (
 /obj/machinery/door/window{
 	dir = 8;
@@ -53477,13 +53242,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/fpmaint)
-"jHT" = (
-/obj/machinery/floodlight,
-/obj/effect/decal/cleanable/cobweb{
-	icon_state = "cobweb2"
-	},
-/turf/simulated/floor/plating,
-/area/engine/engine_smes)
 "jHW" = (
 /obj/structure/cable/orange{
 	icon_state = "2-8"
@@ -53636,13 +53394,6 @@
 /obj/structure/chair/office/dark,
 /turf/simulated/floor/carpet/royalblack,
 /area/ntrep)
-"jJV" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/grass,
-/area/hallway/secondary/entry/south)
 "jJY" = (
 /obj/machinery/keycard_auth{
 	pixel_y = 24
@@ -53965,15 +53716,6 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"jQs" = (
-/obj/machinery/gateway{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
-	},
-/area/space)
 "jQz" = (
 /obj/structure/closet/secure_closet/roboticist,
 /obj/machinery/door_control{
@@ -54476,16 +54218,6 @@
 	icon_state = "vault"
 	},
 /area/security/nuke_storage)
-"jXO" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "jYI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -54663,9 +54395,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fore)
-"kaL" = (
-/turf/simulated/mineral/ancient/outer,
-/area/space)
 "kbd" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -55330,41 +55059,12 @@
 	},
 /turf/space,
 /area/solar/port)
-"kkY" = (
-/obj/machinery/door/airlock/command{
-	name = "Gateway Access";
-	req_access = list(62)
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "kla" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
 /area/medical/morgue)
-"kle" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "klh" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -55945,16 +55645,6 @@
 	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology)
-"kvt" = (
-/obj/machinery/gateway{
-	dir = 6
-	},
-/obj/effect/landmark/join_late_gateway,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "vault"
-	},
-/area/gateway)
 "kvO" = (
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel{
@@ -56063,21 +55753,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/carpet/orange,
 /area/engine/chiefs_office)
-"kxb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/secondary/entry/north)
 "kxf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -56158,12 +55833,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/south)
-"kyi" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/hallway/secondary/entry/south)
 "kyB" = (
 /obj/machinery/computer/guestpass{
 	pixel_x = 30
@@ -56227,14 +55896,6 @@
 	icon_state = "yellow"
 	},
 /area/engine/mechanic_workshop)
-"kzw" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "kzz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -56446,22 +56107,6 @@
 	icon_state = "dark"
 	},
 /area/atmos/distribution)
-"kCn" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/belt/utility,
-/obj/item/storage/belt/utility,
-/obj/item/storage/belt/utility,
-/obj/item/multitool,
-/obj/item/multitool,
-/obj/item/multitool,
-/obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
 "kCq" = (
 /obj/machinery/camera{
 	c_tag = "Blueshield's Office";
@@ -56973,15 +56618,6 @@
 /obj/machinery/seed_extractor,
 /turf/simulated/floor/grass,
 /area/hallway/secondary/garden)
-"kMH" = (
-/obj/machinery/gateway{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
-	},
-/area/space)
 "kMT" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/newscaster/security_unit{
@@ -57056,15 +56692,6 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/fore)
-"kNT" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "kOk" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -57100,23 +56727,6 @@
 	icon_state = "red"
 	},
 /area/security/lobby)
-"kPg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "kPr" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 4
@@ -57781,6 +57391,11 @@
 	},
 /turf/simulated/wall,
 /area/clownoffice)
+"laJ" = (
+/obj/structure/railing,
+/obj/structure/sink/puddle,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/entry/south)
 "lbj" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -57856,16 +57471,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/security/processing)
-"lcQ" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/power/port_gen/pacman,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "lcR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -58033,13 +57638,6 @@
 	icon_state = "red"
 	},
 /area/security/range)
-"lfo" = (
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "rampbottom"
-	},
-/area/space)
 "lfz" = (
 /obj/item/radio/intercom/locked/prison{
 	pixel_y = 25
@@ -58214,12 +57812,6 @@
 /obj/structure/table/wood,
 /turf/simulated/floor/wood,
 /area/maintenance/gambling_den2)
-"lji" = (
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "rampbottom"
-	},
-/area/space)
 "ljp" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -58976,16 +58568,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/starboard)
-"luI" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/effect/decal/warning_stripes/southwest,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "luL" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = -32
@@ -59419,6 +59001,15 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/starboard)
+"lBw" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/entry/south)
 "lBJ" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
@@ -60139,9 +59730,6 @@
 	icon_state = "yellow"
 	},
 /area/hallway/primary/central)
-"lQW" = (
-/turf/simulated/wall/r_wall,
-/area/space)
 "lQX" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/security_officer,
@@ -60172,25 +59760,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/spacebridge/sercom)
-"lRe" = (
-/obj/machinery/door/airlock/command{
-	name = "Gateway Access";
-	req_access = list(62)
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
 "lRI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -60539,23 +60108,6 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/port/east)
-"lXj" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
 "lXo" = (
 /obj/machinery/computer/drone_control,
 /turf/simulated/floor/plating,
@@ -60574,6 +60126,15 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry)
+"lXJ" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "lXM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -61041,12 +60602,6 @@
 	dir = 1
 	},
 /area/security/prison/cell_block/A)
-"met" = (
-/obj/machinery/gateway/centerstation,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "mey" = (
 /obj/effect/spawner/random_spawners/cobweb_left_rare,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -61091,14 +60646,6 @@
 	icon_state = "barber"
 	},
 /area/civilian/barber)
-"mfw" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "mfA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -61256,15 +60803,6 @@
 "mic" = (
 /turf/simulated/wall,
 /area/mine/unexplored/cere/civilian)
-"mim" = (
-/obj/machinery/gateway{
-	density = 0
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
-	},
-/area/space)
 "mio" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
@@ -61416,27 +60954,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/east)
-"mlZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
-"mmi" = (
-/obj/machinery/gravity_generator/main/station,
-/turf/simulated/floor/plating,
-/area/space)
 "mmq" = (
 /obj/structure/dresser,
 /obj/machinery/newscaster{
@@ -63235,24 +62752,6 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/fore/west)
-"mTW" = (
-/obj/structure/table,
-/obj/item/radio{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/radio{
-	pixel_y = 6
-	},
-/obj/item/radio{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/radio,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "mTZ" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -63603,6 +63102,23 @@
 	icon_state = "neutralfull"
 	},
 /area/crew_quarters/locker)
+"naZ" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/grass,
+/area/hallway/secondary/entry/south)
+"nbu" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "blue"
+	},
+/area/hallway/primary/starboard/south)
 "nbv" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 5
@@ -64369,11 +63885,6 @@
 	icon_state = "dark"
 	},
 /area/maintenance/asmaint5)
-"noF" = (
-/obj/structure/railing,
-/obj/structure/sink/puddle,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/entry/south)
 "noO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -65218,6 +64729,16 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/port2)
+"nCq" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/primary/port/south)
 "nCB" = (
 /obj/item/assembly/mousetrap/armed,
 /obj/structure/cable/orange{
@@ -66141,19 +65662,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/mechanic_workshop)
-"nPM" = (
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "rampbottom"
-	},
-/area/space)
-"nQh" = (
-/obj/machinery/door/poddoor/shutters{
-	id_tag = "stationawaygate";
-	name = "Gateway Access Shutters"
-	},
-/turf/space,
-/area/gateway)
 "nQk" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -66352,6 +65860,13 @@
 	icon_state = "dark"
 	},
 /area/assembly/robotics)
+"nTX" = (
+/obj/structure/dispenser/oxygen,
+/obj/effect/decal/warning_stripes/south,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "nUJ" = (
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating,
@@ -66769,16 +66284,6 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
-"obF" = (
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id_tag = "stationawaygate";
-	name = "Gateway Access Shutters"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "obL" = (
 /obj/machinery/light{
 	dir = 4
@@ -67835,11 +67340,6 @@
 	icon_state = "dark"
 	},
 /area/assembly/robotics)
-"ova" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "darkbluecorners"
-	},
-/area/gateway)
 "ovd" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -68092,15 +67592,6 @@
 /obj/item/stack/sheet/metal,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/atmospherics)
-"ozC" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "ozK" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -68209,14 +67700,6 @@
 "oBP" = (
 /turf/simulated/mineral/ancient/outer,
 /area/maintenance/apmaint)
-"oBY" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/engine/gravitygenerator)
 "oCa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -68527,18 +68010,6 @@
 	icon_state = "dark"
 	},
 /area/security/brig)
-"oGx" = (
-/obj/machinery/gateway{
-	dir = 5
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "vault"
-	},
-/area/space)
 "oGy" = (
 /obj/machinery/door/airlock/glass{
 	id = "IAA";
@@ -69042,15 +68513,6 @@
 	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
-"oPM" = (
-/obj/machinery/gateway{
-	dir = 9
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "vault"
-	},
-/area/space)
 "oQa" = (
 /obj/machinery/door/airlock/security{
 	name = "Firing Range";
@@ -69202,12 +68664,6 @@
 	},
 /turf/simulated/wall,
 /area/hallway/primary/central)
-"oSB" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "oSE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -69439,6 +68895,13 @@
 	icon_state = "redcorner"
 	},
 /area/security/processing)
+"oVL" = (
+/obj/structure/flora/rock/jungle,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/grass,
+/area/hallway/secondary/entry/south)
 "oVX" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -69519,6 +68982,15 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/starboard/north)
+"oXj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/entry/south)
 "oXr" = (
 /obj/machinery/light/small,
 /obj/structure/table,
@@ -69800,23 +69272,6 @@
 /obj/structure/statue/bananium/clown/unique,
 /turf/simulated/floor/wood,
 /area/clownoffice)
-"pbs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "pbt" = (
 /obj/machinery/camera{
 	c_tag = "Research Director's Office";
@@ -69885,14 +69340,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/north)
-"pcn" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/hallway/secondary/entry/south)
 "pcI" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -70540,6 +69987,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -70747,6 +70198,22 @@
 "pqy" = (
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/theatre)
+"pqJ" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
+/obj/item/multitool,
+/obj/item/multitool,
+/obj/item/multitool,
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "pqU" = (
 /obj/machinery/door/window/eastright{
 	name = "Theatre Stage"
@@ -71208,6 +70675,16 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/starboard)
+"pyR" = (
+/obj/machinery/gateway{
+	dir = 10
+	},
+/obj/effect/landmark/join_late_gateway,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "vault"
+	},
+/area/gateway)
 "pyZ" = (
 /obj/machinery/suit_storage_unit/rd,
 /turf/simulated/floor/carpet/purple,
@@ -71977,16 +71454,6 @@
 	icon_state = "darkyellowcorners"
 	},
 /area/engine/engine_smes)
-"pLD" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "blue"
-	},
-/area/hallway/primary/starboard/south)
 "pLL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -72326,6 +71793,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/south)
+"pRS" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 26
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/closet/secure_closet/exile,
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "pRV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -72452,13 +71934,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
-"pTE" = (
-/obj/structure/closet/secure_closet/exile,
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "pTJ" = (
 /obj/structure/rack,
 /obj/item/weldingtool/largetank,
@@ -72890,13 +72365,6 @@
 	icon_state = "red"
 	},
 /area/security/main)
-"qau" = (
-/obj/machinery/gateway/centerstation,
-/obj/structure/cable/orange,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "qaC" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security SMES Access";
@@ -73369,17 +72837,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port2)
-"qij" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "qir" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -74400,6 +73857,13 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/library)
+"qxz" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/structure/flora/rock/jungle,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/entry/south)
 "qxB" = (
 /obj/machinery/conveyor/auto,
 /obj/machinery/light/small{
@@ -74412,15 +73876,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/port2)
-"qxL" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/hallway/secondary/entry/south)
 "qyx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -75657,6 +75112,13 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/port/east)
+"qTm" = (
+/obj/effect/decal/warning_stripes/southeast,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "rampbottom"
+	},
+/area/gateway)
 "qTM" = (
 /obj/structure/chair/sofa/right{
 	dir = 4
@@ -76050,19 +75512,6 @@
 	icon_state = "bcircuit"
 	},
 /area/turret_protected/ai_upload)
-"rbE" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
-"rbP" = (
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkbluecorners"
-	},
-/area/space)
 "rbR" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -76372,18 +75821,6 @@
 /obj/effect/spawner/random_spawners/oil_maybe,
 /turf/simulated/floor/plating,
 /area/hallway/primary/fore)
-"rhH" = (
-/obj/machinery/gateway{
-	dir = 9
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "vault"
-	},
-/area/space)
 "rhQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -77136,6 +76573,12 @@
 	icon_state = "whitepurple"
 	},
 /area/toxins/misc_lab)
+"ruq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/toxins/lab)
 "ruW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/orange{
@@ -77320,13 +76763,6 @@
 	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
-"rxE" = (
-/obj/machinery/light,
-/obj/structure/closet/radiation,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "rxW" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -77473,6 +76909,13 @@
 	icon_state = "dark"
 	},
 /area/security/checkpoint2)
+"rAm" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/grass,
+/area/hallway/secondary/entry/south)
 "rAy" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
@@ -77709,22 +77152,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/wood,
 /area/library)
-"rDF" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/belt/utility,
-/obj/item/storage/belt/utility,
-/obj/item/storage/belt/utility,
-/obj/item/multitool,
-/obj/item/multitool,
-/obj/item/multitool,
-/obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "rDY" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/effect/decal/warning_stripes/northwestcorner,
@@ -77795,13 +77222,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/port)
-"rEH" = (
-/obj/effect/decal/warning_stripes/southeast,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "rampbottom"
-	},
-/area/space)
 "rEI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -78134,6 +77554,16 @@
 /obj/structure/table/wood,
 /turf/simulated/floor/plating,
 /area/civilian/vacantoffice)
+"rKv" = (
+/obj/machinery/gateway{
+	dir = 6
+	},
+/obj/effect/landmark/join_late_gateway,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "vault"
+	},
+/area/gateway)
 "rKw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -78329,19 +77759,6 @@
 	icon_state = "darkblue"
 	},
 /area/medical/cmo)
-"rNj" = (
-/obj/structure/cable/orange{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 26
-	},
-/obj/structure/dispenser/oxygen,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "rNo" = (
 /obj/machinery/cooker/deepfryer,
 /obj/structure/window/reinforced{
@@ -80142,6 +79559,12 @@
 /obj/item/reagent_containers/food/drinks/flask/gold,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
+"ssp" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/entry/south)
 "ssq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -80572,13 +79995,6 @@
 /obj/machinery/suit_storage_unit/security,
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
-"szf" = (
-/obj/structure/railing{
-	dir = 6
-	},
-/obj/structure/flora/rock/jungle,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/entry/south)
 "szl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -81450,6 +80866,11 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard/south)
+"sOU" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "darkbluecorners"
+	},
+/area/gateway)
 "sPc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -82245,14 +81666,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/port/north)
-"tdV" = (
-/obj/effect/turf_decal/loading_area/white{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
 "tdX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -83785,18 +83198,6 @@
 	icon_state = "darkbrown"
 	},
 /area/quartermaster/office)
-"tEP" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/medical1{
-	req_access = list(5,62)
-	},
-/obj/effect/decal/warning_stripes/southeast,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
 "tEV" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -83857,6 +83258,13 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay)
+"tGv" = (
+/obj/machinery/door/poddoor/shutters{
+	id_tag = "stationawaygate";
+	name = "Gateway Access Shutters"
+	},
+/turf/space,
+/area/gateway)
 "tGD" = (
 /obj/machinery/door/poddoor/shutters{
 	id_tag = "MiningWarehouse"
@@ -84433,6 +83841,13 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/cloning)
+"tQw" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/entry/south)
 "tQA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -85432,13 +84847,6 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"uhu" = (
-/obj/structure/railing{
-	dir = 9
-	},
-/obj/structure/flora/ausbushes/stalkybush,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/entry/south)
 "uhB" = (
 /obj/machinery/light/small,
 /obj/machinery/embedded_controller/radio/airlock/access_controller{
@@ -85537,21 +84945,6 @@
 	icon_state = "whitegreen"
 	},
 /area/medical/virology)
-"uiT" = (
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkblue"
-	},
-/area/space)
-"uja" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/hallway/secondary/entry/south)
 "ujr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -86086,15 +85479,6 @@
 	icon_state = "red"
 	},
 /area/security/processing)
-"ute" = (
-/obj/structure/closet/radiation,
-/obj/structure/sign/electricshock{
-	pixel_y = -32
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "utq" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/double,
@@ -86766,6 +86150,11 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/port)
+"uEP" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/railing,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/entry/south)
 "uER" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -87477,20 +86866,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"uRi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/command{
-	name = "Gateway Access";
-	req_access = list(62)
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "uRk" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Asteroid Hallway 1";
@@ -88105,15 +87480,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
-"vcY" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
 "vda" = (
 /obj/structure/closet,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -88264,12 +87630,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
-"vgF" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "vgV" = (
 /obj/machinery/r_n_d/circuit_imprinter,
 /turf/simulated/floor/plasteel{
@@ -88619,6 +87979,19 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
 /area/hallway/primary/starboard/south)
+"voz" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/entry/south)
 "voC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/decal/warning_stripes/west{
@@ -88752,6 +88125,13 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/chapel/main)
+"vqO" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/flora/grass/jungle,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/entry/south)
 "vrl" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -88937,13 +88317,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/mimeoffice)
-"vty" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/flora/grass/jungle,
-/turf/simulated/floor/grass,
-/area/hallway/secondary/entry/south)
 "vtz" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -89059,16 +88432,6 @@
 	icon_state = "white"
 	},
 /area/medical/cloning)
-"vuR" = (
-/obj/machinery/gateway{
-	density = 0
-	},
-/obj/effect/landmark/join_late_gateway,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
-	},
-/area/gateway)
 "vuY" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -89702,25 +89065,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft/west)
-"vGZ" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/highsecurity{
-	name = "Gravity Generator Room";
-	req_access = list(19,23)
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "vHl" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -89928,12 +89272,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
-"vKk" = (
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "yellow"
-	},
-/area/hallway/primary/central)
 "vKO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating{
@@ -90009,6 +89347,9 @@
 "vLE" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -90216,14 +89557,6 @@
 "vNP" = (
 /turf/simulated/floor/plating,
 /area/security/permabrig)
-"vNU" = (
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
 "vOe" = (
 /obj/effect/spawner/random_spawners/fungus_maybe,
 /turf/simulated/wall,
@@ -91618,11 +90951,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/engine,
 /area/medical/chemistry)
-"wme" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "darkbluecorners"
-	},
-/area/space)
 "wmj" = (
 /obj/machinery/door/airlock{
 	name = "Chaplain's Office";
@@ -91858,42 +91186,6 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/surgery/north)
-"wpw" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
-"wpx" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 26
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/closet/secure_closet/exile,
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
 "wpB" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -92984,6 +92276,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/external/southeast)
+"wEp" = (
+/obj/machinery/gateway{
+	density = 0
+	},
+/obj/effect/landmark/join_late_gateway,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/gateway)
 "wEs" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -93696,22 +92998,6 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
-"wQb" = (
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id_tag = "stationawaygate";
-	name = "Gateway Access Shutters"
-	},
-/obj/machinery/door_control{
-	id = "stationawaygate";
-	name = "Gateway Shutters Access Control";
-	pixel_x = 24;
-	req_access = list(62)
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "wQf" = (
 /turf/simulated/wall,
 /area/crew_quarters/locker/locker_toilet)
@@ -93883,14 +93169,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior/secondary)
-"wSV" = (
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "wTg" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -93952,16 +93230,6 @@
 	},
 /turf/simulated/wall,
 /area/turret_protected/aisat_interior)
-"wUs" = (
-/obj/machinery/gateway{
-	dir = 10
-	},
-/obj/effect/landmark/join_late_gateway,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "vault"
-	},
-/area/gateway)
 "wUv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -94587,20 +93855,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
 /area/civilian/vacantoffice)
-"xdW" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "xdZ" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
@@ -94648,15 +93902,6 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/cloning)
-"xeH" = (
-/obj/machinery/gateway{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "vault"
-	},
-/area/space)
 "xeI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -94709,14 +93954,6 @@
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/engineering)
-"xgy" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "xhk" = (
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/courtroom)
@@ -94771,12 +94008,6 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/cloning)
-"xia" = (
-/turf/simulated/floor/plasteel{
-	dir = 0;
-	icon_state = "blue"
-	},
-/area/hallway/primary/starboard/south)
 "xiv" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -94879,6 +94110,23 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/maintenance/port)
+"xjS" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "xkf" = (
 /turf/simulated/floor/plasteel,
 /area/security/main)
@@ -95392,6 +94640,10 @@
 /obj/item/coin/clown,
 /turf/simulated/floor/plating,
 /area/clownoffice/secret)
+"xui" = (
+/obj/effect/decal/warning_stripes/east,
+/turf/simulated/floor/engine,
+/area/engine/gravitygenerator)
 "xut" = (
 /turf/simulated/floor/carpet/blue,
 /area/hallway/secondary/garden)
@@ -95469,6 +94721,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/paramedic)
+"xww" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "xwB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/turf_decal/stripes/line{
@@ -96022,15 +95281,6 @@
 	icon_state = "cafeteria"
 	},
 /area/toxins/rdoffice)
-"xEE" = (
-/obj/machinery/gateway{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
-	},
-/area/space)
 "xEJ" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/shieldwallgen,
@@ -96135,6 +95385,14 @@
 	},
 /turf/simulated/floor/carpet,
 /area/medical/psych)
+"xGx" = (
+/obj/effect/turf_decal/loading_area/white{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "xGA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -96218,17 +95476,6 @@
 "xIa" = (
 /turf/simulated/wall,
 /area/toxins/xenobiology)
-"xIi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "xIu" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
@@ -96493,15 +95740,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/permabrig)
-"xNN" = (
-/obj/machinery/door/poddoor/shutters{
-	id_tag = "stationawaygate";
-	name = "Gateway Access Shutters"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "xNP" = (
 /obj/machinery/kitchen_machine/oven,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -96551,6 +95789,14 @@
 /obj/effect/landmark/start/civilian,
 /turf/simulated/floor/carpet/royalblack,
 /area/crew_quarters/bar)
+"xOW" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/engine/gravitygenerator)
 "xOY" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -97314,14 +96560,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/maintenance/gambling_den2)
-"ycm" = (
-/obj/effect/decal/warning_stripes/northwest,
-/obj/structure/closet/l3closet/scientist,
-/obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "ycy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -97428,19 +96666,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/security/detectives_office)
+"yem" = (
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "yellow"
+	},
+/area/hallway/primary/central)
 "yep" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint5)
-"yer" = (
-/obj/effect/turf_decal/bot_white,
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "purple"
-	},
-/area/hallway/primary/aft/west)
 "yes" = (
 /turf/simulated/wall,
 /area/clownoffice)
@@ -97665,20 +96902,6 @@
 	icon_state = "dark"
 	},
 /area/atmos/distribution)
-"yir" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
 "yiw" = (
 /obj/machinery/door/airlock/external{
 	locked = 1;
@@ -97700,14 +96923,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/atmospherics)
-"yiI" = (
-/obj/effect/turf_decal/loading_area/white{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/space)
 "yiP" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
@@ -114290,10 +113505,10 @@ oeY
 bZX
 bZX
 bZX
-bzJ
-bzJ
-bzJ
-bzJ
+nCq
+nCq
+nCq
+nCq
 rzK
 gqA
 bUM
@@ -115049,7 +114264,7 @@ uHd
 bPf
 bPf
 bPf
-acK
+jnR
 baF
 nWU
 rXV
@@ -118181,7 +117396,7 @@ meh
 tBX
 sNo
 obg
-ePy
+ruq
 axa
 xOL
 lyT
@@ -119458,7 +118673,7 @@ vHF
 qWS
 bLp
 ifg
-yer
+fyR
 xWu
 xEd
 udN
@@ -129163,7 +128378,7 @@ cJm
 bqp
 vNe
 vNe
-vKk
+yem
 bwk
 bxv
 byx
@@ -130157,7 +129372,7 @@ fqu
 oWJ
 vEY
 oYM
-bLP
+xui
 jor
 odM
 lTq
@@ -130414,7 +129629,7 @@ vLE
 oWJ
 odM
 odM
-oBY
+xOW
 vlj
 lTq
 lTq
@@ -134581,7 +133796,7 @@ bPL
 pLC
 bRK
 bND
-jHT
+fcQ
 jEh
 rZw
 bND
@@ -136422,7 +135637,7 @@ rrt
 hNb
 pLr
 gUa
-qxL
+lBw
 aok
 leg
 ijl
@@ -136680,7 +135895,7 @@ rAB
 mQN
 aIb
 ebV
-uja
+gOd
 dbg
 eWu
 xQX
@@ -136937,8 +136152,8 @@ kQz
 pLr
 akn
 tWq
-uhu
-dKZ
+eJw
+tQw
 eWu
 xQX
 uXr
@@ -137194,8 +136409,8 @@ qWI
 nFW
 ewv
 tWq
-dBD
-dne
+rAm
+uEP
 eWu
 rFJ
 sHm
@@ -137451,8 +136666,8 @@ vRX
 cjE
 mWg
 tWq
-jJV
-noF
+oVL
+laJ
 eWu
 fZA
 sHm
@@ -137707,9 +136922,9 @@ uCM
 wKu
 kAW
 uKe
-fhi
-bHP
-fTW
+voz
+naZ
+gqO
 eWu
 vjb
 sHm
@@ -137965,7 +137180,7 @@ grJ
 sHm
 wqU
 tWq
-vty
+vqO
 esB
 eWu
 hDf
@@ -138222,10 +137437,10 @@ tji
 sHm
 rcz
 mxo
-gvB
-szf
+azB
+qxz
 ckQ
-fmy
+ikK
 sHm
 rNK
 jqn
@@ -138479,10 +137694,10 @@ tji
 iBp
 kFu
 iFb
-kyi
-gNP
+ssp
+oXj
 cjs
-pcn
+ary
 sHm
 rNK
 jqn
@@ -141288,15 +140503,15 @@ aXn
 aXn
 aXn
 tZz
-wpx
-gul
-tEP
-ova
+pRS
+jir
+fun
+sOU
 rjY
-dXA
-vNU
+qTm
+anH
 dls
-gzZ
+gnA
 tZz
 aXn
 eST
@@ -141551,9 +140766,9 @@ bKS
 tCc
 oKS
 oIS
-wUs
+pyR
 dls
-gbD
+iZX
 tZz
 lXb
 eST
@@ -141803,14 +141018,14 @@ hPZ
 aXn
 tZz
 tHv
-lXj
-eiT
+xjS
+dOn
 vPZ
 kBo
 vPy
-vuR
-tdV
-kCn
+wEp
+xGx
+pqJ
 tZz
 lXb
 fka
@@ -142059,15 +141274,15 @@ lvk
 diY
 aXn
 tZz
-dWz
-yir
+xww
+atM
 bII
 tCc
 aWx
 sJs
-kvt
+rKv
 dls
-jwf
+hBi
 tZz
 vpJ
 vpJ
@@ -142316,13 +141531,13 @@ cbW
 crp
 oQP
 tZz
-bzF
-yir
+nTX
+atM
 dls
 hIA
 rjY
 nQr
-vcY
+lXJ
 dls
 iNr
 tZz
@@ -142574,8 +141789,8 @@ wPr
 ecd
 tZz
 tZz
-lRe
-nQh
+itP
+tGv
 qeR
 tZz
 tZz
@@ -142830,7 +142045,7 @@ mBh
 hJd
 xMv
 jLv
-kxb
+jmk
 pno
 giA
 gZA
@@ -143296,14 +142511,14 @@ bxN
 ipe
 tjS
 tGN
-pLD
+nbu
 dDG
 qqb
-pLD
-pLD
-pLD
+nbu
+nbu
+nbu
 wsO
-pLD
+nbu
 jlh
 xyk
 uZh
@@ -143549,7 +142764,7 @@ aZq
 rnv
 bmS
 bmS
-xia
+gbe
 vXn
 oGF
 tIP
@@ -155676,16 +154891,16 @@ rNK
 rNK
 rNK
 rNK
-lQW
-lQW
-lQW
-lQW
-lQW
-lQW
-lQW
-lQW
-lQW
-lQW
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -155933,16 +155148,16 @@ rNK
 rNK
 rNK
 rNK
-lQW
-rNj
-xgy
-wme
-lji
-rEH
-wSV
-iQn
-kNT
-lQW
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -156190,16 +155405,16 @@ rNK
 rNK
 rNK
 rNK
-uRi
-pbs
-mfw
-uiT
-rhH
-xEE
-eoO
-ikd
-fko
-lQW
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -156447,16 +155662,16 @@ rNK
 rNK
 rNK
 rNK
-obF
-hHD
-cms
-akH
-iWH
-qau
-mim
-yiI
-rDF
-lQW
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -156704,16 +155919,16 @@ rNK
 rNK
 rNK
 rNK
-wQb
-ikd
-jcu
-uiT
-oGx
-jQs
-aER
-ikd
-gBE
-lQW
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -156961,16 +156176,16 @@ rNK
 rNK
 rNK
 rNK
-lQW
-pTE
-luI
-rbP
-lji
-eeA
-ozC
-ikd
-mTW
-lQW
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -157218,29 +156433,29 @@ rNK
 rNK
 rNK
 rNK
-lQW
-lQW
-lQW
-lQW
-lQW
-lQW
-lQW
-lQW
-lQW
-lQW
 rNK
 rNK
 rNK
 rNK
 rNK
 rNK
-lQW
-lQW
-lQW
-lQW
-lQW
-lQW
-lQW
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -157491,13 +156706,13 @@ rNK
 rNK
 rNK
 rNK
-lQW
-ikd
-oPM
-xEE
-eoO
-ikd
-lQW
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -157748,13 +156963,13 @@ rNK
 rNK
 rNK
 rNK
-lQW
-ikd
-kMH
-met
-mim
-yiI
-lQW
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -158005,13 +157220,13 @@ rNK
 rNK
 rNK
 rNK
-lQW
-lfo
-xeH
-jQs
-aER
-ckn
-lQW
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -158262,13 +157477,13 @@ rNK
 rNK
 rNK
 rNK
-lQW
-nPM
-bSK
-ixc
-jXO
-nPM
-lQW
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -158519,13 +157734,13 @@ rNK
 rNK
 rNK
 rNK
-lQW
-rbP
-bfF
-bfF
-bfF
-eKz
-lQW
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -158776,13 +157991,13 @@ rNK
 rNK
 rNK
 rNK
-lQW
-kzw
-oSB
-kle
-iox
-ycm
-lQW
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -159033,13 +158248,13 @@ rNK
 rNK
 rNK
 rNK
-lQW
-brv
-xdW
-xIi
-ikd
-fEP
-lQW
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -159279,24 +158494,24 @@ rNK
 rNK
 rNK
 rNK
-kaL
-kaL
-kaL
-lQW
-lQW
-lQW
-kaL
-kaL
 rNK
 rNK
 rNK
-lQW
-lQW
-kkY
-xNN
-xNN
-lQW
-lQW
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -159536,14 +158751,14 @@ rNK
 rNK
 rNK
 rNK
-lQW
-cgq
-qij
-bGb
-wpw
-cTG
-lcQ
-kaL
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -159793,14 +159008,14 @@ rNK
 rNK
 rNK
 rNK
-lQW
-ghH
-ghH
-ghH
-kPg
-rbE
-fEc
-lQW
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -160050,14 +159265,14 @@ rNK
 rNK
 rNK
 rNK
-lQW
-ghH
-ghH
-mmi
-ewS
-vgF
-ute
-lQW
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -160307,14 +159522,14 @@ rNK
 rNK
 rNK
 rNK
-lQW
-ghH
-ghH
-ghH
-mlZ
-ikd
-rxE
-lQW
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK
@@ -160564,14 +159779,14 @@ rNK
 rNK
 rNK
 rNK
-lQW
-lQW
-lQW
-lTq
-vGZ
-lQW
-lQW
-lQW
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
+rNK
 rNK
 rNK
 rNK

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -52365,9 +52365,6 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},


### PR DESCRIPTION
## Описание
**_Из Глобального было переделано:_**

1.  Бриг (Архитектура в целом, отделы и многое другое. Ремейк требовался долгое время...)
2.  Гейт теперь находится на месте грав гена, сам же грав ген находится на месте Гейта. Последний был переделан.
3. Обновлена Архитектура бара и проходов станции.

**_Из вторичного было сделано:_**

1. Переделан проход к стойке рнд, во избежание очереди в виде змейки и толкучки.
2. Пустующий холл в проходе к отбытию/прибытию заполнен.
3. Пофикшены некоторые приколы(Паутина в воздухе, кривоватый атмос и т.д)
4. Добавлены минимальные пасхалки.

## Ссылка на предложение/Причина создания ПР
**Причина проста...**
_Это было необходимо._
## Демонстрация изменений
**_Бриг_**
![123](https://github.com/ss220-space/Paradise/assets/127967350/a5558245-11d7-4067-b52e-ef39b094c91b)

**_Грав Ген_**
![4](https://github.com/ss220-space/Paradise/assets/127967350/67c0a18c-6b10-4e8c-b20e-350185fbc40f)

**_Гейт_**
![2](https://github.com/ss220-space/Paradise/assets/127967350/bd5f3327-f174-418a-a3bb-266fb6b24886)

**_Приёмная РнД_**
![3](https://github.com/ss220-space/Paradise/assets/127967350/3322e280-7324-4bc9-a599-cdb858b133ee)

**_Бар_**
![13](https://github.com/ss220-space/Paradise/assets/127967350/92ba0202-055f-4617-8b33-66c7702d811d)

**_Проход к Прибытию/Отбытию_**
![14](https://github.com/ss220-space/Paradise/assets/127967350/cca63985-8ba2-461f-b761-0e59104928d1)
