### PR TITLE
add: Тандердом теперь сбрасывается после смерти всех участников.

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -282,6 +282,8 @@
 #define COMSIG_MOB_LOGOUT "mob_logout"
 ///from base of mob/death(): (gibbed)
 #define COMSIG_MOB_DEATH "mob_death"
+///from base of mob/ghostize(): (mob/dead/observer/ghost)
+#define COMSIG_MOB_GHOSTIZE "mob_ghostize"
 ///from base of mob/set_stat(): (new_stat)
 #define COMSIG_MOB_STATCHANGE "mob_statchange"
 ///from base of mob/clickon(): (atom/A, params)

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -200,6 +200,8 @@
 	if(!permanent && !uses)
 		qdel(src)
 
+	return M
+
 // Base version - place these on maps/templates.
 /obj/effect/mob_spawn/human
 	mob_type = /mob/living/carbon/human

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -166,6 +166,7 @@ Works together with spawning an observer, noted above.
 		else
 			GLOB.non_respawnable_keys[ckey] = 1
 		ghost.key = key
+		SEND_SIGNAL(src, COMSIG_MOB_GHOSTIZE, ghost)
 		return ghost
 
 /*

--- a/code/modules/thunderdome/components/death_timer_reset.dm
+++ b/code/modules/thunderdome/components/death_timer_reset.dm
@@ -11,17 +11,13 @@
 
 /datum/component/death_timer_reset/Initialize(death_time)
 	death_time_before = death_time
-	RegisterSignal(parent, list(COMSIG_MOB_DEATH), PROC_REF(reset_death_time))
+	RegisterSignal(parent, list(COMSIG_MOB_GHOSTIZE), PROC_REF(reset_death_time))
 
 /**
- * A bit of a trick with ghostizing dead without possibility to return to left body.
+ * A bit of a trick with ghostized dead without possibility to return to left body. (Because it resets time of death to world.time)
  */
-/datum/component/death_timer_reset/proc/reset_death_time()
-	var/mob/living/L = parent
-	var/mob/dead/observer/ghost = L.ghostize()
-	if(ghost)
-		ghost.can_reenter_corpse = FALSE
-		ghost.timeofdeath = death_time_before
-		//message_admins("time of death for [ghost.ckey] has been successfully reset to [death_time_before]") //debug message
-	UnregisterSignal(parent, list(COMSIG_MOB_DEATH))
+/datum/component/death_timer_reset/proc/reset_death_time(mob/living/creature, mob/dead/observer/ghost)
+	ghost.timeofdeath = death_time_before
+	ghost.can_reenter_corpse = FALSE
+	UnregisterSignal(parent, list(COMSIG_MOB_GHOSTIZE))
 

--- a/code/modules/thunderdome/components/death_timer_reset.dm
+++ b/code/modules/thunderdome/components/death_timer_reset.dm
@@ -1,0 +1,27 @@
+/*
+*	death_timer_reset: component designed for resetting time of death for ghosts when they
+*	spawn for short-temp role such as Thunderdome player
+*
+*	Side effects: ghostizing from dead body even without gibbing, inability to enter it again.
+*
+*/
+
+/datum/component/death_timer_reset
+	var/death_time_before
+
+/datum/component/death_timer_reset/Initialize(death_time)
+	death_time_before = death_time
+	RegisterSignal(parent, list(COMSIG_MOB_DEATH), PROC_REF(reset_death_time))
+
+/**
+ * A bit of a trick with ghostizing dead without possibility to return to left body.
+ */
+/datum/component/death_timer_reset/proc/reset_death_time()
+	var/mob/living/L = parent
+	var/mob/dead/observer/ghost = L.ghostize()
+	if(ghost)
+		ghost.can_reenter_corpse = FALSE
+		ghost.timeofdeath = death_time_before
+		//message_admins("time of death for [ghost.ckey] has been successfully reset to [death_time_before]") //debug message
+	UnregisterSignal(parent, list(COMSIG_MOB_DEATH))
+

--- a/code/modules/thunderdome/components/thunderdome_death_signaler.dm
+++ b/code/modules/thunderdome/components/thunderdome_death_signaler.dm
@@ -1,0 +1,20 @@
+/**
+*	Thunderdome death signaler
+*	Component designed for handling death of Thunderdome participants. Used for tracking.
+*/
+/datum/component/thunderdome_death_signaler
+	var/datum/thunderdome_battle/thunderdome
+
+/**
+ * Death signaler initializing can also be done with custom thunderdome, but for now uses global datum instead.
+ */
+/datum/component/thunderdome_death_signaler/Initialize(datum/thunderdome_battle/thunderdome)
+	src.thunderdome = thunderdome
+	RegisterSignal(parent, list(COMSIG_MOB_DEATH), PROC_REF(signal_death))
+
+/**
+ * Sends signal to thunderdome datum for handling death situation of participant.
+ */
+/datum/component/thunderdome_death_signaler/proc/signal_death()
+	thunderdome.handle_participant_death(parent)
+	UnregisterSignal(parent, list(COMSIG_MOB_DEATH))

