### PR TITLE
bugfix: remove confusing hands overlay again

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -419,7 +419,7 @@
 /obj/screen/inventory/proc/add_overlays()
 	var/mob/user = hud?.mymob
 
-	if(!user || !slot_id)
+	if(!user || !slot_id || slot_id == slot_l_hand || slot_id == slot_r_hand)
 		return
 
 	var/obj/item/holding = user.get_active_hand()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Делаем снова чтобы когда вы наводились на вашу вторую руку с активной рукой у вас не было этого оверлея:
![image](https://github.com/ss220-space/Paradise/assets/120549107/2bd7e803-b520-4eee-8473-43e04b73c4f1)

Оверлей появляется, если навестись на пустую неактивную руку, но по клику происходит смена руки. Данный PR убирает этот оверлей для рук.

<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Это было исправлено в #2659, но потом было случайно отменено в одном из больших ПРов, возвращаем.

<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

