### PR TITLE
bugfix: dinnerware old vendor in delta's Old Restaurant now sells stuff properly

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -85538,9 +85538,7 @@
 	},
 /area/crew_quarters/locker)
 "nRD" = (
-/obj/machinery/vending/dinnerware{
-	products = list(/obj/item/storage/bag/tray=1,/obj/item/kitchen/utensil/fork=2,/obj/item/kitchen/knife=0,/obj/item/kitchen/rollingpin=0,/obj/item/kitchen/sushimat=1,/obj/item/reagent_containers/food/drinks/drinkingglass=2,/obj/item/clothing/suit/chef/classic=1,/obj/item/storage/belt/chef=0,/obj/item/reagent_containers/food/condiment/pack/ketchup=1,/obj/item/reagent_containers/food/condiment/pack/hotsauce=0,/obj/item/reagent_containers/food/condiment/saltshaker=1,/obj/item/reagent_containers/food/condiment/peppermill=2,/obj/item/whetstone=1,/obj/item/mixing_bowl=3,/obj/item/kitchen/mould/bear=1,/obj/item/kitchen/mould/worm=0,/obj/item/kitchen/mould/bean=0,/obj/item/kitchen/mould/ball=1,/obj/item/kitchen/mould/cane=1,/obj/item/kitchen/mould/cash=0,/obj/item/kitchen/mould/coin=0,/obj/item/kitchen/mould/loli=1,/obj/item/kitchen/cutter=0,/obj/item/eftpos=1)
-	},
+/obj/machinery/vending/dinnerware/old,
 /turf/simulated/floor/plasteel{
 	icon_state = "tranquillite"
 	},

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1477,6 +1477,21 @@
 	contraband = list(/obj/item/kitchen/rollingpin = 2, /obj/item/kitchen/knife/butcher = 2)
 	refill_canister = /obj/item/vending_refill/dinnerware
 
+/obj/machinery/vending/dinnerware/old
+	products = list(/obj/item/storage/bag/tray = 1, /obj/item/kitchen/utensil/fork = 2,
+					/obj/item/kitchen/knife = 0, /obj/item/kitchen/rollingpin = 0,
+					/obj/item/kitchen/sushimat = 1,
+					/obj/item/reagent_containers/food/drinks/drinkingglass = 2,
+					/obj/item/clothing/suit/chef/classic = 1,
+					/obj/item/storage/belt/chef = 0, /obj/item/reagent_containers/food/condiment/pack/ketchup = 1,
+					/obj/item/reagent_containers/food/condiment/pack/hotsauce = 0,/obj/item/reagent_containers/food/condiment/saltshaker = 1,
+					/obj/item/reagent_containers/food/condiment/peppermill = 2,/obj/item/whetstone = 1,
+					/obj/item/mixing_bowl = 3,/obj/item/kitchen/mould/bear = 1,
+					/obj/item/kitchen/mould/worm = 0,/obj/item/kitchen/mould/bean = 0,
+					/obj/item/kitchen/mould/ball = 1,/obj/item/kitchen/mould/cane = 1,
+					/obj/item/kitchen/mould/cash = 0,/obj/item/kitchen/mould/coin = 0,
+					/obj/item/kitchen/mould/loli = 1,/obj/item/kitchen/cutter = 0, /obj/item/eftpos = 1)
+
 /obj/machinery/vending/sovietsoda
 	name = "\improper BODA"
 	desc = "Old sweet water vending machine."


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправляет ошибку, при которой в старой кухне автомат по выдаче товаров имел пустые позиции.

Техническая информация:
- Перенёс из dmm дельты содержимое автомата в подтип вендора посуды.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
https://discord.com/channels/617003227182792704/1105171491823308851/1105171491823308851
## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
![изображение](https://github.com/ss220-space/Paradise/assets/73733747/420b9036-2717-4ff9-84d4-65b5f6d40dfd)
![изображение](https://github.com/ss220-space/Paradise/assets/73733747/2708eaef-5e99-444e-9a17-a455b3bc19d8)
