### PR TITLE
add: magboots cyborg upgrade

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1689,7 +1689,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 6
 	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 
-/datum/uplink_item/device_tools/vtec
+/datum/uplink_item/device_tools/cyborg_magboots
 	name = "Syndicate Cyborg Upgrade Module (F-Magnet)"
 	desc = "Позволяет киборгу частично примагничиваться к корпусу, что позволяет игнорировать некоторые условия отсутсвия гравитации."
 	reference = "FMAG"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1689,6 +1689,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 6
 	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 
+/datum/uplink_item/device_tools/vtec
+	name = "Syndicate Cyborg Upgrade Module (F-Magnet)"
+	desc = "Позволяет киборгу частично примагничиваться к корпусу, что позволяет игнорировать некоторые условия отсутсвия гравитации."
+	reference = "FMAG"
+	item = /obj/item/borg/upgrade/magboots
+	cost = 4
+	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
+
 /datum/uplink_item/device_tools/autoimplanter
 	name = "Syndicate Autoimplanter"
 	desc = "Cheaper version of nuclear operatives autoimplanter, this model allows you to install three cybernetic implants on the field."

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -153,6 +153,29 @@
 	return TRUE
 
 
+/obj/item/borg/upgrade/magboots
+	name = "cyborg floor magnet module"
+	desc = "Данный модуль позволить киборгу примагничиваться к полу, таким образом позволяя эффективно передвигаться в условиях отсутсвия гравитации."
+	icon_state = "cyborg_upgrade3"
+	origin_tech = "engineering=4;materials=4powerstorage=4"
+
+/obj/item/borg/upgrade/magboots/action(mob/living/silicon/robot/robot, mob/user)
+	if(!..())
+		return FALSE
+
+	if(robot.magpulse)
+		return FALSE
+
+	robot.magpulse = 1
+	return TRUE
+
+/obj/item/borg/upgrade/magboots/deactivate(mob/living/silicon/robot/robot, mob/user)
+	if(!..())
+		return FALSE
+
+	robot.magpulse = initial(robot.magpulse)
+	return TRUE
+
 /obj/item/borg/upgrade/disablercooler
 	name = "cyborg rapid disabler cooling module"
 	desc = "Used to cool a mounted disabler, increasing the potential current in it and thus its recharge rate."

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -166,7 +166,7 @@
 	if(robot.magpulse)
 		return FALSE
 
-	robot.magpulse = 1
+	robot.magpulse = TRUE
 	return TRUE
 
 /obj/item/borg/upgrade/magboots/deactivate(mob/living/silicon/robot/robot, mob/user)

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1326,6 +1326,16 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
+/datum/design/borg_magboots
+	name = "Cyborg Common Upgrade (F-Magnet)"
+	id = "borg_update_magboots"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/magboots
+	req_tech = list("engineering" = 5, "materials" = 5, "powerstorage" = 5)
+	materials = list(MAT_METAL=5000, MAT_SILVER=3000, MAT_GOLD=4000)
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
+
 /datum/design/borg_upgrade_thrusters
 	name = "Cyborg Common Upgrade (Ion Thrusters)"
 	id = "borg_upgrade_thrusters"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет модуль для боргов, что позволяет им получить "магбутцы" (т.е. передвигаться в условиях невесомости).
Разве что по ТЗ не совсем ясно, должна ли быть это активная способка, должно ли жрать энергию и т.д., так что пока без этого. Если что, можно изменить.

Модуль будет доступен в аплинке нюкеров за 4 ТК и в мехфабе, со следующими требованиями:
Пятые инженерные, электромагнитные и материальные технологии, 5к железа, 4к серебра и 3к золота.
Изначальный исполнитель не я, но изначальный принял некрономикон и занят, так что да.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Предложка: https://discord.com/channels/617003227182792704/755125334097133628/1146460840678138069
Поиск-разрабов: https://discord.com/channels/617003227182792704/1146791044621537304
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->