### PR TITLE
bugfix: Terror Spiders no longer always penetrate hardsuit shields and blocks

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/builder.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/builder.dm
@@ -37,11 +37,16 @@
 	spider_intro_text = "Будучи Дроном Ужаса, ваша задача - постройка и защита гнезда. Плетите паутину, используйте свои замедляющие плевки и замораживающие укусы для защиты яиц и гнезда. Помните, вы не регенерируете и двигаетесь медленно вне паутины!."
 
 /mob/living/simple_animal/hostile/poison/terror_spider/builder/spider_specialattack(mob/living/carbon/human/L, poisonable)
+	. = ..()
+
+	if(!.)
+		return FALSE
+
 	L.Slowed(4 SECONDS)
 	if(!poisonable)
-		return ..()
+		return TRUE
 	if(L.reagents.has_reagent("frostoil", 100))
-		return ..()
+		return TRUE
 	var/inject_target = pick("chest", "head")
 	if(L.IsStunned() || L.can_inject(null, FALSE, inject_target, FALSE))
 		L.reagents.add_reagent("frostoil", 20)
@@ -49,7 +54,7 @@
 	else
 		L.reagents.add_reagent("frostoil", 10)
 		visible_message("<span class='danger'>[src] buries its long fangs deep into the [inject_target] of [target]!</span>")
-	L.attack_animal(src)
+	return TRUE
 
 /mob/living/simple_animal/hostile/poison/terror_spider/builder/Move(atom/newloc, dir, step_x, step_y)  //moves slow while not in web, but fast while in. does not regenerate if not in web
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/defiler.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/defiler.dm
@@ -43,11 +43,16 @@
 	return ..(gibbed)
 
 /mob/living/simple_animal/hostile/poison/terror_spider/defiler/spider_specialattack(mob/living/carbon/human/L, poisonable)
+	. = ..()
+
+	if(!.)
+		return FALSE
+
 	L.AdjustSilence(20 SECONDS)
 	L.adjustStaminaLoss(39)
 	L.attack_animal(src)
 	if(!poisonable)
-		return ..()
+		return TRUE
 	var/inject_target = pick("chest", "head")
 	if(L.IsParalyzed() || L.can_inject(null, FALSE, inject_target, FALSE) && prob(50))
 		new /obj/item/organ/internal/body_egg/terror_eggs(L)
@@ -65,8 +70,8 @@
 
 /proc/IsTSInfected(mob/living/carbon/C) // Terror AI requires this
 	if(C.get_int_organ(/obj/item/organ/internal/body_egg))
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 /obj/structure/spider/terrorweb/white
 	name = "infested web"

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/guardian.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/guardian.dm
@@ -46,15 +46,16 @@
 	var/max_queen_range = 15
 
 /mob/living/simple_animal/hostile/poison/terror_spider/guardian/spider_specialattack(mob/living/carbon/human/L)
+	. = ..()
+
+	if(!.)
+		return FALSE
+
 	L.adjustStaminaLoss(15)
 	if(prob(20))
-		playsound(src, 'sound/creatures/terrorspiders/bite2.ogg', 120, 1)
-		do_attack_animation(L)
 		visible_message("<span class='danger'>[src] rams into [L], knocking [L.p_them()] to the floor!</span>")
 		L.adjustBruteLoss(20)
 		L.Weaken(4 SECONDS)
-	else
-		..()
 
 /mob/living/simple_animal/hostile/poison/terror_spider/guardian/death(gibbed)
 	if(can_die() && spider_myqueen)

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/healer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/healer.dm
@@ -97,17 +97,18 @@
 		seek_cocoon_target()
 
 /mob/living/simple_animal/hostile/poison/terror_spider/healer/spider_specialattack(mob/living/carbon/human/L, poisonable)
+	. = ..()
+	if(!.)
+		return FALSE
 	if(!poisonable)
-		..()
-		return
+		return TRUE
 	var/inject_target = pick("chest","head")
 	if(L.IsStunned() || L.can_inject(null, FALSE, inject_target, FALSE))
 		L.AdjustEyeBlurry(20 SECONDS, 0, 120 SECONDS)
 		// instead of having a venom that only lasts seconds, we just add the eyeblur directly.
-		visible_message("<span class='danger'>[src] buries its fangs deep into the [inject_target] of [target]!</span>")
+		visible_message(span_danger("[src] buries its fangs deep into the [inject_target] of [target]!"))
 	else
-		visible_message("<span class='danger'>[src] bites [target], but cannot inject venom into [target.p_their()] [inject_target]!</span>")
-	L.attack_animal(src)
+		visible_message(span_danger("[src] bites [target], but cannot inject venom into [target.p_their()] [inject_target]!"))
 
 /mob/living/simple_animal/hostile/poison/terror_spider/healer/AttackingTarget()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/lurker.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/lurker.dm
@@ -51,15 +51,22 @@
 		melee_damage_lower = initial(melee_damage_lower) * 3
 		melee_damage_upper = initial(melee_damage_upper) * 3
 		armour_penetration = initial(armour_penetration) * 25
-		visible_message("<span class='danger'>[src] suddenly attacks and savagely mauls [target]!</span>")
-		L.adjustStaminaLoss(45)
-		L.AdjustSilence(10 SECONDS)
 	else
 		melee_damage_lower = initial(melee_damage_lower)
 		melee_damage_upper = initial(melee_damage_upper)
 		armour_penetration = initial(armour_penetration)
 		visible_message("<span class='danger'>[src] bites [target]!</span>")
