### PR TITLE
add: SRM-8 middle missiles module for roboticist hijacker only

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -476,8 +476,8 @@
 	surplus = 0
 
 /datum/uplink_item/jobspecific/missilemedium
-	name = "Missiles for mechs"
-	desc = "Medium power missiles module for mechs like Gygax, Durand, Maule... nevermind. Way more powerful, than missile modules you can produce in legal fabs. It comes without lockbox - plug and play!"
+	name = "SRM-8 Missile Rack"
+	desc = "Medium power missiles module for mechs like Gygax, Durand, Maule... nevermind. Way more powerful, than missile modules you can print on standard mech fabs. It comes without lockbox - plug and play!"
 	item = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/medium
 	cost = 50
 	job = list("Roboticist")

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -475,6 +475,16 @@
 	job = list("Roboticist")
 	surplus = 0
 
+/datum/uplink_item/jobspecific/missilemedium
+	name = "Missiles for mechs"
+	desc = "Medium power missiles module for mechs like Gygax, Durand, Maule... nevermind. Way more powerful, than missile modules you can produce in legal fabs. It comes without lockbox - plug and play!"
+	item = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/medium
+	cost = 50
+	job = list("Roboticist")
+	surplus = 0
+	can_discount = FALSE
+	hijack_only = TRUE
+
 //Librarian
 /datum/uplink_item/jobspecific/etwenty
 	name = "The E20"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -477,7 +477,7 @@
 
 /datum/uplink_item/jobspecific/missilemedium
 	name = "SRM-8 Missile Rack"
-	desc = "Medium power missiles module for mechs like Gygax, Durand, Maule... nevermind. Way more powerful, than missile modules you can print on standard mech fabs. It comes without lockbox - plug and play!"
+	desc = "Those missile launcher are known to be used on high-end mechs like mauler and marauder. Way more powerful, than missile modules you can print on standard mech fabs. It comes without lockbox - plug and play!"
 	item = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/medium
 	cost = 50
 	job = list("Roboticist")


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет в аплинк роботехника-угонщика "средние" ракеты на мех, которые сейчас используются у маулера. Стоимость - 50 ТК, нет скидок, не бывает в ящиках. При покупке даётся сразу модуль, так что открывать оружейный кейс не нужно. Для сравнения мощность ракет из стандартного мех. фабрикатора (лёгких ) - 0, 0, 2, 4 и средних ракет - 0, 2, 3, 4. 
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1184251525967654985
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
