### PR TITLE
tweak: Gliding And Projectiles Tweaks

### DIFF
--- a/code/__HELPERS/heap.dm
+++ b/code/__HELPERS/heap.dm
@@ -24,7 +24,7 @@
 //(i.e the max or the min dependant on the comparison function)
 /datum/heap/proc/Pop()
 	if(!L.len)
-		return 0
+		return null
 	. = L[1]
 
 	L[1] = L[L.len]
@@ -33,33 +33,33 @@
 	Sink(1)
 
 //Get a node up to its right position in the heap
-/datum/heap/proc/Swim(var/index)
+/datum/heap/proc/Swim(index)
 	var/parent = round(index * 0.5)
 
-	while(parent > 0 && (call(cmp)(L[index],L[parent]) > 0))
-		L.Swap(index,parent)
+	while(parent > 0 && (call(cmp)(L[index], L[parent]) > 0))
+		L.Swap(index, parent)
 		index = parent
 		parent = round(index * 0.5)
 
 //Get a node down to its right position in the heap
-/datum/heap/proc/Sink(var/index)
+/datum/heap/proc/Sink(index)
 	var/g_child = GetGreaterChild(index)
 
-	while(g_child > 0 && (call(cmp)(L[index],L[g_child]) < 0))
-		L.Swap(index,g_child)
+	while(g_child > 0 && (call(cmp)(L[index], L[g_child]) < 0))
+		L.Swap(index, g_child)
 		index = g_child
 		g_child = GetGreaterChild(index)
 
 //Returns the greater (relative to the comparison proc) of a node children
 //or 0 if there's no child
-/datum/heap/proc/GetGreaterChild(var/index)
+/datum/heap/proc/GetGreaterChild(index)
 	if(index * 2 > L.len)
 		return 0
 
 	if(index * 2 + 1 > L.len)
 		return index * 2
 
-	if(call(cmp)(L[index * 2],L[index * 2 + 1]) < 0)
+	if(call(cmp)(L[index * 2], L[index * 2 + 1]) < 0)
 		return index * 2 + 1
 	else
 		return index * 2

--- a/code/datums/diseases/viruses/advance/symptoms/limb_throw.dm
+++ b/code/datums/diseases/viruses/advance/symptoms/limb_throw.dm
@@ -77,6 +77,7 @@ Limb Rejection
 	var/obj/item/projectile/limb/limb_projectile = new(user.loc, limb)
 	limb_projectile.current = get_turf(user)
 	limb_projectile.preparePixelProjectile(target, get_turf(target), user)
+	limb_projectile.firer = user
 	limb_projectile.fire()
 	playsound(get_turf(usr), 'sound/effects/splat.ogg', 50, 1)
 

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -42,6 +42,7 @@
 		spawn((i - 1) * projectile_delay)
 			var/obj/item/projectile/A = new projectile(curloc)
 			A.firer = chassis.occupant
+			A.firer_source_atom = src
 			A.original = target
 			A.current = curloc
 

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -187,6 +187,7 @@
 		for(var/obj/machinery/atmospherics/unary/vent_pump/v in view(7,src))
 			if(!v.welded)
 				entry_vent = v
+				glide_for(3)
 				walk_to(src, entry_vent, 1)
 				break
 	if(isturf(loc))
@@ -227,6 +228,7 @@
 		available_turfs += S
 	if(!length(available_turfs))
 		return FALSE
+	glide_for(3)
 	walk_to(src, pick(available_turfs))
 	return TRUE
 

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -130,16 +130,15 @@
 	if(!shock(user, 70))
 		take_damage(user.obj_damage, BRUTE, "melee", 1)
 
+
 /obj/structure/grille/CanPass(atom/movable/mover, turf/target, height=0)
-	if(height==0)
-		return 1
+	if(height == 0)
+		return TRUE
 	if(istype(mover) && mover.checkpass(PASSGRILLE))
