### PR TITLE
bugfix: completed Sirotka's plasmamen operations.

### DIFF
--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -17,6 +17,16 @@
 	/datum/surgery_step/generic/clamp_bleeders, /datum/surgery_step/cavity/make_space,/datum/surgery_step/cavity/place_item,/datum/surgery_step/cavity/close_space,/datum/surgery_step/open_encased/close,/datum/surgery_step/glue_bone, /datum/surgery_step/set_bone,/datum/surgery_step/finish_bone,/datum/surgery_step/generic/cauterize)
 	possible_locs = list("chest","head", "groin")
 
+/datum/surgery/cavity_implant/plasmaman
+	name = "Plasmaman Cavity Implant/Removal"
+	steps = list(/datum/surgery_step/generic/cut_open,/datum/surgery_step/generic/clamp_bleeders, /datum/surgery_step/generic/retract_skin, /datum/surgery_step/open_encased/saw,
+	/datum/surgery_step/open_encased/retract, /datum/surgery_step/cavity/make_space,/datum/surgery_step/cavity/place_item,/datum/surgery_step/cavity/close_space,/datum/surgery_step/open_encased/close,/datum/surgery_step/glue_bone/plasma,/datum/surgery_step/generic/cauterize)
+	possible_locs = list("chest","head")
+
+/datum/surgery/cavity_implant/plasmaman/soft
+	steps = list(/datum/surgery_step/generic/cut_open, /datum/surgery_step/generic/clamp_bleeders, /datum/surgery_step/generic/retract_skin, /datum/surgery_step/generic/cut_open, /datum/surgery_step/cavity/make_space,/datum/surgery_step/cavity/place_item,/datum/surgery_step/cavity/close_space,/datum/surgery_step/generic/cauterize)
+	possible_locs = list("groin")
+
 /datum/surgery/cavity_implant/synth
 	name = "Robotic Cavity Implant/Removal"
 	steps = list(/datum/surgery_step/robotics/external/unscrew_hatch,/datum/surgery_step/robotics/external/open_hatch,/datum/surgery_step/cavity/place_item,/datum/surgery_step/robotics/external/close_hatch)
@@ -25,7 +35,7 @@
 
 /datum/surgery/cavity_implant/can_start(mob/user, mob/living/carbon/human/target)
 	var/mob/living/carbon/human/H = target
-	if(iskidan(H) || iswryn(H))
+	if(iskidan(H) || iswryn(H) || isplasmaman(H))
 		return FALSE
 	if(!istype(target))
 		return FALSE
@@ -47,6 +57,18 @@
 		if(!affected.encased)
 			return FALSE
 		if(iswryn(H) || iskidan(H))
+			return TRUE
+	return FALSE
+
+/datum/surgery/cavity_implant/plasmaman/can_start(mob/user, mob/living/carbon/target)
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		var/obj/item/organ/external/affected = H.get_organ(user.zone_selected)
+		if(!affected)
+			return FALSE
+		if(affected.is_robotic())
+			return FALSE
+		if(isplasmaman(H))
 			return TRUE
 	return FALSE
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет плазмаменам операции по имплантированию предметов, включающие залечивание костей плазмой, вместо стандартного гель-сеттер-гель.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР
СироткаМомент. Забыл (наверное вообще не видел и не проходил на это авоут) заменить плазмачам "Cavity implant" операцию, в которой, по аналогии с "Манипуляцией" и "Залечиванием костей" есть шаг с "Лечением костей". Сейчас выходит так, что кости плазмачей можно лечить и без плазмы на голове/груди, если делать эту операцию.<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
