### PR TITLE
bugfix: Power loss is now calculated correctly on scoreboard

### DIFF
--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -268,7 +268,7 @@ GLOBAL_VAR(scoreboard) // Variable to save the scoreboard string once it's been 
 		if(!is_station_level(apc.z))
 			continue
 		var/obj/item/stock_parts/cell/cell = apc.cell
-		if(!cell?.charge < 2300)
+		if(cell?.charge < 2300)
 			score_power_loss++ //200 charge leeway
 
 

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -268,7 +268,7 @@ GLOBAL_VAR(scoreboard) // Variable to save the scoreboard string once it's been 
 		if(!is_station_level(apc.z))
 			continue
 		var/obj/item/stock_parts/cell/cell = apc.cell
-		if(cell?.charge < 2300 || !cell)
+		if(!cell || cell.charge < 2300)
 			score_power_loss++ //200 charge leeway
 
 

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -268,7 +268,7 @@ GLOBAL_VAR(scoreboard) // Variable to save the scoreboard string once it's been 
 		if(!is_station_level(apc.z))
 			continue
 		var/obj/item/stock_parts/cell/cell = apc.cell
-		if(cell?.charge < 2300)
+		if(cell?.charge < 2300 || !cell)
 			score_power_loss++ //200 charge leeway
 
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление ошибки, при которой всегда считалось, что ЛКП на станции не функционируют, вследствие чего в итоговой сводке очков на 1840 меньше, чем есть на самом деле.

