### PR TITLE
bugfix: Spell Cooldown Visual

### DIFF
--- a/code/datums/spell_cooldown/spell_charges.dm
+++ b/code/datums/spell_cooldown/spell_charges.dm
@@ -61,7 +61,7 @@
 /datum/spell_cooldown/charges/statpanel_info()
 	var/charge_string = charge_duration != 0 ? round(min(1, (charge_duration - (charge_time - world.time)) / charge_duration), 0.01) * 100 : 100 // need this for possible 0 charge duration
 	var/recharge_string = recharge_duration != 0 ? round(min(1, (recharge_duration - (recharge_time - world.time)) / recharge_duration), 0.01) * 100 : 100
-	return "[charge_string != 100 ? "[charge_string]%\n" : ""][recharge_string != 100 ? "[recharge_string]%\n" : ""][current_charges]/[max_charges]"
+	return "[charge_string != 100 ? "[charge_string]%\n" : ""][recharge_string != 100 ? "[recharge_string]%\n" : ""][current_charges != max_charges ? "[current_charges]/[max_charges]" : ""]"
 
 
 /datum/spell_cooldown/charges/get_availability_percentage()


### PR DESCRIPTION
## Описание
Теперь количество зарядов спелла, когда он недоступен, не будет постоянно отображаться на кнопке. Это происходит в случае когда эти заряды уже полностью восстановились, но спелл до сих пор недоступен по другим причинам.