### PR TITLE
fix: normal sec requirements

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -179,7 +179,7 @@
 	alt_titles = list("Security Trainer")
 	minimal_player_age = 14
 	exp_requirements = 600
-	exp_type = EXP_TYPE_SECURITY
+	exp_type = EXP_TYPE_CREW
 	money_factor = 3
 	outfit = /datum/outfit/job/officer
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Меняет требования для должности офицера, делая так, чтобы люди могли играть на них без необходимости ИГРАТЬ НА НИХ ДО ЭТОГО
Ранее - для открытия офицера нужно было наиграть 10 часов на кадете, где и начислялись часы на СБ, теперь часам на СБ браться неоткуда.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
![image](https://github.com/ss220-space/Paradise/assets/116907157/52e59029-e62c-48ba-88ed-d6df5ebf6a36)

<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
