### PR TITLE
 bugfix: Sentience potion dont affect mokey from cubes

### DIFF
--- a/code/modules/food_and_drinks/food/foods/meat.dm
+++ b/code/modules/food_and_drinks/food/foods/meat.dm
@@ -386,12 +386,11 @@
 			add_misc_logs(what = "Cube ([monkey_type]) inflated, last touched by: " + fingerprintslast)
 		else
 			add_misc_logs(what = "Cube ([monkey_type]) inflated, last touched by: NO_DATA")
-		var/mob/living/carbon/human/creature = new /mob/living/carbon/human(get_turf(src))
+		var/mob/living/carbon/human/lesser/monkey/creature = new(get_turf(src))
 		if(faction)
 			creature.faction = faction
 		if(LAZYLEN(fingerprintshidden))
 			creature.fingerprintshidden = fingerprintshidden
-		creature.set_species(monkey_type)
 		SSmobs.cubemonkeys += creature
 		qdel(src)
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
На раундстартовых макак и макак из ксено действует зелье разума, на макак из кубов - нет. Исправляет данную ошибку. Ведь все макаки братья и равны между собой.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

