### PR TITLE
qol: Fireproof rods design can be imported into ore redemption

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -98,6 +98,7 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 	throw_range = 7
 	max_amount = 50
 	attack_verb = list("hit", "bludgeoned", "whacked")
+	materials = list(MAT_METAL=800, MAT_PLASMA=200, MAT_TITANIUM=400)
 	hitsound = 'sound/weapons/grenadelaunch.ogg'
 	toolspeed = 1
 	usesound = 'sound/items/deconstruct.ogg'

--- a/code/game/objects/items/weapons/stock_parts.dm
+++ b/code/game/objects/items/weapons/stock_parts.dm
@@ -268,4 +268,12 @@
 	icon = 'icons/obj/stock_parts.dmi'
 	icon_state = "capacitor"
 	desc = "A debug item for research."
-	origin_tech = "materials=8;programming=8;magnets=8;powerstorage=8;bluespace=8;combat=8;biotech=8;syndicate=8;engineering=8;plasmatech=8;abductor=8"
+	origin_tech = "materials=8;programming=8;magnets=8;powerstorage=8;bluespace=8;combat=8;biotech=8;syndicate=8;engineering=8;plasmatech=8;abductor=8;toxins=8"
+
+/obj/item/stack/debug_resource //This also makes material filling less of a pain
+	name = "resources"
+	icon = 'icons/obj/stock_parts.dmi'
+	icon_state = "high_micro_laser"
+	desc = "A debug item for filling protolathes or furnaces with all types of resources"
+	materials = list(MAT_METAL=8000, MAT_GLASS=8000, MAT_SILVER=8000, MAT_GOLD=8000, MAT_DIAMOND=8000, MAT_URANIUM=8000,
+				 MAT_PLASMA=8000, MAT_BLUESPACE=8000, MAT_BANANIUM=8000, MAT_TRANQUILLITE=8000, MAT_TITANIUM=8000)

--- a/code/modules/research/designs/mining_designs.dm
+++ b/code/modules/research/designs/mining_designs.dm
@@ -126,7 +126,7 @@
 	desc = "Rods made of a complex heat-resistant alloy"
 	id = "firerods"
 	req_tech = list("materials" = 6, "engineering" = 3, "plasmatech" = 4)
-	build_type = PROTOLATHE
+	build_type = PROTOLATHE | SMELTER
 	materials = list(MAT_METAL = 2000, MAT_PLASMA = 500, MAT_TITANIUM = 1000)
 	build_path = /obj/item/stack/fireproof_rods
 	category = list("Mining")


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
QoL, разрешающий использовать дизайн огнеупорных стержней в печке с рудой, а также расплавлять их.
Добавил исследование токсинов в дебажный предмет, дающий все исследования.
Добавил предмет, дающий по 8000ед. каждого материала при расплавлении в печке или протолате для тестов.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

Улучшение доступности огнеупорных стержней