### PR TITLE
bugfix: "MA without combo" don`t count combo-steps with regular combo-acts.

### DIFF
--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -62,18 +62,18 @@
 /datum/martial_art/proc/act(step, mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(!can_use(user))
 		return MARTIAL_ARTS_CANNOT_USE
-	if(combo_timer)
-		deltimer(combo_timer)
 /*
 	if(last_hit + COMBO_ALIVE_TIME < world.time)
 		reset_combos()
 	last_hit = world.time
 */
-	combo_timer = addtimer(CALLBACK(src, PROC_REF(reset_combos)), COMBO_ALIVE_TIME, TIMER_UNIQUE | TIMER_STOPPABLE)
-	streak += intent_to_streak(step)
-	var/mob/living/carbon/human/owner = locateUID(owner_UID)
-	owner?.hud_used.combo_display.update_icon(ALL, streak)
 	if(HAS_COMBOS)
+		if(combo_timer)
+			deltimer(combo_timer)
+		combo_timer = addtimer(CALLBACK(src, PROC_REF(reset_combos)), COMBO_ALIVE_TIME, TIMER_UNIQUE | TIMER_STOPPABLE)
+		streak += intent_to_streak(step)
+		var/mob/living/carbon/human/owner = locateUID(owner_UID)
+		owner?.hud_used.combo_display.update_icon(ALL, streak)
 		return check_combos(step, user, target)
 	return FALSE
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Переносит проки накладывания таймера и оверлея "счётчика комбо" под проверку наличия комбо в БИ, где раньше был только прок сравнивания комбо-акта с имеющимися комбо. Если по простому, то не изменённые акты БИ сразу считаются, как успешный комбо-шаг и добавляются оверлеем в "счётчик", но если у БИ нету комбо, то этот шаг не проверяется на "правильность" и в итоге остаётся в оверлее.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на баг-репорт
https://discord.com/channels/617003227182792704/1177183107883999316/1178069077609160755<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
