### PR TITLE
bugfix: bolts on syndie-prison

### DIFF
--- a/_maps/map_files/generic/CentComm.dmm
+++ b/_maps/map_files/generic/CentComm.dmm
@@ -35230,6 +35230,7 @@
 /obj/machinery/door/airlock/syndicate/extmai/glass{
 	damage_deflection = 999;
 	id_tag = "syndicate_jail_cell";
+	locked = 1;
 	name = "Cell";
 	req_access = list(153)
 	},


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Ставит болты на дверь в тюрьме Синди ЦК.
Таким образом, если у человека будет открывашка (армблейд) - он не сможет открыть дверь из-за болтов.
Если админ будет - он сможет открыть клетки через кнопку в комнате рядом.

## Ссылка на предложение/Причина создания ПР
[Ссылка](https://discord.com/channels/617003227182792704/1139653594841354300/1139653594841354300).
~~Может вовсе убрать щитспавн оружие, чтобы не латать такое? Может вернуть прошлое ЦК, мне оно нравилось.... :pepekotya:~~
Генокрад через контрактника попадал в тюрьму. Оттуда через армблейд попадал к топорищу-3к и выгрызал свой путь до оружейки офицера Синди, а после что хотел то и творил ибо у него вся мощь ЦК в руках.

