### PR TITLE
BALANCE: RND SPAI nerf

### DIFF
--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -39,7 +39,7 @@ other types of metals and chemistry for reagents).
 	var/construction_time				//Amount of time required for building the object
 	var/build_path = null				//The file path of the object that gets created
 	var/list/make_reagents = list()			//Reagents produced. Format: "id" = amount. Currently only supported by the biogenerator.
-	var/locked = 0						//If true it will spawn inside a lockbox with currently sec access
+	var/locked = FALSE						//If true it will spawn inside a lockbox with currently sec access
 	var/access_requirement = list(ACCESS_ARMORY) //What special access requirements will the lockbox have? Defaults to armory.
 	var/category = null //Primarily used for Mech Fabricators, but can be used for anything
 	var/list/reagents_list = list()			//List of reagents. Format: "id" = amount.

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -10,7 +10,7 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 10000, MAT_GLASS = 2000, MAT_URANIUM = 3000, MAT_TITANIUM = 1000)
 	build_path = /obj/item/gun/energy/gun/nuclear
-	locked = 1
+	locked = TRUE
 	category = list("Weapons")
 
 /datum/design/decloner
@@ -22,7 +22,7 @@
 	materials = list(MAT_GOLD = 5000,MAT_URANIUM = 10000)
 	reagents_list = list("mutagen" = 40)
 	build_path = /obj/item/gun/energy/decloner
-	locked = 1
+	locked = TRUE
 	category = list("Weapons")
 
 /datum/design/flora_gun
@@ -44,7 +44,7 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_SILVER = 6000, MAT_METAL = 8000, MAT_URANIUM = 2000)
 	build_path = /obj/item/gun/energy/ionrifle/carbine
-	locked = 1
+	locked = TRUE
 	category = list("Weapons")
 
 /datum/design/wormhole_projector
@@ -55,7 +55,7 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_SILVER = 2000, MAT_METAL = 5000, MAT_DIAMOND = 2000, MAT_BLUESPACE = 3000)
 	build_path = /obj/item/gun/energy/wormhole_projector
-	locked = 1
+	locked = TRUE
 	access_requirement = list(ACCESS_RD) //screw you, HoS, this aint yours; this is only for a man of science---and trouble.
 	category = list("Weapons")
 
@@ -117,7 +117,7 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 10000, MAT_GLASS = 3000, MAT_DIAMOND = 3000)
 	build_path = /obj/item/gun/energy/lasercannon
-	locked = 1
+	locked = TRUE
 	category = list("Weapons")
 
 /datum/design/plasmapistol
@@ -128,7 +128,7 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 5000, MAT_GLASS = 1000, MAT_PLASMA = 3000)
 	build_path = /obj/item/gun/energy/toxgun
-	locked = 1
+	locked = TRUE
 	category = list("Weapons")
 
 //WT550 Mags
@@ -233,7 +233,7 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 10000, MAT_GLASS = 10000, MAT_SILVER = 10000)
 	build_path = /obj/item/gun/energy/shock_revolver
-	locked = 1
+	locked = TRUE
 	category = list("Weapons")
 
 /datum/design/temp_gun
@@ -264,7 +264,7 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_GOLD = 5000, MAT_URANIUM = 4000, MAT_METAL = 5000, MAT_TITANIUM = 2000, MAT_BLUESPACE = 2000)
 	build_path = /obj/item/gun/energy/xray
-	locked = 1
+	locked = TRUE
 	category = list("Weapons")
 
 /datum/design/immolator
@@ -275,7 +275,7 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 4000, MAT_GLASS = 1000, MAT_SILVER = 3000, MAT_PLASMA = 2000)
 	build_path = /obj/item/gun/energy/immolator
-	locked = 1
+	locked = TRUE
 	category = list("Weapons")
 
 /datum/design/bsg
@@ -297,7 +297,7 @@
 	build_type = PROTOLATHE
 	req_tech = list("combat" = 6, "magnets" = 5, "powerstorage" = 5, "engineering" = 4,"programming" = 5)
 	build_path = /obj/item/ipc_combat_upgrade
