### PR TITLE
tweak: Default Screen Filtering

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -196,6 +196,7 @@ window "mapwindow"
 		text-color = none
 		is-default = true
 		saved-params = "icon-size"
+		zoom-mode = "distort"
 		style=".center { text-align: center; } .maptext { font-family: 'MS Serif'; font-size: 7px; -dm-text-outline: 1px black; color: white; line-height: 1.1; } .small { font-size: 6px; } .big { font-size: 8px; } .reallybig { font-size: 9px; } .extremelybig { font-size: 10px; } .clown { color: #FF69Bf;} .tajaran {color: #803B56;} .skrell {color: #00CED1;} .solcom {color: #22228B;} .com_srus {color: #7c4848;} .zombie	{color: #ff0000;} .soghun {color: #228B22;} .vox {color: #AA00AA;} .diona {color: #804000; font-weight: bold;} .trinary {color: #727272;} .kidan {color: #664205;} .slime {color: #0077AA;} .drask {color: #a3d4eb;} .moth {color: #869b29;} .vulpkanin {color: #B97A57;} .abductor {color: #800080; font-style: italic;} .his_grace { color: #15D512; } .hypnophrase { color: #0d0d0d; font-weight: bold; } .yell { font-weight: bold; } .italics { font-size: 6px; } .command_headset { font-weight: bold;	font-size: 8px; }"
 
 window "outputwindow"


### PR DESCRIPTION
## Описание
<!--  -->
Применяем эффект фильтрации Nearest Neighbor по дефолту. В данный момент хоть там и стоит галочка, но игроку всё равно придётся зайти в менюшку и прожать опцию вручную, несмотря на установленный флаг. Данный PR исправляет эту ситуацию.
