### PR TITLE
tweak: Holy water braindamage

### DIFF
--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -433,13 +433,14 @@
 						M.emote("scream")
 					g_vamp.nullified = max(5, g_vamp.nullified + 2)
 
-	if(ishuman(M) && !(isvampire(M) || iscultist(M) || isclocker(M) || isvampirethrall(M) || (M.mind?.isholy)))
-		if(volume <= 10)
-			M.adjustBrainLoss(1, FALSE)
-		else if(volume <= 20 && volume > 10)
-			M.adjustBrainLoss(2, FALSE)
-		else
-			M.adjustBrainLoss(3, FALSE)
+	if(ishuman(M) && !M.mind?.isholy)
+		switch(current_cycle)
+			if(0 to 24)
+				M.adjustBrainLoss(0.5, FALSE)
+			if(25 to 49)
+				M.adjustBrainLoss(1, FALSE)
+			if(50 to INFINITY)
+				M.adjustBrainLoss(2, FALSE)
 
 	return ..() | update_flags
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
1) Оставляет защиту от урона мозга только персонажам с флагом святости, остальные будут страдать одинаково.
2) Изменён принцип нанесения урона
с: 0-10u в организме - 1 урона в тик, 10-20u в организме - 2 урона в тик, больше 20u - 3 урона в тик
на: 0.5 урона мозгу на 0-25 циклах метаболизации, 1 урона мозгу на 25-50 циклах метаболизации, 2 урона на 50 и выше.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1142393742301614080
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

