### PR TITLE
add: Rezadone is returned to it's glory. And also lets you revive people with lots of clone damage.

### DIFF
--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -502,7 +502,8 @@
 					M.visible_message("<span class='warning'>[M]'s body convulses a bit.")
 					playsound(get_turf(src), "bodyfall", 50, 1)
 					playsound(get_turf(src), 'sound/machines/defib_zap.ogg', 50, 1, -1)
-					var/total_cloneloss = H.cloneloss
+					//Oooh the trickery
+					var/total_cloneloss = H.reagents.get_reagent_amount("rezadone") ? 0 : H.cloneloss
 					var/total_bruteloss = 0
 					var/total_burnloss = 0
 					for(var/obj/item/organ/external/O as anything in H.bodyparts)

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -156,7 +156,6 @@
 /datum/reagent/medicine/rezadone/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	M.setCloneLoss(0)
-	update_flags |= M.adjustCloneLoss(-1, FALSE) //What? We just set cloneloss to 0. Why? Simple; this is so external organs properly unmutate. // why don't you fix the code instead // i fix the code dont worry
 	update_flags |= M.adjustBruteLoss(-1, FALSE)
 	update_flags |= M.adjustFireLoss(-1, FALSE)
 	if(ishuman(M))

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -155,7 +155,8 @@
 
 /datum/reagent/medicine/rezadone/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	update_flags |= M.adjustCloneLoss(-5, FALSE) //What? We just set cloneloss to 0. Why? Simple; this is so external organs properly unmutate. // why don't you fix the code instead // i fix the code dont worry
+	M.setCloneLoss(0)
+	update_flags |= M.adjustCloneLoss(-1, FALSE) //What? We just set cloneloss to 0. Why? Simple; this is so external organs properly unmutate. // why don't you fix the code instead // i fix the code dont worry
 	update_flags |= M.adjustBruteLoss(-1, FALSE)
 	update_flags |= M.adjustFireLoss(-1, FALSE)
 	if(ishuman(M))


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Откат резадона к старой механике мгновенного лечения клонурона, а также добавляет возможность воскрешать мертвых со слишком большим клонуроном (>= 180).
____

Мержить после https://github.com/ss220-space/Paradise/pull/4186

____
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Большая редкость данного реагента, которая в т.ч зависит от карты (на Кибериаде и Фаррагусе нет тех самых двух филешек карпа, что есть на Керберосе), желания левой пятки ботаника и правой пятки роботехника.
Также ранее были претензии к резадону как к препарату, который могут легко достать ботаники. Но поскольку странные семяна были успешно вырезаны из массового производства, резадон достать теперь самостоятельно нельзя.

И эти причины в совокупности делают криоксадон (которого можно наделать сотнями у.е за пять минут) намного предпочтительнее резадона, который будет давать лечение с 0.4 юнита резадона равному 2 юнитам криоксадона при многократной редкости относительно криоксадона.
