### PR TITLE
bugfix: VPN whitelist check now works even if ipintel_whitelist is disabled in config

### DIFF
--- a/code/modules/admin/ipintel.dm
+++ b/code/modules/admin/ipintel.dm
@@ -182,8 +182,6 @@
 	return TRUE
 
 /proc/vpn_whitelist_check(target_ckey)
-	if(!CONFIG_GET(flag/ipintel_whitelist))
-		return FALSE
 	var/datum/db_query/query_whitelist_check = SSdbcore.NewQuery("SELECT * FROM [CONFIG_GET(string/utility_database)].[format_table_name("vpn_whitelist")] WHERE ckey=:ckey", list(
 		"ckey" = target_ckey
 	))


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление ошибки, при которой можно было добавлять сикеи в вайтлист для использования ВПНа вне зависимости от наличия в БД, если конфиг ipintel_whitelist отключен.

