### PR TITLE
bugfix: throwing knives neck cut don't make two strikes

### DIFF
--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -197,6 +197,7 @@
 		force = initial(force) + MA.knife_bonus_damage
 		if(user.zone_selected == BODY_ZONE_HEAD && user.a_intent == INTENT_HARM)
 			MA.neck_cut(target, user)
+			return
 	. = ..()
 
 /obj/item/kitchen/knife/combat/afterattack(atom/target, mob/user, proximity, params)

--- a/code/modules/martial_arts/throwing_knives.dm
+++ b/code/modules/martial_arts/throwing_knives.dm
@@ -30,7 +30,7 @@
 		attacker.visible_message(span_danger("[attacker] прикладывает нож к горлу [defender]!"), span_danger("Вы прикладываете нож к горлу [defender]!."))
 		if(do_after(attacker, 20, target = defender))
 			if(defender.blood_volume > BLOOD_VOLUME_SURVIVE)
-				defender.blood_volume -= BLOOD_VOLUME_NORMAL - BLOOD_VOLUME_SURVIVE
+				defender.blood_volume = max(0, defender.blood_volume - (BLOOD_VOLUME_NORMAL - BLOOD_VOLUME_SURVIVE)) //-70% of max blood volume
 				for(var/i in 1 to 2)
 					var/obj/effect/decal/cleanable/blood/B = new(defender.loc)
 					step(B, pick(GLOB.alldirs))


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Перерезание горла с искусством метательных ножей не делает второй обычный удар. Так же убирает возможный баг с отрицательными значениями уровня крови.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

