### PR TITLE
Fix: jittery duration

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/abillities.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/abillities.dm
@@ -310,7 +310,7 @@
 			to_chat(target, "<span class='danger'><b>A spike of pain drives into your head and scrambles your thoughts!</b></span>")
 			target.AdjustConfused(20 SECONDS)
 			target.Slowed(2 SECONDS)
-			target.Jitter(600 SECONDS)
+			target.Jitter(20 SECONDS)
 
 		if(issilicon(target))
 			to_chat(target, "<span class='warning'><b>ERROR $!(@ ERROR )#^! SENSORY OVERLOAD \[$(!@#</b></span>")

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/abillities.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/abillities.dm
@@ -350,7 +350,7 @@
 			to_chat(target, "<span class='danger'><b>A spike of pain drives into your head and scrambles your thoughts!</b></span>")
 			target.adjustStaminaLoss(30)
 			target.Slowed(10 SECONDS)
-			target.Jitter(300 SECONDS)
+			target.Jitter(20 SECONDS)
 
 		if(issilicon(target))
 			to_chat(target, "<span class='warning'><b>ERROR $!(@ ERROR )#^! SENSORY OVERLOAD \[$(!@#</b></span>")
@@ -447,7 +447,7 @@
 				to_chat(target, "<span class='danger'><b>A spike of pain drives into your head and scrambles your thoughts!</b></span>")
 				target.AdjustWeakened(2 SECONDS)
 				target.adjustStaminaLoss(50)
-				target.Jitter(1000 SECONDS)
+				target.Jitter(40 SECONDS)
 				target.Slowed(14 SECONDS)
 
 			if(issilicon(target))


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Снижает продолжительность эффекта "дрожания" накладываемых способностями пауков ужаса с неадекватных значений в 1000 - 600 секунд до 40-20
## Ссылка на предложение/Причина создания ПР
После обновления системы статусных эффектов эти значения до смешного абсурдны. По сути косметика.  Кукол не должно трясти 1000 секунд??

