### PR TITLE
bugfix: sibyl can allow lethal while green seclevel.

### DIFF
--- a/code/__DEFINES/sound.dm
+++ b/code/__DEFINES/sound.dm
@@ -6,7 +6,7 @@
 #define CHANNEL_HEARTBEAT 1020 //sound channel for heartbeats
 #define CHANNEL_BUZZ 1019
 #define CHANNEL_AMBIENCE 1018
-#define CHANNEL_SIBYL_SYSTEM 1017 //В данный момент он не используется, но удалять нельзя! -BeebBeebBoob
+#define CHANNEL_UNUSED 1017	// МОЛЮ, Если кто-то будет добавлять новый канал. ВОСПОЛЬЗУЙСЯ ЭТИМ! ОН ПУСТОЙ! -BeebBeebBoob
 #define CHANNEL_GENERAL 1016 //Sound channel for playsound(), most of the sounds
 #define CHANNEL_JUSTICAR_ARK 1015
 #define CHANNEL_TTS_LOCAL 1014

--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -849,8 +849,8 @@ GLOBAL_LIST_INIT(ungibbable_items_types, get_ungibbable_items_types())
 	min=3
 	max=6
 
-/datum/theft_objective/collect/number/sybil
-	id = "collect_num_sybil"
+/datum/theft_objective/collect/number/sibyl
+	id = "collect_num_sibyl"
 	typepath = /obj/item/sibyl_system_mod
 	name = "системы Сибил"
 	min=4

--- a/code/game/objects/items/weapons/chrono_eraser.dm
+++ b/code/game/objects/items/weapons/chrono_eraser.dm
@@ -49,7 +49,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	flags = NODROP | DROPDEL
 	ammo_type = list(/obj/item/ammo_casing/energy/chrono_beam)
-	can_charge = 0
+	can_charge = FALSE
 	fire_delay = 50
 	var/obj/item/chrono_eraser/TED = null
 	var/obj/structure/chrono_field/field = null

--- a/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_energy_stars.dm
+++ b/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_energy_stars.dm
@@ -38,7 +38,7 @@
 	slot_flags = 0
 	flags = DROPDEL | ABSTRACT | NOBLUDGEON
 	ammo_type = list(/obj/item/ammo_casing/energy/shuriken)
-	can_charge = 0
+	can_charge = FALSE
 	burst_size = 3
 	var/cost = 100
 	var/obj/item/clothing/suit/space/space_ninja/my_suit = null

--- a/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
+++ b/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
@@ -178,10 +178,8 @@
 	desc = "An energy gun that recharges wirelessly during away missions. Does not work on the main station."
 	force = 10
 	origin_tech = null
-	selfcharge = 1
-	can_charge = 0
-	// Selfcharge is enabled and disabled, and used as the away mission tracker
-	selfcharge = TRUE
+	can_charge = FALSE
+	selfcharge = TRUE	// Selfcharge is enabled and disabled, and used as the away mission tracker
 
 /obj/item/gun/energy/laser/awaymission_aeg/Initialize(mapload)
 	. = ..()

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -4,27 +4,27 @@
 	desc = "A basic energy-based gun."
 	icon = 'icons/obj/weapons/energy.dmi'
 	fire_sound_text = "laser blast"
-
-	var/obj/item/stock_parts/cell/cell //What type of power cell this uses
-	var/cell_type = /obj/item/stock_parts/cell/laser
-	var/modifystate = 0
-	var/list/ammo_type = list(/obj/item/ammo_casing/energy)
-	var/select = 1 //The state of the select fire switch. Determines from the ammo_type list what kind of shot is fired next.
-	var/can_charge = 1
-	var/charge_sections = 4
 	ammo_x_offset = 2
-	var/shaded_charge = 0 //if this gun uses a stateful charge bar for more detail
-	var/selfcharge = 0
+
+	var/obj/item/stock_parts/cell/cell	//What type of power cell this uses
+	var/cell_type = /obj/item/stock_parts/cell/laser
+	var/list/ammo_type = list(/obj/item/ammo_casing/energy)
+	var/select = 1	//The state of the select fire switch. Determines from the ammo_type list what kind of shot is fired next.
+	var/modifystate = FALSE
+	var/shaded_charge = FALSE	//if this gun uses a stateful charge bar for more detail
+	var/selfcharge = FALSE
+	var/can_charge = TRUE
+	var/charge_sections = 4
 	var/charge_tick = 0
 	var/charge_delay = 4
 
