### PR TITLE
ref/feat: Radioactivity Component

### DIFF
--- a/code/__HELPERS/atoms.dm
+++ b/code/__HELPERS/atoms.dm
@@ -53,3 +53,17 @@
 			// E.g. medals.
 			if(I.vars[var_name] == src)
 				I.vars[var_name] = null
+
+
+/**
+ * Proc that collects all atoms of passed `path` in our atom contents
+ * and returns it in a list()
+ */
+/atom/proc/collect_all_atoms_of_type(path)
+	var/list/atoms = list()
+	for(var/atom/check in contents)
+		if(istype(check, path))
+			atoms += check
+		if(length(check.contents))
+			check.collect_all_atoms_of_type(path)
+	return atoms

--- a/code/__HELPERS/traits.dm
+++ b/code/__HELPERS/traits.dm
@@ -60,6 +60,10 @@
 Remember to update _globalvars/traits.dm if you're adding/removing/renaming traits.
 */
 
+//atom traits
+/// Trait used to prevent an atom from component radiation emission (see radioactivity.dm)
+#define TRAIT_BLOCK_RADIATION	"block_radiation"
+
 //mob traits
 #define TRAIT_PACIFISM			"pacifism"
 #define TRAIT_WATERBREATH		"waterbreathing"

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -22,6 +22,7 @@
 
 
 /atom/proc/attack_hand(mob/user)
+	SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_HAND, user)
 	return
 
 /*

--- a/code/datums/components/radioactivity.dm
+++ b/code/datums/components/radioactivity.dm
@@ -1,0 +1,235 @@
+/**
+ * Radioactivity Component
+ *
+ * When applied to an atom it will make it radioactive
+ *
+ */
+/datum/component/radioactivity
+	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS // Only one of the component can exist on an item
+	/// How much rads our parent emits per interaction
+	var/rad_per_interaction = 0
+	/// Chance for radiation to fire on interaction, if zero it doesn't count
+	var/rad_interaction_chance = 0
+	/// Cooldown between rads emissions
+	var/rad_interaction_cooldown = 1 SECONDS
+	/// Radius for radiation effect on interaction
+	var/rad_interaction_radius = 0
+	/// How much rads our parent emits per cycle
+	var/rad_per_cycle = 0
+	/// Chance for radiation to fire per cycle, if zero it doesn't count
+	var/rad_cycle_chance = 0
+	/// How ofter radiation fired if rad_per_cycle is anything but zero
+	var/rad_cycle = 2 SECONDS
+	/// Radius for radiation effect per cycle
+	var/rad_cycle_radius = 0
+	/// Wheter radiation should ignore armor protection
+	var/negate_armor = FALSE
+	/// Optional callback to be called when someone interact with our atom
+	var/datum/callback/interact_callback
+	/// Optional callback to be called per cycle
+	var/datum/callback/cycle_callback
+	/// Timestamp for interaction cooldown
+	var/last_interact_time = 0
+	/// Timer ID
+	var/cycle_timer = null
+
+
+/**
+ * Radioactivity Component
+ *
+ * Arguments:
+ * * rad_per_interaction How much rads our parent emits per interaction
+ * * rad_interaction_chance (otional) Chance for emission to occur on interaction (1-100), doesn't count if 0
+ * * rad_interaction_cooldown (otional) Cooldown between rads emission on interaction
+ * * rad_interaction_radius (optional) Radius for radiation effect on interaction, 0 = atom's turf
+ * * rad_per_cycle (optional) How much rads our parent emits per time cycle
+ * * rad_cycle (optional) How ofter radiation fired if rad_per_cycle is not a zero value
+ * * rad_cycle_radius (optional) Radius for radiation effect on cycle, 0 = atom's turf
+ * * negate_armor (optional) Wheter radiation should ignore armor protection
+ * * interact_callback (optional) Additional callback on the parent to be called when someone interact with our atom
+ * * cycle_callback (optional) Additional callback on the parent to be called per cycle
+ */
+/datum/component/radioactivity/Initialize(rad_per_interaction = 0, rad_interaction_chance = 0, rad_interaction_radius = 0, \
+										rad_interaction_cooldown = 1 SECONDS, rad_per_cycle = 0, rad_cycle_chance = 0, rad_cycle = 2 SECONDS, \
+										rad_cycle_radius = 0, negate_armor = FALSE, datum/callback/interact_callback, datum/callback/cycle_callback)
+
+	if(!isatom(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	src.rad_per_interaction = rad_per_interaction
+	src.rad_interaction_chance = clamp(round(rad_interaction_chance), 0, 100)
+	src.rad_interaction_cooldown = rad_interaction_cooldown
+	src.rad_interaction_radius = rad_interaction_radius
+
+	src.rad_per_cycle = rad_per_cycle
+	src.rad_cycle_chance = clamp(round(rad_cycle_chance), 0, 100)
+	src.rad_cycle = rad_cycle
+	src.rad_cycle_radius = rad_cycle_radius
+	src.negate_armor = negate_armor
+
+	if(interact_callback)
+		src.interact_callback = interact_callback
+	if(cycle_callback)
+		src.cycle_callback = cycle_callback
+
+	if(src.rad_per_cycle)
+		cycle_timer = addtimer(CALLBACK(parent, TYPE_PROC_REF(/atom, component_rad_process), rad_per_cycle, rad_cycle_chance, \
+		rad_cycle_radius, negate_armor, src.cycle_callback), src.rad_cycle, TIMER_UNIQUE | TIMER_LOOP | TIMER_STOPPABLE)
+
+
+// Inherit the new values passed to the component
+/datum/component/radioactivity/InheritComponent(datum/component/radioactivity/new_comp, original, rad_per_interaction = 0, rad_interaction_chance = 0, \
+											rad_interaction_cooldown = 0, rad_interaction_radius = 0, rad_per_cycle = 0, rad_cycle = 2 SECONDS, \
+											rad_cycle_radius = 0, negate_armor = FALSE, datum/callback/interact_callback, datum/callback/cycle_callback)
+
+	if(!original)
+		return
+
+	src.rad_per_interaction = rad_per_interaction
+	src.rad_interaction_chance = clamp(round(rad_interaction_chance), 0, 100)
+	src.rad_interaction_cooldown = rad_interaction_cooldown
+	src.rad_interaction_radius = rad_interaction_radius
+
+	src.rad_per_cycle = rad_per_cycle
+	src.rad_cycle_chance = clamp(round(rad_cycle_chance), 0, 100)
+	src.rad_cycle = rad_cycle
+	src.rad_cycle_radius = rad_cycle_radius
+	src.negate_armor = negate_armor
+
+	if(interact_callback)
+		src.interact_callback = interact_callback
+	if(cycle_callback)
+		src.cycle_callback = cycle_callback
+
+	if(cycle_timer)
+		deltimer(cycle_timer)
+		if(src.rad_per_cycle)
+			cycle_timer = addtimer(CALLBACK(parent, TYPE_PROC_REF(/atom, component_rad_process), rad_per_cycle, rad_cycle_chance, \
+			rad_cycle_radius, negate_armor, src.cycle_callback), src.rad_cycle, TIMER_UNIQUE | TIMER_LOOP | TIMER_STOPPABLE)
+		else
+			cycle_timer = null
+
+
+// Register signals withthe parent item
+/datum/component/radioactivity/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_ATOM_BUMPED, PROC_REF(on_bump))
+	RegisterSignal(parent, COMSIG_ATOM_ENTERED, PROC_REF(on_enter))
+	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, PROC_REF(on_attack_by))
+	RegisterSignal(parent, COMSIG_ATOM_ATTACK_HAND, PROC_REF(on_attack_hand))
+
+	if(isitem(parent))
+		RegisterSignal(parent, COMSIG_ITEM_ATTACK, PROC_REF(on_attack_mob))
+		RegisterSignal(parent, COMSIG_ITEM_ATTACK_OBJ, PROC_REF(on_attack_obj))
+
+
+// Remove all siginals registered to the parent item
+/datum/component/radioactivity/UnregisterFromParent()
+	UnregisterSignal(parent, list(COMSIG_ATOM_BUMPED, COMSIG_ATOM_ENTERED, COMSIG_PARENT_ATTACKBY, COMSIG_ATOM_ATTACK_HAND))
+
+	if(isitem(parent))
+		UnregisterSignal(parent, list(COMSIG_ITEM_ATTACK, COMSIG_ITEM_ATTACK_OBJ))
+
+
+// Triggered on atom bump
+/datum/component/radioactivity/proc/on_bump(datum/source, atom/movable/moving_atom)
+	SIGNAL_HANDLER
+	rad_interact(moving_atom)
+
+
+// Triggered on parent being entered by other atom
+/datum/component/radioactivity/proc/on_enter(datum/source, atom/movable/moving_atom)
+	SIGNAL_HANDLER
+	rad_interact(moving_atom)
+
+
+// Triggered on atom being attacked
+/datum/component/radioactivity/proc/on_attack_by(datum/source, obj/item/attacking_item, mob/user)
+	SIGNAL_HANDLER
+	rad_interact(user)
+
+
+// Triggered on atom being attacked by hand
+/datum/component/radioactivity/proc/on_attack_hand(datum/source, mob/user)
+	SIGNAL_HANDLER
+	rad_interact(user)
+
+
+// Triggered on attack mob with the parent item
+/datum/component/radioactivity/proc/on_attack_mob(obj/item/source, mob/target, mob/user)
+	SIGNAL_HANDLER
+	rad_interact(user)
+
+
+// Triggered on attack obj with the parent item
+/datum/component/radioactivity/proc/on_attack_obj(obj/item/source, obj/target, mob/user)
+	SIGNAL_HANDLER
+	rad_interact(user)
+
+
+// Generic interact proc
+/datum/component/radioactivity/proc/rad_interact(datum/interacting_atom)
+	if(QDELETED(parent))
+		return
+
+	if(HAS_TRAIT(parent, TRAIT_BLOCK_RADIATION))
+		return
+
+	if(!rad_per_interaction)
+		return
+
+	if(rad_interaction_chance && !prob(rad_interaction_chance))
+		return
+
+	if(world.time < last_interact_time + rad_interaction_cooldown)
+		return
+	last_interact_time = world.time
+
+	INVOKE_ASYNC(parent, TYPE_PROC_REF(/atom, component_radiate), rad_per_interaction, rad_interaction_radius, 0, 0, negate_armor)
+	interact_callback?.Invoke(parent, interacting_atom)
+
+
+// Generic process proc
+/atom/proc/component_rad_process(rad_per_cycle, rad_cycle_chance, rad_cycle_radius, negate_armor, datum/callback/cycle_callback)
+	if(QDELETED(src))
+		return
+
+	if(HAS_TRAIT(src, TRAIT_BLOCK_RADIATION))
+		return
+
+	if(!rad_per_cycle)
+		return
+
+	if(rad_cycle_chance && !prob(rad_cycle_chance))
+		return
+
+	component_radiate(0, 0, rad_per_cycle, rad_cycle_radius, negate_armor)
+	cycle_callback?.Invoke(src)
+
+
+// Irradiation main proc
+/atom/proc/component_radiate(rad_per_interaction, rad_interaction_radius, rad_per_cycle, rad_cycle_radius, negate_armor)
+	if(QDELETED(src))
+		return
+
+	var/turf/parent_turf = get_turf(src)
+	if(!parent_turf)
+		return
+
+	var/list/irradiated_mobs = list()
+	var/rad_damage = rad_per_interaction
+	var/rad_range = rad_interaction_radius
+
+	if(rad_per_cycle)
+		rad_damage = rad_per_cycle
+		rad_range = rad_cycle_radius
+
+	for(var/turf/target_turf in range(rad_range, parent_turf))
+		irradiated_mobs |= target_turf.collect_all_atoms_of_type(/mob/living)
+
+	if(!length(irradiated_mobs))
+		return
+
+	for(var/mob/living/target as anything in irradiated_mobs)
+		if(!target || QDELETED(target))
+			continue
+		target.apply_effect(rad_damage, IRRADIATE, FALSE, negate_armor)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -253,8 +253,8 @@
 /atom/proc/on_reagent_change()
 	return
 
