### PR TITLE
bugfix: lockermech paintkit recipe typo.

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -254,6 +254,7 @@
 //Spraycan stuff
 
 /obj/item/toy/crayon/spraycan
+	name = "spraycan"
 	icon_state = "spraycan_cap"
 	desc = "A metallic container containing tasty paint."
 	var/capped = 1


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Балончик с краской получает своё законное дешёвое название.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР
Всё просто. Балончик наследует название от мелка и получает своё только после спавна. Но в списке рецептов название, что появляется только после создания предмета, естественно не используется, используется просто "мелок", из-за чего игроки недоумевающе не могут понять почему крафт не происходит.<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

