### PR TITLE
bugfix: obsession symptom can reach unreachable items

### DIFF
--- a/code/datums/diseases/viruses/advance/symptoms/uncotrollable.dm
+++ b/code/datums/diseases/viruses/advance/symptoms/uncotrollable.dm
@@ -166,7 +166,7 @@ Uncontrollable Actions
 /datum/symptom/obsession/proc/TakeItem(mob/living/carbon/human/H)
 	var/list/targets = orange(1, H)
 	var/obj/item/target = locate(/obj/item) in shuffle(targets)
-	if(istype(target) && !target.anchored)
+	if(istype(target) && target.Adjacent(H) && !target.anchored)
 		target.forceMove(get_turf(H))
 		H.put_in_hands(target)
 		return target


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Забыл проверку на Adjacent при подборе предметов для вируса с симптомом неконтролируемых действий.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
