### PR TITLE
bugfix: Plasma glass smelting not giving plasma back

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -137,7 +137,7 @@ GLOBAL_LIST_INIT(pglass_recipes, list ( \
 	singular_name = "glass sheet"
 	icon_state = "sheet-plasmaglass"
 	item_state = "sheet-pglass"
-	materials = list(MAT_GLASS=MINERAL_MATERIAL_AMOUNT*2)
+	materials = list(MAT_PLASMA = MINERAL_MATERIAL_AMOUNT, MAT_GLASS = MINERAL_MATERIAL_AMOUNT)
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 75, "acid" = 100)
 	resistance_flags = ACID_PROOF
 	origin_tech = "plasmatech=2;materials=2"
@@ -179,7 +179,7 @@ GLOBAL_LIST_INIT(prglass_recipes, list ( \
 	singular_name = "reinforced plasma glass sheet"
 	icon_state = "sheet-plasmarglass"
 	item_state = "sheet-prglass"
-	materials = list(MAT_METAL=MINERAL_MATERIAL_AMOUNT/2, MAT_GLASS=MINERAL_MATERIAL_AMOUNT*2)
+	materials = list(MAT_METAL=MINERAL_MATERIAL_AMOUNT/2, MAT_GLASS=MINERAL_MATERIAL_AMOUNT, MAT_PLASMA = MINERAL_MATERIAL_AMOUNT)
 	armor = list("melee" = 20, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 100)
 	resistance_flags = ACID_PROOF
 	origin_tech = "plasmatech=2;materials=2"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Добавляет возможность получения плазмы от расплавления плазменного стекла и укрепленного плазменного стекла в печке. Ранее плазменное стекло расплавлялось на два стекла и укрепленное на два стекла + 0.5 железа.

Теперь плазмостекло расплавляется на 1 стекло и 1 плазму, а укрепленное на 1 стекло, 1 плазму и 0.5 железа.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
https://discord.com/channels/617003227182792704/1148794353049927790/1148794353049927790
## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
Например, 30 плазменных стёкол при расплавке дадут 30 плазмы и 30 стекла. (Что эквивалентно возможности по созданию тридцати плазменных стёкол)
![изображение](https://github.com/ss220-space/Paradise/assets/73733747/52cde89c-370a-4135-897d-f1c3a81b806d)
