### PR TITLE
bugfix: fixed false blastdoor opening

### DIFF
--- a/code/game/mecha/working/gigadrill.dm
+++ b/code/game/mecha/working/gigadrill.dm
@@ -20,6 +20,7 @@
 
 	starting_voice = /obj/item/mecha_modkit/voice/silent
 
+	ruin_mecha = TRUE
 	stepsound = null
 	turnsound = null
 //	wreckage = /obj/effect/decal/mecha_wreckage/gigadrill // no dmi :(

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -156,8 +156,6 @@ GLOBAL_DATUM_INIT(the_gateway, /obj/machinery/gateway/centerstation, null)
 		var/obj/effect/landmark/dest = pick(GLOB.awaydestinations)
 		if(dest)
 			moving_atom.forceMove(dest.loc)
-			var/area/entry_area = get_area(dest)
-			entry_area.Entered(moving_atom)
 			moving_atom.dir = SOUTH
 			use_power(5000)
 		return
@@ -281,8 +279,6 @@ GLOBAL_DATUM_INIT(the_gateway, /obj/machinery/gateway/centerstation, null)
 				return
 	var/turf/destination = get_step(stationgate.loc, SOUTH)
 	moving_atom.forceMove(destination)
-	var/area/entry_area = get_area(destination)
-	entry_area.Entered(moving_atom)
 	moving_atom.setDir(SOUTH)
 	if(ismob(moving_atom))
 		var/mob/M = moving_atom

--- a/code/modules/awaymissions/mission_code/evil_santa.dm
+++ b/code/modules/awaymissions/mission_code/evil_santa.dm
@@ -129,6 +129,7 @@
 			to_chat(trapped_one, span_danger("YOU'VE BEEN TOO NAUGHTY THIS YEAR AND NOW YOU WILL BE PUNISHED!"))
 
 /area/vision_change_area/awaymission/evil_santa/end/santa/proc/ready_or_not()
+	SIGNAL_HANDLER
 	if(!naughty_guys)
 		naughty_guys = list()
 	for(var/mob/living/carbon/naughty in naughty_guys)

--- a/code/modules/mob/living/simple_animal/hostile/winter_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/winter_mobs.dm
@@ -89,15 +89,18 @@
 /mob/living/simple_animal/hostile/winter/santa/death(gibbed)
 	// Only execute the below if we successfully died
 	. = ..(gibbed)
-	bossfight_area.ready_or_not()
 	if(!.)
 		return FALSE
 	if(death_message)
 		visible_message(death_message)
 	if(next_stage)
 		spawn(1 SECONDS)
-			new next_stage(get_turf(src))
-			qdel(src)	//hide the body
+			if(!QDELETED(src))
+				new next_stage(get_turf(src))
+				qdel(src)	//hide the body
+			bossfight_area.ready_or_not()
+	else
+		bossfight_area.ready_or_not()
 
 /mob/living/simple_animal/hostile/winter/santa/stage_1		//stage 1: slow melee
 	maxHealth = 150


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

Исправляет открытие дверей арены до полной победы над сантой или смерти плохишей
Отключает маяк у трактора (меха) в гейте, чтобы его нельзя было увидеть в консоли
Убирает лишний мув атом для спец зоны