-	var/can_add_sibyl_system = TRUE //if a sibyl system's mod can be added or removed if it already has one
+	var/can_add_sibyl_system = TRUE	//if a sibyl system's mod can be added or removed if it already has one
 	var/obj/item/sibyl_system_mod/sibyl_mod = null
 
 /obj/item/gun/energy/examine(mob/user)
 	. = ..()
 	if(sibyl_mod)
-		. += "<span class='notice'>Вы видите индикаторы модуля Sibyl System.</span>"
+		. += span_notice("Вы видите индикаторы модуля Sibyl System.")
 
 /obj/item/gun/energy/attackby(obj/item/I, mob/user, params)
 	..()
@@ -35,9 +35,8 @@
 				M.install(src, user)
 				return
 		if(istype(I, /obj/item/card/id/))
-			if(sibyl_mod)
-				sibyl_mod.toggleAuthorization(I, user)
-				return
+			sibyl_mod?.toggleAuthorization(I, user)
+			return
 
 /obj/item/gun/energy/proc/toggle_voice()
 	set name = "Переключить голос Sibyl System"
@@ -52,60 +51,60 @@
 	if(sibyl_mod && user.a_intent != INTENT_HARM)
 		if(sibyl_mod.state == SIBSYS_STATE_SCREWDRIVER_ACT)
 			sibyl_mod.state = SIBSYS_STATE_INSTALLED
-			to_chat(user, "<span class='notice'>Вы закрутили шурупы мода Sibyl System в [src].</span>")
+			to_chat(user, span_notice("Вы закрутили шурупы мода Sibyl System в [src]."))
 			return
 		else
 			if(prob(90))
 				sibyl_mod.state = SIBSYS_STATE_SCREWDRIVER_ACT
-				to_chat(user, "<span class='notice'>Вы успешно открутили шурупы мода Sibyl System от [src].</span>")
+				to_chat(user, span_notice("Вы успешно открутили шурупы мода Sibyl System от [src]."))
 			else
 				var/mob/living/carbon/human/H = user
 				var/obj/item/organ/external/affecting = H.get_organ(user.r_hand == I ? BODY_ZONE_PRECISE_L_HAND : BODY_ZONE_PRECISE_R_HAND)
 				user.apply_damage(5, BRUTE , affecting)
 				user.emote("scream")
-				to_chat(user, "<span class='warning'>Проклятье! [I] сорвалась и повредила [affecting.name]!</span>")
+				to_chat(user, span_warning("Проклятье! [I] сорвалась и повредила [affecting.name]!"))
 			return
 
 /obj/item/gun/energy/welder_act(mob/living/user, obj/item/I)
 	..()
 	if(sibyl_mod && user.a_intent != INTENT_HARM)
 		if(sibyl_mod.state == SIBSYS_STATE_WELDER_ACT)
-			to_chat(user, "<span class='notice'>Вы начинаете заваривать болты мода Sibyl System от [src]...</span>")
+			to_chat(user, span_notice("Вы начинаете заваривать болты мода Sibyl System от [src]..."))
 			if(I.use_tool(src, user, 16 SECONDS, volume = I.tool_volume))
 				sibyl_mod.state = SIBSYS_STATE_SCREWDRIVER_ACT
-				to_chat(user, "<span class='notice'>Вы заварили болты мода Sibyl System в [src].</span>")
+				to_chat(user, span_notice("Вы заварили болты мода Sibyl System в [src]."))
 			return
 		if(sibyl_mod.state == SIBSYS_STATE_SCREWDRIVER_ACT)
-			to_chat(user, "<span class='notice'>Вы начинаете разваривать болты мода Sibyl System от [src]...</span>")
+			to_chat(user, span_notice("Вы начинаете разваривать болты мода Sibyl System от [src]..."))
 			if(I.use_tool(src, user, 16 SECONDS, volume = I.tool_volume))
 				if(prob(70))
 					sibyl_mod.state = SIBSYS_STATE_WELDER_ACT
-					to_chat(user, "<span class='notice'>Вы успешно разварили болты мода Sibyl System от [src].</span>")
+					to_chat(user, span_notice("Вы успешно разварили болты мода Sibyl System от [src]."))
 				else
 					var/mob/living/carbon/human/H = user
 					var/obj/item/organ/external/affecting = H.get_organ(user.r_hand == I ? BODY_ZONE_PRECISE_L_HAND : BODY_ZONE_PRECISE_R_HAND)
 					user.apply_damage(10, BURN , affecting)
 					user.emote("scream")
