### PR TITLE
bugfix: unique "reference" for new uplink item.

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1979,7 +1979,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/implants/stealthbox
     name = "Stealth Implant"
     desc = "An implant injected into the body, and later activated manually to deploy a box, fully hiding you in the surroundings. Can be used indefinitely"
-    reference = "SB"
+    reference = "BI"
     item = /obj/item/implanter/stealth
     cost = 8
 

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -66,7 +66,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	var/name = "item name"
 	var/category = "item category"
 	var/desc = "Item Description"
-	var/reference = "Item Reference"
+	var/reference = "Item Reference" // Important to use unique "reference" for datums with different "item".
 	var/item = null
 	var/cost = 0
 	var/last = 0 // Appear last


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Меняет референс в аплинке для недавно введённого "Импланта Стелса" на уникальный, ибо прежний дублировал референс у СиндиБомбы и ломал покупку, собственно синдибомбы. Добавляет комментарий к "референсу" датума вещей аплинка, указывающий на нужду в установке уникальных "референсов" для датумов с разными "вещами".
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на баг-репорт
https://discord.com/channels/617003227182792704/1173268670529671240<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
