### PR TITLE
qol: You can now request maintenance drones from Drone Fabricator Console

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_console.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_console.dm
@@ -10,6 +10,8 @@
 	var/drone_call_area = "Engineering"
 	//Used to enable or disable drone fabrication.
 	var/obj/machinery/drone_fabricator/dronefab
+	var/request_cooldown = 30 SECONDS
+	var/last_drone_request_time = 0
 
 /obj/machinery/computer/drone_control/attack_ai(var/mob/user as mob)
 	return src.attack_hand(user)
@@ -52,8 +54,11 @@
 	return
 
 /obj/machinery/computer/drone_control/proc/request_help()
+	if((last_drone_request_time + request_cooldown) > world.time)
+		return
 	notify_ghosts(message = "A Maintenance Drone is requested to repair and serve.", ghost_sound = null,
 		title="Drone Fabricator", source = dronefab, action = NOTIFY_ATTACK)
+	last_drone_request_time = world.time
 
 /obj/machinery/computer/drone_control/Topic(href, href_list)
 	if(..())
@@ -82,6 +87,9 @@
 		if(!dronefab || !dronefab.produce_drones)
 			to_chat(usr, span_warning("You can't request a drone if there is no functional fabricator"))
 		else
+			if((last_drone_request_time + request_cooldown) > world.time)
+				to_chat(usr, span_notice("You can't send a producing request too often."))
+				return
 			to_chat(usr, span_notice("You have sent a producing request to fabricator."))
 			request_help()
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_console.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_console.dm
@@ -41,6 +41,8 @@
 		dat += "<BR>Currently located in: [get_area(D)]."
 		dat += "<BR><A href='?src=[UID()];resync=\ref[D]'>Resync</A> | <A href='?src=[UID()];shutdown=\ref[D]'>Shutdown</A></font>"
 
+	dat += "<BR><B><A href='?src=[UID()];request_help=1'>Request a new drone</A></B>"
+
 	dat += "<BR><BR><B>Request drone presence in area:</B> <A href='?src=[UID()];setarea=1'>[drone_call_area]</A> (<A href='?src=[UID()];ping=1'>Send ping</A>)"
 
 	dat += "<BR><BR><B>Drone fabricator</B>: "
@@ -49,6 +51,9 @@
 	onclose(user, "computer")
 	return
 
+/obj/machinery/computer/drone_control/proc/request_help()
+	notify_ghosts(message = "A Maintenance Drone is requested to repair and serve.", ghost_sound = null,
+		title="Drone Fabricator", source = dronefab, action = NOTIFY_ATTACK)
 
 /obj/machinery/computer/drone_control/Topic(href, href_list)
 	if(..())
@@ -72,6 +77,13 @@
 
 		drone_call_area = t_area
 		to_chat(usr, "<span class='notice'>You set the area selector to [drone_call_area].</span>")
+
+	else if(href_list["request_help"])
+		if(!dronefab || !dronefab.produce_drones)
+			to_chat(usr, span_warning("You can't request a drone if there is no functional fabricator"))
+		else
+			to_chat(usr, span_notice("You have sent a producing request to fabricator."))
+			request_help()
 
 	else if(href_list["ping"])
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -77,15 +77,18 @@
 
 	drone_progress = 0
 
-
+/obj/machinery/drone_fabricator/attack_ghost(mob/dead/observer/user)
+	user.become_drone()
 
 /mob/dead/verb/join_as_drone()
 	set category = "Ghost"
 	set name = "Join As Drone"
 	set desc = "If there is a powered, enabled fabricator in the game world with a prepared chassis, join as a maintenance drone."
+	become_drone(src)
 
+/mob/dead/proc/become_drone(mob/user)
 	if(!(CONFIG_GET(flag/allow_drone_spawn)))
-		to_chat(src, "<span class='warning'>That verb is not currently permitted.</span>")
+		to_chat(src, "<span class='warning'>That action is not currently permitted.</span>")
 		return
 
 	if(!src.stat)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Обновление, позволяющее запросить у фабрикатора дрона обслуживания в консоли дронов.
Призраки получают беззвучное уведомление о том, что станции требуется дрон обслуживания. Нажатие на окошко уведомления открывает всплывающее окно с вопросом о становлении дроном, как если бы призрак прожал Join as Drone в Ghost-панели.

Также нажатие ЛКМ гостом по фабрикатору высвечивает окно согласия на спавн дроном.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Попытка сделать гострольку чуточку интереснее, давая возможность знать призракам о том, что станции требуется дрон обслуживания через IC инструмент.
