### PR TITLE
balance: bomb guardian no longer dismember legs and bomb damage nerfs

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/types/bomb_components/guardian_mine.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/bomb_components/guardian_mine.dm
@@ -72,16 +72,7 @@
 	playsound(get_turf(parent_atom),'sound/effects/explosion1.ogg', 200, 1)
 	victim.ex_act(3)
 	victim.Weaken(6 SECONDS)
-	if(ishuman(victim))
-		dead_legs(victim)
-	victim.adjustBruteLoss(40)
+	victim.adjustBruteLoss(20)
 	is_exploded = TRUE
 	UnregisterFromParent()
 
-/datum/component/guardian_mine/proc/dead_legs(mob/living/carbon/human/human)
-	var/obj/item/organ/external/l = human.get_organ("l_leg")
-	var/obj/item/organ/external/r = human.get_organ("r_leg")
-	if(l && prob(50))
-		l.droplimb(0, DROPLIMB_SHARP)
-	if(r && prob(50))
-		r.droplimb(0, DROPLIMB_SHARP)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Балансирующая правка, убирающая у бомб голопаразита возможность сносить ноги вне зависимости от защиты жертвы.
Уменьшен урон бомбы голопаразита после взрыва, с 40 до 20.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Голопаразит, как оказалось, слишком силён с текущими возможностями по минированию предметов.
Спасибо "Скільки питань у ранковій мові?" a.k.a daeberdir и Corde50 за фидбек по голопаразиту.

