### PR TITLE
bugfix: cult-healing to robots

### DIFF
--- a/code/datums/components/aura_healing.dm
+++ b/code/datums/components/aura_healing.dm
@@ -44,6 +44,9 @@
 	/// Chance to mend fractures
 	var/mend_fractures_chance = 0
 
+	/// Its healing robots as well?
+	var/robot_heal = FALSE
+
 	/// Map of external organs (such as "tail", "wing", "r_foot" etc.). Will stop internal bleedings only on these organs if specified.
 	var/list/external_organ_bleeding_healing
 
@@ -80,6 +83,7 @@
 	stop_internal_bleeding_chance = 0,
 	limit_to_trait = null,
 	healing_color = COLOR_GREEN,
+	robot_heal = FALSE
 )
 	if (!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
@@ -103,6 +107,7 @@
 	src.stop_internal_bleeding_chance = stop_internal_bleeding_chance
 	src.limit_to_trait = limit_to_trait
 	src.healing_color = healing_color
+	src.robot_heal = robot_heal
 
 
 /datum/component/aura_healing/Destroy(force, silent)
@@ -173,7 +178,7 @@
 
 					for(var/index in external_organ_fracture_healing)
 						body_part = human.bodyparts_by_name[index]
-						if(QDELETED(body_part) || !(body_part.status & ORGAN_BROKEN) || body_part.is_robotic())
+						if(QDELETED(body_part) || !(body_part.status & ORGAN_BROKEN) || (body_part.is_robotic() && !robot_heal))
 							continue
 
 						if(prob(mend_fractures_chance))
@@ -183,7 +188,7 @@
 
 				else
 					for(var/obj/item/organ/external/body_part in human.bodyparts)
-						if(QDELETED(body_part) || !(body_part.status & ORGAN_BROKEN) || body_part.is_robotic())
+						if(QDELETED(body_part) || !(body_part.status & ORGAN_BROKEN) || (body_part.is_robotic() && !robot_heal))
 							continue
 
 						if(prob(mend_fractures_chance))

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -235,6 +235,7 @@ GLOBAL_LIST_INIT(blacklisted_pylon_turfs, typecacheof(list(
 			simple_heal = 1.2, \
 			requires_visibility = FALSE, \
 			healing_color = COLOR_CULT_RED, \
+			robot_heal = TRUE, \
 		)
 	else
 		AddComponent( \
@@ -247,6 +248,7 @@ GLOBAL_LIST_INIT(blacklisted_pylon_turfs, typecacheof(list(
 			requires_visibility = FALSE, \
 			limit_to_trait = TRAIT_HEALS_FROM_CULT_PYLONS, \
 			healing_color = COLOR_CULT_RED, \
+			robot_heal = TRUE, \
 		)
 
 	START_PROCESSING(SSobj, src)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Возвращает лечение синтетиков у пилонов культа после #3009 

## Ссылка на предложение/Причина создания ПР
![image](https://github.com/ss220-space/Paradise/assets/87372121/93d4d0a1-1e84-417e-a2d0-68cb2428a8b9)
Убрали лечение. Забыли добавить.
Багфикс.