### PR TITLE
bugfix: big ruins create infinity loop

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -430,6 +430,8 @@
 #define PLACE_SPACE_RUIN "space"
 #define PLACE_LAVA_RUIN "lavaland"
 
+#define MAX_RUIN_SIZE_VALUE 170 // Which ruin should be considered large and create a separate level of space for it.
+
 //Cleaning tool strength
 // 1 is also a valid cleaning strength but completely unused so left undefined
 #define CLEAN_WEAK 			2

--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -136,7 +136,7 @@ GLOBAL_LIST_INIT(potentialRandomZlevels, generateMapList(filename = "config/away
 	return potentialMaps
 
 
-/datum/map_template/ruin/proc/try_to_place(z,allowed_areas)
+/datum/map_template/ruin/proc/try_to_place(z, allowed_areas)
 	var/sanity = PLACEMENT_TRIES
 	while(sanity > 0)
 		sanity--
@@ -145,7 +145,7 @@ GLOBAL_LIST_INIT(potentialRandomZlevels, generateMapList(filename = "config/away
 		var/turf/central_turf = locate(rand(width_border, world.maxx - width_border), rand(height_border, world.maxy - height_border), z)
 		var/valid = TRUE
 
-		for(var/turf/check in get_affected_turfs(central_turf,1))
+		for(var/turf/check as anything in get_affected_turfs(central_turf,1))
 			var/area/new_area = get_area(check)
 			if(!(istype(new_area, allowed_areas)) || check.flags & NO_RUINS)
 				valid = FALSE
@@ -168,7 +168,7 @@ GLOBAL_LIST_INIT(potentialRandomZlevels, generateMapList(filename = "config/away
 		load(central_turf,centered = TRUE)
 		loaded++
 
-		for(var/turf/T in get_affected_turfs(central_turf, 1))
+		for(var/turf/T as anything in get_affected_turfs(central_turf, 1))
 			T.flags |= NO_RUINS
 
 		new /obj/effect/landmark/ruin(central_turf, src)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Делает так, чтобы большие руины спавнились первыми и у них на уровне не появлялись другие руины.
Это позволит избежать бесконечных попыток загрузки больших руин в конце.
Теперь лист выбранных руин создаётся до начала их спавна, если руина большая, то она ставится в начало и появится первой, на свободном уровне.

Большими руинами считаются руины больше 170. Для 170 на 170 руины означает что любая руина 42 на 42 заблокирует её появление. И наоборот. На данный момент.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Это должно убрать долгие загрузки больших руин. На данный момент это станция горький.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->