### PR TITLE
fix: Удаление из камня .357 револьвера в anomalyship

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/anomalyship.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/anomalyship.dmm
@@ -2376,10 +2376,6 @@
 	},
 /turf/simulated/floor,
 /area/ae13/hall)
-"TS" = (
-/obj/item/gun/projectile/revolver,
-/turf/simulated/mineral/iron,
-/area/ae13/asteroid)
 "TU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -5342,7 +5338,7 @@ dR
 dR
 dR
 dR
-TS
+dR
 dR
 dR
 dR


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
ПР удаляет .357 револьвер из внутренностей метеорита (он буквально в камне). Быть его там не должно, о чём написал автор руины.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
https://discord.com/channels/617003227182792704/943940908162875473/1117568414492405801