### PR TITLE
Rework: PowerFist 2.0

### DIFF
--- a/code/game/objects/items/weapons/powerfist.dm
+++ b/code/game/objects/items/weapons/powerfist.dm
@@ -48,14 +48,11 @@
 				to_chat(user, span_warning("[IT] is too small for [src]."))
 				return
 			updateTank(W, FALSE, user)
-			return
-	else if(istype(W, /obj/item/stock_parts/cell))
-		if(cell)
-			to_chat(user, span_notice("[src] already has a cell."))
-		else
-			updateCell(W, FALSE, user)
-	else
-		return ..()
+		return
+	if(istype(W, /obj/item/stock_parts/cell))
+		updateCell(W, FALSE, user)
+		return
+	return ..()
 
 /obj/item/melee/powerfist/attack_self(mob/user)
 	updateCell(cell, TRUE, user)
@@ -117,7 +114,7 @@
 		to_chat(user, span_notice("You insert [thecell] in to [src]."))
 		cell = thecell
 
-/obj/item/melee/powerfist/afterattack(atom/movable/target, mob/living/user, proximity)
+/obj/item/melee/powerfist/afterattack(atom/target, mob/living/user, proximity)
 	if(!proximity)
 		return
 	if(QDELETED(target))

--- a/code/game/objects/items/weapons/powerfist.dm
+++ b/code/game/objects/items/weapons/powerfist.dm
@@ -1,107 +1,168 @@
 /obj/item/melee/powerfist
-	name = "power-fist"
-	desc = "A metal gauntlet with a piston-powered ram ontop for that extra 'ompfh' in your punch."
-	icon_state = "powerfist"
-	item_state = "powerfist"
-	flags = CONDUCT
-	attack_verb = list("whacked", "fisted", "power-punched")
-	force = 12
-	throwforce = 10
-	throw_range = 7
-	w_class = WEIGHT_CLASS_NORMAL
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 40)
-	resistance_flags = FIRE_PROOF
-	origin_tech = "combat=5;powerstorage=3;syndicate=1"
-	var/click_delay = 1.5
-	var/fisto_setting = 1
-	var/gasperfist = 3
-	var/obj/item/tank/internals/tank = null //Tank used for the gauntlet's piston-ram.
+    name = "power-fist"
+    desc = "A metal gauntlet with a piston-powered ram ontop for that extra 'ompfh' in your punch."
+    icon_state = "powerfist"
+    item_state = "powerfist"
+    flags = CONDUCT
+    attack_verb = list("whacked", "fisted", "power-punched")
+    force = 12
+    throwforce = 10
+    throw_range = 7
+    w_class = WEIGHT_CLASS_NORMAL
+    armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 40)
+    resistance_flags = FIRE_PROOF
+    origin_tech = "combat=5;powerstorage=3;syndicate=1"
+    var/attacked = FALSE
+    var/click_delay = 1.5
+    var/fisto_setting = 1
+    var/gasperfist = 3
+    var/obj/item/tank/internals/tank = null //Tank used for the gauntlet's piston-ram.
+    var/obj/item/stock_parts/cell/high/cell = null
+    var/datum/effect_system/spark_spread/spark_system
 
+/obj/item/melee/powerfist/Initialize()
+    . = ..()
+    spark_system = new /datum/effect_system/spark_spread
+    spark_system.set_up(5, 0, src)
+    spark_system.attach(src)
 
 /obj/item/melee/powerfist/Destroy()
-	QDEL_NULL(tank)
-	return ..()
+    QDEL_NULL(spark_system)
+    QDEL_NULL(cell)
+    QDEL_NULL(tank)
+    return ..()
 
 /obj/item/melee/powerfist/examine(mob/user)
-	. = ..()
-	if(!in_range(user, src))
-		. += "<span class='notice'>You'll need to get closer to see any more.</span>"
-	else if(tank)
-		. += "<span class='notice'>[bicon(tank)] It has [tank] mounted onto it.</span>"
+    . = ..()
+    if(in_range(user, src))
+        if(tank)
+            . += "<span class='notice'>[bicon(tank)] It has [tank] mounted onto it.</span>"
+        if(cell)
+            . += "<span class='notice'>[bicon(cell)]The fist is charged for [cell.charge] KW.</span>"
+    else . += "<span class='notice'>You'll need to get closer to see any more.</span>"
 
 /obj/item/melee/powerfist/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/tank/internals))
