### PR TITLE
bugfix: fixed infinite recursion with cluwne curse.

### DIFF
--- a/code/datums/spells/cluwne.dm
+++ b/code/datums/spells/cluwne.dm
@@ -13,11 +13,14 @@
 
 
 /mob/living/carbon/human/proc/makeCluwne()
-	to_chat(src, "<span class='danger'>You feel funny.</span>")
 	if(!get_int_organ(/obj/item/organ/internal/brain/cluwne))
 		var/obj/item/organ/internal/brain/cluwne/idiot_brain = new
+		internal_organs |= idiot_brain	//Well, everything's for recursion prevention.
 		idiot_brain.insert(src, make_cluwne = 0)
 		idiot_brain.dna = dna.Clone()
+	else
+		return
+	to_chat(src, span_danger("You feel funny."))
 	setBrainLoss(80, use_brain_mod = FALSE)
 	set_nutrition(9000)
 	overeatduration = 9000

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -260,8 +260,6 @@
 	squeak = M.AddComponent(/datum/component/squeak, list('sound/items/bikehorn.ogg' = 1), 50, falloff_exponent = 20)
 
 /obj/item/organ/internal/honktumor/remove(mob/living/carbon/M, special = 0)
-	. = ..()
-
 	M.mutations.Remove(CLUMSY)
 	M.mutations.Remove(GLOB.comicblock)
 	M.dna.SetSEState(GLOB.clumsyblock,0)
@@ -270,7 +268,7 @@
 	genemutcheck(M,GLOB.comicblock,null,MUTCHK_FORCED)
 	M.RemoveElement(/datum/element/waddling)
 	QDEL_NULL(squeak)
-	qdel(src)
+	. = ..()
 
 /obj/item/organ/internal/honktumor/on_life()
 	if(organhonked < world.time)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление ошибки, при которой проклятие клувни и стабильный мутаген с кровью другой расы вызывали бесконечную рекурсию и побочные *неприятности*.
Также исправляет рантайм, при котором банановая опухоль не может qdel'нуться
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
https://discord.com/channels/617003227182792704/1170760527832690758/1170760527832690758

