### PR TITLE
bugfix: gem selling for Tulpan

### DIFF
--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -32,6 +32,7 @@ SUBSYSTEM_DEF(shuttle)
 	var/points_per_intel = 250			//points gained per intel returned
 	var/points_per_plasma = 5			//points gained per plasma returned
 	var/points_per_design = 25			//points gained per research design returned
+	var/points_per_gem = 100			//points gained per gem returned
 	var/centcom_message = null			//Remarks from Centcom on how well you checked the last order.
 	var/list/discoveredPlants = list()	//Typepaths for unusual plants we've already sent CentComm, associated with their potencies
 	var/list/techLevels = list()

--- a/code/game/machinery/computer/syndie_cargo.dm
+++ b/code/game/machinery/computer/syndie_cargo.dm
@@ -143,7 +143,8 @@ GLOBAL_LIST_INIT(data_storages, list()) //list of all cargo console data storage
 	var/cash_per_intel = 2500		//points gained per intel returned
 	var/cash_per_plasma = 100		//points gained per plasma returned
 	var/cash_per_design = 500		//points gained per research design returned
-	var/cash_multiplier = 100		//points bonus for plants, designs, etc.
+	var/cash_per_gem = 2000			//points gained per gem returned
+	var/cash_multiplier = 100		//points bonus for plants, tech disks, etc.
 	var/blackmarket_message = null	//Remarks from Black Market on how well you checked the last order.
 /***************************
 Возможные статусы для телепадов
@@ -463,8 +464,14 @@ GLOBAL_LIST_INIT(data_storages, list()) //list of all cargo console data storage
 							data_storage.discoveredPlants[S.type] = S.potency
 							msg += "[span_good("[(S.rarity + S.potency)*data_storage.cash_multiplier]")]: New species discovered: \"[capitalize(S.species)]\". Excellent work.<br>"
 							data_storage.cash += (S.rarity + S.potency)*data_storage.cash_multiplier// That's right, no bonus for potency.  Send a crappy sample first to "show improvement" later
-					qdel(thing)
+					// Sell gems
+					if(istype(thing, /obj/item/gem))
+						var/obj/item/gem/Gem = thing
+						cashEarned = round(Gem.sell_multiplier * data_storage.cash_per_gem)
+						msg += "[span_good("+[cashEarned]")]: Received [Gem.name]. Great work.<br>"
+						data_storage.cash += cashEarned
 
+					qdel(thing)
 			qdel(MA)
 			data_storage.sold_atoms += "."
 

--- a/code/game/objects/items/gems.dm
+++ b/code/game/objects/items/gems.dm
@@ -17,8 +17,8 @@
 	var/analysed_message = null
 	///the thing that spawns in the item.
 	var/sheet_type = null
-	///how many cargo point we will get from sending this to station
-	var/sell_value = 100
+	///how many cargo point or cash we will get from sending this to station
+	var/sell_multiplier = 1
 
 	var/image/shine_overlay //shows this overlay when not scanned
 
@@ -75,7 +75,7 @@
 	materials = list(MAT_URANIUM = 20000)
 	sheet_type = /obj/item/stack/sheet/mineral/uranium{amount = 10}
 	point_value = 800
-	sell_value = 300
+	sell_multiplier = 3
 
 /obj/item/gem/magma
 	name = "\improper calcified auric"
@@ -84,7 +84,7 @@
 	materials = list(MAT_GOLD = 50000)
 	sheet_type = /obj/item/stack/sheet/mineral/gold{amount = 25}
 	point_value = 700 //there is no magmawing tendrills, silly me
-	sell_value = 450
+	sell_multiplier = 4.5
 	light_range = 4
 	light_power = 2
 	light_color = "#ff7b00"
@@ -96,7 +96,7 @@
 	materials = list(MAT_DIAMOND = 30000)
 	sheet_type = /obj/item/stack/sheet/mineral/diamond{amount = 15}
 	point_value = 1200
-	sell_value = 600
+	sell_multiplier = 6
 
 /obj/item/gem/phoron
 	name = "\improper stabilized baroxuldium"
@@ -105,7 +105,7 @@
 	materials = list(MAT_PLASMA = 80000)
 	sheet_type = /obj/item/stack/sheet/mineral/plasma{amount = 40}
 	point_value = 2400
-	sell_value = 800
+	sell_multiplier = 8
 	light_range = 4
 	light_power = 4
 	light_color = "#62326a"
@@ -115,7 +115,7 @@
 	desc = "A strange mass of dilithium which pulses to a steady rhythm. Its strange surface exudes a unique radio signal detectable by GPS."
 	icon_state = "purple"
 	point_value = 2600
-	sell_value = 900
+	sell_multiplier = 9
 	light_range = 4
 	light_power = 2
 	light_color = "#b714cc"
@@ -137,7 +137,7 @@
 	desc = "A brittle, strange mineral that forms when an ash drake's blood hardens after death. Cherished by gemcutters for its faint glow and unique, soft warmth. Poacher tales whisper of the dragon's strength being bestowed to one that wears a necklace of this amber, though such rumors are fictitious."
 	icon_state = "amber"
 	point_value = 2600
-	sell_value = 1200
+	sell_multiplier = 12
 	light_range = 4
 	light_power = 4
 	light_color = "#FFBF00"
@@ -147,7 +147,7 @@
 	desc = "A shard of stellar, crystallized energy. These strange objects occasionally appear spontaneously in areas where the bluespace fabric is largely unstable. Its surface gives a light jolt to those who touch it."
 	icon_state ="void"
 	point_value = 2400
-	sell_value = 1100
+	sell_multiplier = 11
 	light_range = 4
 	light_power = 2
 	light_color = "#4785a4"
@@ -157,7 +157,7 @@
 	desc = "A weird, sticky substance, known to coalesce in the presence of otherwordly phenomena. While shunned by most spiritual groups, this gemstone has unique ties to the occult which find it handsomely valued by mysterious patrons."
 	icon_state = "red"
 	point_value = 3000
-	sell_value = 1500
+	sell_multiplier = 15
 	light_range = 4
 	light_power = 6
 	light_color = "#800000"
@@ -173,7 +173,7 @@
 	light_power = 8
 	light_color = "#0004ff"
 	point_value = 2500
-	sell_value = 1800
+	sell_multiplier = 18
 
 /obj/item/gem/random
 	name = "random gem"
@@ -192,22 +192,22 @@
 	name = "\improper ruby"
 	icon_state = "ruby"
 	point_value = 150
-	sell_value = 75
+	sell_multiplier = 0.75
 
 /obj/item/gem/sapphire
 	name = "\improper sapphire"
 	icon_state = "sapphire"
 	point_value = 150
-	sell_value = 75
+	sell_multiplier = 0.75
 
 /obj/item/gem/emerald
 	name = "\improper emerald"
 	icon_state = "emerald"
 	point_value = 150
-	sell_value = 75
+	sell_multiplier = 0.75
 
 /obj/item/gem/topaz
 	name = "\improper topaz"
 	icon_state = "topaz"
 	point_value = 150
-	sell_value = 75
+	sell_multiplier = 0.75

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -214,7 +214,7 @@
 				// Sell gems
 				if(istype(thing, /obj/item/gem))
 					var/obj/item/gem/G = thing
-					pointsEarned = G.sell_value
+					pointsEarned = round(G.sell_multiplier * SSshuttle.points_per_gem)
 					msg += "<span class='good'>+[pointsEarned]</span>: Received [G]. Excellent work.<br>"
 					SSshuttle.points += pointsEarned
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет тайпану механику конвертирования гемов в кэш в их карго. Используется множитель х20 от очков карго, получаемых на основной станции, по аналогии с продажей плазмы.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на баг-репорт
https://discord.com/channels/617003227182792704/1164731942349049926<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
