### PR TITLE
bugfix: chameleon presets.

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -105,7 +105,13 @@
 			if(chameleon_blacklist[V] || (initial(I.flags) & ABSTRACT) || !initial(I.icon_state))
 				continue
 			var/chameleon_item_name = "[initial(I.name)] ([initial(I.icon_state)])"
-			chameleon_list[chameleon_item_name] = I
+			var/copies = FALSE
+			for(var/chameleon_item_index in chameleon_list)
+				if(chameleon_item_index == chameleon_item_name)
+					copies = TRUE
+					break
+			if(!copies)
+				chameleon_list[chameleon_item_name] = I
 
 /datum/action/item_action/chameleon/change/proc/select_look(mob/user)
 	var/obj/item/picked_item


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
При добавлении предметов в список возможных маскировок для хамелеонов проверяет, есть ли в списке предмет с таким же индексом, предотвращая их замену на предметы с неподходящими для пресетов типами. Спасибо Цвею за обьяснение работы индексов.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на баг-репорт
https://discord.com/channels/617003227182792704/1165408725079687308/1165408725079687308<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Для будущих поколений
Если у кого-то будет желание почистить список маскировок от ненужного мусора. Проверки на сходство иконок только всё сломают, ибо некоторые датумы должностей используют разные вещи с одинаковыми иконками. Пример:
![изображение](https://github.com/ss220-space/Paradise/assets/115735095/52f203ea-f4f6-4687-a096-ca5506111ba4)
Нужно будет именно заполнять блеклист предметами, которые нежелательно видеть в списке маскировок.