### PR TITLE
Balance: Space Dragon want MORE MEAT!

### DIFF
--- a/code/modules/space_dragon/event.dm
+++ b/code/modules/space_dragon/event.dm
@@ -1,4 +1,4 @@
-#define SPACE_DRAGON_SPAWN_THRESHOLD 25
+#define SPACE_DRAGON_SPAWN_THRESHOLD 55
 
 /datum/event/space_dragon
 	announceWhen = 45


### PR DESCRIPTION
Увеличивает минимальное количество  игроков для появления дракона с 25 до 55.

<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Увеличивает количество игроков для привлечения внимания дракона с 25 до 55.

## Ссылка на предложение/Причина создания ПР
Баланс фикс чтобы дракон не появлялся на клеовеге.

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