-/atom/proc/Bumped(atom/movable/AM)
-	SEND_SIGNAL(src, COMSIG_ATOM_BUMPED, AM)
+/atom/proc/Bumped(atom/movable/moving_atom)
+	SEND_SIGNAL(src, COMSIG_ATOM_BUMPED, moving_atom)
 	return
 
 /// Convenience proc to see if a container is open for chemistry handling

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -254,6 +254,7 @@
 	return
 
 /atom/proc/Bumped(atom/movable/AM)
+	SEND_SIGNAL(src, COMSIG_ATOM_BUMPED, AM)
 	return
 
 /// Convenience proc to see if a container is open for chemistry handling

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -338,7 +338,7 @@ GLOBAL_LIST_INIT(blacklisted_pylon_turfs, typecacheof(list(
 /obj/effect/gateway/singularity_pull()
 	return
 
-/obj/effect/gateway/Bumped(atom/movable/AM)
+/obj/effect/gateway/Bumped(atom/movable/moving_atom)
 	return
 
 /obj/effect/gateway/Crossed(atom/movable/AM, oldloc)

--- a/code/game/gamemodes/miniantags/guardian/types/bomb.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/bomb.dm
@@ -130,8 +130,8 @@
 /obj/item/guardian_bomb/MouseDrop(mob/living/user)
 	detonate(user)
 
-/obj/item/guardian_bomb/Bumped(mob/living/user)
-	detonate(user)
+/obj/item/guardian_bomb/Bumped(atom/movable/moving_atom)
+	detonate(moving_atom)
 
 /obj/item/guardian_bomb/can_be_pulled(mob/living/user)
 	detonate(user)

--- a/code/game/gamemodes/miniantags/guardian/types/fire.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/fire.dm
@@ -40,9 +40,9 @@
 	..()
 	collision_ignite(AM)
 
-/mob/living/simple_animal/hostile/guardian/fire/Bumped(AM as mob|obj)
+/mob/living/simple_animal/hostile/guardian/fire/Bumped(atom/movable/moving_atom)
 	..()
-	collision_ignite(AM)
+	collision_ignite(moving_atom)
 
 /mob/living/simple_animal/hostile/guardian/fire/Bump(AM as mob|obj)
 	..()

--- a/code/game/machinery/computer/pod.dm
+++ b/code/game/machinery/computer/pod.dm
@@ -354,14 +354,14 @@
 	var/id_tag = ""
 
 
-/obj/structure/deathsquad_tele/Bumped(var/atom/movable/AM)
+/obj/structure/deathsquad_tele/Bumped(atom/movable/moving_atom)
 	if(!ztarget)	return ..()
-	var/y = AM.y
+	var/y = moving_atom.y
 	spawn()
-		AM.z = ztarget
-		AM.y = y
-		AM.x = world.maxx - TRANSITIONEDGE - 2
-		AM.dir = 8
-		var/atom/target = get_edge_target_turf(AM, AM.dir)
-		AM.throw_at(target, 50, 1)
+		moving_atom.z = ztarget
+		moving_atom.y = y
+		moving_atom.x = world.maxx - TRANSITIONEDGE - 2
+		moving_atom.dir = 8
+		var/atom/target = get_edge_target_turf(moving_atom, moving_atom.dir)
+		moving_atom.throw_at(target, 50, 1)
 	return

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -738,6 +738,7 @@ About the new airlock wires panel:
 		H.attack_hulk(src)
 
 /obj/machinery/door/airlock/attack_hand(mob/user)
+	SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_HAND, user)
 	if(shock_user(user, 100))
 		add_fingerprint(user)
 		return

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -115,10 +115,10 @@
 	. = ..()
 	if(!surpress_send) send_status()
 
-/obj/machinery/door/airlock/Bumped(atom/AM)
-	..(AM)
-	if(istype(AM, /obj/mecha))
-		var/obj/mecha/mecha = AM
+/obj/machinery/door/airlock/Bumped(atom/movable/moving_atom)
+	..(moving_atom)
+	if(istype(moving_atom, /obj/mecha))
+		var/obj/mecha/mecha = moving_atom
 		if(density && radio_connection && mecha.occupant && (allowed(mecha.occupant) || check_access_list(mecha.operation_req_access)))
 			send_status(1)
 	return

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -152,17 +152,14 @@
 	paintable = FALSE
 	var/event_step = 20
 
-/obj/machinery/door/airlock/uranium/New()
-	..()
-	addtimer(CALLBACK(src, PROC_REF(radiate)), event_step)
-
-
-/obj/machinery/door/airlock/uranium/proc/radiate()
-	if(prob(50))
-		for(var/mob/living/L in range (3,src))
-			L.apply_effect(15,IRRADIATE,0)
-	addtimer(CALLBACK(src, PROC_REF(radiate)), event_step)
-
+/obj/machinery/door/airlock/uranium/Initialize()
+	. = ..()
+	AddComponent(/datum/component/radioactivity, \
+				rad_per_cycle = 15, \
+				rad_cycle_chance = 50, \
+				rad_cycle = 2 SECONDS, \
+				rad_cycle_radius = 3 \
+	)
 
 /obj/machinery/door/airlock/uranium/glass
 	opacity = 0

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -88,17 +88,17 @@
 	QDEL_NULL(spark_system)
 	return ..()
 
-/obj/machinery/door/Bumped(atom/AM)
+/obj/machinery/door/Bumped(atom/movable/moving_atom)
 	..()
 
 	if(operating || emagged)
 		return
-	if(ismob(AM))
-		var/mob/B = AM
+	if(ismob(moving_atom))
+		var/mob/B = moving_atom
 		if((isrobot(B)) && B.stat)
 			return
-		if(isliving(AM))
-			var/mob/living/M = AM
+		if(isliving(moving_atom))
+			var/mob/living/M = moving_atom
 			if(world.time - M.last_bumped <= 10)
 				return	//Can bump-open one airlock per second. This is to prevent shock spam.
 			M.last_bumped = world.time
@@ -108,8 +108,8 @@
 				bumpopen(M)
 			return
 
-	if(ismecha(AM))
-		var/obj/mecha/mecha = AM
+	if(ismecha(moving_atom))
+		var/obj/mecha/mecha = moving_atom
 		if(density)
 			if(mecha.occupant)
 				if(world.time - mecha.occupant.last_bumped <= 10)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -89,6 +89,8 @@
 	return ..()
 
 /obj/machinery/door/Bumped(atom/AM)
+	..()
+
 	if(operating || emagged)
 		return
 	if(ismob(AM))

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -73,6 +73,7 @@
 
 /obj/machinery/door/firedoor/Bumped(atom/AM)
 	if(panel_open || operating)
+		SEND_SIGNAL(src, COMSIG_ATOM_BUMPED, AM)
 		return
 	if(!density)
 		return ..()

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -71,9 +71,9 @@
 	affecting_areas.Cut()
 	return ..()
 
-/obj/machinery/door/firedoor/Bumped(atom/AM)
+/obj/machinery/door/firedoor/Bumped(atom/movable/moving_atom)
 	if(panel_open || operating)
-		SEND_SIGNAL(src, COMSIG_ATOM_BUMPED, AM)
+		SEND_SIGNAL(src, COMSIG_ATOM_BUMPED, moving_atom)
 		return
 	if(!density)
 		return ..()

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -30,6 +30,7 @@
 	return
 
 /obj/machinery/door/poddoor/Bumped(atom/AM)
+	SEND_SIGNAL(src, COMSIG_ATOM_BUMPED, AM)
 	if(density)
 		return
 	else

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -29,8 +29,8 @@
 	to_chat(user, "<span class='notice'>The electronic systems in this door are far too advanced for your primitive hacking peripherals.</span>")
 	return
 
-/obj/machinery/door/poddoor/Bumped(atom/AM)
-	SEND_SIGNAL(src, COMSIG_ATOM_BUMPED, AM)
+/obj/machinery/door/poddoor/Bumped(atom/movable/moving_atom)
+	SEND_SIGNAL(src, COMSIG_ATOM_BUMPED, moving_atom)
 	if(density)
 		return
 	else

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -3,6 +3,7 @@
 
 /obj/machinery/door/unpowered/Bumped(atom/AM)
 	if(locked)
+		SEND_SIGNAL(src, COMSIG_ATOM_BUMPED, AM)
 		return
 	..()
 

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -1,9 +1,9 @@
 /obj/machinery/door/unpowered
 	explosion_block = 1
 
-/obj/machinery/door/unpowered/Bumped(atom/AM)
+/obj/machinery/door/unpowered/Bumped(atom/movable/moving_atom)
 	if(locked)
-		SEND_SIGNAL(src, COMSIG_ATOM_BUMPED, AM)
+		SEND_SIGNAL(src, COMSIG_ATOM_BUMPED, moving_atom)
 		return
 	..()
 

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -73,6 +73,7 @@
 	close()
 
 /obj/machinery/door/window/Bumped(atom/movable/AM)
+	SEND_SIGNAL(src, COMSIG_ATOM_BUMPED, AM)
 	if(operating || !density)
 		return
 	if(!ismob(AM))

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -72,13 +72,13 @@
 		sleep(20)
 	close()
 
-/obj/machinery/door/window/Bumped(atom/movable/AM)
-	SEND_SIGNAL(src, COMSIG_ATOM_BUMPED, AM)
+/obj/machinery/door/window/Bumped(atom/movable/moving_atom)
+	SEND_SIGNAL(src, COMSIG_ATOM_BUMPED, moving_atom)
 	if(operating || !density)
 		return
-	if(!ismob(AM))
-		if(ismecha(AM))
-			var/obj/mecha/mecha = AM
+	if(!ismob(moving_atom))
+		if(ismecha(moving_atom))
+			var/obj/mecha/mecha = moving_atom
 			if(mecha.occupant && allowed(mecha.occupant))
 				if(HAS_TRAIT(src, TRAIT_CMAGGED))
 					cmag_switch(FALSE)
@@ -92,7 +92,7 @@
 		return
 	if(!SSticker)
 		return
-	var/mob/living/M = AM
+	var/mob/living/M = moving_atom
 	if(!M.restrained() && M.mob_size > MOB_SIZE_TINY && (!(isrobot(M) && M.stat)))
 		bumpopen(M)
 

--- a/code/game/machinery/mass_driver.dm
+++ b/code/game/machinery/mass_driver.dm
@@ -73,6 +73,8 @@
 	density = 1
 
 /obj/machinery/mass_driver/bumper/Bumped(M as mob|obj)
+	..()
+
 	density = 0
 	step(M, get_dir(M,src))
 	spawn(1)

--- a/code/game/machinery/mass_driver.dm
+++ b/code/game/machinery/mass_driver.dm
@@ -72,11 +72,11 @@
 	desc = "Now you're here, now you're over there."
 	density = 1
 
-/obj/machinery/mass_driver/bumper/Bumped(M as mob|obj)
+/obj/machinery/mass_driver/bumper/Bumped(atom/movable/moving_atom)
 	..()
 
 	density = 0
-	step(M, get_dir(M,src))
+	step(moving_atom, get_dir(moving_atom, src))
 	spawn(1)
 		density = 1
 	drive()

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -99,6 +99,8 @@
 	qdel(src)
 
 /obj/machinery/recharge_station/Bumped(var/mob/AM)
+	..()
+
 	if(ismob(AM))
 		move_inside(AM)
 

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -98,11 +98,11 @@
 	new /obj/effect/decal/cleanable/blood/gibs/clock(get_turf(loc))
 	qdel(src)
 
-/obj/machinery/recharge_station/Bumped(var/mob/AM)
+/obj/machinery/recharge_station/Bumped(atom/movable/moving_atom)
 	..()
 
-	if(ismob(AM))
-		move_inside(AM)
+	if(ismob(moving_atom))
+		move_inside(moving_atom)
 
 /obj/machinery/recharge_station/AllowDrop()
 	return FALSE

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -93,6 +93,7 @@
 		Bumped(AM)
 
 /obj/machinery/recycler/Bumped(atom/movable/AM)
+	..()
 
 	if(stat & (BROKEN|NOPOWER))
 		return

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -92,7 +92,7 @@
 	if(AM)
 		Bumped(AM)
 
-/obj/machinery/recycler/Bumped(atom/movable/AM)
+/obj/machinery/recycler/Bumped(atom/movable/moving_atom)
 	..()
 
 	if(stat & (BROKEN|NOPOWER))
@@ -102,9 +102,9 @@
 	if(emergency_mode)
 		return
 
-	var/move_dir = get_dir(loc, AM.loc)
+	var/move_dir = get_dir(loc, moving_atom.loc)
 	if(move_dir == eat_dir)
-		eat(AM)
+		eat(moving_atom)
 
 /obj/machinery/recycler/proc/eat(atom/AM0, sound = 1)
 	var/list/to_eat = list(AM0)

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -659,7 +659,7 @@
 		spawn(20)
 			alpha = 0
 
-/obj/machinery/shieldwall/syndicate/Bumped(atom/user)
+/obj/machinery/shieldwall/syndicate/Bumped(atom/movable/moving_atom)
 	phaseout()
 	return ..()
 

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -365,15 +365,15 @@
 			break
 	return power_station
 
-/obj/machinery/teleport/hub/Bumped(M as mob|obj)
+/obj/machinery/teleport/hub/Bumped(atom/movable/moving_atom)
 	..()
 
 	if(!is_teleport_allowed(z) && !admin_usage)
-		if(ismob(M))
-			to_chat(M, "You can't use this here.")
+		if(ismob(moving_atom))
+			to_chat(moving_atom, "You can't use this here.")
 		return
-	if(power_station && power_station.engaged && !panel_open && !blockAI(M) && !istype(M, /obj/spacepod))
-		if(!teleport(M) && isliving(M)) // the isliving(M) is needed to avoid triggering errors if a spark bumps the telehub
+	if(power_station && power_station.engaged && !panel_open && !blockAI(moving_atom) && !istype(moving_atom, /obj/spacepod))
+		if(!teleport(moving_atom) && isliving(moving_atom)) // the isliving(M) is needed to avoid triggering errors if a spark bumps the telehub
 			visible_message("<span class='warning'>[src] emits a loud buzz, as its teleport portal flickers and fails!</span>")
 			playsound(loc, 'sound/machines/buzz-sigh.ogg', 50, FALSE)
 			power_station.toggle() // turn off the portal.
@@ -457,17 +457,17 @@
 		return TRUE
 	return FALSE
 
-/obj/machinery/teleport/perma/Bumped(atom/A)
+/obj/machinery/teleport/perma/Bumped(atom/movable/moving_atom)
 	..()
 
 	if(stat & (BROKEN|NOPOWER))
 		return
 	if(!is_teleport_allowed(z))
-		to_chat(A, "You can't use this here.")
+		to_chat(moving_atom, "You can't use this here.")
 		return
 
-	if(target && !recalibrating && !panel_open && !blockAI(A))
-		do_teleport(A, target)
+	if(target && !recalibrating && !panel_open && !blockAI(moving_atom))
+		do_teleport(moving_atom, target)
 		use_power(5000)
 		if(tele_delay)
 			recalibrating = TRUE

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -366,6 +366,8 @@
 	return power_station
 
 /obj/machinery/teleport/hub/Bumped(M as mob|obj)
+	..()
+
 	if(!is_teleport_allowed(z) && !admin_usage)
 		if(ismob(M))
 			to_chat(M, "You can't use this here.")
@@ -456,6 +458,8 @@
 	return FALSE
 
 /obj/machinery/teleport/perma/Bumped(atom/A)
+	..()
+
 	if(stat & (BROKEN|NOPOWER))
 		return
 	if(!is_teleport_allowed(z))

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -70,6 +70,8 @@
 	update_icon()
 
 /obj/machinery/transformer/Bumped(atom/movable/AM)
+	..()
+
 	// They have to be human to be transformed.
 	if(is_on_cooldown || !ishuman(AM))
 		return
@@ -120,6 +122,8 @@
 	desc = "Turns anything placed inside black and white."
 
 /obj/machinery/transformer/mime/Bumped(atom/movable/AM)
+	..()
+
 	if(is_on_cooldown)
 		return
 
@@ -180,6 +184,8 @@
 		icon_state = initial(icon_state)
 
 /obj/machinery/transformer/xray/Bumped(atom/movable/AM)
+	..()
+
 	if(is_on_cooldown)
 		return
 

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -69,14 +69,14 @@
 	is_on_cooldown = FALSE
 	update_icon()
 
-/obj/machinery/transformer/Bumped(atom/movable/AM)
+/obj/machinery/transformer/Bumped(atom/movable/moving_atom)
 	..()
 
 	// They have to be human to be transformed.
-	if(is_on_cooldown || !ishuman(AM))
+	if(is_on_cooldown || !ishuman(moving_atom))
 		return
 
-	var/mob/living/carbon/human/H = AM
+	var/mob/living/carbon/human/H = moving_atom
 	var/move_dir = get_dir(loc, H.loc)
 
 	if((transform_standing || H.lying) && move_dir == acceptdir)
@@ -121,18 +121,18 @@
 	name = "Mimetech Greyscaler"
 	desc = "Turns anything placed inside black and white."
 
-/obj/machinery/transformer/mime/Bumped(atom/movable/AM)
+/obj/machinery/transformer/mime/Bumped(atom/movable/moving_atom)
 	..()
 
 	if(is_on_cooldown)
 		return
 
 	// Crossed didn't like people lying down.
-	if(istype(AM))
-		AM.forceMove(drop_location())
-		do_transform_mime(AM)
+	if(istype(moving_atom))
+		moving_atom.forceMove(drop_location())
+		do_transform_mime(moving_atom)
 	else
-		to_chat(AM, "Only items can be greyscaled.")
+		to_chat(moving_atom, "Only items can be greyscaled.")
 		return
 
 /obj/machinery/transformer/proc/do_transform_mime(obj/item/I)
@@ -183,25 +183,25 @@
 	else
 		icon_state = initial(icon_state)
 
-/obj/machinery/transformer/xray/Bumped(atom/movable/AM)
+/obj/machinery/transformer/xray/Bumped(atom/movable/moving_atom)
 	..()
 
 	if(is_on_cooldown)
 		return
 
 	// Crossed didn't like people lying down.
-	if(ishuman(AM))
+	if(ishuman(moving_atom))
 		// Only humans can enter from the west side, while lying down.
-		var/mob/living/carbon/human/H = AM
+		var/mob/living/carbon/human/H = moving_atom
 		var/move_dir = get_dir(loc, H.loc)
 
 		if(H.lying && move_dir == acceptdir)
 			H.forceMove(drop_location())
 			irradiate(H)
 
-	else if(istype(AM))
-		AM.forceMove(drop_location())
-		scan(AM)
+	else if(istype(moving_atom))
+		moving_atom.forceMove(drop_location())
+		scan(moving_atom)
 
 /obj/machinery/transformer/xray/proc/irradiate(mob/living/carbon/human/H)
 	if(stat & (BROKEN|NOPOWER))

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -124,8 +124,8 @@
 /obj/effect/anomaly/grav/Bump(atom/A)
 	gravShock(A)
 
-/obj/effect/anomaly/grav/Bumped(atom/movable/AM)
-	gravShock(AM)
+/obj/effect/anomaly/grav/Bumped(atom/movable/moving_atom)
+	gravShock(moving_atom)
 
 /obj/effect/anomaly/grav/proc/gravShock(mob/living/A)
 	if(boing && isliving(A) && !A.stat)
@@ -162,8 +162,8 @@
 /obj/effect/anomaly/flux/Bump(atom/A)
 	mobShock(A)
 
-/obj/effect/anomaly/flux/Bumped(atom/movable/AM)
-	mobShock(AM)
+/obj/effect/anomaly/flux/Bumped(atom/movable/moving_atom)
+	mobShock(moving_atom)
 
 /obj/effect/anomaly/flux/proc/mobShock(mob/living/M)
 	if(canshock && istype(M))
@@ -191,10 +191,10 @@
 		do_teleport(M, M, 4)
 		investigate_log("teleported [key_name_log(M)] to [COORD(M)]", INVESTIGATE_TELEPORTATION)
 
-/obj/effect/anomaly/bluespace/Bumped(atom/movable/AM)
-	if(isliving(AM))
-		do_teleport(AM, AM, 8)
-		investigate_log("teleported [key_name_log(AM)] to [COORD(AM)]", INVESTIGATE_TELEPORTATION)
+/obj/effect/anomaly/bluespace/Bumped(atom/movable/moving_atom)
+	if(isliving(moving_atom))
+		do_teleport(moving_atom, moving_atom, 8)
+		investigate_log("teleported [key_name_log(moving_atom)] to [COORD(moving_atom)]", INVESTIGATE_TELEPORTATION)
 
 /obj/effect/anomaly/bluespace/detonate()
 	var/turf/T = pick(get_area_turfs(impact_area))

--- a/code/game/objects/effects/bump_teleporter.dm
+++ b/code/game/objects/effects/bump_teleporter.dm
@@ -26,6 +26,8 @@ GLOBAL_LIST_EMPTY(bump_teleporters)
 	return
 
 /obj/effect/bump_teleporter/Bumped(atom/user)
+	..()
+
 	if(!ismob(user))
 		//user.loc = src.loc	//Stop at teleporter location
 		return

--- a/code/game/objects/effects/bump_teleporter.dm
+++ b/code/game/objects/effects/bump_teleporter.dm
@@ -25,10 +25,10 @@ GLOBAL_LIST_EMPTY(bump_teleporters)
 /obj/effect/bump_teleporter/singularity_pull()
 	return
 
-/obj/effect/bump_teleporter/Bumped(atom/user)
+/obj/effect/bump_teleporter/Bumped(atom/movable/moving_atom)
 	..()
 
-	if(!ismob(user))
+	if(!ismob(moving_atom))
 		//user.loc = src.loc	//Stop at teleporter location
 		return
 

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -69,6 +69,7 @@
 		toggle(user)
 
 /obj/structure/falsewall/attack_hand(mob/user)
+	. = ..()
 	toggle(user)
 
 /obj/structure/falsewall/proc/toggle(mob/user)
@@ -225,26 +226,15 @@
 	var/last_event = 0
 	canSmoothWith = list(/obj/structure/falsewall/uranium, /turf/simulated/wall/mineral/uranium)
 
-/obj/structure/falsewall/uranium/attackby(obj/item/W as obj, mob/user as mob, params)
-	radiate()
-	..()
+/obj/structure/falsewall/uranium/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/radioactivity, \
+				rad_per_interaction = 12, \
+				rad_interaction_radius = 3, \
+				rad_interaction_cooldown = 1.5 SECONDS \
+	)
 
-/obj/structure/falsewall/uranium/attack_hand(mob/user as mob)
-	radiate()
-	..()
 
-/obj/structure/falsewall/uranium/proc/radiate()
-	if(!active)
-		if(world.time > last_event+15)
-			active = 1
-			for(var/mob/living/L in range(3,src))
-				L.apply_effect(12,IRRADIATE,0)
-			for(var/turf/simulated/wall/mineral/uranium/T in range(3,src))
-				T.radiate()
-			last_event = world.time
-			active = null
-			return
-	return
 /*
  * Other misc falsewall types
  */

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -144,6 +144,8 @@
 	. = ..()
 
 /obj/structure/fence/Bumped(atom/user)
+	..()
+
 	if(!ismob(user))
 		return
 	if(shock_cooldown)

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -143,14 +143,14 @@
 		return
 	. = ..()
 
-/obj/structure/fence/Bumped(atom/user)
+/obj/structure/fence/Bumped(atom/movable/moving_atom)
 	..()
 
-	if(!ismob(user))
+	if(!ismob(moving_atom))
 		return
 	if(shock_cooldown)
 		return
-	shock(user, 70)
+	shock(moving_atom, 70)
 	shock_cooldown = TRUE // We do not want bump shock spam!
 	addtimer(CALLBACK(src, PROC_REF(shock_cooldown)), 1 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -334,16 +334,6 @@
 	if(prob(20))
 		opacity = 1
 
-/*
-/obj/structure/bush/Bumped(M as mob)
-	if(istype(M, /mob/living/simple_animal))
-		var/mob/living/simple_animal/A = M
-		A.loc = get_turf(src)
-	else if(istype(M, /mob/living/carbon/monkey))
-		var/mob/living/carbon/monkey/A = M
-		A.loc = get_turf(src)
-*/
-
 /obj/structure/bush/attackby(var/obj/I as obj, var/mob/user as mob, params)
 	//hatchets can clear away undergrowth
 	if(istype(I, /obj/item/hatchet) && !stump)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -96,13 +96,13 @@
 	QDEL_IN(src, 0.2)
 	return RCD_ACT_SUCCESSFULL
 
-/obj/structure/grille/Bumped(atom/user)
+/obj/structure/grille/Bumped(atom/movable/moving_atom)
 	..()
 
-	if(ismob(user))
+	if(ismob(moving_atom))
 		if(!(shockcooldown <= world.time))
 			return
-		shock(user, 70)
+		shock(moving_atom, 70)
 		shockcooldown = world.time + my_shockcooldown
 
 /obj/structure/grille/attack_animal(mob/user)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -97,6 +97,8 @@
 	return RCD_ACT_SUCCESSFULL
 
 /obj/structure/grille/Bumped(atom/user)
+	..()
+
 	if(ismob(user))
 		if(!(shockcooldown <= world.time))
 			return

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -151,16 +151,16 @@
 			shockcd = TRUE
 			addtimer(CALLBACK(src, PROC_REF(cooldown)), 5)
 
-/obj/structure/holosign/barrier/cyborg/hacked/Bumped(atom/movable/AM)
+/obj/structure/holosign/barrier/cyborg/hacked/Bumped(atom/movable/moving_atom)
 	..()
 
 	if(shockcd)
 		return
 
-	if(!isliving(AM))
+	if(!isliving(moving_atom))
 		return
 
-	var/mob/living/M = AM
+	var/mob/living/M = moving_atom
 	M.electrocute_act(15, "Energy Barrier", safety = TRUE)
 	shockcd = TRUE
 	addtimer(CALLBACK(src, PROC_REF(cooldown)), 5)

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -152,6 +152,8 @@
 			addtimer(CALLBACK(src, PROC_REF(cooldown)), 5)
 
 /obj/structure/holosign/barrier/cyborg/hacked/Bumped(atom/movable/AM)
+	..()
+
 	if(shockcd)
 		return
 

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -36,10 +36,10 @@
 	. = ..()
 	move_update_air(T)
 
-/obj/structure/mineral_door/Bumped(atom/user)
+/obj/structure/mineral_door/Bumped(atom/movable/moving_atom)
 	..()
 	if(!state)
-		return TryToSwitchState(user)
+		return TryToSwitchState(moving_atom)
 
 /obj/structure/mineral_door/attack_ai(mob/user) //those aren't machinery, they're just big fucking slabs of a mineral
 	if(isAI(user)) //so the AI can't open it

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -220,7 +220,7 @@
 	name = "statue of a clown"
 	icon_state = "clown"
 
-/obj/structure/statue/bananium/Bumped(atom/user)
+/obj/structure/statue/bananium/Bumped(atom/movable/moving_atom)
 	honk()
 	..()
 

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -41,8 +41,8 @@
 
 
 /obj/structure/statue/attack_hand(mob/living/user)
+	. = ..()
 	user.changeNext_move(CLICK_CD_MELEE)
-	add_fingerprint(user)
 	user.visible_message("[user] rubs some dust off from the [name]'s surface.", \
 						 "<span class='notice'>You rub some dust off from the [name]'s surface.</span>")
 
@@ -76,26 +76,14 @@
 	desc = "This statue has a sickening green colour."
 	icon_state = "eng"
 
-/obj/structure/statue/uranium/attackby(obj/item/W, mob/user, params)
-	radiate()
-	return ..()
+/obj/structure/statue/uranium/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/radioactivity, \
+				rad_per_interaction = 12, \
+				rad_interaction_radius = 3, \
+				rad_interaction_cooldown = 1.5 SECONDS \
+	)
 
-/obj/structure/statue/uranium/Bumped(atom/user)
-	radiate()
-	..()
-
-/obj/structure/statue/uranium/attack_hand(mob/user)
-	radiate()
-	..()
-
-/obj/structure/statue/uranium/proc/radiate()
-	if(!active)
-		if(world.time > last_event+15)
-			active = 1
-			for(var/mob/living/L in range(3,src))
-				L.apply_effect(12,IRRADIATE,0)
-			last_event = world.time
-			active = null
 
 /obj/structure/statue/plasma
 	max_integrity = 200

--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -34,17 +34,17 @@
 /obj/structure/transit_tube/station/should_stop_pod(pod, from_dir)
 	return TRUE
 
-/obj/structure/transit_tube/station/Bumped(mob/living/L)
-	if(!pod_moving && hatch_state == TRANSIT_TUBE_OPEN && isliving(L) && !is_type_in_list(L, disallowed_mobs))
+/obj/structure/transit_tube/station/Bumped(atom/movable/moving_atom)
+	if(!pod_moving && hatch_state == TRANSIT_TUBE_OPEN && isliving(moving_atom) && !is_type_in_list(moving_atom, disallowed_mobs))
 		var/failed = FALSE
 		for(var/obj/structure/transit_tube_pod/pod in loc)
 			if(pod.contents.len)
 				failed = TRUE
 			else if(!pod.moving && (pod.dir in directions()))
-				pod.move_into(L)
+				pod.move_into(moving_atom)
 				return
 		if(failed)
-			to_chat(L, "<span class='warning'>The pod is already occupied.</span>")
+			to_chat(moving_atom, "<span class='warning'>The pod is already occupied.</span>")
 
 
 

--- a/code/game/turfs/simulated/floor/mineral.dm
+++ b/code/game/turfs/simulated/floor/mineral.dm
@@ -219,33 +219,13 @@
 	var/last_event = 0
 	var/active = null
 
-/turf/simulated/floor/mineral/uranium/Entered(mob/AM)
-	.=..()
-	if(!.)
-		if(istype(AM))
-			radiate()
-
-/turf/simulated/floor/mineral/uranium/attackby(obj/item/W, mob/user, params)
-	.=..()
-	if(!.)
-		radiate()
-
-/turf/simulated/floor/mineral/uranium/attack_hand(mob/user)
-	.=..()
-	if(!.)
-		radiate()
-
-/turf/simulated/floor/mineral/uranium/proc/radiate()
-	if(!active)
-		if(world.time > last_event+15)
-			active = 1
-			for(var/mob/living/L in range(3,src))
-				L.apply_effect(1,IRRADIATE,0)
-			for(var/turf/simulated/floor/mineral/uranium/T in orange(1,src))
-				T.radiate()
-			last_event = world.time
-			active = 0
-			return
+/turf/simulated/floor/mineral/uranium/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/radioactivity, \
+				rad_per_interaction = 1, \
+				rad_interaction_radius = 3, \
+				rad_interaction_cooldown = 1.5 SECONDS \
+	)
 
 // ALIEN ALLOY
 /turf/simulated/floor/mineral/abductor

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -104,23 +104,23 @@
 		to_chat(M, "<span class='notice'>You tunnel into the rock.</span>")
 		gets_drilled(M)
 
