### PR TITLE
bugfix: wrong icon state for engineers' closets

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -33,7 +33,7 @@
 /obj/structure/closet/secure_closet/engineering_electrical
 	name = "electrical supplies locker"
 	req_access = list(ACCESS_ENGINE_EQUIP)
-	icon_state = "eng"
+	icon_state = "toolcloset"
 	custom_door_overlay = "engelec"
 
 /obj/structure/closet/secure_closet/engineering_electrical/populate_contents()
@@ -54,7 +54,7 @@
 /obj/structure/closet/secure_closet/engineering_welding
 	name = "welding supplies locker"
 	req_access = list(ACCESS_ENGINE_EQUIP)
-	icon_state = "eng"
+	icon_state = "toolcloset"
 	custom_door_overlay = "engweld"
 
 /obj/structure/closet/secure_closet/engineering_welding/populate_contents()
@@ -69,7 +69,7 @@
 /obj/structure/closet/secure_closet/engineering_personal
 	name = "engineer's locker"
 	req_access = list(ACCESS_ENGINE_EQUIP)
-	icon_state = "eng"
+	icon_state = "toolcloset"
 
 /obj/structure/closet/secure_closet/engineering_personal/populate_contents()
 	if(prob(50))


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Поменял иконку шкафов у некоторых инженерных ящиков, чтобы дверь сочеталась с корпусом
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
По запросу
## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
![изображение](https://github.com/ss220-space/Paradise/assets/73733747/223e0026-e704-445e-9291-5284f720853b)
![изображение](https://github.com/ss220-space/Paradise/assets/73733747/8dd33cd2-82c3-4962-be41-9e1447d36f35)
