### PR TITLE
bugfix: Defib Phys Damage Threshold

### DIFF
--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -463,8 +463,6 @@
 			var/tplus = world.time - H.timeofdeath
 			var/tlimit = DEFIB_TIME_LIMIT
 			var/tloss = DEFIB_TIME_LOSS
-			var/total_burn	= 0
-			var/total_brute	= 0
 			if(do_after(user, 20 * toolspeed * gettoolspeedmod(user), target = M)) //placed on chest and short delay to shock for dramatic effect, revive time is 5sec total
 				for(var/obj/item/carried_item in H.contents)
 					if(istype(carried_item, /obj/item/clothing/suit/space))
@@ -502,10 +500,11 @@
 					M.visible_message("<span class='warning'>[M]'s body convulses a bit.")
 					playsound(get_turf(src), "bodyfall", 50, 1)
 					playsound(get_turf(src), 'sound/machines/defib_zap.ogg', 50, 1, -1)
+					var/phys_damage_threshold = H.cloneloss
 					for(var/obj/item/organ/external/O in H.bodyparts)
-						total_brute	+= O.brute_dam
-						total_burn	+= O.burn_dam
-					if(total_burn <= 180 && total_brute <= 180 && !H.suiciding && !ghost && tplus < tlimit && !(NOCLONE in H.mutations) && (H.mind && H.mind.is_revivable()) && (H.get_int_organ(/obj/item/organ/internal/heart) || H.get_int_organ(/obj/item/organ/internal/brain/slime)))
+						phys_damage_threshold += O.brute_dam
+						phys_damage_threshold += O.burn_dam
+					if(phys_damage_threshold <= 180 && !H.suiciding && !ghost && tplus < tlimit && !(NOCLONE in H.mutations) && (H.mind && H.mind.is_revivable()) && (H.get_int_organ(/obj/item/organ/internal/heart) || H.get_int_organ(/obj/item/organ/internal/brain/slime)))
 						tobehealed = min(health + threshold, 0) // It's HILARIOUS without this min statement, let me tell you
 						tobehealed -= 5 //They get 5 of each type of damage healed so excessive combined damage will not immediately kill them after they get revived
 						H.adjustOxyLoss(tobehealed)
@@ -532,7 +531,7 @@
 					else
 						if(tplus > tlimit|| !H.get_int_organ(/obj/item/organ/internal/heart))
 							user.visible_message("<span class='boldnotice'>[defib || src] buzzes: Resuscitation failed - Heart tissue damage beyond point of no return for defibrillation.</span>")
-						else if(total_burn >= 180 || total_brute >= 180)
+						else if(phys_damage_threshold > 180)
 							user.visible_message("<span class='boldnotice'>[defib || src] buzzes: Resuscitation failed - Severe tissue damage detected.</span>")
 						else if(ghost)
 							if(!ghost.can_reenter_corpse) // DNR or AntagHUD

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -500,18 +500,20 @@
 					M.visible_message("<span class='warning'>[M]'s body convulses a bit.")
 					playsound(get_turf(src), "bodyfall", 50, 1)
 					playsound(get_turf(src), 'sound/machines/defib_zap.ogg', 50, 1, -1)
-					var/phys_damage_threshold = H.cloneloss
+					var/total_cloneloss = H.cloneloss
+					var/total_bruteloss = 0
+					var/total_burnloss = 0
 					for(var/obj/item/organ/external/O in H.bodyparts)
-						phys_damage_threshold += O.brute_dam
-						phys_damage_threshold += O.burn_dam
-					if(phys_damage_threshold <= 180 && !H.suiciding && !ghost && tplus < tlimit && !(NOCLONE in H.mutations) && (H.mind && H.mind.is_revivable()) && (H.get_int_organ(/obj/item/organ/internal/heart) || H.get_int_organ(/obj/item/organ/internal/brain/slime)))
+						total_bruteloss += O.brute_dam
+						total_burnloss += O.burn_dam
+					if(total_cloneloss <= 180 && total_bruteloss <= 180 && total_burnloss <= 180 && !H.suiciding && !ghost && tplus < tlimit && !(NOCLONE in H.mutations) && (H.mind && H.mind.is_revivable()) && (H.get_int_organ(/obj/item/organ/internal/heart) || H.get_int_organ(/obj/item/organ/internal/brain/slime)))
 						tobehealed = min(health + threshold, 0) // It's HILARIOUS without this min statement, let me tell you
 						tobehealed -= 5 //They get 5 of each type of damage healed so excessive combined damage will not immediately kill them after they get revived
 						H.adjustOxyLoss(tobehealed)
 						H.adjustToxLoss(tobehealed)
 						user.visible_message("<span class='boldnotice'>[defib || src] pings: Resuscitation successful.</span>")
 						playsound(get_turf(src), 'sound/machines/defib_success.ogg', 50, 0)
