### PR TITLE
bugfix: rnd server now die properly

### DIFF
--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -81,9 +81,9 @@
 	switch(environment.temperature)
 		if(0 to T0C)
 			health = min(100, health + 1)
-		if((T0C + 1) to (T20C + 20))
+		if(T0C to (T20C + 20))
 			health = clamp(health, 0, 100)
-		if((T20C + 21) to INFINITY)
+		if((T20C + 20) to INFINITY)
 			health = max(0, health - 1)
 	if(health <= 0)
 		/*griefProtection() This seems to get called twice before running any code that deletes/damages the server or it's files anwyay.

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -81,9 +81,9 @@
 	switch(environment.temperature)
 		if(0 to T0C)
 			health = min(100, health + 1)
-		if(T0C to (T20C + 20))
+		if((T0C + 1) to (T20C + 20))
 			health = clamp(health, 0, 100)
-		if((T20C + 20) to (T0C + 70))
+		if((T20C + 21) to INFINITY)
 			health = max(0, health - 1)
 	if(health <= 0)
 		/*griefProtection() This seems to get called twice before running any code that deletes/damages the server or it's files anwyay.


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Исправляет ошибку, когда сервера РнД получали урон ТОЛЬКО если температура окружения 40-70 градусов. Тысяча? Плевать. Десять тысяч? Похуй.
Это, я думаю, баг. Кроме того, чуть исправляет логику свитча. Не уверен что нужно, но все-таки.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багфикс
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->