### PR TITLE
tweak: vampires can't eat simple mobs; reduced nutrition from mobs

### DIFF
--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -76,7 +76,6 @@
 	var/stam_regen_start_time = 0 //used to halt stamina regen temporarily
 	var/stam_regen_start_modifier = 1 //Modifier of time until regeneration starts
 	var/stam_paralyzed = FALSE //knocks you down
-	var/blood_nutrients = 10 //nutrition for devour this creature by vampire
 
 	///if this exists AND the normal sprite is bigger than 32x32, this is the replacement icon state (because health doll size limitations). the icon will always be screen_gen.dmi
 	var/health_doll_icon

--- a/code/modules/mob/living/simple_animal/friendly/butterfly.dm
+++ b/code/modules/mob/living/simple_animal/friendly/butterfly.dm
@@ -12,7 +12,6 @@
 	speak_chance = 0
 	maxHealth = 2
 	health = 2
-	blood_nutrients = 5
 	harm_intent_damage = 1
 	friendly = "nudges"
 	density = 0

--- a/code/modules/mob/living/simple_animal/friendly/crab.dm
+++ b/code/modules/mob/living/simple_animal/friendly/crab.dm
@@ -10,7 +10,6 @@
 	emote_see = list("clacks")
 	death_sound = 'sound/creatures/crack_death2.ogg'
 	speak_chance = 1
-	blood_nutrients = 30
 	turns_per_move = 5
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat = 1)
 	response_help  = "pets"

--- a/code/modules/mob/living/simple_animal/friendly/diona.dm
+++ b/code/modules/mob/living/simple_animal/friendly/diona.dm
@@ -18,7 +18,6 @@
 
 	maxHealth = 50
 	health = 50
-	blood_nutrients = 30
 	voice_name = "diona nymph"
 	speak_emote = list("chirrups")
 	emote_hear = list("chirrups")

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -197,7 +197,6 @@
 	death_sound = 'sound/creatures/mouse_squeak.ogg'
 	health = 3
 	maxHealth = 3
-	blood_nutrients = 20
 	ventcrawler = 2
 	var/amount_grown = 0
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
@@ -257,7 +256,6 @@ GLOBAL_VAR_INIT(chicken_count, 0)
 	talk_sound = list('sound/creatures/chicken_talk.ogg')
 	health = 15
 	maxHealth = 15
-	blood_nutrients = 30
 	ventcrawler = 2
 	var/eggsleft = 0
 	var/eggsFertile = TRUE

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -20,7 +20,6 @@
 	see_in_dark = 6
 	maxHealth = 5
 	health = 5
-	blood_nutrients = 20
 	blood_volume = BLOOD_VOLUME_SURVIVE
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/mouse = 1)
 	response_help  = "pets"
@@ -200,7 +199,6 @@
 /mob/living/simple_animal/mouse/blobinfected
 	maxHealth = 100
 	health = 100
-	blood_nutrients = 500
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	gold_core_spawnable = NO_SPAWN
@@ -287,7 +285,6 @@
 	mouse_color = null
 	maxHealth = 15
 	health = 15
-	blood_nutrients = 30
 	mob_size = MOB_SIZE_SMALL
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/mouse = 2)
 

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -43,7 +43,6 @@
 	emote_see = list("flutters its wings")
 
 	speak_chance = 1	//1% (1 in 100) chance every tick; So about once per 150 seconds, assuming an average tick is 1.5s
-	blood_nutrients = 30
 	turns_per_move = 5
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/cracker = 3)
 

--- a/code/modules/mob/living/simple_animal/tribbles.dm
+++ b/code/modules/mob/living/simple_animal/tribbles.dm
@@ -17,7 +17,6 @@ GLOBAL_VAR_INIT(totaltribbles, 0)   //global variable so it updates for all trib
 	turns_per_move = 5
 	maxHealth = 10
 	health = 10
-	blood_nutrients = 30
 	butcher_results = list(/obj/item/stack/sheet/fur = 1)
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -436,10 +436,7 @@
 		if(affecting.mind)
 			add_attack_logs(attacker, affecting, "Devoured")
 
-		if(isvampire(user))
-			user.adjust_nutrition(affecting.blood_nutrients)
-		else
-			user.adjust_nutrition(10 * affecting.health)
+		user.adjust_nutrition(2 * affecting.health)
 
 		for(var/datum/disease/virus/V in affecting.diseases)
 			if(V.spread_flags > NON_CONTAGIOUS)
@@ -462,8 +459,8 @@
 	var/mob/living/carbon/human/H = attacker
 	var/datum/antagonist/vampire/vamp = H.mind?.has_antag_datum(/datum/antagonist/vampire)
 	var/datum/antagonist/goon_vampire/g_vamp = H.mind?.has_antag_datum(/datum/antagonist/goon_vampire)
-	if(ishuman(H) && (vamp || g_vamp) && istype(prey, /mob/living/simple_animal/mouse)) //vampires can eat mice despite race
-		return 1
+	if(ishuman(H) && (vamp || g_vamp) && istype(prey, /mob/living/simple_animal)) //vampires can't eat simple mobs despite race
+		return 0
 	if(ishuman(H) && is_type_in_list(prey,  H.dna.species.allowed_consumed_mobs)) //species eating of other mobs
 		return 1
 

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -460,7 +460,7 @@
 	var/datum/antagonist/vampire/vamp = H.mind?.has_antag_datum(/datum/antagonist/vampire)
 	var/datum/antagonist/goon_vampire/g_vamp = H.mind?.has_antag_datum(/datum/antagonist/goon_vampire)
 	if(ishuman(H) && (vamp || g_vamp) && istype(prey, /mob/living/simple_animal)) //vampires can't eat simple mobs despite race
-		return 0
+		return FALSE
 	if(ishuman(H) && is_type_in_list(prey,  H.dna.species.allowed_consumed_mobs)) //species eating of other mobs
 		return 1
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Вампиры любой расы больше не могут есть никаких симпл мобов, и соответственно получать с них насыщение. Насыщение поедаемыми мобами уменьшено с (10 * здоровье моба) до (2 * здоровье моба).
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1178739025738211370
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
