### PR TITLE
bugfix: captain-plasmaman give plasmatank (on roundstart)

### DIFF
--- a/code/datums/outfits/plasmamen.dm
+++ b/code/datums/outfits/plasmamen.dm
@@ -212,6 +212,8 @@
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/captain
 	uniform = /obj/item/clothing/under/plasmaman/captain
+	r_hand = null
+	belt = /obj/item/tank/internals/plasmaman/belt/full
 
 /datum/outfit/plasmaman/blueshield
 	name = "Blueshield Plasmaman"

--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -172,6 +172,7 @@
 
 	H.equipOutfit(O, visualsOnly)
 	H.internal = H.r_hand
+	H.internal = H.belt
 	H.update_action_buttons_icon()
 	return FALSE
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
При спавне раундстартом капитан-плазмамен спавнился без баллона плазмы из-за спавна на мыле. Танк перемещён на пояс, чтобы этого не происходило.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1172619892395089990
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
