### PR TITLE
add: Bombarda craft is now configurable. Craft enabled only on Vega/Cleo

### DIFF
--- a/code/controllers/configuration/entries/testing.dm
+++ b/code/controllers/configuration/entries/testing.dm
@@ -1,0 +1,6 @@
+/**
+ * Entries here contain flags that are used only on testing servers
+ */
+
+///Enables bombarda crafting on server.
+/datum/config_entry/flag/enable_bombarda_craft

--- a/code/modules/projectiles/guns/projectile/bombarda.dm
+++ b/code/modules/projectiles/guns/projectile/bombarda.dm
@@ -169,7 +169,12 @@
 	time = 6 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
+	always_availible = FALSE
 
+/datum/crafting_recipe/bombarda/New()
+	. = ..()
+	if(CONFIG_GET(flag/enable_bombarda_craft))
+		always_availible = TRUE
 
 /datum/crafting_recipe/explosion_shell
 	name = "Improvised explosive shell"
@@ -181,6 +186,12 @@
 	time = 2 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
+	always_availible = FALSE
+
+/datum/crafting_recipe/explosion_shell/New()
+	. = ..()
+	if(CONFIG_GET(flag/enable_bombarda_craft))
+		always_availible = TRUE
 
 /datum/crafting_recipe/flame_shell
 	name = "Improvised flame shell"
@@ -195,6 +206,12 @@
 	time = 2 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
+	always_availible = FALSE
+
+/datum/crafting_recipe/flame_shell/New()
+	. = ..()
+	if(CONFIG_GET(flag/enable_bombarda_craft))
+		always_availible = TRUE
 
 /datum/crafting_recipe/smoke_shell
 	name = "Improvised smoke shell"
@@ -208,3 +225,9 @@
 	time = 2 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
+	always_availible = FALSE
+
+/datum/crafting_recipe/smoke_shell/New()
+	. = ..()
+	if(CONFIG_GET(flag/enable_bombarda_craft))
+		always_availible = TRUE

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -1,3 +1,7 @@
+# You can use the "$include" directive to split your configs however you want
+
+$include testing.txt
+
 ## Server name: This appears at the top of the screen in-game. In this case it will read "spacestation13: station_name" where station_name is the randomly generated name of the station for the round. Remove the # infront of SERVERNAME and replace 'spacestation13' with the name of your choice
 # SERVERNAME spacestation13
 

--- a/config/example/testing.txt
+++ b/config/example/testing.txt
@@ -1,0 +1,4 @@
+#Entries here contain flags that are used only on testing.
+
+## Enables bombarda craft.
+#ENABLE_BOMBARDA_CRAFT 

--- a/config/example/testing.txt
+++ b/config/example/testing.txt
@@ -1,4 +1,4 @@
 #Entries here contain flags that are used only on testing.
 
 ## Enables bombarda craft.
-#ENABLE_BOMBARDA_CRAFT 
+ENABLE_BOMBARDA_CRAFT 

--- a/paradise.dme
+++ b/paradise.dme
@@ -251,6 +251,7 @@
 #include "code\controllers\configuration\entries\config.dm"
 #include "code\controllers\configuration\entries\dbconfig.dm"
 #include "code\controllers\configuration\entries\game_options.dm"
+#include "code\controllers\configuration\entries\testing.dm"
 #include "code\controllers\configuration\entries\text_to_speech.dm"
 #include "code\controllers\subsystem\acid.dm"
 #include "code\controllers\subsystem\afk.dm"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
По итогам обсуждений в авоутах насчёт вырезания/нерфа бомбарды, коллективно решили, что бомбарда останется на тестовых серверах для доработки.
Добавлено сокрытие бомбарды, снарядов из меню крафта.
На тандердоме бомбарда и её снаряды останутся в пуле дальнобойных пушек.
____

Серверные изменения:
- Добавить $include testing.txt в начале config.txt
- Добавить testing.txt
- Установить ENABLE_BOMBARDA_CRAFT в желаемое значение

____

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
https://discord.com/channels/617003227182792704/1166119030193668177
https://discord.com/channels/617003227182792704/1166286701472256010

