### PR TITLE
bugfix: Fixed roundstart student scientist loss in lobby menu

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -492,7 +492,7 @@ SUBSYSTEM_DEF(jobs)
 		if(!S)
 			S = locate("start*[rank]") // use old stype
 		if(!S) // still no spawn, fall back to the arrivals shuttle
-			for(var/turf/TS in get_area_turfs(/area/shuttle/arrival))
+			for(var/turf/TS in get_area_turfs(/area/shuttle/arrival/station))
 				if(!TS.density)
 					var/clear = 1
 					for(var/obj/O in TS)

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -363,7 +363,7 @@
 	icon_state = "Sci"
 
 /obj/effect/landmark/start/student_sientist
-	name = "Student Sientist"
+	name = "Student Scientist"
 	icon_state = "Student_Sci"
 
 /obj/effect/landmark/start/roboticist


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление спавна студентов учёных, а также уточнение зоны появления на шаттле если лендмарок таки не удалось найти.
(Уточнение зоны появления на шаттле связано с https://github.com/ss220-space/Paradise/pull/4011, который запретил сканировать дочерние зоны при подборе турфов указанной зоны)

