### PR TITLE
bugfix: fixed incorrect icon rendering upon reloging into robots and creatures

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -134,6 +134,7 @@
 
 			if(action_intent)
 				action_intent.screen_loc = initial(action_intent.screen_loc) //Restore intent selection to the original position
+			. = TRUE
 
 		if(HUD_STYLE_REDUCED)	//Reduced HUD
 			hud_shown = FALSE	//Governs behavior of other procs
@@ -154,6 +155,7 @@
 			if(action_intent)
 				mymob.client.screen += action_intent		//we want the intent switcher visible
 				action_intent.screen_loc = ui_acti_alt	//move this to the alternative position, where zone_select usually is.
+			. = FALSE
 
 		if(HUD_STYLE_NOHUD)	//No HUD
 			hud_shown = FALSE	//Governs behavior of other procs
@@ -165,6 +167,7 @@
 				mymob.client.screen -= hotkeybuttons
 			if(infodisplay.len)
 				mymob.client.screen -= infodisplay
+			. = FALSE
 
 	hud_version = display_hud_version
 	persistent_inventory_update()

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -206,6 +206,13 @@
 	if(!R.module)
 		return
 
+	if(R.module_state_1)
+		R.client.screen += R.module_state_1
+	if(R.module_state_2)
+		R.client.screen += R.module_state_2
+	if(R.module_state_3)
+		R.client.screen += R.module_state_3
+
 	if(R.shown_robot_modules && hud_shown)
 		//Modules display is shown
 		R.client.screen += module_store_icon	//"store" icon


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление ошибки, при которой иконки боргов рендерились некорректно при переключении HUDа, релоге, вселении в борга.
Также прок show_hud теперь корректно возвращает результат, на который ориентируются наследники метода.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
https://discord.com/channels/617003227182792704/1156389842670866543/1156389842670866543
## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
![166](https://github.com/ss220-space/Paradise/assets/73733747/9e5c8a72-5524-4862-9eac-54454764377d)
