### PR TITLE
tweak: The cloning machine can only be obtained from cargo.

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -66337,7 +66337,7 @@
 	},
 /area/turret_protected/ai)
 "jru" = (
-/obj/machinery/computer/cloning,
+/obj/structure/computerframe,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "whiteblue"
@@ -81399,7 +81399,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "mWR" = (
-/obj/machinery/dna_scannernew,
+/obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -100848,13 +100848,13 @@
 	},
 /area/bridge)
 "rlp" = (
-/obj/machinery/clonepod/biomass,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -30744,9 +30744,6 @@
 /turf/simulated/floor/plating,
 /area/atmos/distribution)
 "dAn" = (
-/obj/structure/cable/orange{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
@@ -39583,7 +39580,7 @@
 /area/civilian/vacantoffice)
 "gjD" = (
 /obj/machinery/light,
-/obj/machinery/dna_scannernew,
+/obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
 	},
@@ -49508,7 +49505,7 @@
 /area/maintenance/starboard)
 "jdT" = (
 /obj/structure/cable/orange{
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -53928,13 +53925,16 @@
 /obj/item/book/manual/medical_cloning{
 	pixel_y = 6
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
 /obj/structure/table/glass,
 /obj/item/storage/box/masks{
 	pixel_y = 5
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -94733,9 +94733,7 @@
 	},
 /area/maintenance/engineering)
 "wxv" = (
-/obj/machinery/computer/cloning{
-	dir = 1
-	},
+/obj/structure/computerframe,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "whiteblue"
@@ -97018,14 +97016,11 @@
 /turf/simulated/floor/engine,
 /area/toxins/mixing)
 "xhW" = (
-/obj/structure/cable/orange{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
+/obj/machinery/constructable_frame/machine_frame,
+/obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/machinery/clonepod,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whiteblue"

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -39953,13 +39953,13 @@
 	},
 /area/medical/cloning)
 "bWC" = (
-/obj/machinery/computer/cloning,
+/obj/structure/computerframe,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
 /area/medical/cloning)
 "bWD" = (
-/obj/machinery/dna_scannernew,
+/obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -39985,8 +39985,8 @@
 	},
 /area/medical/cloning)
 "bWF" = (
-/obj/machinery/clonepod/biomass,
 /obj/machinery/light,
+/obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1004,6 +1004,16 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 	access = ACCESS_CMO
 	announce_beacons = list("Medbay" = list("Virology", "Chief Medical Officer's Desk"))
 
+/datum/supply_packs/medical/cloning
+	name = "NanoTrasen Special Delivery Crate"
+	contains = list(/obj/item/circuitboard/clonepod,
+					/obj/item/circuitboard/cloning)
+	cost = 900
+	containertype = /obj/structure/closet/crate/secure
+	containername = "NanoTrasen special delivery crate"
+	access = ACCESS_CMO
+	announce_beacons = list("Medbay" = list("Chief Medical Officer's Desk"))
+
 /datum/supply_packs/medical/vending
 	name = "Medical Vending Crate"
 	cost = 20

--- a/code/datums/syndiesupplypacks.dm
+++ b/code/datums/syndiesupplypacks.dm
@@ -865,6 +865,15 @@ GLOBAL_LIST_INIT(all_syndie_supply_groups, list(SYNDIE_SUPPLY_EMERGENCY,SYNDIE_S
 	containername = "virus crate"
 	access = ACCESS_CMO
 
+/datum/syndie_supply_packs/medical/cloning
+	name = "Cloning Kit Crate"
+	contains = list(/obj/item/circuitboard/clonepod,
+					/obj/item/circuitboard/cloning)
+	cost = 9000
+	containertype = /obj/structure/closet/crate/secure
+	containername = "cloning kit crate"
+	access = ACCESS_CMO
+
 /datum/syndie_supply_packs/medical/vending
 	name = "Medical Vending Crate"
 	cost = 200

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -85,6 +85,11 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 	component_parts += new /obj/item/stack/sheet/glass(null)
 	component_parts += new /obj/item/stack/cable_coil(null, 1)
 	component_parts += new /obj/item/stack/cable_coil(null, 1)
+	component_parts += new /obj/item/stock_parts/capacitor/quadratic(null)
+	component_parts += new /obj/item/stock_parts/capacitor/quadratic(null)
+	component_parts += new /obj/item/stock_parts/capacitor/quadratic(null)
+	component_parts += new /obj/item/stock_parts/capacitor/quadratic(null)
+	component_parts += new /obj/item/stock_parts/capacitor/quadratic(null)
 	RefreshParts()
 	update_icon()
 
@@ -99,6 +104,11 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 	component_parts += new /obj/item/stack/sheet/glass(null)
 	component_parts += new /obj/item/stack/cable_coil(null, 1)
 	component_parts += new /obj/item/stack/cable_coil(null, 1)
+	component_parts += new /obj/item/stock_parts/capacitor/quadratic(null)
+	component_parts += new /obj/item/stock_parts/capacitor/quadratic(null)
+	component_parts += new /obj/item/stock_parts/capacitor/quadratic(null)
+	component_parts += new /obj/item/stock_parts/capacitor/quadratic(null)
+	component_parts += new /obj/item/stock_parts/capacitor/quadratic(null)
 	biomass = CLONE_BIOMASS
 	RefreshParts()
 

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -23,7 +23,7 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 
 /obj/machinery/clonepod
 	anchored = TRUE
-	name = "cloning pod"
+	name = "experimental biomass pod"
 	desc = "An electronically-lockable pod for growing organic tissue."
 	density = TRUE
 	icon = 'icons/obj/machines/cloning.dmi'

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -218,7 +218,7 @@
 	origin_tech = "programming=3"
 
 /obj/item/circuitboard/cloning
-	board_name = "Cloning Machine Console"
+	board_name = "Biomass Pod Console"
 	build_path = /obj/machinery/computer/cloning
 	origin_tech = "programming=2;biotech=2"
 

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -2,7 +2,7 @@
 #define MENU_RECORDS 2
 
 /obj/machinery/computer/cloning
-	name = "cloning console"
+	name = "biomass pod console"
 	icon = 'icons/obj/machines/computer.dmi'
 	icon_keyboard = "med_key"
 	icon_screen = "dna"

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -806,7 +806,8 @@ to destroy them and players will be able to make replacements.
 							/obj/item/stack/cable_coil = 2,
 							/obj/item/stock_parts/scanning_module = 2,
 							/obj/item/stock_parts/manipulator = 2,
-							/obj/item/stack/sheet/glass = 1)
+							/obj/item/stack/sheet/glass = 1,
+							/obj/item/stock_parts/capacitor/quadratic = 5)
 
 /obj/item/circuitboard/clonescanner
 	board_name = "Cloning Scanner"

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -798,7 +798,7 @@ to destroy them and players will be able to make replacements.
 
 
 /obj/item/circuitboard/clonepod
-	board_name = "Clone Pod"
+	board_name = "Experimental Biomass Pod"
 	build_path = /obj/machinery/clonepod
 	board_type = "machine"
 	origin_tech = "programming=2;biotech=2"
@@ -810,7 +810,7 @@ to destroy them and players will be able to make replacements.
 							/obj/item/stock_parts/capacitor/quadratic = 5)
 
 /obj/item/circuitboard/clonescanner
-	board_name = "Cloning Scanner"
+	board_name = "\improper DNA Scanner"
 	build_path = /obj/machinery/dna_scannernew
 	board_type = "machine"
 	origin_tech = "programming=2;biotech=2"

--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -62,7 +62,7 @@
 	build_path = /obj/item/circuitboard/camera
 	category = list("Computer Boards")
 
-/datum/design/clonecontrol
+/*	/datum/design/clonecontrol
 	name = "Console Board (Cloning Machine Console)"
 	desc = "Allows for the construction of circuit boards used to build a new Cloning Machine console."
 	id = "clonecontrol"
@@ -71,7 +71,7 @@
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/cloning
 	category = list("Computer Boards")
-
+*/
 /datum/design/comconsole
 	name = "Console Board (Communications Console)"
 	desc = "Allows for the construction of circuit boards used to build a communications console."

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -122,7 +122,7 @@
 	build_path = /obj/item/circuitboard/bodyscanner
 	category = list("Medical Machinery")
 
-/datum/design/clonepod
+/*	/datum/design/clonepod
 	name = "Machine Board (Cloning Pod)"
 	desc = "Allows for the construction of circuit boards used to build a Cloning Pod."
 	id = "clonepod"
@@ -131,7 +131,7 @@
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/clonepod
 	category = list("Medical Machinery")
-
+*/
 /datum/design/clonescanner
 	name = "Machine Board (Cloning Scanner)"
 	desc = "Allows for the construction of circuit boards used to build a Cloning Scanner."


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
- Убирает клонировальное оборудование со стандартных станционных карт (Цере, Дельта, Коробка), на их месте оставляет фрейм компьютера и машин (ещё на Цере поменял местами АПЦ и фаералярм, чтобы провод к АПЦ проходил под столом, а не под машиной, ибо это ужас). 
- Убирает возможность печати плат клонпода и его консоли в РнД. 
- Добавляет в карго в медицинский раздел "NanoTrasen Special Delivery Crate", в котором находится по одной плате клонпода и его консоли. Стоит это дело 900 очков карго, а у Тайпана 9000 кредитов. 
- Машинам и их платам изменены названия на "Clone Pod"->"Experimental Biomass Pod"; "Cloning Machine Console"->"Biomass Pod Console"; "Cloning Scanner"->"DNA Scanner".<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение
https://discord.com/channels/617003227182792704/755125334097133628/1166361873009102888<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
