### PR TITLE
feat: Cargo expansion upgrade

### DIFF
--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -156,7 +156,7 @@
 	if(istype(src.loc, /obj/mecha/working))
 		var/obj/mecha/working/R = src.loc
 		R.cargo_expanded = FALSE
-		R.cargo_capacity = 15
+		R.cargo_capacity = initial(R.cargo_capacity)
 
 /obj/item/mecha_parts/mecha_equipment/rcd
 	name = "Mounted RCD"

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -32,11 +32,11 @@
 		if(!O.anchored)
 			if(cargo_holder.cargo.len < cargo_holder.cargo_capacity)
 				chassis.visible_message("[chassis] lifts [target] and starts to load it into cargo compartment.")
-				O.anchored = 1
+				O.anchored = TRUE
 				if(do_after_cooldown(target))
 					cargo_holder.cargo += O
 					O.loc = chassis
-					O.anchored = 0
+					O.anchored = FALSE
 					occupant_message("<span class='notice'>[target] successfully loaded.</span>")
 					log_message("Loaded [O]. Cargo compartment capacity: [cargo_holder.cargo_capacity - cargo_holder.cargo.len]")
 				else
@@ -50,15 +50,18 @@
 		var/mob/living/M = target
 		if(M.stat == DEAD && !issilicon(M))
 			return
-		if(M.stat == DEAD && issilicon(M))
+		if(M.stat == DEAD && issilicon(M) || chassis.cargo_expanded == TRUE)
+			if(ismegafauna(M))
+				occupant_message(SPAN_WARNING("БЕГИ, ИДИОТ, НЕ ВРЕМЯ ДЛЯ ОБНИМАШЕК!!!"))
+				return
 			if(!M.anchored)
 				if(cargo_holder.cargo.len < cargo_holder.cargo_capacity)
 					chassis.visible_message("[chassis] lifts [target] and starts to load it into cargo compartment.")
-					M.anchored = 1
+					M.anchored = TRUE
 					if(do_after_cooldown(target))
 						cargo_holder.cargo += M
 						M.loc = chassis
-						M.anchored = 0
+						M.anchored = FALSE
 						occupant_message("<span class='notice'>[target] successfully loaded.</span>")
 						log_message("Loaded [M]. Cargo compartment capacity: [cargo_holder.cargo_capacity - cargo_holder.cargo.len]")
 					else
@@ -78,7 +81,7 @@
 			add_attack_logs(chassis.occupant, M, "Squeezed with [src] ([uppertext(chassis.occupant.a_intent)]) ([uppertext(damtype)])")
 			start_cooldown()
 		else
-			if(issilicon(M) && M.stat == DEAD)
+			if(M.stat == DEAD && issilicon(M) || chassis.cargo_expanded == TRUE)
 				return
 			step_away(M,chassis)
 			occupant_message("<span class='notice'>You push [target] out of the way.</span>")
@@ -129,6 +132,31 @@
 			step_away(M,chassis)
 			target.visible_message("[chassis] tosses [target] like a piece of paper.")
 			return 1
+
+/obj/item/mecha_parts/mecha_equipment/cargo_upgrade
+	name = "Cargo expansion upgrade"
+	desc = "A working exosuit module that allows you to turn your Ripley into a hearse, zoo, or armored personnel carrier."
+	icon_state = "tesla"
+	origin_tech = "materials=5;bluespace=6;"
+	selectable = FALSE
+
+/obj/item/mecha_parts/mecha_equipment/cargo_upgrade/can_attach(obj/mecha/M)
+	if(..())
+		if(istype(M, /obj/mecha/working) || istype(M, /obj/mecha/combat/lockersyndie))
+			return TRUE
+	return FALSE
+
+/obj/item/mecha_parts/mecha_equipment/cargo_upgrade/attach_act()
+	if(istype(src.loc, /obj/mecha/working))
+		var/obj/mecha/working/W = src.loc
+		W.cargo_expanded = TRUE
+		W.cargo_capacity = 40
+
+/obj/item/mecha_parts/mecha_equipment/cargo_upgrade/detach_act()
+	if(istype(src.loc, /obj/mecha/working))
+		var/obj/mecha/working/R = src.loc
+		R.cargo_expanded = FALSE
+		R.cargo_capacity = 15
 
 /obj/item/mecha_parts/mecha_equipment/rcd
 	name = "Mounted RCD"

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -41,6 +41,7 @@
 	var/emagged = FALSE
 	var/frozen = FALSE
 	var/repairing = FALSE
+	var/cargo_expanded = FALSE // for wide cargo module
 
 	//inner atmos
 	var/use_internal_tank = 0

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -118,7 +118,7 @@
 /obj/mecha/working/ripley/full_load
 	name = "Тестовый Рипли"
 	desc = "Рипли, который несет в себе все возможные модули, предназначенные для рабочих мехов, с целью их испытания в индивидуальном порядке. Конструкция надежна как Nokia 3310, скорость как у гоночного болида, но стоимость производства настолько высока, что в массовое производство он никогда не пойдет. Специально для ведущих гениев робототехники."
-	max_equip = 11
+	max_equip = 40
 	strafe_allowed = TRUE
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0) // для тестов урона
 	max_integrity = 1000
@@ -154,6 +154,8 @@
 	ME = new /obj/item/mecha_parts/mecha_equipment/mining_scanner
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/eng_toolset
+	ME.attach(src)
+	ME = new /obj/item/mecha_parts/mecha_equipment/cargo_upgrade
 	ME.attach(src)
 
 /obj/mecha/working/ripley/full_load/add_cell()

