### PR TITLE
bugfix: replacing the glass on the lavaland cyberiad

### DIFF
--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -1669,10 +1669,6 @@
 	icon_state = "brown"
 	},
 /area/mine/living_quarters)
-"dV" = (
-/obj/effect/spawner/window,
-/turf/simulated/floor/plating,
-/area/mine/production)
 "dW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -24787,7 +24783,7 @@ bq
 cX
 dn
 bq
-dV
+bN
 en
 bN
 bN


### PR DESCRIPTION
bugfix: replacing the normal glass window on the lavalier of the cyberiad, with a reinforced one

<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Замена неукрепленного стекла на лаваленде Кибериады, на укрепленное.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/943940908162875473/1171486451289030666
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
Было:
![image](https://github.com/ss220-space/Paradise/assets/150155172/a26ba6d3-d46e-4085-8be8-51a7d5a42b93)
Стало:
![image](https://github.com/ss220-space/Paradise/assets/150155172/09822c52-0a79-4a18-8900-d555bc990dc1)

<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
