### PR TITLE
Bugfix: remove missclicked windows spawner  

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -23896,12 +23896,6 @@
 	icon_state = "grimy"
 	},
 /area/crew_quarters/heads/hop)
-"czU" = (
-/obj/effect/spawner/window/reinforced/polarized{
-	id = "conferenceroomwindows"
-	},
-/turf/simulated/wall,
-/area/crew_quarters/locker)
 "czV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -179904,7 +179898,7 @@ cnP
 cnP
 cnP
 cnP
-czU
+cnP
 cnP
 cnP
 cnP


### PR DESCRIPTION
## Описание
Удаляет спавнер окна в стене кабинки дорм на Дельте.

##Причина создания ПР
Миссклик 
![image](https://github.com/ss220-space/Paradise/assets/110329212/470db12d-7827-4d59-97c3-98dedaafaa7c)

