### PR TITLE
TWEAK: Mecha can load dead silicons

### DIFF
--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -51,7 +51,25 @@
 
 	else if(istype(target,/mob/living))
 		var/mob/living/M = target
-		if(M.stat == DEAD) return
+		if(M.stat == DEAD && !issilicon(M))
+			return
+		if(M.stat == DEAD && issilicon(M))
+			if(!M.anchored)
+				if(cargo_holder.cargo.len < cargo_holder.cargo_capacity)
+					chassis.visible_message("[chassis] lifts [target] and starts to load it into cargo compartment.")
+					M.anchored = 1
+					if(do_after_cooldown(target))
+						cargo_holder.cargo += M
+						M.loc = chassis
+						M.anchored = 0
+						occupant_message("<span class='notice'>[target] successfully loaded.</span>")
+						log_message("Loaded [M]. Cargo compartment capacity: [cargo_holder.cargo_capacity - cargo_holder.cargo.len]")
+					else
+						M.anchored = initial(M.anchored)
+				else
+					occupant_message("<span class='warning'>Not enough room in cargo compartment!</span>")
+			else
+				occupant_message("<span class='warning'>[target] is buckled to something!</span>")
 		if(chassis.occupant.a_intent == INTENT_HARM)
 			M.take_overall_damage(dam_force)
 			if(!M)
@@ -63,6 +81,8 @@
 			add_attack_logs(chassis.occupant, M, "Squeezed with [src] ([uppertext(chassis.occupant.a_intent)]) ([uppertext(damtype)])")
 			start_cooldown()
 		else
+			if(issilicon(M) && M.stat == DEAD)
+				return
 			step_away(M,chassis)
 			occupant_message("<span class='notice'>You push [target] out of the way.</span>")
 			chassis.visible_message("<span class='notice'>[chassis] pushes [target] out of the way.</span>")

--- a/code/game/mecha/working/working.dm
+++ b/code/game/mecha/working/working.dm
@@ -58,6 +58,8 @@
 	if(cargo.len)
 		for(var/obj/O in cargo)
 			output += "<a href='?src=[UID()];drop_from_cargo=\ref[O]'>Unload</a> : [O]<br>"
+		for(var/mob/living/silicon/M in cargo)
+			output += "<a href='?src=[UID()];drop_from_cargo=\ref[M]'>Unload</a> : [M]<br>"
 	else
 		output += "Nothing"
 	output += "</div>"


### PR DESCRIPTION
Позволяет хваталке Рипли брать в карго мертвых силиконов, что есть сломанные борги и  неактивные/мертвые ИИ.

<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1114168866638139412

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
