### PR TITLE
qol: Robots can now take tanks from tank dispenser

### DIFF
--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -61,6 +61,10 @@
 /obj/structure/dispenser/attack_ghost(mob/user)
 	ui_interact(user)
 
+/obj/structure/dispenser/attack_robot(mob/user)
+	if(Adjacent(user))
+		ui_interact(user)
+
 /obj/structure/dispenser/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
QoL, позволяющий боргам доставать баллоны из раздатчика баллонов.

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Довольно странно, что инжеборг имеет возможность брать баллоны, но при этом не имеет возможности их доставать.
## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
![изображение](https://github.com/ss220-space/Paradise/assets/73733747/4babf966-dba3-46f8-9e9d-87287e7ee4ad)
