### PR TITLE
fix: now indestructible tiles can't be pried, screwdrivered, weldered.

### DIFF
--- a/code/game/turfs/simulated/floor/indestructible.dm
+++ b/code/game/turfs/simulated/floor/indestructible.dm
@@ -33,6 +33,15 @@
 /turf/simulated/floor/indestructible/mech_melee_attack(obj/mecha/M)
 	return
 
+/turf/simulated/floor/indestructible/crowbar_act(mob/user, obj/item/I)
+	return
+
+/turf/simulated/floor/indestructible/screwdriver_act(mob/living/user, obj/item/I)
+	return
+
+/turf/simulated/floor/indestructible/welder_act(mob/living/user, obj/item/I)
+	return
+
 /turf/simulated/floor/indestructible/plating
 	name = "plating"
 	icon_state = "plating"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправляет ошибку, при которой неразрушимые плитки можно было выдрать монтировкой, а пол под ней разобрать, выводя пробоину в космос/лаву.
Теперь неразрушимые плитки нельзя поддеть монтировкой, использовать на них отвертку или сварку.
В частности, убирает возможность разобрать песок и воду в гейтах.

Проблема в том, что почти все неразрушимые турфы при разборе монтировкой получают из себя разрушимый plating, который можно спокойно разобрать отверткой и сваркой. Решил поступить более радикально и вообще запретить взаимодействие инструментам с неразрушимыми турфами.

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Багфикс.
## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
![51](https://github.com/ss220-space/Paradise/assets/73733747/2f56e000-9d90-4507-a6d7-4aae785023d3)

