### PR TITLE
Fix pacifist mech

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -423,6 +423,7 @@
 	projectile_energy_cost = 800
 	equip_cooldown = 60
 	var/det_time = 20
+	harmful = TRUE
 	size=1
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flashbang/action(target, params)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -215,8 +215,17 @@
 		return
 
 	if(GLOB.pacifism_after_gt)
-		to_chat(user, "<span class='warning'>You don't want to harm!</span>")
-		return
+		var/mob/living/L = user
+		if(!target.Adjacent(src))
+			if(selected && selected.is_ranged())
+				if(selected.harmful)
+					to_chat(L, "<span class='warning'>You don't want to harm other living beings!</span>")
+					return
+				selected.action(target, params)
+		else if(selected && selected.is_melee())
+			if(isliving(target) && selected.harmful)
+				to_chat(user, "<span class='warning'>You don't want to harm other living beings!</span>")
+				return
 
 	var/dir_to_target = get_dir(src, target)
 	if(dir_to_target && !(dir_to_target & dir))//wrong direction


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Придает глобу PACIFISM_AFTER_GT свойства полноценного пацифизма в отношении мехов, запрещающий им пользоваться только вредными предметами. На данный момент он полностью вырубает любые интеракции меха, что выглядит как глупость и порождает очень неприятные моменты.

> Дополнительно присвоена плашка harmful флешке и кластерной флешке. Потому что я ненавижу флешки. Никто не любит флешки.

## Ссылка на предложение/Причина создания ПР
Очевидный недочет при разработке глоба, совершенно полностью вырубающий меха. Это не пафифизм, это глупость.

## Демонстрация изменений
АМЛГ после грина не стреляет, тазеры, буры(не по людям), прочее  - спокойно работает.
![image](https://github.com/ss220-space/Paradise/assets/114731039/a0a44b3c-c376-478a-a58f-5aa275ea0061)
