### PR TITLE
tweak: Put In Hand Null Item

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -283,7 +283,7 @@
  */
 /mob/proc/put_in_hand(obj/item/I, hand_id, force = FALSE, ignore_anim = TRUE)
 
-	// Its always TRUE if there is no item, since we are using helpers to check
+	// Its always 'TRUE' if there is no item, since we are using helpers with this proc in 'if()' statements
 	if(!I)
 		return TRUE
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -283,6 +283,10 @@
  */
 /mob/proc/put_in_hand(obj/item/I, hand_id, force = FALSE, ignore_anim = TRUE)
 
+	// Its always TRUE if there is no item, since we are using helpers to check
+	if(!I)
+		return TRUE
+
 	if(!force && !put_in_hand_check(I, hand_id))
 		return FALSE
 

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -334,6 +334,11 @@
  * * 'ignore_anime' set to `TRUE` to prevent pick up animation.
  */
 /mob/living/carbon/put_in_hands(obj/item/I, force = FALSE, qdel_on_fail = FALSE, merge_stacks = TRUE, ignore_anim = TRUE)
+
+	// Its always TRUE if there is no item, since we are using this proc in 'if()' statements
+	if(!I)
+		return TRUE
+
 	if(QDELETED(I))
 		return FALSE
 


### PR DESCRIPTION
## Описание
<!--. -->
Сделал так, что проки put_in_hand и put_in_hands всегда возвращают истину, если предмета не было, по аналогии с do_unEquip. Данная особенность необходима, если любой из хэлперов, связанных с руками, используется в качестве проверки.