### PR TITLE
tweak: replace .357 speedloader into ammo box

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -1068,6 +1068,20 @@
 	new /obj/item/clothing/gloves/combat(src)
 	new /obj/item/storage/backpack/security(src)
 
+/obj/item/storage/box/a357
+	name = "ammo box (.357)"
+	desc = "A box of ammo?"
+	icon_state = "357OLD"
+	icon = 'icons/obj/weapons/ammo.dmi'
+	display_contents_with_number = TRUE
+	can_hold = list(/obj/item/ammo_casing/a357)
+	storage_slots = 20
+	max_combined_w_class = 20
+
+/obj/item/storage/box/a357/populate_contents()
+	for(var/I in 1 to 20)
+		new /obj/item/ammo_casing/a357(src)
+
 #undef NODESIGN
 #undef NANOTRASEN
 #undef SYNDI

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -882,11 +882,11 @@
 	category = list("hacked", "Security")
 
 /datum/design/a357
-	name = "Speed Loader (.357)"
+	name = "Ammo Box (.357)"
 	id = "a357"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
-	build_path = /obj/item/ammo_box/a357
+	materials = list(MAT_METAL = 75000)
+	build_path = /obj/item/storage/box/a357
 	category = list("hacked", "Security")
 
 /datum/design/c10mm


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Убирает спидлоадер 357 из автолата заменив его коробкой на 20 пулек с х2.5 стоимостью.

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1128729364041842820

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
