### PR TITLE
Fix: duplicate coat on throwing to the coat rack

### DIFF
--- a/code/game/objects/structures/coathanger.dm
+++ b/code/game/objects/structures/coathanger.dm
@@ -32,7 +32,7 @@
 	for(var/T in allowed)
 		if(istype(W,T))
 			can_hang = TRUE
-			continue
+			break
 
 	if(can_hang && !coat)
 		add_fingerprint(user)
@@ -43,21 +43,37 @@
 	else
 		return ..()
 
-/obj/structure/coatrack/CanPass(atom/movable/mover, turf/target, height=0)
+/obj/structure/coatrack/MouseDrop_T(obj/item/W, mob/user)
 	var/can_hang = FALSE
 	for(var/T in allowed)
-		if(istype(mover,T))
+		if(istype(W,T))
 			can_hang = TRUE
-			continue
+			break
 
 	if(can_hang && !coat)
-		visible_message("[mover] lands on \the [src].")
-		coat = mover
-		coat.loc = src
+		add_fingerprint(user)
+		user.visible_message("[user] hangs [W] on \the [src].", "You hang [W] on the \the [src].")
+		coat = W
+		user.drop_transfer_item_to_loc(W, src)
 		update_icon()
-		return 0
 	else
 		return ..()
+
+// Hanging a coat on the hanger only after a bump. Force stoping throwing
+/obj/structure/coatrack/Bumped(atom/movable/moving_atom)
+	..()
+
+	if (coat)
+		return
+
+	for (var/T in allowed)
+		if (!istype(moving_atom, T))
+			continue
+		visible_message("[moving_atom] lands on \the [src].")
+		moving_atom.forceMove(src)
+		coat = moving_atom
+		update_icon()
+		return
 
 /obj/structure/coatrack/update_icon()
 	overlays.Cut()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Фикс бага с дублированием халата (по факту оставался одним объектом) и прочих вещей (которые можно повесить на вешалку) при броске на соседний тайл с вешалкой: халат одновременно оказывался на тайле и на вешалке.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Проверил на локале, воспроизводится каждый раз.
Ссылка на багрепорт:
https://discord.com/channels/617003227182792704/1191978857134313584/1191978857134313584
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
Теперь этого не происходит и халат остается висеть на вешалке, если она была пустая. Так же добавлена возможность повесить вещь перетаскиванием ее на вешалку.
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
