### PR TITLE
add: Counterfeiter Bundle, uplink item that allows to forge all types of existing documents. 

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1400,22 +1400,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/stealthy_tools
 	category = "Stealth and Camouflage Items"
 
-/datum/uplink_item/stealthy_tools/chameleon_stamp
-	name = "Chameleon Stamp"
-	desc = "A stamp that can be activated to imitate an official Nanotrasen Stamp. The disguised stamp will work exactly like the real stamp and will allow you to forge false documents to gain access or equipment; \
-	it can also be used in a washing machine to forge clothing."
+/datum/uplink_item/stealthy_tools/syndie_kit/counterfeiter_bundle
+	name = "Syndicate Counterfeiter Bundle"
+	desc = "A cleverly implemented bundle designed to document counterfeiting. Comes with a chameleon stamp, capable of imitating any NanoTrasen issued stamps and a fakesign pen to alter the world through the sheer force of paperwork. While making the user capable of faking almost any document, this Syndicate technology has been rumored to cause a huge upheaval on NT objects. "
 	reference = "CHST"
-	item = /obj/item/stamp/chameleon
-	cost = 1
-	surplus = 35
-
-/datum/uplink_item/stealthy_tools/chameleonpen
-	name = "Chameleon Pen"
-	desc = "A pen with customized ultra-super high-tech tip, that makes everything you write look like a real signature."
-	reference = "CHPEN"
-	item = /obj/item/pen/fakesign
-	cost = 1
-	surplus = 35
+	cost = 1 
+	surplus = 35 
+	item = /obj/item/storage/box/syndie_kit/counterfeiter_bundle 
 
 /datum/uplink_item/stealthy_tools/chameleonflag
 	name = "Chameleon Flag"

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -174,6 +174,15 @@
 	can_hold = list(/obj/item/clothing/suit/space/hardsuit/contractor/agent, /obj/item/tank/internals/emergency_oxygen/engi/syndi, /obj/item/clothing/mask/gas/syndicate)
 	max_w_class = WEIGHT_CLASS_NORMAL
 
+
+/obj/item/storage/box/syndie_kit/counterfeiter_bundle
+	name = "Counterfeiter Bundle"
+	desc = "A box containing all the neccessary equipment to forge stamps and insignias, making the user capable of faking any NanoTrasen documents."
+
+/obj/item/storage/box/syndie_kit/counterfeiter_bundle/populate_contents()
+	new obj/item/stamp/chameleon
+	new obj/item/pen/fakesign
+	
 /obj/item/storage/box/syndie_kit/chameleon_hardsuit/populate_contents()
 	new /obj/item/clothing/suit/space/hardsuit/contractor/agent(src)
 	new /obj/item/clothing/mask/gas/syndicate(src)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -180,8 +180,8 @@
 	desc = "A box containing all the neccessary equipment to forge stamps and insignias, making the user capable of faking any NanoTrasen documents."
 
 /obj/item/storage/box/syndie_kit/counterfeiter_bundle/populate_contents()
-	new obj/item/stamp/chameleon
-	new obj/item/pen/fakesign
+	new /obj/item/stamp/chameleon(src)
+	new /obj/item/pen/fakesign(src)
 	
 /obj/item/storage/box/syndie_kit/chameleon_hardsuit/populate_contents()
 	new /obj/item/clothing/suit/space/hardsuit/contractor/agent(src)


### PR DESCRIPTION
Removes the chameleon pen / chameleon stamp from uplink & adds Counterfeiter bundle - a 1 TC solution to all of your paperwork forgery. 


## Описание

Удаляет хамелеон-ручку и хамелеон-печать из аплинка, заменяет набором для подделки документов за 1 ТК. 

## Ссылка на предложение/Причина создания ПР

Пройденная предложка: 

https://discord.com/channels/617003227182792704/755125334097133628/1154955635209810011

