### PR TITLE
fix: no fracture after saw step

### DIFF
--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -67,7 +67,7 @@
 	// standing is poor
 	if(stance_damage >= 8)
 		if(!(lying || resting))
-			if(!(NO_PAIN in dna.species.species_traits))
+			if(has_pain())
 				emote("scream")
 			custom_emote(1, "падает!")
 		Weaken(5) //can't emote while weakened, apparently.
@@ -95,7 +95,7 @@
 					continue
 
 			var/emote_scream = pick("крич[pluralize_ru(src.gender,"ит","ат")] от боли и ", "изда[pluralize_ru(src.gender,"ёт","ют")] резкий крик и ", "вскрикива[pluralize_ru(src.gender,"ет","ют")] и ")
-			custom_emote(1, "[(NO_PAIN in dna.species.species_traits) ? "" : emote_scream ]броса[pluralize_ru(src.gender,"ет","ют")] предмет, который держал[genderize_ru(src.gender,"","а","о","и")] в [E.declent_ru(PREPOSITIONAL)]!")
+			custom_emote(1, "[(has_pain()) ? emote_scream :  "" ]броса[pluralize_ru(src.gender,"ет","ют")] предмет, который держал[genderize_ru(src.gender,"","а","о","и")] в [E.declent_ru(PREPOSITIONAL)]!")
 
 		else if(E.is_malfunctioning())
 

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -249,9 +249,13 @@
 	if(iscarbon(M))
 		if(method == REAGENT_TOUCH)
 			M.adjustBruteLoss(-volume)
-			if(show_message && !(NO_PAIN in M.dna.species.species_traits))
+			var/has_pain = TRUE
+			if(ishuman(M))
+				var/mob/living/carbon/human/H = M
+				has_pain = H.has_pain()
+			if(show_message && has_pain)
 				to_chat(M, "<span class='notice'>The styptic powder stings like hell as it closes some of your wounds!</span>")
-		if(method == REAGENT_INGEST)
+		else if(method == REAGENT_INGEST)
 			M.adjustToxLoss(0.5*volume)
 			if(show_message)
 				to_chat(M, "<span class='warning'>You feel gross!</span>")

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -648,15 +648,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			"<span class='danger'>Something feels like it shattered in your [name]!</span>",\
 			"You hear a sickening crack.")
 		playsound(owner, "bonebreak", 150, 1)
-		if(owner.reagents.has_reagent("morphine"))
-			return
-		if(owner.reagents.has_reagent("syntmorphine"))
-			return
-		if(owner.reagents.has_reagent("hydrocodone"))
-			return
-		if(owner.stat == UNCONSCIOUS)
-			return
-		if(owner.dna.species && !(NO_PAIN in owner.dna.species.species_traits))
+		if(owner.has_pain())
 			owner.emote("scream")
 
 	status |= ORGAN_BROKEN

--- a/code/modules/surgery/organs/pain.dm
+++ b/code/modules/surgery/organs/pain.dm
@@ -1,3 +1,5 @@
+#define MIN_SHOCK_REDUCTION 50 //The minimum amount of shock reduction in reagents for absence of pain
+
 /mob/living/carbon/human
 	var/last_pain_message = ""
 	var/next_pain_time = 0
@@ -7,11 +9,7 @@
 		return FALSE
 	if(NO_PAIN in dna.species.species_traits)
 		return FALSE
-	if(reagents.has_reagent("morphine"))
-		return FALSE
-	if(reagents.has_reagent("syntmorphine"))
-		return FALSE
-	if(reagents.has_reagent("hydrocodone"))
+	if(shock_reduction() >= MIN_SHOCK_REDUCTION)
 		return FALSE
 	return TRUE
 
@@ -78,3 +76,5 @@
 		if(I.damage > 2 && prob(2))
 			var/obj/item/organ/external/parent = get_organ(I.parent_organ)
 			custom_pain("You feel a sharp pain in your [parent.limb_name]")
+
+#undef MIN_SHOCK_REDUCTION

--- a/code/modules/surgery/organs/pain.dm
+++ b/code/modules/surgery/organs/pain.dm
@@ -2,18 +2,25 @@
 	var/last_pain_message = ""
 	var/next_pain_time = 0
 
+/mob/living/carbon/human/proc/has_pain()
+	if(!stat)
+		return FALSE
+	if(NO_PAIN in dna.species.species_traits)
+		return FALSE
+	if(reagents.has_reagent("morphine"))
+		return FALSE
+	if(reagents.has_reagent("syntmorphine"))
+		return FALSE
+	if(reagents.has_reagent("hydrocodone"))
+		return FALSE
+	return TRUE
+
 // partname is the name of a body part
 // amount is a num from 1 to 100
 /mob/living/carbon/human/proc/pain(partname, amount)
-	if(stat >= UNCONSCIOUS)
+	if(reagents.has_reagent("sal_acid"))
 		return
-	if(reagents?.has_reagent("sal_acid"))
-		return
-	if(reagents?.has_reagent("morphine"))
-		return
-	if(reagents?.has_reagent("syntmorphine"))
-		return
-	if(reagents?.has_reagent("hydrocodone"))
+	if(!has_pain())
 		return
 	if(world.time < next_pain_time)
 		return
@@ -33,16 +40,7 @@
 
 // message is the custom message to be displayed
 /mob/living/carbon/human/proc/custom_pain(message)
-	if(stat >= UNCONSCIOUS)
-		return
-
-	if(NO_PAIN in dna.species.species_traits)
-		return
-	if(reagents?.has_reagent("morphine"))
-		return
-	if(reagents?.has_reagent("syntmorphine"))
-		return
-	if(reagents?.has_reagent("hydrocodone"))
+	if(!has_pain())
 		return
 
 	var/msg = "<span class='userdanger'>[message]</span>"
@@ -56,15 +54,7 @@
 /mob/living/carbon/human/proc/handle_pain()
 	// not when sleeping
 
-	if(stat >= UNCONSCIOUS)
-		return
-	if(NO_PAIN in dna.species.species_traits)
-		return
-	if(reagents?.has_reagent("morphine"))
-		return
-	if(reagents?.has_reagent("syntmorphine"))
-		return
-	if(reagents?.has_reagent("hydrocodone"))
+	if(!has_pain())
 		return
 
 	var/maxdam = 0

--- a/code/modules/surgery/organs/pain.dm
+++ b/code/modules/surgery/organs/pain.dm
@@ -3,7 +3,7 @@
 	var/next_pain_time = 0
 
 /mob/living/carbon/human/proc/has_pain()
-	if(!stat)
+	if(stat)
 		return FALSE
 	if(NO_PAIN in dna.species.species_traits)
 		return FALSE


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Теперь вы вновь будете получать перелом во время шага с распиливанием. Сейчас если у вас есть обезболивающее вы не получаете его, но звук и сообщение перелома присутствуют. Это произошло после https://github.com/ss220-space/Paradise/pull/1787 и там не задумывалось.
Также теперь ваша боль будет учитываться в паре мест, где до этого учитывалось например лишь расовый модификатор.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Баг, раз звук и сообщение есть.
Репорт: https://discord.com/channels/617003227182792704/981470952061804604/1120385400725307533
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

