### PR TITLE
refactor: jobs correctly apply jobs config, and can be changed before round start

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -360,7 +360,7 @@ SUBSYSTEM_DEF(ticker)
 
 	if(playercount >= highpop_trigger)
 		log_debug("Playercount: [playercount] versus trigger: [highpop_trigger] - loading highpop job config")
-		SSjobs.LoadJobs("config/jobs_highpop.txt")
+		SSjobs.ApplyHighpopConfig()
 	else
 		log_debug("Playercount: [playercount] versus trigger: [highpop_trigger] - keeping standard job config")
 

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -18,6 +18,10 @@
 	//How many players can spawn in as this job
 	var/spawn_positions = 0
 
+	//Position count override from config/jobs.txt and jobs_highpop.txt
+	var/positions_lowpop = null
+	var/positions_highpop = null
+
 	//How many players have this job
 	var/current_positions = 0
 

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -2,7 +2,7 @@
 	title = "AI"
 	flag = JOB_AI
 	department_flag = JOBCAT_ENGSEC
-	total_positions = 0 // Not used for AI, see is_position_available below and modules/mob/living/silicon/ai/latejoin.dm
+	total_positions = -1 // Not used for AI, see is_position_available below and modules/mob/living/silicon/ai/latejoin.dm
 	spawn_positions = 1
 	selection_color = "#ccffcc"
 	supervisors = "your laws"
@@ -17,7 +17,7 @@
 		return 0
 
 /datum/job/ai/is_position_available()
-	return (GLOB.empty_playable_ai_cores.len != 0)
+	return GLOB.empty_playable_ai_cores.len && CONFIG_GET(flag/allow_ai)
 
 
 /datum/job/cyborg

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -580,7 +580,7 @@ GLOBAL_VAR_INIT(nologevent, 0)
 		return
 
 	CONFIG_SET(flag/allow_ai, !CONFIG_GET(flag/allow_ai))
-	if(!( CONFIG_GET(flag/allow_ai) ))
+	if(!CONFIG_GET(flag/allow_ai))
 		to_chat(world, "<B>The AI job is no longer chooseable.</B>")
 	else
 		to_chat(world, "<B>The AI job is chooseable now.</B>")


### PR DESCRIPTION
Подсистема jobs теперь правильно читает и применяет конфиг лимита профессий, количество слотов можно поменять через VV перед началом раунда