### PR TITLE
bugfix: Immortality Talisman Consume

### DIFF
--- a/code/__DEFINES/span.dm
+++ b/code/__DEFINES/span.dm
@@ -35,6 +35,7 @@
 #define span_boldnotice(str) ("<span class='boldnotice'>" + str + "</span>")
 #define span_boldwarning(str) ("<span class='boldwarning'>" + str + "</span>")
 //#define span_centcomradio(str) ("<span class='centcomradio'>" + str + "</span>")
+#define span_caution(str) ("<span class='caution'>" + str + "</span>")
 #define span_changeling(str) ("<span class='changeling'>" + str + "</span>")
 #define span_clown(str) ("<span class='clown'>" + str + "</span>")
 #define span_colossus(str) ("<span class='colossus'>" + str + "</span>")

--- a/code/datums/spells/summonitem.dm
+++ b/code/datums/spells/summonitem.dm
@@ -19,7 +19,6 @@
 /obj/effect/proc_holder/spell/targeted/summonitem/cast(list/targets, mob/user = usr)
 	for(var/mob/living/target in targets)
 		var/list/hand_items = list(target.get_active_hand(),target.get_inactive_hand())
-		var/butterfingers = 0
 		var/message
 
 		if(!marked_item) //linking item to the spell
@@ -38,17 +37,17 @@
 
 			if(!marked_item)
 				if(hand_items)
-					message = "<span class='caution'>You aren't holding anything that can be marked for recall.</span>"
+					message = span_caution("You aren't holding anything that can be marked for recall.")
 				else
-					message = "<span class='notice'>You must hold the desired item in your hands to mark it for recall.</span>"
+					message = span_notice("You must hold the desired item in your hands to mark it for recall.")
 
 		else if(marked_item && (marked_item in hand_items)) //unlinking item to the spell
-			message = "<span class='notice'>You remove the mark on [marked_item] to use elsewhere.</span>"
+			message = span_notice("You remove the mark on [marked_item] to use elsewhere.")
 			name = "Instant Summons"
 			marked_item = 		null
 
 		else if(marked_item && !marked_item.loc) //the item was destroyed at some point
-			message = "<span class='warning'>You sense your marked item has been destroyed!</span>"
+			message = span_warning("You sense your marked item has been destroyed!")
 			name = "Instant Summons"
 			marked_item = 		null
 
@@ -61,9 +60,13 @@
 					var/mob/M = item_to_retrieve.loc
 
 					if(issilicon(M) || !M.drop_item_ground(item_to_retrieve)) //Items in silicons warp the whole silicon
-						M.visible_message("<span class='warning'>[M] suddenly disappears!</span>", "<span class='danger'>A force suddenly pulls you away!</span>")
-						M.forceMove(target.loc)
-						M.loc.visible_message("<span class='caution'>[M] suddenly appears!</span>")
+						var/turf/target_turf = get_turf(target)
+						if(!target_turf)
+							return
+
+						M.visible_message(span_warning("[M] suddenly disappears!"), span_danger("A force suddenly pulls you away!"))
+						M.forceMove(target_turf)
+						M.loc.visible_message(span_caution("[M] suddenly appears!"))
 						item_to_retrieve = null
 						break
 
@@ -80,7 +83,7 @@
 							var/obj/item/organ/external/part = X
 							if(item_to_retrieve in part.embedded_objects)
 								part.embedded_objects -= item_to_retrieve
-								to_chat(C, "<span class='warning'>The [item_to_retrieve] that was embedded in your [part] has mysteriously vanished. How fortunate!</span>")
+								to_chat(C, span_warning("The [item_to_retrieve] that was embedded in your [part] has mysteriously vanished. How fortunate!"))
 								if(!C.has_embedded_objects())
 									C.clear_alert("embeddedobject")
 								break
@@ -99,24 +102,20 @@
 			if(!item_to_retrieve)
 				return
 
-			item_to_retrieve.loc.visible_message("<span class='warning'>The [item_to_retrieve.name] suddenly disappears!</span>")
+			item_to_retrieve.loc.visible_message(span_warning("The [item_to_retrieve.name] suddenly disappears!"))
 
