### PR TITLE
Fix: Guardian issues

### DIFF
--- a/code/datums/spells/lightning.dm
+++ b/code/datums/spells/lightning.dm
@@ -29,6 +29,7 @@
 	clothes_req = FALSE
 	invocation = "За С+инд+ик+ат!"
 	energy_divisor = 4
+	human_req = FALSE
 
 
 /obj/effect/proc_holder/spell/charge_up/bounce/lightning/New()

--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -206,12 +206,6 @@
 		if(M && M.client && M.stat == DEAD && !isnewplayer(M))
 			to_chat(M, "<span class='alien'><i>Guardian Communication from <b>[src]</b> ([ghost_follow_link(src, ghost=M)]): [input]</i>")
 
-//override set to true if message should be passed through instead of going to host communication
-/mob/living/simple_animal/hostile/guardian/say(message, override = FALSE)
-	if(admin_spawned || override)//if it's an admin-spawned guardian without a host it can still talk normally
-		return ..(message)
-	Communicate(message)
-
 
 /mob/living/simple_animal/hostile/guardian/proc/ToggleMode()
 	to_chat(src, span_danger("У вас нет другого режима!"))


### PR DESCRIPTION
Тот кто рефакторил молнию, не вернул human_req = 0 для молнии гварда, как итог у него было заклинание которое он не мог скастовать.

По задумке голопары должны были свободно общаться с окружающими, но я забыл про эту строчку во время оверхола.

TODO: заставить молнию игнорировать хозяина, а не прыгать без урона, забирая заряд молнии. Да, это тоже было раньше, но пропало при рефакторе.

<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Фикс проблем с гвардами

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
