### PR TITLE
add: Added nice presents positioning around Christmas trees

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -14,15 +14,18 @@
 	name = "pine tree"
 	icon = 'icons/obj/flora/pinetrees.dmi'
 	icon_state = "pine_1"
+	var/randomize_tree = TRUE
 
 /obj/structure/flora/tree/pine/Initialize(mapload)
 	. = ..()
-	icon_state = "pine_[rand(1, 3)]"
+	if(randomize_tree)
+		icon_state = "pine_[rand(1, 3)]"
 
 /obj/structure/flora/tree/pine/xmas
 	name = "xmas tree"
 	icon = 'icons/obj/flora/pinetrees.dmi'
 	icon_state = "pine_c"
+	randomize_tree = FALSE
 
 /obj/structure/flora/tree/dead
 	icon = 'icons/obj/flora/deadtrees.dmi'

--- a/code/modules/holiday/christmas.dm
+++ b/code/modules/holiday/christmas.dm
@@ -1,9 +1,12 @@
 /datum/holiday/xmas/handle_event()
-	for(var/obj/structure/flora/tree/pine/xmas in world)
+	for(var/obj/structure/flora/tree/pine/xmas/xmas in world)
 		if(!is_station_level(xmas.z))	continue
-		for(var/turf/simulated/floor/T in orange(1,xmas))
+		for(var/turf/simulated/floor/T in (xmas.get_all_adjacent_turfs() - get_turf(xmas)))
+			var/direction = get_dir(xmas, T)
 			for(var/i=1,i<=rand(1,5),i++)
-				new /obj/item/a_gift(T)
+				var/obj/item/a_gift/gift = new(T)
+				handle_present_location(gift, direction, 16)
+
 	for(var/mob/living/simple_animal/pet/dog/corgi/Ian/Ian in GLOB.mob_list)
 		Ian.place_on_head(new /obj/item/clothing/head/helmet/space/santahat)
 	for(var/datum/crafting_recipe/snowman/S in GLOB.crafting_recipes)
@@ -13,6 +16,40 @@
 	xmas.special = FALSE
 	if(prob(eventChance))
 		spawnTree()
+/**
+ * Offsets pixel location for presents to move visually closer to direction
+ */
+/datum/holiday/xmas/proc/handle_present_location(obj/present, center_direction, offset)
+	var/pixel_x_offset = 0
+	var/pixel_y_offset = 0
+	switch(center_direction)
+		if(NORTH)
+			pixel_x_offset = rand(-offset, offset)
+			pixel_y_offset = rand(-offset, 0)
+		if(SOUTH)
+			pixel_x_offset = rand(-offset, offset)
+			pixel_y_offset = rand(0, offset)
+		if(EAST)
+			pixel_x_offset = rand(-offset, 0)
+			pixel_y_offset = rand(-offset, offset)
+		if(WEST)
+			pixel_x_offset = rand(0, offset)
+			pixel_y_offset = rand(-offset, offset)
+		if(NORTHEAST)
+			pixel_x_offset = rand(-offset, 0)
+			pixel_y_offset = rand(-offset, 0)
+		if(NORTHWEST)
+			pixel_x_offset = rand(0, offset)
+			pixel_y_offset = rand(-offset, 0)
+		if(SOUTHEAST)
+			pixel_x_offset = rand(-offset, 0)
+			pixel_y_offset = rand(0, offset)
+		if(SOUTHWEST)
+			pixel_x_offset = rand(0, offset)
+			pixel_y_offset = rand(0, offset)
+
+	present.pixel_x = pixel_x_offset
+	present.pixel_y = pixel_y_offset
 
 /datum/holiday/xmas/proc/spawnTree()
 	for(var/obj/structure/flora/tree/pine/xmas in world)

--- a/code/modules/holiday/christmas.dm
+++ b/code/modules/holiday/christmas.dm
@@ -14,8 +14,11 @@
 		break
 	var/datum/supply_packs/misc/snow_machine/xmas = SSshuttle.supply_packs["[/datum/supply_packs/misc/snow_machine]"]
 	xmas.special = FALSE
-	if(prob(eventChance))
-		spawnTree()
+
+	//As fun at it is sounds, peacefulness is better
+	//if(prob(eventChance))
+	//	spawnTree()
+
 /**
  * Offsets pixel location for presents to move visually closer to direction
  */


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Обновление, добавляющее смещение подарков при их помещении во время Рождества такое, что они будут расположены ближе к ёлке.
Также включает исправление, позволяющее инициализироваться рождественским деревьям с корректной иконкой.
Выключил ивент враждебных ёлок, т.к это приводит только к несуразице (и ёлкам, которые жрут бармена раундстартом)
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Праздник к нам приходит
## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
![изображение](https://github.com/ss220-space/Paradise/assets/73733747/745f5e86-becb-4986-a08d-ae9439540a3a)

![изображение](https://github.com/ss220-space/Paradise/assets/73733747/b42261e0-f255-43c4-839a-a1fd4dd9ade4)
