### PR TITLE
QOL: Remove Check Pulse

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -40,8 +40,7 @@
 
 
 //proc/get_pulse methods
-#define GETPULSE_HAND	0	//less accurate (hand)
-#define GETPULSE_TOOL	1	//more accurate (med scanner, sleeper, etc)
+#define GETPULSE	1	// med scanner, sleeper, etc
 
 //Reagent Metabolization flags, defines the type of reagents that affect this mob
 #define PROCESS_ORG 1		//Only processes reagents with "ORGANIC" or "ORGANIC | SYNTHETIC"

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -199,7 +199,7 @@
 		// I'm not sure WHY you'd want to put a simple_animal in a sleeper, but precedent is precedent
 		// Runtime is aptly named, isn't she?
 		if(ishuman(occupant) && !(NO_BLOOD in occupant.dna.species.species_traits))
-			occupantData["pulse"] = occupant.get_pulse(GETPULSE_TOOL)
+			occupantData["pulse"] = occupant.get_pulse(GETPULSE)
 			occupantData["hasBlood"] = 1
 			occupantData["bloodLevel"] = round(occupant.blood_volume)
 			occupantData["bloodMax"] = occupant.max_blood

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -253,7 +253,7 @@
 			bloodData["hasBlood"] = TRUE
 			bloodData["volume"] = occupant.blood_volume
 			bloodData["percent"] = round(((occupant.blood_volume / BLOOD_VOLUME_NORMAL)*100))
-			bloodData["pulse"] = occupant.get_pulse(GETPULSE_TOOL)
+			bloodData["pulse"] = occupant.get_pulse(GETPULSE)
 			bloodData["bloodLevel"] = occupant.blood_volume
 			bloodData["bloodMax"] = occupant.max_blood
 		occupantData["blood"] = bloodData

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -110,7 +110,7 @@
 		occupantData["btFaren"] = ((occupant.bodytemperature - T0C) * (9.0/5.0))+ 32
 
 		if(ishuman(occupant) && !(NO_BLOOD in occupant.dna.species.species_traits))
-			occupantData["pulse"] = occupant.get_pulse(GETPULSE_TOOL)
+			occupantData["pulse"] = occupant.get_pulse(GETPULSE)
 			occupantData["hasBlood"] = 1
 			occupantData["bloodLevel"] = round(occupant.blood_volume)
 			occupantData["bloodMax"] = occupant.max_blood

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -564,7 +564,7 @@ REAGENT SCANNER
 		else
 			. += "Уровень крови: [blood_percent] %, [H.blood_volume] cl, тип: [blood_type], кровь расы: [blood_species]"
 
-	. += "Пульс: <font color='[H.pulse == PULSE_THREADY || H.pulse == PULSE_NONE ? "red" : "#0080ff"]'>[H.get_pulse(GETPULSE_TOOL)] bpm.</font>"
+	. += "Пульс: <font color='[H.pulse == PULSE_THREADY || H.pulse == PULSE_NONE ? "red" : "#0080ff"]'>[H.get_pulse(GETPULSE)] bpm.</font>"
 	var/list/implant_detect = list()
 	for(var/obj/item/organ/internal/cyberimp/CI in H.internal_organs)
 		if(CI.is_robotic())

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1171,40 +1171,6 @@
 		dna.real_name = name
 	return name
 
-/mob/living/carbon/human/verb/check_pulse()
-	set category = null
-	set name = "Check pulse"
-	set desc = "Approximately count somebody's pulse. Requires you to stand still at least 6 seconds."
-	set src in view(1)
-	var/self = 0
-
-	if(usr.stat == 1 || usr.restrained() || !isliving(usr) || usr.is_dead()) return
-
-	if(usr == src)
-		self = 1
-	if(!self)
-		usr.visible_message("<span class='notice'>[usr] kneels down, puts [usr.p_their()] hand on [src]'s wrist and begins counting [p_their()] pulse.</span>",\
-		"You begin counting [src]'s pulse")
-	else
-		usr.visible_message("<span class='notice'>[usr] begins counting [p_their()] pulse.</span>",\
-		"You begin counting your pulse.")
-
-	if(src.pulse)
-		to_chat(usr, "<span class='notice'>[self ? "You have a" : "[src] has a"] pulse! Counting...</span>")
-	else
-		to_chat(usr, "<span class='warning'>[src] has no pulse!</span>")//it is REALLY UNLIKELY that a dead person would check his own pulse
-
-		return
-
-	to_chat(usr, "Don't move until counting is finished.")
-	var/time = world.time
-	sleep(60)
-	if(usr.l_move_time >= time)	//checks if our mob has moved during the sleep()
-		to_chat(usr, "You moved while counting. Try again.")
-	else
-		to_chat(usr, "<span class='notice'>[self ? "Your" : "[src]'s"] pulse is [src.get_pulse(GETPULSE_HAND)].</span>")
-
-
 /mob/living/carbon/human/proc/change_dna(datum/dna/new_dna, include_species_change = FALSE, keep_flavor_text = FALSE)
 	if(include_species_change)
 		set_species(new_dna.species.type, retain_damage = TRUE)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
ни разу не спизжено с https://github.com/ParadiseSS13/Paradise/pull/22501

Удаляет прок проверки пульса, который бесполезен чуть больше чем полностью. Слишком долгий каст, забивает меню ПКМ, практической пользы - ноль, ибо есть examine и внешние признаки что кому-то очень плохо. Это во всех смыслах бесполезнейшая фича, которая совершенно не влияет на геймплей, несмотря на статус геймплейной фичи.

## Ссылка на предложение/Причина создания ПР
Увидел пр на оффах, решил спиздить, ибо согласен с мнением что данная фича - мусорный кусок кода, который можно спокойно удалить и НИКТО не заметит, если отдельно не напомнить. Так же -1 пункт в ПКМ функциях, полезно.

Обычно на предложки меняющий геймплей нужно проходить авоут, но это.. ничего не меняет. Кроме -1 в ПКМ.

## Демонстрация изменений
Это настолько бесполезная функция что её пропажу можно заметить только если напомнить о ней. Это абсолютно не нужно. 
![image](https://github.com/ss220-space/Paradise/assets/114731039/b439f6cd-42f4-41db-968c-927d5401824a)
![image](https://github.com/ss220-space/Paradise/assets/114731039/de7a5069-e253-47b9-a145-c7b49cd0f36c)
Как выглядит в игре
![image](https://github.com/ss220-space/Paradise/assets/114731039/d8a99de6-c7fc-4c65-a283-617b54db0dcc)



![image](https://github.com/ss220-space/Paradise/assets/114731039/c8ed14a9-b1d2-427f-ad13-2f09dafc4ad9)
Как выглядит в игре. Гораздо же лучше. Ничего лишнего. Осталось только карму удалить, но там целая система, её лучше стандартной предлогой имхо
![image](https://github.com/ss220-space/Paradise/assets/114731039/a5fb8352-1d58-4344-a030-d2977f22de71)

