### PR TITLE
balance: adrenaline implant

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1910,6 +1910,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "AI"
 	item = /obj/item/implanter/adrenalin
 	cost = 8
+	cant_discount = TRUE
+	surplus = 0
 
 /datum/uplink_item/implants/microbomb
 	name = "Microbomb Implant"

--- a/code/game/objects/items/weapons/implants/implant_misc.dm
+++ b/code/game/objects/items/weapons/implants/implant_misc.dm
@@ -38,13 +38,14 @@
 	imp_in.SetStunned(0)
 	imp_in.SetWeakened(0)
 	imp_in.SetParalysis(0)
-	imp_in.adjustStaminaLoss(-75)
+	imp_in.adjustStaminaLoss(-100)
 	imp_in.lying = 0
 	imp_in.update_canmove()
 
 	imp_in.reagents.add_reagent("synaptizine", 10)
 	imp_in.reagents.add_reagent("omnizine", 10)
 	imp_in.reagents.add_reagent("stimulative_agent", 10)
+	imp_in.reagents.add_reagent("adrenaline", 2)
 	if(!uses)
 		qdel(src)
 

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -951,10 +951,9 @@
 	var/update_flags = STATUS_UPDATE_NONE
 	ADD_TRAIT(M, TRAIT_GOTTAGOFAST, id)
 	if(M.health < 50 && M.health > 0)
-		update_flags |= M.adjustOxyLoss(-0.5, FALSE)
-		update_flags |= M.adjustToxLoss(-0.5, FALSE)
-		update_flags |= M.adjustBruteLoss(-0.5, FALSE)
-		update_flags |= M.adjustFireLoss(-0.5, FALSE)
+		update_flags |= M.adjustOxyLoss(-2, FALSE)
+		update_flags |= M.adjustBruteLoss(-2, FALSE)
+		update_flags |= M.adjustFireLoss(-2, FALSE)
 	M.AdjustParalysis(-6 SECONDS)
 	M.AdjustStunned(-6 SECONDS)
 	M.AdjustWeakened(-6 SECONDS)
@@ -1447,3 +1446,31 @@
 	..()
 	return TRUE
 
+/datum/reagent/medicine/adrenaline
+	name = "adrenaline"
+	id = "adrenaline"
+	description = "A powerfull stimulant that makes you immune to stuns for duration"
+	color = "#C8A5DC"
+	metabolization_rate = 0.8 * REAGENTS_METABOLISM
+	overdose_threshold = 2.1
+	shock_reduction = 80
+	harmless = TRUE
+	can_synth = FALSE
+
+/datum/reagent/medicine/adrenaline/on_mob_life(mob/living/M)
+	var/update_flags = STATUS_UPDATE_NONE
+	update_flags |= M.setStaminaLoss(0, FALSE)
+	var/status = CANSTUN | CANWEAKEN | CANPARALYSE
+	M.status_flags &= ~status
+
+	return ..() | update_flags
+
+/datum/reagent/medicine/adrenaline/on_mob_delete(mob/living/M)
+	M.status_flags |= CANSTUN | CANWEAKEN | CANPARALYSE
+	..()
+
+/datum/reagent/medicine/adrenaline/overdose_process(mob/living/M, severity)
+	var/update_flags = STATUS_UPDATE_NONE
+	update_flags |= M.adjustToxLoss(10, FALSE)
+
+	return list(0, update_flags)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Изменения адреналин импланта.
Восстановление выносливости при актиации повышено с 75 до 100
Теперь при активации вводит новый реагент, дерующий иммунитет к оглушению и стамина урону и повышает болевой порог на 80 единиц. При повторной активации до выветривания старого реагента, вы словите передозировку, что приведет к 50~ токс урона.
Адреналин имплант больше не имеет возможности выпадения скидок и не попадается в ящиках

P.S
Цифорки в коде немного отличаются от предложки, потому что при тех, что там, не совпадали с тем, какой исход обещан в предложке. Скорректировал цифры так, чтобы последствия в игре соответствовали предложке.

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1156047277325029436
## Демонстрация изменений
Демонстрирую иммунитета к оглушению на 10~ секунд(пруфы)
https://github.com/ss220-space/Paradise/assets/88409706/75dbbd07-319c-41a8-934e-34383b8b07a1


