### PR TITLE
bugfix: holster logic and dupe naming cryopod

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -666,8 +666,6 @@
 	go_out()
 	add_fingerprint(usr)
 
-	name = initial(name)
-
 /obj/machinery/cryopod/verb/move_inside()
 	set name = "Enter Pod"
 	set category = "Object"
@@ -729,6 +727,8 @@
 		icon_state = "[base_icon_state]-r"
 	else
 		icon_state = base_icon_state
+
+	name = initial(name)
 
 	return
 

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -10,7 +10,9 @@
 	w_class = WEIGHT_CLASS_NORMAL // so it doesn't fit in pockets
 
 /obj/item/clothing/accessory/holster/Destroy()
-	QDEL_NULL(holstered)
+	if(holstered?.loc == src)
+		QDEL_NULL(holstered)
+	holstered = null
 	return ..()
 
 //subtypes can override this to specify what can be holstered


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Оружие в кобуре удаляется только в том случае, если оно в кобуре. Это нужно чтобы при криоудалении его не стирало.
Теперь при выходе из криопода его имя сбрасывается на изначальное, а не остаётся висеть 10 ваших.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
В т.ч. закрывает багрепорт: https://discord.com/channels/617003227182792704/1125560823784423445
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

