### PR TITLE
bugfix: Mecha equipment no longer can be dropped by mecha actions except detach.

### DIFF
--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -146,6 +146,7 @@
 		M.selected = src
 	update_chassis_page()
 	attach_act(M)
+	flags |= NODROP
 	if(M.occupant)
 		give_targeted_action()
 
@@ -173,6 +174,7 @@
 		update_chassis_page()
 		chassis.log_message("[src] removed from equipment.")
 		chassis = null
+		flags &= ~NODROP
 		set_ready_state(1)
 
 /obj/item/mecha_parts/mecha_equipment/proc/detach_act()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление ошибки, при которой в некоторых случаях можно было выложить модуль меха, обходя процесс нормального отсоединения.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
https://discord.com/channels/617003227182792704/1172890712556175390/1172890712556175390
