### PR TITLE
Fix: Нечувствительность к боли теперь работает правильно

### DIFF
--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -285,7 +285,7 @@
 			for(var/datum/reagent/R in H.reagents.reagent_list)
 				if(R.shock_reduction)
 					health_deficiency -= R.shock_reduction
-		if(health_deficiency >= 40)
+		if(health_deficiency >= 40 && !(NO_PAIN in H.dna.species.species_traits))
 			if(flight)
 				. += (health_deficiency / 75)
 			else

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -285,7 +285,7 @@
 			for(var/datum/reagent/R in H.reagents.reagent_list)
 				if(R.shock_reduction)
 					health_deficiency -= R.shock_reduction
-		if(health_deficiency >= 40 && !(NO_PAIN in H.dna.species.species_traits))
+		if(health_deficiency >= 40 && !isnucleation(H))
 			if(flight)
 				. += (health_deficiency / 75)
 			else

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -243,7 +243,7 @@
 	if(iscarbon(M))
 		if(method == REAGENT_TOUCH)
 			M.adjustBruteLoss(-volume)
-			if(show_message)
+			if(show_message && !(NO_PAIN in M.dna.species.species_traits))
 				to_chat(M, "<span class='notice'>The styptic powder stings like hell as it closes some of your wounds!</span>")
 				M.emote("scream")
 		if(method == REAGENT_INGEST)


### PR DESCRIPTION
## Описание
Нуклеации теперь не замедляется от повреждений.

Дополнительно убраны крики боли при лечении кровоостанавливающей пудрой для всех не чувствующих боли рас (очевидный баг).

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1103971865753567252

## Видео с демонстрацией скорости
https://github.com/ss220-space/Paradise/assets/3854741/a7e07657-e08c-4cee-9dbc-6b88fe6d2eef


