### PR TITLE
bugfix: wrong carpet smoothing

### DIFF
--- a/code/game/objects/items/devices/floor_painter.dm
+++ b/code/game/objects/items/devices/floor_painter.dm
@@ -51,6 +51,7 @@
 	playsound(loc, usesound, 30, TRUE)
 	F.icon_state = floor_state
 	F.icon_regular_floor = floor_state
+	F.floor_regular_dir = floor_dir
 	F.dir = floor_dir
 
 /obj/item/floor_painter/attack_self(var/mob/user)

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -26,6 +26,7 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 	icon_state = "dont_use_this_floor"
 	plane = FLOOR_PLANE
 	var/icon_regular_floor = "floor" //used to remember what icon the tile should have by default
+	var/floor_regular_dir = SOUTH  //used to remember what dir the tile should have by default
 	var/icon_plating = "plating"
 	thermal_conductivity = 0.040
 	heat_capacity = 10000
@@ -50,6 +51,7 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 		icon_regular_floor = "floor"
 	else
 		icon_regular_floor = icon_state
+		floor_regular_dir = dir
 
 //turf/simulated/floor/CanPass(atom/movable/mover, turf/target, height=0)
 //	if((istype(mover, /obj/machinery/vehicle) && !(src.burnt)))
@@ -152,6 +154,7 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 	var/old_icon = icon_regular_floor
 	var/old_plating = icon_plating
 	var/old_dir = dir
+	var/old_regular_dir = floor_regular_dir
 
 	var/turf/simulated/floor/W = ..()
 
@@ -161,6 +164,7 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 		W.icon_regular_floor = old_icon
 		W.icon_plating = old_plating
 	if(W.keep_dir)
+		W.floor_regular_dir = old_regular_dir
 		W.dir = old_dir
 	if(W.transparent_floor)
 		for(R in W)

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -125,6 +125,7 @@
 /turf/simulated/floor/carpet/update_icon()
 	if(!..())
 		return
+	dir = 0 //Prevents wrong smoothing
 	if(!broken && !burnt)
 		if(smooth)
 			queue_smooth(src)

--- a/code/game/turfs/simulated/floor/plasteel_floor.dm
+++ b/code/game/turfs/simulated/floor/plasteel_floor.dm
@@ -9,6 +9,7 @@
 		return 0
 	if(!broken && !burnt)
 		icon_state = icon_regular_floor
+		dir = floor_regular_dir
 
 /turf/simulated/floor/plasteel/airless
 	name = "airless floor"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление ошибки, при которой ковры ставились некорректно.
Теперь постановка ковра ставит dir турфа на 0.

В процессе:
- ~~корректное сохранение dir турфа~~ сделано

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Making коврижничество great again!

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
Демонстрация корректного сглаживания
![изображение](https://github.com/ss220-space/Paradise/assets/73733747/494ce8cb-e37a-4f50-89fc-d01e50321947)
~~Увы, из-за сброса dir плитки ковром, будет такое (синие полоски должны быть сверху)
В процессе фикса~~
Исправлено

![163](https://github.com/ss220-space/Paradise/assets/73733747/c246649b-cc5b-446d-a165-1c16f94833c9)
