### PR TITLE
bugfix: T-rays can now see hiden safes.

### DIFF
--- a/code/ATMOSPHERICS/pipes/cap.dm
+++ b/code/ATMOSPHERICS/pipes/cap.dm
@@ -18,7 +18,7 @@
 
 /obj/machinery/atmospherics/pipe/cap/hide(var/i)
 	if(level == 1 && istype(loc, /turf/simulated))
-		invisibility = i ? 101 : 0
+		invisibility = i ? INVISIBILITY_ABSTRACT : 0
 	update_icon()
 
 /obj/machinery/atmospherics/pipe/cap/pipeline_expansion()

--- a/code/ATMOSPHERICS/pipes/manifold.dm
+++ b/code/ATMOSPHERICS/pipes/manifold.dm
@@ -62,7 +62,7 @@
 
 /obj/machinery/atmospherics/pipe/manifold/hide(var/i)
 	if(level == 1 && istype(loc, /turf/simulated))
-		invisibility = i ? 101 : 0
+		invisibility = i ? INVISIBILITY_ABSTRACT : 0
 
 /obj/machinery/atmospherics/pipe/manifold/pipeline_expansion()
 	return list(node1, node2, node3)

--- a/code/ATMOSPHERICS/pipes/manifold4w.dm
+++ b/code/ATMOSPHERICS/pipes/manifold4w.dm
@@ -133,7 +133,7 @@
 
 /obj/machinery/atmospherics/pipe/manifold4w/hide(var/i)
 	if(level == 1 && istype(loc, /turf/simulated))
-		invisibility = i ? 101 : 0
+		invisibility = i ? INVISIBILITY_ABSTRACT : 0
 
 /obj/machinery/atmospherics/pipe/manifold4w/atmos_init()
 	..()

--- a/code/ATMOSPHERICS/pipes/simple/pipe_simple.dm
+++ b/code/ATMOSPHERICS/pipes/simple/pipe_simple.dm
@@ -165,4 +165,4 @@
 
 /obj/machinery/atmospherics/pipe/simple/hide(var/i)
 	if(level == 1 && istype(loc, /turf/simulated))
-		invisibility = i ? 101 : 0
+		invisibility = i ? INVISIBILITY_ABSTRACT : 0

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -188,7 +188,6 @@
 
 #define STATUS_UPDATE_NONE 0
 #define STATUS_UPDATE_ALL (~0)
-#define INVISIBILITY_ABSTRACT 101
 
 // Incorporeal movement
 #define INCORPOREAL_NONE 0

--- a/code/__DEFINES/sight.dm
+++ b/code/__DEFINES/sight.dm
@@ -28,6 +28,7 @@
 
 
 #define INVISIBILITY_MAXIMUM 100
+#define INVISIBILITY_ABSTRACT 101
 
 //Some mob defines below
 #define AI_CAMERA_LUMINOSITY 6

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1380,7 +1380,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	GLOB.dview_mob.loc = null
 
 /mob/dview
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 	density = 0
 	move_force = 0
 	pull_force = 0

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -49,7 +49,7 @@
 		affected_mob.canmove = 0
 		affected_mob.icon = null
 		affected_mob.overlays.Cut()
-		affected_mob.invisibility = 101
+		affected_mob.invisibility = INVISIBILITY_ABSTRACT
 		for(var/obj/item/W in affected_mob)
 			if(istype(W, /obj/item/implant))
 				qdel(W)

--- a/code/game/dna/genes/monkey.dm
+++ b/code/game/dna/genes/monkey.dm
@@ -24,7 +24,7 @@
 	H.SetStunned(2 SECONDS)
 	H.canmove = FALSE
 	H.icon = null
-	H.invisibility = 101
+	H.invisibility = INVISIBILITY_ABSTRACT
 	var/has_primitive_form = H.dna.species.primitive_form // cache this
 	if(has_primitive_form)
 		H.set_species(has_primitive_form)
@@ -60,7 +60,7 @@
 	H.SetStunned(2 SECONDS)
 	H.canmove = 0
 	H.icon = null
