### PR TITLE
fix: deleting "illegal" tech from laser arm implant

### DIFF
--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -200,7 +200,7 @@
 	name = "arm-mounted laser implant"
 	desc = "A variant of the arm cannon implant that fires lethal laser beams. The cannon emerges from the subject's arm and remains inside when not in use."
 	icon_state = "arm_laser"
-	origin_tech = "materials=4;combat=4;biotech=4;powerstorage=4;syndicate=3"
+	origin_tech = "materials=4;combat=4;biotech=4;powerstorage=4"
 	contents = newlist(/obj/item/gun/energy/laser/mounted)
 
 /obj/item/organ/internal/cyberimp/arm/gun/laser/l


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Имплант лазера в руку (laser arm implant) больше не содержит при разборе в деструктивном анализаторе уровни технологий синдиката.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Предыдущее изменение этого импланта (https://github.com/ss220-space/Paradise/pull/3316) убрало у него требования в 4 уровне "illegal" для производства, тем самым позволив делать его в протолате без изучения контрабанды. Однако сам предмет всё ещё содержит в себе 3 уровень нелегальных технологий при разборе, позволяя без какой-либо контрабанды в принципе поднять нелегальные изучения до 4 уровня, просто создав и изучив два таких импланта. Закрываем очевидную дыру.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
