### PR TITLE
bugfix: Fix animal ability to see in darkness

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -632,6 +632,7 @@
 			return
 
 	SEND_SIGNAL(src, COMSIG_MOB_UPDATE_SIGHT)
+	overlay_fullscreen("see_through_darkness", /obj/screen/fullscreen/see_through_darkness)
 	sync_lighting_plane_alpha()
 
 /mob/living/simple_animal/proc/toggle_ai(togglestatus)


### PR DESCRIPTION
## Описание
Фиксит возможность симпл энималов видеть во тьме.

## Причина создания ПР
В данный момент симпл энималы абсолютно не видят во тьме, хотя показатели их радиуса виденья во тьме выше чем у людей.