--- a/code/modules/thunderdome/thunderdome_battle.dm
+++ b/code/modules/thunderdome/thunderdome_battle.dm
@@ -54,6 +54,7 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
 	var/when_cleansing_happened = 0 //storing (in ticks) moment of arena cleansing
 	var/obj/thunderdome_poller/last_poller = null
 	var/list/fighters = list()	//list of current players on thunderdome, used for tracking winners and stuff.
+	var/is_cleansing_going = FALSE
 
 	var/list/melee_pool = list(
 		/obj/item/melee/rapier = 1,
@@ -213,6 +214,8 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
  *
 */
 /datum/thunderdome_battle/proc/clear_thunderdome()
+	is_cleansing_going = TRUE
+
 	clear_area(GLOB.tdome_arena)
 	clear_area(GLOB.tdome_arena_melee)
 
@@ -221,6 +224,7 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
 	add_game_logs("Thunderdome battle has ended.")
 	var/image/alert_overlay = image('icons/obj/assemblies.dmi', "thunderdome-bomb-active-wires")
 	notify_ghosts(message = "Thunderdome is ready for battle!", title="Thunderdome News", alert_overlay = alert_overlay, source = last_poller, action = NOTIFY_JUMP)
+	is_cleansing_going = FALSE
 
 /**
  * Clears area from:
@@ -252,7 +256,7 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
 /datum/thunderdome_battle/proc/handle_participant_death(mob/living/dead_fighter)
 	if(dead_fighter in fighters)
 		fighters -= dead_fighter
-	if(length(fighters) == 0)
+	if(length(fighters) == 0 && !is_cleansing_going)
 		for(var/datum/timedevent/timer in active_timers)
 			qdel(timer)
 		addtimer(CALLBACK(src, PROC_REF(clear_thunderdome)), 5 SECONDS) //Everyone died. Time to reset.

--- a/code/modules/thunderdome/thunderdome_battle.dm
+++ b/code/modules/thunderdome/thunderdome_battle.dm
@@ -256,9 +256,10 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
 /datum/thunderdome_battle/proc/handle_participant_death(mob/living/dead_fighter)
 	if(dead_fighter in fighters)
 		fighters -= dead_fighter
-	if(length(fighters) == 0 && !is_cleansing_going)
+	if(!length(fighters) && !is_cleansing_going)
 		for(var/datum/timedevent/timer in active_timers)
 			qdel(timer)
+		is_cleansing_going = TRUE
 		addtimer(CALLBACK(src, PROC_REF(clear_thunderdome)), 5 SECONDS) //Everyone died. Time to reset.
 		//Also avoiding all issues with death handling of thunderdome participants by letting fighters' components do their stuff.
 		if(last_poller)

--- a/code/modules/thunderdome/thunderdome_battle.dm
+++ b/code/modules/thunderdome/thunderdome_battle.dm
@@ -225,7 +225,7 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
 /**
  * Clears area from:
  * All mobs
- * All object except thunderdome poller and poddors (shutters included)
+ * All objects except thunderdome poller and poddors (shutters included)
  * *Arguments:
  * *zone - specific area
  */
@@ -250,7 +250,6 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
  * Handles thunderdome's participants deaths. Called from /datum/component/death_timer_reset/
  */
 /datum/thunderdome_battle/proc/handle_participant_death(mob/living/dead_fighter)
-	message_admins(span_dangerbigger("[dead_fighter] has been tracked for being dead. What a shame")) //debug message
 	if(dead_fighter in fighters)
 		fighters -= dead_fighter
 	if(length(fighters) == 0)
@@ -258,8 +257,8 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
 			qdel(timer)
 		addtimer(CALLBACK(src, PROC_REF(clear_thunderdome)), 5 SECONDS) //Everyone died. Time to reset.
 		//Also avoiding all issues with death handling of thunderdome participants by letting fighters' components do their stuff.
-
-		//Maybe it will be a good idea to add winner tracker
+		if(last_poller)
+			last_poller.visible_message(span_danger("Thunderdome has ended with death of all participants! Cleansing in 5 seconds..."))
 	return
 
 /**

--- a/paradise.dme
+++ b/paradise.dme
@@ -2797,6 +2797,8 @@
 #include "code\modules\tgui\states\self.dm"
 #include "code\modules\tgui\states\zlevel.dm"
 #include "code\modules\thunderdome\thunderdome_battle.dm"
+#include "code\modules\thunderdome\components\death_timer_reset.dm"
+#include "code\modules\thunderdome\components\thunderdome_death_signaler.dm"
 #include "code\modules\tooltip\tooltip.dm"
 #include "code\modules\unit_tests\_unit_tests.dm"
 #include "code\modules\vehicle\ambulance.dm"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Данное обновление вводит:
- Отслеживание смертей участников тандердома.
- Сброс арены после смерти всех участников.
- При смерти бойца время смерти будет сброшено до момента вступления на арену. 

_Пояснение:_ К примеру, если участник тандердома вступил в игру с таймером смерти 5 минут и после смерти на нём таймер стал 0 минут, то теперь таймер смерти для призрака будет считаться 5 минут + время пребывания на тандердоме.

## Причины для ввода

Возобновляю работу над своим детищем

