### PR TITLE
mining camera

### DIFF
--- a/_maps/map_files/Delta/Lavaland.dmm
+++ b/_maps/map_files/Delta/Lavaland.dmm
@@ -3017,10 +3017,6 @@
 	dir = 1;
 	on = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Mining Hall South";
-	network = list("Mining Outpost")
-	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -7348,6 +7344,10 @@
 	on = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Mining Hall South";
+	network = list("Mining Outpost")
+	},
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "Uf" = (


### PR DESCRIPTION
## Описание
Камера не видит правый шлюз шаттла шахтеров, при этом с левым шлюзом такой проблемы нет. Переместил камеру на три тайла влево, теперь всё видно и ИИ сможет открывать этот шлюз нормально.

## Ссылка на предложение/Причина создания ПР
Не думаю что так было задумано при расстановке камер, ведь левый шлюз шаттла виден с камер, а правый почему-то нет.

## Демонстрация изменений
![image](https://github.com/ss220-space/Paradise/assets/140404099/07964422-5d8c-4a44-b4b9-9691ce9d1267)
![image](https://affectedarc07.blob.core.windows.net/mdb2/images/365505203/17228383264/m/_maps_map_files_Delta_Lavaland/0-diff.png)

