### PR TITLE
bugfix: Dead do not should spam death message

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -28,7 +28,7 @@
 				if(use_brain_mod)
 					amount = amount * dna.species.brain_mod
 			sponge.damage = clamp(sponge.damage + amount, 0, 120)
-			if(sponge.damage >= 120)
+			if(sponge.damage >= 120 && stat != DEAD)
 				visible_message("<span class='alert'><B>[src]</B> goes limp, [p_their()] facial expression utterly blank.</span>")
 				death()
 	if(updating_health)
@@ -46,7 +46,7 @@
 				if(use_brain_mod)
 					amount = amount * dna.species.brain_mod
 			sponge.damage = clamp(amount, 0, 120)
-			if(sponge.damage >= 120)
+			if(sponge.damage >= 120 && stat != DEAD)
 				visible_message("<span class='alert'><B>[src]</B> goes limp, [p_their()] facial expression utterly blank.</span>")
 				death()
 	if(updating_health)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Создаёт проверку `жив ли` человек, прежде чем показать сообщение о смерти.

## Ссылка на предложение/Причина создания ПР
Засорял чат.
[Ссылка на запрос](https://discord.com/channels/617003227182792704/734823601110515882/1140753788798500935).