-		if(!tank)
-			var/obj/item/tank/internals/IT = W
-			if(IT.volume <= 3)
-				to_chat(user, "<span class='warning'>[IT] is too small for [src].</span>")
-				return
-			updateTank(W, 0, user)
-			return
-	return ..()
+    if(istype(W, /obj/item/tank/internals))
+        if(!tank)
+            var/obj/item/tank/internals/IT = W
+            if(IT.volume <= 3)
+                to_chat(user, "<span class='warning'>[IT] is too small for [src].</span>")
+                return
+            updateTank(W, 0, user)
+            return
+    else if(istype(W, /obj/item/stock_parts/cell))
+        if(cell)
+            to_chat(user, "<span class='notice'>[src] already has a cell.</span>")
+        else
+            if(!user.drop_transfer_item_to_loc(W, src))
+                return
+            cell = W
+            to_chat(user, "<span class='notice'>You install a cell in [src].</span>")
+            update_icon()
+
+/obj/item/melee/powerfist/attack_self(mob/user)
+    cell.loc = get_turf(src.loc)
+    cell = null
+    to_chat(user, "<span class='notice'>You remove a cell from [src].</span>")
 
 /obj/item/melee/powerfist/wrench_act(mob/user, obj/item/I)
-	. = TRUE
-	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
-		return
-	switch(fisto_setting)
-		if(1)
-			fisto_setting = 2
-		if(2)
-			fisto_setting = 3
-		if(3)
-			fisto_setting = 1
-	to_chat(user, "<span class='notice'>You tweak [src]'s piston valve to [fisto_setting].</span>")
+    . = TRUE
+    if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+        return
+    switch(fisto_setting)
+        if(1)
+            fisto_setting = 2
+        if(2)
+            fisto_setting = 3
+        if(3)
+            fisto_setting = 1
+    to_chat(user, "<span class='notice'>You tweak [src]'s piston valve to [fisto_setting].</span>")
 
 /obj/item/melee/powerfist/screwdriver_act(mob/user, obj/item/I)
-	if(!tank)
-		return
-	. = TRUE
-	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
-		return
-	updateTank(tank, 1, user)
+    if(!tank)
+        return
+    . = TRUE
+    if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+        return
+    updateTank(tank, 1, user)
 
 /obj/item/melee/powerfist/proc/updateTank(obj/item/tank/thetank, removing = 0, mob/living/carbon/human/user)
-	if(removing)
-		if(!tank)
-			to_chat(user, "<span class='notice'>[src] currently has no tank attached to it.</span>")
-			return
-		to_chat(user, "<span class='notice'>You detach [thetank] from [src].</span>")
-		tank.forceMove_turf()
-		user.put_in_hands(tank, ignore_anim = FALSE)
-		tank = null
-	if(!removing)
-		if(tank)
-			to_chat(user, "<span class='warning'>[src] already has a tank.</span>")
-			return
-		if(!user.drop_transfer_item_to_loc(thetank, src))
-			return
-		to_chat(user, "<span class='notice'>You hook [thetank] up to [src].</span>")
-		tank = thetank
+    if(removing)
+        if(!tank)
+            to_chat(user, "<span class='notice'>[src] currently has no tank attached to it.</span>")
+            return
+        to_chat(user, "<span class='notice'>You detach [thetank] from [src].</span>")
+        tank.forceMove(get_turf(user))
+        user.put_in_hands(tank)
+        tank = null
+    if(!removing)
+        if(tank)
+            to_chat(user, "<span class='warning'>[src] already has a tank.</span>")
+            return
+        if(!user.drop_transfer_item_to_loc(thetank, src))
+            return
+        to_chat(user, "<span class='notice'>You hook [thetank] up to [src].</span>")
+        tank = thetank
+        thetank.forceMove(src)
 
 
 /obj/item/melee/powerfist/attack(mob/living/target, mob/living/user)
-	if(!tank)
-		to_chat(user, "<span class='warning'>[src] can't operate without a source of gas!</span>")
-		return
-	if(tank && !tank.air_contents.remove(gasperfist * fisto_setting))
-		to_chat(user, "<span class='warning'>[src]'s piston-ram lets out a weak hiss, it needs more gas!</span>")
-		playsound(loc, 'sound/effects/refill.ogg', 50, 1)
-		return
+    if(!tank)
+        to_chat(user, "<span class='warning'>[src] can't operate without a source of gas!</span>")
+        return
+    if(tank && !tank.air_contents.remove(gasperfist * fisto_setting))
+        to_chat(user, "<span class='warning'>[src]'s piston-ram lets out a weak hiss, it needs more gas!</span>")
+        playsound(loc, 'sound/effects/refill.ogg', 50, 1)
+        return
 
-	user.do_attack_animation(target)
+    user.do_attack_animation(target)
 
-	target.apply_damage(force * fisto_setting, BRUTE)
-	target.visible_message("<span class='danger'>[user]'s powerfist lets out a loud hiss as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
-		"<span class='userdanger'>You cry out in pain as [user]'s punch flings you backwards!</span>")
-	new /obj/effect/temp_visual/kinetic_blast(target.loc)
-	playsound(loc, 'sound/weapons/resonator_blast.ogg', 50, 1)
-	playsound(loc, 'sound/weapons/genhit2.ogg', 50, 1)
+    new /obj/effect/temp_visual/kinetic_blast(target.loc)
+    playsound(loc, 'sound/weapons/resonator_blast.ogg', 50, 1)
+    playsound(loc, 'sound/weapons/genhit2.ogg', 50, 1)
 
