### PR TITLE
qol: Breaking windoors now gives airlock electronics

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -206,10 +206,22 @@
 
 /obj/machinery/door/window/deconstruct(disassembled = TRUE)
 	if(!(flags & NODECONSTRUCT) && !disassembled)
+		var/obj/item/airlock_electronics/ae
 		for(var/obj/fragment in debris)
 			fragment.forceMove(get_turf(src))
 			transfer_fingerprints_to(fragment)
 			debris -= fragment
+		if(!electronics)
+			ae = new/obj/item/airlock_electronics(loc)
+			if(!req_access)
+				check_access()
+			ae.selected_accesses = req_access
+			ae.one_access = check_one_access
+		else
+			ae = electronics
+			electronics = null
+			ae.forceMove(loc)
+
 	qdel(src)
 
 /obj/machinery/door/window/narsie_act()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Разрушение windoor'ов теперь возвращает плату аирлока, аналогично разрушению обычных шлюзов (airlock)
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Устранение неудобства по ремонту оконных дверей в виде необходимости бегать до автолата за платой шлюзов/в инженерку, выставления нужных доступов, что вливается в беготню по всей станции ради починки одной двери. 
## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
![изображение](https://github.com/ss220-space/Paradise/assets/73733747/174fde8e-b11a-45ea-a270-6efead15c6f9)