### PR TITLE
add: CQC for Blueshield

### DIFF
--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -201,6 +201,12 @@ GLOBAL_DATUM_INIT(captain_announcement, /datum/announcement/minor, new(do_newsca
 	satchel = /obj/item/storage/backpack/satchel_blueshield
 	dufflebag = /obj/item/storage/backpack/duffel/blueshield
 
+/datum/outfit/job/blueshield/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	if(visualsOnly)
+		return
+	var/datum/martial_art/cqc/CQC = new
+	CQC.teach(H)
 
 /datum/job/judge
 	title = "Magistrate"


### PR DESCRIPTION
## Описание
Добавляет полноценный CQC для синего щита, вшитый в него, не мануал.

## Ссылка на предложение/Причина создания ПР
Сделано согласно
https://discord.com/channels/617003227182792704/755125334097133628/1137633977914634260
(Авоут пройден)

## Демонстрация изменений
Посмотрите на то, как работает повар, идентично для БШ, только сикуси полноценный.
