### PR TITLE
fix: ninja protection for blood collecting quest.

### DIFF
--- a/code/modules/antagonists/vampire/vampire_powers/dantalion_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/dantalion_powers.dm
@@ -73,6 +73,14 @@
 						span_notice("Your faith in [SSticker.Bible_deity_name] has kept your mind clear of all evil."))
 		return
 
+	if(isninja(C))
+		var/obj/item/clothing/suit/space/space_ninja/ninja_suit = C.wear_suit
+		if(istype(ninja_suit) && ninja_suit.vamp_protection_active && ninja_suit.s_initialized)
+			C.visible_message(span_warning("Looks like [C] resists!"), \
+								span_notice("You suddenly felt a severe headache and a tiny prick in your neck. It looks like your suit protected your sanity..."))
+			C.setBrainLoss(20)
+			return FALSE
+
 	return TRUE
 
 

--- a/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
@@ -252,6 +252,14 @@
 		if(!target.affects_vampire(user))
 			continue
 
+		if(isninja(target))
+			var/mob/living/carbon/human/target_human = target
+			var/obj/item/clothing/glasses/ninja/ninja_visor = target_human.glasses
+
+			if(istype(ninja_visor) && ninja_visor.vamp_protection_active && ninja_visor.current_mode == "flashprotection")
+				to_chat(target, span_warning("[user]'s eyes emit a blinding flash, but your visor protected you."))
+				continue
+
 		var/deviation
 		if(user.lying || user.resting)
 			deviation = DEVIATION_PARTIAL


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Возвращает ниндзе защиту от глаз новых вампиров и траллинга подкласса "Данталльёна" (не возвращает защиту от крика, бикос у нас его ТУПО НЕТУ) (не даёт защиты от способностей других вампиров, ну, потому-что я ебал пытаться в баланс), следуя эксплейн тексту при выполнении цели на сбор крови вампиров. Пока фиг знает чё дальше.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР
Ну. Вампиры новые это кнчн прикольно, но и надо честь иметь не проебать механ, что делался лично нашими кодерами.<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
