### PR TITLE
FIX: Undestructiable Cryopod and Freezer

### DIFF
--- a/code/game/machinery/Freezer.dm
+++ b/code/game/machinery/Freezer.dm
@@ -11,6 +11,7 @@
 	current_heat_capacity = 1000
 	layer = 3
 	plane = GAME_PLANE
+	resistance_flags = null
 	max_integrity = 300
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 100, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 30)
 

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -10,6 +10,7 @@
 	anchored = 1.0
 	layer = ABOVE_WINDOW_LAYER
 	plane = GAME_PLANE
+	resistance_flags = null
 	interact_offline = 1
 	max_integrity = 350
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 100, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 30, "acid" = 30)


### PR DESCRIPTION
Исправляет ошибку в коде, где две имеющие сопротивление огню не 100%  машинерии имели иммунитет к огню из-за флага в родительском коде.

<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
баг, делающий криокапсулы(не те что криохранилище) и фризеры неуязвимыми к огню, когда как у них не 100% резист к оному.

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
