### PR TITLE
fix: jacob ladder ignore safed zones

### DIFF
--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -149,6 +149,9 @@
 		if(is_admin_level(i) || is_away_level(i) || is_taipan(i))
 			continue
 		var/turf/T2 = locate(ladder_x, ladder_y, i)
+		var/area/new_area = get_area(T2)
+		if(new_area.tele_proof)
+			continue
 		last_ladder = new /obj/structure/ladder/unbreakable/jacob(T2, null, last_ladder)
 	qdel(src)
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Например, сейчас с помощью этой лестницы можно попасть в зону некрополя, обходя босса-легиона, где телепорты и т.п. запрещены. Исправляем это.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Я считаю это багом, нужно проходить в защищённые зоны правильно.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
