### PR TITLE
FIX FIX: Drasks now correctly crash any non-admin types of obstacles

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -63,6 +63,16 @@
 	else
 		return !density
 
+/obj/structure/barricade/attack_hand(mob/user)
+	SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_HAND, user)
+	if(user.a_intent == INTENT_HARM && ishuman(user) && user.dna.species.obj_damage)
+		add_fingerprint(user)
+		user.changeNext_move(CLICK_CD_MELEE)
+		attack_generic(user, user.dna.species.obj_damage)
+		return
+	else
+		..()
+
 
 
 /////BARRICADE TYPES///////

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -64,8 +64,8 @@
 		return !density
 
 /obj/structure/barricade/attack_hand(mob/user)
-	SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_HAND, user)
 	if(user.a_intent == INTENT_HARM && ishuman(user) && user.dna.species.obj_damage)
+		SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_HAND, user)
 		add_fingerprint(user)
 		user.changeNext_move(CLICK_CD_MELEE)
 		attack_generic(user, user.dna.species.obj_damage)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -746,7 +746,7 @@ About the new airlock wires panel:
 	if(user.a_intent == INTENT_HARM && ishuman(user) && user.dna.species.obj_damage)
 		add_fingerprint(user)
 		user.changeNext_move(CLICK_CD_MELEE)
-		attack_generic(user, user.dna.species.obj_damage, damage_flag = "melee")
+		attack_generic(user, user.dna.species.obj_damage)
 		return
 	if(remove_airlock_note(user, FALSE))
 		add_fingerprint(user)

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -311,6 +311,11 @@
 	normal_integrity = 1000
 	security_level = 6
 
+/obj/machinery/door/airlock/centcom/attack_hand(mob/user)
+	. = ..()
+	if(user.a_intent == INTENT_HARM && ishuman(user) && user.dna.species.obj_damage)
+		return
+
 /obj/machinery/door/airlock/centcom/emag_act(mob/user)
 	to_chat(user, span_notice("The electronic systems in this door are far too advanced for your primitive hacking peripherals."))
 	return
@@ -840,6 +845,11 @@
 	opacity = 0
 	glass = TRUE
 	normal_integrity = 300
+
+/obj/machinery/door/airlock/syndicate/extmai/glass/attack_hand(mob/user)
+	. = ..()
+	if(user.a_intent == INTENT_HARM && ishuman(user) && user.dna.species.obj_damage)
+		return
 
 /*
 	Misc Airlocks

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -91,7 +91,7 @@
 	if(user.a_intent == INTENT_HARM && ishuman(user) && user.dna.species.obj_damage)
 		add_fingerprint(user)
 		user.changeNext_move(CLICK_CD_MELEE)
-		attack_generic(user, user.dna.species.obj_damage, damage_flag = "melee")
+		attack_generic(user, user.dna.species.obj_damage)
 		return
 	if(operating || !density)
 		return

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -235,7 +235,7 @@
 	if(user.a_intent == INTENT_HARM && ishuman(user) && user.dna.species.obj_damage)
 		add_fingerprint(user)
 		user.changeNext_move(CLICK_CD_MELEE)
-		attack_generic(user, user.dna.species.obj_damage, damage_flag = "melee")
+		attack_generic(user, user.dna.species.obj_damage)
 		return
 	return try_to_activate_door(user)
 

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -57,7 +57,7 @@
 	if(user.a_intent == INTENT_HARM && ishuman(user) && user.dna.species.obj_damage)
 		add_fingerprint(user)
 		user.changeNext_move(CLICK_CD_MELEE)
-		attack_generic(user, user.dna.species.obj_damage, damage_flag = "melee")
+		attack_generic(user, user.dna.species.obj_damage)
 		return
 	. = ..()
 

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -117,7 +117,7 @@
 	user.changeNext_move(CLICK_CD_MELEE)
 	if(user.a_intent == INTENT_HARM && ishuman(user) && user.dna.species.obj_damage)
 		user.changeNext_move(CLICK_CD_MELEE)
-		attack_generic(user, user.dna.species.obj_damage, damage_flag = "melee")
+		attack_generic(user, user.dna.species.obj_damage)
 	user.do_attack_animation(src, ATTACK_EFFECT_KICK)
 	user.visible_message("<span class='warning'>[user] hits [src].</span>")
 	if(!shock(user, 70))

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -91,7 +91,7 @@
 	if(user.a_intent == INTENT_HARM && ishuman(user) && user.dna.species.obj_damage)
 		add_fingerprint(user)
 		user.changeNext_move(CLICK_CD_MELEE)
-		attack_generic(user, user.dna.species.obj_damage, damage_flag = "melee")
+		attack_generic(user, user.dna.species.obj_damage)
 		return
 	. = ..()
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -181,7 +181,7 @@ GLOBAL_LIST_INIT(wcCommon, pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e",
 	if(user.a_intent == INTENT_HARM)
 		user.changeNext_move(CLICK_CD_MELEE)
 		if(ishuman(user) && user.dna.species.obj_damage)
-			attack_generic(user, user.dna.species.obj_damage, damage_flag = "melee")
+			attack_generic(user, user.dna.species.obj_damage)
 		else
 			playsound(src, 'sound/effects/glassknock.ogg', 80, 1)
 			user.visible_message("<span class='warning'>[user] bangs against [src]!</span>", \


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Фикс фикса https://github.com/ss220-space/Paradise/pull/3312, когда ден своими флажками полностью сломал вообще любую способность драсков ломать хоть что-то. 

Теперь драск ломает корректно все виды препятствий на своем пути: двери, остатки дверей, айрлоки, баррикады. Админские двери он теперь не может атаковать, но может по ним стучать.

## Ссылка на предложение/Причина создания ПР
Сломали драсков а чинить мне. Эх. Заодно добавил забытый тип "двери" в виде баррикад, что делал драсков не самыми мемными тварями в техах, которые все еще не могли попасть куда они хотят голыми руками. Не дело, исправляем.

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
