### PR TITLE
bugfix: Temperature gun's projectile blocking & reflecting

### DIFF
--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -50,6 +50,7 @@
 	damage = 0
 	damage_type = BURN
 	nodamage = 1
+	reflectability = REFLECTABILITY_ENERGY
 	flag = "energy"
 	var/temperature = 300
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
@@ -93,7 +94,9 @@
 
 
 /obj/item/projectile/temp/on_hit(var/atom/target, var/blocked = 0)//These two could likely check temp protection on the mob
-	..()
+	if(!..())
+		return FALSE
+
 	if(isliving(target))
 		var/mob/living/M = target
 		M.bodytemperature = temperature


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Проджектайлы температурной пушки, по факту являясь энергетическими, имели тип отражения как у булетов. К тому же накладывали свой эффект несмотря ни на щитовой риг, ни на шанс блока предметов в руках. Карп со щитом ловил снаряды пушки блоком и замедлялся. Теперь будет работать как любой энерджи проджектайл, отражаясь и блокируясь и тратя заряд щитового рига нормально.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
