### PR TITLE
fix: no more /list when you attack carp

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -13,7 +13,6 @@
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/carpmeat = 2)
 	response_help = "pets"
 	response_disarm = "gently pushes aside"
-	response_harm = list("hits", "gnawing", "bites")
 	emote_taunt = list("gnashes")
 	taunt_chance = 30
 	speed = 0


### PR DESCRIPTION
## Описание

Убирает переменную response_harm у карпов, убирая мерзотный пикрил. Все. Сделано при помощи Дена.
![image](https://github.com/ss220-space/Paradise/assets/103588397/087eff2e-f81f-4080-849d-1967204f6be7)
