### PR TITLE
bugfix: correct checks and correct desc changing for poncho repainting

### DIFF
--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -76,7 +76,7 @@
 			var/new_softcap_icon_state = ""
 			var/new_softcap_name = ""
 			var/new_poncho_icon_state = ""
-			var/new_poncho_item_state = ""
+			var/new_poncho_desc = ""
 			var/new_poncho_name = ""
 			var/new_desc = "The colors are a bit dodgy."
 			for(var/T in typesof(/obj/item/clothing/under))
@@ -134,7 +134,7 @@
 				var/obj/item/clothing/neck/poncho/P = new T
 				if(wash_color == P.item_color)
 					new_poncho_icon_state = P.icon_state
-					new_poncho_item_state = P.item_state
+					new_poncho_desc = P.desc
 					new_poncho_name = P.name
 					qdel(P)
 					break
@@ -193,14 +193,14 @@
 					H.item_color = wash_color
 					H.name = new_softcap_name
 					H.desc = new_desc
-			if(new_poncho_icon_state && new_poncho_item_state && new_poncho_name)
+			if(new_poncho_icon_state && new_poncho_name)
 				for(var/obj/item/clothing/neck/poncho/P in contents)
 					if(!P.dyeable)
 						continue
-					P.item_state = new_poncho_item_state
 					P.icon_state = new_poncho_icon_state
 					P.item_color = wash_color
 					P.name = new_poncho_name
+					P.desc = "[new_poncho_desc] [new_desc]"
 		QDEL_NULL(crayon)
 
 

--- a/code/modules/clothing/neck/ponchos.dm
+++ b/code/modules/clothing/neck/ponchos.dm
@@ -134,6 +134,7 @@
 	icon_state = "shameponcho"
 	item_color = "shame"
 	flags = NODROP
+	dyeable = FALSE
 
 /obj/item/clothing/neck/poncho/security
 	name = "corporate poncho"
@@ -159,3 +160,4 @@
 	icon_state = "tacticalponcho"
 	item_color = "tactical"
 	sprite_sheets = list()
+	dyeable = FALSE

--- a/code/modules/paperwork/stamps.dm
+++ b/code/modules/paperwork/stamps.dm
@@ -106,7 +106,7 @@
 	name = "BIG DENY rubber stamp"
 	icon_state = "stamp-BIGdeny"
 	item_color = "redcoat"
-	
+
 /obj/item/stamp/navcom
 	name = "Nanotrasen Naval Command rubber stamp"
 	icon_state = "stamp-navcom"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Убирает ненужную проверку на айтем_стейт у пончо, которые вообще не имеют спрайта в руке, при перекраске в стиралке. Пончо получают свои законные крутые дескрипшены при перекраске, а не стандартные перекрасочные. Щитспавновые пончо стали неперекрашиваемыми, увынск.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Баг-репорт
![image](https://github.com/ss220-space/Paradise/assets/115735095/f239c123-2b2d-41b6-94c1-40aa8f582824)
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