-/turf/simulated/mineral/Bumped(atom/movable/AM)
+/turf/simulated/mineral/Bumped(atom/movable/moving_atom)
 	..()
-	if(ishuman(AM))
-		var/mob/living/carbon/human/H = AM
+	if(ishuman(moving_atom))
+		var/mob/living/carbon/human/H = moving_atom
 		if((istype(H.l_hand,/obj/item/pickaxe)) && (!H.hand))
 			attackby(H.l_hand,H)
 		else if((istype(H.r_hand,/obj/item/pickaxe)) && H.hand)
 			attackby(H.r_hand,H)
 		return
 
-	else if(isrobot(AM))
-		var/mob/living/silicon/robot/R = AM
+	else if(isrobot(moving_atom))
+		var/mob/living/silicon/robot/R = moving_atom
 		if(istype(R.module_active, /obj/item/pickaxe))
 			attackby(R.module_active, R)
 
-	else if(ismecha(AM))
-		var/obj/mecha/M = AM
+	else if(ismecha(moving_atom))
+		var/obj/mecha/M = moving_atom
 		if(istype(M.selected, /obj/item/mecha_parts/mecha_equipment/drill))
 			M.selected.action(src)
 

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -61,30 +61,13 @@
 	sheet_type = /obj/item/stack/sheet/mineral/uranium
 	canSmoothWith = list(/turf/simulated/wall/mineral/uranium, /obj/structure/falsewall/uranium, /turf/simulated/wall/indestructible/uranium)
 
