### PR TITLE
TWEAK: Ghost now follow ALL hiveminds

### DIFF
--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -324,6 +324,7 @@
 	colour = "abductor"
 	key = "^"
 	flags = RESTRICTED | HIVEMIND
+	follow = TRUE
 
 /datum/language/grey/broadcast(mob/living/speaker, message, speaker_mask)
 	..(speaker,message,speaker.real_name)
@@ -581,6 +582,7 @@
 /datum/language/abductor/golem
 	name = "Golem Mindlink"
 	desc = "Communicate with other alien alloy golems through a psychic link."
+	follow = TRUE
 
 /datum/language/abductor/golem/check_special_condition(mob/living/carbon/human/other, mob/living/carbon/human/speaker)
 	return TRUE


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
порт https://github.com/ParadiseSS13/Paradise/pull/20877.

Теперь хайвмайнд Греев и големов из сплава может преследоваться гостами. Хз почему этого раньше не было.

## Ссылка на предложение/Причина создания ПР
это настолько очевидно что все хайвмайнды имеют follow = TRUE что я даже не знаю что добавить.

## Демонстрация изменений
![image](https://github.com/ss220-space/Paradise/assets/114731039/2965b4eb-4890-4013-8bc5-3a873865bd7c)

