### PR TITLE
feat: Limitless Strafe for Advanced Mechas

### DIFF
--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -61,6 +61,7 @@
 	wreckage = /obj/structure/mecha_wreckage/durand/rover
 	wall_type = /obj/effect/forcefield/mecha/syndicate //energywall icon_state
 	large_wall = TRUE
+	strafe_allowed = TRUE
 
 /obj/mecha/combat/durand/rover/GrantActions(mob/living/user, human_occupant = 0)
 	..()

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -80,6 +80,7 @@
 	maxsize = 2
 	starting_voice = /obj/item/mecha_modkit/voice/syndicate
 	destruction_sleep_duration = 1
+	strafe_allowed = TRUE
 
 /obj/mecha/combat/gygax/dark/GrantActions(mob/living/user, human_occupant = 0)
 	. = ..()

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -18,6 +18,7 @@
 	max_equip = 5
 	starting_voice = /obj/item/mecha_modkit/voice/nanotrasen
 	destruction_sleep_duration = 1
+	strafe_allowed = TRUE
 
 /obj/mecha/combat/marauder/GrantActions(mob/living/user, human_occupant = 0)
 	. = ..()


### PR DESCRIPTION
## Описание
<!--  -->Вводим стрейф, не требующий наличия модуля и не потребляющий энергию, на все мехи нюки (Dark Gygax, Rover, Mauler) и на продвинутые мехи НТ (Marauder, Seraph). Assault Jaeger остался без стрейфа, потому что это просто респрайт обычного гигакcа ERT Special.

## Ссылка на предложение/Причина создания ПР
<!--  -->
https://discord.com/channels/617003227182792704/755125334097133628/1107911090878292058