-	locked = 1
+	locked = TRUE
 	category = list("Weapons")
 
 /datum/design/laser_arm
@@ -308,7 +308,7 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 15000, MAT_URANIUM = 10000, MAT_TITANIUM = 6000, MAT_GOLD = 4500, MAT_DIAMOND = 3500)
 	build_path = /obj/item/organ/internal/cyberimp/arm/gun/laser
-	locked = 1
+	locked = TRUE
 	category = list("Weapons")
 
 /////////////////////////////////////////
@@ -323,7 +323,7 @@
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 100)
 	build_path = /obj/item/aiModule/antimov
-	locked = 1
+	locked = TRUE
 	category = list("ILLEGAL")
 
 /datum/design/tyrant_module
@@ -334,7 +334,7 @@
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 100)
 	build_path = /obj/item/aiModule/tyrant
-	locked = 1
+	locked = TRUE
 	category = list("ILLEGAL")
 
 /datum/design/largecrossbow
@@ -345,7 +345,7 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 5000, MAT_GLASS = 1500, MAT_URANIUM = 1500, MAT_SILVER = 1500)
 	build_path = /obj/item/gun/energy/kinetic_accelerator/crossbow/large
-	locked = 1
+	locked = TRUE
 	category = list("ILLEGAL")
 
 /datum/design/suppressor
@@ -356,7 +356,7 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 2000, MAT_SILVER = 500)
 	build_path = /obj/item/suppressor
-	locked = 1
+	locked = TRUE
 	category = list("ILLEGAL")
 
 /datum/design/stechkin
@@ -367,7 +367,7 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 4500, MAT_SILVER = 1500, MAT_TITANIUM = 5000)
 	build_path = /obj/item/gun/projectile/automatic/pistol
-	locked = 1
+	locked = TRUE
 	category = list("ILLEGAL")
 
 /datum/design/chameleon_kit
@@ -378,7 +378,7 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 4500, MAT_GLASS = 3000, MAT_SILVER = 2000, MAT_DIAMOND = 1000)
 	build_path = /obj/item/storage/box/syndie_kit/chameleon
-	locked = 1
+	locked = TRUE
 	category = list("ILLEGAL")
 
 /datum/design/chameleon_hud
@@ -389,7 +389,7 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 1000, MAT_GLASS = 500, MAT_SILVER = 500)
 	build_path = /obj/item/clothing/glasses/hud/security/chameleon
-	locked = 1
+	locked = TRUE
 	category = list("ILLEGAL")
 
 /datum/design/e_dagger
@@ -400,7 +400,7 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 15000, MAT_DIAMOND = 3000, MAT_TITANIUM = 3000)
 	build_path = /obj/item/pen/edagger
-	locked = 1
+	locked = TRUE
 	category = list("ILLEGAL")
 
 /datum/design/a_tuner
@@ -411,7 +411,7 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 9000, MAT_DIAMOND = 2500, MAT_SILVER = 2000)
 	build_path = /obj/item/door_remote/omni/access_tuner
-	locked = 1
+	locked = TRUE
 	category = list("ILLEGAL")
 
 /datum/design/c_flash
@@ -422,7 +422,7 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 5000, MAT_DIAMOND = 1000, MAT_TITANIUM = 1500)
 	build_path = /obj/item/flash/cameraflash
-	locked = 1
+	locked = TRUE
 	category = list("ILLEGAL")
 
 /datum/design/dna_scrambler
@@ -434,7 +434,7 @@
 	materials = list(MAT_METAL = 2000, MAT_DIAMOND = 1500)
 	reagents_list = list("stable_mutagen" = 20)
 	build_path = /obj/item/dnascrambler
-	locked = 1
+	locked = TRUE
 	category = list("ILLEGAL")
 
 /datum/design/c_bug
@@ -445,7 +445,7 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 5000, MAT_GLASS = 3000)
 	build_path = /obj/item/camera_bug
-	locked = 1
+	locked = TRUE
 	category = list("ILLEGAL")
 
 /datum/design/ai_detector
