### PR TITLE
bugfix: icons for holders

### DIFF
--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -74,17 +74,20 @@
 	return
 
 //Mob procs and vars for scooping up
-/mob/living/var/holder_type
+/mob/living
+	var/holder_type = null
 
 /mob/living/proc/get_scooped(var/mob/living/carbon/grabber)
-	if(!holder_type)	return
+	if(!holder_type)
+		return
 
 	var/obj/item/holder/H = new holder_type(loc)
 	src.forceMove(H)
 	H.name = name
-	if(istype(H, /obj/item/holder/mouse))	H.icon_state = icon_state
-	if(istype(H, /obj/item/holder/chicken))	H.icon_state = icon_state
-	if(desc)	H.desc = desc
+	H.icon = icon
+	H.icon_state = icon_state
+	if(desc)
+		H.desc = desc
 	H.attack_hand(grabber)
 
 	to_chat(grabber, "<span class='notice'>Вы подняли [src.name].")

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -561,21 +561,16 @@
 	if(!istype(H))
 		return
 	if(stat == DEAD)
-		H.icon = 'icons/mob/pai.dmi'
-		H.icon_state = "[chassis]_dead"
 		return
 	if(resting)
 		icon_state = "[chassis]"
 		resting = 0
 	if(custom_sprite)
-		H.icon = 'icons/mob/custom_synthetic/custom-synthetic.dmi'
 		H.icon_override = 'icons/mob/custom_synthetic/custom_head.dmi'
 		H.lefthand_file = 'icons/mob/custom_synthetic/custom_lefthand.dmi'
 		H.righthand_file = 'icons/mob/custom_synthetic/custom_righthand.dmi'
-		H.icon_state = "[icon_state]"
 		H.item_state = "[icon_state]_hand"
 	else
-		H.icon_state = "pai-[icon_state]"
 		H.item_state = "pai-[icon_state]"
 	grabber.put_in_active_hand(H)//for some reason unless i call this it dosen't work
 	grabber.update_inv_l_hand()

--- a/code/modules/mob/living/silicon/robot/drone/drone_abilities.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_abilities.dm
@@ -90,13 +90,10 @@
 		H.icon_override = 'icons/mob/custom_synthetic/custom_head.dmi'
 		H.lefthand_file = 'icons/mob/custom_synthetic/custom_lefthand.dmi'
 		H.righthand_file = 'icons/mob/custom_synthetic/custom_righthand.dmi'
-		H.icon_state = "[icon_state]"
 		H.item_state = "[icon_state]_hand"
 	else if(emagged)
-		H.icon_state = "drone-emagged"
 		H.item_state = "drone-emagged"
 	else
-		H.icon_state = "drone"
 		H.item_state = "drone"
 	grabber.put_in_active_hand(H, ignore_anim = FALSE)//for some reason unless i call this it dosen't work
 	grabber.update_inv_l_hand()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Теперь холдеры используют иконки мобов, которые берутся.
Теперь не надо иконки по сто раз копировать в файлах

## Ссылка на предложение/Причина создания ПР
~~Пупс бля.~~
[Ссылка.](https://discord.com/channels/617003227182792704/734823601110515882/1140185918003761193)
Легче щитспавнить, легче следить за иконками.

## Демонстрация изменений
Видео

https://github.com/ss220-space/Paradise/assets/87372121/fd1d9d6c-c4cb-46ff-a5d2-6a1a9b30a156


