### PR TITLE
fix: dragon

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -149,10 +149,9 @@
 /mob/living/simple_animal/hostile/carp/megacarp/Initialize()
 	. = ..()
 	name = "[pick(GLOB.megacarp_first_names)] [pick(GLOB.megacarp_last_names)]"
-	melee_damage_lower += rand(2, 10)
+	melee_damage_lower += rand(5, 10)
 	melee_damage_upper += rand(10, 20)
-	maxHealth += rand(30, 60)
-	move_to_delay = rand(3, 7)
+	maxHealth += rand(60, 90)
 
 /mob/living/simple_animal/hostile/carp/megacarp/adjustHealth(amount, updating_health = TRUE)
 	. = ..()
@@ -191,6 +190,9 @@
 	harm_intent_damage = 1
 	melee_damage_lower = 2
 	melee_damage_upper = 2
+	obj_damage = 5
+	maxHealth = 25
+	health = 25
 	speak_emote = list("blurps")
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/salmonmeat = 1)
 

--- a/code/modules/space_dragon/carp.dm
+++ b/code/modules/space_dragon/carp.dm
@@ -2,8 +2,8 @@
 	a_intent = INTENT_HARM
 	see_in_dark = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
-	health = 60
-	maxHealth = 60
+	health = 65
+	maxHealth = 65
 	/// Ability which lets carp teleport around
 	var/datum/action/innate/lesser_carp_rift/teleport
 

--- a/code/modules/space_dragon/carp_rift.dm
+++ b/code/modules/space_dragon/carp_rift.dm
@@ -159,7 +159,7 @@
 
 	// Can we increase the carp spawn pool size?
 	if(last_carp_inc >= carp_interval)
-		carp_stored++
+		carp_stored += 3
 		icon_state = "carp_rift_carpspawn"
 		if(light_color != LIGHT_COLOR_PURPLE)
 			light_color = LIGHT_COLOR_PURPLE
@@ -186,7 +186,7 @@
 			dragon.riftTimer = 0
 			dragon.rift_empower()
 		for(var/obj/structure/carp_rift/rift in dragon.rift_list)
-			rift.carp_stored +=15
+			rift.carp_stored += 15
 		// Early return, nothing to do after this point.
 		return
 

--- a/code/modules/space_dragon/carp_rift.dm
+++ b/code/modules/space_dragon/carp_rift.dm
@@ -210,12 +210,12 @@
 	if(carp_stored <= 0)//Not enough carp points
 		return FALSE
 	var/is_listed = FALSE
-	if (user.ckey in ckey_list)
+	if(user.ckey in ckey_list)
 		if(carp_stored == 2)
 			to_chat(user, span_warning("Вы уже появлялись карпом из этого разлома дважды! Пожалуйста, ожидайте избытка карпов или следующего разлома!"))
 			return FALSE
 		is_listed = TRUE
-	var/carp_ask = alert(user, "Стать карпом? количество смертей: [carp_stored]", "Разлом карпов", "Да", "Нет")
+	var/carp_ask = alert(user, "Стать карпом?", "Разлом карпов", "Да", "Нет")
 	if(carp_ask != "Да" || QDELETED(src) || QDELETED(user))
 		return FALSE
 	if(carp_stored <= 0)

--- a/code/modules/space_dragon/mob.dm
+++ b/code/modules/space_dragon/mob.dm
@@ -52,7 +52,7 @@
 	turns_per_move = 5
 	ranged = TRUE
 	mouse_opacity = MOUSE_OPACITY_ICON
-	butcher_results = list(/obj/item/stack/ore/diamond = 5, /obj/item/stack/sheet/sinew = 5, /obj/item/stack/sheet/bone = 30, /obj/item/reagent_containers/food/snacks/carpmeat = 15)
+	butcher_results = list(/obj/item/stack/ore/diamond = 5, /obj/item/stack/sheet/animalhide/ashdrake = 10, /obj/item/stack/sheet/sinew = 5, /obj/item/stack/sheet/bone = 30, /obj/item/reagent_containers/food/snacks/carpmeat = 15)
 	deathmessage = "визжит, крылья превращаются в пыль, а в глазах угасает жизнь, после чего дракон падает замертво."
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0


### PR DESCRIPTION
пофиксил слишком жирных и слишком дамажных коев, пропорционально ужирнил слишком тощих акул, вернул карпам +5 хп ибо у них дублирующийся код, который выставлял им 60 хп. Пофиксил надписи, дал пожирнее награду за победу над дракошей

<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Ссылка на предложение/Причина создания ПР
Мы фиксики мы фиксики такова наша работа

кои что грызут мехи как бумагу не есть норма
акулы что всего в полтора раза жирнее карпов не есть норма. До ввода драконов разница была в 2-3 раза.

Ну и награда за дракона не содержит шкуру дракона, кринге

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
