### PR TITLE
bugfix: mecha extinguishers do extinguish burning mobs now

### DIFF
--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -573,6 +573,10 @@
 						W.reagents.reaction(W_turf)
 						for(var/atom/atm in W_turf)
 							W.reagents.reaction(atm)
+							if(isliving(atm)) //For extinguishing mobs on fire
+								var/mob/living/M = atm
+								M.ExtinguishMob()
+
 						if(W.loc == my_target)
 							break
 						sleep(2)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление ошибки, при которой огнетушитель на мехе не мог тушить горящих мобов.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
https://discord.com/channels/617003227182792704/1172971695041155192