-		return 1
-	else
-		if(istype(mover, /obj/item/projectile))
-			return prob(30)
-		else
-			return !density
+		return TRUE
+	if(istype(mover, /obj/item/projectile))
+		return (prob(30) || !density)
+	return !density
 
 
 /obj/structure/grille/CanPathfindPass(obj/item/card/id/ID, dir, caller, no_id = FALSE)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -135,12 +135,13 @@ GLOBAL_LIST_INIT(wcCommon, pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e",
 	else
 		..(FULLTILE_WINDOW_DIR)
 
+
 /obj/structure/window/CanPass(atom/movable/mover, turf/target, height=0)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
-		return 1
-	if(dir == FULLTILE_WINDOW_DIR)
-		return 0	//full tile window, you can't move into it!
-	if(get_dir(loc, target) == dir)
+		return TRUE
+	if(dir == FULLTILE_WINDOW_DIR)	// full tile window, you can't move into it!
+		return FALSE
+	if(dir == get_dir(loc, target))
 		return !density
 	if(istype(mover, /obj/structure/window))
 		var/obj/structure/window/W = mover
@@ -152,14 +153,15 @@ GLOBAL_LIST_INIT(wcCommon, pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e",
 			return FALSE
 	else if(istype(mover, /obj/machinery/door/window) && !valid_window_location(loc, mover.dir))
 		return FALSE
-	return 1
+	return TRUE
 
-/obj/structure/window/CheckExit(atom/movable/O, target)
-	if(istype(O) && O.checkpass(PASSGLASS))
-		return 1
-	if(get_dir(O.loc, target) == dir)
-		return 0
-	return 1
+
+/obj/structure/window/CheckExit(atom/movable/mover, turf/target)
+	if(istype(mover) && mover.checkpass(PASSGLASS))
+		return TRUE
+	if(dir == get_dir(loc, target))
+		return FALSE
+	return TRUE
 
 
 /obj/structure/window/CanPathfindPass(obj/item/card/id/ID, to_dir, atom/movable/caller, no_id = FALSE)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -134,7 +134,8 @@
 	..()
 	return FALSE
 
-/turf/Enter(atom/movable/mover as mob|obj, atom/forget)
+
+/turf/Enter(atom/movable/mover, atom/oldloc)
 	if(!mover)
 		return TRUE
 
@@ -142,7 +143,7 @@
 	if(isturf(mover.loc))
 		// Nothing but border objects stop you from leaving a tile, only one loop is needed
 		for(var/obj/obstacle in mover.loc)
-			if(!obstacle.CheckExit(mover, src) && obstacle != mover && obstacle != forget)
+			if(!obstacle.CheckExit(mover, src) && obstacle != mover && obstacle != oldloc)
 				mover.Bump(obstacle, TRUE)
 				return FALSE
 
@@ -150,23 +151,31 @@
 	//Next, check objects to block entry that are on the border
 	for(var/atom/movable/border_obstacle in src)
 		if(border_obstacle.flags & ON_BORDER)
-			if(!border_obstacle.CanPass(mover, mover.loc, 1) && (forget != border_obstacle))
+			if(!border_obstacle.CanPass(mover, mover.loc, 1) && border_obstacle != oldloc)
 				mover.Bump(border_obstacle, TRUE)
 				return FALSE
 		else
 			large_dense += border_obstacle
 
 	//Then, check the turf itself
-	if(!src.CanPass(mover, src))
+	if(!CanPass(mover, src))
 		mover.Bump(src, TRUE)
 		return FALSE
 
 	//Finally, check objects/mobs to block entry that are not on the border
+	var/atom/movable/tompost_bump
+	var/top_layer = 0
 	for(var/atom/movable/obstacle in large_dense)
-		if(!obstacle.CanPass(mover, mover.loc, 1) && (forget != obstacle))
-			mover.Bump(obstacle, TRUE)
-			return FALSE
+		if(!obstacle.CanPass(mover, mover.loc, 1) && obstacle != oldloc)
+			if(obstacle.layer > top_layer)
+				tompost_bump = obstacle
+				top_layer = obstacle.layer	//Probably separate variable is a better solution, but its good for now.
+	if(tompost_bump)
+		mover.Bump(tompost_bump, TRUE)
+		return FALSE
+
 	return TRUE //Nothing found to block so return success!
+
 
 /turf/Entered(atom/movable/M, atom/OL, ignoreRest = FALSE)
 	..()

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -233,6 +233,7 @@ GLOBAL_LIST_INIT(major_hallutinations, list("fake"=20,"death"=10,"xeno"=10,"sing
 	if(pump)
 		borer = new(pump.loc,target)
 		for(var/i in 0 to 10)
+			borer.glide_for(3)
 			walk_to(borer, get_step(borer, get_cardinal_dir(borer, T)))
 			if(borer.Adjacent(T))
 				to_chat(T, "<span class='userdanger'>You feel a creeping, horrible sense of dread come over you, freezing your limbs and setting your heart racing.</span>")

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -102,6 +102,7 @@
 			T.on_projectile_fire(D, user)
 		D.preparePixelProjectile(target, get_turf(target), user, clickparams)
 		D.firer = user
+		D.firer_source_atom = src
 		D.hammer_synced = src
 		playsound(user, 'sound/weapons/crusher_shot.ogg', 160, 1)
 		D.fire()

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -498,6 +498,7 @@
 	var/obj/item/projectile/A = new projectile(loc)
 	playsound(loc, shoot_sound, 50, 1)
 	A.current = U
+	A.firer = src
 	A.yo = U.y - T.y
 	A.xo = U.x - T.x
 	A.fire()

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -382,6 +382,7 @@
 
 				else								// not next to perp
 					var/turf/olddist = get_dist(src, target)
+					glide_for(BOT_STEP_DELAY)
 					walk_to(src, target,1,4)
 					if((get_dist(src, target)) >= (olddist))
 						frustration++

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -165,6 +165,7 @@
 						break
 			if(movement_target)
 				stop_automated_movement = 1
+				glide_for(3)
 				walk_to(src,movement_target,0,3)
 
 /mob/living/simple_animal/pet/cat/emote(act, m_type = 1, message = null, force)

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -799,6 +799,7 @@
 	A.icon_state = "eyelasers"
 	playsound(src.loc, 'sound/weapons/taser2.ogg', 75, 1)
 	A.current = T
+	A.firer = src
 	A.yo = U.y - T.y
 	A.xo = U.x - T.x
 	A.fire()

--- a/code/modules/mob/living/simple_animal/hostile/floorcluwne.dm
+++ b/code/modules/mob/living/simple_animal/hostile/floorcluwne.dm
@@ -123,6 +123,7 @@
 
 /mob/living/simple_animal/hostile/floor_cluwne/Goto(target, delay, minimum_distance)
 	if(!manifested && !is_type_in_typecache(get_area(current_victim.loc), invalid_area_typecache))
+		glide_for(delay)
 		walk_to(src, target, minimum_distance, delay)
 	else
 		walk_to(src,0)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -113,13 +113,14 @@
 	var/static/list/cardinal_sidestep_directions = list(-90, -45, 0, 45, 90)
 	var/static/list/diagonal_sidestep_directions = list(-45, 0, 45)
 	var/chosen_dir = 0
-	if (target_dir & (target_dir - 1))
+	if(target_dir & (target_dir - 1))
 		chosen_dir = pick(diagonal_sidestep_directions)
 	else
 		chosen_dir = pick(cardinal_sidestep_directions)
 	if(chosen_dir)
 		chosen_dir = turn(target_dir, chosen_dir)
-		Move(get_step(src, chosen_dir))
+		var/step_loc = get_step(src, chosen_dir)
+		Move(step_loc, chosen_dir, 3)
 		face_atom(target) //Looks better if they keep looking at you when dodging
 
 /mob/living/simple_animal/hostile/attacked_by(obj/item/I, mob/living/user)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -488,20 +488,27 @@
 
 
 /mob/living/simple_animal/hostile/Move(atom/newloc, direct, movetime)
-	if(!client && dodging && approaching_target && prob(dodge_prob) && !moving_diagonally && isturf(loc) && isturf(newloc))
-		return dodge(newloc, direct, movetime)
-	return ..()
+	. = dodge(direct, movetime)
+	if(!.)
+		. = ..()
 
 
-/mob/living/simple_animal/hostile/proc/dodge(moving_to, move_direction, movetime)
-	//Assuming we move towards the target we want to swerve toward them to get closer
+/mob/living/simple_animal/hostile/proc/dodge(direct, movetime)
+	. = FALSE
+	if(client)
+		return .
+	if(!dodging || !approaching_target || moving_diagonally)
+		return .
+	if(!isturf(loc))
+		return .
+	if(!prob(dodge_prob))
+		return .
+	var/turf/dodge_loc = get_step(loc, pick(turn(direct, 45), turn(direct, -45)))
+	if(!length(get_path_to(src, dodge_loc, max_distance = 1, simulated_only = FALSE, skip_first = FALSE)))
+		return .
 	dodging = FALSE
-	var/turf/new_loc = get_step(loc, pick(turn(move_direction, 45), turn(move_direction, -45)))
-	. = Move(new_loc, move_direction, movetime)
-	if(!.)	// Can't dodge there so we just carry on
-		. = Move(moving_to, move_direction, movetime)
+	. = Move(dodge_loc, direct, movetime)
 	dodging = TRUE
-	return FALSE
 
 
 /mob/living/simple_animal/hostile/proc/DestroyObjectsInDirection(direction)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -337,6 +337,7 @@
 			return 1
 		if(retreat_distance != null) //If we have a retreat distance, check if we need to run from our target
 			if(target_distance <= retreat_distance) //If target's closer than our retreat distance, run
+				glide_for(move_to_delay)
 				walk_away(src,target,retreat_distance,move_to_delay)
 			else
 				Goto(target,move_to_delay,minimum_distance) //Otherwise, get to our minimum distance so we chase them
@@ -370,6 +371,7 @@
 		approaching_target = TRUE
 	else
 		approaching_target = FALSE
+	glide_for(delay)
 	walk_to(src, target, minimum_distance, delay)
 
 /mob/living/simple_animal/hostile/adjustHealth(damage, updating_health = TRUE)
@@ -484,21 +486,23 @@
 /mob/living/simple_animal/hostile/proc/CanSmashTurfs(turf/T)
 	return iswallturf(T) || (ismineralturf(T) && !istype(T, /turf/simulated/mineral/ancient/outer))
 
-/mob/living/simple_animal/hostile/Move(atom/newloc, dir , step_x , step_y)
+
+/mob/living/simple_animal/hostile/Move(atom/newloc, direct, movetime)
 	if(!client && dodging && approaching_target && prob(dodge_prob) && !moving_diagonally && isturf(loc) && isturf(newloc))
-		return dodge(newloc, dir)
+		return dodge(newloc, direct, movetime)
+	return ..()
 
-	. = ..()
 
-/mob/living/simple_animal/hostile/proc/dodge(moving_to,move_direction)
+/mob/living/simple_animal/hostile/proc/dodge(moving_to, move_direction, movetime)
 	//Assuming we move towards the target we want to swerve toward them to get closer
-	var/cdir = turn(move_direction, 45)
-	var/ccdir = turn(move_direction, -45)
 	dodging = FALSE
-	. = Move(get_step(loc,pick(cdir,ccdir)))
-	if(!.)//Can't dodge there so we just carry on
-		. =  Move(moving_to,move_direction)
+	var/turf/new_loc = get_step(loc, pick(turn(move_direction, 45), turn(move_direction, -45)))
+	. = Move(new_loc, move_direction, movetime)
+	if(!.)	// Can't dodge there so we just carry on
+		. = Move(moving_to, move_direction, movetime)
 	dodging = TRUE
+	return FALSE
+
 
 /mob/living/simple_animal/hostile/proc/DestroyObjectsInDirection(direction)
 	var/turf/T = get_step(targets_from, direction)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
@@ -338,6 +338,7 @@ Difficulty: Very Hard
 					return
 				var/obj/item/projectile/energy/shock_revolver/ancient/O = new /obj/item/projectile/energy/shock_revolver/ancient(S)
 				O.current = S
+				O.firer = src
 				O.yo = T.y - S.y
 				O.xo = T.x - S.x
 				O.fire()
@@ -382,6 +383,7 @@ Difficulty: Very Hard
 		return
 	var/obj/item/projectile/bullet/rock/O = new /obj/item/projectile/bullet/rock(spot)
 	O.current = spot
+	O.firer = src
 	O.yo = T.y - spot.y
 	O.xo = T.x - spot.x
 	O.fire()

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/reproduction.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/reproduction.dm
@@ -151,6 +151,7 @@
 							new_area.Entered(src)
 		else
 			frustration++
+			glide_for(3)
 			walk_to(src, entry_vent, 1)
 			if(frustration > 2)
 				entry_vent = null
@@ -166,6 +167,7 @@
 		for(var/obj/machinery/atmospherics/unary/vent_pump/v in view(7,src))
 			if(!v.welded)
 				entry_vent = v
+				glide_for(3)
 				walk_to(src, entry_vent, 1)
 				break
 

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -456,6 +456,7 @@
 			parrot_state = PARROT_SWOOP|PARROT_RETURN
 			return
 
+		glide_for(parrot_speed)
 		walk_to(src, path_to_take[2], 0, parrot_speed)
 		return
 
@@ -481,6 +482,7 @@
 			parrot_state = PARROT_WANDER
 			return
 
+		glide_for(parrot_speed)
 		walk_to(src, path_to_take[2], 0, parrot_speed)
 		return
 
@@ -539,6 +541,7 @@
 		//Otherwise, fly towards the mob!
 		else
 			// No pathfinding here because the parrot is pissed and isn't thinking rationally.
+			glide_for(parrot_speed)
 			walk_to(src, parrot_interest, 1, parrot_speed)
 		return
 //-----STATE MISHAP

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -205,6 +205,7 @@
 		fire_delay = rand(minimum_fire_delay, maximum_fire_delay)
 		shot_number = 0
 	P.setDir(dir)
+	P.firer_source_atom = src
 	P.starting = loc
 	P.Angle = null
 	P.fire()

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -437,12 +437,11 @@
 /obj/item/ammo_casing/caseless
 	desc = "A caseless bullet casing."
 
-/obj/item/ammo_casing/caseless/fire(atom/target as mob|obj|turf, mob/living/user as mob|obj, params, distro, quiet, zone_override = "", spread)
+/obj/item/ammo_casing/caseless/fire(atom/target, mob/living/user, params, distro, quiet, zone_override = "", spread, atom/firer_source_atom)
 	if(..())
-		loc = null
+		qdel(src)
 		return TRUE
-	else
-		return FALSE
+	return FALSE
 
 /obj/item/ammo_casing/caseless/a75
 	desc = "A .75 bullet casing."

--- a/code/modules/projectiles/firing.dm
+++ b/code/modules/projectiles/firing.dm
@@ -1,8 +1,8 @@
-/obj/item/ammo_casing/proc/fire(atom/target as mob|obj|turf, mob/living/user as mob|obj, params, distro, quiet, zone_override = "", spread)
+/obj/item/ammo_casing/proc/fire(atom/target, mob/living/user, params, distro, quiet, zone_override = "", spread, atom/firer_source_atom)
 	distro += variance
 	for(var/i = max(1, pellets), i > 0, i--)
 		var/targloc = get_turf(target)
-		ready_proj(target, user, quiet, zone_override)
+		ready_proj(target, user, quiet, zone_override, firer_source_atom)
 		if(distro) //We have to spread a pixel-precision bullet. throw_proj was called before so angles should exist by now...
 			if(randomspread)
 				spread = round((rand() - 0.5) * distro)
@@ -18,13 +18,15 @@
 		user.changeNext_move(CLICK_CD_RANGE)
 	user.newtonian_move(get_dir(target, user))
 	update_icon()
-	return 1
+	return TRUE
 
-/obj/item/ammo_casing/proc/ready_proj(atom/target, mob/living/user, quiet, zone_override = "")
+
+/obj/item/ammo_casing/proc/ready_proj(atom/target, mob/living/user, quiet, zone_override = "", atom/firer_source_atom)
 	if(!BB)
 		return
 	BB.original = target
 	BB.firer = user
+	BB.firer_source_atom = firer_source_atom
 	if(zone_override)
 		BB.def_zone = zone_override
 	else
@@ -34,6 +36,7 @@
 	if(reagents && BB.reagents)
 		reagents.trans_to(BB, reagents.total_volume) //For chemical darts/bullets
 		qdel(reagents)
+
 
 /obj/item/ammo_casing/proc/throw_proj(atom/target, turf/targloc, mob/living/user, params, spread)
 	var/turf/curloc = get_turf(user)
@@ -59,14 +62,16 @@
 		BB.fire()
 	materials = list(MAT_METAL=0)
 	BB = null
-	return 1
+	return TRUE
+
 
 /obj/item/ammo_casing/proc/spread(turf/target, turf/current, distro)
 	var/dx = abs(target.x - current.x)
 	var/dy = abs(target.y - current.y)
 	return locate(target.x + round(gaussian(0, distro) * (dy+2)/8, 1), target.y + round(gaussian(0, distro) * (dx+2)/8, 1), target.z)
 
-/obj/item/projectile/proc/preparePixelProjectile(atom/target, var/turf/targloc, mob/living/user, params, spread)
+
+/obj/item/projectile/proc/preparePixelProjectile(atom/target, turf/targloc, mob/living/user, params, spread)
 	var/turf/curloc = get_turf(user)
 	loc = get_turf(user)
 	starting = get_turf(user)
@@ -101,3 +106,4 @@
 			Angle = angle
 	if(spread)
 		Angle += spread
+

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -251,7 +251,7 @@
 					sprd = round((rand() - 0.5) * (randomized_gun_spread + randomized_bonus_spread))
 				else
 					sprd = round((i / burst_size - 0.5) * (randomized_gun_spread + randomized_bonus_spread))
-				if(!chambered.fire(target, user, params, ,suppressed, zone_override, sprd))
+				if(!chambered.fire(target = target, user = user, params = params, distro = null, quiet = suppressed, zone_override = zone_override, spread = sprd, firer_source_atom = src))
 					shoot_with_empty_chamber(user)
 					break
 				else
@@ -273,7 +273,7 @@
 					to_chat(user, "<span class='warning'>[src] is lethally chambered! You don't want to risk harming anyone...</span>")
 					return
 			sprd = round((pick(1,-1)) * (randomized_gun_spread + randomized_bonus_spread))
-			if(!chambered.fire(target, user, params, , suppressed, zone_override, sprd))
+			if(!chambered.fire(target = target, user = user, params = params, distro = null, quiet = suppressed, zone_override = zone_override, spread = sprd, firer_source_atom = src))
 				shoot_with_empty_chamber(user)
 				return
 			else
@@ -296,7 +296,8 @@
 		else
 			user.update_inv_r_hand()
 	SSblackbox.record_feedback("tally", "gun_fired", 1, type)
-	if(rusted_weapon == TRUE)
+
+	if(rusted_weapon)
 		malf_counter -= burst_size
 		if(malf_counter <= 0 && prob(50))
 			new /obj/effect/decal/cleanable/ash(user.loc)
@@ -311,6 +312,7 @@
 			to_chat(user, "<span class='userdanger'>[src] blows up in your face!</span>")
 			user.take_organ_damage(0,10)
 			return FALSE
+
 
 /obj/item/gun/attack(mob/M, mob/user)
 	if(user.a_intent == INTENT_HARM) //Flogging

--- a/code/modules/projectiles/guns/misc/blastcannon.dm
+++ b/code/modules/projectiles/guns/misc/blastcannon.dm
@@ -80,6 +80,8 @@
 	add_attack_logs(user, target, "Blast waved with power [heavy]/[medium]/[light].", ATKLOG_MOST)
 	var/obj/item/projectile/blastwave/BW = new(loc, heavy, medium, light)
 	BW.preparePixelProjectile(target, get_turf(target), user, params, 0)
+	BW.firer = user
+	BW.firer_source_atom = src
 	BW.fire()
 
 /obj/item/projectile/blastwave

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -279,7 +279,7 @@
 
 		if(chambered)
 			var/obj/item/ammo_casing/AC = chambered
-			if(AC.fire(user, user))
+			if(AC.fire(user, user, firer_source_atom = src))
 				playsound(user, fire_sound, 50, 1)
 				var/zone = check_zone(user.zone_selected)
 				if(zone == "head" || zone == "eyes" || zone == "mouth")

--- a/code/modules/spacepods/equipment.dm
+++ b/code/modules/spacepods/equipment.dm
@@ -36,9 +36,11 @@
 		var/obj/item/projectile/projtwo = new projectile_type(secondloc)
 		projone.starting = get_turf(my_atom)
 		projone.firer = usr
+		projone.firer_source_atom = src
 		projone.def_zone = "chest"
 		projtwo.starting = get_turf(my_atom)
 		projtwo.firer = usr
+		projtwo.firer_source_atom = src
 		projtwo.def_zone = "chest"
 		spawn()
 			playsound(src, fire_sound, 50, 1)


### PR DESCRIPTION
## Описание
Убираем перемещение симпл мобов рывками, а также добавляем снаряду информацию о том из какого оружия или объекта он был выпущен.

Также вроде как исправил проблему с перемещением внутрь окон с решётками.