### PR TITLE
bugfix: EMP no longer discharge borgs weaponry

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -38,6 +38,9 @@
 	icon_state = "emittercannon"
 	var/charge_cost = 750
 
+/obj/item/gun/energy/emittercannon/emp_act(severity)
+	return
+
 /obj/item/borg/overdrive
 	name = "Overdrive"
 	icon = 'icons/obj/decals.dmi'

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -53,3 +53,6 @@
 /obj/item/gun/energy/disabler/cyborg/newshot()
 	..()
 	robocharge()
+
+/obj/item/gun/energy/disabler/cyborg/emp_act(severity)
+	return


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление ошибки, при которой ЕМП на боргов "разряжало" внутренние запасы энергии оружия, из-за чего ими нельзя было пользоваться.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
https://discord.com/channels/617003227182792704/1172875827755630603/1172875827755630603

