### PR TITLE
bugfix: dragon destroyng own portals

### DIFF
--- a/code/modules/space_dragon/mob.dm
+++ b/code/modules/space_dragon/mob.dm
@@ -176,6 +176,10 @@
 		if("carp" in L.faction)
 			to_chat(src, span_warning("Вы почти укусили своего сородича, но вовремя остановились."))
 			return
+	if (istype(target, /obj/structure/carp_rift))
+		var/obj/structure/carp_rift/rift = target
+		if (rift.dragon == src)
+			to_chat(src, span_warning("Вы почти укусили свой разлом, но вовремя остановились."))
 	. = ..()
 	if(ismecha(target))
 		var/obj/mecha/M = target

--- a/code/modules/space_dragon/mob.dm
+++ b/code/modules/space_dragon/mob.dm
@@ -176,9 +176,9 @@
 		if("carp" in L.faction)
 			to_chat(src, span_warning("Вы почти укусили своего сородича, но вовремя остановились."))
 			return
-	if (istype(target, /obj/structure/carp_rift))
+	if(istype(target, /obj/structure/carp_rift))
 		var/obj/structure/carp_rift/rift = target
-		if (rift.dragon == src)
+		if(rift.dragon == src)
 			to_chat(src, span_warning("Вы почти укусили свой разлом, но вовремя остановились."))
 	. = ..()
 	if(ismecha(target))

--- a/code/modules/space_dragon/mob.dm
+++ b/code/modules/space_dragon/mob.dm
@@ -180,6 +180,7 @@
 		var/obj/structure/carp_rift/rift = target
 		if(rift.dragon == src)
 			to_chat(src, span_warning("Вы почти укусили свой разлом, но вовремя остановились."))
+			return
 	. = ..()
 	if(ismecha(target))
 		var/obj/mecha/M = target


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Не даёт космическому дракону кусать свои собственные разломы. Разломы других драконов всё ещё можно кусать и уничтожать (на случай щитспавна).

## Ссылка на предложение/Причина создания ПР
Багфикс https://discord.com/channels/617003227182792704/1131862715724480516/1131862715724480516
