### PR TITLE
add: Original cola

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drink_cold.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_cold.dm
@@ -177,3 +177,27 @@
 /datum/reagent/consumable/drink/cold/rewriter/on_mob_life(mob/living/M)
 	M.Jitter(5)
 	return ..()
+
+/datum/reagent/consumable/drink/cold/cocacola
+	name = "Original Cola"
+	id = "cocacola"
+	description = "Cola, original cola never changes."
+	color = "#100800" // rgb: 16, 8, 0
+	adj_sleepy = -4 SECONDS
+	drink_icon = "cocacola_bottle"
+	drink_name = "Coca Cola"
+	drink_desc = "Original Cola drink"
+	harmless = FALSE
+	taste_description = "Coca Cola"
+
+/datum/reagent/consumable/drink/cold/cocacola/on_mob_life(mob/living/M)
+	var/update_flags = STATUS_UPDATE_NONE
+	M.Druggy(10 SECONDS)
+	M.AdjustStunned(-1 SECONDS)
+	M.AdjustWeakened(-1 SECONDS)
+	if(isturf(M.loc) && !istype(M.loc,/turf/space))
+		if(M.canmove && !M.restrained())
+			step(M, pick(GLOB.cardinal))
+	if(prob(7))
+		M.emote(pick("laugh","giggle"))
+	return ..() | update_flags

--- a/code/modules/reagents/chemistry/recipes/drinks.dm
+++ b/code/modules/reagents/chemistry/recipes/drinks.dm
@@ -885,3 +885,11 @@
 	result_amount = 3
 	mix_message = "The ingredients mix into a dark brown godly substance"
 	mix_sound = 'sound/goonstation/misc/drinkfizz.ogg'
+
+/datum/chemical_reaction/cocacola
+	name = "Coca cola"
+	id = "cocacola"
+	result = "cocacola"
+	required_reagents = list("cocaine" = 2, "cola" = 1)
+	result_amount = 3
+	mix_sound = 'sound/goonstation/misc/drinkfizz.ogg'


### PR DESCRIPTION
## Changelog
add: Original cola drink and sprite

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет напиток Original cola, и рецепт 2 коки 1 кола, напиток создает наркоэкран на 10 сек и дает -1 сек к слабости и -1 сек к стану 
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1182696718941290496
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

