### PR TITLE
bugfix: lighter hitting obj sound

### DIFF
--- a/code/game/objects/items/weapons/lighters.dm
+++ b/code/game/objects/items/weapons/lighters.dm
@@ -56,6 +56,7 @@
 	lit = FALSE
 	w_class = WEIGHT_CLASS_TINY
 	icon_state = icon_off
+	damtype = BRUTE
 	hitsound = "swing_hit"
 	force = 0
 	attack_verb = null //human_defense.dm takes care of it


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Исправлено: при ударе объекта не горящей зажигалкой воспроизводится звук ожога.
Шаги воспроизведения: зажечь зажигалку, потушить зажигалку, ударить зажигалкой любой объект (не моба).
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
bugfix
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

