### PR TITLE
hotfix: PDA Drop and Mining Satchel Fix

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -143,7 +143,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	storage_slots = 10
 	max_combined_w_class = 200 //Doesn't matter what this is, so long as it's more or equal to storage_slots * ore.w_class
-	max_w_class = WEIGHT_CLASS_NORMAL
+	max_w_class = WEIGHT_CLASS_BULKY
 	can_hold = list(/obj/item/stack/ore)
 
 /obj/item/storage/bag/ore/cyborg

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -181,6 +181,8 @@
 				drop_item_ground(wear_id, force = TRUE)
 			if(belt)
 				drop_item_ground(belt, force = TRUE)
+			if(wear_pda)
+				drop_item_ground(wear_pda, force = TRUE)
 		w_uniform = null
 		if(!QDELETED(src))
 			update_inv_w_uniform()


### PR DESCRIPTION
## Описание
<!--  -->
PDA теперь выпадает, при снятии комбинезона. Максимальный стак руды может поместиться в сумку.
