### PR TITLE
Add: Rebalances the damage output of default energy gun.

### DIFF
--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -19,10 +19,13 @@
 	e_cost = 250
 
 /obj/item/ammo_casing/energy/lasergun
-	projectile_type = /obj/item/projectile/beam/laser
+	projectile_type = /obj/item/projectile/beam/laser/energy_gun // allows balancing the energy / lasergun separately from other energy weapons. 
 	muzzle_flash_color = LIGHT_COLOR_DARKRED
-	e_cost = 65
+	e_cost = 40
 	select_name = "kill"
+
+/obj/item/ammo_casing/energy/armory_laser
+	projectile_type = /obj/item/projectile/beam/laser/armory_laser_gun 
 
 /obj/item/ammo_casing/energy/laser/hos //allows balancing of HoS and blueshit guns seperately from other energy weapons
 	e_cost = 75

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -602,7 +602,7 @@
 	name = "small encased laser projector magazine"
 	desc = "Fits experimental laser ammo casings."
 	icon_state = "lmag-12"
-	ammo_type = /obj/item/ammo_casing/laser
+	ammo_type = /obj/item/ammo_casing/laser 
 	origin_tech = "combat=3"
 	caliber = "laser"
 	max_ammo = 12

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -6,7 +6,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	materials = list(MAT_METAL=2000)
 	origin_tech = "combat=4;magnets=2"
-	ammo_type = list(/obj/item/ammo_casing/energy/lasergun)
+	ammo_type = list(/obj/item/projectile/beam/laser/armory_gun)
 	ammo_x_offset = 1
 	shaded_charge = 1
 

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -6,7 +6,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	materials = list(MAT_METAL=2000)
 	origin_tech = "combat=4;magnets=2"
-	ammo_type = list(/obj/item/projectile/beam/laser/armory_gun)
+	ammo_type = list(/obj/item/projectile/beam/laser/armory_laser_gun)
 	ammo_x_offset = 1
 	shaded_charge = 1
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -17,6 +17,13 @@
 
 /obj/item/projectile/beam/laser
 
+/obj/item/projectile/beam/laser/armory_laser_gun
+	damage = 25 
+
+/obj/item/projectile/beam/laser/energy_gun
+	damage = 23 
+
+
 /obj/item/projectile/beam/laser/heavylaser
 	name = "heavy laser"
 	icon_state = "heavylaser"


### PR DESCRIPTION
## Описание
1) Увеличивает урон Energy Gun до 23 ожоговыми и увеличивает количество боезапаса. 
2) Увеличивает урон Laser Gun до 25 ожоговыми. 

## Ссылка на предложение/Причина создания ПР
Ссылка на пройденные: 1) https://discord.com/channels/617003227182792704/755125334097133628/1167451821372084274
2) https://discord.com/channels/617003227182792704/755125334097133628/1167451873746374666


