### PR TITLE
tweak: changed cyborg's storage increase upgrade name

### DIFF
--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1408,7 +1408,7 @@
 	category = list("Cyborg Upgrade Modules")
 
 /datum/design/borg_upgrade_storageincreaser
-	name = "Engineer Cyborg Upgrade (Storage Increaser)"
+	name = "Cyborg Common Upgrade (Storage Increaser)"
 	id = "borg_upgrade_storageincreaser"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/storageincreaser


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Измененил название типа модуля увеличения хранилища боргов с инженерного на обычный, поскольку обновление доступно ВСЕМ киборгам без исключений.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Устраняем трудности восприятия и споры боргов с роботехами о том, что медюнитам нельзя вставлять увеличение хранилища.
