### PR TITLE
fix: Runtimes Caused by No Suit&Head on Xenos

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/update_icons.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/update_icons.dm
@@ -59,8 +59,8 @@
 	if(notransform)
 		return
 
-	update_inv_head()
-	update_inv_wear_suit()
+	//update_inv_head()
+	//update_inv_wear_suit()
 	update_inv_r_hand()
 	update_inv_l_hand()
 	update_inv_pockets()


### PR DESCRIPTION
## Описание
<!-- -->
У ксеносов не восстановлено функционирование костюма и головного убора, что вызывает рантаймы при апдейте иконок. Пока не будет восстановлено - закомментил.