### PR TITLE
bugfix: correct loot dropping from "watchers" and fixed gems duping.

### DIFF
--- a/code/modules/mining/lavaland/loot/colossus_loot.dm
+++ b/code/modules/mining/lavaland/loot/colossus_loot.dm
@@ -308,7 +308,7 @@
 	activation_sound = 'sound/magic/timeparadox2.ogg'
 	var/list/banned_items_typecache = list(/obj/item/storage, /obj/item/implant, /obj/item/implanter, /obj/item/disk/nuclear,
 										   /obj/item/projectile, /obj/item/spellbook, /obj/item/clothing/mask/facehugger, /obj/item/contractor_uplink,
-										   /obj/item/dice/d20/fate, /obj/item/gem) //////suda ebat
+										   /obj/item/dice/d20/fate, /obj/item/gem)
 
 /obj/machinery/anomalous_crystal/refresher/New()
 	..()

--- a/code/modules/mining/lavaland/loot/colossus_loot.dm
+++ b/code/modules/mining/lavaland/loot/colossus_loot.dm
@@ -308,7 +308,7 @@
 	activation_sound = 'sound/magic/timeparadox2.ogg'
 	var/list/banned_items_typecache = list(/obj/item/storage, /obj/item/implant, /obj/item/implanter, /obj/item/disk/nuclear,
 										   /obj/item/projectile, /obj/item/spellbook, /obj/item/clothing/mask/facehugger, /obj/item/contractor_uplink,
-										   /obj/item/dice/d20/fate)
+										   /obj/item/dice/d20/fate, /obj/item/gem) //////suda ebat
 
 /obj/machinery/anomalous_crystal/refresher/New()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/mining/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/basilisk.dm
@@ -82,15 +82,20 @@
 	crusher_loot = /obj/item/crusher_trophy/watcher_wing
 	loot = list()
 	butcher_results = list(/obj/item/stack/ore/diamond = 2, /obj/item/stack/sheet/sinew = 2, /obj/item/stack/sheet/bone = 1)
+	var/jewelry_loot = null
 
-/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/random/Initialize(mapload)
+/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/Initialize(mapload)
 	. = ..()
-	if(prob(40)) //60 for classic, 20/20 for magma and ice
-		if(prob(50))
-			new /mob/living/simple_animal/hostile/asteroid/basilisk/watcher/magmawing(loc)
-		else
-			new /mob/living/simple_animal/hostile/asteroid/basilisk/watcher/icewing(loc)
-		return INITIALIZE_HINT_QDEL
+	if(prob(70) && jewelry_loot)
+		jewelry_loot = null
+
+/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/death(gibbed)
+	if(!fromtendril && && jewelry_loot)
+		var/obj/gem = new jewelry_loot(loc)
+		deathmessage = "spits out a [gem.name] as it dies!"
+		jewelry_loot = null
+	. = ..()
+	deathmessage = initial(deathmessage)
 
 /mob/living/simple_animal/hostile/asteroid/basilisk/watcher/magmawing
 	name = "magmawing watcher"
@@ -105,6 +110,7 @@
 	light_power = 2.5
 	light_color = LIGHT_COLOR_LAVA
 	projectiletype = /obj/item/projectile/temp/basilisk/magmawing
+	jewelry_loot = /obj/item/gem/magma
 	crusher_loot = /obj/item/crusher_trophy/blaster_tubes/magma_wing
 	crusher_drop_mod = 60
 
@@ -119,8 +125,18 @@
 	health = 170
 	projectiletype = /obj/item/projectile/temp/basilisk/icewing
 	butcher_results = list(/obj/item/stack/ore/diamond = 5, /obj/item/stack/sheet/bone = 1) //No sinew; the wings are too fragile to be usable
+	jewelry_loot = /obj/item/gem/fdiamond
 	crusher_loot = /obj/item/crusher_trophy/watcher_wing/ice_wing
 	crusher_drop_mod = 60
