### PR TITLE
bugfix: View Range Fixes

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -799,6 +799,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		to_chat(usr, "[t] [ADMIN_VV(t,"VV")] ")
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Check Contents") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+
 /client/proc/toggle_view_range()
 	set category = "Admin"
 	set name = "Change View Range"
@@ -807,15 +808,26 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!check_rights(R_ADMIN))
 		return
 
-	if(view == world.view)
-		view = input("Select view range:", "View Range", world.view) in list(1,2,3,4,5,6,7,8,9,10,11,12,13,14,128)
+	var/client_view = prefs.viewrange
+	if(view == client_view)
+		var/input = input("Select view range:", "View Range", 7) in list(1,2,3,4,5,6,7,8,9,10,11,12,13,14,128)
+		if(!input)
+			return
+
+		var/list/viewscales = getviewsize(client_view)
+		var/aspect_ratio = viewscales[1] / viewscales[2]
+		var/view_y = (input * 2) % 2 ? input * 2 : input * 2 + 1
+		var/rounded_x = round(view_y * aspect_ratio)
+		var/view_x = rounded_x % 2 ? rounded_x : rounded_x + 1
+		view = "[view_x]x[view_y]"
 	else
-		view = world.view
+		view = client_view
+
+	fit_viewport()
 
 	log_admin("[key_name(usr)] changed their view range to [view].")
-	//message_admins("<span class='notice'>[key_name_admin(usr)] changed their view range to [view].</span>", 1)	//why? removed by order of XSI
-
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Change View Range") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
 
 /client/proc/admin_call_shuttle()
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -809,17 +809,21 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		return
 
 	var/client_view = prefs.viewrange
+
 	if(view == client_view)
-		var/input = input("Select view range:", "View Range", 7) in list(1,2,3,4,5,6,7,8,9,10,11,12,13,14,128)
+		var/input = input("Select view range:", "View Range", 7) in list(1,2,3,4,5,6,7,8,9,10,11,12,13,14,"MAX")
 		if(!input)
 			return
 
+		input = input == "MAX" ? 28 : input
 		var/list/viewscales = getviewsize(client_view)
 		var/aspect_ratio = viewscales[1] / viewscales[2]
-		var/view_y = (input * 2) % 2 ? input * 2 : input * 2 + 1
+
+		var/view_y =  (input * 2) % 2 ? input * 2 : input * 2 + 1
 		var/rounded_x = round(view_y * aspect_ratio)
 		var/view_x = rounded_x % 2 ? rounded_x : rounded_x + 1
 		view = "[view_x]x[view_y]"
+
 	else
 		view = client_view
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -815,13 +815,23 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		if(!input)
 			return
 
-		input = input == "MAX" ? 28 : input
 		var/list/viewscales = getviewsize(client_view)
 		var/aspect_ratio = viewscales[1] / viewscales[2]
 
-		var/view_y =  (input * 2) % 2 ? input * 2 : input * 2 + 1
-		var/rounded_x = round(view_y * aspect_ratio)
-		var/view_x = rounded_x % 2 ? rounded_x : rounded_x + 1
+		var/view_x
+		var/view_y
+		if(input == "MAX")
+			if(viewscales[1] == viewscales[2])
+				view_x = 71	// 71 is max for X
+				view_y = 67	// 67 is max for Y
+			else
+				view_x = 71
+				view_y = round(71 / aspect_ratio)
+		else
+			view_y = (input * 2) % 2 ? input * 2 : input * 2 + 1
+			var/rounded_x = round(view_y * aspect_ratio)
+			view_x = rounded_x % 2 ? rounded_x : rounded_x + 1
+
 		view = "[view_x]x[view_y]"
 
 	else

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -2251,6 +2251,7 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 
 					if(actual_new_range != parent.view)
 						parent.view = actual_new_range
+						parent.fit_viewport()
 						// Update the size of the click catcher
 						var/list/actualview = getviewsize(parent.view)
 						parent.void.UpdateGreed(actualview[1],actualview[2])


### PR DESCRIPTION
## Описание
- теперь после смены разрешения окно автоматически подстраивается под новое
- исправлена работа админской кнопки Change View Range

Максимальный размер экрана не может превышать 71x67 турф, поэтому в случае выставления максимального размера обзора, будет резаться максимальная высота, для того чтобы избежать чёрных полос по бокам экрана.