### PR TITLE
Фикс снайперских патронов в наборах триторов

### DIFF
--- a/code/datums/syndiesupplypacks.dm
+++ b/code/datums/syndiesupplypacks.dm
@@ -2233,8 +2233,8 @@ GLOBAL_LIST_INIT(all_syndie_supply_groups, list(SYNDIE_SUPPLY_EMERGENCY,SYNDIE_S
 /datum/syndie_supply_packs/syndicate_special/professional
 	name = "Syndicate 'Professional' Bundle"
 	contains = list(/obj/item/gun/projectile/automatic/sniper_rifle/syndicate/penetrator, // 16TC
-					/obj/item/ammo_box/magazine/sniper_rounds/penetrator, // 5TC
-					/obj/item/ammo_box/magazine/sniper_rounds/soporific, // 3TC
+					/obj/item/ammo_box/magazine/sniper_rounds/compact/penetrator, // 5TC
+					/obj/item/ammo_box/magazine/sniper_rounds/compact/soporific, // 3TC
 					/obj/item/clothing/glasses/chameleon/thermal, // 6TC
 					/obj/item/clothing/gloves/combat, // 0 TC
 					/obj/item/clothing/under/suit_jacket/really_black, // 0 TC

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -99,8 +99,8 @@
 
 	var/static/list/professional = list( // 34TC + two 0TC
 		/obj/item/gun/projectile/automatic/sniper_rifle/syndicate/penetrator, // 16TC
-		/obj/item/ammo_box/magazine/sniper_rounds/penetrator, // 5TC
-		/obj/item/ammo_box/magazine/sniper_rounds/soporific, // 3TC
+		/obj/item/ammo_box/magazine/sniper_rounds/compact/penetrator, // 5TC
+		/obj/item/ammo_box/magazine/sniper_rounds/compact/soporific, // 3TC
 		/obj/item/clothing/glasses/chameleon/thermal, // 6TC
 		/obj/item/clothing/gloves/combat, // 0 TC
 		/obj/item/clothing/under/suit_jacket/really_black, // 0 TC


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Теперь в наборах из карго и аплинка спавнятся компактные магазины снайперки, которые подходят триторским варианатм этой винтовки

## Ссылка на предложение/Причина создания ПР
Багрепорт. Видимо я просто забыл про эти наборы, когда фиксил абуз патронов с тайпана
