### PR TITLE
tweak: taipan remoter no longer works cross-sector

### DIFF
--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -3,7 +3,6 @@
 #define WAND_EMERGENCY "Toggle Emergency Access"
 #define WAND_SPEED "Change Closing Speed"
 #define WAND_ELECTRIFY "Electrify Door"
-#define WAND_REACH 10
 
 /obj/item/door_remote
 	icon_state = "gangtool-white"
@@ -18,7 +17,6 @@
 	var/additional_access = list()
 	var/obj/item/card/id/ID
 	var/emagged = FALSE
-	var/reach_distance = WAND_REACH
 
 /obj/item/door_remote/New()
 	..()
@@ -242,4 +240,3 @@
 #undef WAND_BOLT
 #undef WAND_EMERGENCY
 #undef WAND_SPEED
-#undef WAND_REACH

--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -17,6 +17,7 @@
 	var/additional_access = list()
 	var/obj/item/card/id/ID
 	var/emagged = FALSE
+	var/z_cross = TRUE //Allows using remoters cross-sectory
 
 /obj/item/door_remote/New()
 	..()
@@ -68,7 +69,8 @@
 		D = locate() in get_turf(D)
 	if(!istype(D))
 		return
-	if(D.z != user.z)
+	var/turf/t = get_turf(user)
+	if((D.z != t.z) && !z_cross)
 		to_chat(user, span_danger("[D] is too far away to be controlled!"))
 		return
 	if(HAS_TRAIT(D, TRAIT_CMAGGED))
@@ -206,6 +208,7 @@
 	desc = "High-ranking Syndicate officials only."
 	icon_state = "gangtool-syndie"
 	region_access = list(REGION_TAIPAN)
+	z_cross = FALSE
 
 /obj/item/door_remote/omni/access_tuner
 	name = "access tuner"
@@ -218,9 +221,6 @@
 
 /obj/item/door_remote/omni/access_tuner/afterattack(obj/machinery/door/airlock/D, mob/user)
 	if(!istype(D))
-		return
-	if(D.z != user.z)
-		to_chat(user, span_danger("[D] is too far away to be controlled!"))
 		return
 	if(HAS_TRAIT(D, TRAIT_CMAGGED))
 		to_chat(user, span_danger("The door doesn't respond to [src]!"))


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление, без которого door remote Тайпана мог взаимодействовать с дверями на других z-уровнях.
Всё ещё возможно взаимодействовать с дверями на том же z-уровне, например через камеры.
Исправляю только для Тайпана, так как может затрагивать баланс других ремоутеров.
Техническая информация:
- Отрефакторил спаны в сообщениях
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
https://discord.com/channels/617003227182792704/1103102071907041300/1103102071907041300

