### PR TITLE
bugfix: Bridge disposal pipes and some improvements

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -306,7 +306,7 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "aax" = (
 /obj/machinery/light{
@@ -688,7 +688,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "ads" = (
 /obj/structure/closet/wardrobe/red,
@@ -983,7 +983,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
 /area/bridge/meeting_room)
 "ahv" = (
 /obj/item/twohanded/required/kirbyplants,
@@ -2951,7 +2953,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/ntrep)
 "axD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -6395,6 +6397,9 @@
 	},
 /obj/effect/decal/cleanable/dirt{
 	layer = 2.1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -9885,9 +9890,9 @@
 "boh" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 26
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/ntrep)
 "boi" = (
 /obj/structure/cable{
@@ -12113,18 +12118,17 @@
 	},
 /area/security/checkpoint)
 "byL" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/item/flag/nt,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault"
+	icon_state = "darkblue"
 	},
 /area/bridge)
 "byM" = (
@@ -13198,7 +13202,7 @@
 "bCr" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -25
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
@@ -13900,7 +13904,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "bFs" = (
 /obj/item/radio/intercom{
@@ -14027,7 +14031,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/blueshield)
 "bFK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14883,7 +14887,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain)
 "bKF" = (
 /obj/machinery/conveyor{
@@ -16064,7 +16068,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain)
 "bQg" = (
 /obj/effect/spawner/window/reinforced,
@@ -16982,7 +16986,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/ntrep)
 "bUc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -18077,7 +18081,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "bYY" = (
 /obj/item/radio/intercom{
@@ -18418,7 +18422,9 @@
 	name = "Bridge Lockdown"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
 /area/bridge)
 "caj" = (
 /obj/machinery/newscaster{
@@ -19354,8 +19360,9 @@
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 4;
-	tag = "icon-pipe-j1 (EAST)"
+	dir = 8;
+	icon_state = "pipe-j2";
+	tag = "icon-pipe-j1 (WEST)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -19661,13 +19668,10 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "cfL" = (
 /obj/structure/lattice,
@@ -20799,6 +20803,9 @@
 	dir = 4
 	},
 /obj/structure/grille,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "clQ" = (
@@ -21975,7 +21982,7 @@
 /area/atmos)
 "crr" = (
 /obj/machinery/suit_storage_unit/blueshield,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/blueshield)
 "crv" = (
 /obj/structure/table/reinforced,
@@ -22349,7 +22356,7 @@
 "ctL" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 26
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -22712,7 +22719,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain)
 "cvu" = (
 /obj/machinery/vending/cigarette,
@@ -22763,7 +22770,7 @@
 	pixel_x = 24;
 	pixel_y = 24
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain/bedroom)
 "cvH" = (
 /obj/machinery/gateway{
@@ -23854,7 +23861,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain)
 "czQ" = (
 /obj/machinery/recharge_station,
@@ -24206,7 +24213,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 25
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "cBk" = (
 /obj/machinery/door/firedoor,
@@ -24632,7 +24639,7 @@
 /area/atmos/control)
 "cCQ" = (
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 26
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -25840,29 +25847,19 @@
 	},
 /area/mimeoffice)
 "cHC" = (
+/obj/item/twohanded/required/kirbyplants,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge";
-	req_access = list(19)
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "BridgeLockdown";
-	name = "Bridge Lockdown"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+	icon_state = "grimy"
 	},
-/area/bridge)
+/area/bridge/meeting_room)
 "cHF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27145,6 +27142,12 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/toxins/test_area)
+"cNH" = (
+/obj/machinery/papershredder,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/bridge/meeting_room)
 "cNI" = (
 /turf/simulated/wall,
 /area/medical/reception)
@@ -29410,7 +29413,7 @@
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood/fancy/light,
 /area/ntrep)
 "cWn" = (
 /obj/effect/decal/warning_stripes/yellow,
@@ -31191,7 +31194,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
 /area/bridge/meeting_room)
 "ddE" = (
 /obj/machinery/computer/crew,
@@ -35434,7 +35439,7 @@
 	pixel_x = -24;
 	pixel_y = -22
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain)
 "dvg" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -35917,7 +35922,7 @@
 	},
 /area/toxins/launch)
 "dxf" = (
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "dxg" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -35926,7 +35931,7 @@
 /obj/item/radio/intercom{
 	pixel_y = -26
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/blueshield)
 "dxh" = (
 /obj/structure/cable{
@@ -37019,7 +37024,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "dCc" = (
 /obj/effect/decal/warning_stripes/south,
@@ -37345,7 +37350,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/ntrep)
 "dDl" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -37726,7 +37731,7 @@
 /area/crew_quarters/heads/hop)
 "dFb" = (
 /obj/machinery/vending/cart/free,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "dFc" = (
 /obj/structure/table/wood,
@@ -37762,7 +37767,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "dFm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -39991,7 +39996,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 25
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain)
 "dNW" = (
 /obj/structure/table/glass,
@@ -42553,7 +42558,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/ntrep)
 "dXy" = (
 /obj/effect/decal/warning_stripes/yellow,
@@ -47799,7 +47804,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "eYP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -48495,7 +48500,7 @@
 /area/security/permabrig)
 "fgQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain)
 "fhd" = (
 /obj/structure/bed,
@@ -49486,7 +49491,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain/bedroom)
 "fuE" = (
 /turf/simulated/floor/plasteel{
@@ -51998,7 +52003,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain)
 "fYR" = (
 /obj/structure/disposalpipe/segment{
@@ -53953,7 +53958,7 @@
 	pixel_x = 1;
 	pixel_y = 3
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "gzs" = (
 /obj/effect/decal/warning_stripes/north,
@@ -54502,7 +54507,7 @@
 	pixel_x = -24;
 	pixel_y = 24
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "gFr" = (
 /obj/machinery/chem_master{
@@ -54817,7 +54822,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "gIq" = (
 /obj/effect/decal/warning_stripes/north,
@@ -54844,7 +54849,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "gIA" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -55192,7 +55197,7 @@
 /obj/item/radio/intercom{
 	pixel_x = 28
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "gLL" = (
 /obj/structure/cable{
@@ -57766,7 +57771,7 @@
 "hpE" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 26
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -59759,7 +59764,7 @@
 	dir = 6
 	},
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain/bedroom)
 "hPr" = (
 /obj/machinery/light{
@@ -61434,7 +61439,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "ikN" = (
 /obj/effect/decal/warning_stripes/east,
@@ -63708,7 +63713,7 @@
 	layer = 3.3;
 	pixel_y = -27
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/blueshield)
 "iLA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -64622,7 +64627,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood/fancy/light,
 /area/ntrep)
 "iXI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -65420,6 +65425,12 @@
 	icon_state = "caution"
 	},
 /area/maintenance/asmaint4)
+"jiz" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/crew_quarters/heads/hop)
 "jiD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -68604,7 +68615,7 @@
 	icon_state = "1-2"
 	},
 /obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "jVb" = (
 /turf/simulated/floor/plasteel{
@@ -68646,7 +68657,7 @@
 /area/toxins/test_chamber)
 "jVx" = (
 /obj/machinery/photocopier,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "jVz" = (
 /obj/structure/sign/nosmoking_2,
@@ -68838,7 +68849,7 @@
 	c_tag = "Captain's Quarters";
 	dir = 8
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain)
 "jXE" = (
 /obj/effect/decal/warning_stripes/west,
@@ -69814,7 +69825,7 @@
 /obj/structure/closet/secure_closet/blueshield,
 /obj/item/stack/tape_roll,
 /obj/item/taperecorder,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/blueshield)
 "klN" = (
 /obj/structure/window/reinforced,
@@ -70181,7 +70192,12 @@
 /area/storage/secure)
 "kpT" = (
 /obj/item/flag/nt,
-/turf/simulated/floor/wood,
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -26
+	},
+/obj/structure/cable,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "kpV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -71319,7 +71335,7 @@
 	name = "Head of Personnel Requests Console";
 	pixel_x = 30
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "kFz" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -72196,7 +72212,7 @@
 	id = "conferenceroomwindows";
 	id_tag = "conferenceroombolts"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "kRE" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -73848,7 +73864,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "loT" = (
 /obj/machinery/door/airlock/command{
@@ -73858,7 +73874,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "loV" = (
 /obj/structure/bookcase,
@@ -73996,7 +74012,7 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood/fancy/light,
 /area/ntrep)
 "lqe" = (
 /obj/item/twohanded/required/kirbyplants,
@@ -75615,6 +75631,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -75633,18 +75652,18 @@
 /area/medical/chemistry)
 "lKX" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	invisibility = 101
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/area/bridge)
+/area/hallway/primary/central/nw)
 "lLb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -75654,6 +75673,9 @@
 	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -75928,16 +75950,16 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -75956,12 +75978,6 @@
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	icon_state = "pipe-j2s";
-	name = "HoP Office";
-	sortType = 15
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -75971,6 +75987,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
 	initialize_directions = 11
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -76897,17 +76917,8 @@
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "man" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	cell_type = 5000;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 26
-	},
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/wood,
+/obj/structure/filingcabinet/chestdrawer,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "mav" = (
 /obj/structure/cable{
@@ -77585,7 +77596,7 @@
 "mjs" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain)
 "mjx" = (
 /obj/structure/disposalpipe/segment,
@@ -78161,7 +78172,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain/bedroom)
 "mpA" = (
 /obj/structure/cable{
@@ -82009,7 +82020,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain/bedroom)
 "ngy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -82936,7 +82947,7 @@
 "nrD" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 26
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -83187,7 +83198,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain/bedroom)
 "ntS" = (
 /obj/structure/disposalpipe/segment,
@@ -83324,6 +83335,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -86127,7 +86141,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain/bedroom)
 "ocK" = (
 /obj/machinery/light/small{
@@ -86478,7 +86492,7 @@
 /area/engine/break_room)
 "ohb" = (
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood/fancy/light,
 /area/ntrep)
 "ohk" = (
 /obj/structure/cable{
@@ -87212,7 +87226,9 @@
 	name = "Bridge Lockdown"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
 /area/bridge)
 "oqs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -87404,10 +87420,10 @@
 /turf/simulated/wall/r_wall,
 /area/toxins/explab)
 "osE" = (
-/obj/structure/table/wood,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -87755,7 +87771,7 @@
 	pixel_x = 6;
 	pixel_y = 6
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain/bedroom)
 "oxi" = (
 /obj/machinery/vending/cigarette,
@@ -88022,7 +88038,7 @@
 /area/security/prison/cell_block/A)
 "oAf" = (
 /obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain/bedroom)
 "oAg" = (
 /obj/effect/spawner/window/reinforced,
@@ -88505,7 +88521,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "oGM" = (
 /obj/machinery/door/airlock/security/glass{
@@ -89786,7 +89802,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "oVf" = (
 /obj/structure/rack,
@@ -91459,7 +91478,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain)
 "ppp" = (
 /obj/machinery/computer/card/minor/hos,
@@ -91755,7 +91774,7 @@
 	pixel_y = -24;
 	pixel_x = 40
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "psj" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -92747,7 +92766,7 @@
 /area/maintenance/starboard)
 "pCP" = (
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 26
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -93062,7 +93081,7 @@
 	name = "Emergency NanoMed";
 	pixel_y = 32
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "pFI" = (
 /obj/structure/closet/firecloset,
@@ -93195,7 +93214,14 @@
 /turf/simulated/floor/plating,
 /area/security/prison/cell_block/A)
 "pHr" = (
-/turf/simulated/floor/wood,
+/obj/item/flag/nt,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
 /area/bridge/meeting_room)
 "pHv" = (
 /obj/machinery/atmospherics/binary/pump{
@@ -93287,16 +93313,13 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "pIp" = (
 /obj/machinery/vending/cola/free,
@@ -94036,7 +94059,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/blueshield)
 "pPR" = (
 /obj/structure/table,
@@ -94521,7 +94544,7 @@
 /obj/item/reagent_containers/food/drinks/bottle/whiskey,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/blueshield)
 "pVP" = (
 /obj/effect/decal/warning_stripes/south,
@@ -96448,10 +96471,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -96460,6 +96479,11 @@
 	},
 /obj/effect/decal/cleanable/dirt{
 	layer = 2.1
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2";
+	tag = "icon-pipe-j1 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -96629,6 +96653,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "qsE" = (
@@ -96741,6 +96768,9 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "qtq" = (
@@ -96778,6 +96808,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -96962,6 +96995,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -97841,7 +97878,7 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain/bedroom)
 "qFz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -98426,7 +98463,9 @@
 	id_tag = "BridgeLockdown";
 	name = "Bridge Lockdown"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
 /area/bridge)
 "qMN" = (
 /obj/structure/table,
@@ -98757,7 +98796,7 @@
 /obj/machinery/camera{
 	c_tag = "Head of Personnel's Office"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "qQQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -98952,7 +98991,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/blueshield)
 "qUc" = (
 /obj/structure/cable{
@@ -101111,7 +101150,7 @@
 "rsM" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 26
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -101690,7 +101729,7 @@
 /turf/simulated/floor/mech_bay_recharge_floor,
 /area/assembly/robotics)
 "rzU" = (
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain)
 "rAh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -101803,7 +101842,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "rBz" = (
 /obj/structure/disposalpipe/segment,
@@ -104658,6 +104697,10 @@
 	dir = 8;
 	initialize_directions = 11
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -104749,6 +104792,9 @@
 	name = "Bridge Lockdown"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -104977,7 +105023,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "soz" = (
 /obj/machinery/door/airlock/hatch/gamma{
@@ -109148,16 +109194,7 @@
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "tnm" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 26;
-	pixel_y = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
+/obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -109276,7 +109313,7 @@
 	pixel_x = 38;
 	pixel_y = 6
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "tou" = (
 /obj/structure/lattice/catwalk,
@@ -109819,7 +109856,7 @@
 	pixel_x = 28
 	},
 /obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain/bedroom)
 "tvZ" = (
 /obj/structure/cable{
@@ -111538,6 +111575,10 @@
 /area/toxins/xenobiology)
 "tNB" = (
 /obj/item/flag/nt,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -111658,7 +111699,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/blueshield)
 "tOB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -112485,7 +112526,7 @@
 /obj/structure/table/wood,
 /obj/item/clipboard,
 /obj/item/toy/figure/ian,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "tYM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -112941,7 +112982,7 @@
 	id = "conferenceroomwindows";
 	id_tag = "conferenceroombolts"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "ufl" = (
 /obj/structure/grille,
@@ -113589,7 +113630,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 26
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -115953,7 +115994,7 @@
 /area/hydroponics)
 "uPo" = (
 /obj/structure/chair/comfy/brown,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain)
 "uPv" = (
 /obj/machinery/hydroponics/soil,
@@ -116760,7 +116801,7 @@
 /area/toxins/lab)
 "uZv" = (
 /obj/item/flag/nt,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain)
 "uZC" = (
 /obj/machinery/atmospherics/binary/pump,
@@ -117245,7 +117286,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/ntrep)
 "vgk" = (
 /obj/structure/cable{
@@ -119657,7 +119698,7 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain)
 "vHh" = (
 /obj/machinery/door/airlock/glass{
@@ -119840,7 +119881,7 @@
 	dir = 9
 	},
 /obj/effect/landmark/start/hop,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "vJS" = (
 /obj/structure/sign/poster/official/random{
@@ -120440,7 +120481,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "vSD" = (
 /turf/simulated/floor/plasteel{
@@ -122797,7 +122838,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "wtv" = (
 /obj/machinery/door/firedoor,
@@ -123423,7 +123464,7 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/blueshield)
 "wCy" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer{
@@ -123743,7 +123784,7 @@
 /area/maintenance/fpmaint)
 "wFJ" = (
 /obj/machinery/computer/card,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "wFR" = (
 /obj/structure/cable{
@@ -124262,7 +124303,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain/bedroom)
 "wMC" = (
 /obj/machinery/photocopier,
@@ -125858,7 +125899,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "xgc" = (
 /obj/structure/table/reinforced,
@@ -128668,7 +128709,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/ntrep)
 "xJv" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -128903,7 +128944,7 @@
 	},
 /area/security/execution)
 "xLF" = (
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/ntrep)
 "xLG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -129148,7 +129189,9 @@
 	id_tag = "BridgeLockdown";
 	name = "Bridge Lockdown"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
 /area/bridge)
 "xOk" = (
 /obj/structure/table,
@@ -129801,7 +129844,7 @@
 	name = "NT Representative's Office";
 	req_access = list(73)
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/royalblack,
 /area/ntrep)
 "xUb" = (
 /turf/simulated/wall/r_wall/rust,
@@ -130139,6 +130182,7 @@
 "xXP" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
+/obj/item/pen/fancy,
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
 "xXS" = (
@@ -130355,7 +130399,7 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain/bedroom)
 "xZM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -131046,7 +131090,7 @@
 /area/toxins/launch)
 "ygt" = (
 /obj/machinery/vending/boozeomat,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain)
 "ygy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -131286,7 +131330,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "yjn" = (
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -163334,7 +163378,7 @@ cuQ
 cSI
 baF
 bEi
-aIP
+bhx
 rpY
 sgK
 cIX
@@ -164106,7 +164150,7 @@ mLE
 pyj
 qbQ
 qvg
-mLE
+lKX
 skB
 mLE
 dil
@@ -164878,7 +164922,7 @@ bOA
 bOA
 bwf
 cFK
-lKX
+lVo
 byU
 nZz
 cks
@@ -165135,7 +165179,7 @@ coE
 aaq
 bwf
 mMQ
-byL
+srd
 mMQ
 mMQ
 cks
@@ -165392,7 +165436,7 @@ coE
 aaq
 bwf
 bwf
-cHC
+lXs
 cJr
 bwf
 cks
@@ -165649,7 +165693,7 @@ coE
 aaq
 bwf
 rlm
-lKX
+lVo
 byU
 cKT
 cks
@@ -165906,7 +165950,7 @@ coE
 coE
 bwf
 rma
-lKX
+lVo
 byU
 bCr
 cks
@@ -166181,7 +166225,7 @@ bSE
 bSE
 bSE
 qQz
-wCG
+jiz
 ylM
 oKQ
 bSE
@@ -167204,7 +167248,7 @@ bwf
 aaq
 aaq
 bHj
-pHr
+kiG
 ddy
 bSE
 bSE
@@ -167464,7 +167508,7 @@ bHj
 tdn
 pYW
 kiG
-tNB
+pHr
 bSE
 bSE
 bSE
@@ -167718,13 +167762,13 @@ bJh
 bJh
 coE
 bHj
-mOw
+cHC
 nvt
 gQD
 kiG
 cyh
 xbk
-mOw
+cNH
 quv
 bHj
 wMO
@@ -170288,7 +170332,7 @@ bwf
 aaq
 aaq
 bHj
-pHr
+kiG
 aht
 bST
 bST
@@ -170537,7 +170581,7 @@ byU
 tLy
 bwf
 lbE
-xdE
+byL
 lTb
 xdE
 wsN

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -5291,6 +5291,12 @@
 	},
 /turf/space,
 /area/solar/auxstarboard)
+"aMq" = (
+/obj/effect/turf_decal/siding/brown/corner{
+	dir = 4
+	},
+/turf/simulated/floor/wood/fancy/light,
+/area/crew_quarters/courtroom)
 "aMr" = (
 /obj/structure/closet/wardrobe/grey,
 /turf/simulated/floor/shuttle,
@@ -6572,6 +6578,9 @@
 	icon_state = "neutralfull"
 	},
 /area/engine/break_room)
+"aUh" = (
+/turf/simulated/floor/wood/fancy/light,
+/area/ntrep)
 "aUm" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -12119,18 +12128,14 @@
 /area/security/checkpoint)
 "byL" = (
 /obj/item/flag/nt,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+	dir = 4;
+	pixel_x = 26
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkblue"
+	icon_state = "grimy"
 	},
-/area/bridge)
+/area/bridge/meeting_room)
 "byM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -12788,6 +12793,7 @@
 /obj/structure/sign/securearea{
 	pixel_y = 32
 	},
+/obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -13903,6 +13909,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/effect/turf_decal/siding/brown/corner{
+	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
@@ -19671,6 +19680,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
 /turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "cfL" = (
@@ -27142,12 +27154,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/toxins/test_area)
-"cNH" = (
-/obj/machinery/papershredder,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/bridge/meeting_room)
 "cNI" = (
 /turf/simulated/wall,
 /area/medical/reception)
@@ -37183,6 +37189,20 @@
 	icon_state = "white"
 	},
 /area/crew_quarters/kitchen)
+"dCE" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	invisibility = 101
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/primary/central/nw)
 "dCH" = (
 /obj/machinery/light{
 	dir = 1
@@ -37767,6 +37787,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
 /turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "dFm" = (
@@ -47804,6 +47827,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/effect/turf_decal/siding/brown,
 /turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "eYP" = (
@@ -49949,6 +49973,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
 /area/teleporter)
 "fBl" = (
@@ -50912,6 +50937,10 @@
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/port)
+"fNq" = (
+/obj/effect/turf_decal/siding/brown/corner,
+/turf/simulated/floor/wood/fancy/light,
+/area/crew_quarters/courtroom)
 "fNx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -54822,6 +54851,9 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
 /turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "gIq" = (
@@ -54849,6 +54881,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
 /turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "gIA" = (
@@ -59580,6 +59615,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
+"hMR" = (
+/obj/machinery/papershredder,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/bridge/meeting_room)
 "hMY" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -61439,6 +61480,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/siding/brown,
 /turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "ikN" = (
@@ -65425,12 +65467,6 @@
 	icon_state = "caution"
 	},
 /area/maintenance/asmaint4)
-"jiz" = (
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/crew_quarters/heads/hop)
 "jiD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -72212,6 +72248,9 @@
 	id = "conferenceroomwindows";
 	id_tag = "conferenceroombolts"
 	},
+/obj/effect/turf_decal/siding/brown/corner{
+	dir = 4
+	},
 /turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "kRE" = (
@@ -73372,6 +73411,13 @@
 /obj/structure/lattice,
 /turf/simulated/wall/r_wall,
 /area/security/podbay)
+"lij" = (
+/obj/effect/decal/warning_stripes/northwestcorner,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/central/east)
 "lin" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -73864,6 +73910,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
 /turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "loT" = (
@@ -75651,19 +75700,11 @@
 /turf/simulated/wall/r_wall,
 /area/medical/chemistry)
 "lKX" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	invisibility = 101
-	},
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "grimy"
 	},
-/area/hallway/primary/central/nw)
+/area/crew_quarters/heads/hop)
 "lLb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -77001,6 +77042,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
+/obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -93081,6 +93123,7 @@
 	name = "Emergency NanoMed";
 	pixel_y = 32
 	},
+/obj/effect/turf_decal/siding/brown/corner,
 /turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "pFI" = (
@@ -93214,15 +93257,12 @@
 /turf/simulated/floor/plating,
 /area/security/prison/cell_block/A)
 "pHr" = (
-/obj/item/flag/nt,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
-	},
+/obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	dir = 8;
+	icon_state = "neutralcorner"
 	},
-/area/bridge/meeting_room)
+/area/hallway/primary/central/east)
 "pHv" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1
@@ -101842,6 +101882,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/effect/turf_decal/siding/brown,
 /turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "rBz" = (
@@ -104608,6 +104649,7 @@
 	c_tag = "Teleporter";
 	dir = 8
 	},
+/obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plasteel,
 /area/teleporter)
 "sjm" = (
@@ -105023,6 +105065,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/siding/brown,
 /turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "soz" = (
@@ -111576,8 +111619,8 @@
 "tNB" = (
 /obj/item/flag/nt,
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
+	dir = 8;
+	pixel_x = -26
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -112981,6 +113024,9 @@
 	req_access = list(19);
 	id = "conferenceroomwindows";
 	id_tag = "conferenceroombolts"
+	},
+/obj/effect/turf_decal/siding/brown/corner{
+	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
@@ -120212,6 +120258,10 @@
 	pixel_x = 24;
 	pixel_y = -22
 	},
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = 28
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkblue"
@@ -121399,9 +121449,6 @@
 /obj/machinery/camera{
 	c_tag = "Bridge West Hallway";
 	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_x = -30
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -125899,6 +125946,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/brown,
 /turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "xgc" = (
@@ -128944,6 +128992,10 @@
 	},
 /area/security/execution)
 "xLF" = (
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = 28
+	},
 /turf/simulated/floor/wood/fancy/light,
 /area/ntrep)
 "xLG" = (
@@ -131329,6 +131381,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
+	},
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
@@ -164150,7 +164205,7 @@ mLE
 pyj
 qbQ
 qvg
-lKX
+dCE
 skB
 mLE
 dil
@@ -165960,7 +166015,7 @@ xYq
 hRv
 mFi
 xLF
-xLF
+aUh
 boh
 bSE
 tEl
@@ -166225,7 +166280,7 @@ bSE
 bSE
 bSE
 qQz
-jiz
+lKX
 ylM
 oKQ
 bSE
@@ -167508,7 +167563,7 @@ bHj
 tdn
 pYW
 kiG
-pHr
+tNB
 bSE
 bSE
 bSE
@@ -167768,7 +167823,7 @@ gQD
 kiG
 cyh
 xbk
-cNH
+hMR
 quv
 bHj
 wMO
@@ -170078,7 +170133,7 @@ bHj
 tdn
 hCH
 kiG
-tNB
+byL
 bST
 bST
 bST
@@ -170581,7 +170636,7 @@ byU
 tLy
 bwf
 lbE
-byL
+xdE
 lTb
 xdE
 wsN
@@ -173162,10 +173217,10 @@ xxi
 wML
 puJ
 hAu
-wML
+pHr
 dDv
 dDv
-wML
+lij
 deo
 grv
 wML
@@ -175475,11 +175530,11 @@ nzg
 cJT
 rlI
 fLk
-fLk
+fNq
 krh
 hYl
 krh
-fLk
+aMq
 fLk
 fKj
 nou
@@ -175731,13 +175786,13 @@ pOC
 ydS
 gwA
 fLk
-fLk
+fNq
 mqV
 izf
 pIL
 nuE
 nee
-fLk
+aMq
 fLk
 mCg
 ydS


### PR DESCRIPTION
## Описание
В первую очередь исправляет баг с мусорными трубами НТРа и магистрата, из-за неверного расположения которых нарушалась логика трубопровода.

Добавляет в офис ГП ящик для хранения бумаг; принтер, шредер и стильную ручку в переговорную, меняет расположение АЦП в этих же помещениях.
Меняет деревянные полы на мостике с обычных, на модные приятного цвета(дорого и богато, как и положено).
Добавляет немного декалей, и незначительно меняет расположение настенной машинерии, добавляя недостающей.

https://github.com/ss220-space/Paradise/pull/3361