### PR TITLE
tweak: MA combo steps explain_text.

### DIFF
--- a/code/modules/martial_arts/combos/adminfu/healing_palm.dm
+++ b/code/modules/martial_arts/combos/adminfu/healing_palm.dm
@@ -2,7 +2,6 @@
 	name = "Healing Palm"
 	steps = list(MARTIAL_COMBO_STEP_GRAB, MARTIAL_COMBO_STEP_HELP)
 	explaination_text = "Heals or revives a creature."
-	combo_text_override = "Grab, Help"
 
 /datum/martial_combo/adminfu/healing_palm/perform_combo(mob/living/carbon/human/user, mob/living/target, datum/martial_art/MA)
 	user.do_attack_animation(target)

--- a/code/modules/martial_arts/combos/adminfu/healing_palm.dm
+++ b/code/modules/martial_arts/combos/adminfu/healing_palm.dm
@@ -2,7 +2,7 @@
 	name = "Healing Palm"
 	steps = list(MARTIAL_COMBO_STEP_GRAB, MARTIAL_COMBO_STEP_HELP)
 	explaination_text = "Heals or revives a creature."
-	combo_text_override = "Grab, switch hands, Help"
+	combo_text_override = "Grab, Help"
 
 /datum/martial_combo/adminfu/healing_palm/perform_combo(mob/living/carbon/human/user, mob/living/target, datum/martial_art/MA)
 	user.do_attack_animation(target)

--- a/code/modules/martial_arts/combos/cqc/restrain.dm
+++ b/code/modules/martial_arts/combos/cqc/restrain.dm
@@ -1,8 +1,8 @@
 /datum/martial_combo/cqc/restrain
 	name = "Restrain"
 	steps = list(MARTIAL_COMBO_STEP_GRAB, MARTIAL_COMBO_STEP_GRAB)
-	explaination_text = "Locks opponents into a restraining position, disarm to knock them out with a choke hold."
-	combo_text_override = "Grab, switch hands, Grab"
+	explaination_text = "Locks opponents into a restraining position. Disarm grabbed opponents after combo to knock them out with a choke hold."
+	combo_text_override = "Grab, Grab"
 
 /datum/martial_combo/cqc/restrain/perform_combo(mob/living/carbon/human/user, mob/living/target, datum/martial_art/MA)
 	var/datum/martial_art/cqc/CQC = MA

--- a/code/modules/martial_arts/combos/cqc/restrain.dm
+++ b/code/modules/martial_arts/combos/cqc/restrain.dm
@@ -2,7 +2,6 @@
 	name = "Restrain"
 	steps = list(MARTIAL_COMBO_STEP_GRAB, MARTIAL_COMBO_STEP_GRAB)
 	explaination_text = "Locks opponents into a restraining position. Disarm grabbed opponents after combo to knock them out with a choke hold."
-	combo_text_override = "Grab, Grab"
 
 /datum/martial_combo/cqc/restrain/perform_combo(mob/living/carbon/human/user, mob/living/target, datum/martial_art/MA)
 	var/datum/martial_art/cqc/CQC = MA

--- a/code/modules/martial_arts/combos/cqc/slam.dm
+++ b/code/modules/martial_arts/combos/cqc/slam.dm
@@ -2,7 +2,6 @@
 	name = "Slam"
 	steps = list(MARTIAL_COMBO_STEP_GRAB, MARTIAL_COMBO_STEP_HARM)
 	explaination_text = "Slam opponent into the ground, knocking them down."
-	combo_text_override = "Grab, Harm"
 
 /datum/martial_combo/cqc/slam/perform_combo(mob/living/carbon/human/user, mob/living/target, datum/martial_art/MA)
 	if(!target.IsWeakened() && !target.resting && !target.lying)

--- a/code/modules/martial_arts/combos/cqc/slam.dm
+++ b/code/modules/martial_arts/combos/cqc/slam.dm
@@ -2,7 +2,7 @@
 	name = "Slam"
 	steps = list(MARTIAL_COMBO_STEP_GRAB, MARTIAL_COMBO_STEP_HARM)
 	explaination_text = "Slam opponent into the ground, knocking them down."
-	combo_text_override = "Grab, switch hands, Harm"
+	combo_text_override = "Grab, Harm"
 
 /datum/martial_combo/cqc/slam/perform_combo(mob/living/carbon/human/user, mob/living/target, datum/martial_art/MA)
 	if(!target.IsWeakened() && !target.resting && !target.lying)

--- a/code/modules/martial_arts/combos/mimejutsu/silencer.dm
+++ b/code/modules/martial_arts/combos/mimejutsu/silencer.dm
@@ -2,7 +2,7 @@
 	name = "Silencer"
 	steps = list(MARTIAL_COMBO_STEP_GRAB, MARTIAL_COMBO_STEP_DISARM)
 	explaination_text = "Weakens the opponent and prevents him from speaking for a while."
-	combo_text_override = "Grab, switch hands, Disarm"
+	combo_text_override = "Grab, Disarm"
 
 /datum/martial_combo/mimejutsu/silencer/perform_combo(mob/living/carbon/human/user, mob/living/target, datum/martial_art/MA)
 	var/datum/martial_art/mimejutsu/mimejutsu = MA

