### PR TITLE
bugfix: you can't eat grab now

### DIFF
--- a/code/datums/spell_targeting/matter_eater_targeting.dm
+++ b/code/datums/spell_targeting/matter_eater_targeting.dm
@@ -33,6 +33,8 @@
 		if((O in user) && is_type_in_list(O, own_blacklist))
 			continue
 		if(is_type_in_list(O, types_allowed))
+			if(O.flags & ABSTRACT)
+				continue
 			if(isanimal(O))
 				var/mob/living/simple_animal/SA = O
 				if(!SA.gold_core_spawnable)

--- a/code/game/dna/genes/goon_powers.dm
+++ b/code/game/dna/genes/goon_powers.dm
@@ -304,6 +304,10 @@
 			limb.droplimb(0, DROPLIMB_SHARP)
 			doHeal(user)
 	else
+		if(the_item.flags & ABSTRACT)
+			to_chat(usr, "Вы не можете съесть это!")
+			revert_cast()
+			return FALSE
 		user.visible_message("<span class='danger'>[user] eats \the [the_item].</span>")
 		playsound(user.loc, 'sound/items/eatfood.ogg', 50, 0)
 		qdel(the_item)

--- a/code/game/dna/genes/goon_powers.dm
+++ b/code/game/dna/genes/goon_powers.dm
@@ -304,10 +304,6 @@
 			limb.droplimb(0, DROPLIMB_SHARP)
 			doHeal(user)
 	else
-		if(the_item.flags & ABSTRACT)
-			to_chat(usr, "Вы не можете съесть это!")
-			revert_cast()
-			return FALSE
 		user.visible_message("<span class='danger'>[user] eats \the [the_item].</span>")
 		playsound(user.loc, 'sound/items/eatfood.ogg', 50, 0)
 		qdel(the_item)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Исправляет баг, когда с помощью гена Eat можно было жрать граб и подобные абстрактные предметы.

Да, было бы лучше переработать это так, что бы не было возможности даже увидеть их в списке, но это потребует перерабатывать всю систему выбора целей у этих генов, так что эм да. Возможно, позже.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багфикс, https://discord.com/channels/617003227182792704/1147488366707879976
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->