### PR TITLE
Теперь призраки видны после грина. Добавляет админам кнопку переключения видимости призраков после гринтекста.

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -470,6 +470,7 @@ SUBSYSTEM_DEF(ticker)
 
 /datum/controller/subsystem/ticker/proc/declare_completion()
 	GLOB.nologevent = TRUE //end of round murder and shenanigans are legal; there's no need to jam up attack logs past this point.
+	set_observer_default_invisibility(0) //spooks things up
 	//Round statistics report
 	var/datum/station_state/ending_station_state = new /datum/station_state()
 	ending_station_state.count()

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -63,6 +63,8 @@ SUBSYSTEM_DEF(ticker)
 	var/real_reboot_time = 0
 	/// Do we need to switch pacifism after Greentext
 	var/toggle_pacifism = TRUE
+	/// Do we need to make ghosts visible after greentext
+	var/toogle_gv = TRUE
 
 	var/list/randomtips = list()
 	var/list/memetips = list()
@@ -470,7 +472,8 @@ SUBSYSTEM_DEF(ticker)
 
 /datum/controller/subsystem/ticker/proc/declare_completion()
 	GLOB.nologevent = TRUE //end of round murder and shenanigans are legal; there's no need to jam up attack logs past this point.
-	set_observer_default_invisibility(0) //spooks things up
+	if(toogle_gv)
+		set_observer_default_invisibility(0) //spooks things up
 	//Round statistics report
 	var/datum/station_state/ending_station_state = new /datum/station_state()
 	ending_station_state.count()

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -71,7 +71,8 @@ GLOBAL_LIST_INIT(admin_verbs_admin, list(
 	/client/proc/start_vote,
 	/client/proc/list_ssds_afks,
 	/client/proc/ccbdb_lookup_ckey,
-	/client/proc/toggle_pacifism_gt
+	/client/proc/toggle_pacifism_gt,
+	/client/proc/toogle_ghost_vision
 ))
 GLOBAL_LIST_INIT(admin_verbs_ban, list(
 	/client/proc/ban_panel,

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -897,6 +897,28 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Toggle Pacifism")
 
+/client/proc/toogle_ghost_vision()
+	set name = "Toggle Ghost Vision After Greentext"
+	set category = "Admin"
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	if(SSticker.current_state == GAME_STATE_FINISHED)
+		if(!GLOB.observer_default_invisibility)
+			if(alert(src, "Вы хотите выключить видимость призраков?",, "Да", "Нет") == "Нет")
+				return
+			set_observer_default_invisibility(INVISIBILITY_OBSERVER)
+			log_and_message_admins("Ghosts are no longer visible.")
+		else
+			if(alert(src, "Вы хотите включить видимость призраков?",,"Да", "Нет") == "Нет")
+				return
+			set_observer_default_invisibility(0)
+			log_and_message_admins("Ghosts are now visible.")
+	else
+		SSticker.toogle_gv = (SSticker.toogle_gv) ? FALSE : TRUE
+		log_and_message_admins("toggled ghost vision after greentext in [(SSticker.toogle_gv) ? "On" : "Off"].")
+
 /client/proc/admin_deny_shuttle()
 	set category = "Admin"
 	set name = "Toggle Deny Shuttle"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Теперь после конца раунда все призраки становятся видимыми. По ["договоренности"](https://discord.com/channels/617003227182792704/617003951606333442/1121044706797822023) с администрацией, им добавляется специальная кнопка, которая:
До гринтекста может отключить/включить видимость призраков после гринтекста
После гринтекста переключает видимость призраков при подтверждении
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1120811472386277567
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->