-	var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
+    target.apply_damage(force * fisto_setting, BRUTE)
+    target.visible_message("<span class='danger'>[user]'s powerfist lets out a loud hiss as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
+        "<span class='userdanger'>You cry out in pain as [user]'s punch flings you backwards!</span>")
+    new /obj/effect/temp_visual/kinetic_blast(target.loc)
+    playsound(loc, 'sound/weapons/resonator_blast.ogg', 50, 1)
+    playsound(loc, 'sound/weapons/genhit2.ogg', 50, 1)
 
-	target.throw_at(throw_target, 5 * fisto_setting, 0.5 + (fisto_setting / 2))
+    var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
 
-	add_attack_logs(user, target, "POWER FISTED with [src]")
+    target.throw_at(throw_target, 5 * fisto_setting, 0.5 + (fisto_setting / 2))
 
-	user.changeNext_move(CLICK_CD_MELEE * click_delay)
+    add_attack_logs(user, target, "POWER FISTED with [src]")
+    user.changeNext_move(CLICK_CD_MELEE * click_delay)
+    if(cell.charge > 0 && cell)
+        target.emp_act(1)
+        spark_system.start()
+        if(cell.charge >= 15000)
+            target.electrocute_act(cell.charge/1250, src, 1)
+        cell.charge = 0
+        to_chat(user, "[src] sparkles violently")
+
+/obj/item/melee/powerfist/afterattack(atom/A as obj|mob, mob/user, proximity)
+    if(!proximity) return
+    if(!ismob(A))
+        if(!tank)
+            to_chat(user, "<span class='warning'>[src] can't operate without a source of gas!</span>")
+            return
+        if(tank && !tank.air_contents.remove(gasperfist * fisto_setting))
+            to_chat(user, "<span class='warning'>[src]'s piston-ram lets out a weak hiss, it needs more gas!</span>")
+            playsound(loc, 'sound/effects/refill.ogg', 50, 1)
+            return
+        user.do_attack_animation(A)
+        if(cell.charge > 0)
+            A.emp_act(1)
+            cell.charge = 0
+            spark_system.start()
+            new /obj/effect/temp_visual/kinetic_blast(A.loc)
+            playsound(loc, 'sound/weapons/resonator_blast.ogg', 50, 1)
+            playsound(loc, 'sound/weapons/genhit2.ogg', 50, 1)
+            A.visible_message("<span class='danger'>As [user]'s powerfist comes into contact with an [A.name], you see how sparks fly out of it and it remain cracked at the point of impact!</span>")
+        else if(!ismob(A))
+            new /obj/effect/temp_visual/kinetic_blast(A.loc)
+            playsound(loc, 'sound/weapons/resonator_blast.ogg', 50, 1)
+            playsound(loc, 'sound/weapons/genhit2.ogg', 50, 1)
+            A.visible_message("<span class='danger'>As [user]'s powerfist comes into contact with an [A.name], you see how it remain cracked at the point of impact!</span>")

--- a/code/game/objects/items/weapons/powerfist.dm
+++ b/code/game/objects/items/weapons/powerfist.dm
@@ -1,168 +1,167 @@
 /obj/item/melee/powerfist
-    name = "power-fist"
-    desc = "A metal gauntlet with a piston-powered ram ontop for that extra 'ompfh' in your punch."
-    icon_state = "powerfist"
-    item_state = "powerfist"
-    flags = CONDUCT
-    attack_verb = list("whacked", "fisted", "power-punched")
-    force = 12
-    throwforce = 10
-    throw_range = 7
-    w_class = WEIGHT_CLASS_NORMAL
-    armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 40)
-    resistance_flags = FIRE_PROOF
-    origin_tech = "combat=5;powerstorage=3;syndicate=1"
-    var/attacked = FALSE
-    var/click_delay = 1.5
-    var/fisto_setting = 1
-    var/gasperfist = 3
-    var/obj/item/tank/internals/tank = null //Tank used for the gauntlet's piston-ram.
-    var/obj/item/stock_parts/cell/high/cell = null
-    var/datum/effect_system/spark_spread/spark_system
+	name = "power-fist"
+	desc = "A metal gauntlet with a piston-powered ram ontop for that extra 'ompfh' in your punch."
+	icon_state = "powerfist"
+	item_state = "powerfist"
+	flags = CONDUCT
+	attack_verb = list("whacked", "fisted", "power-punched")
+	force = 12
+	throwforce = 10
+	throw_range = 7
+	w_class = WEIGHT_CLASS_NORMAL
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 40)
+	resistance_flags = FIRE_PROOF
+	origin_tech = "combat=5;powerstorage=3;syndicate=1"
+	var/click_delay = 1.5
+	var/fisto_setting = 1
+	var/gasperfist = 3
+	var/obj/item/tank/internals/tank = null //Tank used for the gauntlet's piston-ram.
+	var/obj/item/stock_parts/cell/high/cell = null
+	var/datum/effect_system/spark_spread/spark_system
 
 /obj/item/melee/powerfist/Initialize()