-	H.invisibility = 101
+	H.invisibility = INVISIBILITY_ABSTRACT
 	var/has_greater_form = H.dna.species.greater_form //cache this
 	if(has_greater_form)
 		H.set_species(has_greater_form)

--- a/code/game/machinery/Beacon.dm
+++ b/code/game/machinery/Beacon.dm
@@ -43,7 +43,7 @@
 	return ..()
 
 /obj/machinery/bluespace_beacon/hide(var/intact)
-	invisibility = intact ? 101 : 0
+	invisibility = intact ? INVISIBILITY_ABSTRACT : 0
 	update_icon()
 
 // update the icon_state

--- a/code/game/machinery/computer/pod.dm
+++ b/code/game/machinery/computer/pod.dm
@@ -312,7 +312,7 @@
 		var/obj/effect/landmark/L = thing
 		if(L.name == "Marauder Exit")
 			var/obj/effect/portal/P = new(L.loc, pick(spawn_marauder))
-			P.invisibility = 101//So it is not seen by anyone.
+			P.invisibility = INVISIBILITY_ABSTRACT//So it is not seen by anyone.
 			P.failchance = 0//So it has no fail chance when teleporting.
 			P.can_mecha_pass = TRUE
 			spawn_marauder.Remove(P.target)

--- a/code/game/machinery/magnet.dm
+++ b/code/game/machinery/magnet.dm
@@ -46,7 +46,7 @@
 
 	// update the invisibility and icon
 /obj/machinery/magnetic_module/hide(intact)
-	invisibility = intact ? 101 : 0
+	invisibility = intact ? INVISIBILITY_ABSTRACT : 0
 	updateicon()
 
 	// update the icon_state

--- a/code/game/objects/effects/bump_teleporter.dm
+++ b/code/game/objects/effects/bump_teleporter.dm
@@ -4,9 +4,9 @@ GLOBAL_LIST_EMPTY(bump_teleporters)
 	name = "bump-teleporter"
 	icon = 'icons/mob/screen_gen.dmi'
 	icon_state = "x2"
-	var/id = null			//id of this bump_teleporter.
-	var/id_target = null	//id of bump_teleporter which this moves you to.
-	invisibility = 101 		//nope, can't see this
+	var/id = null							//id of this bump_teleporter.
+	var/id_target = null					//id of bump_teleporter which this moves you to.
+	invisibility = INVISIBILITY_ABSTRACT 	//nope, can't see this
 	anchored = 1
 	density = 1
 	opacity = 0

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -10,7 +10,7 @@
 
 	..()
 	set_tag()
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 
 	switch(name)			//some of these are probably obsolete
 		if("start")

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -119,7 +119,7 @@
 	if(triggered)
 		return
 	triggered = 1
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 	mineEffect(victim)
 	qdel(src)
 

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -105,7 +105,7 @@ REAGENT SCANNER
 
 			var/temp_invisibility = in_turf_object.invisibility
 			var/temp_alpha = in_turf_object.alpha
-			if(temp_invisibility == 101 || temp_invisibility == INVISIBILITY_ANOMALY)
+			if(temp_invisibility == INVISIBILITY_ABSTRACT || temp_invisibility == INVISIBILITY_ANOMALY)
 				in_turf_object.invisibility = 0
 				in_turf_object.alpha = 128
 				in_turf_object.drain_act_protected = TRUE

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -412,7 +412,7 @@
 
 /obj/item/storage/backpack/satchel_flat/hide(var/intact)
 	if(intact)
-		invisibility = 101
+		invisibility = INVISIBILITY_ABSTRACT
 		anchored = 1 //otherwise you can start pulling, cover it, and drag around an invisible backpack.
 		icon_state = "[initial(icon_state)]2"
 	else

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -375,7 +375,7 @@ GLOBAL_LIST_EMPTY(safes)
 		hide(T.intact)
 
 /obj/structure/safe/floor/hide(intact)
