### PR TITLE
fix: kitchen machines not drop contents when deconstucted

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -84,6 +84,9 @@
 		return 0
 	new recipe.output(get_turf(src))
 
+/obj/machinery/cooker/deepfryer/on_deconstruction()
+	dropContents()
+
 //////////////////////////////////
 //		Deepfryer Special		//
 //		Interaction Datums		//

--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -81,7 +81,8 @@
 			to_chat(user, "<span class='alert'>\The [src] is now secured.</span>")
 			return
 
-	default_deconstruction_crowbar(user, O)
+	if(default_deconstruction_crowbar(user, O))
+		return
 
 	if(broken > 0)
 		if(broken == 2 && istype(O, /obj/item/screwdriver)) // If it's broken and they're using a screwdriver
@@ -165,6 +166,9 @@
 /obj/machinery/kitchen_machine/proc/special_attack(obj/item/grab/G, mob/user)
 	to_chat(user, "<span class='alert'>This is ridiculous. You can not fit [G.affecting] in this [src].</span>")
 	return 0
+
+/obj/machinery/kitchen_machine/on_deconstruction()
+	dropContents()
 
 /********************
 *   Machine Menu	*


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Делает так, чтобы машины повара при разборе выкидывали всё, что в них хранится из еды, на свой турф.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Закрывает багрепорт: https://discord.com/channels/617003227182792704/1111561114753445908
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