-					to_chat(user, "<span class='warning'>Проклятье! [I] дёрнулась и прожгла [affecting.name]!</span>")
+					to_chat(user, span_warning("Проклятье! [I] дёрнулась и прожгла [affecting.name]!"))
 			return
 
 /obj/item/gun/energy/crowbar_act(mob/living/user, obj/item/I)
 	..()
 	if(sibyl_mod && user.a_intent != INTENT_HARM)
 		if(sibyl_mod.state == SIBSYS_STATE_WELDER_ACT)
-			to_chat(user, "<span class='notice'>Вы начинаете отковыривать болты мода Sibyl System от [src]...</span>")
+			to_chat(user, span_notice("Вы начинаете отковыривать болты мода Sibyl System от [src]..."))
 			if(!I.use_tool(src, user, 16 SECONDS, volume = I.tool_volume))
 				return
 			if(prob(95))
 				if(sibyl_mod.state == SIBSYS_STATE_WELDER_ACT)
 					sibyl_mod.uninstall(src)
-					to_chat(user, "<span class='notice'>Вы успешно отковыряли болты мода Sibyl System от [src].</span>")
+					to_chat(user, span_notice("Вы успешно отковыряли болты мода Sibyl System от [src]."))
 			else
 				var/mob/living/carbon/human/H = user
 				var/obj/item/organ/external/affecting = H.get_organ(user.r_hand == I ? BODY_ZONE_PRECISE_L_HAND : BODY_ZONE_PRECISE_R_HAND)
 				user.apply_damage(5, BRUTE , affecting)
 				user.emote("scream")
-				to_chat(user, "<span class='warning'>Проклятье! [I] соскальзнула и повредила [affecting.name]!</span>")
+				to_chat(user, span_warning("Проклятье! [I] соскальзнула и повредила [affecting.name]!"))
 			return
 
 /obj/item/gun/energy/emag_act(mob/user)
@@ -114,7 +113,7 @@
 		sibyl_mod.emagged = TRUE
 		sibyl_mod.unlock()
 		if(user)
-			user.visible_message("<span class='warning'>От [src] летят искры!</span>", "<span class='notice'>Вы взломали [src], что привело к выключению болтов предохранителя.</span>")
+			user.visible_message(span_warning("От [src] летят искры!"), span_notice("Вы взломали [src], что привело к выключению болтов предохранителя."))
 		playsound(src.loc, 'sound/effects/sparks4.ogg', 30, 1)
 		do_sparks(5, 1, src)
 		return
@@ -175,14 +174,10 @@
 /obj/item/gun/energy/proc/on_recharge()
 	newshot()
 
-/obj/item/gun/energy/attack_self(mob/living/user as mob)
+/obj/item/gun/energy/attack_self(mob/living/user)
 	if(ammo_type.len > 1)
 		select_fire(user)
 		update_icon()
-		if(istype(user,/mob/living/carbon/human)) //This has to be here or else if you toggle modes by clicking the gun in hand
-			var/mob/living/carbon/human/H = user //Otherwise the mob icon doesn't update, blame shitty human update_icons() code
-			H.update_inv_l_hand()
-			H.update_inv_r_hand()
 
 /obj/item/gun/energy/can_shoot(mob/living/user)
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
@@ -215,7 +210,9 @@
 	return ..()
 
 /obj/item/gun/energy/proc/select_fire(mob/living/user)
-	if(++select > ammo_type.len)
+	if(!user)	// If it's called by something, but not human (Security level changing), drop firemode to non-lethal.
+		select = 1
+	else if(++select > ammo_type.len)
 		select = 1
 	else
 		if(sibyl_mod && !sibyl_mod.check_select(select))
@@ -224,7 +221,7 @@
 	fire_sound = shot.fire_sound
 	fire_delay = shot.delay
 	if(!isnull(user) && shot.select_name)
-		to_chat(user, "<span class='notice'>[src] is now set to [shot.select_name].</span>")
+		to_chat(user, span_notice("[src] is now set to [shot.select_name]."))
 	if(chambered)//phil235
 		if(chambered.BB)
 			qdel(chambered.BB)
@@ -232,6 +229,10 @@
 		chambered = null
 	newshot()
 	update_icon()
+	if(istype(user,/mob/living/carbon/human)) //This has to be here or else if you toggle modes by clicking the gun in hand
+		var/mob/living/carbon/human/H = user //Otherwise the mob icon doesn't update, blame shitty human update_icons() code
+		H.update_inv_l_hand()
+		H.update_inv_r_hand()
 	return
 
 /obj/item/gun/energy/update_icon()
@@ -271,20 +272,20 @@
 
 /obj/item/gun/energy/suicide_act(mob/user)
 	if(can_shoot())