@@ -456,7 +456,7 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 5000, MAT_GLASS = 3000, MAT_SILVER = 1500)
 	build_path = /obj/item/multitool/ai_detect
-	locked = 1
+	locked = TRUE
 	category = list("ILLEGAL")
 
 /datum/design/adv_pointer
@@ -467,7 +467,7 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 20000, MAT_TITANIUM = 4000, MAT_DIAMOND = 5000)
 	build_path = /obj/item/pinpointer/advpinpointer
-	locked = 1
+	locked = TRUE
 	category = list("ILLEGAL")
 
 /datum/design/encryptionkey_binary
@@ -478,7 +478,7 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 1000, MAT_GLASS = 1000,)
 	build_path = /obj/item/encryptionkey/binary
-	locked = 1
+	locked = TRUE
 	category = list("ILLEGAL")
 
 /datum/design/encryptionkey_syndicate
@@ -489,7 +489,7 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 1000, MAT_GLASS = 1000,)
 	build_path = /obj/item/encryptionkey/syndicate
-	locked = 1
+	locked = TRUE
 	category = list("ILLEGAL")
 
 /datum/design/aiModule_syndicate
@@ -500,7 +500,7 @@
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 100)
 	build_path = /obj/item/aiModule/syndicate
-	locked = 1
+	locked = TRUE
 	category = list("ILLEGAL")
 
 /datum/design/incendiary_10mm
@@ -511,7 +511,7 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 18000, MAT_SILVER = 1600, MAT_PLASMA = 2400)
 	build_path = /obj/item/ammo_box/magazine/m10mm/fire
-	locked = 1
+	locked = TRUE
 	category = list("ILLEGAL")
 
 /datum/design/radio_jammer
@@ -522,7 +522,7 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 2000, MAT_GLASS = 1000, MAT_SILVER = 500)
 	build_path = /obj/item/jammer
-	locked = 1
+	locked = TRUE
 	category = list("ILLEGAL")
 
 /datum/design/syndie_rcd
@@ -533,7 +533,7 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 20000, MAT_GLASS=8000, MAT_PLASMA = 10000, MAT_TITANIUM = 10000)
 	build_path = /obj/item/rcd/syndicate
-	locked = 1
+	locked = TRUE
 	category = list("ILLEGAL")
 
 /datum/design/syndie_rcd_ammo
@@ -544,7 +544,6 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 8000, MAT_GLASS = 4000, MAT_TITANIUM = 4000, MAT_PLASMA = 4000)
 	build_path = /obj/item/rcd_ammo/syndicate
-	locked = 0
 	category = list("ILLEGAL")
 
 /datum/design/syndie_rcd_ammo_large
@@ -555,7 +554,6 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 40000, MAT_GLASS = 20000, MAT_TITANIUM = 20000, MAT_PLASMA = 20000)
 	build_path = /obj/item/rcd_ammo/syndicate/large
-	locked = 0
 	category = list("ILLEGAL")
 
 /datum/design/paicard_cartridge
@@ -564,8 +562,9 @@
 	id = "paicardcartridge"
 	req_tech = list("syndicate" = 3, "programming" = 3)
 	build_type = PROTOLATHE
-	materials = list(MAT_GOLD=500, MAT_GLASS=500)
+	materials = list(MAT_METAL = 4000, MAT_GLASS = 8000, MAT_GOLD = 6000, MAT_DIAMOND = 5000)
 	build_path = /obj/item/paicard_upgrade/protolate
+	locked = TRUE
 	category = list("ILLEGAL")
 
 /datum/design/pyroclaw


### PR DESCRIPTION
## Описание

Наконец-то исправляет кринж с СПИИ который в рнд был абсолютно бесплатен и доступен всем. Теперь он далеко не бесплатный и заперт на нормальный замок.

## Ссылка на предложение/Причина создания ПР
Две в одном
https://discord.com/channels/617003227182792704/755125334097133628/1144920258759634946
https://discord.com/channels/617003227182792704/755125334097133628/1144920178732302336

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
