### PR TITLE
tweak: setCloneLoss now can unmutate organs

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -182,6 +182,12 @@
 			O.heal_damage(0, -amount, internal = FALSE, robo_repair = O.is_robotic(), updating_health = updating_health)
 	return STATUS_UPDATE_HEALTH
 
+/mob/living/carbon/human/setCloneLoss(amount, updating_health)
+	. = ..()
+	if(getCloneLoss() < 1) //assuming cloneloss was set to 0
+		for(var/obj/item/organ/external/bodypart as anything in bodyparts)
+			bodypart.unmutate()
+
 /mob/living/carbon/human/adjustCloneLoss(amount, updating_health)
 	if(dna.species && amount > 0)
 		amount = amount * (dna.species.clone_mod + get_vampire_bonus(CLONE))


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
setCloneLoss может теперь убирать мутации внешних органов при условии, что вызван setCloneLoss(0)
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Надо для реализации PR'a https://github.com/ss220-space/Paradise/pull/4101, да и просто QoL кодерам без необходимости лепить костыль в виде adjustCloneLoss(-1)