### PR TITLE
tweak: Adding Flag No Random Drop

### DIFF
--- a/code/game/objects/items/cardboard_cutouts.dm
+++ b/code/game/objects/items/cardboard_cutouts.dm
@@ -4,6 +4,7 @@
 	desc = "A vaguely humanoid cardboard cutout. It's completely blank."
 	icon = 'icons/obj/cardboard_cutout.dmi'
 	icon_state = "cutout_basic"
+	flags = NO_PIXEL_RANDOM_DROP
 	resistance_flags = FLAMMABLE
 	w_class = WEIGHT_CLASS_BULKY
 	var/list/possible_appearances = list("Assistant", "Clown", "Mime",

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -11,7 +11,7 @@
 	icon_state = "powersink0"
 	item_state = "electronic"
 	w_class = WEIGHT_CLASS_BULKY
-	flags = CONDUCT
+	flags = CONDUCT | NO_PIXEL_RANDOM_DROP
 	throwforce = 5
 	throw_speed = 1
 	throw_range = 2

--- a/code/game/objects/items/misc.dm
+++ b/code/game/objects/items/misc.dm
@@ -21,4 +21,4 @@
 	throwforce = 0.0
 	throw_speed = 1
 	throw_range = 20
-	flags = CONDUCT
+	flags = CONDUCT | NO_PIXEL_RANDOM_DROP

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -162,6 +162,7 @@
 	desc = "\"Singulo\" brand spinning toy."
 	icon = 'icons/obj/engines_and_power/singularity.dmi'
 	icon_state = "singularity_s1"
+	flags = NO_PIXEL_RANDOM_DROP
 
 /*
  * Toy swords

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -10,6 +10,7 @@ LINEN BINS
 	icon = 'icons/obj/items.dmi'
 	icon_state = "sheet"
 	item_state = "sheet"
+	flags = NO_PIXEL_RANDOM_DROP
 	layer = 4.0
 	throwforce = 1
 	throw_speed = 1

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -223,6 +223,7 @@
 	name = "potted plant"
 	icon = 'icons/obj/flora/plants.dmi'
 	icon_state = "plant-1"
+	flags = NO_PIXEL_RANDOM_DROP
 	anchored = 0
 	layer = ABOVE_MOB_LAYER
 	w_class = WEIGHT_CLASS_HUGE


### PR DESCRIPTION
## Описание
<!--  -->
Добавляем предметам, которые не должны иметь смещения при выбрасывании, нужный флаг. Забыл это сделать на момент рефактора инвентаря.