### PR TITLE
tweak: Shadowling Glare Autotarget

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -42,8 +42,10 @@
 
 
 /obj/effect/proc_holder/spell/shadowling_glare/create_new_targeting()
-	var/datum/spell_targeting/click/T = new()
-	T.click_radius = 0
+	var/datum/spell_targeting/targeted/T = new()
+	T.random_target = TRUE
+	T.target_priority = SPELL_TARGET_CLOSEST
+	T.max_targets = 1
 	T.range = 10
 	return T
 


### PR DESCRIPTION
## Описание
Позволяет тенелингу не выбирать цели, а применять способность Glare автоматически, на ближайшую цель.

## Ссылка на предложение/Причина создания ПР
Возвращение того что было введено ранее и сломалось при рефакторе: https://discord.com/channels/617003227182792704/755125334097133628/1078732629689507891