### PR TITLE
balance: Demons now do not spawn on lowpop

### DIFF
--- a/code/modules/events/slaughterevent.dm
+++ b/code/modules/events/slaughterevent.dm
@@ -1,5 +1,10 @@
+#define SLAUGHTER_MINPLAYERS 30
+#define LAUGHTER_MINPLAYERS 30
+#define SHADOW_MINPLAYERS 40
+
 /datum/event/spawn_slaughter
 	var/key_of_slaughter
+	var/minplayers = SLAUGHTER_MINPLAYERS
 	var/mob/living/simple_animal/demon/demon = /mob/living/simple_animal/demon/slaughter
 
 
@@ -51,14 +56,21 @@
 
 
 /datum/event/spawn_slaughter/start()
+	if((length(GLOB.clients)) <= minplayers)
+		var/datum/event_container/EC = SSevents.event_containers[EVENT_LEVEL_MAJOR]
+		EC.next_event_time = world.time + (60 * 10)
+		return	//we don't spawn demons on lowpop. Instead, we reroll!
+
 	INVOKE_ASYNC(src, PROC_REF(get_slaughter))
 
 
 /datum/event/spawn_slaughter/laughter
 	demon = /mob/living/simple_animal/demon/slaughter/laughter
+	minplayers = LAUGHTER_MINPLAYERS
 
 /datum/event/spawn_slaughter/shadow
 	demon = /mob/living/simple_animal/demon/shadow
+	minplayers = SHADOW_MINPLAYERS
 
 
 /datum/event/spawn_slaughter/shadow/get_spawn_loc()
@@ -69,3 +81,6 @@
 		return check // return the first turf that is dark nearby.
 	kill()
 
+#undef SLAUGHTER_MINPLAYERS
+#undef LAUGHTER_MINPLAYERS
+#undef SHADOW_MINPLAYERS


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Демоны теперь не спавнятся на лоупопе, но:
- Демоны смеха и резни спавнятся от 30+ игроков
- Демон тени спавнится от 40+ игроков
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Однажды в лоупоп (10 человек, 4 живых) "повезло" встретить в одном раунде электродемона и тенедемона.

