### PR TITLE
bugfix: Defined Descreation Sound

### DIFF
--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -89,7 +89,7 @@
 		var/obj/item/organ/external/head/head = H.bodyparts_by_name["head"]
 		if(head)
 			head.droplimb(0, DROPLIMB_BLUNT, FALSE, TRUE)
-			playsound(loc,pick('sound/misc/desceration-01.ogg','sound/misc/desceration-02.ogg','sound/misc/desceration-01.ogg') ,50, 1, -1)
+			playsound(loc,"desceration" ,50, 1, -1)
 	return BRUTELOSS
 
 /obj/item/wirecutters/power/attack_self(mob/user)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -235,6 +235,8 @@ falloff_distance - Distance at which falloff begins. Sound is at peak volume (in
 				soundin = pick('sound/voice/unathi/m_u_scream.ogg', 'sound/voice/unathi/m_u_scream2.ogg')
 			if("clownstep")
 				soundin = pick('sound/effects/clownstep1.ogg','sound/effects/clownstep2.ogg')
+			if("desceration")
+				soundin = pick('sound/misc/desceration-01.ogg','sound/misc/desceration-02.ogg','sound/misc/desceration-03.ogg')
 			else
 				var/check_sound = FALSE
 				for(var/format in SOUND_ALLOWED_FILE_FORMATS)

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -148,7 +148,7 @@
 		var/obj/item/organ/external/affecting = H.get_organ("head")
 		if(affecting)
 			affecting.droplimb(1, DROPLIMB_SHARP)
-			playsound(loc, pick('sound/misc/desceration-01.ogg','sound/misc/desceration-02.ogg','sound/misc/desceration-01.ogg'), 50, 1, -1)
+			playsound(loc, "desceration", 50, 1, -1)
 	return BRUTELOSS
 
 /obj/item/scythe/pre_attackby(atom/A, mob/living/user, params)


### PR DESCRIPTION
## Описание
Убираем рантаймы у пилы шахтёра, при обращении к пустому листу. Заодно и двух других действий унифицировал звук.
