### PR TITLE
FIX: Brain damage

### DIFF
--- a/code/modules/mob/living/carbon/human/species/diona.dm
+++ b/code/modules/mob/living/carbon/human/species/diona.dm
@@ -36,13 +36,13 @@
 	reagent_tag = PROCESS_ORG
 
 	has_organ = list(
-		"nutrient channel" =   /obj/item/organ/internal/liver/diona,
-		"filtrating vacuoles" =   /obj/item/organ/internal/kidneys/diona,
-		"neural strata" =   /obj/item/organ/internal/brain/diona,
-		"receptor node" =   /obj/item/organ/internal/eyes/diona, //Default darksight of 2.
-		"gas bladder" =   /obj/item/organ/internal/lungs/diona,
-		"polyp segment" =   /obj/item/organ/internal/appendix/diona,
-		"anchoring ligament" = /obj/item/organ/internal/heart/diona
+		"liver" =   /obj/item/organ/internal/liver/diona,
+		"kidneys" =   /obj/item/organ/internal/kidneys/diona,
+		"brain" =   /obj/item/organ/internal/brain/diona,
+		"eyes" =   /obj/item/organ/internal/eyes/diona, //Default darksight of 2.
+		"lungs" =   /obj/item/organ/internal/lungs/diona,
+		"appendix" =   /obj/item/organ/internal/appendix/diona,
+		"heart" = /obj/item/organ/internal/heart/diona
 		)
 
 	mutantears = /obj/item/organ/internal/ears/diona

--- a/code/modules/mob/living/carbon/human/species/nucleation.dm
+++ b/code/modules/mob/living/carbon/human/species/nucleation.dm
@@ -22,7 +22,7 @@
 	reagent_tag = PROCESS_ORG
 	has_organ = list(
 		"heart" =    /obj/item/organ/internal/heart,
-		"crystallized brain" =    /obj/item/organ/internal/brain/crystal,
+		"brain" =    /obj/item/organ/internal/brain/crystal,
 		"eyes" =     /obj/item/organ/internal/eyes/luminescent_crystal, //Standard darksight of 2.
 		"strange crystal" = /obj/item/organ/internal/nucleation/strange_crystal
 		)

--- a/code/modules/mob/living/carbon/human/species/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/vox.dm
@@ -61,7 +61,7 @@
 		"lungs" =    /obj/item/organ/internal/lungs/vox,
 		"liver" =    /obj/item/organ/internal/liver/vox,
 		"kidneys" =  /obj/item/organ/internal/kidneys/vox,
-		"cortical stack" =    /obj/item/organ/internal/brain/vox,
+		"brain" =    /obj/item/organ/internal/brain/vox,
 		"appendix" = /obj/item/organ/internal/appendix,
 		"eyes" =     /obj/item/organ/internal/eyes/vox, //Default darksight of 2.
 		)												//for determining the success of the heist game-mode's 'leave nobody behind' objective, while this is just an organ.


### PR DESCRIPTION
Исправляет ошибку в проке "Получить урон мозгу", которая требует иметь в теле организма непосредственно сам мозг.

Какая жаль, что у дион хрен пойми что, у воксов стек, а у нуклеаций КРИСТАЛЬНЫЙ мозг. Но игра самого мозга не видит...

Не изменяет названия внутри игры, но теперь игра будет видеть наличие мозгов у этих рас.

<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багфикс в 3 строчки, убирающий иммунитет к мозгу у 5 рас.

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
