### PR TITLE
bugfix: Terror Spiders Fixes

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/empress.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/empress.dm
@@ -20,7 +20,7 @@
 	ai_playercontrol_allowtype = 0
 	canlay = 1000
 	spider_tier = TS_TIER_5
-	projectiletype = /obj/item/projectile/terrorqueenspit/empress
+	projectiletype = /obj/item/projectile/terrorspider/empress
 	icon = 'icons/mob/terrorspider64.dmi'
 	pixel_x = -16
 	move_resist = MOVE_FORCE_STRONG // no more pushing a several hundred if not thousand pound spider
@@ -30,7 +30,6 @@
 	icon_dead = "terror_empress_dead"
 	var/datum/action/innate/terrorspider/queen/empress/empresslings/empresslings_action
 	var/datum/action/innate/terrorspider/queen/empress/empresserase/empresserase_action
-	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	tts_seed = "Queen"
 
 /mob/living/simple_animal/hostile/poison/terror_spider/queen/empress/New()
@@ -108,6 +107,9 @@
 		qdel(T)
 	to_chat(src, "<span class='userdanger'>All Terror Spiders, except yourself, will die off shortly.</span>")
 
-/obj/item/projectile/terrorqueenspit/empress
-	damage = 90
 
+/obj/item/projectile/terrorspider/empress
+	name = "empress venom"
+	icon_state = "toxin5"
+	damage = 90
+	damage_type = BRUTE

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -43,12 +43,12 @@ GLOBAL_LIST_EMPTY(ts_spiderling_list)
 	//HEALTH
 	maxHealth = 120
 	health = 120
-	unsuitable_atmos_damage = 0
 	a_intent = INTENT_HARM
 	var/regeneration = 2 //pure regen on life
 	var/degenerate = FALSE // if TRUE, they slowly degen until they all die off.
 	//also regenerates by using /datum/status_effect/terror/food_regen when wraps a carbon, wich grants full health witin ~25 seconds
 	damage_coeff = list(BRUTE = 0.75, BURN = 1.25, TOX = 1, CLONE = 0, STAMINA = 0, OXY = 0.2)
+	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 
 	//ATTACK
 	melee_damage_lower = 15

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/widow.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/widow.dm
@@ -60,7 +60,7 @@
 	name = "sinister web"
 	desc = "This web has beads of a dark fluid on its strands."
 
-/obj/structure/spider/terrorweb/black/web_special_ability(mob/living/carbon/C)
+/obj/structure/spider/terrorweb/widow/web_special_ability(mob/living/carbon/C)
 	if(istype(C))
 		if(!C.reagents.has_reagent("terror_black_toxin", 60))
 			var/inject_target = pick("chest","head")


### PR DESCRIPTION
## Описание
Исправление нескольких багов у терроров:
- Нелли поставил переменную урона от атмоса равной нулю, в итоге пауки не получают урона от газов вообще, но алёрты, например о недостатке кислорода, всё равно всплывают, чего нам не нужно
- путь у специального эффекта паутины вдовы переименован на корректный
- исправлена дальнобойная атака императрицы, чтобы она не стреляла пулями