### PR TITLE
bugfix: completed `can_hold` for construction bag.

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -405,7 +405,7 @@
 	max_w_class = WEIGHT_CLASS_NORMAL
 	w_class = WEIGHT_CLASS_TINY
 	can_hold = list(
-	 /obj/item/assembly, /obj/item/circuitboard,
+	 /obj/item/assembly, /obj/item/circuitboard, /obj/item/intercom_electronics,
 	 /obj/item/airlock_electronics, /obj/item/firelock_electronics,
 	 /obj/item/firealarm_electronics, /obj/item/airalarm_electronics, /obj/item/apc_electronics,
 	 /obj/item/stock_parts/cell, /obj/item/stock_parts, /obj/item/camera_assembly)

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -406,7 +406,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	can_hold = list(
 	 /obj/item/assembly, /obj/item/circuitboard, /obj/item/intercom_electronics,
-	 /obj/item/airlock_electronics, /obj/item/firelock_electronics,
+	 /obj/item/airlock_electronics, /obj/item/firelock_electronics, /obj/item/tracker_electronics,
 	 /obj/item/firealarm_electronics, /obj/item/airalarm_electronics, /obj/item/apc_electronics,
 	 /obj/item/stock_parts/cell, /obj/item/stock_parts, /obj/item/camera_assembly)
 	resistance_flags = FLAMMABLE


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
В эту новую сумочку забыли добавить возможность вмещать платы интеркома и трекера соляров. +2-2.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на баг-репорт
https://discord.com/channels/617003227182792704/1184763119877230602<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