+
+/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/random/Initialize(mapload)
+	. = ..()
+	if(prob(40)) //60 for classic, 20/20 for magma and ice
+		if(prob(50))
+			new /mob/living/simple_animal/hostile/asteroid/basilisk/watcher/magmawing(loc)
+		else
+			new /mob/living/simple_animal/hostile/asteroid/basilisk/watcher/icewing(loc)
+		return INITIALIZE_HINT_QDEL
 
 /obj/item/projectile/watcher
 	name = "stunning blast"
@@ -181,17 +197,3 @@
 
 /mob/living/simple_animal/hostile/asteroid/basilisk/watcher/magmawing/tendril
 	fromtendril = TRUE
-
-/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/icewing/death(gibbed)
-	if(prob(30) && !fromtendril)
-		new /obj/item/gem/fdiamond(loc)
-		deathmessage = "spits out a diamond as it dies!"
-	. = ..()
-	deathmessage = initial(deathmessage)
-
-/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/magmawing/death(gibbed)
-	if(prob(30) && !fromtendril)
-		new /obj/item/gem/magma(loc)
-		deathmessage = "spits out a golden gem as it dies!"
-	. = ..()
-	deathmessage = initial(deathmessage)

--- a/code/modules/mob/living/simple_animal/hostile/mining/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/basilisk.dm
@@ -90,7 +90,7 @@
 		jewelry_loot = null
 
 /mob/living/simple_animal/hostile/asteroid/basilisk/watcher/death(gibbed)
-	if(!fromtendril && && jewelry_loot)
+	if(!fromtendril && jewelry_loot)
 		var/obj/gem = new jewelry_loot(loc)
 		deathmessage = "spits out a [gem.name] as it dies!"
 		jewelry_loot = null

--- a/code/modules/mob/living/simple_animal/hostile/mining/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/basilisk.dm
@@ -84,15 +84,11 @@
 	butcher_results = list(/obj/item/stack/ore/diamond = 2, /obj/item/stack/sheet/sinew = 2, /obj/item/stack/sheet/bone = 1)
 	var/jewelry_loot = null
 
-/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/Initialize(mapload)
-	. = ..()
-	if(prob(70) && jewelry_loot)
-		jewelry_loot = null
-
 /mob/living/simple_animal/hostile/asteroid/basilisk/watcher/death(gibbed)
 	if(!fromtendril && jewelry_loot)
-		var/obj/gem = new jewelry_loot(loc)
-		deathmessage = "spits out a [gem.name] as it dies!"
+		if(prob(30))
+			var/obj/gem = new jewelry_loot(loc)
+			deathmessage = "spits out a [gem.name] as it dies!"
 		jewelry_loot = null
 	. = ..()
 	deathmessage = initial(deathmessage)
@@ -137,6 +133,15 @@
 		else
 			new /mob/living/simple_animal/hostile/asteroid/basilisk/watcher/icewing(loc)
 		return INITIALIZE_HINT_QDEL
+
+/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/tendril
+	fromtendril = TRUE
+
+/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/icewing/tendril
+	fromtendril = TRUE
+
+/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/magmawing/tendril
+	fromtendril = TRUE
 
 /obj/item/projectile/watcher
 	name = "stunning blast"
@@ -188,12 +193,3 @@
 		var/mob/living/L = target
 		if(istype(L))
 			L.apply_status_effect(/datum/status_effect/freon/watcher)
-
-/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/tendril
-	fromtendril = TRUE
-
-/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/icewing/tendril
-	fromtendril = TRUE
-
-/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/magmawing/tendril
-	fromtendril = TRUE


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет самоцветы в чёрный список аномального обновляющего кристалла. Фауна-смотритель теперь дропает гем лишь при первой смерти, всё ещё со старым шансом. Небольшая сортировка кода для удобства.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на баг-репорт
https://discord.com/channels/617003227182792704/1180765411378212864/1180765411378212864<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
