### PR TITLE
bugfix: bread monster's max hp now rises on teleportation

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/bread_monster.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bread_monster.dm
@@ -40,6 +40,7 @@ GLOBAL_LIST_EMPTY(bread_monsters)
 		current_teleport_count += 1
 		src.transform = src.transform.Scale(scaling_coeff, scaling_coeff)
 		health = initial(health) + health_increase * current_teleport_count
+		maxHealth = initial(maxHealth) + health_increase * current_teleport_count
 		harm_intent_damage = initial(harm_intent_damage) + damage_increase * current_teleport_count
 		melee_damage_lower = initial(melee_damage_lower) + damage_increase * current_teleport_count
 		melee_damage_upper = initial(melee_damage_upper) + damage_increase * current_teleport_count


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление ошибки, при которой максимальное ХП хлебного монстра не повышается при телепортации, вследствие чего воскрешенный хлебный монстр имеет мало очков здоровья.

