### PR TITLE
fix: Hardsuit's helmets don't wash with cleaner

### DIFF
--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -64,6 +64,9 @@
 	else
 		if(O.simulated)
 			O.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
+			var/obj/item/clothing/suit/space/hardsuit/H = O
+			if(istype(H) && H.helmet)
+				H.helmet.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
 		O.clean_blood()
 
 /datum/reagent/space_cleaner/reaction_turf(turf/T, volume)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Шлемы хардсьютов теперь тоже очищаются от краски/зелий, если в них брызнуть спейс клинером, как и основная часть хардсьюта. (Эффекты зелья всё так же остаются, убирается только цвет).
Ура! Больше никакой невозможности смыть всю краску с твоего крутого синего рига, в котором от спрайта совершенно ничего не видно.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->