### PR TITLE
QoL: Equip To Appropriate Slot

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -67,7 +67,7 @@
 		return FALSE
 
 	var/priority_list = list( \
-		slot_back, slot_wear_id, slot_wear_pda, \
+		slot_back, slot_wear_pda, slot_wear_id, \
 		slot_w_uniform, slot_wear_suit, slot_wear_mask, \
 		slot_neck, slot_glasses, slot_l_ear, \
 		slot_r_ear, slot_head, slot_belt, \


### PR DESCRIPTION
## Описание
<!-- . -->
Поскольку PDA помещается и в слот ID-карты и в слот PDA, то слоту PDA стоит дать больший приоритет, для лучшего взаимодействия.


## Причина создания PR
<!-- . -->
https://discord.com/channels/617003227182792704/1121014963813744681