-/turf/simulated/wall/mineral/uranium/proc/radiate()
-	if(!active)
-		if(world.time > last_event+15)
-			active = 1
-			for(var/mob/living/L in range(3,src))
-				L.apply_effect(12,IRRADIATE,0)
-			for(var/turf/simulated/wall/mineral/uranium/T in range(3,src))
-				T.radiate()
-			last_event = world.time
-			active = null
-			return
-	return
-
-/turf/simulated/wall/mineral/uranium/attack_hand(mob/user as mob)
-	radiate()
-	..()
-
-/turf/simulated/wall/mineral/uranium/attackby(obj/item/W as obj, mob/user as mob, params)
-	radiate()
-	..()
-
-/turf/simulated/wall/mineral/uranium/Bumped(AM as mob|obj)
-	radiate()
-	..()
+/turf/simulated/wall/mineral/uranium/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/radioactivity, \
+				rad_per_interaction = 12, \
+				rad_interaction_radius = 3, \
+				rad_interaction_cooldown = 1.5 SECONDS \
+	)
 
 /turf/simulated/wall/mineral/plasma
 	name = "plasma wall"

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -95,6 +95,7 @@
 	..()
 
 /turf/attack_hand(mob/user as mob)
+	SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_HAND, user)
 	user.Move_Pulled(src)
 
 /turf/ex_act(severity)
