### PR TITLE
qol: allow cables to be laid on fireproof catwalks on lava

### DIFF
--- a/code/game/turfs/simulated/floor/lava.dm
+++ b/code/game/turfs/simulated/floor/lava.dm
@@ -139,7 +139,6 @@
 		else
 			return
 	else if(istype(C, /obj/item/stack/cable_coil))
-		var/obj/item/stack/cable_coil/cable = C
 		var/obj/structure/lattice/catwalk/fireproof/W = locate(/obj/structure/lattice/catwalk/fireproof, src)
 		if(!W)
 			return

--- a/code/game/turfs/simulated/floor/lava.dm
+++ b/code/game/turfs/simulated/floor/lava.dm
@@ -138,6 +138,13 @@
 				new /obj/structure/lattice/catwalk/fireproof(src)
 		else
 			return
+	else if(istype(C, /obj/item/stack/cable_coil))
+		var/obj/item/stack/cable_coil/cable = C
+		var/obj/structure/lattice/catwalk/fireproof/W = locate(/obj/structure/lattice/catwalk/fireproof, src)
+		if(!W)
+			return
+		else
+			return ..()
 	else return
 
 /turf/simulated/floor/plating/lava/screwdriver_act()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Изменение, позволяющее класть кабели на огнеупорные мостики, расположенные над лавой.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Довольно странный момент, который мы с [NeonNik2245](https://github.com/ss220-space/Paradise/issues?q=is%3Apr+is%3Aopen+author%3ANeonNik2245) не учли при разработке огнеупорных стержней в
https://github.com/ss220-space/Paradise/pull/2746
## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
![изображение](https://github.com/ss220-space/Paradise/assets/73733747/c8bceebe-cd9a-4d3e-ba77-d72593ad9d0e)