-		user.visible_message("<span class='suicide'>[user] is putting the barrel of the [name] in [user.p_their()] mouth.  It looks like [user.p_theyre()] trying to commit suicide.</span>")
+		user.visible_message(span_suicide("[user] is putting the barrel of the [name] in [user.p_their()] mouth.  It looks like [user.p_theyre()] trying to commit suicide."))
 		sleep(25)
 		if(user.l_hand == src || user.r_hand == src)
-			user.visible_message("<span class='suicide'>[user] melts [user.p_their()] face off with the [name]!</span>")
+			user.visible_message(span_suicide("[user] melts [user.p_their()] face off with the [name]!"))
 			playsound(loc, fire_sound, 50, 1, -1)
 			var/obj/item/ammo_casing/energy/shot = ammo_type[select]
 			cell.use(shot.e_cost)
 			update_icon()
 			return FIRELOSS
 		else
-			user.visible_message("<span class='suicide'>[user] panics and starts choking to death!</span>")
+			user.visible_message(span_suicide("[user] panics and starts choking to death!"))
 			return OXYLOSS
 	else
-		user.visible_message("<span class='suicide'>[user] is pretending to blow [user.p_their()] brains out with the [name]! It looks like [user.p_theyre()] trying to commit suicide!</b></span>")
+		user.visible_message(span_suicide("[user] is pretending to blow [user.p_their()] brains out with the [name]! It looks like [user.p_theyre()] trying to commit suicide!"))
 		playsound(loc, 'sound/weapons/empty.ogg', 50, 1, -1)
 		return OXYLOSS
 

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -8,7 +8,7 @@
 	origin_tech = "combat=4;magnets=2"
 	ammo_type = list(/obj/item/ammo_casing/energy/lasergun)
 	ammo_x_offset = 1
-	shaded_charge = 1
+	shaded_charge = TRUE
 
 /obj/item/gun/energy/laser/practice
 	name = "practice laser gun"
@@ -32,7 +32,7 @@
 	force = 10
 	origin_tech = null
 	ammo_x_offset = 3
-	selfcharge = 1
+	selfcharge = TRUE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	unique_reskin = TRUE
 
@@ -57,13 +57,13 @@
 	desc = "An industrial-grade heavy-duty laser rifle with a modified laser lense to scatter its shot into multiple smaller lasers. The inner-core can self-charge for theorically infinite use."
 	origin_tech = "combat=5;materials=4;powerstorage=4"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/scatter, /obj/item/ammo_casing/energy/laser)
-	shaded_charge = 0
+	shaded_charge = FALSE
 	unique_reskin = FALSE
 
 /obj/item/gun/energy/laser/cyborg
-	can_charge = 0
 	desc = "An energy-based laser gun that draws power from the cyborg's internal energy cell directly. So this is what freedom looks like?"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/cyborg)
+	can_charge = FALSE
 	origin_tech = null
 
 /obj/item/gun/energy/laser/cyborg/newshot()
@@ -132,7 +132,7 @@
 	item_state = "laser"
 	ammo_type = list(/obj/item/ammo_casing/energy/immolator)
 	origin_tech = "combat=4;magnets=4;powerstorage=3"
-	shaded_charge = 1
+	shaded_charge = TRUE
 
 /obj/item/gun/energy/immolator/multi
 	name = "multi lens immolator cannon"
@@ -158,10 +158,10 @@
 	name = "laser tag gun"
 	desc = "Standard issue weapon of the Imperial Guard"
 	origin_tech = "combat=2;magnets=2"
-	clumsy_check = 0
-	needs_permit = 0
+	clumsy_check = FALSE
+	needs_permit = FALSE
 	ammo_x_offset = 2
-	selfcharge = 1
+	selfcharge = TRUE
 
 /obj/item/gun/energy/laser/tag/blue
 	icon_state = "bluetag"

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -5,8 +5,8 @@
 	item_state = null	//so the human update icon uses the icon_state instead.
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler, /obj/item/ammo_casing/energy/laser)
 	origin_tech = "combat=4;magnets=3"
-	modifystate = 2
-	can_flashlight = 1
+	modifystate = TRUE
+	can_flashlight = TRUE
 	ammo_x_offset = 3
 	flight_x_offset = 15
 	flight_y_offset = 10
@@ -60,7 +60,7 @@
 	force = 7
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode/blueshield, /obj/item/ammo_casing/energy/disabler/blueshield, /obj/item/ammo_casing/energy/laser/blueshield)
 	ammo_x_offset = 1