@@ -444,6 +445,7 @@
 		GLOB.cameranet.updateVisibility(src)
 
 /turf/attackby(obj/item/I, mob/user, params)
+	SEND_SIGNAL(src, COMSIG_PARENT_ATTACKBY, I, user, params)
 	if(can_lay_cable())
 		if(istype(I, /obj/item/stack/cable_coil))
 			var/obj/item/stack/cable_coil/C = I

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -269,8 +269,8 @@
 /obj/effect/beam/i_beam/Bump()
 	qdel(src)
 
-/obj/effect/beam/i_beam/Bumped(atom/movable/AM)
-	hit(AM)
+/obj/effect/beam/i_beam/Bumped(atom/movable/moving_atom)
+	hit(moving_atom)
 
 /obj/effect/beam/i_beam/Crossed(atom/movable/AM, oldloc)
 	if(!isobj(AM) && !isliving(AM))

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -141,7 +141,7 @@ GLOBAL_DATUM_INIT(the_gateway, /obj/machinery/gateway/centerstation, null)
 
 
 //okay, here's the good teleporting stuff
-/obj/machinery/gateway/centerstation/Bumped(atom/movable/M as mob|obj)
+/obj/machinery/gateway/centerstation/Bumped(atom/movable/moving_atom)
 	if(!ready)
 		return
 	if(!active)
