### PR TITLE
Fix: infinity feeding and sound loc logic on "item_eat" proc.

### DIFF
--- a/code/modules/food_and_drinks/item_food/eat_items.dm
+++ b/code/modules/food_and_drinks/item_food/eat_items.dm
@@ -48,7 +48,7 @@
 
 //Eat all thing in my hand
 /obj/item/proc/item_eat(mob/living/carbon/target, mob/user)
-	if (!check_item_eat(target, user))
+	if(!check_item_eat(target, user))
 		return FALSE
 
 	var/chat_message_to_user = "Вы кормите [target] [src.name]."
@@ -77,8 +77,8 @@
 	to_chat(user, "<span class='notice'>[chat_message_to_user]</span>")
 
 	current_bites++
-	playsound(user.loc, 'sound/items/eatfood.ogg', 50, 0)
-	if(!target.mind.vampire) //Dont give nutrition to vampires
+	playsound(target.loc, 'sound/items/eatfood.ogg', 50, 0)
+	if(!target.mind?.vampire) //Dont give nutrition to vampires
 		target.adjust_nutrition(nutritional_value)
 	obj_integrity = max(obj_integrity - integrity_bite, 0)
 	colour_change()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Очередного Пупц момент, где была хуёвая проверка на вампира при кормёжке кататоников, которая в итоге херовила чтение кода до конца и одежда только "кусалась", но не давала таргету сытости, не обновляла спрайт от степени повреждений и не удалялась, если укусов было больше, чем нужно. Фикс фиксит (А ещё звук съедания теперь играется на том, кто ест, а не на том, кто кормит).<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на баг-репорт
https://discord.com/channels/617003227182792704/1104701018874318958<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