--- a/code/modules/martial_arts/combos/mimejutsu/silencer.dm
+++ b/code/modules/martial_arts/combos/mimejutsu/silencer.dm
@@ -2,7 +2,6 @@
 	name = "Silencer"
 	steps = list(MARTIAL_COMBO_STEP_GRAB, MARTIAL_COMBO_STEP_DISARM)
 	explaination_text = "Weakens the opponent and prevents him from speaking for a while."
-	combo_text_override = "Grab, Disarm"
 
 /datum/martial_combo/mimejutsu/silencer/perform_combo(mob/living/carbon/human/user, mob/living/target, datum/martial_art/MA)
 	var/datum/martial_art/mimejutsu/mimejutsu = MA

--- a/code/modules/martial_arts/combos/mrchang/steal_card.dm
+++ b/code/modules/martial_arts/combos/mrchang/steal_card.dm
@@ -2,7 +2,7 @@
 	name = "Bonus card please!"
 	steps = list(MARTIAL_COMBO_STEP_GRAB, MARTIAL_COMBO_STEP_DISARM)
 	explaination_text = "Забирает у цели любой предмет, находящийся в слоте ID-карты и помещает его в руку атакующего."
-	combo_text_override = "Grab, switch hands, Disarm"
+	combo_text_override = "Grab, Disarm"
 
 /datum/martial_combo/mr_chang/steal_card/perform_combo(mob/living/carbon/human/user, mob/living/target, datum/martial_art/MA)
 	var/mob/living/carbon/human/T = target

--- a/code/modules/martial_arts/combos/mrchang/steal_card.dm
+++ b/code/modules/martial_arts/combos/mrchang/steal_card.dm
@@ -2,7 +2,6 @@
 	name = "Bonus card please!"
 	steps = list(MARTIAL_COMBO_STEP_GRAB, MARTIAL_COMBO_STEP_DISARM)
 	explaination_text = "Забирает у цели любой предмет, находящийся в слоте ID-карты и помещает его в руку атакующего."
-	combo_text_override = "Grab, Disarm"
 
 /datum/martial_combo/mr_chang/steal_card/perform_combo(mob/living/carbon/human/user, mob/living/target, datum/martial_art/MA)
 	var/mob/living/carbon/human/T = target

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -192,6 +192,7 @@
 	explaination_header(user)
 	explaination_combos(user)
 	explaination_footer(user)
+	explaination_notice(user)
 
 // Put after the header and before the footer in the explaination text
 /datum/martial_art/proc/explaination_combos(user)
@@ -207,6 +208,9 @@
 // Put below the combos in the explaination text
 /datum/martial_art/proc/explaination_footer(user)
 	return
+
+/datum/martial_art/proc/explaination_notice(user)
+	return to_chat(user, "<b><i>Combo steps can be provided only with empty hand!</b></i>")
 
 /datum/martial_art/proc/try_deflect(mob/user)
 	return prob(deflection_chance)

--- a/code/modules/martial_arts/mrchang.dm
+++ b/code/modules/martial_arts/mrchang.dm
@@ -36,3 +36,6 @@
 	to_chat(user, "<span class='notice'>Business lunch</span>: Глутамат натрия теперь восстанавливает 0,75 ожогового/физического урона. (Содержится в малом количестве в еде Mr. Chang)")
 	to_chat(user, "<span class='notice'>TAKEYOMONEY</span>: Пачка купюр при броске наносит урон, пропорциональный толщине пачки.")
 	to_chat(user, "<span class='notice'>Change please!</span>: Монеты при броске имеют шанс в 30% застрять в теле жертвы, нанося малый периодический урон")
+
+/datum/martial_art/mr_chang/explaination_notice(user)
+	to_chat(user, "<b><i>Шаги комбо могут быть произведены только пустой активной рукой!</i></b>")

--- a/code/modules/martial_arts/sleeping_carp.dm
+++ b/code/modules/martial_arts/sleeping_carp.dm
@@ -59,5 +59,8 @@
 /datum/martial_art/the_sleeping_carp/explaination_footer(user)
 	to_chat(user, "<b><i>Кроме того, если при стрельбе в вас включен режим броска, вы переходите в режим активной обороны, в котором блокируете и отклоняете все выпущенные в вас снаряды!</i></b>")
 
+/datum/martial_art/the_sleeping_carp/explaination_notice(user)
+	to_chat(user, "<b><i>Шаги комбо могут быть произведены только пустой активной рукой!</i></b>")
+
 /datum/martial_art/the_sleeping_carp/try_deflect(mob/user)
 	return user.in_throw_mode && ..() // in case an admin wants to var edit carp to have less deflection chance


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Убирает из описания комбух несуществующий шаг со сменой рук, вводящий игроков в заблуждение. Добавляет строчку в конец "обьяснения" БИ, уточняющий то, как правильно само БИ нужно использовать.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Обьяснение этого недочёта Контрибьютором
![image](https://github.com/ss220-space/Paradise/assets/115735095/2a3488b7-beb5-4e67-a450-3aee60107512)
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
