### PR TITLE
bugfix: fixed anomalies spawn on wrong spots, get_area_turfs fix

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -640,7 +640,7 @@ Returns 1 if the chain up to the area contains the given typepath
 
 	var/list/turfs = new/list()
 	for(var/area/N in world)
-		if(area.type == areatype)
+		if(N.type == areatype)
 			for(var/turf/T in N) turfs += T
 	return turfs
 

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -640,7 +640,7 @@ Returns 1 if the chain up to the area contains the given typepath
 
 	var/list/turfs = new/list()
 	for(var/area/N in world)
-		if(istype(N, areatype))
+		if(area.type == areatype)
 			for(var/turf/T in N) turfs += T
 	return turfs
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление ошибки, при которой анонс места аномалии мог не совпадать с её реальной зоной.
Также исправляет ошибки, которые могут возникать у других вещей, которые используют прок get_area_turfs

Техническое описание:
Ошибка заключалась в том, что get_area_turfs возвращал также турфы из дочерних зон areatype, что приводило к некорректной выборке турфов.
Поменял на то, что турфы выбираются теперь СТРОГО из зоны типа, указанного в параметре прока.

