### PR TITLE
bugfix: chameleon hardsuit now toggles light properly

### DIFF
--- a/code/modules/antagonists/traitor/contractor/items/contractor_hardsuit.dm
+++ b/code/modules/antagonists/traitor/contractor/items/contractor_hardsuit.dm
@@ -60,6 +60,7 @@
 	description_antag = "Шлем хардсьюта-хамелеона, замаскированный изначально под инженерный шлем."
 	icon_state = "hardsuit0-engineering"
 	item_state = "eng_helm"
+	item_color = "engineering"
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
 
 /obj/item/clothing/suit/space/hardsuit/contractor/agent


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Суть бага: при покупке хамелеон рига за 10ТК и включении фонарика вместо того, чтобы включался фонарь инженерного хардсъюта, спрайт шлема меняется на спрайт шлема контрактора, что выглядит очень смешно и криво. Сиротка так и не исправил этот баг, ибо забросил разработку. Меня этот баг уже окончательно достал, поэтому фикс за него.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багфикс
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
