### PR TITLE
fix: take damage after deletion runtime in fire_act

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -187,6 +187,8 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 		if((T.intact && level == 1) || T.transparent_floor) //fire can't damage things hidden below the floor.
 			return
 	..()
+	if(QDELETED(src)) // no taking damage after deletion
+		return
 	if(exposed_temperature && !(resistance_flags & FIRE_PROOF))
 		take_damage(clamp(0.02 * exposed_temperature, 0, 20), BURN, "fire", 0)
 	if(!(resistance_flags & ON_FIRE) && (resistance_flags & FLAMMABLE) && !(resistance_flags & FIRE_PROOF))


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Если вдруг у вас есть имплант распыления или вы взрывающаяся раса и вы погибли в лаве ваши вещи будут рантаймить из-за уничтожения при взрыве, а потом и при fire_act() в лаве (при уничтожении вещей на мобах их сначала выбрасывает под вас и потом qdelит). Запрещаем получать урон, если вещь уже удалена.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Крестики плохо. Некоторые виды големов с лавы могут вызвать их. https://github.com/ss220-space/Paradise/actions/runs/5305105278/jobs/9601853205
![image](https://github.com/ss220-space/Paradise/assets/120549107/f958a091-f690-494b-a23f-7f6203f87622)

<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