-	shaded_charge = 1
+	shaded_charge = TRUE
 
 /obj/item/gun/energy/gun/blueshield/can_shoot()
     . = ..()
@@ -77,7 +77,7 @@
 	force = 7
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode/hos, /obj/item/ammo_casing/energy/laser/hos)
 	ammo_x_offset = 1
-	shaded_charge = 1
+	shaded_charge = TRUE
 
 /obj/item/gun/energy/gun/pdw9/ert
 
@@ -107,9 +107,8 @@
 	icon_state = "nucgun"
 	item_state = "nucgun"
 	origin_tech = "combat=4;magnets=4;powerstorage=4"
-	var/fail_tick = 0
 	charge_delay = 5
-	can_charge = 0
+	can_charge = FALSE
 	ammo_x_offset = 1
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode, /obj/item/ammo_casing/energy/disabler, /obj/item/ammo_casing/energy/laser)
-	selfcharge = 1
+	selfcharge = TRUE

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -41,7 +41,7 @@
 	item_state = "gun"
 	can_holster = TRUE
 	cell_type = /obj/item/stock_parts/cell/pulse/pistol
-	can_charge = 0
+	can_charge = FALSE
 
 /obj/item/gun/energy/pulse/destroyer
 	name = "pulse destroyer"

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -55,9 +55,9 @@
 	fire_sound = 'sound/effects/stealthoff.ogg'
 	ammo_type = list(/obj/item/ammo_casing/energy/flora/yield, /obj/item/ammo_casing/energy/flora/mut)
 	origin_tech = "materials=2;biotech=4"
-	modifystate = 1
+	modifystate = TRUE
 	ammo_x_offset = 1
-	selfcharge = 1
+	selfcharge = TRUE
 
 // Meteor Gun //
 /obj/item/gun/energy/meteorgun
@@ -70,8 +70,8 @@
 	w_class = WEIGHT_CLASS_BULKY
 	ammo_type = list(/obj/item/ammo_casing/energy/meteor)
 	cell_type = /obj/item/stock_parts/cell/potato
-	clumsy_check = 0 //Admin spawn only, might as well let clowns use it.
-	selfcharge = 1
+	clumsy_check = FALSE //Admin spawn only, might as well let clowns use it.
+	selfcharge = TRUE
 
 /obj/item/gun/energy/meteorgun/pen
 	name = "meteor pen"
@@ -141,7 +141,7 @@
 	desc = "A mining tool capable of expelling concentrated plasma bursts. You could use it to cut limbs off of xenos! Or, you know, mine stuff."
 	icon_state = "plasmacutter"
 	item_state = "plasmacutter"
-	modifystate = -1
+	modifystate = FALSE
 	origin_tech = "combat=1;materials=3;magnets=2;plasmatech=3;engineering=1"
 	ammo_type = list(/obj/item/ammo_casing/energy/plasma)
 	usesound = 'sound/items/welder.ogg'
@@ -151,7 +151,7 @@
 	attack_verb = list("attacked", "slashed", "cut", "sliced")
 	force = 12
 	sharp = 1
-	can_charge = 0
+	can_charge = FALSE
 
 /obj/item/gun/energy/plasmacutter/examine(mob/user)
 	. = ..()
@@ -187,7 +187,6 @@
 	name = "advanced plasma cutter"
 	icon_state = "adv_plasmacutter"
 	item_state = "adv_plasmacutter"
-	modifystate = "adv_plasmacutter"
 	origin_tech = "combat=3;materials=4;magnets=3;plasmatech=4;engineering=2"
 	ammo_type = list(/obj/item/ammo_casing/energy/plasma/adv)
 	force = 15
@@ -274,7 +273,7 @@
 	icon = 'icons/obj/weapons/projectile.dmi'
 	cell_type = /obj/item/stock_parts/cell/secborg
 	ammo_type = list(/obj/item/ammo_casing/energy/c3dbullet)
-	can_charge = 0
+	can_charge = FALSE
 
 /obj/item/gun/energy/printer/update_icon()
 	return
@@ -314,8 +313,8 @@
 	icon_state = "honkrifle"
 	item_state = null
 	ammo_type = list(/obj/item/ammo_casing/energy/clown)
-	clumsy_check = 0
-	selfcharge = 1
+	clumsy_check = FALSE
+	selfcharge = TRUE
 	ammo_x_offset = 3
 
 /obj/item/gun/energy/toxgun
@@ -325,7 +324,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	origin_tech = "combat=4;magnets=4;powerstorage=3"
 	ammo_type = list(/obj/item/ammo_casing/energy/toxplasma)
