### PR TITLE
Фикс возможности пронести оружие жертвам контрактника на СиндиЦК

### DIFF
--- a/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
@@ -398,6 +398,14 @@
 		if(M.drop_item_ground(I))
 			stuff_to_transfer += I
 
+	// Remove accessories from the suit if present
+	if(length(H.w_uniform?.accessories))
+		for(var/obj/item/clothing/accessory/A in H.w_uniform.accessories)
+			A.on_removed(H)
+			H.w_uniform.accessories -= A
+			H.drop_item_ground(A)
+			stuff_to_transfer += A
+
 	// Transfer it all (or drop it if not possible)
 	for(var/i in stuff_to_transfer)
 		var/obj/item/I = i


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Когда жертва контрактора телепортируется на СЦК в клетку, принудительно снимает с нее все украшения на костюме. Позволяет не дать жертве контрактника пронести кобуру с оружием, карту в ошейнике с любым доступом и любые иные предметы, что способны крепиться на костюм как аксессуары. 
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
На данный момент, жертва контрактника переносится в клетку со своей кобурой и со всеми иными аксессуарами. Администрации может не понравиться, если при попытке РП с взятым в заложники офицером, по ним откроется огонь.
Так быть не должно, багфикс
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