-						H.update_revive()
+						H.update_revive(TRUE, TRUE)
 						H.KnockOut()
 						H.Paralyse(10 SECONDS)
 						H.emote("gasp")
@@ -531,7 +533,7 @@
 					else
 						if(tplus > tlimit|| !H.get_int_organ(/obj/item/organ/internal/heart))
 							user.visible_message("<span class='boldnotice'>[defib || src] buzzes: Resuscitation failed - Heart tissue damage beyond point of no return for defibrillation.</span>")
-						else if(phys_damage_threshold > 180)
+						else if(total_cloneloss > 180 || total_bruteloss > 180 || total_burnloss > 180)
 							user.visible_message("<span class='boldnotice'>[defib || src] buzzes: Resuscitation failed - Severe tissue damage detected.</span>")
 						else if(ghost)
 							if(!ghost.can_reenter_corpse) // DNR or AntagHUD

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -108,7 +108,7 @@
 	if(SSticker && SSticker.mode)
 		SSblackbox.ReportDeath(src)
 
-/mob/living/carbon/human/update_revive(updating)
+/mob/living/carbon/human/update_revive(updating, defib_revive)
 	. = ..()
 	if(. && healthdoll)
 		// We're alive again, so re-build the entire healthdoll

--- a/code/modules/mob/living/silicon/robot/update_status.dm
+++ b/code/modules/mob/living/silicon/robot/update_status.dm
@@ -33,7 +33,7 @@
 			add_misc_logs(src, "revived, trigger reason: [reason]")
 	..()
 
-/mob/living/silicon/robot/update_revive(updating = TRUE)
+/mob/living/silicon/robot/update_revive(updating = TRUE, defib_revive = FALSE)
 	. = ..(updating)
 	if(.)
 		update_icons()

--- a/code/modules/mob/living/stat_states.dm
+++ b/code/modules/mob/living/stat_states.dm
@@ -38,11 +38,11 @@
 // death() is used to make a mob die
 
 // handles revival through other means than cloning or adminbus (defib, IPC repair)
-/mob/living/proc/update_revive(updating = TRUE)
+/mob/living/proc/update_revive(updating = TRUE, defib_revive = FALSE)
 	if(stat != DEAD)
-		return 0
-	if(!can_be_revived())
-		return 0
+		return FALSE
+	if(!can_be_revived() && !defib_revive)
+		return FALSE
 	add_attack_logs(src, null, "Came back to life", ATKLOG_ALL)
 	stat = CONSCIOUS
 	GLOB.dead_mob_list -= src
@@ -70,7 +70,7 @@
 			var/obj/effect/proc_holder/spell/spell = S
 			spell.updateButtonIcon()
 
-	return 1
+	return TRUE
 
 /mob/living/proc/check_death_method()
 	return TRUE

--- a/code/modules/mob/living/stat_states.dm
+++ b/code/modules/mob/living/stat_states.dm
@@ -38,10 +38,10 @@
 // death() is used to make a mob die
 
 // handles revival through other means than cloning or adminbus (defib, IPC repair)
-/mob/living/proc/update_revive(updating = TRUE, defib_revive = FALSE)
+/mob/living/proc/update_revive(updating = TRUE, force = FALSE)
 	if(stat != DEAD)
 		return FALSE
-	if(!can_be_revived() && !defib_revive)
+	if(!force && !can_be_revived())
 		return FALSE
 	add_attack_logs(src, null, "Came back to life", ATKLOG_ALL)
 	stat = CONSCIOUS


### PR DESCRIPTION
## Описание
<!--  -->
Добавил порог урона в 180 единиц, после которого дефибриллятор будет выдавать сообщение об ошибке и отменять реанимацию пациента. Этот порог применяется к генетическому урону, бруту и бёрну по отдельности. Если все три показателя ниже 180, то дефибрилляция будет успешной, но пациент сразу умрёт, по понятным причинам.

## Ссылка на предложение/Причина создания ПР
<!--  -->
https://discord.com/channels/617003227182792704/1132422233265029272
