### PR TITLE
fix: simple mob reconnect in vents make screen black

### DIFF
--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -1,5 +1,7 @@
 /mob/living/Login()
 	..()
+	//Should update regardless of if we can ventcrawl, since we can end up in pipes in other ways.
+	update_pipe_vision(loc)
 	//Mind updates
 	sync_mind()
 	update_stat("mob login")
@@ -25,8 +27,5 @@
 			var/datum/action/changeling/S = power
 			if(istype(S) && S.needs_button)
 				S.Grant(src)
-
-	//Should update regardless of if we can ventcrawl, since we can end up in pipes in other ways.
-	update_pipe_vision(loc)
 
 	return .


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Если вы реконнектаетесь в вентиляции за симплмоба у вас были только трубы. Небольшим изменением порядка обновления зрения это исправляется.

<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/734823601110515882/1123287749475172443
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
https://discord.com/channels/617003227182792704/734823601110515882/1123310251299569805