+			if(!target.put_in_active_hand(item_to_retrieve) && !target.put_in_inactive_hand(item_to_retrieve))
+				var/turf/target_turf = get_turf(target)
+				if(!target_turf)
+					return
 
-			if(target.hand) //left active hand
-				if(!target.equip_to_slot_if_possible(item_to_retrieve, slot_l_hand, disable_warning = TRUE))
-					if(!target.equip_to_slot_if_possible(item_to_retrieve, slot_r_hand, disable_warning = TRUE))
-						butterfingers = 1
-			else			//right active hand
-				if(!target.equip_to_slot_if_possible(item_to_retrieve, slot_r_hand, disable_warning = TRUE))
-					if(!target.equip_to_slot_if_possible(item_to_retrieve, slot_l_hand, disable_warning = TRUE))
-						butterfingers = 1
-			if(butterfingers)
-				item_to_retrieve.loc = target.loc
-				item_to_retrieve.loc.visible_message("<span class='caution'>The [item_to_retrieve.name] suddenly appears!</span>")
-				playsound(get_turf(target),'sound/magic/summonitems_generic.ogg',50,1)
+				item_to_retrieve.loc = target_turf
+				item_to_retrieve.loc.visible_message(span_caution("The [item_to_retrieve.name] suddenly appears!"))
+				playsound(target_turf, 'sound/magic/summonitems_generic.ogg', 50, TRUE)
+
 			else
-				item_to_retrieve.loc.visible_message("<span class='caution'>The [item_to_retrieve.name] suddenly appears in [target]'s hand!</span>")
-				playsound(get_turf(target),'sound/magic/summonitems_generic.ogg',50,1)
+				item_to_retrieve.loc.visible_message(span_caution("The [item_to_retrieve.name] suddenly appears in [target]'s hand!"))
+				playsound(get_turf(target), 'sound/magic/summonitems_generic.ogg', 50, TRUE)
 
 		if(message)
 			to_chat(target, message)

--- a/code/datums/spells/summonitem.dm
+++ b/code/datums/spells/summonitem.dm
@@ -102,20 +102,18 @@
 			if(!item_to_retrieve)
 				return
 
+			var/turf/target_turf = get_turf(target)
+			if(!target_turf)
+				return
+
 			item_to_retrieve.loc.visible_message(span_warning("The [item_to_retrieve.name] suddenly disappears!"))
+			playsound(target_turf, 'sound/magic/summonitems_generic.ogg', 50, TRUE)
 
 			if(!target.put_in_active_hand(item_to_retrieve) && !target.put_in_inactive_hand(item_to_retrieve))
-				var/turf/target_turf = get_turf(target)
-				if(!target_turf)
-					return
-
 				item_to_retrieve.loc = target_turf
 				item_to_retrieve.loc.visible_message(span_caution("The [item_to_retrieve.name] suddenly appears!"))
-				playsound(target_turf, 'sound/magic/summonitems_generic.ogg', 50, TRUE)
-
 			else
 				item_to_retrieve.loc.visible_message(span_caution("The [item_to_retrieve.name] suddenly appears in [target]'s hand!"))
-				playsound(get_turf(target), 'sound/magic/summonitems_generic.ogg', 50, TRUE)
 
 		if(message)
 			to_chat(target, message)

--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -455,7 +455,7 @@
 		return
 
 	var/turf/effect_turf = get_turf(effect)
-	if(!source_turf)
+	if(!effect_turf)
 		stack_trace("[effect] is outside of the turf contents")
 		return
 

--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -403,8 +403,8 @@
 	QDEL_NULL(chain)
 	return ..()
 
-//Immortality Talisman
 
+//Immortality Talisman
 /obj/item/immortality_talisman
 	name = "Immortality Talisman"
 	desc = "A dread talisman that can render you completely invulnerable."
@@ -412,10 +412,12 @@
 	icon_state = "talisman"
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	actions_types = list(/datum/action/item_action/immortality)
-	var/cooldown = 0
+	COOLDOWN_DECLARE(last_used_immortality_talisman)
+
 
 /datum/action/item_action/immortality
 	name = "Immortality"
+
 
 /obj/item/immortality_talisman/Destroy(force)
 	if(force)
