### PR TITLE
feat: now boxes with monkey cubes can be used to fill xenobio consoles

### DIFF
--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -155,7 +155,7 @@
 			current_potion = O
 			to_chat(user, "<span class='notice'>You load [O] in the console's potion slot[replaced ? ", replacing the one that was there before" : ""].</span>")
 		return
-	else if(istype(O, /obj/item/storage/bag))
+	else if(istype(O, /obj/item/storage/bag/bio) || istype(O, /obj/item/storage/box/monkeycubes))
 		var/obj/item/storage/P = O
 		var/loaded = 0
 		for(var/obj/item/reagent_containers/food/snacks/monkeycube/MC in P.contents)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Разрешает использовать коробки с манкикубами на консолях ксенобиологии, чтобы мгновенно пополнять их содержимым оной.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
QoL ксенобиологам, сделано по запросу.
## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
![42](https://github.com/ss220-space/Paradise/assets/73733747/edee77d1-e528-4a8a-bfca-5f53b5e8de85)
