### PR TITLE
Fix: airlock correctly drop all contents.

### DIFF
--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -51,9 +51,9 @@
 		colors = GLOB.wire_color_directory[holder_type]
 
 /datum/wires/Destroy()
-	holder = null
 	for(var/color in colors)
 		detach_assembly(color)
+	holder = null
 	return ..()
 
 /**


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Дверь при вытягивании из неё платы проигрывает выбрасывание сигналеров, прикреплённых к проводам. Из-за того, что при вытягивании платы сперва провода отвязываются от шлюза, сигналеры не могут найти путь к привязанному шлюзу, чтобы выпасть под него. Это вызывало рантайм. Фикс фиксит, вызывая выбрасывание под привязанный шлюз перед его отвязкой от проводов.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на баг-репорт
https://discord.com/channels/617003227182792704/1102226392936103936<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
