### PR TITLE
bugfix/tweak: DNA and Species Change Fixes

### DIFF
--- a/code/datums/diseases/viruses/kingstons.dm
+++ b/code/datums/diseases/viruses/kingstons.dm
@@ -54,7 +54,7 @@
 					affected_mob.visible_message(span_danger("[affected_mob]'s form contorts into something more feline!"), \
 													span_userdanger("YOU TURN INTO A TAJARAN!"))
 					var/mob/living/carbon/human/catface = affected_mob
-					catface?.set_species(/datum/species/tajaran, retain_damage = TRUE)
+					catface?.set_species(/datum/species/tajaran, retain_damage = TRUE, keep_missing_bodyparts = TRUE)
 
 
 /datum/disease/virus/kingstons_advanced
@@ -113,7 +113,7 @@
 					if(prob(5))
 						H.visible_message(span_danger("[H]'s skin splits and form contorts!"), \
 														span_userdanger("Your body mutates into a [initial(chosentype.name)]!"))
-						H.set_species(chosentype, retain_damage = TRUE)
+						H.set_species(chosentype, retain_damage = TRUE, keep_missing_bodyparts = TRUE)
 				else
 					if(prob(5))
 						H.visible_message(span_danger("[H] scratches at thier skin!"), \

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -53,6 +53,7 @@ GLOBAL_LIST_EMPTY(bad_blocks)
 	var/datum/dna/new_dna = new()
 	new_dna.unique_enzymes = unique_enzymes
 	new_dna.struc_enzymes_original = struc_enzymes_original // will make clone's SE the same as the original, do we want this?
+	new_dna.default_blocks = default_blocks
 	new_dna.blood_type = blood_type
 	new_dna.real_name = real_name
 	new_dna.species = new species.type
@@ -446,7 +447,7 @@ GLOBAL_LIST_EMPTY(bad_blocks)
 		return
 
 	// We manually set the species to ensure all proper species change procs are called.
-	destination.set_species(species.type, retain_damage = TRUE)
+	destination.set_species(species.type, retain_damage = TRUE, keep_missing_bodyparts = TRUE)
 	var/datum/dna/new_dna = Clone()
 	new_dna.species = destination.dna.species
 	destination.dna = new_dna

--- a/code/game/dna/genes/monkey.dm
+++ b/code/game/dna/genes/monkey.dm
@@ -27,7 +27,7 @@
 	H.invisibility = INVISIBILITY_ABSTRACT
 	var/has_primitive_form = H.dna.species.primitive_form // cache this
 	if(has_primitive_form)
-		H.set_species(has_primitive_form)
+		H.set_species(has_primitive_form, keep_missing_bodyparts = TRUE)
 
 	new /obj/effect/temp_visual/monkeyify(H.loc)
 	sleep(22)
@@ -63,7 +63,7 @@
 	H.invisibility = INVISIBILITY_ABSTRACT
 	var/has_greater_form = H.dna.species.greater_form //cache this
 	if(has_greater_form)
-		H.set_species(has_greater_form)
+		H.set_species(has_greater_form, keep_missing_bodyparts = TRUE)
 
 	new /obj/effect/temp_visual/monkeyify/humanify(H.loc)
 	sleep(22)

--- a/code/game/gamemodes/miniantags/abduction/gland.dm
+++ b/code/game/gamemodes/miniantags/abduction/gland.dm
@@ -184,7 +184,7 @@
 		old_control_uses = gland.mind_control_uses
 	var/list/random_species = list(/datum/species/human, /datum/species/unathi, /datum/species/skrell, /datum/species/diona, /datum/species/tajaran, /datum/species/vulpkanin, /datum/species/kidan, /datum/species/grey)
 	random_species -= h_owner.dna.species.type
-	h_owner.set_species(pick(random_species))
+	h_owner.set_species(pick(random_species), keep_missing_bodyparts = TRUE)
 	addtimer(CALLBACK(h_owner, TYPE_PROC_REF(/mob/living/carbon/human, insert_new_gland), old_control_uses), 0)
 
 

--- a/code/modules/antagonists/changeling/powers/humanform.dm
+++ b/code/modules/antagonists/changeling/powers/humanform.dm
@@ -24,7 +24,7 @@
 	genemutcheck(user, GLOB.monkeyblock, null, MUTCHK_FORCED)
 
 	if(istype(user))
-		user.set_species(chosen_dna.species.type)
+		user.set_species(chosen_dna.species.type, keep_missing_bodyparts = TRUE)
 
 	user.dna = chosen_dna.Clone()
 	user.real_name = chosen_dna.real_name

--- a/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
@@ -62,7 +62,7 @@
 			legcuffed = I
 			update_legcuffed_status()
 
-	I.equipped(src, slot, initial)
+	return I.equipped(src, slot, initial)
 
 
 /mob/living/carbon/alien/humanoid/can_equip(obj/item/I, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE, bypass_obscured = FALSE)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -392,6 +392,11 @@
 	return 0
 
 
+/mob/living/carbon/proc/create_dna()
+	if(!dna)
+		dna = new()
+
+
 /mob/living/carbon/proc/getDNA()
 	return dna
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -6,43 +6,30 @@
 	icon_state = "body_m_s"
 	deathgasp_on_death = TRUE
 
+
 /mob/living/carbon/human/New(loc)
 	icon = null // This is now handled by overlays -- we just keep an icon for the sake of the map editor.
 	. = ..()
 
+
 /mob/living/carbon/human/Initialize(mapload, datum/species/new_species = /datum/species/human)
-	if(!dna)
-		dna = new /datum/dna(null)
-		// Species name is handled by set_species()
+	create_dna()
 
 	. = ..()
 
-	set_species(new_species, 1, delay_icon_update = 1, skip_same_check = TRUE)
+	if(!tts_seed)
+		tts_seed = SStts.get_random_seed(src)
 
-	if(dna.species)
-		real_name = dna.species.get_random_name(gender)
-		name = real_name
-		if(mind)
-			mind.name = real_name
-
-		if (!tts_seed)
-			tts_seed = SStts.get_random_seed(src)
+	setup_dna(new_species)
 
 	create_reagents(330)
 
 	handcrafting = new()
 
-	// Set up DNA.
-	if(dna)
-		dna.ready_dna(src)
-		dna.real_name = real_name
-		dna.tts_seed_dna = tts_seed
-		sync_organ_dna(1)
-
 	AddComponent(/datum/component/footstep, FOOTSTEP_MOB_HUMAN, 1, -6)
-
 	UpdateAppearance()
 	GLOB.human_list += src
+
 
 /mob/living/carbon/human/OpenCraftingMenu()
 	handcrafting.ui_interact(src)
@@ -1199,25 +1186,63 @@
 		to_chat(usr, "<span class='notice'>[self ? "Your" : "[src]'s"] pulse is [src.get_pulse(GETPULSE_HAND)].</span>")
 
 
+/**
+  * Set up DNA and species.
+  *
+  * Arguments:
+  * * new_species - The new species to assign.
+  */
+/mob/living/carbon/human/proc/setup_dna(datum/species/new_species)
+	set_species(new_species, use_default_color = TRUE, delay_icon_update = TRUE, skip_same_check = TRUE)
+	// Name
+	real_name = dna.species.get_random_name(gender)
+	name = real_name
+	if(mind)
+		mind.name = real_name
+
+	// DNA ready
+	dna.ready_dna(src)
+	dna.species.handle_dna(src)
+	dna.real_name = real_name
+	dna.tts_seed_dna = tts_seed
+	sync_organ_dna()
+
+
 /mob/living/carbon/human/proc/change_dna(datum/dna/new_dna, include_species_change = FALSE, keep_flavor_text = FALSE)
 	if(include_species_change)
-		set_species(new_dna.species.type, retain_damage = TRUE)
+		set_species(new_dna.species.type, retain_damage = TRUE, transformation = TRUE, keep_missing_bodyparts = TRUE)
 	dna = new_dna.Clone()
+	if(include_species_change) //We have to call this after new_dna.Clone() so that species actions don't get overwritten
+		dna.species.on_species_gain(src)
 	real_name = new_dna.real_name
 	domutcheck(src, null, MUTCHK_FORCED) //Ensures species that get powers by the species proc handle_dna keep them
 	if(!keep_flavor_text)
 		flavor_text = ""
 	dna.UpdateSE()
 	dna.UpdateUI()
-	sync_organ_dna(TRUE)
+	sync_organ_dna()
 	UpdateAppearance()
 	sec_hud_set_ID()
 
 
-/mob/living/carbon/human/proc/set_species(datum/species/new_species, default_colour, delay_icon_update = FALSE, skip_same_check = FALSE, retain_damage = FALSE, save_appearance = FALSE)
-	if(!skip_same_check)
-		if(dna.species.name == initial(new_species.name))
-			return
+/**
+ * Change a mob's species.
+ *
+ * Arguments:
+ * * new_species - The user's new species.
+ * * use_default_color - If `TRUE`, use the species' default color for the new mob.
+ * * delay_icon_update - If `TRUE`, UpdateAppearance() won't be called in this proc.
+ * * skip_same_check - If `TRUE`, don't bail out early if we would be changing to our current species and run through everything anyway.
+ * * retain_damage - If `TRUE`, damage on the mob will be re-applied post-transform. Otherwise, the mob will have its organs healed.
+ * * transformation - If `TRUE`, don't apply new species traits to the mob. A false value should be used when creating a new mob instead of transforming into a new species.
+ * * keep_missing_bodyparts - If `TRUE`, any bodyparts (legs, head, etc.) and racial internal organs (heart, liver, etc.) that were missing on the mob before species change will be missing post-change as well. Note that racial internal organs of new species (kidan lantern, wryn antennae, etc.) will be always created.
+ * * transfer_special_internals - If `TRUE`, all special internal organs (implants, spider eggs, xeno embryos, etc.), will be present on the mob post-change. Does not affect racial internal organs (heart, liver, etc.).
+ * * save_appearance - If `TRUE`, all bodyparts appearances (head hair style, body tattoos, tail type, etc.) will be transfered to new species.
+ */
+/mob/living/carbon/human/proc/set_species(datum/species/new_species, use_default_color, delay_icon_update = FALSE, skip_same_check = FALSE, retain_damage = FALSE, transformation = FALSE, keep_missing_bodyparts = FALSE, transfer_special_internals = TRUE, save_appearance = FALSE)
+	if(!skip_same_check && dna.species.name == initial(new_species.name))
+		return
+
 	var/datum/species/oldspecies = dna.species
 
 	if(oldspecies)
@@ -1230,16 +1255,15 @@
 		if(gender == PLURAL && oldspecies.has_gender)
 			change_gender(pick(MALE, FEMALE))
 
-		if(oldspecies.default_genes.len)
-			oldspecies.handle_dna(src, TRUE) // Remove any genes that belong to the old species
+		oldspecies.handle_dna(src, remove = TRUE) // Remove any genes that belong to the old species
 
 		oldspecies.on_species_loss(src)
 
 	dna.species = new new_species()
 
-	tail = save_appearance ? oldspecies.tail : dna.species.tail
+	tail = (save_appearance && oldspecies) ? oldspecies.tail : dna.species.tail
 
-	wing = save_appearance ? oldspecies.wing : dna.species.wing
+	wing = (save_appearance && oldspecies) ? oldspecies.wing : dna.species.wing
 
 	maxHealth = dna.species.total_health
 
@@ -1252,7 +1276,7 @@
 	hunger_drain = dna.species.hunger_drain
 	digestion_ratio = dna.species.digestion_ratio
 
-	if(dna.species.base_color && default_colour)
+	if(dna.species.base_color && use_default_color)
 		//Apply colour.
 		skin_colour = dna.species.base_color
 	else
@@ -1262,14 +1286,56 @@
 		s_tone = 0
 
 	var/list/thing_to_check = list(slot_wear_mask, slot_head, slot_shoes, slot_gloves, slot_l_ear, slot_r_ear, slot_glasses, slot_l_hand, slot_r_hand, slot_neck)
-	var/list/kept_items[0]
-	var/list/item_flags[0]
+	var/list/kept_items = list()
+	var/list/item_flags = list()
 	for(var/thing in thing_to_check)
 		var/obj/item/I = get_item_by_slot(thing)
 		if(I)
 			kept_items[I] = thing
 			item_flags[I] = I.flags
-			I.flags = 0 // Temporary set the flags to 0
+			I.flags = NONE // Temporary set the flags to NONE
+
+	if(!transformation) //Distinguish between creating a mob and switching species
+		dna.species.on_species_gain(src)
+
+	var/list/missing_bodyparts = list()  // should line up here to pop out only what's missing
+	if(keep_missing_bodyparts)
+		if(!oldspecies)
+			stack_trace("Keep missing bodypart argument set to true, [src] has no original species to compare.")
+
+		for(var/organ_name in bodyparts_by_name)
+			if(isnull(bodyparts_by_name[organ_name]))
+				missing_bodyparts |= organ_name
+
+		for(var/index in dna.species.has_organ)
+			if(!(index in oldspecies.has_organ))	// new species organs are fine to create
+				continue
+			var/obj/item/organ/internal/organ_check = dna.species.has_organ[index]
+			var/organ_found
+			for(var/O in internal_organs)
+				var/obj/item/organ/internal/organ = O
+				organ_found = (organ.slot == initial(organ_check.slot))
+				if(organ_found)
+					break
+			if(!organ_found)
+				missing_bodyparts |= index
+
+	var/list/additional_organs = list()
+	if(transfer_special_internals)
+		if(!oldspecies)
+			stack_trace("Transfer special internals argument set to true, [src] has no original species to compare.")
+
+		var/list/racial_organs = (oldspecies.has_organ|dna.species.has_organ)	// all internal organs, except racial, will be recreated
+		for(var/O in internal_organs)
+			var/obj/item/organ/internal/organ_check = O
+			var/organ_found
+			for(var/index in racial_organs)
+				var/obj/item/organ/internal/organ = dna.species.has_organ[index]
+				organ_found = (initial(organ.slot) == organ_check.slot)
+				if(organ_found)
+					break
+			if(!organ_found)
+				additional_organs |= organ_check.type
 
 	var/list/old_bodyparts
 	if(save_appearance)
@@ -1301,7 +1367,7 @@
 			internal_damages += list(stats)
 
 		//Create the new organs for the species change
-		dna.species.create_organs(src)
+		dna.species.create_organs(src, missing_bodyparts, additional_organs)
 
 		//Apply relevant damages and variables to the new organs.
 		for(var/B in bodyparts)
@@ -1331,21 +1397,23 @@
 				if(istype(I, organ_type))
 					var/damage = part[2]
 					var/broken = part[3]
-					I.receive_damage(damage, 1)
+					I.receive_damage(damage, TRUE)
 					if(broken && !(I.status & ORGAN_BROKEN))
 						I.status |= ORGAN_BROKEN
 					qdel(part)
 
 	else
-		dna.species.create_organs(src)
+		dna.species.create_organs(src, missing_bodyparts, additional_organs)
 
 	for(var/obj/item/thing in kept_items)
-		equip_to_slot_if_possible(thing, kept_items[thing])
-		thing.flags = item_flags[thing] // Reset the flags to the origional ones
+		var/equipped = equip_to_slot(thing, kept_items[thing], initial = TRUE)	// we can skip [mob_can_equip()] checks here
+		thing.flags = item_flags[thing] // Reset the flags to the original ones
+		if(!equipped)
+			thing.dropped() // Ensures items know they are dropped. Using their original flags
 
 	//Handle hair/head accessories for created mobs.
 	var/obj/item/organ/external/head/H = get_organ("head")
-	if(save_appearance && old_bodyparts)
+	if(istype(H) && save_appearance && old_bodyparts)
 		var/obj/item/organ/external/head/old_head = old_bodyparts["head"]
 		if(istype(old_head))
 			if(old_head.h_style)
@@ -1361,7 +1429,7 @@
 			if(old_head.headacc_colour)
 				H.headacc_colour = old_head.headacc_colour
 
-	else
+	else if(istype(H))
 		if(dna.species.default_hair)
 			H.h_style = dna.species.default_hair
 		else
@@ -1398,8 +1466,6 @@
 
 	dna.real_name = real_name
 
-	dna.species.on_species_gain(src)
-
 	update_sight()
 
 	dna.species.handle_dna(src) //Give them whatever special dna business they got.
@@ -1417,6 +1483,7 @@
 		return TRUE
 	else
 		return FALSE
+
 
 /mob/living/carbon/human/get_default_language()
 	if(default_language)

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -134,18 +134,21 @@
 		var/obj/item/organ/internal/O = pick(bodyparts)
 		O.trace_chemicals[A.name] = 100
 
-/*
-When assimilate is 1, organs that have a different UE will still have their DNA overriden by that of the host
-Otherwise, this restricts itself to organs that share the UE of the host.
 
-old_ue: Set this to a UE string, and this proc will overwrite the dna of organs that have that UE, instead of the host's present UE
-*/
-/mob/living/carbon/human/proc/sync_organ_dna(var/assimilate = 1, var/old_ue = null)
+/**
+ * Sync internal and exteranl organs with DNA unique enzymes.
+ *
+ * Arguments:
+ * * assimilate - If `TRUE`, organs that have a different UE will still have their DNA overriden by that of the host. Otherwise, this restricts itself to organs that share the UE of the host.
+ * * old_ue - Set this to a UE string, and this proc will overwrite the dna of organs that have that UE, instead of the host's present UE.
+ */
+/mob/living/carbon/human/proc/sync_organ_dna(assimilate = TRUE, old_ue = null)
 	var/ue_to_compare = (old_ue) ? old_ue : dna.unique_enzymes
 	var/list/all_bits = internal_organs|bodyparts
 	for(var/obj/item/organ/O in all_bits)
 		if(assimilate || O.dna.unique_enzymes == ue_to_compare)
 			O.set_dna(dna)
+
 
 /*
 Given the name of an organ, returns the external organ it's contained in

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -425,7 +425,7 @@
 		else
 			to_chat(src, span_warning("You are trying to equip this item to an unsupported inventory slot. Report this to a coder!"))
 
-	I.equipped(src, slot, initial)
+	return I.equipped(src, slot, initial)
 
 
 /**

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -231,7 +231,16 @@
 	var/datum/language/species_language = GLOB.all_languages[language]
 	return species_language.get_random_name(gender)
 
-/datum/species/proc/create_organs(mob/living/carbon/human/H) //Handles creation of mob organs.
+
+/**
+ * Handles creation of mob organs.
+ *
+ * Arguments:
+ * * H - The human to create organs inside of
+ * * bodyparts_to_omit - Any bodyparts in this list (and organs within them) should not be added.
+ * * additional_organs - List of paths to generate additional internal organs.
+ */
+/datum/species/proc/create_organs(mob/living/carbon/human/H, list/bodyparts_to_omit, list/additional_organs)
 	QDEL_LIST(H.internal_organs)
 	QDEL_LIST(H.bodyparts)
 
@@ -239,26 +248,54 @@
 	LAZYREINITLIST(H.bodyparts_by_name)
 	LAZYREINITLIST(H.internal_organs)
 
-	for(var/limb_type in has_limbs)
-		var/list/organ_data = has_limbs[limb_type]
+	for(var/limb_name in has_limbs)
+		if(limb_name in bodyparts_to_omit)
+			H.bodyparts_by_name[limb_name] = null  // Null it out, but leave the name here so it's still "there"
+			continue
+
+		var/list/organ_data = has_limbs[limb_name]
 		var/limb_path = organ_data["path"]
 		var/obj/item/organ/O = new limb_path(H)
 		organ_data["descriptor"] = O.name
 
 	for(var/index in has_organ)
-		var/organ = has_organ[index]
-		// organ new code calls `insert` on its own
-		new organ(H)
+		var/obj/item/organ/internal/organ_path = has_organ[index]
+		if((initial(organ_path.parent_organ) in bodyparts_to_omit) || (index in bodyparts_to_omit))
+			continue
+
+		// heads up for any brave future coders:
+		// it's essential that a species' internal organs are intialized with the mob, instead of just creating them and calling insert() separately.
+		// not doing so (as of now) causes weird issues for some organs like posibrains, which need a mob on init or they'll qdel themselves.
+		// for the record: this caused every single IPC's brain to be deleted randomly throughout a round, killing them instantly.
+
+		new organ_path(H)
+
+	for(var/organ_path in additional_organs)
+		var/obj/item/organ/internal/check_organ = organ_path
+		if((initial(check_organ.parent_organ) in bodyparts_to_omit))
+			continue
+		var/organ_found
+		for(var/O in H.internal_organs)
+			var/obj/item/organ/internal/organ = O
+			organ_found = (initial(check_organ.slot) == organ.slot)
+			if(organ_found)
+				break
+		if(!organ_found)
+			new organ_path(H)
 
 	create_mutant_organs(H)
 
 	for(var/name in H.bodyparts_by_name)
-		H.bodyparts |= H.bodyparts_by_name[name]
+		var/part_type = H.bodyparts_by_name[name]
+		if(!isnull(part_type))
+			H.bodyparts |= part_type  // we do not want nulls here, even though it's alright to have them in bodyparts_by_name
+
+	for(var/obj/item/organ/external/O in H.bodyparts)
+		O.owner = H
 
 	H.update_tail()
 	H.update_wing()
-	for(var/obj/item/organ/external/O in H.bodyparts)
-		O.owner = H
+
 
 /datum/species/proc/create_mutant_organs(mob/living/carbon/human/H)
 	var/obj/item/organ/internal/ears/ears = H.get_int_organ(/obj/item/organ/internal/ears)

--- a/code/modules/mob/living/carbon/human/species/grey.dm
+++ b/code/modules/mob/living/carbon/human/species/grey.dm
@@ -37,12 +37,26 @@
 	disliked_food = SUGAR | FRIED
 	liked_food = VEGETABLES | GRAIN | MEAT
 
-/datum/species/grey/handle_dna(mob/living/carbon/human/H, remove)
+
+/datum/species/grey/on_species_gain(mob/living/carbon/human/H)
 	..()
-	H.gene_stability += GENE_INSTABILITY_MODERATE // better genetic code
-	H.dna.SetSEState(GLOB.remotetalkblock, !remove, 1)
+	H.gene_stability += GENE_INSTABILITY_MODERATE
+
+
+/datum/species/grey/on_species_loss(mob/living/carbon/human/H)
+	..()
+	H.gene_stability -= GENE_INSTABILITY_MODERATE
+
+
+/datum/species/grey/handle_dna(mob/living/carbon/human/H, remove = FALSE)
+	..()
+	H.dna.SetSEState(GLOB.remotetalkblock, !remove)
 	genemutcheck(H, GLOB.remotetalkblock, null, MUTCHK_FORCED)
-	H.dna.default_blocks.Add(GLOB.remotetalkblock)
+	if(remove)
+		H.dna.default_blocks -= GLOB.remotetalkblock
+	else
+		H.dna.default_blocks |= GLOB.remotetalkblock
+
 
 /datum/species/grey/water_act(mob/living/carbon/human/H, volume, temperature, source, method = REAGENT_TOUCH)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -530,6 +530,8 @@
 	if(!slot)
 		return FALSE
 
+	. = TRUE
+
 	I.pixel_x = initial(I.pixel_x)
 	I.pixel_y = initial(I.pixel_y)
 	I.layer = ABOVE_HUD_LAYER


### PR DESCRIPTION
## Описание
1. Набор различных исправлений, связанных со сменой расы и ДНК. Теперь конечности и внутренние органы нельзя восстановить из воздуха, при различных трансформациях, а именно:
- смена формы и монкефикация генки
- стабильный мутаген
- монкефикация и обратное очеловечивание в генетике
- абдукторская железа
- вирус кингстон

2. Также теперь все объекты, которые считаются внутренними органами (импланты, яйца терроров, эмбрионы ксеноморфов, ядра легиона и т.п.) будут передаваться при любом варианте смены расы. Исключение - внутренние органы, определённые в расовом ДНК (сердце, лёгкие и т.п.) - они подчиняются логике, описанной в пункте 1.