### PR TITLE
tweak: remove confusion effect for stunbatons

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -154,7 +154,6 @@
 		user.visible_message("<span class='danger'>[user] accidentally hits [user.p_them()]self with [src]!</span>", \
 							"<span class='userdanger'>You accidentally hit yourself with [src]!</span>")
 		user.Weaken(stunforce * 3)
-		user.Confused(stunforce * 3)
 		deductcharge(hitcost)
 		return
 
@@ -201,7 +200,6 @@
 		C.shock_internal_organs(33)
 
 	L.Weaken(stunforce)
-	L.Confused(stunforce)
 	L.SetStuttering(stunforce)
 	L.adjustStaminaLoss(staminaforce)
 	if(user)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -226,7 +226,6 @@
 		flick("baton_active", source)
 		user.Stun(stunforce)
 		user.Weaken(stunforce)
-		user.Confused(stunforce)
 		user.SetStuttering(stunforce)
 		deductcharge(hitcost)
 		user.visible_message("<span class='warning'>[user] shocks [user.p_them()]self while attempting to wash the active [src]!</span>", \


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Убирает эффект замешательства при ударах станбатонами.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Многим не понравился этот эффект, он слишком сильно влияет на тех, кого бьют, не давая убегать.
Я перенес это с оффов при ПРе на станы, но не совсем подумал об этом эффекте замешательства.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
