### PR TITLE
bugfix: fixed security & command sub-professions not being visible on crew monitor

### DIFF
--- a/code/datums/cache/crew.dm
+++ b/code/datums/cache/crew.dm
@@ -48,8 +48,8 @@ GLOBAL_DATUM_INIT(crew_repository, /datum/repository/crew, new())
 		crewmemberData["name"] = H.get_authentification_name(if_no_id="Unknown")
 		crewmemberData["rank"] = H.get_authentification_rank(if_no_id="Unknown", if_no_job="No Job")
 		crewmemberData["assignment"] = H.get_assignment(if_no_id="Unknown", if_no_job="No Job")
-		crewmemberData["is_command"] = (crewmemberData["assignment"] in bold_jobs)
-		crewmemberData["is_security"] = (crewmemberData["assignment"] in security_jobs_list)
+		crewmemberData["is_command"] = (crewmemberData["rank"] in bold_jobs)
+		crewmemberData["is_security"] = (crewmemberData["rank"] in security_jobs_list)
 
 		if(C.sensor_mode >= SUIT_SENSOR_BINARY)
 			crewmemberData["dead"] = H.stat == DEAD

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -50,6 +50,7 @@ GLOBAL_LIST_INIT(security_positions, list(
 	"Head of Security",
 	"Warden",
 	"Detective",
+	"Forensic Technician"
 	"Security Officer",
 	"Brig Physician",
 	"Security Pod Pilot",

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -50,13 +50,9 @@ GLOBAL_LIST_INIT(security_positions, list(
 	"Head of Security",
 	"Warden",
 	"Detective",
-	"Forensic Technician"
 	"Security Officer",
 	"Brig Physician",
 	"Security Pod Pilot",
-	"Security Trainer",
-	"Patrol Officer",
-	"Security Medic",
 	"Magistrate"
 ))
 

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -55,6 +55,7 @@ GLOBAL_LIST_INIT(security_positions, list(
 	"Security Pod Pilot",
 	"Security Trainer",
 	"Patrol Officer",
+	"Security Medic",
 	"Magistrate"
 ))
 

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -53,6 +53,8 @@ GLOBAL_LIST_INIT(security_positions, list(
 	"Security Officer",
 	"Brig Physician",
 	"Security Pod Pilot",
+	"Security Trainer",
+	"Patrol Officer",
 	"Magistrate"
 ))
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление ошибки, при которой бригмедский крю-монитор не видел офицеров СБ с подпрофессиями офицера и бригмеда (Security Trainer, Patrol Officer, Security Medic)
Также исправляет аналогичную ошибку у крю монитора командования
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
https://discord.com/channels/617003227182792704/1168244949691662490/1168244949691662490
## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
![изображение](https://github.com/ss220-space/Paradise/assets/73733747/b9341338-241c-4781-9829-5c1608997d0f)
