### PR TITLE
bugfix: bananapeels makes you laugh normally.

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -490,6 +490,6 @@
 
 /datum/plant_gene/trait/plant_laughter/on_slip(obj/item/reagent_containers/food/snacks/grown/G, mob/living/carbon/C)
 
-	if(C.IsStunned())
-		playsound(G, pick(sounds), 100, 1)
+	if(C.IsWeakened())
+		playsound(C, pick(sounds), 100, 1)
 		C.visible_message("<span class='notice'>[G] lets out burst of laughter.</span>")


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
В одном месте проверка на "ослабление" таки не догнала рефактор станов, исправлено. Ещё сделал, чтобы звук в гене галюнов проигрывался из самого юзера, а не из кожурки, ибо кожурка может быть перемещена или уничтожена перед проигрыванием звука, второе вообще вызовет рантайм (а ещё это звук у нас в голове же по логике, галюны, вся хуйня).<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на баг-репорт
https://discord.com/channels/617003227182792704/1164089970340921397<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
