### PR TITLE
tweak/fix: server cooling on Delta

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -87886,7 +87886,8 @@
 	external_pressure_bound_default = 140;
 	name = "server vent";
 	on = 1;
-	pressure_checks = 0
+	pressure_checks = 0;
+	pump_direction = 0
 	},
 /turf/simulated/floor/bluegrid{
 	icon_state = "gcircuit";


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Меняет одну вентиляцию с "Закачивать воздух" до "Брать воздух" в комнате "Серверная RиD", карта "Делта"

## Ссылка на предложение/Причина создания ПР
[Баг репорт](https://discord.com/channels/617003227182792704/1152273136818073701/1152273136818073701)
На других картах сделано через другие трубы. Венты никакую работу не выполняют в серверной.
Только у дельты такие ошибки.

