### PR TITLE
fix: leg implants no more duplicate actions

### DIFF
--- a/code/modules/mining/equipment/mining_charges.dm
+++ b/code/modules/mining/equipment/mining_charges.dm
@@ -22,8 +22,6 @@
 			visible_message("<span class='notice'>This rock appears to be resistant to all mining tools except pickaxes!</span>")
 			return
 		..()
-	else
-		return
 
 /obj/item/grenade/plastic/miningcharge/prime()
 	var/turf/simulated/mineral/location = get_turf(target)

--- a/code/modules/mining/equipment/mining_charges.dm
+++ b/code/modules/mining/equipment/mining_charges.dm
@@ -23,7 +23,7 @@
 			return
 		..()
 	else
-		to_chat(user,span_warning("The charge only works on rocks!"))
+		return
 
 /obj/item/grenade/plastic/miningcharge/prime()
 	var/turf/simulated/mineral/location = get_turf(target)

--- a/code/modules/surgery/organs/augments_legs.dm
+++ b/code/modules/surgery/organs/augments_legs.dm
@@ -116,6 +116,7 @@
 	var/obj/item/organ/internal/cyberimp/leg/jumpboots/left = owner.get_organ_slot("r_leg_device")
 	if(left.implant_ability)
 		left.implant_ability.Remove(owner)
+		left.implant_ability = null
 
 /datum/action/bhop
 	name = "Activate Jump Boots"

--- a/code/modules/surgery/organs/augments_legs.dm
+++ b/code/modules/surgery/organs/augments_legs.dm
@@ -107,12 +107,15 @@
 	parent_organ = BODY_ZONE_L_LEG
 
 /obj/item/organ/internal/cyberimp/leg/jumpboots/AddEffect()
-	implant_ability = new(src)
-	implant_ability.Grant(owner)
+	var/obj/item/organ/internal/cyberimp/leg/jumpboots/left = owner.get_organ_slot("r_leg_device") //leading leg or somethin
+	if(!left.implant_ability)
+		left.implant_ability = new(src)
+		left.implant_ability.Grant(owner)
 
 /obj/item/organ/internal/cyberimp/leg/jumpboots/RemoveEffect()
-	if(implant_ability)
-		implant_ability.Remove(owner)
+	var/obj/item/organ/internal/cyberimp/leg/jumpboots/left = owner.get_organ_slot("r_leg_device")
+	if(left.implant_ability)
+		left.implant_ability.Remove(owner)
 
 /datum/action/bhop
 	name = "Activate Jump Boots"
@@ -142,7 +145,7 @@
 	var/after_jump_callback = CALLBACK(src, PROC_REF(after_jump), owner, isflying)
 	if(owner.throw_at(target, jumpdistance, jumpspeed, spin = FALSE, diagonals_first = TRUE, callback = after_jump_callback))
 		last_jump = after_jump_callback
-		playsound(src, 'sound/effects/stealthoff.ogg', 50, 1, 1)
+		playsound(owner.loc, 'sound/effects/stealthoff.ogg', 50, 1, 1)
 		owner.visible_message("<span class='warning'>[usr] dashes forward into the air!</span>")
 		recharging_time = world.time + recharging_rate
 	else


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Если произойдет такое, что у человека с имплантами оторвет ногу, то приклеивание ноги обратно дублирует кнопку действия, позволяя прыгать дважды (трижды, или даже больше, в зависимости от того, сколько раз вы потеряли ногу)
Меняет логику импланта, теперь одна из ног является ведущей, к которой прикреплено действие. Потеря любой ноги отбирает действие, для возвращения которого нужно переустановить имплант в ногу (вроде)
Так же убирает спам сообщений про камни у взрывчатки, ибо они пишутся даже тогда, когда ты суешь эту взрывчатку в карман/рюкзак
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1157233098916888656
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->