### PR TITLE
fix: time stat now doesn't go zero when 24h of round have passed

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -19,6 +19,8 @@
 
 #define ROUND_TIME_TEXT(...) ( "[world.time - SSticker.round_start_time > MIDNIGHT_ROLLOVER ? "[round((world.time - SSticker.round_start_time)/MIDNIGHT_ROLLOVER)]:[worldtime2text()]" : worldtime2text()]" )
 
+#define SHIFT_TIME_TEXT(...) ( "[SSticker.round_start_time > MIDNIGHT_ROLLOVER ? "[round(SSticker.round_start_time/MIDNIGHT_ROLLOVER)]:[shifttime2text()]" : shifttime2text()]" )
+
 /* This proc should only be used for world/Topic.
  * If you want to display the time for which dream daemon has been running ("round time") use worldtime2text.
  * If you want to display the canonical station "time" (aka the in-character time of the station) use station_time_timestamp
@@ -30,6 +32,9 @@
 //Returns the world time in english
 /proc/worldtime2text()
 	return gameTimestamp("hh:mm:ss", world.time)
+
+/proc/shifttime2text()
+	return gameTimestamp("hh:mm:ss", world.time - SSticker.round_start_time)
 
 // This is ISO-8601
 // If anything that uses this proc shouldn't be ISO-8601, change that thing, not this proc. This is important for logging.

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -17,6 +17,8 @@
 
 #define TICKS2DS(T) ((T) TICKS)
 
+#define ROUND_TIME_TEXT(...) ( "[world.time - SSticker.round_start_time > MIDNIGHT_ROLLOVER ? "[round((world.time - SSticker.round_start_time)/MIDNIGHT_ROLLOVER)]:[worldtime2text()]" : worldtime2text()]" )
+
 /* This proc should only be used for world/Topic.
  * If you want to display the time for which dream daemon has been running ("round time") use worldtime2text.
  * If you want to display the canonical station "time" (aka the in-character time of the station) use station_time_timestamp

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -479,7 +479,7 @@ SUBSYSTEM_DEF(ticker)
 	ending_station_state.count()
 	var/station_integrity = min(round( 100.0 *  GLOB.start_state.score(ending_station_state), 0.1), 100.0)
 
-	to_chat(world, "<BR>[TAB]Shift Duration: <B>[ROUND_TIME_TEXT()]</B>")
+	to_chat(world, "<BR>[TAB]Shift Duration: <B>[SHIFT_TIME_TEXT()]</B>")
 	to_chat(world, "<BR>[TAB]Station Integrity: <B>[mode.station_was_nuked ? "<font color='red'>Destroyed</font>" : "[station_integrity]%"]</B>")
 	to_chat(world, "<BR>")
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -479,7 +479,7 @@ SUBSYSTEM_DEF(ticker)
 	ending_station_state.count()
 	var/station_integrity = min(round( 100.0 *  GLOB.start_state.score(ending_station_state), 0.1), 100.0)
 
-	to_chat(world, "<BR>[TAB]Shift Duration: <B>[round(ROUND_TIME / 36000)]:[add_zero("[ROUND_TIME / 600 % 60]", 2)]:[ROUND_TIME / 100 % 6][ROUND_TIME / 100 % 10]</B>")
+	to_chat(world, "<BR>[TAB]Shift Duration: <B>[ROUND_TIME_TEXT()]</B>")
 	to_chat(world, "<BR>[TAB]Station Integrity: <B>[mode.station_was_nuked ? "<font color='red'>Destroyed</font>" : "[station_integrity]%"]</B>")
 	to_chat(world, "<BR>")
 

--- a/code/controllers/subsystem/tickets/tickets.dm
+++ b/code/controllers/subsystem/tickets/tickets.dm
@@ -331,7 +331,7 @@ SUBSYSTEM_DEF(tickets)
 	raw_title = raw_tit
 	content = list()
 	content += cont
-	timeOpened = worldtime2text()
+	timeOpened = ROUND_TIME_TEXT()
 	timeUntilStale = world.time + TICKET_TIMEOUT
 	setCooldownPeriod()
 	ticketNum = num
@@ -344,7 +344,7 @@ SUBSYSTEM_DEF(tickets)
 //Set the last staff who responded as the client passed as an arguement.
 /datum/ticket/proc/setLastStaffResponse(client/C)
 	lastStaffResponse = C
-	lastResponseTime = worldtime2text()
+	lastResponseTime = ROUND_TIME_TEXT()
 
 //Return the ticket state as a colour coded text string.
 /datum/ticket/proc/state2text()

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -237,7 +237,7 @@ GLOBAL_LIST_EMPTY(world_topic_handlers)
 		s += "<br>[config.server_tag_line]"
 
 	if(SSticker && ROUND_TIME > 0)
-		s += "<br>[round(ROUND_TIME / 36000)]:[add_zero(num2text(ROUND_TIME / 600 % 60), 2)], " + capitalize(get_security_level())
+		s += "<br>[ROUND_TIME_TEXT()], " + capitalize(get_security_level())
 	else
 		s += "<br><b>STARTING</b>"
 

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -352,7 +352,7 @@
 	if(SSticker && SSticker.current_state >= GAME_STATE_PLAYING)
 		var/dat = {"<html><meta charset="UTF-8"><head><title>Round Status</title></head><body><h1><B>Round Status</B></h1>"}
 		dat += "Current Game Mode: <B>[SSticker.mode.name]</B><BR>"
-		dat += "Round Duration: <B>[round(ROUND_TIME / 36000)]:[add_zero(num2text(ROUND_TIME / 600 % 60), 2)]:[add_zero(num2text(ROUND_TIME / 10 % 60), 2)]</B><BR>"
+		dat += "Round Duration: <B>[ROUND_TIME_TEXT()]</B><BR>"
 		dat += "<B>Emergency shuttle</B><BR>"
 		if(SSshuttle.emergency.mode < SHUTTLE_CALL)
 			dat += "<a href='?src=[UID()];call_shuttle=1'>Call Shuttle</a><br>"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -751,7 +751,7 @@
 	stat(null, "Current Map: [SSmapping.map_datum.name]")
 	if(SSmapping.next_map)
 		stat(null, "Next Map: [SSmapping.next_map.name]")
-	stat(null, "Round Time: [worldtime2text()]")
+	stat(null, "Round Time: [ROUND_TIME_TEXT()]")
 	stat(null, "Station Time: [station_time_timestamp()]")
 	stat(null, "Server TPS: [world.fps]")
 	stat(null, "Desired Client FPS: [client?.prefs?.clientfps]")

--- a/code/modules/world_topic/status.dm
+++ b/code/modules/world_topic/status.dm
@@ -12,7 +12,7 @@
 	status_info["ai"] = config.allow_ai
 	status_info["host"] = world.host ? world.host : null
 	status_info["players"] = list()
-	status_info["roundtime"] = worldtime2text()
+	status_info["roundtime"] = ROUND_TIME_TEXT()
 	status_info["stationtime"] = station_time_timestamp()
 	status_info["oldstationtime"] = classic_worldtime2text() // more "consistent" indication of the round's running time
 	status_info["listed"] = "Public"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Небольшой рефактор/фикс, позволяющий корректно отслеживать время в раундах, длящихся дольше 24-х часов, также приведение к тексту длительности раунда унифицировано и упаковано в макрос.
Добавлен отдельный макрос для получения текста времени смены на станции для статистики в конце игры.
Там, где надо отобразить время с помощью worldtime2text, поставил макрос
Портировано с TG, адаптировано мной.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
https://discord.com/channels/617003227182792704/1124301156764622988/1124301156764622988
