### PR TITLE
bugfix: maybe fixing many legion skulls spawn from dead bodies

### DIFF
--- a/code/modules/mining/equipment/regenerative_core.dm
+++ b/code/modules/mining/equipment/regenerative_core.dm
@@ -262,6 +262,9 @@
 	owner.forceMove(L)
 	if(prob(75) && owner.get_int_organ(/obj/item/organ/internal/legion_tumour))
 		qdel(src) // Congratulations you haven't won a very special prize: second cancer in a row!
+	else
+		stage = 0
+		elapsed_time = 0
 
 /obj/item/organ/internal/legion_tumour/on_find(mob/living/finder)
 	. = ..()

--- a/code/modules/mining/equipment/regenerative_core.dm
+++ b/code/modules/mining/equipment/regenerative_core.dm
@@ -260,10 +260,8 @@
 	owner.adjustBruteLoss(1000)
 	L.stored_mob = owner
 	owner.forceMove(L)
-	qdel(src)
-	if(prob(25) && !owner.get_int_organ(/obj/item/organ/internal/legion_tumour)) // Congratulations you have won a very special prize: second cancer in a row!
-		var/obj/item/organ/internal/legion_tumour/cancer = new()
-		cancer.insert(owner, special = TRUE)
+	if(prob(75) && owner.get_int_organ(/obj/item/organ/internal/legion_tumour))
+		qdel(src) // Congratulations you haven't won a very special prize: second cancer in a row!
 
 /obj/item/organ/internal/legion_tumour/on_find(mob/living/finder)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/mining/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/hivelord.dm
@@ -209,7 +209,7 @@
 	visible_message("<span class='warning'>The skulls on [src] wail in anger as they flee from their dying host!</span>")
 	var/turf/T = get_turf(src)
 	for(var/i in 1 to 2)
-		new brood_type(T)
+		new /mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion/weaken(T)
 	if(T)
 		if(stored_mob)
 			stored_mob.forceMove(get_turf(src))
@@ -248,10 +248,11 @@
 	del_on_death = TRUE
 	stat_attack = UNCONSCIOUS
 	robust_searching = 1
+	var/can_infest = TRUE
 	var/can_infest_dead = FALSE
 
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion/Life(seconds, times_fired)
-	if(isturf(loc))
+	if(isturf(loc) && can_infest)
 		for(var/mob/living/carbon/human/H in view(src,1)) //Only for corpse right next to/on same tile
 			if(H.stat == UNCONSCIOUS || (can_infest_dead && H.stat == DEAD))
 				infest(H)
@@ -300,6 +301,12 @@
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion/advanced
 	stat_attack = DEAD
 	can_infest_dead = TRUE
+
+/mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion/weaken
+	melee_damage_lower = 6
+	melee_damage_upper = 6
+	can_infest = FALSE
+
 
 //Legion that spawns Legions
 /mob/living/simple_animal/hostile/big_legion


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Меняет логику добавления раковой опухоли (мне сказали, что писать код после "qdel" это очень плохо и так работать не должно)
Меняет черепки легионов, спавнящиеся при смерти родителя на специальные ослабленные версии, которые не слегка слабее и не могут заражать, чтобы не происходило вероятного бага, когда кукла, выпадающая из легиона, заражалась ими же.
В теории это должно починить проблемы с легионами. Если не починит, попробуем решить радикально.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багфикс
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
