### PR TITLE
add: Draconids & Ash Walkers Customization

### DIFF
--- a/code/modules/mining/lavaland/loot/ashdragon_loot.dm
+++ b/code/modules/mining/lavaland/loot/ashdragon_loot.dm
@@ -156,7 +156,7 @@
 
 	var/mob/living/carbon/human/H = user
 	to_chat(user, span_danger("You feel warmth spread through you, paired with an odd desire to burn down a village. You're suddenly a very small, humanoid ash dragon!"))
-	H.set_species(/datum/species/unathi/draconid)
+	H.set_species(/datum/species/unathi/draconid, save_appearance = TRUE)
 
 	playsound(user.loc,'sound/items/drink.ogg', rand(10,50), 1)
 	qdel(src)

--- a/code/modules/mob/living/carbon/human/body_accessories.dm
+++ b/code/modules/mob/living/carbon/human/body_accessories.dm
@@ -225,16 +225,16 @@ GLOBAL_LIST_INIT(body_accessory_by_species, list())
 	name = "Smooth"
 	icon_state = "smooth"
 	animated_icon_state = "smooth_a"
-	allowed_species = list("Unathi")
+	allowed_species = list("Unathi", "Ash Walker", "Ash Walker Shaman", "Draconid")
 
 /datum/body_accessory/tail/tiger
 	name = "Tiger"
 	icon_state = "dtiger"
 	animated_icon_state = "dtiger_a"
-	allowed_species = list("Unathi")
+	allowed_species = list("Unathi", "Ash Walker", "Ash Walker Shaman", "Draconid")
 
 /datum/body_accessory/tail/spikes
 	name = "Spikes"
 	icon_state = "spikes"
 	animated_icon_state = "spikes_a"
-	allowed_species = list("Unathi")
+	allowed_species = list("Unathi", "Ash Walker", "Ash Walker Shaman", "Draconid")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1220,7 +1220,7 @@
 	sec_hud_set_ID()
 
 
-/mob/living/carbon/human/proc/set_species(datum/species/new_species, default_colour, delay_icon_update = FALSE, skip_same_check = FALSE, retain_damage = FALSE)
+/mob/living/carbon/human/proc/set_species(datum/species/new_species, default_colour, delay_icon_update = FALSE, skip_same_check = FALSE, retain_damage = FALSE, save_appearance = FALSE)
 	if(!skip_same_check)
 		if(dna.species.name == initial(new_species.name))
 			return
@@ -1243,9 +1243,9 @@
 
 	dna.species = new new_species()
 
-	tail = dna.species.tail
+	tail = save_appearance ? oldspecies.tail : dna.species.tail
 
-	wing = dna.species.wing
+	wing = save_appearance ? oldspecies.wing : dna.species.wing
 
 	maxHealth = dna.species.total_health
 
@@ -1276,6 +1276,10 @@
 			kept_items[I] = thing
 			item_flags[I] = I.flags
 			I.flags = 0 // Temporary set the flags to 0
+
+	var/list/old_bodyparts
+	if(save_appearance)
+		old_bodyparts = bodyparts_by_name.Copy()
 
 	if(retain_damage)
 		//Create a list of body parts which are damaged by burn or brute and save them to apply after new organs are generated. First we just handle external organs.
@@ -1345,41 +1349,58 @@
 		equip_to_slot_if_possible(thing, kept_items[thing])
 		thing.flags = item_flags[thing] // Reset the flags to the origional ones
 
-	//Handle default hair/head accessories for created mobs.
+	//Handle hair/head accessories for created mobs.
 	var/obj/item/organ/external/head/H = get_organ("head")
-	if(dna.species.default_hair)
-		H.h_style = dna.species.default_hair
-	else
-		H.h_style = "Bald"
-	if(dna.species.default_fhair)
-		H.f_style = dna.species.default_fhair
-	else
-		H.f_style = "Shaved"
-	if(dna.species.default_headacc)
-		H.ha_style = dna.species.default_headacc
-	else
-		H.ha_style = "None"
+	if(save_appearance && old_bodyparts)
+		var/obj/item/organ/external/head/old_head = old_bodyparts["head"]
+		if(istype(old_head))
+			if(old_head.h_style)
+				H.h_style = old_head.h_style
+			if(old_head.f_style)
+				H.f_style = old_head.f_style
+			if(old_head.ha_style)
+				H.ha_style = old_head.ha_style
+			if(old_head.hair_colour)
+				H.hair_colour = old_head.hair_colour
+			if(old_head.facial_colour)
+				H.facial_colour = old_head.facial_colour
+			if(old_head.headacc_colour)
+				H.headacc_colour = old_head.headacc_colour
 
-	if(dna.species.default_hair_colour)
-		//Apply colour.
-		H.hair_colour = dna.species.default_hair_colour
 	else
-		H.hair_colour = "#000000"
-	if(dna.species.default_fhair_colour)
-		H.facial_colour = dna.species.default_fhair_colour
-	else
-		H.facial_colour = "#000000"
-	if(dna.species.default_headacc_colour)
-		H.headacc_colour = dna.species.default_headacc_colour
-	else
-		H.headacc_colour = "#000000"
+		if(dna.species.default_hair)
+			H.h_style = dna.species.default_hair
+		else
+			H.h_style = "Bald"
+		if(dna.species.default_fhair)
+			H.f_style = dna.species.default_fhair
+		else
+			H.f_style = "Shaved"
+		if(dna.species.default_headacc)
+			H.ha_style = dna.species.default_headacc
+		else
+			H.ha_style = "None"
 
