### PR TITLE
add: Thunderdome update

### DIFF
--- a/code/modules/thunderdome/thunderdome_battle.dm
+++ b/code/modules/thunderdome/thunderdome_battle.dm
@@ -335,6 +335,7 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
 	death = FALSE
 	min_hours = 0
 	allow_tts_pick = FALSE
+	banType = ROLE_THUNDERDOME
 	var/datum/thunderdome_battle/thunderdome
 
 /obj/effect/mob_spawn/human/thunderdome/attack_ghost(mob/dead/observer/user)

--- a/code/modules/thunderdome/thunderdome_battle.dm
+++ b/code/modules/thunderdome/thunderdome_battle.dm
@@ -47,7 +47,7 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
 	var/ranged_arena_radius = RANGED_ARENA_RADIUS
 	var/voting_poll_time = VOTING_POLL_TIME
 	var/role = ROLE_THUNDERDOME
-	var/melee_random_items_count = 1
+	var/melee_random_items_count = 2
 	var/ranged_random_items_count = 2
 	var/mixed_random_items_count = 1
 	var/who_started_last_poll = null //storing ckey of whoever started poll last. Preventing fastest hands of Wild West from polling twice in a row

--- a/code/modules/thunderdome/thunderdome_battle.dm
+++ b/code/modules/thunderdome/thunderdome_battle.dm
@@ -72,7 +72,12 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
 		/obj/item/storage/toolbox/surgery = 1,
 		/obj/item/storage/toolbox/mechanical = 1,
 		/obj/item/storage/toolbox/syndicate = 1,
-		/obj/item/storage/box/syndie_kit/mantisblade = 1
+		/obj/item/storage/box/syndie_kit/mantisblade = 1,
+		/obj/item/CQC_manual = 1,
+		/obj/item/sleeping_carp_scroll = 1,
+		/obj/item/clothing/gloves/color/black/krav_maga/sec = 1,
+		/obj/item/clothing/gloves/fingerless/rapid = 1,
+		/obj/item/storage/box/syndie_kit/mr_chang_technique
 	)
 
 	var/list/ranged_pool = list(
@@ -382,10 +387,7 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
 /datum/outfit/thunderdome/cqc
 	name = "Fighter"
 	backpack_contents = list(
-		/obj/item/CQC_manual = 1,
-		/obj/item/sleeping_carp_scroll = 1,
-		/obj/item/clothing/gloves/color/black/krav_maga/sec = 1,
-		/obj/item/clothing/gloves/fingerless/rapid = 1
+
 	)
 
 /datum/outfit/thunderdome/ranged

--- a/code/modules/thunderdome/thunderdome_battle.dm
+++ b/code/modules/thunderdome/thunderdome_battle.dm
@@ -371,6 +371,8 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
 	var/mob/living/created = ..()
 	thunderdome.fighters += created
 
+	created.mutations |= RUN
+
 	created.AddComponent(/datum/component/thunderdome_death_signaler, thunderdome)
 	created.AddComponent(/datum/component/death_timer_reset, death_time_before)
 

--- a/code/modules/thunderdome/thunderdome_battle.dm
+++ b/code/modules/thunderdome/thunderdome_battle.dm
@@ -376,8 +376,7 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
 
 /datum/outfit/thunderdome
 	implants = list(
-		/obj/item/implant/postponed_death,
-		/obj/item/implant/adrenalin
+		/obj/item/implant/postponed_death
 	)
 	uniform = /obj/item/clothing/under/misc/durathread
 	shoes = /obj/item/clothing/shoes/combat


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Обновление, вводящее следующие изменения для Тандердома
- Тип банов для участия в Тандердоме изменён на роль Тандердома. (раньше было ориентирование на ghost role)
- Гарантированно выдаваемые боевые искусства перемещены в пул случайного вооружения ближнего боя.
- Добавлено Боевое искусство: Техника Маркетинга (Mr.Cheng)
- Удалены адреналы из снаряжения
- Добавлена мутация на отсутствие замедления у участников
- Изменено количество вооружения на ближнебойный режим 1 -> 2
