### PR TITLE
bugfix: mass hallucinations of guardian now have owner

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/types/fire.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/fire.dm
@@ -74,7 +74,7 @@
 	aoe_range = 10
 
 
-/obj/effect/proc_holder/spell/aoe/guardian_hallucination/hallucination/New(mob/living/summoned_by)
+/obj/effect/proc_holder/spell/aoe/guardian_hallucination/New(mob/living/summoned_by)
 	. = ..()
 	summoner = summoned_by
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Из-за странного описания спелла голопары "Хаос" не вызывался кастомный New(), что приводило к тому, что спелл не знал, кто хозяин, потому действовал даже на валедльца голопары.

## Ссылка на предложение/Причина создания ПР
Багфикс https://discord.com/channels/617003227182792704/1134835942197317732
