### PR TITLE
bugfix: normal security enforcer in "enforcer kit"

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1227,7 +1227,7 @@
 		add_fingerprint(user)
 		var/list/available_kits = list(
 			"Dominator Kit" = list(/obj/item/gun/energy/dominator/sibyl, /obj/item/clothing/accessory/holster),
-			"Enforcer Kit" = list(/obj/item/gun/projectile/automatic/pistol/enforcer, /obj/item/ammo_box/magazine/enforcer, /obj/item/ammo_box/magazine/enforcer, /obj/item/clothing/accessory/holster),
+			"Enforcer Kit" = list(/obj/item/gun/projectile/automatic/pistol/enforcer/security, /obj/item/ammo_box/magazine/enforcer, /obj/item/ammo_box/magazine/enforcer, /obj/item/clothing/accessory/holster),
 		)
 		var/weapon_kit = input(user, "Select a weaponary kit.") as null|anything in available_kits
 		if(!weapon_kit)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Меняет энфорсер в наборе ваучеров СБ на офицерский.
Офицерский энфорсер:
-Среднего размера, не даёт хранить его в кармане.
-Не имеет нелегала в технологиях (обычный энфорсер наследует нелегал от Стечкина).
-Имеет русифицированое описание.
-Всегда был у офицеров, в отличие от оригинального энфорсера, что в игре встречается только у торгашей.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багфикс
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
