### PR TITLE
TWEAK: MouseDrop CM & GPS

### DIFF
--- a/code/game/objects/items/devices/sensor_device.dm
+++ b/code/game/objects/items/devices/sensor_device.dm
@@ -19,6 +19,12 @@
 /obj/item/sensor_device/attack_self(mob/user as mob)
 	ui_interact(user)
 
+/obj/item/sensor_device/MouseDrop(obj/over_object as obj, src_location, over_location)
+	var/mob/M = usr
+	if((!istype(over_object, /obj/screen)))
+		return attack_self(M)
+
+
 /obj/item/sensor_device/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)
 	crew_monitor.ui_interact(user, ui_key, ui, force_open)
 

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -119,6 +119,11 @@ GLOBAL_LIST_EMPTY(GPS_list)
 /obj/item/gps/attack_self(mob/user)
 	ui_interact(user)
 
+/obj/item/gps/MouseDrop(obj/over_object as obj, src_location, over_location)
+	var/mob/M = usr
+	if((!istype(over_object, /obj/screen)))
+		return attack_self(M)
+
 /obj/item/gps/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.inventory_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)


### PR DESCRIPTION
Позволяет крю мониторам и ГПС устройствам открывать свой интерфейс перетягиванием спрайта на экран, как у ПДА.

<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Авоут конечно прошел только для ГПС, но нет ничего плохого выдать это и крю мониторам
https://discord.com/channels/617003227182792704/755125334097133628/1114168932534845450

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