@@ -423,44 +425,76 @@
 	else
 		return QDEL_HINT_LETMELIVE
 
+
 /obj/item/immortality_talisman/attack_self(mob/user)
-	if(cooldown < world.time)
-		SSblackbox.record_feedback("amount", "immortality_talisman_uses", 1) // usage
-		cooldown = world.time + 600
-		user.visible_message("<span class='danger'>[user] vanishes from reality, leaving a a hole in [user.p_their()] place!</span>")
-		var/obj/effect/immortality_talisman/Z = new(get_turf(src.loc))
-		Z.name = "hole in reality"
-		Z.desc = "It's shaped an awful lot like [user.name]."
-		Z.setDir(user.dir)
-		user.forceMove(Z)
-		user.notransform = 1
-		user.status_flags |= GODMODE
-		spawn(100)
-			user.status_flags &= ~GODMODE
-			user.notransform = 0
-			user.forceMove(get_turf(Z))
-			user.visible_message("<span class='danger'>[user] pops back into reality!</span>")
-			Z.can_destroy = TRUE
-			qdel(Z)
-	else
-		to_chat(user, "<span class'warning'>[src] is still recharging.</span>")
+	if(!COOLDOWN_FINISHED(src, last_used_immortality_talisman))
+		to_chat(user, span_warning("[src] is still recharging."))
+		return
+
+	var/turf/source_turf = get_turf(src)
+	if(!source_turf)
+		return
+
+	COOLDOWN_START(src, last_used_immortality_talisman, 60 SECONDS)
+	SSblackbox.record_feedback("amount", "immortality_talisman_uses", 1)
+	user.visible_message(span_danger("[user] vanishes from reality, leaving a a hole in [user.p_their()] place!"))
+
+	var/obj/effect/immortality_talisman/effect = new(source_turf)
+	effect.name = "hole in reality"
+	effect.desc = "It's shaped an awful lot like [user.name]."
+	effect.setDir(user.dir)
+	user.forceMove(effect)
+	user.notransform = TRUE
+	user.status_flags |= GODMODE
+
+	addtimer(CALLBACK(src, PROC_REF(reappear), user, effect), 10 SECONDS)
+
+
+/obj/item/immortality_talisman/proc/reappear(mob/user, obj/effect/immortality_talisman/effect)
+	if(QDELETED(src) || QDELETED(user) || QDELETED(effect))
+		return
+
+	var/turf/effect_turf = get_turf(effect)
+	if(!source_turf)
+		stack_trace("[effect] is outside of the turf contents")
+		return
+
+	user.status_flags &= ~GODMODE
+	user.notransform = FALSE
+	user.forceMove(effect_turf)
+	user.visible_message(span_danger("[user] pops back into reality!"))
+	effect.can_destroy = TRUE
+
+	if(length(effect.contents))
+		for(var/obj/atom as anything in effect.contents)	// Since we are using `as anything` this loop will pickup every atom in contents
+			if(QDELETED(atom))
+				continue
+			atom.loc = effect_turf
+
+	qdel(effect)
+
 
 /obj/effect/immortality_talisman
 	icon_state = "blank"
 	icon = 'icons/effects/effects.dmi'
 	var/can_destroy = FALSE
 
+
 /obj/effect/immortality_talisman/attackby()
 	return
+
 
 /obj/effect/immortality_talisman/ex_act()
 	return
 
+
 /obj/effect/immortality_talisman/singularity_act()
 	return
 
+
 /obj/effect/immortality_talisman/singularity_pull()
 	return 0
+
 
 /obj/effect/immortality_talisman/Destroy(force)
 	if(!can_destroy && !force)


### PR DESCRIPTION
## Описание
<!--  -->
Заклинание моментального призыва теперь перемещает предмет или его носителя на турф под призвавшим, а не на его локацию. Данное изменение необходимо в связи с тем, что иначе призываемый предмет (или даже существа/объекты, в которых предмет находится) может оказаться в местах, откуда никак невозможно выбраться. И это ещё в лучшем случае.

Также отрефакторил код талисмана и на всякий случай добавил там опустошение содержимого, перед удалением.

## Ссылка на предложение/Причина создания ПР
<!--  -->
https://discord.com/channels/617003227182792704/1124862229636984912