@@ -150,14 +150,14 @@ GLOBAL_DATUM_INIT(the_gateway, /obj/machinery/gateway/centerstation, null)
 		return
 
 	if(awaygate.calibrated)
-		M.forceMove(get_step(awaygate.loc, SOUTH))
-		M.dir = SOUTH
+		moving_atom.forceMove(get_step(awaygate.loc, SOUTH))
+		moving_atom.dir = SOUTH
 		return
 	else
 		var/obj/effect/landmark/dest = pick(GLOB.awaydestinations)
 		if(dest)
-			M.forceMove(dest.loc)
-			M.dir = SOUTH
+			moving_atom.forceMove(dest.loc)
+			moving_atom.dir = SOUTH
 			use_power(5000)
 		return
 
@@ -255,30 +255,30 @@ GLOBAL_DATUM_INIT(the_gateway, /obj/machinery/gateway/centerstation, null)
 	toggleoff()
 
 
-/obj/machinery/gateway/centeraway/Bumped(atom/movable/AM)
+/obj/machinery/gateway/centeraway/Bumped(atom/movable/moving_atom)
 	if(!ready)
 		return
 	if(!active)
 		return
 	if(!stationgate || QDELETED(stationgate))
 		return
-	if(isliving(AM))
-		if(exilecheck(AM))
+	if(isliving(moving_atom))
+		if(exilecheck(moving_atom))
 			return
 	else
