### PR TITLE
Fix: red damage overlay for carbons

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -474,11 +474,11 @@
 				clear_fullscreen("oxy")
 
 		//Fire and Brute damage overlay (BSSR)
-		var/hurtdamage = getBruteLoss() + getFireLoss() + damageoverlaytemp
+		var/percent_damage = (getBruteLoss() + getFireLoss() + damageoverlaytemp)/(maxHealth/100)
 		damageoverlaytemp = 0 // We do this so we can detect if someone hits us or not.
-		if(hurtdamage)
+		if(percent_damage)
 			var/severity = 0
-			switch(hurtdamage)
+			switch(percent_damage)
 				if(5 to 15) severity = 1
 				if(15 to 30) severity = 2
 				if(30 to 45) severity = 3


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Привязывает степерь покраснения экрана для карбонов к их максимальному хп. Раньше была просто шкала от 0 до 100 урона, из за которой у королевы ксеноморфов, например, экран краснел уже на 90% хп, сильно мешая этим.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