-    . = ..()
-    spark_system = new /datum/effect_system/spark_spread
-    spark_system.set_up(5, 0, src)
-    spark_system.attach(src)
+	. = ..()
+	spark_system = new /datum/effect_system/spark_spread
+	spark_system.set_up(5, 0, src)
+	spark_system.attach(src)
 
 /obj/item/melee/powerfist/Destroy()
-    QDEL_NULL(spark_system)
-    QDEL_NULL(cell)
-    QDEL_NULL(tank)
-    return ..()
+	QDEL_NULL(spark_system)
+	QDEL_NULL(cell)
+	QDEL_NULL(tank)
+	return ..()
 
 /obj/item/melee/powerfist/examine(mob/user)
-    . = ..()
-    if(in_range(user, src))
-        if(tank)
-            . += "<span class='notice'>[bicon(tank)] It has [tank] mounted onto it.</span>"
-        if(cell)
-            . += "<span class='notice'>[bicon(cell)]The fist is charged for [cell.charge] KW.</span>"
-    else . += "<span class='notice'>You'll need to get closer to see any more.</span>"
+	. = ..()
+	if(in_range(user, src))
+		if(tank)
+			. += "<span class='notice'>[bicon(tank)] It has [tank] mounted onto it.</span>"
+		if(cell)
+			. += "<span class='notice'>[bicon(cell)]The fist is charged for [cell.charge] KW.</span>"
+	else . += "<span class='notice'>You'll need to get closer to see any more.</span>"
 
 /obj/item/melee/powerfist/attackby(obj/item/W, mob/user, params)
-    if(istype(W, /obj/item/tank/internals))
-        if(!tank)
-            var/obj/item/tank/internals/IT = W
-            if(IT.volume <= 3)
-                to_chat(user, "<span class='warning'>[IT] is too small for [src].</span>")
-                return
-            updateTank(W, 0, user)
-            return
-    else if(istype(W, /obj/item/stock_parts/cell))
-        if(cell)
-            to_chat(user, "<span class='notice'>[src] already has a cell.</span>")
-        else
-            if(!user.drop_transfer_item_to_loc(W, src))
-                return
-            cell = W
-            to_chat(user, "<span class='notice'>You install a cell in [src].</span>")
-            update_icon()
+	if(istype(W, /obj/item/tank/internals))
+		if(!tank)
+			var/obj/item/tank/internals/IT = W
+			if(IT.volume <= 3)
+				to_chat(user, "<span class='warning'>[IT] is too small for [src].</span>")
+				return
+			updateTank(W, 0, user)
+			return
+	else if(istype(W, /obj/item/stock_parts/cell))
+		if(cell)
+			to_chat(user, "<span class='notice'>[src] already has a cell.</span>")
+		else
+			if(!user.drop_transfer_item_to_loc(W, src))
+				return
+			cell = W
+			to_chat(user, "<span class='notice'>You install a cell in [src].</span>")
+			update_icon()
 
 /obj/item/melee/powerfist/attack_self(mob/user)
-    cell.loc = get_turf(src.loc)
-    cell = null
-    to_chat(user, "<span class='notice'>You remove a cell from [src].</span>")
+	cell.loc = get_turf(src.loc)
+	cell = null
+	to_chat(user, "<span class='notice'>You remove a cell from [src].</span>")
 
 /obj/item/melee/powerfist/wrench_act(mob/user, obj/item/I)
-    . = TRUE
-    if(!I.use_tool(src, user, 0, volume = I.tool_volume))
-        return
-    switch(fisto_setting)
-        if(1)
-            fisto_setting = 2
-        if(2)
-            fisto_setting = 3
-        if(3)
-            fisto_setting = 1
-    to_chat(user, "<span class='notice'>You tweak [src]'s piston valve to [fisto_setting].</span>")
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	switch(fisto_setting)
+		if(1)
+			fisto_setting = 2
+		if(2)
+			fisto_setting = 3
+		if(3)
+			fisto_setting = 1
+	to_chat(user, "<span class='notice'>You tweak [src]'s piston valve to [fisto_setting].</span>")
 
 /obj/item/melee/powerfist/screwdriver_act(mob/user, obj/item/I)
-    if(!tank)
-        return
-    . = TRUE
-    if(!I.use_tool(src, user, 0, volume = I.tool_volume))
-        return
-    updateTank(tank, 1, user)
+	if(!tank)
+		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	updateTank(tank, 1, user)
 
 /obj/item/melee/powerfist/proc/updateTank(obj/item/tank/thetank, removing = 0, mob/living/carbon/human/user)