-		for(var/mob/living/L in AM.contents)
+		for(var/mob/living/L in moving_atom.contents)
 			if(exilecheck(L))
-				atom_say("Rejecting [AM]: Exile implant detected in contained lifeform.")
+				atom_say("Rejecting [moving_atom]: Exile implant detected in contained lifeform.")
 				return
-	if(AM.has_buckled_mobs())
-		for(var/mob/living/L in AM.buckled_mobs)
+	if(moving_atom.has_buckled_mobs())
+		for(var/mob/living/L in moving_atom.buckled_mobs)
 			if(exilecheck(L))
-				atom_say("Rejecting [AM]: Exile implant detected in close proximity lifeform.")
+				atom_say("Rejecting [moving_atom]: Exile implant detected in close proximity lifeform.")
 				return
-	AM.forceMove(get_step(stationgate.loc, SOUTH))
-	AM.setDir(SOUTH)
-	if(ismob(AM))
-		var/mob/M = AM
+	moving_atom.forceMove(get_step(stationgate.loc, SOUTH))
+	moving_atom.setDir(SOUTH)
+	if(ismob(moving_atom))
+		var/mob/M = moving_atom
 		if(M.client)
 			M.client.move_delay = max(world.time + 5, M.client.move_delay)
 

--- a/code/modules/awaymissions/mission_code/wildwest.dm
+++ b/code/modules/awaymissions/mission_code/wildwest.dm
@@ -138,15 +138,16 @@
 /obj/effect/meatgrinder/Crossed(AM as mob|obj, oldloc)
 	Bumped(AM)
 
-/obj/effect/meatgrinder/Bumped(mob/M as mob|obj)
+/obj/effect/meatgrinder/Bumped(atom/movable/moving_atom)
 
-	if(triggered) return
+	if(triggered)
+		return
 
-	if(istype(M, /mob/living/carbon/human))
+	if(istype(moving_atom, /mob/living/carbon/human))
 		for(var/mob/O in viewers(world.view, src.loc))
-			to_chat(O, "<font color='red'>[M] triggered the [bicon(src)] [src]</font>")
+			to_chat(O, "<font color='red'>[moving_atom] triggered the [bicon(src)] [src]</font>")
 		triggered = 1
-		call(src,triggerproc)(M)
+		call(src,triggerproc)(moving_atom)
 
 /obj/effect/meatgrinder/proc/triggerrad1(mob)
 	for(var/mob/O in viewers(world.view, src.loc))

--- a/code/modules/events/dust.dm
+++ b/code/modules/events/dust.dm
@@ -94,8 +94,8 @@
 /obj/effect/space_dust/proc/on_shatter(turf/where)
 	return
 
-/obj/effect/space_dust/Bumped(atom/A)
-	Bump(A)
+/obj/effect/space_dust/Bumped(atom/movable/moving_atom)
+	Bump(moving_atom)
 	return
 
 /obj/effect/space_dust/ex_act(severity)

--- a/code/modules/mining/lavaland/loot/colossus_loot.dm
+++ b/code/modules/mining/lavaland/loot/colossus_loot.dm
@@ -68,10 +68,10 @@
 	playsound(user, activation_sound, 100, 1)
 	return 1
 
-/obj/machinery/anomalous_crystal/Bumped(atom/AM as mob|obj)
+/obj/machinery/anomalous_crystal/Bumped(atom/movable/moving_atom)
 	..()
-	if(ismob(AM))
-		ActivationReaction(AM,"mob_bump")
+	if(ismob(moving_atom))
+		ActivationReaction(moving_atom,"mob_bump")
 
 /obj/machinery/anomalous_crystal/ex_act()
 	ActivationReaction(null,"bomb")

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -508,7 +508,7 @@
 	return
 
 /mob/living/silicon/pai/Bumped()
