### PR TITLE
bugfix: Gamma Shuttle button.

### DIFF
--- a/_maps/map_files/generic/CentComm.dmm
+++ b/_maps/map_files/generic/CentComm.dmm
@@ -691,14 +691,6 @@
 /turf/simulated/floor/plating,
 /area/centcom/bridge)
 "aoB" = (
-/obj/machinery/door_control{
-	id = "CC_GAMMA";
-	name = "GAMMA SHUTTLE";
-	pixel_x = 24;
-	pixel_y = -24;
-	req_access = list(114);
-	wires = 1
-	},
 /obj/item/flag/nt,
 /turf/simulated/floor/wood,
 /area/centcom/specops)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Убирает кнопку старую кнопку шаттеров Гамма шаттла, которую Кей забыл убрать при переносе шаттла в другое место.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на разрешение Момочан<3
https://discord.com/channels/617003227182792704/943940908162875473/1157369108917133393<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
