### PR TITLE
FIX: Allow Skeleton Race plays on his Bones

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -316,7 +316,7 @@
 			to_chat(src, "<span class='info'>Вы полностью истощены.</span>")
 		else
 			to_chat(src, "<span class='info'>Вы чувствуете усталость.</span>")
-	if((SKELETON in H.mutations) && (!H.w_uniform) && (!H.wear_suit))
+	if((isskeleton(H) || SKELETON in H.mutations) && (!H.w_uniform) && (!H.wear_suit))
 		H.play_xylophone()
 
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -316,7 +316,7 @@
 			to_chat(src, "<span class='info'>Вы полностью истощены.</span>")
 		else
 			to_chat(src, "<span class='info'>Вы чувствуете усталость.</span>")
-	if((isskeleton(H) || SKELETON in H.mutations) && (!H.w_uniform) && (!H.wear_suit))
+	if((isskeleton(H) || (SKELETON in H.mutations)) && (!H.w_uniform) && (!H.wear_suit))
 		H.play_xylophone()
 
 


### PR DESCRIPTION

## Описание
Позволяет не только существам с мутацией Скелетон играть на костях, но и расе Скелетов тоже. А то у нас одни могут, а другие нет.

## Ссылка на предложение/Причина создания ПР
Педали сказали, что не на всех скелетах работала данная фича.

