### PR TITLE
bugfix: cleaning IPC with space cleaner

### DIFF
--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -54,6 +54,7 @@
 	reagent_state = LIQUID
 	color = "#61C2C2"
 	harmless = TRUE
+	process_flags = ORGANIC | SYNTHETIC
 	taste_description = "floor cleaner"
 
 /datum/reagent/space_cleaner/reaction_obj(obj/O, volume)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
КПБ не чистятся клинером, потому что его не переваривают. Логика в этом есть, но слишком извращённая. Исправлено.

## Ссылка на предложение/Причина создания ПР
Бафгикс https://discord.com/channels/617003227182792704/1134931697595596952/1134931697595596952