-	invisibility = intact ? 101 : 0
+	invisibility = intact ? INVISIBILITY_ABSTRACT : 0
 
 /**
   * # Safe Internals

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -375,7 +375,7 @@ GLOBAL_LIST_EMPTY(safes)
 		hide(T.intact)
 
 /obj/structure/safe/floor/hide(intact)
-	invisibility = intact ? INVISIBILITY_MAXIMUM : 0
+	invisibility = intact ? 101 : 0
 
 /**
   * # Safe Internals

--- a/code/modules/arcade/mob_hunt/mob_avatar.dm
+++ b/code/modules/arcade/mob_hunt/mob_avatar.dm
@@ -2,7 +2,7 @@
 /obj/effect/nanomob
 	name = "Nano-Mob Avatar"					//will be overridden by the mob datum name value when created
 	desc = "A wild Nano-Mob appeared! Hit it with your PDA with the game open to attempt to capture it!"
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 	alpha = 128
 	anchored = 1								//just in case
 	density = 0

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -244,7 +244,7 @@
 		left--
 	if(left < 1)
 		if(!(visible))
-			invisibility = 101
+			invisibility = INVISIBILITY_ABSTRACT
 		else
 			invisibility = FALSE
 	else

--- a/code/modules/awaymissions/map_rng.dm
+++ b/code/modules/awaymissions/map_rng.dm
@@ -2,7 +2,7 @@
 	name = "map loader"
 	icon = 'icons/mob/screen_gen.dmi'
 	icon_state = "x2"
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 	anchored = 1
 	density = 0
 	opacity = 0

--- a/code/modules/awaymissions/mission_code/beach.dm
+++ b/code/modules/awaymissions/mission_code/beach.dm
@@ -6,7 +6,7 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	density = 0
 	anchored = 1
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 
 	var/water_frequency = 15
 	var/water_timer = 0

--- a/code/modules/awaymissions/mission_code/spacehotel.dm
+++ b/code/modules/awaymissions/mission_code/spacehotel.dm
@@ -192,7 +192,7 @@
 	name = "Deep Space Hotel 419"
 	icon = 'icons/mob/screen_gen.dmi'
 	icon_state = "x"
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 	anchored = 1
 	density = 0
 	opacity = 0

--- a/code/modules/awaymissions/mission_code/stationCollision.dm
+++ b/code/modules/awaymissions/mission_code/stationCollision.dm
@@ -196,7 +196,7 @@ GLOBAL_VAR_INIT(sc_safecode5, "[rand(0,9)]")
 			for(var/obj/O in T.contents)
 				if(O.level != 1)
 					continue
-				if(O.invisibility == 101)
+				if(O.invisibility == INVISIBILITY_ABSTRACT)
 					src.consume(O)
 		T.ChangeTurf(T.baseturf)
 	return

--- a/code/modules/awaymissions/zvis.dm
+++ b/code/modules/awaymissions/zvis.dm
@@ -9,7 +9,7 @@
 	name = "level reference"
 	icon = 'icons/mob/screen_gen.dmi'
 	icon_state = "x2"
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 
 	var/id = null
 	var/obj/effect/levelref/other = null
@@ -46,7 +46,7 @@
 // Used by /turf/simulated/floor/indestructible/upperlevel and /obj/effect/view_portal/visual
 // to know if the world changed on the remote side
 /obj/effect/portal_sensor
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 	var/light_hash = -1
 	var/triggered_this_tick = 0
 	var/datum/owner			// owner that receive signals
@@ -154,7 +154,7 @@
 	name = "portal target"
 	icon = 'icons/mob/screen_gen.dmi'
 	icon_state = "x2"
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 	anchored = 1
 
 	var/id = null				// id of other portal turf we connect to

--- a/code/modules/clothing/spacesuits/chronosuit.dm
+++ b/code/modules/clothing/spacesuits/chronosuit.dm
@@ -181,7 +181,7 @@
 	name = "Chronosuit View"
 	density = 0
 	anchored = 1
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 	opacity = 0
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	var/mob/holder = null

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -535,7 +535,7 @@
 	eat(user)
 
 /obj/structure/spacevine_controller
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 	var/list/obj/structure/spacevine/vines = list()
 	var/list/growth_queue = list()
 	var/spread_multiplier = 5

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -4,7 +4,7 @@
 /obj/effect/light_emitter
 	name = "Light emitter"
 	anchored = TRUE
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 	var/set_luminosity = 8
 	var/set_cap = 0
 

--- a/code/modules/mob/camera/camera.dm
+++ b/code/modules/mob/camera/camera.dm
@@ -8,7 +8,7 @@
 	status_flags = GODMODE  // You can't damage it.
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	see_in_dark = 8
-	invisibility = 101  // No one can see us
+	invisibility = INVISIBILITY_ABSTRACT  // No one can see us
 	sight = SEE_SELF
 	move_on_shuttle = 0
 

--- a/code/modules/mob/living/carbon/alien/death.dm
+++ b/code/modules/mob/living/carbon/alien/death.dm
@@ -6,7 +6,7 @@
 	notransform = 1
 	canmove = 0
 	icon = null
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 
 	animation = new(loc)
 	animation.icon_state = "blank"
@@ -29,7 +29,7 @@
 	notransform = 1
 	canmove = 0
 	icon = null
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 	dust_animation()
 	new /obj/effect/decal/remains/xeno(loc)
 	GLOB.dead_mob_list -= src

--- a/code/modules/mob/living/carbon/brain/death.dm
+++ b/code/modules/mob/living/carbon/brain/death.dm
@@ -15,7 +15,7 @@
 	notransform = 1
 	canmove = 0
 	icon = null
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 
 	gibs(loc, dna)
 

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -5,7 +5,7 @@
 	notransform = 1
 	canmove = 0
 	icon = null
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 	if(!ismachineperson(src))
 		animation = new(loc)
 		animation.icon_state = "blank"
@@ -52,7 +52,7 @@
 	notransform = 1
 	canmove = 0
 	icon = null
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 	dust_animation()
 	QDEL_IN(src, 0)
 	return TRUE
@@ -77,7 +77,7 @@
 	notransform = 1
 	canmove = 0
 	icon = null
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 
 	animation = new(loc)
 	animation.icon_state = "blank"

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -7,7 +7,7 @@
 	notransform = 1
 	canmove = 0
 	icon = null
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 
 	playsound(src.loc, 'sound/goonstation/effects/gib.ogg', 50, 1)
 	gibs(loc, dna)
@@ -25,7 +25,7 @@
 	notransform = 1
 	canmove = 0
 	icon = null
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 	QDEL_IN(src, 0)
 	return TRUE
 
@@ -36,7 +36,7 @@
 	notransform = 1
 	canmove = 0
 	icon = null
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 	QDEL_IN(src, 0)
 	return TRUE
 

--- a/code/modules/mob/living/silicon/death.dm
+++ b/code/modules/mob/living/silicon/death.dm
@@ -4,7 +4,7 @@
 	notransform = 1
 	canmove = 0
 	icon = null
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 
 	animation = new(loc)
 	animation.icon_state = "blank"
@@ -28,7 +28,7 @@
 	notransform = 1
 	canmove = 0
 	icon = null
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 	dust_animation()
 	GLOB.dead_mob_list -= src
 	QDEL_IN(src, 15)

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -6,7 +6,7 @@
 	notransform = 1
 	canmove = 0
 	icon = null
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 
 	animation = new(loc)
 	animation.icon_state = "blank"
@@ -35,7 +35,7 @@
 	notransform = 1
 	canmove = 0
 	icon = null
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 	if(mmi)
 		qdel(mmi)	//Delete the MMI first so that it won't go popping out.
 	GLOB.dead_mob_list -= src

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -5,7 +5,7 @@
 	var/totalPlayersReady = 0
 	universal_speak = 1
 
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 
 	density = 0
 	stat = 2

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -26,7 +26,7 @@
 	notransform = 1
 	canmove = 0
 	icon = null
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 	return ..()
 
 /mob/proc/AIize()
@@ -73,7 +73,7 @@
 	notransform = 1
 	canmove = 0
 	icon = null
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 
 	// Creating a new borg here will connect them to a default AI and notify that AI, if `connect_to_default_AI` is TRUE.
 	var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(loc, connect_to_AI = connect_to_default_AI)
@@ -130,7 +130,7 @@
 	notransform = 1
 	canmove = 0
 	icon = null
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 	for(var/t in bodyparts)	//this really should not be necessary
 		qdel(t)
 
@@ -155,7 +155,7 @@
 	notransform = 1
 	canmove = 0
 	icon = null
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 
 	for(var/t in bodyparts)
 		qdel(t)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -100,7 +100,7 @@ By design, d1 is the smallest direction and d2 is the highest
 /obj/structure/cable/hide(i)
 
 	if(level == 1 && isturf(loc))
-		invisibility = i ? 101 : 0
+		invisibility = i ? INVISIBILITY_ABSTRACT : 0
 	updateicon()
 
 /obj/structure/cable/proc/updateicon()

--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -29,7 +29,7 @@
 
 /obj/machinery/power/terminal/hide(i)
 	if(i)
-		invisibility = 101
+		invisibility = INVISIBILITY_ABSTRACT
 		icon_state = "term-f"
 	else
 		invisibility = 0

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -162,7 +162,7 @@
 		M.canmove = FALSE
 		M.icon = null
 		M.overlays.Cut()
-		M.invisibility = 101
+		M.invisibility = INVISIBILITY_ABSTRACT
 
 		if(isrobot(M))
 			var/mob/living/silicon/robot/Robot = M

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -70,7 +70,7 @@
 // hide called by levelupdate if turf intact status changes
 // change visibility status and force update of icon
 /obj/structure/disposalconstruct/hide(var/intact)
-	invisibility = (intact && level==1) ? 101: 0	// hide if floor is intact
+	invisibility = (intact && level==1) ? INVISIBILITY_ABSTRACT: 0	// hide if floor is intact
 	update()
 
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -636,7 +636,7 @@
 // this allows the gas flushed to be tracked
 
 /obj/structure/disposalholder
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	var/datum/gas_mixture/gas = null	// gas used to flush, will appear at exit point
 	var/active = 0	// true if the holder is moving, otherwise inactive
@@ -890,7 +890,7 @@
 // hide called by levelupdate if turf intact status changes
 // change visibility status and force update of icon
 /obj/structure/disposalpipe/hide(var/intact)
-	invisibility = intact ? 101: 0	// hide if floor is intact
+	invisibility = intact ? INVISIBILITY_ABSTRACT: 0	// hide if floor is intact
 	update_icon()
 
 // update actual icon_state depending on visibility
@@ -968,7 +968,7 @@
 				var/obj/structure/disposalpipe/broken/P = new(src.loc)
 				P.setDir(D)
 
-	invisibility = 101	// make invisible (since we won't delete the pipe immediately)
+	invisibility = INVISIBILITY_ABSTRACT	// make invisible (since we won't delete the pipe immediately)
 	var/obj/structure/disposalholder/H = locate() in src
 	if(H)
 		// holder was present

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -4,7 +4,7 @@
 
 //NORTH default dir
 /obj/docking_port
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 	icon = 'icons/obj/device.dmi'
 	//icon = 'icons/dirsquare.dmi'
 	icon_state = "pinonfar"

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -135,7 +135,7 @@ GLOBAL_LIST_INIT(non_simple_animals, typecacheof(list(/mob/living/carbon/human/l
 	name = "big machinery part"
 	density = 1
 	anchored = 1
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 	var/obj/machinery/parent
 
 /obj/structure/filler/Destroy()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Возвращает сейфам под полом "неАдминское" значение инвиза, чтобы их мог улавливать Т-рей сканер. И ещё дефайны там потыкал, да.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на баг-репорт
https://discord.com/channels/617003227182792704/1165491558368411648<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
![image](https://github.com/ss220-space/Paradise/assets/115735095/e903a8ef-2e3e-425a-9d7f-daf947f82255)
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
