### PR TITLE
fix: no stimulants for nukies

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -545,7 +545,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	category = "Racial Specific Tools"
 	cant_discount = TRUE
 	surplus = 0
-	excludefrom = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST) 
+	excludefrom = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 
 //IPC
 
@@ -1882,6 +1882,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "ST"
 	item = /obj/item/reagent_containers/hypospray/autoinjector/stimulants
 	cost = 5
+	excludefrom = list(UPLINK_TYPE_NUCLEAR)
 
 // IMPLANTS
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Убирает Стимулянты из аплинка нюкеров. 
Оставляет их ССТшникам (ибо щитспавн, в крайней случае админ может сам сказать не брать).

А ещё там убирается пробел. Я хз почему, ВСкод сам его убирает, но по идее проблем вызывать не должно.

<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/981470952061804604/1164283276521898126 (разрешение от Димача)
Кроме того есть предложка (https://discord.com/channels/617003227182792704/708456634468270100/1164141149678739508), она прошла
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
