### PR TITLE
bugfix: cardboard boxes rendering

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -10,6 +10,7 @@
 	integrity_failure = 0
 	sound = 'sound/effects/rustle2.ogg'
 	material_drop = /obj/item/stack/sheet/cardboard
+	var/decal = ""
 	var/amt = 4
 	var/move_delay = 0
 	var/egged = 0
@@ -82,12 +83,24 @@
 			if(W != user.get_active_hand())
 				to_chat(user, "You must be holding the pen to perform this action.")
 				return
-			if(! Adjacent(user))
+			if(!Adjacent(user))
 				to_chat(user, "You have moved too far away from the cardboard box.")
 				return
 			add_fingerprint(user)
 			decalselection = replacetext(decalselection, " ", "_")
 			decalselection = lowertext(decalselection)
-			icon_opened = ("cardboard_open_"+decalselection)
-			icon_closed = ("cardboard_"+decalselection)
-			update_icon() // a proc declared in the closets parent file used to update opened/closed sprites on normal closets
+			decal = decalselection
+
+			update_icon()
+
+/obj/structure/closet/cardboard/update_icon() //Not deriving, because of different logic.
+	if(!opened)
+		if(decal)
+			icon_state = "cardboard_" + decal
+		else
+			icon_state = "cardboard"
+	else
+		if(decal)
+			icon_state = "cardboard_open_" + decal
+		else
+			icon_state = "cardboard_open"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправляет рендер подкрашенных ручкой коробок.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
https://discord.com/channels/617003227182792704/1150751908642947113/1150751908642947113
## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
![148](https://github.com/ss220-space/Paradise/assets/73733747/7cfd07e0-1c40-4e47-8d3b-f008dae59305)
