### PR TITLE
tweak: deleting cloning circuits from tech storage.

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -12998,26 +12998,22 @@
 /area/maintenance/bar)
 "bBL" = (
 /obj/structure/rack,
-/obj/item/circuitboard/cloning{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/circuitboard/clonescanner,
-/obj/item/circuitboard/clonepod{
-	pixel_x = 3;
-	pixel_y = -3
+/obj/item/circuitboard/clonescanner{
+	pixel_x = -4;
+	pixel_y = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/circuitboard/chem_dispenser{
-	pixel_x = 4;
-	pixel_y = 3
+	pixel_x = -1;
+	pixel_y = 1
 	},
 /obj/item/circuitboard/chem_heater{
-	pixel_y = 5
+	pixel_x = 2;
+	pixel_y = -2
 	},
 /obj/item/circuitboard/chem_master{
-	pixel_x = -4;
-	pixel_y = 8
+	pixel_x = 5;
+	pixel_y = -5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -74220,13 +74220,11 @@
 /area/maintenance/atmospherics)
 "qkQ" = (
 /obj/structure/rack,
-/obj/item/circuitboard/cloning,
 /obj/item/circuitboard/med_data{
 	pixel_x = 3;
 	pixel_y = -3
 	},
 /obj/item/circuitboard/clonescanner,
-/obj/item/circuitboard/clonepod,
 /obj/item/circuitboard/scan_consolenew,
 /obj/item/circuitboard/cryo_tube{
 	pixel_x = 3

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -52605,13 +52605,11 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/circuitboard/cloning,
 /obj/item/circuitboard/med_data{
 	pixel_x = 3;
 	pixel_y = -3
 	},
 /obj/item/circuitboard/clonescanner,
-/obj/item/circuitboard/clonepod,
 /obj/item/circuitboard/scan_consolenew,
 /obj/item/circuitboard/cryo_tube{
 	pixel_x = 3


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Убирает из хранилища плат те, которые связаны напрямую с клонированием. Понятия не имею, почему это не упомянул в ТЗ автор, но получится хрень, если мы выпиливаем клонилку, но платы к ней всё равно есть раундстартом. Дополнение к #3897. <!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Репорт
![image](https://github.com/ss220-space/Paradise/assets/115735095/60c64ae1-7881-42a1-9b5f-8d2df62500d4)
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