--- a/code/game/mecha/working/working.dm
+++ b/code/game/mecha/working/working.dm
@@ -73,8 +73,8 @@
 	if(cargo.len)
 		for(var/obj/O in cargo)
 			output += "<a href='?src=[UID()];drop_from_cargo=\ref[O]'>Unload</a> : [O]<br>"
-		for(var/mob/living/silicon/M in cargo)
-			output += "<a href='?src=[UID()];drop_from_cargo=\ref[M]'>Unload</a> : [M]<br>"
+		for(var/mob/living/L in cargo)
+			output += "<a href='?src=[UID()];drop_from_cargo=\ref[L]'>Unload</a> : [L]<br>"
 	else
 		output += "Nothing"
 	output += "</div>"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -811,7 +811,7 @@
 //Exosuit Equipment
 
 /datum/design/mech_drill
-	name = "Exosuit Mining Equipment (Drill)"
+	name = "Exosuit Working Equipment (Drill)"
 	id = "mech_drill"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/drill
@@ -820,7 +820,7 @@
 	category = list("Exosuit Equipment")
 
 /datum/design/mech_diamond_drill
-	name = "Exosuit Mining Equipment (Diamond Mining Drill)"
+	name = "Exosuit Working Equipment (Diamond Mining Drill)"
 	desc = "An upgraded version of the standard drill."
 	id = "mech_diamond_drill"
 	build_type = MECHFAB
@@ -831,7 +831,7 @@
 	category = list("Exosuit Equipment")
 
 /datum/design/mech_plasma_cutter
-	name = "Exosuit Mining Equipment (217-D Plasma Cutter)"
+	name = "Exosuit Working Equipment (217-D Plasma Cutter)"
 	desc = "A device that shoots resonant plasma bursts at extreme velocity. The blasts are capable of crushing rock and demolishing solid obstacles."
 	id = "mech_plasma_cutter"
 	build_type = MECHFAB
@@ -842,7 +842,7 @@
 	category = list("Exosuit Equipment")
 
 /datum/design/mech_mining_scanner
-	name = "Exosuit Mining Equipment (Mining Scanner)"
+	name = "Exosuit Working Equipment (Mining Scanner)"
 	id = "mech_mscanner"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/mining_scanner
@@ -851,7 +851,7 @@
 	category = list("Exosuit Equipment")
 
 /datum/design/mech_hydraulic_clamp
-	name = "Exosuit Mining Equipment (Hydraulic Clamp)"
+	name = "Exosuit Working Equipment (Hydraulic Clamp)"
 	id = "mech_hydraulic_clamp"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp
@@ -860,7 +860,7 @@
 	category = list("Exosuit Equipment")
 
 /datum/design/mech_atmos_module
-	name = "Exosuit Engineering Module (ATMOS module)"
+	name = "Exosuit Working Module (ATMOS module)"
 	id = "mech_atmos_module"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/multimodule/atmos_module
@@ -869,7 +869,7 @@
 	category = list("Exosuit Equipment")
 
 /datum/design/mech_rcd
-	name = "Exosuit Engineering Equipment (RCD Module)"
+	name = "Exosuit Working Equipment (RCD Module)"
 	desc = "An exosuit-mounted Rapid Construction Device."
 	id = "mech_rcd"
 	build_type = MECHFAB
@@ -880,7 +880,7 @@
 	category = list("Exosuit Equipment")
 
 /datum/design/mech_eng_toolset
-	name = "Exosuit Engineering Equipment (Engineering Toolset)"
+	name = "Exosuit Working Equipment (Engineering Toolset)"
 	desc = "Exosuit toolset. Gives a set of good tools."
 	id = "mech_eng_toolset"
 	build_type = MECHFAB
@@ -888,6 +888,17 @@
 	build_path = /obj/item/mecha_parts/mecha_equipment/eng_toolset
 	materials = list(MAT_METAL=10000,MAT_TITANIUM =2000,MAT_PLASMA=2000)
 	construction_time = 20 SECONDS
+	category = list("Exosuit Equipment")
+
+/datum/design/mech_cargo_update
+	name = "Exosuit Working Equipment (Cargo Capacity Upgrade)"
+	desc = "Cargo capacity upgrade module for working mecha, allow you carry more stuffs and even living beings. Turn your Ripley into walking hearse!"
+	id = "mech_cargo_update"
+	build_type = MECHFAB
+	req_tech = list("materials" = 6, "programming" = 6, "bluespace" = 7)
+	build_path = /obj/item/mecha_parts/mecha_equipment/cargo_upgrade
+	materials = list(MAT_METAL=15000,MAT_TITANIUM =5000,MAT_BLUESPACE=3000)
+	construction_time = 15 SECONDS
 	category = list("Exosuit Equipment")
 
 /datum/design/mech_gravcatapult


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Вводит в игру улучшение грузоподъемности Рипли, увеличивая внутренний склад с 15 до 40 единиц и позволяя загружать любого моба кроме мегафауны в меха. Разумный моб может спокойно прожать B и выбраться из меха.

Заодно поменял engineering/mining эквип на working для облегчения поиска в мехфабе. Это было ошибкой делать разницу между ними..

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1126413439061987398

## Демонстрация изменений
Зашел как-то ботаник-антаг пополнить свои яблочки и видя эту картину плачет в подушку. Даже Витамина спиздили.
![image](https://github.com/ss220-space/Paradise/assets/114731039/30e1e84b-59d9-46e7-8749-d61af76c9cda)

