### PR TITLE
fix: Changelings no longer get "steal indentity" objectives on offstation roles

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -346,7 +346,7 @@ GLOBAL_LIST_EMPTY(all_objectives)
 /datum/objective/escape/escape_with_identity/find_target()
 	var/list/possible_targets = list() //Copypasta because NO_DNA races, yay for snowflakes.
 	for(var/datum/mind/possible_target in SSticker.minds)
-		if(possible_target != owner && ishuman(possible_target.current) && (possible_target.current.stat != DEAD) && possible_target.current.client)
+		if(!(is_invalid_target(possible_target)))
 			var/mob/living/carbon/human/H = possible_target.current
 			if(!(NO_DNA in H.dna.species.species_traits))
 				possible_targets += possible_target


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправляет ошибку, при которой генокрады получали задание украсть личность жертвы, не имеющей станционной роли.
Все ещё можно вручную, через Traitor Panel, задавать эту цель.

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
https://discord.com/channels/617003227182792704/1114965267437596742/1114965267437596742
