### PR TITLE
qol: configurable loading taipan and lavaland

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -317,6 +317,9 @@
 	var/override_map = null
 	var/item_animations_enabled = FALSE
 
+	var/disable_taipan = FALSE
+	var/disable_lavaland = FALSE
+
 /datum/configuration/New()
 	for(var/T in subtypesof(/datum/game_mode))
 		var/datum/game_mode/M = T
@@ -908,6 +911,12 @@
 
 				if("item_animations_enabled")
 					config.item_animations_enabled = TRUE
+
+				if("disable_taipan")
+					config.disable_taipan = TRUE
+
+				if("disable_lavaland")
+					config.disable_lavaland = TRUE
 
 				else
 					log_config("Unknown setting in configuration: '[name]'")

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -38,9 +38,10 @@ SUBSYSTEM_DEF(mapping)
 	// Load the station
 	loadStation()
 
-	loadLavaland()
-
-	loadTaipan()
+	if(!config.disable_lavaland)
+		loadLavaland()
+	if(!config.disable_taipan)
+		loadTaipan()
 	// Pick a random away mission.
 	if(!config.disable_away_missions)
 		createRandomZlevel()
@@ -69,12 +70,13 @@ SUBSYSTEM_DEF(mapping)
 	// Setup the Z-level linkage
 	GLOB.space_manager.do_transition_setup()
 
-	// Spawn Lavaland ruins and rivers.
-	log_startup_progress("Populating lavaland...")
-	var/lavaland_setup_timer = start_watch()
-	seedRuins(list(level_name_to_num(MINING)), config.lavaland_budget, /area/lavaland/surface/outdoors/unexplored, GLOB.lava_ruins_templates)
-	spawn_rivers(level_name_to_num(MINING))
-	log_startup_progress("Successfully populated lavaland in [stop_watch(lavaland_setup_timer)]s.")
+	if(!config.disable_lavaland)
+		// Spawn Lavaland ruins and rivers.
+		log_startup_progress("Populating lavaland...")
+		var/lavaland_setup_timer = start_watch()
+		seedRuins(list(level_name_to_num(MINING)), config.lavaland_budget, /area/lavaland/surface/outdoors/unexplored, GLOB.lava_ruins_templates)
+		spawn_rivers(level_name_to_num(MINING))
+		log_startup_progress("Successfully populated lavaland in [stop_watch(lavaland_setup_timer)]s.")
 
 	// Now we make a list of areas for teleport locs
 	// TOOD: Make these locs into lists on the SS itself, not globs

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -541,7 +541,7 @@
 	dir = S1.dir
 
 	// Update mining and labor shuttle ash storm audio
-	if(id in list("mining", "laborcamp"))
+	if(id in list("mining", "laborcamp") && !config.disable_lavaland)
 		var/mining_zlevel = level_name_to_num(MINING)
 		var/datum/weather/ash_storm/W = SSweather.get_weather(mining_zlevel, /area/lavaland/surface/outdoors)
 		if(W)

--- a/code/modules/space_management/level_traits.dm
+++ b/code/modules/space_management/level_traits.dm
@@ -66,6 +66,8 @@ GLOBAL_LIST_INIT(default_map_traits, MAP_TRANSITION_CONFIG)
 
 /proc/level_name_to_num(name)
 	var/datum/space_level/S = GLOB.space_manager.get_zlev_by_name(name)
+	if(!S)
+		CRASH("Unknown z-level name: [name]")
 	return S.zpos
 
 /**

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -593,3 +593,9 @@ DEFAULT_MAP /datum/map/cyberiad
 ## Enable animations on item pickup and drop down
 # ITEM_ANIMATIONS_ENABLED
 
+## Disable the loading of "Taipan"
+# DISABLE_TAIPAN
+
+## Disable the loading of Lavaland
+# DISABLE_LAVALAND
+


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Теперь подгрузку лаваленда и тайпана можно отключить конфигом. При отключенных руинах космоса и гейте и этом у меня экономит минуту их двух.
Изначально, как и с косморуинами и гейтом,  подгрузка лаваленда и тайпана включена, нужно разкомментить в конфиге для выключения.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Иногда хочется сделать побыстрее загрузку. Добавляем к уже существующим в конфиге гейту и космическим руинам лаваленд и тайпан.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

