### PR TITLE
bugfix: pet collar announces mob death to "station owner" channel.

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -194,6 +194,11 @@
 	icon_state = "cap_cypherkey"
 	channels = list("Command" = 1, "Security" = 1, "Engineering" = 1, "Science" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1, "AI Private" = 1, "Procedure" = 1)
 
+/obj/item/encryptionkey/admin //totally shitspawn
+	name = "Admin Radio Encryption Key"
+	channels = list("Common" = 1, "Science" = 1, "Command" = 1, "Medical" = 1, "Engineering" = 1, "Security" = 1, "Supply" = 1, "Service" = 1, "Procedure" = 1, "AI Private" = 1, "Syndicate" = 1, \
+		"Response Team" = 1, "Special Ops" = 1, "SyndTaipan" = 1, "SyndTeam" = 1, "Soviet" = 1, "Medical(I)" = 1, "Security(I)" = 1, "Spy Spider" = 1, "Spider Clan" = 1, "Alpha wave" = 1, "Beta wave" = 1, "Gamma wave" = 1)
+
 /obj/item/encryptionkey/event_1
 	name = "Encryption key"
 	desc = "An encryption key for a radio headset. To access special radio channel, use :q."

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -392,6 +392,9 @@
 		return FALSE
 	return ..()
 
+/obj/item/radio/headset/all_channels // Its only feature is all channels.
+	ks1type = /obj/item/encryptionkey/admin
+
 /obj/item/radio/headset/event_1
 	name = "Radio headset"
 	desc = "A headset linked to special long range alpha frequency in this sector."

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -819,14 +819,25 @@
 	// if it wasn't intentionally unequipped but isn't being worn, possibly gibbed
 	if(istype(M) && src == M.pcollar && M.stat != DEAD)
 		return
-
+	var/announce_channel = "Common"			// Channel toggler for mobs, who dies in specific locations.
 	var/area/t = get_area(M)
-	var/obj/item/radio/headset/a = new /obj/item/radio/headset(src)
-	if(istype(t, /area/syndicate_mothership) || istype(t, /area/shuttle/syndicate_elite))
-		//give the syndicats a bit of stealth
-		a.autosay("[M] has been vandalized in Space!", "[M]'s Death Alarm")
-	else
-		a.autosay("[M] has been vandalized in [t.name]!", "[M]'s Death Alarm")
+	var/obj/item/radio/headset/all_channels/a = new /obj/item/radio/headset/all_channels(src)
+	if(M.z == level_name_to_num(RAMSS_TAIPAN))
+		announce_channel = "SyndTaipan"		// Taipan channel for Руж.
+	else if(istype(t, /area/centcom))
+		announce_channel = "Response Team"	// For animals who dare to infiltrate CC.
+	else if(istype(t, /area/syndicate_mothership) || istype(t, /area/shuttle/syndicate_elite) || istype(t, /area/shuttle/syndicate_sit))
+		announce_channel = "SyndTeam"		// Just to be sure ...
+	else if(istype(t, /area/ninja))
+		announce_channel = "Spider Clan"	// Even ninja may have a little pet.
+	else if(istype(t, /area/ussp_centcom))
+		announce_channel = "Soviet"			// MISHA, FU!
+	else if((M.z == level_name_to_num(CENTCOMM) || z == level_name_to_num(ADMIN_ZONE)) && SSticker.current_state != GAME_STATE_FINISHED)
+		a.autosay("[M] has been vandalized in Space!", "[M]'s Death Alarm")	// For the rest of CC map locations like Abductors UFO, Vox home or TSF home.
+		qdel(a)
+		STOP_PROCESSING(SSobj, src)
+		return
+	a.autosay("[M] has been vandalized in [t.name]!", "[M]'s Death Alarm", announce_channel)
 	qdel(a)
 	STOP_PROCESSING(SSobj, src)
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Меняет канал, в который ошейник орёт о смерти питомца, в зависимости от того, на какой локации сам питомец находится, а точнее:
- Сектор Тайпана = Канал Тайпана.
- ЦК = Канал ЕРТ.
- СЦК и шаттлы ССТ/СИТ = Канал СЦК.
- Додзё Ниндзи = Канал Ниндзи.
- Кабинет Секретаря СССП = Канал Советов (Скорее всего можно уже напичкать локации из Горького сюда, не знаю, но как задумку на будущие обновы СССП локаций стоило оставить).

**Дополнительно**. Если моб умирает на любой другой локации в секторе ЦК или А-руме, то ошейник просто не анонсирует локацию моба. Скрытность перестаёт работать после гринтекста.

А, да. Ещё влепил в код ключик шифрования и наушник с этим ключиком. Щитспавновые штуки, которые просто имеют все радиоканалы, что есть в билде. Может быть полезно будет ещё для чего, так что да. В любом случае, убрать его и вписать заменяемый тип наушника не так сложно.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на баг-репорт
https://discord.com/channels/617003227182792704/1175539619929018480<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
