### PR TITLE
bugfix: add other immune flags, alien move delay after stunbaton, absorb_status_effect

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -13,6 +13,7 @@
 #define STUN		"stun"
 #define WEAKEN		"weaken"
 #define PARALYZE	"paralize"
+#define IMMOBILIZE	"immobilize"
 #define IRRADIATE	"irradiate"
 #define STUTTER		"stutter"
 #define SLUR		"slur"

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -34,11 +34,9 @@
 #define CANPARALYSE	4
 #define CANPUSH		8
 #define PASSEMOTES	16      //Mob has a cortical borer or holders inside of it that need to see emotes.
-#define GOTTAGOFAST	32
-#define IGNORESLOWDOWN	128
-#define IGNORE_SPEED_CHANGES	256
-#define GOTTAGONOTSOFAST 512 //This is used for nukacola, mormal meth is a "1" speed up, nuka is 0.5 and they don't stack, feel free to use this one somewhere else
-#define GODMODE		4096
+#define IGNORESLOWDOWN	32
+#define IGNORE_SPEED_CHANGES	64
+#define GODMODE		128
 
 //Health Defines
 #define HEALTH_THRESHOLD_CRIT 0

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -66,7 +66,8 @@
 			H.dna.species.clone_mod *= 0.1
 			H.dna.species.stamina_mod *= 0.1
 		add_attack_logs(owner, owner, "gained blood-drunk stun immunity", ATKLOG_ALL)
-		owner.add_stun_absorption("blooddrunk", INFINITY, 4)
+		owner.add_status_effect_absorption("blooddrunk_weaken", INFINITY, 4, status_effect = WEAKEN)
+		owner.add_status_effect_absorption("blooddrunk_stun", INFINITY, 4, status_effect = STUN)
 		owner.playsound_local(get_turf(owner), 'sound/effects/singlebeat.ogg', 40, TRUE, use_reverb = FALSE)
 
 /datum/status_effect/blooddrunk/on_remove()
@@ -82,9 +83,11 @@
 		H.dna.species.stamina_mod *= 10
 	add_attack_logs(owner, owner, "lost blood-drunk stun immunity", ATKLOG_ALL)
 	owner.status_flags &= ~IGNORESLOWDOWN
-	if(islist(owner.stun_absorption) && owner.stun_absorption["blooddrunk"])
-		owner.stun_absorption -= "blooddrunk"
-
+	if(islist(owner.status_effect_absorption))
+		if(owner.status_effect_absorption["blooddrunk_stun"])
+			owner.status_effect_absorption -= "blooddrunk_stun"
+		if(owner.status_effect_absorption["blooddrunk_weaken"])
+			owner.status_effect_absorption -= "blooddrunk_weaken"
 /datum/status_effect/exercised
 	id = "Exercised"
 	duration = 1200

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -230,7 +230,7 @@
 	if(!.)
 		return
 	var/dir = sin(world.time)
-	var/amplitude = min(strength * 0.02, 32)
+	var/amplitude = min(strength * 0.003, 32)
 	px_diff = cos(world.time * 3) * amplitude * dir
 	py_diff = sin(world.time * 3) * amplitude * dir
 	owner.client?.pixel_x = px_diff

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -169,9 +169,9 @@
 	stat(null, "Move Mode: [m_intent]")
 	show_stat_emergency_shuttle_eta()
 
-/mob/living/carbon/alien/SetStunned(amount, updating = 1, force = 0)
+/mob/living/carbon/alien/SetWeakened(amount, ignore_canweaken)
 	..()
-	if(!(status_flags & CANSTUN) && amount)
+	if(!(status_flags & CANWEAKEN) && amount)
 		// add some movement delay
 		move_delay_add = min(move_delay_add + round(amount / 2), 10) // a maximum delay of 10
 

--- a/code/modules/mob/living/carbon/status_procs.dm
+++ b/code/modules/mob/living/carbon/status_procs.dm
@@ -4,7 +4,7 @@
 /mob/living/carbon/proc/enter_stamcrit()
 	if(!(status_flags & CANWEAKEN))
 		return
-	if(absorb_stun(0)) //continuous effect, so we don't want it to increment the stuns absorbed.
+	if(absorb_status_effect(0, status_effect = WEAKEN)) //continuous effect, so we don't want it to increment the stuns absorbed.
 		return
 	if(!IsWeakened())
 		to_chat(src, "<span class='notice'>You're too exhausted to keep going...</span>")

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -72,7 +72,7 @@
 
 	var/deathgasp_on_death = FALSE
 
-	var/stun_absorption = null //converted to a list of stun absorption sources this mob has when one is added
+	var/status_effect_absorption = null //converted to a list of status effect absorption sources this mob has when one is added
 	var/stam_regen_start_time = 0 //used to halt stamina regen temporarily
 	var/stam_regen_start_modifier = 1 //Modifier of time until regeneration starts
 	var/stam_paralyzed = FALSE //knocks you down

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -113,9 +113,11 @@ Difficulty: Medium
 	force_on = 10
 
 /obj/item/melee/energy/cleaving_saw/miner/attack(mob/living/target, mob/living/carbon/human/user)
-	target.add_stun_absorption("miner", 10, INFINITY)
+	target.add_status_effect_absorption("miner_weaken", 10, INFINITY, status_effect = WEAKEN)
+	target.add_status_effect_absorption("miner_stun", 10, INFINITY, status_effect = STUN)
 	..()
-	target.stun_absorption -= "miner"
+	target.status_effect_absorption -= "miner_weaken"
+	target.status_effect_absorption -= "miner_stun"
 
 /obj/item/projectile/kinetic/miner
 	damage = 20


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавил проверки для статус проков паралича и ослабления отдельно, на на стан, убрал эту проверку у jitter, оставил у shuttering.
Теперь алиены будут замедляться от ударов станбатона вновь.
Переделал absorb_stun в absorb_status_effect, чтобы было понятнее, что это относится не только к станам но и ко всем эффектам.
Уменьшает смещение экрана при эффекте головокружения. Теперь центр экрана не будет улетать на три клетки от одной банки пива.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->


## Ссылка на предложение/Причина создания ПР
Репорт zwei: https://discord.com/channels/617003227182792704/734823601110515882/1150028150852571147
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
