### PR TITLE
tweak: remove sacid beakers from imprinters

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -65351,7 +65351,6 @@
 /area/quartermaster/storage)
 "jhc" = (
 /obj/effect/decal/warning_stripes/southeast,
-/obj/item/reagent_containers/glass/beaker/sulphuric,
 /obj/machinery/r_n_d/circuit_imprinter{
 	pixel_x = -1;
 	pixel_y = 3
@@ -81512,7 +81511,6 @@
 /obj/machinery/r_n_d/circuit_imprinter{
 	pixel_y = 3
 	},
-/obj/item/reagent_containers/glass/beaker/sulphuric,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
@@ -83142,7 +83140,6 @@
 	pixel_x = -1;
 	pixel_y = 3
 	},
-/obj/item/reagent_containers/glass/beaker/sulphuric,
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -32858,7 +32858,6 @@
 /area/medical/chemistry)
 "bGw" = (
 /obj/machinery/r_n_d/circuit_imprinter,
-/obj/item/reagent_containers/glass/beaker/sulphuric,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -35141,7 +35140,6 @@
 	pixel_x = 3;
 	pixel_y = 5
 	},
-/obj/item/reagent_containers/glass/beaker/sulphuric,
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/toxins/lab)

--- a/_maps/map_files/generic/syndicatebase.dmm
+++ b/_maps/map_files/generic/syndicatebase.dmm
@@ -5689,7 +5689,6 @@
 	icon_state = "syndie_circuit_imprinter"
 	},
 /obj/effect/decal/warning_stripes/southwest,
-/obj/item/reagent_containers/glass/beaker/sulphuric,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault";

--- a/code/modules/reagents/reagent_containers/glass_containers.dm
+++ b/code/modules/reagents/reagent_containers/glass_containers.dm
@@ -285,11 +285,10 @@
 /obj/item/reagent_containers/glass/beaker/cryoxadone
 	list_reagents = list("cryoxadone" = 30)
 
-/obj/item/reagent_containers/glass/beaker/sulphuric
+/obj/item/reagent_containers/glass/beaker/sacid
 	list_reagents = list("sacid" = 50)
 
-
-/obj/item/reagent_containers/glass/beaker/slime
+/obj/item/reagent_containers/glass/beaker/slimejelly
 	list_reagents = list("slimejelly" = 50)
 
 /obj/item/reagent_containers/glass/beaker/drugs/meth


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Ушла эпоха. 
Удаляет бикеры с серной кислотой со всех принтеров плат раундстартом.

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1151095351089049600

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
