### PR TITLE
bugfix: contractor support unit can use special traitor items

### DIFF
--- a/code/modules/antagonists/traitor/contractor/datums/contractor_support.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/contractor_support.dm
@@ -1,6 +1,7 @@
 /datum/antagonist/contractor_support
 	name = "Contractor Support Unit"
 	roundend_category = "Contractor Support"
+	special_role = SPECIAL_ROLE_TRAITOR
 
 /datum/antagonist/contractor_support/on_gain()
 	var/datum/objective/generic_objective = new


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Суть проблемы: у юнита поддержи контрактника - призывного дурачка нет возможности использовать некоторые особенности стандартного тритора - копировать доступ с помощью карты предателя, видеть "Антагонист" описания предметов, совать бох в бох без необходимых 9000 минут и так далее.
Добавление спец.роли в теории ничего не ломает, но добавляет ему необходимые особенности
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багфикс 
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
