### PR TITLE
bugfix: Protolathe now shows correct buildability state

### DIFF
--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -81,9 +81,9 @@ Note: Must be placed west/left of and R&D console to function.
 	var/A = materials.amount(M)
 	if(!A)
 		A = reagents.get_reagent_amount(M)
-		A = A / max(1, (being_built.reagents_list[M]))
+		A = A / max(1, (being_built.reagents_list[M] * efficiency_coeff))
 	else
-		A = A / max(1, (being_built.materials[M]))
+		A = A / max(1, (being_built.materials[M] * efficiency_coeff))
 	return A
 
 /obj/machinery/r_n_d/protolathe/attackby(var/obj/item/O as obj, var/mob/user as mob, params)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление ошибки, при которой предварительный подсчёт возможности склепать изделие по чертежу в портолате не учитывал скидку на производство от компонентов.

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
Было
![изображение](https://github.com/ss220-space/Paradise/assets/73733747/395e07fa-5658-4694-b206-79a84a1a2345)
![изображение](https://github.com/ss220-space/Paradise/assets/73733747/cfaa79e5-e679-4dc3-bf84-8c6fe911833f)
Стало
![изображение](https://github.com/ss220-space/Paradise/assets/73733747/5072a7d6-ee47-4a3b-b245-d315971099dc)

