### PR TITLE
tweak: Muzzle Emotes Runechatted

### DIFF
--- a/code/datums/emote/emote.dm
+++ b/code/datums/emote/emote.dm
@@ -187,12 +187,9 @@
 
 	msg = genderize_decode(user, msg)
 
-	var/suppressed = FALSE
-
 	// Keep em quiet if they can't speak
-	if(!can_vocalize_emotes(user) && ((emote_type & (EMOTE_MOUTH|EMOTE_AUDIBLE)) || (emote_type & (EMOTE_MOUTH|EMOTE_SOUND))))
+	if(!can_vocalize_emotes(user) && ((emote_type & EMOTE_MOUTH) && (emote_type & (EMOTE_AUDIBLE|EMOTE_SOUND))))
 		var/noise_emitted = pick(muzzled_noises)
-		suppressed = TRUE
 		msg = "изда[pluralize_ru(user.gender, "ёт", "ют")] [noise_emitted] звуки."
 
 	var/tmp_sound = get_sound(user)
@@ -228,7 +225,7 @@
 		else
 			user.visible_message(displayed_msg, blind_message = span_italics("You hear how someone [msg]"))
 
-		if(!((emote_type & (EMOTE_FORCE_NO_RUNECHAT|EMOTE_SOUND)) || suppressed) && !isobserver(user))
+		if(!(emote_type & (EMOTE_FORCE_NO_RUNECHAT|EMOTE_SOUND)) && !isobserver(user))
 			runechat_emote(user, msg)
 
 	SEND_SIGNAL(user, COMSIG_MOB_EMOTED(key), src, key, emote_type, message, intentional)

--- a/code/datums/emote/emote_verbs.dm
+++ b/code/datums/emote/emote_verbs.dm
@@ -69,10 +69,12 @@
 	set category = "Эмоции"
 	emote("sniff", intentional = TRUE)
 
-/mob/living/carbon/human/verb/emote_snore()
+/*
+/mob/living/carbon/human/verb/emote_snore()	// locked to unconscious stat
 	set name = "▷ Храпеть "
 	set category = "Эмоции"
 	emote("snore", intentional = TRUE)
+*/
 
 /mob/living/carbon/human/verb/emote_whistle()
 	set name = "▷ Свистеть "

--- a/code/modules/mob/living/carbon/human/human_emote.dm
+++ b/code/modules/mob/living/carbon/human/human_emote.dm
@@ -360,7 +360,7 @@
 	key = "johnny"
 	message = "затягива%(ет,ют)%ся сигаретой и выдыха%(ет,ют)% дым в форме %(своего,их)% имени."
 	message_param = "dummy"  // Gets handled in select_param
-	emote_type = EMOTE_AUDIBLE
+	emote_type = EMOTE_AUDIBLE|EMOTE_MOUTH
 	target_behavior = EMOTE_TARGET_BHVR_DEFAULT_TO_BASE
 	emote_target_type = EMOTE_TARGET_MOB
 	cooldown = 8 SECONDS
@@ -1249,7 +1249,7 @@
 /**
  * Tajaran
  */
-/datum/emote/living/carbon/human/tajaran/hiss
+/datum/emote/living/carbon/human/tajaran
 	species_type_whitelist_typecache = list(/datum/species/tajaran)
 
 


### PR DESCRIPTION
## Описание
Эмоции которые заблокированы намордником или немотой, теперь будут отображаться в рунчате.