-	L.attack_animal(src)
+
+	. = ..() //eat victim
+
+	if(!.)
+		return FALSE
+
+	if(W)	//apply debuffs if failed to block
+		L.adjustStaminaLoss(45)
+		L.AdjustSilence(10 SECONDS)
+	return TRUE
+
 
 /mob/living/simple_animal/hostile/poison/terror_spider/lurker/spider_special_action()
 	if(prob(prob_ai_massweb))

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/prince.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/prince.dm
@@ -59,6 +59,7 @@
 			var/obj/item/organ/external/NB = pick(L.bodyparts)
 			visible_message(span_warning("[src] Tears appart the [NB.name] of [L] with his razor sharp jaws!"))
 			NB.droplimb()  //dismemberment
+			L.adjustStaminaLoss(35)
 	else
 		. = ..()
 		if(.)

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/prince.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/prince.dm
@@ -48,15 +48,20 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/poison/terror_spider/prince/spider_specialattack(mob/living/carbon/human/L)
-	L.adjustStaminaLoss(35) //3 hits for stam crit
 	if(prob(delimb_chance))
 		if(L.stat != DEAD) //no dismemberment for dead carbons, less griefy
 			do_attack_animation(L)
+			if(L.check_shields(src, 25, "[name]", MELEE_ATTACK, armour_penetration))
+				return FALSE
 			L.adjustBruteLoss(25)
 			L.Weaken(2 SECONDS)
 			playsound(src, 'sound/creatures/terrorspiders/rip.ogg', 100, 1)
 			var/obj/item/organ/external/NB = pick(L.bodyparts)
-			visible_message("<span class='warning'>[src] Tears appart the [NB.name] of [L] with his razor sharp jaws!</span>")
+			visible_message(span_warning("[src] Tears appart the [NB.name] of [L] with his razor sharp jaws!"))
 			NB.droplimb()  //dismemberment
 	else
-		..()
+		. = ..()
+		if(.)
+			L.adjustStaminaLoss(35) //3 hits for stam crit
+
+

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/reaper.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/reaper.dm
@@ -29,9 +29,10 @@
 		adjustBruteLoss(1) //degenerates on life, can only get heals from other spiders, or from killing
 
 /mob/living/simple_animal/hostile/poison/terror_spider/reaper/spider_specialattack(mob/living/carbon/human/L)
+	. = ..()
+	if(!.)
+		return FALSE
+
 	if(L.stat != DEAD) //no healing when biting corpses
-		L.attack_animal(src)
 		L.bleed(25) //bloodsucker
 		src.adjustBruteLoss(-30)   //vampirism
-	else
-		..()

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -201,7 +201,7 @@ GLOBAL_LIST_EMPTY(ts_spiderling_list)
 		target.attack_animal(src)
 
 /mob/living/simple_animal/hostile/poison/terror_spider/proc/spider_specialattack(mob/living/carbon/human/L, poisonable)
-	L.attack_animal(src)
+	return L.attack_animal(src)
 
 /mob/living/simple_animal/hostile/poison/terror_spider/proc/consume_jelly(obj/structure/spider/royaljelly/J)
 	if(health == maxHealth)

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/widow.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/widow.dm
@@ -35,25 +35,27 @@
 	spider_intro_text = "Будучи Вдовой Ужаса, ваша цель - внести хаос на поле боя при помощи своих плевков, вы также смертоносны вблизи и с каждым укусом вводите в противников опасный яд. Несмотря на скорость и смертоносность, вы довольно хрупки, поэтому не стоит атаковать тяжело вооружённых противников!"
 
 /mob/living/simple_animal/hostile/poison/terror_spider/widow/spider_specialattack(mob/living/carbon/human/L, poisonable)
+	. = ..()
+	if(!.)
+		return FALSE
 	L.AdjustSilence(10 SECONDS)
 	if(!poisonable)
-		return ..()
+		return TRUE
 	if(L.reagents.has_reagent("terror_black_toxin", 100))
-		return ..()
+		return TRUE
 	var/inject_target = pick("chest", "head")
 	if(L.IsStunned() || L.can_inject(null, FALSE, inject_target, FALSE))
 		L.reagents.add_reagent("terror_black_toxin", 33) // inject our special poison
-		visible_message("<span class='danger'>[src] buries its long fangs deep into the [inject_target] of [target]!</span>")
+		visible_message(span_danger("[src] buries its long fangs deep into the [inject_target] of [target]!"))
 	else
 		L.reagents.add_reagent("terror_black_toxin", 20)
-		visible_message("<span class='danger'>[src] pierces armour and buries its long fangs deep into the [inject_target] of [target]!</span>")
-	L.attack_animal(src)
+		visible_message(span_danger("[src] pierces armour and buries its long fangs deep into the [inject_target] of [target]!"))
 	if(!ckey && (!(target in enemies) || L.reagents.has_reagent("terror_black_toxin", 60)))
 		step_away(src, L)
 		step_away(src, L)
 		LoseTarget()
 		step_away(src, L)
-		visible_message("<span class='notice'>[src] jumps away from [L]!</span>")
+		visible_message(span_notice("[src] jumps away from [L]!"))
 
 
 /obj/structure/spider/terrorweb/widow


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Багфикс, убирающий абсолютное пробитие спецатакой любой защиты жертвы у пауков террора. В том числе:
- У Принца терроров возможность пробиваться сквозь любую защиту и наносить урон стамине с отрубанием конечностей.
- Эффекты от специальных атак других пауков больше не работают, если атака была заблокирована.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
https://discord.com/channels/617003227182792704/1169576524370956380

