### PR TITLE
Tweak: Taipan and SO Earbang protection for headsets

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -122,12 +122,14 @@
 	ks2type = /obj/item/encryptionkey/syndicate/taipan
 	freerange = TRUE
 	freqlock = FALSE
+	flags = EARBANGPROTECT
 
 /obj/item/radio/headset/syndicate/taipan
 	name = "syndicate taipan headset"
 	icon_state = "taipan_headset"
 	item_state = "taipan_headset"
 	ks1type = /obj/item/encryptionkey/syndicate/taipan
+	flags = EARBANGPROTECT
 
 /obj/item/radio/headset/syndicate/taipan/New()
 	. = ..()


### PR DESCRIPTION
## Описание
Добавил защиту от светошумовых для наушников Тайпана и Офицера СЦК

modified:   code/game/objects/items/devices/radio/headset.dm

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1153729577923924108

## Демонстрация изменений

![кадет](https://github.com/ss220-space/Paradise/assets/129214736/d2af0f8d-9d7d-41f4-b4b9-3e94a5608295)
