### PR TITLE
feat: Thunderdome for ghosts, patch 1

### DIFF
--- a/_maps/map_files/generic/Admin_Zone.dmm
+++ b/_maps/map_files/generic/Admin_Zone.dmm
@@ -632,6 +632,9 @@
 /obj/item/gun/projectile/revolver/doublebarrel,
 /turf/simulated/floor/wood,
 /area/admin)
+"ga" = (
+/turf/simulated/wall/indestructible,
+/area/tdome/newtdome/CQC)
 "ge" = (
 /obj/structure/table/wood,
 /obj/item/gun/projectile/revolver/fingergun/fake,
@@ -4192,6 +4195,9 @@
 "Yq" = (
 /turf/space,
 /area/space)
+"Yz" = (
+/turf/simulated/wall/indestructible,
+/area/tdome/newtdome)
 "YC" = (
 /turf/simulated/floor/beach/sand,
 /area/holodeck/source_beach)
@@ -59642,6 +59648,7 @@ Yq
 Yq
 QQ
 ac
+Yz
 ac
 ac
 ac
@@ -59659,8 +59666,7 @@ ac
 ac
 ac
 ac
-ac
-ac
+Yz
 ac
 QQ
 Yq
@@ -59900,6 +59906,7 @@ Yq
 QQ
 ac
 ac
+Yz
 ac
 ac
 ac
@@ -59907,6 +59914,7 @@ ac
 ac
 ac
 ac
+Yz
 ac
 ac
 ac
@@ -59914,9 +59922,7 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
+Yz
 ac
 ac
 QQ
@@ -60161,6 +60167,7 @@ ac
 ac
 ac
 ac
+Yz
 ac
 ac
 ac
@@ -60168,8 +60175,7 @@ ac
 ac
 ac
 ac
-ac
-ac
+Yz
 ac
 ac
 ac
@@ -60932,15 +60938,15 @@ ac
 ad
 yQ
 yQ
+ga
 yQ
 yQ
 yQ
+ga
 yQ
 yQ
 yQ
-yQ
-yQ
-yQ
+ga
 yQ
 yQ
 ad
@@ -61185,7 +61191,7 @@ Yq
 QQ
 ac
 ac
-ac
+Yz
 ad
 yQ
 yQ
@@ -61201,7 +61207,7 @@ yQ
 yQ
 yQ
 ad
-ac
+Yz
 ac
 ac
 QQ
@@ -61448,11 +61454,11 @@ yQ
 yQ
 yQ
 yQ
+ga
 yQ
 yQ
 yQ
-yQ
-yQ
+ga
 yQ
 yQ
 yQ
@@ -61706,9 +61712,9 @@ yQ
 yQ
 yQ
 yQ
+ga
 yQ
-yQ
-yQ
+ga
 yQ
 yQ
 yQ
@@ -62212,25 +62218,25 @@ Yq
 Yq
 QQ
 ac
-ac
+Yz
 ac
 ad
 yQ
+ga
 yQ
 yQ
-yQ
-yQ
+ga
 yQ
 Uw
 yQ
+ga
 yQ
 yQ
-yQ
-yQ
+ga
 yQ
 ad
 ac
-ac
+Yz
 ac
 QQ
 Yq
@@ -62734,9 +62740,9 @@ yQ
 yQ
 yQ
 yQ
+ga
 yQ
-yQ
-yQ
+ga
 yQ
 yQ
 yQ
@@ -62990,11 +62996,11 @@ yQ
 yQ
 yQ
 yQ
+ga
 yQ
 yQ
 yQ
-yQ
-yQ
+ga
 yQ
 yQ
 yQ
@@ -63241,7 +63247,7 @@ Yq
 QQ
 ac
 ac
-ac
+Yz
 ad
 yQ
 yQ
@@ -63257,7 +63263,7 @@ yQ
 yQ
 yQ
 ad
-ac
+Yz
 ac
 ac
 QQ
@@ -63502,15 +63508,15 @@ ac
 ad
 yQ
 yQ
+ga
 yQ
 yQ
 yQ
+ga
 yQ
 yQ
 yQ
-yQ
-yQ
-yQ
+ga
 yQ
 yQ
 ad
@@ -64273,6 +64279,7 @@ ac
 ac
 ac
 ac
+Yz
 ac
 ac
 ac
@@ -64280,8 +64287,7 @@ ac
 ac
 ac
 ac
-ac
-ac
+Yz
 ac
 ac
 ac
@@ -64526,6 +64532,7 @@ Yq
 QQ
 ac
 ac
+Yz
 ac
 ac
 ac
@@ -64533,6 +64540,7 @@ ac
 ac
 ac
 ac
+Yz
 ac
 ac
 ac
@@ -64540,9 +64548,7 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
+Yz
 ac
 ac
 QQ
@@ -64782,6 +64788,7 @@ Yq
 Yq
 QQ
 ac
+Yz
 ac
 ac
 ac
@@ -64799,8 +64806,7 @@ ac
 ac
 ac
 ac
-ac
-ac
+Yz
 ac
 QQ
 Yq

--- a/code/modules/thunderdome/thunderdome_battle.dm
+++ b/code/modules/thunderdome/thunderdome_battle.dm
@@ -5,7 +5,7 @@
 #define ARENA_COOLDOWN 5 MINUTES //After which time thunderdome will be once again allowed to use
 #define CQC_ARENA_RADIUS 6 //how much tiles away from a center players will spawn
 #define RANGED_ARENA_RADIUS 10
-#define VOTING_POLL_TIME 60 SECONDS
+#define VOTING_POLL_TIME 35 SECONDS
 #define MAX_PLAYERS_COUNT 16
 #define MIN_PLAYERS_COUNT 2
 #define SPAWN_COEFFICENT 0.85 //how many (polled * spawn_coefficent) players will go brawling

--- a/code/modules/thunderdome/thunderdome_battle.dm
+++ b/code/modules/thunderdome/thunderdome_battle.dm
@@ -165,7 +165,7 @@ GLOBAL_DATUM_INIT(thunderdome_battle, /datum/thunderdome_battle, new())
 		var/ang = phi * 180 / PI
 		curr_x = center.x + radius * cos(ang)
 		curr_y = center.y + radius * sin(ang)
-		var/obj/effect/mob_spawn/human/thunderdome/brawler = new brawler_type(get_rounded_location(curr_x, curr_y, center.z))
+		var/obj/effect/mob_spawn/human/thunderdome/brawler = new brawler_type(locate(curr_x, curr_y, center.z))
 		brawler.outfit.backpack_contents += random_stuff
 		var/mob/dead/observer/ghost = candidates[currpoint]
 		brawler.attack_ghost(ghost)

--- a/code/modules/thunderdome/thunderdome_battle.dm
+++ b/code/modules/thunderdome/thunderdome_battle.dm
@@ -18,6 +18,7 @@
 #define ARENA_COOLDOWN 30 SECONDS
 #define VOTING_POLL_TIME 10 SECONDS
 #define MIN_PLAYERS_COUNT 1
+#define PICK_PENALTY 0
 #endif
 */
 
@@ -147,16 +148,21 @@ GLOBAL_DATUM_INIT(thunderdome_battle, /datum/thunderdome_battle, new())
 		for(var/obj/machinery/door/poddoor/M in GLOB.airlocks)
 			if(M.id_tag != "TD_CloseCombat")
 				continue
-			spawn(0)
-				M.close()
+			M.do_animate("closing")
+			M.density = TRUE
+			M.set_opacity(1)
+			M.layer = M.closingLayer
+			M.update_icon()
 
 	if(mode == RANGED_MODE || mode == MIXED_MODE)
 		for(var/obj/machinery/door/poddoor/M in GLOB.airlocks)
 			if(M.id_tag != "TD_CloseCombat")
 				continue
 			if(M.density)
-				spawn(0)
-					M.open()
+				M.do_animate("opening")
+				M.density = FALSE
+				M.set_opacity(0)
+				M.update_icon()
 
 
 	while(currpoint <= points)

--- a/code/modules/thunderdome/thunderdome_battle.dm
+++ b/code/modules/thunderdome/thunderdome_battle.dm
@@ -52,8 +52,6 @@ GLOBAL_DATUM_INIT(thunderdome_battle, /datum/thunderdome_battle, new())
 	var/when_cleansing_happened = 0 //storing (in ticks) moment of arena cleansing
 
 	var/list/melee_pool = list(
-		/obj/item/melee/baton/loaded = 1,
-		/obj/item/melee/baseball_bat = 1,
 		/obj/item/melee/rapier = 1,
 		/obj/item/melee/energy/axe = 1,
 		/obj/item/melee/energy/sword/saber/red = 1,
@@ -65,7 +63,10 @@ GLOBAL_DATUM_INIT(thunderdome_battle, /datum/thunderdome_battle, new())
 		/obj/item/twohanded/fireaxe = 1,
 		/obj/item/melee/icepick = 1,
 		/obj/item/melee/candy_sword = 1,
-		/obj/item/melee/energy/sword/pirate = 1
+		/obj/item/melee/energy/sword/pirate = 1,
+		/obj/item/storage/toolbox/surgery = 1,
+		/obj/item/storage/toolbox/mechanical = 1,
+		/obj/item/storage/toolbox/syndicate = 1,
 	)
 
 	var/list/ranged_pool = list(
@@ -84,7 +85,6 @@ GLOBAL_DATUM_INIT(thunderdome_battle, /datum/thunderdome_battle, new())
 		/obj/item/gun/projectile/shotgun/riot/buckshot = 3,
 		/obj/item/gun/projectile/shotgun/boltaction = 1,
 		/obj/item/gun/projectile/shotgun/automatic/combat = 2,
-		/obj/item/gun/projectile/automatic/pistol/enforcer = 2,
 		/obj/item/gun/projectile/automatic/pistol/APS = 1,
 		/obj/item/gun/projectile/automatic/pistol/sp8ar = 1,
 		/obj/item/gun/projectile/automatic/pistol/m1911 = 1,
@@ -396,6 +396,12 @@ GLOBAL_DATUM_INIT(thunderdome_battle, /datum/thunderdome_battle, new())
 	icon = 'icons/effects/blood.dmi'
 	icon_state = "remains"
 	var/time_to_live = DEFAULT_TIME_LIMIT
+	actions_types = list(/datum/action/item_action/postponed_death)
+
+/datum/action/item_action/postponed_death
+	name = "Suicide"
+	check_flags = FALSE
+
 
 /obj/item/implant/postponed_death/implant(mob/source, mob/user)
 	. = ..()

--- a/code/modules/thunderdome/thunderdome_battle.dm
+++ b/code/modules/thunderdome/thunderdome_battle.dm
@@ -290,7 +290,7 @@ GLOBAL_DATUM_INIT(thunderdome_battle, /datum/thunderdome_battle, new())
 		to_chat(user, "Вы сможете начать набор только спустя [PICK_PENALTY / 10] секунд после очистки Тандердома.")
 		return
 	if(!SSghost_spawns.is_eligible(user, ROLE_THUNDERDOME))
-		to_chat(user, "Вы не можете использовать Тандердом. Включите эту возможность в Game Preferences!")
+		to_chat(user, "Вы не можете использовать Тандердом. Включите эту возможность, отметив роль Thunderdome в Game Preferences!")
 		return
 	if(thunderdome.isGoing)
 		to_chat(user, "Битва все ещё идёт или прошло недостаточно времени с момента последнего голосования!")

--- a/code/modules/thunderdome/thunderdome_battle.dm
+++ b/code/modules/thunderdome/thunderdome_battle.dm
@@ -5,7 +5,7 @@
 #define ARENA_COOLDOWN 5 MINUTES //After which time thunderdome will be once again allowed to use
 #define CQC_ARENA_RADIUS 6 //how much tiles away from a center players will spawn
 #define RANGED_ARENA_RADIUS 10
-#define VOTING_POLL_TIME 35 SECONDS
+#define VOTING_POLL_TIME 30 SECONDS
 #define MAX_PLAYERS_COUNT 16
 #define MIN_PLAYERS_COUNT 2
 #define SPAWN_COEFFICENT 0.85 //how many (polled * spawn_coefficent) players will go brawling
@@ -67,6 +67,7 @@ GLOBAL_DATUM_INIT(thunderdome_battle, /datum/thunderdome_battle, new())
 		/obj/item/storage/toolbox/surgery = 1,
 		/obj/item/storage/toolbox/mechanical = 1,
 		/obj/item/storage/toolbox/syndicate = 1,
+		/obj/item/storage/box/syndie_kit/mantisblade = 1
 	)
 
 	var/list/ranged_pool = list(


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Первый патч Тандердома для призраков.

- На арене добавлены стенки для укрытий.
- Убрано звуковое оповещение о том, что тандердом готов к использованию.
- Теперь один и тот же игрок при выборе тандердома два раза подряд имеет штраф ко времени выбора в 30 секунд.
- Убраны и добавлены новые предметы в пулл случайного оружия для ближнего и дальнего боя.
- Время набора на тандердом уменьшено с 60 до 30 секунд.
- Теперь нельзя использовать тандердом во время "лобби" и конца раунда
- Теперь нельзя забежать в закрывающиеся шаттеры, ограничивающие арену
- Имплант смерти теперь можно активировать даже будучи мертвым

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Сделано по отзывам первого дня, большое спасибо GuteKatze, Ha1t и других за фидбек и возможность опробовать эксперименты с ареной на самом сервере.

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
![изображение](https://github.com/ss220-space/Paradise/assets/73733747/bc90a380-5ea9-48d1-b439-4c605b439a43)

