### PR TITLE
Fix: no more xray from advanced camera consoles and other ai eye mechanisms

### DIFF
--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -115,6 +115,12 @@
 	origin = null
 	return ..()
 
+/mob/camera/aiEye/remote/update_remote_sight(mob/living/user)
+	user.see_invisible = SEE_INVISIBLE_LIVING //can't see ghosts through cameras
+	user.sight = SEE_TURFS | SEE_BLACKNESS
+	user.see_in_dark = 2
+	return 1
+
 /mob/camera/aiEye/remote/RemoveImages()
 	..()
 	if(visible_icon)

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -48,9 +48,8 @@
 /mob/camera/aiEye/proc/RemoveImages()
 	var/client/C = GetViewerClient()
 	if(C && use_static)
-		for(var/V in visibleCameraChunks)
-			var/datum/camerachunk/chunk = V
-			C.images -= chunk.obscured
+		for(var/datum/camerachunk/chunk in visibleCameraChunks)
+			chunk.remove(src)
 
 /mob/camera/aiEye/Destroy()
 	if(ai)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправляет ошибку, при которой ИИ, консоли улучшенного слежения за камерами на ЦК, Тайпане, Абдукторов, Ксенобиологии (ксено варианта), выбора местоположения шаттла, а также ИИ в мехе могли видеть места, не покрытые взором камер.
Также исправлен графический баг, при котором в зонах, непокрытых камерами можно было видеть препятствия.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
https://discord.com/channels/617003227182792704/1103101870907588619/1103101870907588619

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
Демонстрация графического бага с препятствиями
![изображение](https://github.com/ss220-space/Paradise/assets/73733747/b25a7938-06cf-48cd-b9c6-e753ce059cdc)
Демонстрация отсутствия иксрея у ИИ для меха
![изображение](https://github.com/ss220-space/Paradise/assets/73733747/7e69e77d-ed0a-48ed-8e97-cd20b799c7e8)
