### PR TITLE
fix: observers trigger mousetraps

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -162,8 +162,8 @@
 /obj/item/storage/proc/show_to(mob/user)
 	if(!user.client)
 		return
-	if(user.s_active != src)
-		for(var/obj/item/I in src)
+	if(user.s_active != src && !isobserver(user))
+		for(var/obj/item/I in src) // For bombs with mousetraps, facehuggers etc
 			if(I.on_found(user))
 				return
 	orient2hud(user)  // this only needs to happen to make .contents show properly as screen objects.

--- a/code/modules/awaymissions/mission_code/blackmarketpackers.dm
+++ b/code/modules/awaymissions/mission_code/blackmarketpackers.dm
@@ -148,13 +148,6 @@
 	new /obj/item/assembly/mousetrap/armed(src)
 	new /obj/item/paper/taunt(src)
 
-/obj/item/storage/firstaid/with_mousetrap/tactical/AltClick(var/mob/user)
-	if (isliving(user))
-		return ..()
-
-/obj/item/storage/firstaid/with_mousetrap/tactical/attack_ghost(var/mob/user)
-	return
-
 /obj/item/paper/taunt
 	name = "Shrot note"
 	info = "<b>Ha-ha! Gotcha! As always!</b>"
@@ -171,13 +164,6 @@
 /obj/item/storage/firstaid/with_mousetrap/syndie/populate_contents()
 	new /obj/item/assembly/mousetrap/armed(src)
 	new /obj/item/paper/taunt(src)
-
-/obj/item/storage/firstaid/with_mousetrap/syndie/AltClick(var/mob/user)
-	if (isliving(user))
-		return ..()
-
-/obj/item/storage/firstaid/with_mousetrap/syndie/attack_ghost(var/mob/user)
-	return
 
 // Дисплей кейс с лодкой
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Делает, чтобы наблюдатели не активировали мышеловки, бомбы на них и фейсхаггеров, если всё это лежит в каком-нибудь хранилище.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Закрывает багрепорт: https://discord.com/channels/617003227182792704/1114527338462453810
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

