### PR TITLE
bugfix: fixed yarn watch warning spam

### DIFF
--- a/tgui/packages/tgui/webpack.config.js
+++ b/tgui/packages/tgui/webpack.config.js
@@ -70,6 +70,7 @@ module.exports = (env = {}, argv) => {
                   'babel-plugin-inferno',
                   'babel-plugin-transform-remove-console',
                   'common/string.babel-plugin.cjs',
+                  ['@babel/plugin-transform-private-methods', { loose: false }],
                 ],
               },
             },


### PR DESCRIPTION


<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Добавил ['@babel/plugin-transform-private-methods', { loose: false }], чтобы yarn watch не спамил сообщениями
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

```Though the "loose" option was set to "true" in your @babel/preset-env config, it will not be used for @babel/plugin-transform-private-methods since the "loose" mode option was set to "false" for @babel/plugin-transform-class-properties.
The "loose" option must be the same for @babel/plugin-transform-class-properties,
 @babel/plugin-transform-private-methods 
and @babel/plugin-transform-private-property-in-object
 (when they are enabled): you can silence this warning by explicitly adding
        ["@babel/plugin-transform-private-methods", { "loose": false }]```
