### PR TITLE
bugfix: contractor no longer gets two syndicate encryption keys

### DIFF
--- a/code/modules/antagonists/traitor/contractor/items/contractor_kit.dm
+++ b/code/modules/antagonists/traitor/contractor/items/contractor_kit.dm
@@ -59,7 +59,6 @@
 	new /obj/item/card/id/syndicate(src)
 	new /obj/item/storage/fancy/cigarettes/cigpack_syndicate(src)
 	new /obj/item/lighter/zippo(src)
-	new /obj/item/encryptionkey/syndicate(src)
 
 /obj/item/paper/contractor_guide
 	name = "Инструкции контрактнику"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление ошибки, при которой контрактник получал два ключа шифрования синдиката заместо одного.

