### PR TITLE
bugfix: Anomaly extract don't remove underwear

### DIFF
--- a/code/game/objects/items/weapons/anomaly_extract.dm
+++ b/code/game/objects/items/weapons/anomaly_extract.dm
@@ -8,23 +8,29 @@
 	var/used = FALSE
 
 /obj/item/anomaly_extract/attack_self(mob/user)
-	if(!used)
-		if(user.dna.species.name == "Slime People")
-			var/obj/item/organ/internal/heart/slime/anomaly/H = new
-			H.replaced(user)
-			to_chat(user, span_warning("Something changes inside you. It feel SOO warm!"))
-			used = TRUE
-			icon_state = "slime_extract0"
-		else
-			to_chat(user, span_notice("Looks like your skin is too hard for this syringe."))
-	else
+	if(used)
 		to_chat(user, span_notice("Looks like somebody already used it."))
-	. = ..()
+		return FALSE
 
-/obj/item/anomaly_extract/afterattack(atom/target, mob/user, proximity, params)
+	if(!isslimeperson(user))
+		to_chat(user, span_notice("Looks like your skin is too hard for this syringe."))
+		return FALSE
+
+	var/mob/living/carbon/human/attacker = user
+	if(attacker.get_int_organ(/obj/item/organ/internal/heart/slime/anomaly))
+		to_chat(user, span_notice("You already have the abilities that this extract can provide."))
+		return FALSE
+
+	var/obj/item/organ/internal/heart/slime/anomaly/H = new
+	H.replaced(user)
+	to_chat(user, span_warning("Something changes inside you. It feel SOO warm!"))
+	used = TRUE
+	icon_state = "slime_extract0"
+	return TRUE
+
+/obj/item/anomaly_extract/attack(mob/living/target, mob/living/user, def_zone)
 	if(target == user)
-		attack_self(user)
-	. = ..()
+		return attack_self(user)
 
 
 /obj/effect/proc_holder/spell/slime_degradation
@@ -95,6 +101,11 @@
 	for(var/obj/item/I in user)
 		if(!istype(I, /obj/item/implant))
 			user.drop_item_ground(I, force = TRUE)
+
+	user.underwear = "Nude"
+	user.undershirt = "Nude"
+	user.socks = "Nude"
+	user.regenerate_icons()
 
 	var/mob/living/simple_animal/slime/invalid/slimeme = new /mob/living/simple_animal/slime/invalid(user.loc, "red", new /datum/slime_age/adult, 1200,  user, src)
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Аномальный экстракт полностью убирает все вещи при превращении, в т.ч. нижнее бельё. Свободу жопе, так сказать.
Ну и небольшой рефактор. Так же убрано избивание себя шприцом при каждой попытке что то с ним сделать.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
