### PR TITLE
qol: Object tab for ghosts now always exist, annoying interface update fix

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -735,3 +735,11 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	var/datum/spawners_menu/menu = new /datum/spawners_menu(src)
 	menu.ui_interact(src)
+
+/**
+ * Placeholder for ghosts in object category. If it does not exist, flying nearby windows\objects will
+ * cause constant interface lags and annoying updates with appearing/disappearing "Object" tab.
+ */
+/mob/dead/observer/verb/object_placeholder()
+	set name = " "
+	set category = "Object"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Небольшой QoL-костыль, призванный смягчить лаги при полете гостом по станции. Теперь вкладка Object существует для призраков всегда. Добавил пустой верб для гостов в этой категории, чтобы не было постоянного апдейта вкладок при полёте по карте.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
При полёте через станцию очень быстро появляется/пропадает вкладка Object, что мягко говоря раздражает.
## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
![изображение](https://github.com/ss220-space/Paradise/assets/73733747/029c8435-dd05-48b3-9c23-bd48d202c8e3)
Слегка костыльно, но воркает :fearlul:
![изображение](https://github.com/ss220-space/Paradise/assets/73733747/f5cd7186-487b-41d7-b216-c7c0996eba3f)