-    if(removing)
-        if(!tank)
-            to_chat(user, "<span class='notice'>[src] currently has no tank attached to it.</span>")
-            return
-        to_chat(user, "<span class='notice'>You detach [thetank] from [src].</span>")
-        tank.forceMove(get_turf(user))
-        user.put_in_hands(tank)
-        tank = null
-    if(!removing)
-        if(tank)
-            to_chat(user, "<span class='warning'>[src] already has a tank.</span>")
-            return
-        if(!user.drop_transfer_item_to_loc(thetank, src))
-            return
-        to_chat(user, "<span class='notice'>You hook [thetank] up to [src].</span>")
-        tank = thetank
-        thetank.forceMove(src)
+	if(removing)
+		if(!tank)
+			to_chat(user, "<span class='notice'>[src] currently has no tank attached to it.</span>")
+			return
+		to_chat(user, "<span class='notice'>You detach [thetank] from [src].</span>")
+		tank.forceMove(get_turf(user))
+		user.put_in_hands(tank)
+		tank = null
+	if(!removing)
+		if(tank)
+			to_chat(user, "<span class='warning'>[src] already has a tank.</span>")
+			return
+		if(!user.drop_transfer_item_to_loc(thetank, src))
+			return
+		to_chat(user, "<span class='notice'>You hook [thetank] up to [src].</span>")
+		tank = thetank
+		thetank.forceMove(src)
 
 
 /obj/item/melee/powerfist/attack(mob/living/target, mob/living/user)
-    if(!tank)
-        to_chat(user, "<span class='warning'>[src] can't operate without a source of gas!</span>")
-        return
-    if(tank && !tank.air_contents.remove(gasperfist * fisto_setting))
-        to_chat(user, "<span class='warning'>[src]'s piston-ram lets out a weak hiss, it needs more gas!</span>")
-        playsound(loc, 'sound/effects/refill.ogg', 50, 1)
-        return
+	if(!tank)
+		to_chat(user, "<span class='warning'>[src] can't operate without a source of gas!</span>")
+		return
+	if(tank && !tank.air_contents.remove(gasperfist * fisto_setting))
+		to_chat(user, "<span class='warning'>[src]'s piston-ram lets out a weak hiss, it needs more gas!</span>")
+		playsound(loc, 'sound/effects/refill.ogg', 50, 1)
+		return
 
-    user.do_attack_animation(target)
+	user.do_attack_animation(target)
 
-    new /obj/effect/temp_visual/kinetic_blast(target.loc)
-    playsound(loc, 'sound/weapons/resonator_blast.ogg', 50, 1)
-    playsound(loc, 'sound/weapons/genhit2.ogg', 50, 1)
+	new /obj/effect/temp_visual/kinetic_blast(target.loc)
+	playsound(loc, 'sound/weapons/resonator_blast.ogg', 50, 1)
+	playsound(loc, 'sound/weapons/genhit2.ogg', 50, 1)
 
-    target.apply_damage(force * fisto_setting, BRUTE)
-    target.visible_message("<span class='danger'>[user]'s powerfist lets out a loud hiss as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
-        "<span class='userdanger'>You cry out in pain as [user]'s punch flings you backwards!</span>")
-    new /obj/effect/temp_visual/kinetic_blast(target.loc)
-    playsound(loc, 'sound/weapons/resonator_blast.ogg', 50, 1)
-    playsound(loc, 'sound/weapons/genhit2.ogg', 50, 1)
+	target.apply_damage(force * fisto_setting, BRUTE)
+	target.visible_message("<span class='danger'>[user]'s powerfist lets out a loud hiss as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
+		"<span class='userdanger'>You cry out in pain as [user]'s punch flings you backwards!</span>")
+	new /obj/effect/temp_visual/kinetic_blast(target.loc)
+	playsound(loc, 'sound/weapons/resonator_blast.ogg', 50, 1)
+	playsound(loc, 'sound/weapons/genhit2.ogg', 50, 1)
 
-    var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
+	var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
 
-    target.throw_at(throw_target, 5 * fisto_setting, 0.5 + (fisto_setting / 2))
+	target.throw_at(throw_target, 5 * fisto_setting, 0.5 + (fisto_setting / 2))
 
-    add_attack_logs(user, target, "POWER FISTED with [src]")
-    user.changeNext_move(CLICK_CD_MELEE * click_delay)
-    if(cell.charge > 0 && cell)
-        target.emp_act(1)
-        spark_system.start()
-        if(cell.charge >= 15000)
-            target.electrocute_act(cell.charge/1250, src, 1)
-        cell.charge = 0
-        to_chat(user, "[src] sparkles violently")
+	add_attack_logs(user, target, "POWER FISTED with [src]")
+	user.changeNext_move(CLICK_CD_MELEE * click_delay)
+	if(cell.charge > 0 && cell)
+		target.emp_act(1)
+		spark_system.start()
+		if(cell.charge >= 15000)
+			target.electrocute_act(cell.charge/1250, src, 1)
+		cell.charge = 0
+		to_chat(user, "[src] sparkles violently")
 
 /obj/item/melee/powerfist/afterattack(atom/A as obj|mob, mob/user, proximity)
