### PR TITLE
bugfix: Nuke core container ex_act() fixes

### DIFF
--- a/code/game/objects/items/theft_items.dm
+++ b/code/game/objects/items/theft_items.dm
@@ -62,17 +62,16 @@
 /obj/item/nuke_core_container/ex_act(severity)
 	if(!sealed) //core now immune to blast if not used yet
 		return
-	if(isturf(loc)) //if in hands/backpack, can't be cracked open
-		switch(severity)
-			if(EXPLODE_DEVASTATE)
-				if(!cracked)
-					crack_open()
-					sealed = FALSE
-			if(EXPLODE_HEAVY)
-				if(!dented)
-					dented = TRUE
-	else
+	if(!isturf(loc)) //if in hands/backpack, can't be cracked open
 		return
+	switch(severity)
+		if(EXPLODE_DEVASTATE)
+			if(!cracked)
+				crack_open()
+				sealed = FALSE
+		if(EXPLODE_HEAVY)
+			if(!dented)
+				dented = TRUE
 
 /obj/item/nuke_core_container/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/theft_items.dm
+++ b/code/game/objects/items/theft_items.dm
@@ -53,19 +53,26 @@
 	var/obj/item/nuke_core/plutonium/core
 	var/dented = FALSE
 	var/cracked = FALSE
+	var/sealed = FALSE
 
 /obj/item/nuke_core_container/Destroy()
 	QDEL_NULL(core)
 	return ..()
 
 /obj/item/nuke_core_container/ex_act(severity)
-	switch(severity)
-		if(EXPLODE_DEVASTATE)
-			if(!cracked)
-				crack_open()
-		if(EXPLODE_HEAVY)
-			if(!dented)
-				dented = TRUE
+	if(!sealed) //core now immune to blast if not used yet
+		return
+	if(isturf(loc)) //if in hands/backpack, can't be cracked open
+		switch(severity)
+			if(EXPLODE_DEVASTATE)
+				if(!cracked)
+					crack_open()
+					sealed = FALSE
+			if(EXPLODE_HEAVY)
+				if(!dented)
+					dented = TRUE
+	else
+		return
 
 /obj/item/nuke_core_container/examine(mob/user)
 	. = ..()
@@ -102,6 +109,7 @@
 		STOP_PROCESSING(SSobj, core)
 		ADD_TRAIT(core, TRAIT_BLOCK_RADIATION, src)
 		icon_state = "core_container_sealed"
+		sealed = TRUE
 		playsound(src, 'sound/items/deconstruct.ogg', 60, TRUE)
 		if(ismob(loc))
 			to_chat(loc, "<span class='warning'>[src] is permanently sealed, [core]'s radiation is contained.</span>")
@@ -250,6 +258,7 @@
 		ADD_TRAIT(sliver, TRAIT_BLOCK_RADIATION, src)
 		icon_state = "supermatter_container_sealed"
 		playsound(src, 'sound/items/deconstruct.ogg', 60, TRUE)
+		sealed = TRUE
 		if(ismob(loc))
 			to_chat(loc, "<span class='warning'>[src] is permanently sealed, [sliver] is safely contained.</span>")
 

--- a/code/game/objects/items/theft_items.dm
+++ b/code/game/objects/items/theft_items.dm
@@ -290,6 +290,7 @@
 		user.gib()
 		icon_state = "core_container_cracked_empty"
 		qdel(sliver)
+		sliver = null
 	else
 		return ..()
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание

1. Исправляет баг, при котором контейнер для ядра вскрывался в тот момент, когда он попадал в зону взрыва, находясь в руках или инвентаре, и при этом не менял спрайт на "уничтоженный". Отныне контейнер можно вскрыть только, если он находится на полу
2. Меняет логику взрыва. Теперь контейнер нельзя уничтожить, пока он в открытом состоянии. (если контейнер подвергался взрыву в момент таймера на "seal", то он дублировался)
3. Испраляет баг, связанный с тем, что контейнер суперматерии гибает людей при попытке его взять даже если внутри уже нет осколка.

<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багфиксы по [запросу](https://discord.com/channels/617003227182792704/1127360120951685120). Нихрена себе, первый по-человечески названный ПР???
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
