### PR TITLE
bugfix: getting wrong materials on machine deconstruct

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -218,7 +218,11 @@
 						if(istype(P, /obj/item/stack))
 							var/obj/item/stack/S = P
 							var/camt = min(S.get_amount(), req_components[I])
-							var/obj/item/stack/NS = new P.type(src, camt)
+							var/obj/item/stack/NS
+							if (S.is_cyborg && S.cyborg_construction_stack)
+								NS = new S.cyborg_construction_stack(src, camt)
+							else
+								NS = new P.type(src, camt)
 							NS.update_icon()
 							S.use(camt)
 							components += NS

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -77,6 +77,7 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 /obj/item/stack/rods/cyborg
 	materials = list()
 	is_cyborg = 1
+	cyborg_construction_stack = /obj/item/stack/rods
 
 /obj/item/stack/rods/cyborg/update_icon()
 	return

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -45,6 +45,7 @@ GLOBAL_LIST_INIT(glass_recipes, list(
 /obj/item/stack/sheet/glass/cyborg
 	materials = list()
 	is_cyborg = 1
+	cyborg_construction_stack = /obj/item/stack/sheet/glass
 
 /obj/item/stack/sheet/glass/Initialize(mapload, new_amount, merge = TRUE)
 	. = ..()

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -123,6 +123,7 @@ GLOBAL_LIST_INIT(metal_recipes, list(
 /obj/item/stack/sheet/metal/cyborg
 	materials = list()
 	is_cyborg = 1
+	cyborg_construction_stack = /obj/item/stack/sheet/metal
 
 /obj/item/stack/sheet/metal/fifty
 	amount = 50
@@ -247,6 +248,7 @@ GLOBAL_LIST_INIT(wood_recipes, list(
 
 /obj/item/stack/sheet/wood/cyborg
 	is_cyborg = 1
+	cyborg_construction_stack = /obj/item/stack/sheet/wood
 
 /obj/item/stack/sheet/wood/Initialize(mapload, new_amount, merge = TRUE)
 	. = ..()
@@ -535,6 +537,7 @@ GLOBAL_LIST_INIT(brass_recipes, list(
 /obj/item/stack/sheet/brass/cyborg
 	materials = list()
 	is_cyborg = 1
+	cyborg_construction_stack = /obj/item/stack/sheet/brass
 
 
 /*

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -32,6 +32,8 @@
 	var/datum/robot_energy_storage/source
 	/// Related to above. How much energy it costs from storage to use stack items
 	var/cost = 1
+	/// Related to above. Determines what stack will actually be put in machine when using cyborg stacks on construction to avoid spawning those on deconstruction.
+	var/cyborg_construction_stack
 
 
 /obj/item/stack/Initialize(mapload, new_amount, merge = TRUE)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Фикс получения материала, используемого синтетиками, при разборе машинерии с ним. Основная проблема была со стеклом. Вместо стака, находящегося в инвентаре у синтетиков, внутрь машины будет вставляться указанный отдельно новый стак материала.

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Фикс https://discord.com/channels/617003227182792704/1128591098093240410