-	return
+	return ..()
 
 /mob/living/silicon/pai/start_pulling(atom/movable/AM, state, force = pull_force, show_message = FALSE)
 	return FALSE

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -507,7 +507,7 @@
 /mob/living/silicon/pai/Bump()
 	return
 
-/mob/living/silicon/pai/Bumped()
+/mob/living/silicon/pai/Bumped(atom/movable/moving_atom)
 	return ..()
 
 /mob/living/silicon/pai/start_pulling(atom/movable/AM, state, force = pull_force, show_message = FALSE)

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -350,7 +350,7 @@
 		return ..()
 
 /mob/living/silicon/robot/drone/Bumped(atom/movable/AM)
-	return
+	return ..()
 
 /mob/living/silicon/robot/drone/start_pulling(atom/movable/AM, state, force = pull_force, show_message = FALSE)
 

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -349,7 +349,7 @@
 	if(is_type_in_list(AM, allowed_bumpable_objects))
 		return ..()
 
-/mob/living/silicon/robot/drone/Bumped(atom/movable/AM)
+/mob/living/silicon/robot/drone/Bumped(atom/movable/moving_atom)
 	return ..()
 
 /mob/living/silicon/robot/drone/start_pulling(atom/movable/AM, state, force = pull_force, show_message = FALSE)

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -79,8 +79,8 @@
 	godsmack(A)
 	return
 
-/obj/singularity/narsie/Bumped(atom/A)
-	godsmack(A)
+/obj/singularity/narsie/Bumped(atom/movable/moving_atom)
+	godsmack(moving_atom)
 	return
 
 /obj/singularity/narsie/proc/godsmack(atom/A)

--- a/code/modules/power/singularity/ratvar.dm
+++ b/code/modules/power/singularity/ratvar.dm
@@ -69,8 +69,8 @@
 	godsmack(A)
 	return
 
-/obj/singularity/ratvar/Bumped(atom/A)
-	godsmack(A)
+/obj/singularity/ratvar/Bumped(atom/movable/moving_atom)
+	godsmack(moving_atom)
 	return
 
 /obj/singularity/ratvar/proc/godsmack(atom/A)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -104,8 +104,8 @@
 	return
 
 
-/obj/singularity/Bumped(atom/A)
-	consume(A)
+/obj/singularity/Bumped(atom/movable/moving_atom)
+	consume(moving_atom)
 	return
 
 

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -386,20 +386,20 @@
 
 		user.apply_effect(150, IRRADIATE)
 
-/obj/machinery/power/supermatter_shard/Bumped(atom/AM as mob|obj)
-	if(istype(AM, /mob/living))
-		AM.visible_message("<span class='danger'>\The [AM] slams into \the [src] inducing a resonance... [AM.p_their(TRUE)] body starts to glow and catch flame before flashing into ash.</span>",\
+/obj/machinery/power/supermatter_shard/Bumped(atom/movable/moving_atom)
+	if(istype(moving_atom, /mob/living))
+		moving_atom.visible_message("<span class='danger'>\The [moving_atom] slams into \the [src] inducing a resonance... [moving_atom.p_their(TRUE)] body starts to glow and catch flame before flashing into ash.</span>",\
 		"<span class='userdanger'>You slam into \the [src] as your ears are filled with unearthly ringing. Your last thought is \"Oh, fuck.\"</span>",\
 		"<span class='italics'>You hear an unearthly noise as a wave of heat washes over you.</span>")
-	else if(isobj(AM) && !istype(AM, /obj/effect))
-		AM.visible_message("<span class='danger'>\The [AM] smacks into \the [src] and rapidly flashes to ash.</span>",\
+	else if(isobj(moving_atom) && !istype(moving_atom, /obj/effect))
+		moving_atom.visible_message("<span class='danger'>\The [moving_atom] smacks into \the [src] and rapidly flashes to ash.</span>",\
 		"<span class='italics'>You hear a loud crack as you are washed with a wave of heat.</span>")
 	else
 		return
 
 	playsound(get_turf(src), 'sound/effects/supermatter.ogg', 50, 1)
 
-	Consume(AM)
+	Consume(moving_atom)
 
 
 /obj/machinery/power/supermatter_shard/proc/Consume(atom/movable/AM)

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -113,8 +113,8 @@
 /obj/singularity/energy_ball/Bump(atom/A)
 	dust_mobs(A)
 
-/obj/singularity/energy_ball/Bumped(atom/A)
-	dust_mobs(A)
+/obj/singularity/energy_ball/Bumped(atom/movable/moving_atom)
+	dust_mobs(moving_atom)
 
 /obj/singularity/energy_ball/attack_tk(mob/user)
 	if(iscarbon(user))

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -579,6 +579,8 @@
 	return
 
 /obj/machinery/disposal/deliveryChute/Bumped(atom/movable/AM) //Go straight into the chute
+	..()
+
 	if(istype(AM, /obj/item/projectile))  return
 	switch(dir)
 		if(NORTH)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -578,25 +578,25 @@
 /obj/machinery/disposal/deliveryChute/update()
 	return
 
-/obj/machinery/disposal/deliveryChute/Bumped(atom/movable/AM) //Go straight into the chute
+/obj/machinery/disposal/deliveryChute/Bumped(atom/movable/moving_atom) //Go straight into the chute
 	..()
 
-	if(istype(AM, /obj/item/projectile))  return
+	if(istype(moving_atom, /obj/item/projectile))  return
 	switch(dir)
 		if(NORTH)
-			if(AM.loc.y != src.loc.y+1) return
+			if(moving_atom.loc.y != src.loc.y+1) return
 		if(EAST)
-			if(AM.loc.x != src.loc.x+1) return
+			if(moving_atom.loc.x != src.loc.x+1) return
 		if(SOUTH)
-			if(AM.loc.y != src.loc.y-1) return
+			if(moving_atom.loc.y != src.loc.y-1) return
 		if(WEST)
-			if(AM.loc.x != src.loc.x-1) return
+			if(moving_atom.loc.x != src.loc.x-1) return
 
-	if(istype(AM, /obj))
-		var/obj/O = AM
+	if(istype(moving_atom, /obj))
+		var/obj/O = moving_atom
 		O.loc = src
-	else if(istype(AM, /mob))
-		var/mob/M = AM
+	else if(istype(moving_atom, /mob))
+		var/mob/M = moving_atom
 		M.loc = src
 	if(mode != OFF)
 		flush()

--- a/paradise.dme
+++ b/paradise.dme
@@ -363,6 +363,7 @@
 #include "code\datums\components\material_container.dm"
 #include "code\datums\components\paintable.dm"
 #include "code\datums\components\proximity_monitor.dm"
+#include "code\datums\components\radioactivity.dm"
 #include "code\datums\components\slippery.dm"
 #include "code\datums\components\spawner.dm"
 #include "code\datums\components\spooky.dm"


### PR DESCRIPTION
## Описание
<!-- -->
Добавил компонент радиоактивности, и заодно отрефакторил те немногочисленные воздействия, связанные с ней.
- компонент имеет два варианта работы (применимы оба сразу): радиация при взаимодействии и радиация за цикл
- всё можно достаточно гибко настроить (количество радиации, время цикла, радиус поражения, игнорирование защиты и т.п.)
- есть два колбека, на дополнительные эффекты, если хочется добавить что-то своё сверху
- есть трейт, блокирующий радиацию от компонента, на случай если атом находится в "безопасной среде"
- компонент можно добавлять несколько раз, на один и тот же атом, все параметры будут перезаписаны
