### PR TITLE
bugfix: sofas `dir` corrections.

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -124401,7 +124401,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
 "wHp" = (
-/obj/structure/chair/sofa/corner,
+/obj/structure/chair/sofa/corner{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 4;

--- a/_maps/map_files/RandomZLevels/spacehotel.dmm
+++ b/_maps/map_files/RandomZLevels/spacehotel.dmm
@@ -3974,7 +3974,7 @@
 /area/awaymission/spacehotel/reception)
 "kq" = (
 /obj/structure/chair/sofa/corner{
-	dir = 4
+	dir = 1
 	},
 /turf/simulated/floor/indestructible/carpet,
 /area/awaymission/spacehotel)

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -17150,9 +17150,7 @@
 	},
 /area/crew_quarters/dorms)
 "aTE" = (
-/obj/structure/chair/sofa/corner{
-	dir = 4
-	},
+/obj/structure/chair/sofa/corner,
 /obj/structure/window/reinforced{
 	dir = 1;
 	layer = 2.9
@@ -70887,8 +70885,7 @@
 /area/security/permabrig)
 "eje" = (
 /obj/structure/chair/sofa/corner{
-	color = "#85130b";
-	dir = 1
+	color = "#85130b"
 	},
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/wood,

--- a/_maps/map_files/generic/syndicatebase.dmm
+++ b/_maps/map_files/generic/syndicatebase.dmm
@@ -22820,9 +22820,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/chair/sofa/corner{
-	dir = 4
-	},
+/obj/structure/chair/sofa/corner,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkred"
@@ -26258,9 +26256,6 @@
 	},
 /area/syndicate/unpowered/syndicate_space_base/cargo)
 "vDO" = (
-/obj/structure/chair/sofa{
-	dir = 10
-	},
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 30
 	},
@@ -26269,6 +26264,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/structure/chair/sofa/corner{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
На Дельте, Коробке, Тайпане и гейте-Отеле меняет направление у углов диванов на правильное. Проблемы из всех текущих в игре мап с этой деталью остались только на ЦК и в гейте-Академии, но их не трогал, ибо они на стадии активной переработки.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на баг-репорт
https://discord.com/channels/617003227182792704/1176401296950038548/1176401296950038548<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
