### PR TITLE
Fix/feat memories changes when mind/body changes 

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -16,6 +16,7 @@
 	var/list/stage4 = list("You feel white bread.")
 	var/list/stage5 = list("Oh the humanity!")
 	var/new_form = /mob/living/carbon/human
+	var/is_new_mind = FALSE
 
 /datum/disease/transformation/stage_act()
 	..()
@@ -62,6 +63,8 @@
 			new_mob.a_intent = "harm"
 			if(affected_mob.mind)
 				affected_mob.mind.transfer_to(new_mob)
+				if(is_new_mind)
+					new_mob.mind.wipe_memory()
 			else
 				new_mob.key = affected_mob.key
 		qdel(affected_mob)
@@ -84,6 +87,7 @@
 	visibility_flags = 0
 	agent = "Kongey Vibrion M-909"
 	new_form = /mob/living/carbon/human/lesser/monkey
+	is_new_mind = TRUE
 
 	stage1	= null
 	stage2	= null
@@ -121,12 +125,14 @@
 	desc = "This disease, actually acute nanomachine infection, converts the victim into a cyborg."
 	severity = DANGEROUS
 	visibility_flags = 0
+	new_form = /mob/living/silicon/robot
+	is_new_mind = TRUE
+
 	stage1	= null
 	stage2	= list("Your joints feel stiff.", "<span class='danger'>Beep...boop..</span>")
 	stage3	= list("<span class='danger'>Your joints feel very stiff.</span>", "Your skin feels loose.", "<span class='danger'>You can feel something move...inside.</span>")
 	stage4	= list("<span class='danger'>Your skin feels very loose.</span>", "<span class='danger'>You can feel... something...inside you.</span>")
 	stage5	= list("<span class='danger'>Your skin feels as if it's about to burst off!</span>")
-	new_form = /mob/living/silicon/robot
 
 
 /datum/disease/transformation/robot/stage_act()
@@ -219,6 +225,7 @@
 	stage4	= list("<span class='danger'>Visions of washing machines assail your mind!</span>")
 	stage5	= list("<span class='danger'>AUUUUUU!!!</span>")
 	new_form = /mob/living/simple_animal/pet/dog/corgi
+	is_new_mind = TRUE
 
 /datum/disease/transformation/corgi/stage_act()
 	..()

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -134,11 +134,14 @@
 
 /datum/mind/proc/wipe_memory()
 	memory = null
+	if(current)
+		name = current.real_name
+		to_chat(current, span_danger("Вы потеряли свою личность и память! Отыгрывайте новое существо!"))
 
 /datum/mind/proc/show_memory(mob/recipient, window = 1)
 	if(!recipient)
 		recipient = current
-	var/output = {"<meta charset="UTF-8"><B>[current.real_name]'s Memories:</B><HR>"}
+	var/output = {"<meta charset="UTF-8"><B>[name]'s Memories:</B><HR>"}
 	output += memory
 
 	var/antag_datum_objectives = FALSE


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
* fix: Memories are now showing mind's name, not mob's name

* feat: Wabbajack replaces memories

* tweak: Wipe memory now confirms you don't have memories

* feat: Transformation disease can wipe memories

fix: Morph transformation keeps memories

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
