### PR TITLE
bugfix: fixed crossbow arrows damage scaling

### DIFF
--- a/code/modules/projectiles/guns/throw/crossbow.dm
+++ b/code/modules/projectiles/guns/throw/crossbow.dm
@@ -63,7 +63,7 @@
 	if(cell && on_chamber && istype(I, /obj/item/arrow/rod))
 		var/obj/item/arrow/rod/R = I
 		visible_message(span_danger("[R] is ready!"))
-		R.modify_rod()
+		R.modify_arrow()
 
 /obj/item/gun/throw/crossbow/get_throwspeed()
 	return tension * speed_multiplier
@@ -73,8 +73,6 @@
 
 /obj/item/gun/throw/crossbow/process_chamber()
 	..()
-	if(to_launch)
-		modify_projectile(to_launch, 1)
 	update_icon()
 
 /obj/item/gun/throw/crossbow/attack_self(mob/living/user)
@@ -83,6 +81,7 @@
 			user.visible_message(span_notice("[user] relaxes the tension on [src]'s string and removes [to_launch]."), span_notice("You relax the tension on [src]'s string and remove [to_launch]."))
 			to_launch.forceMove(get_turf(src))
 			var/obj/item/arrow/A = to_launch
+			A.reset_arrow()
 			to_launch = null
 			A.removed()
 			process_chamber()
@@ -104,6 +103,8 @@
 	if(cell && cell.charge > 499) //I really hope there is no way to get 499.5 charge or something
 		if(do_after(user, 5 * drawtension, target = user))
 			tension = drawtension
+			if(to_launch)
+				modify_projectile(to_launch, 1)
 			cell.use(500)
 			user.visible_message("[src] mechanism draws back the string!","[src] clunks as its mechanism draw the string to its maximum tension!!")
 			update_icon()
@@ -178,6 +179,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	sharp = TRUE
 	var/overlay_prefix = "" //used for crossbow bolt overlay render. Don't override it in children if you don't have an overlay icon for your bolt
+	var/superheated = 0
 
 /obj/item/arrow/proc/removed() //Helper for metal rods falling apart.
 	return
@@ -187,25 +189,24 @@
 	desc = "A sharpened metal rod that can be fired out of a crossbow."
 	icon_state = "metal-rod"
 	throwforce = 10
-	var/superheated = 0
 
-/obj/item/arrow/rod/proc/modify_rod()
+/obj/item/arrow/proc/modify_arrow()
 	throwforce = 33
 	superheated = 1 //guess this useless now...
 	armour_penetration = 15
 	embed_chance = 50
 	embedded_ignore_throwspeed_threshold = TRUE
 
-/obj/item/arrow/rod/proc/reset_rod() //Doing this in case rod was not destroyed in process.
+/obj/item/arrow/proc/reset_arrow() //Doing this in case rod was not destroyed in process.
 	throwforce = initial(throwforce)
 	superheated = initial(superheated)
 	armour_penetration = initial(armour_penetration)
 	embed_chance = initial(embed_chance)
 	embedded_ignore_throwspeed_threshold = initial(embedded_ignore_throwspeed_threshold)
 
-/obj/item/arrow/rod/afterattack(atom/target, mob/user, proximity, params)
+/obj/item/arrow/rod/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	. = ..()
-	reset_rod()
+	reset_arrow()
 
 /obj/item/arrow/rod/removed()
 	if(superheated) // The rod has been superheated - we don't want it to be useable when removed from the bow.
@@ -240,7 +241,7 @@
 	subcategory = CAT_AMMO
 
 
-/obj/item/arrow/rod/fire/modify_rod()
+/obj/item/arrow/rod/fire/modify_arrow()
 	throwforce = 25
 	armour_penetration = 15
 	embed_chance = 30


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление механики работы арбалетных болтов.
- Теперь они получают свою силу только при натяжении тетивы и теряют её при столкновении с чем-либо.
*До исправления сила болтов создавалась при помещении в арбалет.*

- Исправлена механика работы сброса силы болта, теперь она сбрасывается только при конце полёта. _(То есть, при throw_impact)_
*До исправления сила болтов модифицировалась и тут же убиралась при помещении в арбалет.*

- Также исправлен эксплоит, позволявший вытащить из арбалета болт с модифицированной силой метания в 33 ед. и использовать его как метательное оружие без арбалета.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
 
![изображение](https://github.com/ss220-space/Paradise/assets/73733747/18140791-7506-415d-ad07-dea2d0a5c959)

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
![174](https://github.com/ss220-space/Paradise/assets/73733747/e6884f18-1d63-4940-9374-cf141fdc6f10)

