### PR TITLE
bugfix: wormholes teleport only to other wormholes

### DIFF
--- a/code/modules/events/wormholes.dm
+++ b/code/modules/events/wormholes.dm
@@ -26,7 +26,7 @@
 	for(var/i in 1 to number_of_wormholes)
 		var/turf/anomaly_turf = pick_n_take(temp_turfs)
 		if(anomaly_turf)
-			wormholes |= new /obj/effect/portal/wormhole(anomaly_turf, null, null, -1)
+			wormholes.Add(new /obj/effect/portal/wormhole(anomaly_turf, null, null, -1, wormholes))
 
 
 /datum/event/wormholes/announce()
@@ -43,9 +43,7 @@
 
 
 /datum/event/wormholes/end()
-	for(var/obj/effect/portal/wormhole/wormhole in wormholes)
-		qdel(wormhole)
-	wormholes.Cut()
+	QDEL_LIST(wormholes)
 
 
 /obj/effect/portal/wormhole
@@ -54,6 +52,13 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "anom"
 	failchance = 0
+	var/list/linked_portals
+
+
+/obj/effect/portal/wormhole/New(loc, turf/target, creator = null, lifespan = 300, list/link_portals)
+	..()
+
+	linked_portals = link_portals
 
 
 /obj/effect/portal/wormhole/can_teleport(atom/movable/M)
@@ -68,8 +73,8 @@
 		return FALSE
 
 	var/turf/target
-	if(GLOB.portals.len)
-		var/obj/effect/portal/P = pick(GLOB.portals)
+	if(linked_portals)
+		var/obj/effect/portal/P = pick(linked_portals)
 		if(P && isturf(P.loc))
 			target = P.loc
 


### PR DESCRIPTION
Червоточины могли телепортировать атом к лобому порталу, включая порталы ЦК и тайпана, теперь не могут