### PR TITLE
bugfix: SpaceBar shuttle fix window

### DIFF
--- a/_maps/map_files/generic/CentComm.dmm
+++ b/_maps/map_files/generic/CentComm.dmm
@@ -4614,7 +4614,7 @@
 "cnn" = (
 /obj/structure/grille,
 /obj/structure/window/full/shuttle,
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating,
 /area/shuttle/spacebar)
 "cnr" = (
 /turf/simulated/wall/shuttle/nosmooth{


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Меняет пол под шаттлом Спейсбара с `песок` на `плитку`, как у остальных шаттлов.
## Ссылка на предложение/Причина создания ПР
Почему-то окна не летают с шаттлом.
![image](https://github.com/ss220-space/Paradise/assets/87372121/f762d618-cfdd-4fec-8ee2-22c91a903883)
![image](https://github.com/ss220-space/Paradise/assets/87372121/a3120368-cf32-454b-ac0b-51ec32e7f20c)

## Демонстрация изменений
![image](https://github.com/ss220-space/Paradise/assets/87372121/88d08539-1320-41b7-b066-36f689faf555)
