### PR TITLE
FIX: Undestructuble and Unrepairable vendomates now work properly

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -80063,7 +80063,7 @@
 	},
 /area/storage/primary)
 "mJJ" = (
-/obj/machinery/vending/paivendor,
+/obj/machinery/vending/pai,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "purple"

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -291,7 +291,8 @@ to destroy them and players will be able to make replacements.
 		"Departament Cargo ClothesMate" =		/obj/machinery/vending/clothing/departament/cargo,
 		"Departament Law ClothesMate" =			/obj/machinery/vending/clothing/departament/law,
 		"Service Departament ClothesMate Botanical" = /obj/machinery/vending/clothing/departament/service/botanical,
-		"Service Departament ClothesMate Chaplain" 	= /obj/machinery/vending/clothing/departament/service/chaplain,)
+		"Service Departament ClothesMate Chaplain" 	= /obj/machinery/vending/clothing/departament/service/chaplain,
+		"RoboFriends" =                         /obj/machinery/vending/pai,)
 
 /obj/item/circuitboard/vendor/screwdriver_act(mob/user, obj/item/I)
 	. = TRUE

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -907,7 +907,7 @@
 	req_access = list(ACCESS_SYNDICATE)
 
 /obj/machinery/vending/coffee
-	name = "\improper Hot Drinks machine"
+	name = "\improper Solar's Best Hot Drinks"
 	desc = "A vending machine which dispenses hot drinks."
 	ads_list = list("Выпейте!","Выпьем!","На здоровье!","Не хотите горячего супчику?","Я бы убил за чашечку кофе!","Лучшие зёрна в галактике","Для Вас — только лучшие напитки","М-м-м-м… Ничто не сравнится с кофе","Я люблю кофе, а Вы?","Кофе помогает работать!","Возьмите немного чайку","Надеемся, Вы предпочитаете лучшее!","Отведайте наш новый шоколад!","Admin conspiracies")
 	icon_state = "coffee"
@@ -1081,7 +1081,7 @@
 
 
 /obj/machinery/vending/cigarette
-	name = "cigarette machine"
+	name = "ShadyCigs Deluxe"
 	desc = "If you want to get cancer, might as well do it in style."
 	slogan_list = list("Космосигареты весьма хороши на вкус, какими они и должны быть","I'd rather toolbox than switch.","Затянитесь!","Не верьте исследованиям — курите!")
 	ads_list = list("Наверняка не очень-то и вредно для Вас!","Не верьте учёным!","На здоровье!","Не бросайте курить, купите ещё!","Затянитесь!","Никотиновый рай","Лучшие сигареты с 2150 года","Сигареты с множеством наград")
@@ -2486,9 +2486,9 @@
 	refill_canister = /obj/item/vending_refill/nta
 
 
-/obj/machinery/vending/paivendor
-	name = "\improper PAI Vendor machine"
-	desc = "Wonderful vendor of friends"
+/obj/machinery/vending/pai
+	name = "\improper RoboFriends"
+	desc = "Wonderful vendor of PAI friends"
 	icon_state = "paivend"
 	ads_list = list("А вы любите нас?","Мы твои друзья!","Эта покупка войдет в историю","Я ПАИ простой, купишь меня, а я тебе друга!","Спасибо за покупку.")
 	resistance_flags = FIRE_PROOF
@@ -2516,3 +2516,4 @@
 		/obj/item/pai_cartridge/reset = 500,
 		/obj/item/pai_cartridge/memory = 350
 	)
+	refill_canister = /obj/item/vending_refill/pai

--- a/code/game/objects/items/weapons/vending_items.dm
+++ b/code/game/objects/items/weapons/vending_items.dm
@@ -183,3 +183,6 @@
 /obj/item/vending_refill/nta
 	machine_name = "NT Ammunition"
 	icon_state = "refill_nta"
+
+/obj/item/vending_refill/pai
+	machine_name = "RoboFriends"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
- Фиксит невозможность сборки вендоматов с кофе и сигаретами, так как привязка машины идет от имени, а оно разнилось.
- Фиксит невозможность сборки И РАЗБОРКИ(!) пии вендомата путем добавления стандартной адресации. Переименован в RoboFriends, потому что "PAI vendor" это звучит скучно и конкретно выбивается из стиля наименований остальных автоматов + лозунги "купи друга" теперь выглядят органично.

## Ссылка на предложение/Причина создания ПР
Охуел с торгового вируса который сломал вообще все автоматы с кофе и сигаретами, еще и в личку пожаловались на ПИИ вендор.

## Демонстрация изменений
после накатывания фикса смог спокойно собрать и пересобрать вендоры с кофе, сигаретами и пии. Всё работает.