### PR TITLE
FIX: AI now can't power on broken APCs

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -175,9 +175,6 @@
 	if(!can_use(user, TRUE))
 		to_chat(user, "<span class='warning'>AI control for \the [src] interface has been disabled.</span>")
 		return
-	if(BROKEN)
-		to_chat(user, "<span class='warning'>AI control for \the [src] interface has been disabled.</span>")
-		return
 	toggle_breaker(user)
 
 

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -175,6 +175,9 @@
 	if(!can_use(user, TRUE))
 		to_chat(user, "<span class='warning'>AI control for \the [src] interface has been disabled.</span>")
 		return
+	if(BROKEN)
+		to_chat(user, "<span class='warning'>AI control for \the [src] interface has been disabled.</span>")
+		return
 	toggle_breaker(user)
 
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -965,8 +965,10 @@
 		INVOKE_ASYNC(L, TYPE_PROC_REF(/obj/machinery/light, update), FALSE)
 
 /obj/machinery/power/apc/proc/can_use(var/mob/user, var/loud = 0) //used by attack_hand() and Topic()
+	if(BROKEN)
+		return FALSE
 	if(user.can_admin_interact())
-		return 1
+		return TRUE
 
 	autoflag = 5
 	if(istype(user, /mob/living/silicon))
@@ -1002,17 +1004,17 @@
 
 /obj/machinery/power/apc/proc/is_authenticated(mob/user as mob)
 	if(user.can_admin_interact())
-		return 1
+		return TRUE
 	if(isAI(user) || isrobot(user) && !iscogscarab(user))
-		return 1
+		return TRUE
 	else
 		return !locked
 
 /obj/machinery/power/apc/proc/is_locked(mob/user as mob)
 	if(user.can_admin_interact())
-		return 0
+		return FALSE
 	if(isAI(user) || isrobot(user) && !iscogscarab(user))
-		return 0
+		return FALSE
 	else
 		return locked
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -965,7 +965,7 @@
 		INVOKE_ASYNC(L, TYPE_PROC_REF(/obj/machinery/light, update), FALSE)
 
 /obj/machinery/power/apc/proc/can_use(var/mob/user, var/loud = 0) //used by attack_hand() and Topic()
-	if(BROKEN == TRUE)
+	if(stat & BROKEN)
 		return FALSE
 	if(user.can_admin_interact())
 		return TRUE

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -965,7 +965,7 @@
 		INVOKE_ASYNC(L, TYPE_PROC_REF(/obj/machinery/light, update), FALSE)
 
 /obj/machinery/power/apc/proc/can_use(var/mob/user, var/loud = 0) //used by attack_hand() and Topic()
-	if(BROKEN)
+	if(BROKEN == TRUE)
 		return FALSE
 	if(user.can_admin_interact())
 		return TRUE


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Фиксит альтклик у боргов и ИИ на сломанный апц, включая его. Теперь они не могут включать сломанные АПЦ.

## Ссылка на предложение/Причина создания ПР
Баг репорт https://discord.com/channels/617003227182792704/1157694144140025966/1157694144140025966

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
