### PR TITLE
Tweak: demons now have dirslash

### DIFF
--- a/code/game/gamemodes/miniantags/slaughter/slaughter.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughter.dm
@@ -29,6 +29,7 @@
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	del_on_death = TRUE
 	var/datum/action/innate/demon/whisper/whisper_action
+	var/dirslash_enabled = TRUE
 
 
 /mob/living/simple_animal/demon/Initialize(mapload)
@@ -42,6 +43,15 @@
 		whisper_action = null
 	return ..()
 
+/mob/living/simple_animal/demon/RangedAttack(atom/A, params)
+	. = ..()
+	if(dirslash_enabled && a_intent != INTENT_HELP)
+		var/turf/turf_attacking = get_step(src, get_compass_dir(src, A))
+		if(turf_attacking)
+			var/mob/living/target = locate() in turf_attacking
+			if(target && Adjacent(target))
+				changeNext_move(CLICK_CD_MELEE)
+				return UnarmedAttack(target, TRUE)
 
 /mob/living/simple_animal/demon/slaughter
 	name = "slaughter demon"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Теперь у демонов есть дирслеш, как у всех хостайл мобов и ксеноморфов

## Ссылка на предложение/Причина создания ПР
Из предложки на дирслеш было понятно, что все боевые мобы должны получить его, но демонов это не затронуло, ведь у них в пути нету /hostile. Собсна, заметили это только сейчас, нужно исправить.

