### PR TITLE
tweak: bumped python dependency from 3.7.9 to 3.11.6

### DIFF
--- a/_build_dependencies.sh
+++ b/_build_dependencies.sh
@@ -17,4 +17,4 @@ export RUSTG_VERSION=3.0.0-ss220
 export DMJIT_VERSION=v0.1.0
 
 # Python version for mapmerge and other tools
-export PYTHON_VERSION=3.7.9
+export PYTHON_VERSION=3.11.6


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Поднятие версии пакета Python с 3.7.9 до 3.11.6 в build_dependencies.sh для совместимости с Pillow версии 10.0.1
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Недавнее обновление Pillow https://github.com/ss220-space/Paradise/pull/3665 не работает с Python версии 3.7.9