-	shaded_charge = 1
+	shaded_charge = TRUE
 
 // Energy Sniper //
 /obj/item/gun/energy/sniperrifle
@@ -341,7 +340,7 @@
 	can_holster = FALSE
 	zoomable = TRUE
 	zoom_amt = 7 //Long range, enough to see in front of you, but no tiles behind you.
-	shaded_charge = 1
+	shaded_charge = TRUE
 
 /obj/item/gun/energy/bsg
 	name = "\improper Б.С.П"
@@ -458,12 +457,12 @@
 	origin_tech = "combat=4;materials=4;powerstorage=3;magnets=2"
 
 	ammo_type = list(/obj/item/ammo_casing/energy/temp)
-	selfcharge = 1
+	selfcharge = TRUE
 
 	var/powercost = ""
 	var/powercostcolor = ""
 
-	var/emagged = 0			//ups the temperature cap from 500 to 1000, targets hit by beams over 500 Kelvin will burst into flames
+	var/emagged = FALSE			//ups the temperature cap from 500 to 1000, targets hit by beams over 500 Kelvin will burst into flames
 	var/dat = ""
 
 /obj/item/gun/energy/temperature/Initialize(mapload, ...)
@@ -635,8 +634,8 @@
 	desc = "A self-defense weapon that exhausts organic targets, weakening them until they collapse. Why does this one have teeth?"
 	icon_state = "disabler"
 	ammo_type = list(/obj/item/ammo_casing/energy/mimic)
-	clumsy_check = 0 //Admin spawn only, might as well let clowns use it.
-	selfcharge = 1
+	clumsy_check = FALSE //Admin spawn only, might as well let clowns use it.
+	selfcharge = TRUE
 	ammo_x_offset = 3
 	var/mimic_type = /obj/item/gun/projectile/automatic/pistol //Setting this to the mimicgun type does exactly what you think it will.
 

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -14,8 +14,8 @@
 	item_state = "gun"
 	origin_tech = "combat=4;materials=4;powerstorage=4"
 	ammo_type = list(/obj/item/ammo_casing/energy/shock_revolver)
-	can_flashlight = 0
-	shaded_charge = 1
+	can_flashlight = FALSE
+	shaded_charge = TRUE
 
 /obj/item/gun/energy/gun/advtaser
 	name = "hybrid taser"
@@ -28,8 +28,8 @@
 /obj/item/gun/energy/gun/advtaser/cyborg
 	name = "cyborg taser"
 	desc = "An integrated hybrid taser that draws directly from a cyborg's power cell. The weapon contains a limiter to prevent the cyborg's power cell from overheating."
-	can_flashlight = 0
-	can_charge = 0
+	can_flashlight = FALSE
+	can_charge = FALSE
 
 /obj/item/gun/energy/gun/advtaser/cyborg/newshot()
 	..()
@@ -48,7 +48,7 @@
 	name = "cyborg disabler"
 	desc = "An integrated disabler that draws from a cyborg's power cell. This weapon contains a limiter to prevent the cyborg's power cell from overheating."
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler/cyborg)
-	can_charge = 0
+	can_charge = FALSE
 
 /obj/item/gun/energy/disabler/cyborg/newshot()
 	..()

--- a/code/modules/projectiles/guns/energy/telegun.dm
+++ b/code/modules/projectiles/guns/energy/telegun.dm
@@ -7,7 +7,7 @@
 	item_state = "telegun"
 	origin_tech = "combat=6;materials=7;powerstorage=5;bluespace=5;syndicate=4"
 	ammo_type = list(/obj/item/ammo_casing/energy/teleport)
-	shaded_charge = 1
+	shaded_charge = TRUE
 	var/teleport_target = null
 
 /obj/item/gun/energy/telegun/Destroy()

--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -4,9 +4,8 @@
 	icon = 'icons/obj/items_cyborg.dmi'
 	icon_state = "taser"
 	item_state = "armcannonstun4"
-	force = 5
-	selfcharge = 1
-	can_flashlight = 0
+	selfcharge = TRUE
+	can_flashlight = FALSE
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL // Has no trigger at all, uses neural signals instead
 
 /obj/item/gun/energy/laser/mounted
@@ -15,6 +14,5 @@
 	icon = 'icons/obj/items_cyborg.dmi'
 	icon_state = "laser"
 	item_state = "armcannonlase"
-	force = 5
-	selfcharge = 1
+	selfcharge = TRUE
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL

