### PR TITLE
Hotfix: У контрактников неожиданно теряется возможность вызывать эвакуацию

### DIFF
--- a/code/modules/antagonists/traitor/contractor/datums/contractor_hub_ui.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/contractor_hub_ui.dm
@@ -66,7 +66,6 @@
 
 	switch(page)
 		if(HUB_PAGE_CONTRACTS)
-			var/contract_target
 			var/list/contracts_out = list()
 			data["contracts"] = contracts_out
 			for(var/c in contracts)
@@ -101,7 +100,6 @@
 						contract_data["fail_reason"] = C.fail_reason
 
 				if(C.contract.extraction_zone)
-					contract_target = C.contract.target?.current
 					var/area/A = get_area(user)
 					contract_data["objective"] = list(
 						extraction_name = C.contract.extraction_zone.map_name,
@@ -115,9 +113,7 @@
 					)
 				contracts_out += list(contract_data)
 
-			data["can_extract"] = FALSE
-			if(contract_target)
-				data["can_extract"] = current_contract?.contract.can_start_extraction_process(user, contract_target)
+			data["can_extract"] = current_contract?.contract.can_start_extraction_process(user) || FALSE
 		if(HUB_PAGE_SHOP)
 			var/list/buyables = list()
 			for(var/p in purchases)

--- a/code/modules/antagonists/traitor/contractor/datums/objective_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/objective_contract.dm
@@ -260,8 +260,7 @@
   * Returns whether the extraction process can be started.
   *
   * Arguments:
-  * * M - The contractor.
-  * * target - The target.
+  * * caller - The person trying to call the extraction.
   */
-/datum/objective/contract/proc/can_start_extraction_process(mob/living/carbon/human/M, mob/living/carbon/human/target)
-	return get_area(M) == extraction_zone && get_area(target) == extraction_zone
+/datum/objective/contract/proc/can_start_extraction_process(mob/living/carbon/human/caller)
+	return get_area(caller) == extraction_zone && get_area(target.current) == extraction_zone


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
У контрактников через некоторое время просто перестает работать планшет и кнопка "call extraction" остается навсегда серой. Этот фикс должен исправить проблему, в теории. На локалке проверить не удалось, потому что не совсем понятно, что вызывает баг
Фактически - это откат части кода ТГУИ до старых параметров, когда ничего не было сломано. Должно помочь. Не люблю делать ПРы без возможности их обкатать на локалке.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Фикс
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->