### PR TITLE
Window replacement on the cyberiad lavaland

### DIFF
--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -1669,10 +1669,6 @@
 	icon_state = "brown"
 	},
 /area/mine/living_quarters)
-"dV" = (
-/obj/effect/spawner/window,
-/turf/simulated/floor/plating,
-/area/mine/production)
 "dW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -24787,7 +24783,7 @@ bq
 cX
 dn
 bq
-dV
+bN
 en
 bN
 bN


### PR DESCRIPTION
Replaced the unreinforced glass window on the cyberiad lavaland with a reinforced glass window

<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Заменил неукрепленное окно из стекла на лаваленде Кибериады на укрепленное окно из стекла
<!--  -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/943940908162875473/1171486451289030666

## Демонстрация изменений

Было:
![image](https://github.com/ss220-space/Paradise/assets/150155172/9e831062-c747-4378-b4ae-2e6d81e35c91)
Стало:
![image](https://github.com/ss220-space/Paradise/assets/150155172/9752fa51-34ed-4dbe-8323-7fabc306b5a5)
