### PR TITLE
refactor: Returned "Point to" verb instead of dummy "Object" verb

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -735,11 +735,3 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	var/datum/spawners_menu/menu = new /datum/spawners_menu(src)
 	menu.ui_interact(src)
-
-/**
- * Placeholder for ghosts in object category. If it does not exist, flying nearby windows\objects will
- * cause constant interface lags and annoying updates with appearing/disappearing "Object" tab.
- */
-/mob/dead/observer/verb/object_placeholder()
-	set name = " "
-	set category = "Object"

--- a/code/modules/point/point.dm
+++ b/code/modules/point/point.dm
@@ -140,8 +140,6 @@
  * note: ghosts can point, this is intended
  *
  * visible_message will handle invisibility properly
- *
- * overridden here and in /mob/dead/observer for different point span classes and sanity checks
  */
 /mob/verb/pointed(atom/target as mob|obj|turf in view(client.view, src))
 	set name = "Point To"

--- a/code/modules/point/point.dm
+++ b/code/modules/point/point.dm
@@ -140,6 +140,11 @@
  * note: ghosts can point, this is intended
  *
  * visible_message will handle invisibility properly
+ *
+ * Be noted, that this verb also serves as placeholder for "Object" tab.
+ *
+ * Removing it causes interface update lags with appearing/disappearing "Object"
+ * tab when walking nearby "Object"-verbed things
  */
 /mob/verb/pointed(atom/target as mob|obj|turf in view(client.view, src))
 	set name = "Point To"

--- a/code/modules/point/point.dm
+++ b/code/modules/point/point.dm
@@ -145,9 +145,9 @@
  */
 /mob/verb/pointed(atom/target as mob|obj|turf in view(client.view, src))
 	set name = "Point To"
-	set category = null
+	set category = "Object"
 
-	if(next_move >= world.time)
+	if(next_move >= world.time || !Master.current_runlevel) //No usage until subsystems initialized properly.
 		return
 
 	if(istype(target, /obj/effect/temp_visual/point))


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
ПР возвращает убранный из категории "Object" верб "Point To" (после рефакторов поинтов) для замены пустого верба из категории "Object".
Также запрещает использовать Point To до инициализации подсистем.
Поскольку pointed не перезаписан у гостов, убрал соответствующий комментарий.

