### PR TITLE
qol: deal_overall_damage now can be configured to damage robotic limbs, Pentetic Acid no longer damages robotic limbs

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -278,9 +278,11 @@
 	return parts
 
 //Returns a list of damageable organs
-/mob/living/carbon/human/proc/get_damageable_organs()
+/mob/living/carbon/human/proc/get_damageable_organs(affect_robotic = TRUE)
 	var/list/obj/item/organ/external/parts = list()
 	for(var/obj/item/organ/external/O in bodyparts)
+		if(!affect_robotic && O.is_robotic())
+			continue
 		if(O.brute_dam + O.burn_dam < O.max_damage)
 			parts += O
 	return parts
@@ -334,10 +336,10 @@
 		UpdateDamageIcon()
 
 // damage MANY external organs, in random order
-/mob/living/carbon/human/take_overall_damage(brute, burn, updating_health = TRUE, used_weapon = null, sharp = 0, edge = 0)
+/mob/living/carbon/human/take_overall_damage(brute, burn, updating_health = TRUE, used_weapon = null, sharp = 0, edge = 0, affect_robotic = 1)
 	if(status_flags & GODMODE)
 		return ..()	//godmode
-	var/list/obj/item/organ/external/parts = get_damageable_organs()
+	var/list/obj/item/organ/external/parts = get_damageable_organs(affect_robotic)
 
 	var/update = 0
 	while(parts.len && (brute>0 || burn>0) )

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -470,8 +470,8 @@
 			var/mob/living/carbon/human/human = M
 			human.take_overall_damage(0.5, 0.5, FALSE, affect_robotic = FALSE)
 		else
-			M.adjustBruteLoss(0.5)
-			M.adjustFireLoss(0.5)
+			update_flags |= M.adjustBruteLoss(0.5, FALSE)
+			update_flags |= M.adjustFireLoss(0.5, FALSE)
 
 	return ..() | update_flags
 

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -457,7 +457,7 @@
 	harmless = FALSE
 	taste_description = "a purge"
 
-/datum/reagent/medicine/pen_acid/on_mob_life(mob/living/carbon/human/M)
+/datum/reagent/medicine/pen_acid/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	for(var/datum/reagent/R in M.reagents.reagent_list)
 		if(R != src)
@@ -466,7 +466,13 @@
 	if(prob(75))
 		update_flags |= M.adjustToxLoss(-2, FALSE)
 	if(prob(33))
-		M.take_overall_damage(0.5, 0.5, FALSE, affect_robotic = FALSE)
+		if(ishuman(M))
+			var/mob/living/carbon/human/human = M
+			human.take_overall_damage(0.5, 0.5, FALSE, affect_robotic = FALSE)
+		else
+			M.adjustBruteLoss(0.5)
+			M.adjustFireLoss(0.5)
+
 	return ..() | update_flags
 
 /datum/reagent/medicine/sal_acid

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -457,7 +457,7 @@
 	harmless = FALSE
 	taste_description = "a purge"
 
-/datum/reagent/medicine/pen_acid/on_mob_life(mob/living/M)
+/datum/reagent/medicine/pen_acid/on_mob_life(mob/living/carbon/human/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	for(var/datum/reagent/R in M.reagents.reagent_list)
 		if(R != src)
@@ -466,8 +466,7 @@
 	if(prob(75))
 		update_flags |= M.adjustToxLoss(-2, FALSE)
 	if(prob(33))
-		update_flags |= M.adjustBruteLoss(0.5, FALSE)
-		update_flags |= M.adjustFireLoss(0.5, FALSE)
+		M.take_overall_damage(0.5, 0.5, FALSE, affect_robotic = FALSE)
 	return ..() | update_flags
 
 /datum/reagent/medicine/sal_acid


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
В deal_overall_damage теперь можно выбрать, наносить ли урон по роботическим органам и конечностям.
QoL, запрещающий пентетиковой кислоте наносить урон по робоконечностям.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Довольно странно, что метаболизм данного препарата наносит урон по робоконечностям, который нельзя скомпенсировать метаболизмом какого-нибудь другого препарата
