### PR TITLE
fix: Shadowling Nutrition

### DIFF
--- a/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
@@ -102,6 +102,7 @@ GLOBAL_LIST_INIT(possibleShadowlingNames, list("U'ruan", "Y`shej", "Nex", "Hel-u
 				sleep(10)
 				to_chat(H, "<span class='shadowling'><b><i>Your powers are awoken. You may now live to your fullest extent. Remember your goal. Cooperate with your thralls and allies.</b></i></span>")
 				H.ExtinguishMob()
+				H.set_nutrition(NUTRITION_LEVEL_FED + 50)
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadow_vision(null))
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/click/enthrall(null))
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/click/glare(null))


### PR DESCRIPTION
## Описание
<!-- . -->
Поскольку раскрывшийся тенелинг не может есть из-за "невидимого скафандра", то если он превратится, будучи голодным, его скорость передвижения навсегда останется замедленной. До вмешательства админов конечно.

Исправляем эту проблему полностью восстанавливая уровень еды, после трансформации.