-    if(!proximity) return
-    if(!ismob(A))
-        if(!tank)
-            to_chat(user, "<span class='warning'>[src] can't operate without a source of gas!</span>")
-            return
-        if(tank && !tank.air_contents.remove(gasperfist * fisto_setting))
-            to_chat(user, "<span class='warning'>[src]'s piston-ram lets out a weak hiss, it needs more gas!</span>")
-            playsound(loc, 'sound/effects/refill.ogg', 50, 1)
-            return
-        user.do_attack_animation(A)
-        if(cell.charge > 0)
-            A.emp_act(1)
-            cell.charge = 0
-            spark_system.start()
-            new /obj/effect/temp_visual/kinetic_blast(A.loc)
-            playsound(loc, 'sound/weapons/resonator_blast.ogg', 50, 1)
-            playsound(loc, 'sound/weapons/genhit2.ogg', 50, 1)
-            A.visible_message("<span class='danger'>As [user]'s powerfist comes into contact with an [A.name], you see how sparks fly out of it and it remain cracked at the point of impact!</span>")
-        else if(!ismob(A))
-            new /obj/effect/temp_visual/kinetic_blast(A.loc)
-            playsound(loc, 'sound/weapons/resonator_blast.ogg', 50, 1)
-            playsound(loc, 'sound/weapons/genhit2.ogg', 50, 1)
-            A.visible_message("<span class='danger'>As [user]'s powerfist comes into contact with an [A.name], you see how it remain cracked at the point of impact!</span>")
+	if(!proximity) return
+	if(!ismob(A))
+		if(!tank)
+			to_chat(user, "<span class='warning'>[src] can't operate without a source of gas!</span>")
+			return
+		if(tank && !tank.air_contents.remove(gasperfist * fisto_setting))
+			to_chat(user, "<span class='warning'>[src]'s piston-ram lets out a weak hiss, it needs more gas!</span>")
+			playsound(loc, 'sound/effects/refill.ogg', 50, 1)
+			return
+		user.do_attack_animation(A)
+		if(cell.charge > 0)
+			A.emp_act(1)
+			cell.charge = 0
+			spark_system.start()
+			new /obj/effect/temp_visual/kinetic_blast(A.loc)
+			playsound(loc, 'sound/weapons/resonator_blast.ogg', 50, 1)
+			playsound(loc, 'sound/weapons/genhit2.ogg', 50, 1)
+			A.visible_message("<span class='danger'>As [user]'s powerfist comes into contact with an [A.name], you see how sparks fly out of it and it remain cracked at the point of impact!</span>")
+		else if(!ismob(A))
+			new /obj/effect/temp_visual/kinetic_blast(A.loc)
+			playsound(loc, 'sound/weapons/resonator_blast.ogg', 50, 1)
+			playsound(loc, 'sound/weapons/genhit2.ogg', 50, 1)
+			A.visible_message("<span class='danger'>As [user]'s powerfist comes into contact with an [A.name], you see how it remain cracked at the point of impact!</span>")

--- a/code/game/objects/items/weapons/powerfist.dm
+++ b/code/game/objects/items/weapons/powerfist.dm
@@ -35,28 +35,28 @@
 	. = ..()
 	if(in_range(user, src))
 		if(tank)
-			. += "<span class='notice'>[bicon(tank)] It has [tank] mounted onto it.</span>"
+			. += span_notice("[bicon(tank)] It has [tank] mounted onto it.")
 		if(cell)
-			. += "<span class='notice'>[bicon(cell)]The fist is charged for [cell.charge] W.</span>"
-	else . += "<span class='notice'>You'll need to get closer to see any more.</span>"
+			. += span_notice("[bicon(cell)]The fist is charged for [cell.charge] W")
+	else . += span_notice("You'll need to get closer to see any more.")
 
 /obj/item/melee/powerfist/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/tank/internals))
 		if(!tank)
 			var/obj/item/tank/internals/IT = W
 			if(IT.volume <= 3)
-				to_chat(user, "<span class='warning'>[IT] is too small for [src].</span>")
+				to_chat(user, span_warning("[IT] is too small for [src]."))
 				return
-			updateTank(W, 0, user)
+			updateTank(W, FALSE, user)
 			return
 	else if(istype(W, /obj/item/stock_parts/cell))
 		if(cell)
-			to_chat(user, "<span class='notice'>[src] already has a cell.</span>")
+			to_chat(user, span_notice("[src] already has a cell."))
 		else
