### PR TITLE
bugfix: wizarditis teleports in CentComm sector

### DIFF
--- a/code/datums/diseases/viruses/wizarditis.dm
+++ b/code/datums/diseases/viruses/wizarditis.dm
@@ -84,6 +84,9 @@ STI KALY - blind
 
 
 /datum/disease/virus/wizarditis/proc/teleport()
+	if(affected_mob.z == level_name_to_num(CENTCOMM) || affected_mob.z == level_name_to_num(ADMIN_ZONE))
+		return
+
 	var/list/theareas = get_areas_in_range(80, affected_mob)
 	for(var/area/space/S in theareas)
 		theareas -= S


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Визардитис мог телепортировать носителя внутри любого сектора, в т.ч. ЦК.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->