### PR TITLE
BUGFIX Plastic Dupe through the Curtain Disassembly

### DIFF
--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -75,7 +75,7 @@
 
 /obj/structure/curtain/deconstruct(disassembled = TRUE)
 	new /obj/item/stack/sheet/cloth(loc, 2)
-	new /obj/item/stack/sheet/plastic(loc, 2)
+	new /obj/item/stack/sheet/plastic(loc, 1)
 	new /obj/item/stack/rods(loc, 1)
 	qdel(src)
 


### PR DESCRIPTION
You can dupe infinite amount of plastic because it takes 1 plastic sheet to build the curtain and two to remove one. This update will fix that.



## Описание

1. После разбора пластиковой шторки получается больше пластика, чем нужно
2. Создать пластиковую шторку - разобрать - понять, что дало на 2 пластика больше = бесконечный пластик.


## Ссылка на предложение/Причина создания ПР
Багфикс. Теперь нельзя дюпать пластик создавая бесконечное количество штор. 

