### PR TITLE
fix: add missed restricted network for gorky 17 cameras

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/USSP_gorky17.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/USSP_gorky17.dmm
@@ -4011,9 +4011,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
 /obj/machinery/door_control{
 	id = "g17extlock";
 	name = "Gorky17 exterior lockdown";
@@ -4041,6 +4038,11 @@
 	dir = 8;
 	name = "Gorky17 rank console bridge";
 	req_access = list(125)
+	},
+/obj/machinery/camera/autoname{
+	dir = 8;
+	name = "Gorky17 security camera";
+	network = list("USSP_gorky17")
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluefull"
@@ -4159,10 +4161,13 @@
 	icon_state = "2-8"
 	},
 /obj/effect/decal/warning_stripes/northeast,
-/obj/machinery/camera/autoname,
 /obj/machinery/suit_storage_unit/engine{
 	name = "Soviet engineering suit storage unit";
 	req_access = list(122)
+	},
+/obj/machinery/camera/autoname{
+	name = "Gorky17 security camera";
+	network = list("USSP_gorky17")
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/USSP_gorky17/solmaintnorth)
@@ -14380,7 +14385,10 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/camera/autoname,
+/obj/machinery/camera/autoname{
+	name = "Gorky17 security camera";
+	network = list("USSP_gorky17")
+	},
 /turf/simulated/floor/plating,
 /area/ruin/space/USSP_gorky17/engineering)
 "Yb" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/USSP_gorky17_collapsed.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/USSP_gorky17_collapsed.dmm
@@ -4793,9 +4793,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
 /obj/machinery/door_control{
 	id = "g17extlock";
 	name = "Gorky17 exterior lockdown";
@@ -4813,6 +4810,11 @@
 /obj/structure/table,
 /obj/machinery/photocopier/faxmachine/longrange/ussp{
 	department = "Gorky 17"
+	},
+/obj/machinery/camera/autoname{
+	dir = 8;
+	name = "Gorky17 security camera";
+	network = list("USSP_gorky17")
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluefull"
@@ -4933,11 +4935,14 @@
 	icon_state = "2-8"
 	},
 /obj/effect/decal/warning_stripes/northeast,
-/obj/machinery/camera/autoname,
 /obj/machinery/suit_storage_unit{
 	name = "Soviet hardsuit storage unit";
 	req_access = list(122);
 	state_open = 1
+	},
+/obj/machinery/camera/autoname{
+	name = "Gorky17 security camera";
+	network = list("USSP_gorky17")
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/USSP_gorky17/collapsed/solmaintnorth)
@@ -17012,7 +17017,6 @@
 	dir = 1;
 	flickering = 1
 	},
-/obj/machinery/camera/autoname,
 /turf/simulated/floor/plating,
 /area/ruin/space/USSP_gorky17/collapsed/engineering)
 "Yb" = (


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Добавлена ограниченная сеть в несколько упущенных камер на картах "Горький 17"
## Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
ИИ мог использовать камеры на "Горький 17" 