--- a/code/modules/projectiles/sibyl/sibyl_system_mod.dm
+++ b/code/modules/projectiles/sibyl/sibyl_system_mod.dm
@@ -80,7 +80,7 @@ GLOBAL_VAR_INIT(sibsys_automode, TRUE)
 	auth_id = null
 	weapon.update_icon()
 	if(!silent && user)
-		to_chat(user, span_notice("Блокировка [weapon] включенаю"))
+		to_chat(user, span_notice("Блокировка [weapon] включена"))
 	return TRUE
 
 /obj/item/sibyl_system_mod/proc/unlock(mob/user, obj/item/card/id/ID)

--- a/code/modules/projectiles/sibyl/sibyl_system_mod.dm
+++ b/code/modules/projectiles/sibyl/sibyl_system_mod.dm
@@ -45,22 +45,19 @@ GLOBAL_VAR_INIT(sibsys_automode, TRUE)
 	sync_limit()
 	W.update_icon()
 	if(user)
-		to_chat(user, "<span class='notice'>Вы установили [src] в [W]. Установка доступных режимов в соответствии с уровнем опасности ([get_security_level_ru()]).</span>")
+		to_chat(user, span_notice("Вы установили [src] в [W]. Установка доступных режимов в соответствии с уровнем опасности ([get_security_level_ru()])."))
 		if(!auth_id)
-			to_chat(user, "<span class='notice'>Требуется авторизация! Приложите ID-карту.</span>")
+			to_chat(user, span_notice("Требуется авторизация! Приложите ID-карту."))
 
 
 /obj/item/sibyl_system_mod/proc/register(mob/user)
-	if(!isnull(GLOB.sybsis_registry))
-		for(var/obj/item/sibyl_system_mod/mod in GLOB.sybsis_registry)
-			if(mod.UID() == src.UID())
-				return FALSE
 	GLOB.sybsis_registry += list(src)
 	if(!auth_id && user && voice_is_enabled && !voice_cd)
 		voice_cd = addtimer(CALLBACK(src, PROC_REF(play_sound), user, 'sound/voice/dominator/link.ogg'), 4 SECONDS)
 	return TRUE
 
 /obj/item/sibyl_system_mod/proc/uninstall(obj/item/gun/energy/W)
+	GLOB.sybsis_registry -= list(src)
 	forceMove(get_turf(src))
 	W.verbs -= /obj/item/gun/energy/proc/toggle_voice
 
@@ -75,7 +72,7 @@ GLOBAL_VAR_INIT(sibsys_automode, TRUE)
 /obj/item/sibyl_system_mod/proc/toggle_voice(mob/user)
 	voice_is_enabled = !voice_is_enabled
 	if(user)
-		to_chat(user,"<span class='notice'>Голосовая подсистема [voice_is_enabled ? "включена" : "отключена"].</span>")
+		to_chat(user,span_notice("Голосовая подсистема [voice_is_enabled ? "включена" : "отключена"]."))
 
 /obj/item/sibyl_system_mod/proc/lock(mob/user, silent = FALSE)
 	if(emagged)
@@ -83,7 +80,7 @@ GLOBAL_VAR_INIT(sibsys_automode, TRUE)
 	auth_id = null
 	weapon.update_icon()
 	if(!silent && user)
-		to_chat(user, "<span class='notice'>Блокировка [weapon] включена.</span>")
+		to_chat(user, span_notice("Блокировка [weapon] включенаю"))
 	return TRUE
 
 /obj/item/sibyl_system_mod/proc/unlock(mob/user, obj/item/card/id/ID)
@@ -95,26 +92,26 @@ GLOBAL_VAR_INIT(sibsys_automode, TRUE)
 		auth_id = TRUE
 	weapon.update_icon()
 	if(user)
-		to_chat(user, "<span class='notice'>Блокировка [weapon] отключена.</span>")
+		to_chat(user, span_notice("Блокировка [weapon] отключена."))
 	return TRUE
 
 /obj/item/sibyl_system_mod/proc/toggleAuthorization(obj/item/card/id/ID, mob/user)
 	if(state != SIBSYS_STATE_INSTALLED)
 		return FALSE
 	if(emagged)
-		to_chat(user, "<span class='danger'>As you try to swipe [ID], sparks flying out of it!</span>")
+		to_chat(user, span_danger("As you try to swipe [ID], sparks flying out of it!"))
 		return
 	if(!auth_id)
 		unlock(user, ID)
-		to_chat(user, "<span class='notice'>Вы авторизировали [weapon] в системе Sibyl System под именем [auth_id.registered_name].</span>")
+		to_chat(user, span_notice("Вы авторизировали [weapon] в системе Sibyl System под именем [auth_id.registered_name]."))
 		if(user && voice_is_enabled && !voice_cd)
 			voice_cd = addtimer(CALLBACK(src, PROC_REF(play_sound), user, 'sound/voice/dominator/user.ogg'), 2 SECONDS)
 	else if(auth_id == ID)
 		lock(user)