-			updateCell(W, 0, user)
+			updateCell(W, FALSE, user)
 
 /obj/item/melee/powerfist/attack_self(mob/user)
-	updateCell(cell, 1, user)
+	updateCell(cell, TRUE, user)
 
 /obj/item/melee/powerfist/wrench_act(mob/user, obj/item/I)
 	. = TRUE
@@ -69,7 +69,7 @@
 			fisto_setting = 3
 		if(3)
 			fisto_setting = 1
-	to_chat(user, "<span class='notice'>You tweak [src]'s piston valve to [fisto_setting].</span>")
+	to_chat(user, span_notice("You tweak [src]'s piston valve to [fisto_setting]."))
 
 /obj/item/melee/powerfist/screwdriver_act(mob/user, obj/item/I)
 	if(!tank)
@@ -77,54 +77,56 @@
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-	updateTank(tank, 1, user)
+	updateTank(tank, TRUE, user)
 
-/obj/item/melee/powerfist/proc/updateTank(obj/item/tank/thetank, removing = 0, mob/living/carbon/human/user)
+/obj/item/melee/powerfist/proc/updateTank(obj/item/tank/thetank, removing = FALSE, mob/living/carbon/human/user)
 	if(removing)
 		if(!tank)
-			to_chat(user, "<span class='notice'>[src] currently has no tank attached to it.</span>")
+			to_chat(user, span_notice("[src] currently has no tank attached to it."))
 			return
-		to_chat(user, "<span class='notice'>You detach [thetank] from [src].</span>")
+		to_chat(user, span_notice("You detach [thetank] from [src]."))
 		tank.forceMove_turf()
 		user.put_in_hands(tank, ignore_anim = FALSE)
 		tank = null
-	if(!removing)
+	else
 		if(tank)
-			to_chat(user, "<span class='warning'>[src] already has a tank.</span>")
+			to_chat(user, span_warning("[src] already has a tank."))
 			return
 		if(!user.drop_transfer_item_to_loc(thetank, src))
 			return
-		to_chat(user, "<span class='notice'>You hook [thetank] up to [src].</span>")
+		to_chat(user, span_notice("You hook [thetank] up to [src]."))
 		tank = thetank
 
-/obj/item/melee/powerfist/proc/updateCell(obj/item/stock_parts/cell/thecell, removing = 0, mob/living/carbon/human/user)
+/obj/item/melee/powerfist/proc/updateCell(obj/item/stock_parts/cell/thecell, removing = FALSE, mob/living/carbon/human/user)
 	if(removing)
 		if(!cell)
-			to_chat(user, "<span class='notice'>[src] currently has no cell inside.</span>")
+			to_chat(user, span_notice("[src] currently has no cell inside."))
 			return
-		to_chat(user, "<span class='notice'>You detach [thecell] from [src].</span>")
+		to_chat(user, span_notice("You detach [thecell] from [src]."))
 		cell.forceMove_turf()
 		user.put_in_hands(cell, ignore_anim = FALSE)
 		cell = null
-	if(!removing)
+	else
 		if(cell)
-			to_chat(user, "<span class='warning'>[src] already has a cell.</span>")
+			to_chat(user, span_warning("[src] already has a cell."))
 			return
 		if(!user.drop_transfer_item_to_loc(thecell, src))
 			return
-		to_chat(user, "<span class='notice'>You insert [thecell] in to [src].</span>")
+		to_chat(user, span_notice("You insert [thecell] in to [src]."))
 		cell = thecell
 
-/obj/item/melee/powerfist/attack()
-
 /obj/item/melee/powerfist/afterattack(atom/target as mob|obj, mob/living/user, proximity)
-	if(!proximity || !isobj(target) && !ismob(target))
+	if(!proximity)
+		return
+	if(QDELETED(target))
+		return
+	if(!isobj(target) && !isliving(target))
 		return
 	if(!tank)
-		to_chat(user, "<span class='warning'>[src] can't operate without a source of gas!</span>")
+		to_chat(user, span_warning("[src] can't operate without a source of gas!"))
 		return
 	if(tank && !tank.air_contents.remove(gasperfist * fisto_setting))
-		to_chat(user, "<span class='warning'>[src]'s piston-ram lets out a weak hiss, it needs more gas!</span>")
+		to_chat(user, span_warning("[src]'s piston-ram lets out a weak hiss, it needs more gas!"))
 		playsound(loc, 'sound/effects/refill.ogg', 50, 1)
 		return
 
@@ -133,25 +135,25 @@
 	playsound(loc, 'sound/weapons/resonator_blast.ogg', 50, 1)
 	playsound(loc, 'sound/weapons/genhit2.ogg', 50, 1)
 
-	if(ismob(target))
+	if(isliving(target))
 		var/mob/living/mobtarget = target
 		var/atom/throw_target = get_edge_target_turf(mobtarget, get_dir(src, get_step_away(target, src)))
 		mobtarget.throw_at(throw_target, 5 * fisto_setting, 0.5 + (fisto_setting / 2))
 		mobtarget.apply_damage(force * fisto_setting, BRUTE)
