### PR TITLE
tweak: cargo tweaks

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -246,14 +246,6 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 
 ////// Armor: Basic
 
-/datum/supply_packs/security/helmets
-	name = "Helmets Crate"
-	contains = list(/obj/item/clothing/head/helmet,
-					/obj/item/clothing/head/helmet,
-					/obj/item/clothing/head/helmet)
-	cost = 10
-	containername = "helmet crate"
-
 /datum/supply_packs/security/justiceinbound
 	name = "Standard Justice Enforcer Crate"
 	contains = list(/obj/item/clothing/head/helmet/justice,
@@ -264,10 +256,13 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 	containername = "justice enforcer crate"
 
 /datum/supply_packs/security/armor
-	name = "Armor Crate"
+	name = "Standard Armor Crate"
 	contains = list(/obj/item/clothing/suit/armor/vest,
 					/obj/item/clothing/suit/armor/vest,
-					/obj/item/clothing/suit/armor/vest)
+					/obj/item/clothing/suit/armor/vest,
+					/obj/item/clothing/head/helmet,
+					/obj/item/clothing/head/helmet,
+					/obj/item/clothing/head/helmet)
 	cost = 10
 	containername = "armor crate"
 
@@ -487,6 +482,7 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 /datum/supply_packs/security/armory/expenergy
 	name = "Energy Guns Crate"
 	contains = list(/obj/item/gun/energy/gun,
+					/obj/item/gun/energy/gun,
 					/obj/item/gun/energy/gun)
 	cost = 25
 	containertype = /obj/structure/closet/crate/secure/plasma
@@ -532,8 +528,9 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 /datum/supply_packs/security/armory/lr30
 	name = "LR-30 Crate"
 	contains = list(/obj/item/gun/projectile/automatic/lr30,
+					/obj/item/gun/projectile/automatic/lr30,
 					/obj/item/gun/projectile/automatic/lr30)
-	cost = 15
+	cost = 25
 	containername = "laser rifle crate"
 
 /datum/supply_packs/security/armory/lr30ammo
@@ -541,13 +538,21 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 	contains = list(/obj/item/ammo_box/magazine/lr30mag,
 					/obj/item/ammo_box/magazine/lr30mag,
 					/obj/item/ammo_box/magazine/lr30mag,
+					/obj/item/ammo_box/magazine/lr30mag,
+					/obj/item/ammo_box/magazine/lr30mag,
+					/obj/item/ammo_box/magazine/lr30mag,
+					/obj/item/ammo_box/magazine/lr30mag,
 					/obj/item/ammo_box/magazine/lr30mag)
-	cost = 20
+	cost = 30
 	containername = "laser rifle ammo crate"
 
 /datum/supply_packs/security/armory/wt550ammo
 	name = "WT-550 Rifle Ammo Crate"
 	contains = list(/obj/item/ammo_box/magazine/wt550m9,
+					/obj/item/ammo_box/magazine/wt550m9,
+					/obj/item/ammo_box/magazine/wt550m9,
+					/obj/item/ammo_box/magazine/wt550m9,
+					/obj/item/ammo_box/magazine/wt550m9,
 					/obj/item/ammo_box/magazine/wt550m9,
 					/obj/item/ammo_box/magazine/wt550m9,
 					/obj/item/ammo_box/magazine/wt550m9)
@@ -557,6 +562,10 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 /datum/supply_packs/security/armory/wt550apammo
 	name = "WT-550 Rifle Armor-Piercing Ammo Crate"
 	contains = list(/obj/item/ammo_box/magazine/wt550m9/wtap,
+					/obj/item/ammo_box/magazine/wt550m9/wtap,
+					/obj/item/ammo_box/magazine/wt550m9/wtap,
+					/obj/item/ammo_box/magazine/wt550m9/wtap,
+					/obj/item/ammo_box/magazine/wt550m9/wtap,
 					/obj/item/ammo_box/magazine/wt550m9/wtap,
 					/obj/item/ammo_box/magazine/wt550m9/wtap,
 					/obj/item/ammo_box/magazine/wt550m9/wtap)

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -263,7 +263,7 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 					/obj/item/clothing/head/helmet,
 					/obj/item/clothing/head/helmet,
 					/obj/item/clothing/head/helmet)
-	cost = 10
+	cost = 20
 	containername = "armor crate"
 
 ////// Weapons: Basic


### PR DESCRIPTION

## Описание
Стандартизирует энергетическое оружие до трех штук в ящике. Стандартизирует магазины на вт и лр по 8 штук в каждом. Убирает ящик со стандартными сб шлемами и закидывает их в набор к броне, повышая цену до 20. Стандартизирует цены на лр и вт до одного значения. Карго реворка жду пиздец
## Ссылка на предложение/Причина создания ПР
[Maan i want more butterbeer](https://discord.com/channels/617003227182792704/755125334097133628/1178473993024581652)
