### PR TITLE
tweak: stun to weaken while being pulled in walk mode

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -631,11 +631,11 @@
 					var/mob/living/carbon/human/H = pulling
 					if(!H.lying)
 						if(H.get_confusion() > 0 && prob(4))
-							H.Stun(4 SECONDS)
+							H.Weaken(4 SECONDS)
 							pulling.stop_pulling()
 							visible_message(span_danger("Ноги [H] путаются и [genderize_ru(H.gender,"он","она","оно","они")] с грохотом падает на пол!"))
 						if(H.m_intent == MOVE_INTENT_WALK && prob(4))
-							H.Stun(4 SECONDS)
+							H.Weaken(4 SECONDS)
 							visible_message(span_danger("[H] не поспевает за [src] и с грохотом падает на пол!"))
 			else
 				pulling.pixel_x = initial(pulling.pixel_x)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Меняет эффект у оглушения при хотьбе когда вас пуллят с stun на weaken

## Ссылка на предложение/Причина создания ПР
Запрос игрока. 
Раньше был визуальный эффект падения, теперь это вызывает фрустрацию(кукла оглушена, но все еще стоит, что довольно тупо с учетом сообщения в чате)