-		mobtarget.visible_message("<span class='danger'>[user]'s powerfist lets out a loud hiss as [user.p_they()] punch[user.p_es()] [mobtarget.name]!</span>", \
-			"<span class='userdanger'>You cry out in pain as [user]'s punch flings you backwards!</span>")
+		mobtarget.visible_message(span_danger("[user]'s powerfist lets out a loud hiss as [user.p_they()] punch[user.p_es()] [mobtarget.name]!"), \
+			span_userdanger("You cry out in pain as [user]'s punch flings you backwards!"))
 		if(cell?.charge > 0)
 			mobtarget.emp_act(1)
 			spark_system.start()
 			if(cell.charge >= 15000)
 				mobtarget.electrocute_act(cell.charge/1250, src, 1)
-			cell.charge = 0
+			cell.use(cell.maxcharge)
 			to_chat(user, "[src] sparkles violently")
 	else
-		target.visible_message("<span class='danger'>As [user]'s powerfist comes into contact with an [target.name], you see how it remain cracked at the point of impact!</span>")
+		target.visible_message(span_danger("As [user]'s powerfist comes into contact with an [target.name], you see how it remain cracked at the point of impact!"))
 		if(cell?.charge > 0)
 			target.emp_act(1)
-			cell.charge = 0
+			cell.use(cell.maxcharge)
 			spark_system.start()
 			to_chat(user, "[src] sparkles violently")
 	user.changeNext_move(CLICK_CD_MELEE * click_delay)

--- a/code/game/objects/items/weapons/powerfist.dm
+++ b/code/game/objects/items/weapons/powerfist.dm
@@ -54,6 +54,8 @@
 			to_chat(user, span_notice("[src] already has a cell."))
 		else
 			updateCell(W, FALSE, user)
+	else
+		return ..()
 
 /obj/item/melee/powerfist/attack_self(mob/user)
 	updateCell(cell, TRUE, user)
@@ -115,7 +117,7 @@
 		to_chat(user, span_notice("You insert [thecell] in to [src]."))
 		cell = thecell
 
-/obj/item/melee/powerfist/afterattack(atom/target as mob|obj, mob/living/user, proximity)
+/obj/item/melee/powerfist/afterattack(atom/movable/target, mob/living/user, proximity)
 	if(!proximity)
 		return
 	if(QDELETED(target))

--- a/code/game/objects/items/weapons/powerfist.dm
+++ b/code/game/objects/items/weapons/powerfist.dm
@@ -133,7 +133,7 @@
 
 	add_attack_logs(user, target, "POWER FISTED with [src]")
 	user.changeNext_move(CLICK_CD_MELEE * click_delay)
-	if(cell.charge > 0 && cell)
+	if(cell && cell.charge > 0)
 		target.emp_act(1)
 		spark_system.start()
 		if(cell.charge >= 15000)
@@ -141,7 +141,7 @@
 		cell.charge = 0
 		to_chat(user, "[src] sparkles violently")
 
-/obj/item/melee/powerfist/afterattack(atom/A as obj|mob, mob/user, proximity)
+/obj/item/melee/powerfist/afterattack(atom/movable/A, mob/user, proximity)
 	if(!proximity) return
 	if(!ismob(A))
 		if(!tank)


### PR DESCRIPTION

## Описание
В пневматический кулак теперь можно поместить батарейку или любой иной источник питания (овощная батарейка или жёлтый экстракт слайма).

Что это даёт: При ударе, вся ёмкость батареи расходуется ровно на первый удар, помимо имеющегося урона 12/24/36, пневмокулак теперь ещё даёт и сильное ЭМИ (но только по самой цели удара и по вещам, которые на ней экипированы, HИКАКОГО ЭМИ-взрыва).

Если заряд батареи (не макс. ёмкость, именно заряд) составлял более 15.000 Ватт, дополнительно по цели проходит стан+ожоговый урон. Дополнительный ожоговый урон скалируется и вычисляется по формуле расходуемый заряд/1250. Если удар наносится по экзокостюму, то гарантированно провоцирует одну из двух аварий — "Внутреннее воспламенение (Internal Fire)" или "Сбой калибровки (Calibration Failure)".

После выполненного удара, заряд батареи всегда сбрасывается до 0 Ватт, батарею можно удалить нажатием на пневмокулак (Z).
Эффект от ЭМИ, как и сброс заряда, производится только после удара по: куклам, боргам, экзокостюмам, симпл мобам. (это не будет ЭМИ-фонарик 2.0)
Стоимость предмета в аплинке не меняется.

## Ссылка на предложение/Причина создания ПР
Согласно прошедшей предложке: https://discord.com/channels/617003227182792704/755125334097133628/1113287577605251095