### PR TITLE
bugfix: correct calc_decay for disgust status effect

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -598,7 +598,7 @@
 			to_chat(carbon, "<span class='warning'>[pick("You feel nauseous.", "You feel like you're going to throw up!")]</span>")
 		carbon.Jitter(9 SECONDS)
 	if(strength >= DISGUST_LEVEL_VERYGROSS)
-		var/pukeprob = 5 + 0.005 * carbon.AmountDisgust()
+		var/pukeprob = 5 + 0.005 * strength
 		if(prob(pukeprob))
 			carbon.AdjustConfused(9 SECONDS)
 			carbon.AdjustStuttering(3 SECONDS)
@@ -615,6 +615,9 @@
 
 /datum/status_effect/transient/disgust/on_remove()
 	owner.update_disgust_alert()
+
+/datum/status_effect/transient/disgust/calc_decay()
+	return -1 * initial(tick_interval)
 
 /datum/status_effect/transient/deaf
 	id = "deafened"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Теперь скорость понижения эффекта отвращения от еды варьируется в соответствии с интервалом тиков. 
Без этого понижение в 5 раз меньше чем раньше.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багрепорт: https://discord.com/channels/617003227182792704/734823601110515882/1133036788408123462
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
