### PR TITLE
bugfix: strange reagent reviving.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -806,7 +806,7 @@
 				if(!M.ghost_can_reenter())
 					M.visible_message("<span class='warning'>[M] twitches slightly, but is otherwise unresponsive!</span>")
 					return
-				if(!M.suiciding && !(NOCLONE in M.mutations) && (!M.mind || M.mind && M.mind.is_revivable()))
+				if(!M.suiciding && !(NOCLONE in M.mutations) && (!M.mind || M.mind?.is_revivable()))
 					var/time_dead = world.time - M.timeofdeath
 					M.visible_message("<span class='warning'>[M] seems to rise from the dead!</span>")
 					M.adjustCloneLoss(50)
@@ -828,8 +828,8 @@
 									O.germ_level = INFECTION_LEVEL_THREE
 						H.update_body()
 
+					M.update_revive(TRUE, TRUE)
 					M.grab_ghost()
-					M.update_revive()
 					add_attack_logs(M, M, "Revived with strange reagent") //Yes, the logs say you revived yourself.
 	..()
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Дал странному реагенту параметр форсирования в прок реанимирования. И ещё подвинул прок закидывания госта в труп ниже прока реанимирования.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Скрины баг-репорта (да, это они)
![изображение](https://github.com/ss220-space/Paradise/assets/115735095/b22d6dfb-47de-41b9-b3c1-909bbe877096)
![изображение](https://github.com/ss220-space/Paradise/assets/115735095/84af6c50-c772-4d20-9e19-f6a8a6608701)
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Всё же нужно обьяснение ... да
Там меняли дефибы куда-то чё-та и реанимация стала требовать полноценное тело без урона, а не только БРУТ+БЁРН+КЛОН, так что реанимацию у дефиба сделали форсированной, если тело подходит под личные дефибские параметры. У странного были такие же параметры, но не было форсированной реанимации, из-за чего наличие в теле слишком большого количества токсинов в купе с другим уроном провоцировало отсутствие воскрешения, при присутствии всего остального (гниения органов, клон урона, логов "ОН ВОСКРЕС").
