### PR TITLE
fix: Adjacency Check For Storage Insertion

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -309,6 +309,11 @@
 	if(!W.can_enter_storage(src, usr))
 		return FALSE
 
+	if(!W.Adjacent(src))
+		if(!stop_messages)
+			to_chat(usr, "<span class='warning'>[src] is too far from [W]!</span>")
+		return FALSE
+
 	if(contents.len >= storage_slots)
 		if(!stop_messages)
 			to_chat(usr, "<span class='warning'>[W] won't fit in [src], make some space!</span>")


### PR DESCRIPTION
## Описание
<!--  -->
В данный момент предметы можно помещать в открытый инвентарь контейнера, даже если контейнер не находится рядом. Например, если открыть инвентарь коробки, а затем её выбросить, то панель инвентаря не закроется и внутрь можно будет класть предметы на любом расстоянии

## Ссылка на предложение/Причина создания ПР
<!-- -->
Фиксим недоработки