-		to_chat(user, "<span class='notice'>Вы деавторизировали [weapon] в системе Sibyl System.</span>")
+		to_chat(user, span_notice("Вы деавторизировали [weapon] в системе Sibyl System."))
 	else if(ACCESS_ARMORY in ID.GetAccess())
 		lock(user)
-		to_chat(user, "<span class='notice'>Вы принудительно деавторизировали [weapon] в системе Sibyl System.</span>")
+		to_chat(user, span_notice("Вы принудительно деавторизировали [weapon] в системе Sibyl System."))
 	weapon.update_icon()
 	return TRUE
 
@@ -132,10 +129,10 @@ GLOBAL_VAR_INIT(sibsys_automode, TRUE)
 		return FALSE
 	if(!emagged)
 		if(!auth_id)
-			to_chat(user, "<span class='warning'>Требуется авторизация! Приложите ID-карту.</span>")
+			to_chat(user, span_warning("Требуется авторизация! Приложите ID-карту."))
 			return FALSE
 		if(!find_and_compare_id_cards(user, auth_id))
-			to_chat(user, "<span class='warning'>Ваша ID-карта не совпадает с авторизованной.</span>")
+			to_chat(user, span_warning("Ваша ID-карта не совпадает с авторизованной."))
 			return FALSE
 	if(!check_charge)
 		if(user && voice_is_enabled && !voice_cd)
@@ -165,7 +162,7 @@ GLOBAL_VAR_INIT(sibsys_automode, TRUE)
 	var/message = "Для [weapon] теперь доступны только данные режимы: [get_available_text()]!"
 	weapon.update_icon()
 	if(ismob(weapon.loc))
-		to_chat(weapon.loc, "<span class='notice'>[message]</span>")
+		to_chat(weapon.loc, span_notice("[message]"))
 	return TRUE
 
 /obj/item/sibyl_system_mod/proc/sync_limit()
@@ -182,6 +179,8 @@ GLOBAL_VAR_INIT(sibsys_automode, TRUE)
 			set_limit(SIBYL_DESTRUCTIVE)
 		if(SEC_LEVEL_DELTA)
 			set_limit(SIBYL_DESTRUCTIVE)
+	if(!check_select(weapon?.select))
+		weapon.select_fire()
 
 /obj/item/sibyl_system_mod/proc/check_unknown_names()
 	for(var/obj/item/ammo_casing/energy/ammo in weapon.ammo_type)

--- a/code/modules/security_levels/security_levels.dm
+++ b/code/modules/security_levels/security_levels.dm
@@ -127,23 +127,8 @@ GLOBAL_DATUM_INIT(security_announcement_down, /datum/announcement/priority/secur
 		SSblackbox.record_feedback("tally", "security_level_changes", 1, level)
 
 		if(GLOB.sibsys_automode && !isnull(GLOB.sybsis_registry))
-			var/limit = SIBYL_NONLETHAL
-			switch(GLOB.security_level)
-				if(SEC_LEVEL_GREEN)
-					limit = SIBYL_NONLETHAL
-				if(SEC_LEVEL_BLUE)
-					limit = SIBYL_LETHAL
-				if(SEC_LEVEL_RED)
-					limit = SIBYL_LETHAL
-				if(SEC_LEVEL_GAMMA)
-					limit = SIBYL_DESTRUCTIVE
-				if(SEC_LEVEL_EPSILON)
-					limit = SIBYL_DESTRUCTIVE
-				if(SEC_LEVEL_DELTA)
-					limit = SIBYL_DESTRUCTIVE
-
 			for(var/obj/item/sibyl_system_mod/mod in GLOB.sybsis_registry)
-				mod.set_limit(limit)
+				mod.sync_limit()
 	else
 		return
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
- На изменении "Кода Безопасности" оставляет к циклу с сибилами их встроенный прок проверки соответствия режима стрельбы - коду. Туда уже впихивает прок на смену режима стрельбы.
- Исправляет и удаляет некоторые *тупые* переменные в коде лазерного оружия и расставляет проки-дефайники для лучшей читабельности.
- Меняет дефайн `CHANNEL_SIBYL_SYSTEM` неиспользуемого канала и его комментарий на "более актуальные" по просьбе Бипа.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на баг-репорт
https://discord.com/channels/617003227182792704/1185126780621836319<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
