### PR TITLE
FIX: Сброс покраски сварочного шлема

### DIFF
--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -95,20 +95,64 @@
 /obj/item/clothing/head/welding/proc/toggle()
 	if(up)
 		up = !up
-		flags_cover |= (HEADCOVERSEYES | HEADCOVERSMOUTH)
-		flags_inv |= (HIDEMASK|HIDEHEADSETS|HIDEGLASSES|HIDENAME)
-		icon_state = initial(icon_state)
-		to_chat(usr, "You flip the [src] down to protect your eyes.")
-		flash_protect = 2
-		tint = 2
+		if(icon_state == "welding_redflameup")
+		 flags_cover |= (HEADCOVERSEYES | HEADCOVERSMOUTH)
+		 flags_inv |= (HIDEMASK|HIDEHEADSETS|HIDEGLASSES|HIDENAME)
+		 icon_state = "welding_redflame"
+		 to_chat(usr, "You flip the [src] down to protect your eyes.")
+		 flash_protect = 2
+		 tint = 2
+		else if(icon_state == "welding_blueflameup")
+		 flags_cover |= (HEADCOVERSEYES | HEADCOVERSMOUTH)
+		 flags_inv |= (HIDEMASK|HIDEHEADSETS|HIDEGLASSES|HIDENAME)
+		 icon_state = "welding_blueflame"
+		 to_chat(usr, "You flip the [src] down to protect your eyes.")
+		 flash_protect = 2
+		 tint = 2
+		else if(icon_state == "welding_whiteup")
+		 flags_cover |= (HEADCOVERSEYES | HEADCOVERSMOUTH)
+		 flags_inv |= (HIDEMASK|HIDEHEADSETS|HIDEGLASSES|HIDENAME)
+		 icon_state = "welding_white"
+		 to_chat(usr, "You flip the [src] down to protect your eyes.")
+		 flash_protect = 2
+		 tint = 2
+		else
+		 flags_cover |= (HEADCOVERSEYES | HEADCOVERSMOUTH)
+		 flags_inv |= (HIDEMASK|HIDEHEADSETS|HIDEGLASSES|HIDENAME)
+		 icon_state = initial(icon_state)
+		 to_chat(usr, "You flip the [src] down to protect your eyes.")
+		 flash_protect = 2
+		 tint = 2
 	else
 		up = !up
-		flags_cover &= ~(HEADCOVERSEYES | HEADCOVERSMOUTH)
-		flags_inv &= ~(HIDEMASK|HIDEHEADSETS|HIDEGLASSES|HIDENAME)
-		icon_state = "[initial(icon_state)]up"
-		to_chat(usr, "You push the [src] up out of your face.")
-		flash_protect = 0
-		tint = 0
+		if(icon_state == "welding_redflame")
+		 flags_cover &= ~(HEADCOVERSEYES | HEADCOVERSMOUTH)
+		 flags_inv &= ~(HIDEMASK|HIDEHEADSETS|HIDEGLASSES|HIDENAME)
+		 icon_state = "welding_redflameup"
+		 to_chat(usr, "You push the [src] up out of your face.")
+		 flash_protect = 0
+		 tint = 0
+		else if(icon_state == "welding_blueflame")
+		 flags_cover &= ~(HEADCOVERSEYES | HEADCOVERSMOUTH)
+		 flags_inv &= ~(HIDEMASK|HIDEHEADSETS|HIDEGLASSES|HIDENAME)
+		 icon_state = "welding_blueflameup"
+		 to_chat(usr, "You push the [src] up out of your face.")
+		 flash_protect = 0
+		 tint = 0
+		else if(icon_state == "welding_white")
+		 flags_cover &= ~(HEADCOVERSEYES | HEADCOVERSMOUTH)
+		 flags_inv &= ~(HIDEMASK|HIDEHEADSETS|HIDEGLASSES|HIDENAME)
+		 icon_state = "welding_whiteup"
+		 to_chat(usr, "You push the [src] up out of your face.")
+		 flash_protect = 0
+		 tint = 0
+		else
+		 flags_cover &= ~(HEADCOVERSEYES | HEADCOVERSMOUTH)
+		 flags_inv &= ~(HIDEMASK|HIDEHEADSETS|HIDEGLASSES|HIDENAME)
+		 icon_state = "[initial(icon_state)]up"
+		 to_chat(usr, "You push the [src] up out of your face.")
+		 flash_protect = 0
+		 tint = 0
 	var/mob/living/carbon/user = usr
 	user.update_tint()
 	user.update_inv_head()	//so our mob-overlays update

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -95,7 +95,7 @@
 /obj/item/clothing/head/welding/proc/toggle()
 	if(up)
 		up = !up
-		if(icon_state == "welding_redflameup")
+		if(icon_state == "welding_redflameup") //painting check 
 		 flags_cover |= (HEADCOVERSEYES | HEADCOVERSMOUTH)
 		 flags_inv |= (HIDEMASK|HIDEHEADSETS|HIDEGLASSES|HIDENAME)
 		 icon_state = "welding_redflame"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Если покрасить сварочный шлем и после этого поднять его козырек, то покраска сбрасывается. Этот фикс исправляет это
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Фикс бага, который заметил в недавнем раунде
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
Было: 
![dreamseeker_52f2rXxo4O](https://github.com/ss220-space/Paradise/assets/67709054/a2a63afd-712f-4ed0-b840-db387619fff5)
Стало: 
![dreamseeker_IXAA6N1zQ9](https://github.com/ss220-space/Paradise/assets/67709054/6cfe1644-d0a1-4540-8c57-3c3227e2af2d)


<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
