### PR TITLE
fix: Revenant Resurrection

### DIFF
--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -220,6 +220,7 @@
 	var/reforming_essence = essence_regen_cap //retain the gained essence capacity
 	R.essence = max(reforming_essence - 15 * perfectsouls, 75) //minus any perfect souls
 	R.client_to_revive = src.client //If the essence reforms, the old revenant is put back in the body
+	R.reforming = TRUE
 	ghostize()
 	qdel(src)
 


### PR DESCRIPTION
## Описание
<!--  -->
В игре задумана механика возвращения ревенанта из эктоплазмы, через минуту после смерти. Но она сломана из-за отсутствия одной строчки кода.

## Ссылка на предложение/Причина создания ПР
<!--  -->
Восстанавливаем задуманную механику.
