### PR TITLE
tweak: GPS & PDA Mousedrop

### DIFF
--- a/code/modules/pda/PDA.dm
+++ b/code/modules/pda/PDA.dm
@@ -106,18 +106,13 @@ GLOBAL_LIST_EMPTY(PDAs)
 
 /obj/item/pda/MouseDrop(atom/over)
 	. = ..()
-	if(!.)
-		return FALSE
 
 	var/mob/user = usr
-	if(user.incapacitated() || !ishuman(user))
+	if(!ishuman(user) || !Adjacent(user) || user.incapacitated())
 		return FALSE
 
-	if(over == user)
-		attack_self(user)
-		return TRUE
-
-	return FALSE
+	attack_self(user)
+	return TRUE
 
 
 /obj/item/pda/attack_self(mob/user as mob)

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -122,21 +122,13 @@ GLOBAL_LIST_EMPTY(GPS_list)
 
 /obj/item/gps/MouseDrop(atom/over)
 	. = ..()
-	if(!.)
-		return FALSE
 
 	var/mob/user = usr
-	if(istype(over, /obj/screen))
+	if(!ishuman(user) || !Adjacent(user) || user.incapacitated())
 		return FALSE
 
-	if(user.incapacitated() || !ishuman(user))
-		return FALSE
-
-	if(over == user)
-		attack_self(user)
-		return TRUE
-
-	return FALSE
+	attack_self(user)
+	return TRUE
 
 
 /obj/item/gps/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.inventory_state)


### PR DESCRIPTION
## Описание
Вернул возможность открывать GPS и PDA, при перетаскивании на что угодно. 