### PR TITLE
bugfix: Mousedropping into inventory screen elements now considered to be pickup. Energy Katana no longer can be equipped without damaging wrists

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -547,6 +547,8 @@
 		(slot_id == slot_r_hand && !user.put_in_r_hand(I, ignore_anim = FALSE)))
 		return FALSE
 
+	I.pickup(user)
+
 
 /obj/screen/inventory/hand
 	var/image/active_overlay

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -232,6 +232,7 @@
 			S.orient2hud(user)
 			S.show_to(user)
 	else // If it's not in the storage, try putting it inside
+		I.pickup(user) //Do not actually put in hands, but rather make some funny effects out of it
 		S.attackby(I, user)
 	return TRUE
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление, убирающее возможность брать катану без урона в руки через перетаскивание мыши.
А также в процессе маусдропа по инвентарю заставляет проводить pickup предмета если все проверки пройдены успешно
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
https://discord.com/channels/617003227182792704/918070331716010014/1187784966185177158

