### PR TITLE
bugfix: user sight updating while modifying glasses prescription.

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -17,6 +17,8 @@
 			to_chat(H, "You fit \the [name] with lenses from \the [O].")
 			prescription = 1
 			name = "prescription [name]"
+			if(H.glasses == src)
+				H.update_nearsighted_effects()
 			return
 		if(prescription && istype(O, /obj/item/screwdriver))
 			var/obj/item/clothing/glasses/regular/G = locate() in src
@@ -26,6 +28,8 @@
 			prescription = 0
 			name = initial(name)
 			H.put_in_hands(G)
+			if(H.glasses == src)
+				H.update_nearsighted_effects()
 			return
 	return ..()
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет проки обновления краткозорости при вставлянии и вытягивании медицинских линз в очки и из очков, пока они одеты на карбоне.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР
Очки после модификации линзами нужно снимать с себя и одевать, чтобы персонаж с краткозоростью начал нормально видеть, теперь поправлено.<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
