### PR TITLE
bugfix: few fixes

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/ussp_laboratory.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/ussp_laboratory.dmm
@@ -1963,7 +1963,6 @@
 	},
 /mob/living/simple_animal/hostile/alien/drone{
 	dir = 8;
-	health = 0
 	},
 /obj/structure/alien/weeds,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2920,7 +2919,6 @@
 	},
 /mob/living/simple_animal/hostile/alien/drone{
 	dir = 8;
-	health = 0
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -3711,7 +3709,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /mob/living/simple_animal/hostile/alien/drone{
 	dir = 8;
-	health = 0
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"

--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -56,13 +56,13 @@
 /datum/outfit/proc/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	pre_equip(H, visualsOnly)
 
-	//Start with uniform,suit,backpack for additional slots
+	//Start with backpack,suit,uniform for additional slots
+	if(back)
+		equip_item(H, back, slot_back)
 	if(uniform)
 		equip_item(H, uniform, slot_w_uniform)
 	if(suit)
 		equip_item(H, suit, slot_wear_suit)
-	if(back)
-		equip_item(H, back, slot_back)
 	if(belt)
 		equip_item(H, belt, slot_belt)
 	if(gloves)

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -177,7 +177,7 @@
 	..()
 
 /obj/item/dnainjector/xraymut
-	name = "DNA-Injector (Xray)"
+	name = "DNA-Injector (X-ray)"
 	desc = "Finally you can see what the Captain does."
 	datatype = DNA2_BUF_SE
 	value = 0xFFF
@@ -188,7 +188,7 @@
 	..()
 
 /obj/item/dnainjector/antixray
-	name = "DNA-Injector (Anti-Xray)"
+	name = "DNA-Injector (Anti-X-ray)"
 	desc = "It will make you see harder."
 	datatype = DNA2_BUF_SE
 	value = 0x001

--- a/code/modules/food_and_drinks/item_food/eat_items.dm
+++ b/code/modules/food_and_drinks/item_food/eat_items.dm
@@ -36,7 +36,8 @@
 		bites_damage_string = "Видна внутренняя часть..."
 	else if((current_bites >= bites_split * 3))
 		bites_damage_string = "Осталась одна труха..."
-	material_string += "\n[bites_damage_string]"
+	if(bites_damage_string)
+		material_string += "\n[bites_damage_string]"
 
 	return material_string
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -147,10 +147,10 @@
 			var/obj/item/storage/backpack = back
 			if(backpack.can_be_inserted(I, stop_messages = TRUE))
 				backpack.handle_item_insertion(I, prevent_warning = TRUE)
-			else
-				var/turf/T = get_turf(src)
-				if(istype(T))
-					I.forceMove(T)
+				return
+		var/turf/T = get_turf(src)
+		if(istype(T))
+			I.forceMove(T)
 
 
 /**

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -400,6 +400,7 @@
 
 /obj/item/ammo_casing/a545/fusty
 	desc = "A fusty 5.45x39mm bullet casing."
+	caliber = "f545"
 	materials = list(MAT_METAL = 1000)
 	projectile_type = /obj/item/projectile/bullet/f545
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_STRONG

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -119,7 +119,7 @@
 	return
 
 /obj/item/gun/energy/xray
-	name = "xray laser gun"
+	name = "x-ray laser gun"
 	desc = "A high-power laser gun capable of expelling concentrated xray blasts. These blasts will penetrate solid objects, but will decrease in power the longer they have to travel."
 	icon_state = "xray"
 	origin_tech = "combat=6;materials=4;magnets=4"

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -366,7 +366,7 @@
 	icon_state = "lasercarbine[magazine ? "-[CEILING(get_ammo(0)/5, 1)*5]" : ""]"
 
 /obj/item/gun/projectile/automatic/lr30
-	name = "\improper IR-30 Laser Rifle"
+	name = "\improper LR-30 Laser Rifle"
 	desc = "A compact rifle, relying more on battery cartridges rather than a built in power cell. Utilized by the Nanotrasen Navy for combat operations."
 	icon_state = "lr30"
 	item_state = "lr30"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -41,7 +41,7 @@
 	damage = 5
 
 /obj/item/projectile/beam/xray
-	name = "xray beam"
+	name = "x-ray beam"
 	icon_state = "xray"
 	damage = 10
 	hitsound = 'sound/weapons/plasma_cutter.ogg'

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -257,7 +257,7 @@
 	category = list("Weapons")
 
 /datum/design/xray
-	name = "Xray Laser Gun"
+	name = "X-ray Laser Gun"
 	desc = "Not quite as menacing as it sounds"
 	id = "xray"
 	req_tech = list("combat" = 7, "magnets" = 5, "biotech" = 5, "powerstorage" = 4)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
1 - Меняет калибр у ржавого патрона, чтобы он влезал в магазин откуда доставался.
2 - Меняет название у IR-30 на LR-30, как сказано в #2607
3 - Меняет логику выдачи предметов:
- Перемещает рюкзак выше всех других выдаваемых предметов (кроме pre_equip)
- Если уже из лодаута что-то выдано - оно кидает одежду профы на пол, или в рюкзак. (Раньше оно оставляло в кукле, не в рюкзаке, не на полу)

4 - Исправлена грамматика слова `x-ray` в пару строках (правильно через `-`)
5 - Исправлена ошибка этой пустой строки у предметов
6 - Чинит мед ХУДы ксеносов на руине в космосе. Показывали, что они в крите, хотя ХП полное

## Ссылка на предложение/Причина создания ПР
1- [Ссылка](https://discord.com/channels/617003227182792704/1141160427116572672/1141160427116572672) на репорт
2 - Выглядела как очепятка
3 - [Ссылка](https://discord.com/channels/617003227182792704/734823601110515882/1141236630749982771)

## Демонстрация изменений (пункт 5)
![image](https://github.com/ss220-space/Paradise/assets/87372121/0662cb6b-01dd-4e9f-b176-ffe75a705066)

