### PR TITLE
bugfix: Not working cameras on Lavaland Outposts

### DIFF
--- a/_maps/map_files/Delta/Lavaland.dmm
+++ b/_maps/map_files/Delta/Lavaland.dmm
@@ -2416,7 +2416,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Mining Bar";
-	network = list("Mining    Outpost")
+	network = list("Mining Outpost")
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -3023,7 +3023,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Mining Hall South";
-	network = list("Mining    Outpost")
+	network = list("Mining Outpost")
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -3773,7 +3773,7 @@
 /obj/machinery/camera{
 	c_tag = "Mining Toilets";
 	dir = 6;
-	network = list("Mining    Outpost")
+	network = list("Mining Outpost")
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -3827,7 +3827,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Mining Medpoint";
-	network = list("Mining    Outpost")
+	network = list("Mining Outpost")
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -4277,7 +4277,7 @@
 /obj/machinery/camera{
 	c_tag = "Mining Storage";
 	dir = 8;
-	network = list("Mining    Outpost")
+	network = list("Mining Outpost")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -4467,7 +4467,7 @@
 /obj/machinery/camera{
 	c_tag = "Mining East Hallway";
 	dir = 4;
-	network = list("Mining    Outpost")
+	network = list("Mining Outpost")
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -5248,7 +5248,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Mining Airlock";
-	network = list("Mining    Outpost")
+	network = list("Mining Outpost")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -5955,7 +5955,7 @@
 /obj/machinery/camera{
 	c_tag = "Mining EVA";
 	dir = 6;
-	network = list("Mining    Outpost")
+	network = list("Mining Outpost")
 	},
 /obj/structure/sign/poster/random{
 	pixel_y = 32
@@ -6184,7 +6184,7 @@
 /obj/machinery/camera{
 	c_tag = "Mining West Hallway";
 	dir = 8;
-	network = list("Mining    Outpost")
+	network = list("Mining Outpost")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -6351,7 +6351,7 @@
 /obj/machinery/camera{
 	c_tag = "Mining Coin Press";
 	dir = 1;
-	network = list("Mining    Outpost")
+	network = list("Mining Outpost")
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -6749,7 +6749,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Mining Smeltery";
-	network = list("Mining    Outpost")
+	network = list("Mining Outpost")
 	},
 /obj/machinery/conveyor{
 	dir = 8;
@@ -6761,7 +6761,7 @@
 /obj/machinery/camera{
 	c_tag = "Mining Hall North-West";
 	dir = 1;
-	network = list("Mining    Outpost")
+	network = list("Mining Outpost")
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "brown"
@@ -6810,7 +6810,7 @@
 /obj/machinery/tcomms/relay/mining,
 /obj/machinery/camera{
 	c_tag = "Mining Communications Relay";
-	network = list("Mining    Outpost")
+	network = list("Mining Outpost")
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/mine/maintenance)
@@ -6901,7 +6901,7 @@
 /obj/machinery/camera{
 	c_tag = "Mining Visitor Area";
 	dir = 8;
-	network = list("Mining    Outpost")
+	network = list("Mining Outpost")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -7045,7 +7045,7 @@
 /obj/machinery/camera{
 	c_tag = "Mining Hall North-East";
 	dir = 10;
-	network = list("Mining    Outpost")
+	network = list("Mining Outpost")
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "brown"

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
@@ -38,7 +38,7 @@
 /area/ruin/unpowered/misc_lavaruin)
 "C" = (
 /obj/machinery/computer/security/wooden_tv{
-	network = list("SS13","Research  Outpost","Mining  Outpost")
+	network = list("SS13","Research  Outpost","Mining Outpost")
 	},
 /turf/simulated/floor/wood/cold,
 /area/ruin/unpowered/misc_lavaruin)

--- a/_maps/map_files/generic/CentComm.dmm
+++ b/_maps/map_files/generic/CentComm.dmm
@@ -7126,7 +7126,7 @@
 	pixel_x = -32
 	},
 /obj/machinery/computer/security{
-	network = list("SS13","Research  Outpost","Mining  Outpost","Telecomms")
+	network = list("SS13","Research  Outpost","Mining Outpost","Telecomms")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -13759,7 +13759,7 @@
 /area/shuttle/pod_3)
 "hgG" = (
 /obj/machinery/computer/security{
-	network = list("SS13","Telecomms","Research  Outpost","Mining  Outpost","ERT","CentComm","Thunderdome")
+	network = list("SS13","Telecomms","Research  Outpost","Mining Outpost","ERT","CentComm","Thunderdome")
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -17275,7 +17275,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the Special Ops team.";
 	name = "Security Station Monitor";
-	network = list("SS13","Research  Outpost","Mining  Outpost");
+	network = list("SS13","Research  Outpost","Mining Outpost");
 	pixel_y = -30
 	},
 /turf/simulated/floor/shuttle{
@@ -23677,7 +23677,7 @@
 /area/wizard_station)
 "mmX" = (
 /obj/machinery/computer/security/wooden_tv{
-	network = list("SS13","Research  Outpost","Mining  Outpost")
+	network = list("SS13","Research  Outpost","Mining Outpost")
 	},
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/jail)

--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -649,7 +649,7 @@
 /obj/machinery/camera{
 	c_tag = "EVA";
 	dir = 4;
-	network = list("Mining    Outpost")
+	network = list("Mining Outpost")
 	},
 /obj/machinery/alarm{
 	dir = 4;
@@ -1110,7 +1110,7 @@
 /obj/machinery/camera{
 	c_tag = "Shuttle Docking Foyer North";
 	dir = 8;
-	network = list("Mining    Outpost")
+	network = list("Mining Outpost")
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/production)
@@ -1541,7 +1541,7 @@
 /obj/machinery/camera{
 	c_tag = "Shuttle Docking Foyer South";
 	dir = 8;
-	network = list("Mining    Outpost")
+	network = list("Mining Outpost")
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/production)
@@ -1576,7 +1576,7 @@
 /obj/machinery/camera{
 	c_tag = "Communications Relay";
 	dir = 8;
-	network = list("Mining    Outpost")
+	network = list("Mining Outpost")
 	},
 /turf/simulated/floor/bluegrid,
 /area/mine/maintenance)
@@ -1584,7 +1584,7 @@
 /obj/machinery/camera{
 	c_tag = "Processing Area Room";
 	dir = 8;
-	network = list("Mining    Outpost")
+	network = list("Mining Outpost")
 	},
 /obj/item/radio/intercom{
 	dir = 8;
@@ -1602,7 +1602,7 @@
 /obj/machinery/camera{
 	c_tag = "Sleeper Room";
 	dir = 1;
-	network = list("Mining    Outpost")
+	network = list("Mining Outpost")
 	},
 /obj/item/reagent_containers/iv_bag/bloodsynthetic/oxygenis,
 /obj/item/reagent_containers/iv_bag/bloodsynthetic/oxygenis,
@@ -1818,7 +1818,7 @@
 "ec" = (
 /obj/machinery/camera{
 	c_tag = "Crew Area Hallway East";
-	network = list("Mining    Outpost")
+	network = list("Mining Outpost")
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -1828,7 +1828,7 @@
 "ed" = (
 /obj/machinery/camera{
 	c_tag = "Crew Area Hallway West";
-	network = list("Mining    Outpost")
+	network = list("Mining Outpost")
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
@@ -2457,7 +2457,7 @@
 "fv" = (
 /obj/machinery/camera{
 	c_tag = "Storage";
-	network = list("Mining    Outpost")
+	network = list("Mining Outpost")
 	},
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2573,7 +2573,7 @@
 /obj/machinery/camera{
 	c_tag = "Dormitories";
 	dir = 4;
-	network = list("Mining    Outpost")
+	network = list("Mining Outpost")
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -2828,7 +2828,7 @@
 /obj/machinery/camera{
 	c_tag = "Crew Area";
 	dir = 1;
-	network = list("Mining    Outpost")
+	network = list("Mining Outpost")
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -32


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление ошибки, при которой камеры лаваленда не отображались в консоли видеонаблюдения. Также исправляет некоторые кастомные консоли на картах, чтобы они могли видеть камеры аванпоста.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Пробелы в названиях сетей.
## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
![изображение](https://github.com/ss220-space/Paradise/assets/73733747/3c239eaf-6503-4f60-b7b3-4fd97e21a6b0)