-	m_styles = DEFAULT_MARKING_STYLES //Wipes out markings, setting them all to "None".
-	m_colours = DEFAULT_MARKING_COLOURS //Defaults colour to #00000 for all markings.
-	if(dna.species.bodyflags & HAS_BODY_ACCESSORY)
-		body_accessory = GLOB.body_accessory_by_name[dna.species.default_bodyacc]
-	else
-		body_accessory = null
+		if(dna.species.default_hair_colour)
+			//Apply colour.
+			H.hair_colour = dna.species.default_hair_colour
+		else
+			H.hair_colour = "#000000"
+		if(dna.species.default_fhair_colour)
+			H.facial_colour = dna.species.default_fhair_colour
+		else
+			H.facial_colour = "#000000"
+		if(dna.species.default_headacc_colour)
+			H.headacc_colour = dna.species.default_headacc_colour
+		else
+			H.headacc_colour = "#000000"
+
+		m_styles = DEFAULT_MARKING_STYLES //Wipes out markings, setting them all to "None".
+		m_colours = DEFAULT_MARKING_COLOURS //Defaults colour to #00000 for all markings.
+		if(dna.species.bodyflags & HAS_BODY_ACCESSORY)
+			body_accessory = GLOB.body_accessory_by_name[dna.species.default_bodyacc]
+		else
+			body_accessory = null
 
 	dna.real_name = real_name
 

--- a/code/modules/mob/living/carbon/human/species/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/unathi.dm
@@ -295,8 +295,7 @@ They're basically just lizards with all-around marginally better stats and fire 
 	if(shoes && C.can_unEquip(shoes))
 		C.drop_item_ground(shoes)
 	var/obj/item/organ/external/head/head_organ = C.get_organ("head")
-	C.skin_colour = base_color
-	head_organ.h_style = "Drake"
+	head_organ?.ha_style = "Drake"
 	C.change_eye_color("#A02720")
 	C.update_dna()
 	C.update_inv_head()

--- a/code/modules/mob/new_player/sprite_accessories/unathi/unathi_alt_heads.dm
+++ b/code/modules/mob/new_player/sprite_accessories/unathi/unathi_alt_heads.dm
@@ -1,5 +1,5 @@
 /datum/sprite_accessory/alt_heads/una_sharp_snout
 	name = "Unathi Sharp Snout"
-	species_allowed = list("Unathi")
+	species_allowed = list("Unathi", "Ash Walker", "Ash Walker Shaman", "Draconid")
 	icon_state = "head_sharp"
 	suffix = "sharp"

--- a/code/modules/mob/new_player/sprite_accessories/unathi/unathi_body_markings.dm
+++ b/code/modules/mob/new_player/sprite_accessories/unathi/unathi_body_markings.dm
@@ -1,6 +1,6 @@
 /datum/sprite_accessory/body_markings/unathi
     icon = 'icons/mob/sprite_accessories/unathi/unathi_body_markings.dmi'
-    species_allowed = list("Unathi")
+    species_allowed = list("Unathi", "Ash Walker", "Ash Walker Shaman", "Draconid")
 
 /datum/sprite_accessory/body_markings/unathi/stripe_una
 	name = "Unathi Stripe"

--- a/code/modules/mob/new_player/sprite_accessories/unathi/unathi_facial_hair.dm
+++ b/code/modules/mob/new_player/sprite_accessories/unathi/unathi_facial_hair.dm
@@ -1,6 +1,6 @@
 /datum/sprite_accessory/facial_hair/unathi
 	icon = 'icons/mob/sprite_accessories/unathi/unathi_facial_hair.dmi'
-	species_allowed = list("Unathi")
+	species_allowed = list("Unathi", "Ash Walker", "Ash Walker Shaman", "Draconid")
 	gender = NEUTER
 	over_hair = 1
 

--- a/code/modules/mob/new_player/sprite_accessories/unathi/unathi_head_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories/unathi/unathi_head_accessories.dm
@@ -2,7 +2,7 @@
 
 /datum/sprite_accessory/head_accessory/unathi
 	icon = 'icons/mob/sprite_accessories/unathi/unathi_hair.dmi'
-	species_allowed = list("Unathi")
+	species_allowed = list("Unathi", "Ash Walker", "Ash Walker Shaman", "Draconid")
 	over_hair = 1
 
 /datum/sprite_accessory/head_accessory/unathi/knight

--- a/code/modules/mob/new_player/sprite_accessories/unathi/unathi_head_markings.dm
+++ b/code/modules/mob/new_player/sprite_accessories/unathi/unathi_head_markings.dm
@@ -1,6 +1,6 @@
 /datum/sprite_accessory/body_markings/head/unathi
 	icon = 'icons/mob/sprite_accessories/unathi/unathi_head_markings.dmi'
-	species_allowed = list("Unathi")
+	species_allowed = list("Unathi", "Ash Walker", "Ash Walker Shaman", "Draconid")
 
 /datum/sprite_accessory/body_markings/head/unathi/tiger_head_una
 	name = "Unathi Tiger Head"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание

- Добавляет возможность кастомизации для драконидов и эшей точно так же, как это сделано у унатхов. 
- При использовании refined dragons blood черты изначальной расы наследуются. Уникальные черты драконида (чернота, рога и красные глаза) замещают изначальные.

<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
QoL :clueless:
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
Было:
![image](https://github.com/ss220-space/Paradise/assets/100733800/911536a6-938f-4d41-aab7-de5db3410d99)
Стало: 
![image](https://github.com/ss220-space/Paradise/assets/100733800/a7a25c19-4dea-44a2-ac71-385e04e3ae8f)

<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
