### PR TITLE
del/bugfix: Admin-spawn key for steal target

### DIFF
--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -761,7 +761,6 @@ GLOBAL_LIST_INIT(ungibbable_items_types, get_ungibbable_items_types())
 		/obj/item/encryptionkey/headset_iaa,
 		/obj/item/encryptionkey/headset_medsec,
 		/obj/item/encryptionkey/headset_eng,
-		/obj/item/encryptionkey/headset_rob,
 		/obj/item/encryptionkey/headset_med,
 		/obj/item/encryptionkey/headset_sci,
 		/obj/item/encryptionkey/headset_medsci,


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Удаляет ключ `/obj/item/encryptionkey/headset_rob` из цели вора.

## Ссылка на предложение/Причина создания ПР
Ключ роботехов можно достать только через админов и админскую зону.
Этот ключ делает задачу антагу невыполнимой, в некоторых ситуациях.