### PR TITLE
bugfix: cerestation door button in Magistrate's office.

### DIFF
--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -61976,7 +61976,7 @@
 "mIP" = (
 /obj/machinery/door/airlock/glass{
 	id = "Magistrate";
-	id_tag = "Magistrate";
+	id_tag = null;
 	name = "Magistrate's Office";
 	req_access = list(74)
 	},
@@ -92502,7 +92502,8 @@
 	},
 /obj/machinery/door_control{
 	id = "Magistrate";
-	name = "Privacy Shutters Control";
+	name = "Office Door";
+	normaldoorcontrol = 1;
 	pixel_y = -32;
 	req_access = list(74)
 	},


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Переименовывает кнопку в кабинете Магистрата на Фаррагусе с "Контроль Шаттеров (которых нет)" на "Офисная Дверь" и даёт ей функцию по открыванию, собственно двери из корридора.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Картинка-баг-репорт
![image](https://github.com/ss220-space/Paradise/assets/115735095/49c7d6f7-0266-47a9-9002-f951c15fa9c8)
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
