### PR TITLE
FIX: Megafauna bug blink

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -172,6 +172,8 @@ Difficulty: Hard
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/charge(atom/chargeat = target, delay = 5, chargepast = 2)
 	if(!chargeat)
 		return
+	if(target.z != z)
+		return
 	var/chargeturf = get_turf(chargeat)
 	if(!chargeturf)
 		return
@@ -368,6 +370,8 @@ Difficulty: Hard
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/hallucination_charge_around(times = 4, delay = 9, chargepast = 0, useoriginal = 1, radius)
 	var/startingangle = rand(1, 360)
 	if(!target)
+		return
+	if(target.z != z)
 		return
 	var/turf/chargeat = get_turf(target)
 	var/srcplaced = FALSE

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -316,6 +316,8 @@ Difficulty: Hard
 /mob/living/simple_animal/hostile/megafauna/hierophant/proc/blink(mob/victim) //blink to a target
 	if(blinking || !victim)
 		return
+	if(victim.z != z)
+		return
 	var/turf/T = get_turf(victim)
 	var/turf/source = get_turf(src)
 	new /obj/effect/temp_visual/hierophant/telegraph(T, src)


### PR DESCRIPTION


<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Не позволяет бубле и Иерофанту телепортироваться к цели, если та в другом Z уровне. Фиксит телепорты бубли/иеро на станцию, вызванные применением фултона, не емагнутого джаунтера, шаттла аванпоста и прочим способам телепортации себя, но не мегафауны.

## Ссылка на предложение/Причина создания ПР
давно пора пофиксить причину бана многих шахтеров. Теперь телепорт фауны будет возможен только если это требуется, а не случайно, проебав тайминги.

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
