### PR TITLE
FIX: SPAI lock bug

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -555,4 +555,5 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_GOLD=500, MAT_GLASS=500)
 	build_path = /obj/item/paicard_upgrade
+	locked = 1
 	category = list("ILLEGAL")


### PR DESCRIPTION
Исправляет баг СПИИ, который появлялся в незакрытом кейсе из протолата. Это единственный предмет в секции нелегала(за исключением кардтриджей на боевой РЦД) который не появлялся закрытым. Но в отличии от картриджей, у которых установлено locked = 0, у СПИИ ВПРИНЦИПЕ не было параметра locked. Как итог, это признаю недоработкой, багом, etc и это нужно исправлять.

<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
