### PR TITLE
Fix: корректное отображение боли для ксенорас

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -971,3 +971,11 @@ so that different stomachs can handle things in different ways VB*/
 			if(R.shock_reduction)
 				shock_reduction += R.shock_reduction
 	return shock_reduction
+
+/mob/living/carbon/proc/species_shock_reduction()
+	var/species_shock_reduction = 0
+	if(reagents)
+		for(var/datum/reagent/R in reagents.reagent_list)
+			if(R.species_shock_reduction)
+				species_shock_reduction += R.species_shock_reduction
+	return species_shock_reduction

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -286,6 +286,8 @@
 			for(var/datum/reagent/R in H.reagents.reagent_list)
 				if(R.shock_reduction)
 					health_deficiency -= R.shock_reduction
+				if(R.species_shock_reduction)
+					health_deficiency -= R.species_shock_reduction
 		if(health_deficiency >= 40 && !isnucleation(H))
 			if(flight)
 				. += (health_deficiency / 75)

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -9,6 +9,7 @@
 	var/metabolization_rate = REAGENTS_METABOLISM
 	var/color = "#000000" // rgb: 0, 0, 0 (does not support alpha channels - yet!)
 	var/shock_reduction = 0
+	var/species_shock_reduction = 0
 	var/heart_rate_increase = 0
 	var/heart_rate_decrease = 0
 	var/heart_rate_stop = 0

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -1393,7 +1393,7 @@
 	reagent_state = LIQUID
 	color = "#00ff15"
 	metabolization_rate = REAGENTS_METABOLISM
-	shock_reduction = 20
+	species_shock_reduction = 20
 	taste_description = "blessing"
 	can_synth = FALSE
 
@@ -1410,7 +1410,7 @@
 	reagent_state = LIQUID
 	color = "#b521c2"
 	metabolization_rate = REAGENTS_METABOLISM
-	shock_reduction = 20
+	species_shock_reduction = 20
 	taste_description = "Superiority"
 	can_synth = FALSE
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Когда в игру вводился https://github.com/ss220-space/Paradise/pull/2819, основной его задачей было неправильное отображение "полоски" здоровья исключительно для создаваемых/станционных обезболивающих. 
Однако, все расовые обезболы были построены на принципе все того же "shock reduction"
Данный ПР вводит новую переменную - расовое понижение боли, которое отвечает за тот увеличенный порог урона до замедления, однако более не обманывает полоску здоровья, ибо ксенорасы должны прекрасно чувствовать боль, просто быть более выносливыми.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Багфикс это, вроде как...
## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
https://discord.com/channels/617003227182792704/734823601110515882/1120312261211336714