### PR TITLE
bugfix: normal chair smashing logic.

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -596,6 +596,9 @@
 	if(istype(dreamer.buckled, /obj/structure/bed))
 		var/obj/structure/bed/bed = dreamer.buckled
 		comfort += bed.comfort
+	else if(istype(dreamer.buckled, /obj/structure/chair))
+		var/obj/structure/chair/chair = dreamer.buckled
+		comfort += chair.comfort
 	for(var/obj/item/bedsheet/bedsheet in range(dreamer.loc,0))
 		if(bedsheet.loc != dreamer.loc) //bedsheets in your backpack/neck don't give you comfort
 			continue

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -1,4 +1,4 @@
-/obj/structure/chair	// fuck you Pete
+/obj/structure/chair	// fuck you Pete and Jonsonmt
 	name = "chair"
 	desc = "You sit in this. Either by will or force."
 	icon = 'icons/obj/chairs.dmi'
@@ -15,7 +15,7 @@
 	var/item_chair = /obj/item/chair // if null it can't be picked up
 	var/movable = FALSE // For mobility checks
 	var/propelled = FALSE // Check for fire-extinguisher-driven chairs
-	var/comfort = 0
+	var/comfort = 0.3
 
 /obj/structure/chair/narsie_act()
 	if(prob(20))
@@ -45,7 +45,7 @@
 	if(istype(W, /obj/item/assembly/shock_kit))
 		var/obj/item/assembly/shock_kit/SK = W
 		if(!SK.status)
-			to_chat(user, "<span class='notice'>[SK] is not ready to be attached!</span>")
+			to_chat(user, span_notice("[SK] is not ready to be attached!"))
 			return
 		user.drop_from_active_hand()
 		var/obj/structure/chair/e_chair/E = new /obj/structure/chair/e_chair(get_turf(src), SK)
@@ -61,7 +61,7 @@
 /obj/structure/chair/wrench_act(mob/user, obj/item/I)
 	. = TRUE
 	if(flags & NODECONSTRUCT)
-		to_chat(user, "<span class='warning'>Try as you might, you can't figure out how to deconstruct [src].</span>")
+		to_chat(user, span_warning("Try as you might, you can't figure out how to deconstruct [src]."))
 		return
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
@@ -79,23 +79,23 @@
 		if(!item_chair || has_buckled_mobs() || anchored)
 			return
 		if(usr.incapacitated())
-			to_chat(usr, "<span class='warning'>You can't do that right now!</span>")
+			to_chat(usr, span_warning("You can't do that right now!"))
 			return
 		if(!usr.has_right_hand() && !usr.has_left_hand())
-			to_chat(usr, "<span class='warning'>You try to grab the chair, but you are missing both of your hands!</span>")
+			to_chat(usr, span_warning("You try to grab the chair, but you are missing both of your hands!"))
 			return
 		if(usr.get_active_hand() && usr.get_inactive_hand())
-			to_chat(usr, "<span class='warning'>You try to grab the chair, but your hands are already full!</span>")
+			to_chat(usr, span_warning("You try to grab the chair, but your hands are already full!"))
 			return
 		if(!ishuman(usr))
 			return
-		usr.visible_message("<span class='notice'>[usr] grabs \the [src.name].</span>", "<span class='notice'>You grab \the [src.name].</span>")
+		usr.visible_message(span_notice("[usr] grabs \the [src]."), span_notice("You grab \the [src]."))
 		var/C = new item_chair(drop_location())
 		usr.put_in_hands(C, ignore_anim = FALSE)
 		transfer_fingerprints_to(C)
 		qdel(src)
 
-/obj/structure/chair/attack_tk(mob/user as mob)
+/obj/structure/chair/attack_tk(mob/user)
 	if(!anchored || has_buckled_mobs() || !isturf(user.loc))
 		..()
 	else
@@ -177,6 +177,7 @@
 	max_integrity = 70
 	buildstackamount = 2
 	item_chair = null
+	comfort = 0.6
 	var/image/armrest = null
 
 /obj/structure/chair/comfy/Initialize(mapload)
@@ -232,12 +233,6 @@
 /obj/structure/chair/comfy/lime
 	color = rgb(255,251,0)
 
-/obj/structure/chair/office
-	movable = TRUE
-	item_chair = null
-	buildstackamount = 5
-	pull_push_speed_modifier = 1
-
 /obj/structure/chair/comfy/shuttle
 	name = "shuttle seat"
 	desc = "A comfortable, secure seat. It has a more sturdy looking buckling system, for smoother flights."
@@ -253,6 +248,12 @@
 /obj/structure/chair/comfy/shuttle/dark/GetArmrest()
 	return mutable_appearance('icons/obj/chairs.dmi', "shuttle_chair_dark_armrest")
 
+/obj/structure/chair/office
+	movable = TRUE
+	item_chair = null
+	buildstackamount = 5
+	pull_push_speed_modifier = 1
+
 /obj/structure/chair/office/Bump(atom/A)
 	..()
 	if(!has_buckled_mobs())
@@ -267,7 +268,7 @@
 			buckled_mob.Stuttering(12 SECONDS)
 			buckled_mob.take_organ_damage(10)
 			playsound(loc, 'sound/weapons/punch1.ogg', 50, 1, -1)
-			buckled_mob.visible_message("<span class='danger'>[buckled_mob] crashed into [A]!</span>")
+			buckled_mob.visible_message(span_danger("[buckled_mob] crashed into [A]!"))
 
 /obj/structure/chair/office/light
 	icon_state = "officechair_white"
@@ -277,7 +278,6 @@
 
 /obj/structure/chair/barber
 	icon_state = "barber_chair"
-	buildstackamount = 1
 	item_chair = null
 	anchored = TRUE
 
@@ -287,7 +287,7 @@
 	icon_state = "leather_sofa_middle"
 	anchored = TRUE
 	item_chair = null
-	buildstackamount = 1
+	comfort = 0.6
 	var/image/armrest = null
 
 /obj/structure/chair/sofa/Initialize(mapload)
@@ -343,8 +343,8 @@
 	name = "pew"
 	desc = "Rigid and uncomfortable, perfect for keeping you awake and alert."
 	icon_state = "pewmiddle"
-	buildstackamount = 1
 	buildstacktype = /obj/item/stack/sheet/wood
+	comfort = 0.2
 
 /obj/structure/chair/sofa/pew/left
 	icon_state = "pewend_left"
@@ -396,8 +396,6 @@
 	icon_state = "stool_toppled"
 	item_state = "stool"
 	force = 10
-	throwforce = 10
-	w_class = WEIGHT_CLASS_HUGE
 	origin_type = /obj/structure/chair/stool
 	break_chance = 0 //It's too sturdy.
 
@@ -421,16 +419,16 @@
 
 	for(var/obj/A in get_turf(loc))
 		if(istype(A, /obj/structure/chair))
-			to_chat(user, "<span class='danger'>There is already [A] here.</span>")
+			to_chat(user, span_danger("There is already [A] here."))
 			return
 
-	user.visible_message("<span class='notice'>[user] rights \the [src.name].</span>", "<span class='notice'>You right \the [name].</span>")
+	user.visible_message(span_notice("[user] rights \the [src]."), span_notice("You right \the [src]."))
 	var/obj/structure/chair/C = new origin_type(get_turf(loc))
 	transfer_fingerprints_to(C)
 	C.setDir(dir)
 	qdel(src)
 
-/obj/item/chair/proc/smash(mob/living/user)
+/obj/item/chair/proc/smash()
 	var/stack_type = initial(origin_type.buildstacktype)
 	if(!stack_type)
 		return
@@ -443,35 +441,27 @@
 
 /obj/item/chair/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(attack_type == UNARMED_ATTACK && prob(hit_reaction_chance))
-		owner.visible_message("<span class='danger'>[owner] fends off [attack_text] with [src]!</span>")
-		return 1
-	return 0
+		owner.visible_message(span_danger("[owner] fends off [attack_text] with [src]!"))
+		return TRUE
+	return FALSE
 
-/obj/item/chair/afterattack(atom/target, mob/living/carbon/user, proximity)
-	..()
-	if(!proximity)
-		return
-	if(prob(break_chance))
-		user.visible_message("<span class='danger'>[user] smashes \the [src] to pieces against \the [target]</span>")
-		if(iscarbon(target))
-			var/mob/living/carbon/C = target
+/obj/item/chair/attack(mob/M, mob/user)
+	if(..() && prob(break_chance))
+		user.visible_message(span_combatdanger("[user] smashes \the [src] to pieces against \the [M]."))
+		if(iscarbon(M))
+			var/mob/living/carbon/C = M
 			if(C.health < C.maxHealth*0.5)
 				C.Weaken(12 SECONDS)
 				C.Stuttering(12 SECONDS)
-				playsound(src.loc, 'sound/weapons/punch1.ogg', 50, 1, -1)
-		smash(user)
+				playsound(loc, 'sound/weapons/punch1.ogg', 50, TRUE, -1)
+		smash()
+		return TRUE
 
-/obj/item/chair/stool/attack(mob/M as mob, mob/user as mob)
-	if(prob(5) && isliving(M))
-		user.visible_message("<span class='danger'>[user] breaks [src] over [M]'s back!.</span>")
-		user.drop_item_ground(src)
-		var/obj/item/stack/sheet/metal/m = new/obj/item/stack/sheet/metal
-		m.loc = get_turf(src)
-		qdel(src)
-		var/mob/living/T = M
-		T.Weaken(6 SECONDS)
-		return
+/obj/item/chair/attack_obj(obj/O, mob/living/user, params)
 	..()
+	if(prob(break_chance))
+		user.visible_message(span_danger("[user] smashes \the [src] to pieces against \the [O]."))
+		smash()
 
 /obj/item/chair/wood
 	name = "wooden chair"
@@ -496,6 +486,7 @@
 	desc = "You sit in this. Either by will or force. Looks REALLY uncomfortable."
 	icon_state = "chairold"
 	item_chair = null
+	comfort = 0
 
 // Brass chair
 /obj/structure/chair/brass
@@ -504,8 +495,8 @@
 	icon_state = "brass_chair"
 	max_integrity = 150
 	buildstacktype = /obj/item/stack/sheet/brass
-	buildstackamount = 1
 	item_chair = null
+	comfort = 0.2
 	var/turns = 0
 
 /obj/structure/chair/brass/Destroy()
@@ -513,7 +504,7 @@
 	. = ..()
 
 /obj/structure/chair/brass/process()
-	setDir(turn(dir,-90))
+	setDir(turn(dir, -90))
 	playsound(src, 'sound/effects/servostep.ogg', 50, FALSE)
 	turns++
 	if(turns >= 8)
@@ -524,19 +515,19 @@
 
 /obj/structure/chair/brass/AltClick(mob/living/user)
 	if(!istype(user) || user.incapacitated())
-		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
+		to_chat(user, span_warning("You can't do that right now!"))
 		return
 	if(!in_range(src, user))
 		return
 	add_fingerprint(user)
 	turns = 0
 	if(!isprocessing)
-		user.visible_message("<span class='notice'>[user] spins [src] around, and Ratvarian technology keeps it spinning FOREVER.</span>", \
-		"<span class='notice'>Automated spinny chairs. The pinnacle of Ratvarian technology.</span>")
+		user.visible_message(span_notice("[user] spins [src] around, and Ratvarian technology keeps it spinning FOREVER."), \
+		span_notice("Automated spinny chairs. The pinnacle of Ratvarian technology."))
 		START_PROCESSING(SSfastprocess, src)
 	else
-		user.visible_message("<span class='notice'>[user] stops [src]'s uncontrollable spinning.</span>", \
-		"<span class='notice'>You grab [src] and stop its wild spinning.</span>")
+		user.visible_message(span_notice("[user] stops [src]'s uncontrollable spinning."), \
+		span_notice("You grab [src] and stop its wild spinning."))
 		STOP_PROCESSING(SSfastprocess, src)
 
 /obj/structure/chair/brass/fake
@@ -551,7 +542,6 @@
 	anchored = TRUE
 	max_integrity = 375
 	buildstacktype = /obj/item/stack/sheet/mineral/abductor
-	buildstackamount = 2
 
 /obj/structure/chair/comfy/abductor/GetArmrest()
 	return mutable_appearance('icons/obj/chairs.dmi', "alien_chair_armrest")

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -412,10 +412,11 @@ emp_act
 		w_uniform.add_fingerprint(user)
 	return ..()
 
-//Returns 1 if the attack hit, 0 if it missed.
+
+//Returns TRUE if the attack hit, FALSE if it missed.
 /mob/living/carbon/human/attacked_by(obj/item/I, mob/living/user, def_zone)
 	if(!I || !user)
-		return 0
+		return FALSE
 
 	if((istype(I, /obj/item/kitchen/knife/butcher/meatcleaver) || istype(I, /obj/item/twohanded/chainsaw)) && stat == DEAD && user.a_intent == INTENT_HARM)
 		var/obj/item/reagent_containers/food/snacks/meat/human/newmeat = new /obj/item/reagent_containers/food/snacks/meat/human(get_turf(loc))
@@ -426,23 +427,23 @@ emp_act
 		reagents.trans_to(newmeat, round((reagents.total_volume) / 3, 1))
 		add_mob_blood(src)
 		--meatleft
-		to_chat(user, "<span class='warning'>You hack off a chunk of meat from [name]</span>")
+		to_chat(user, span_warning("You hack off a chunk of meat from [name]."))
 		if(!meatleft)
 			add_attack_logs(user, src, "Chopped up into meat")
 			qdel(src)
 
 	var/obj/item/organ/external/affecting = get_organ(ran_zone(user.zone_selected))
 	if(!affecting)
-		to_chat(user, "<span class='danger'>They are missing that limb!</span>")
-		return 1
+		to_chat(user, span_danger("They are missing that limb!"))
+		return TRUE
 	var/hit_area = parse_zone(affecting.limb_zone)
 
 	if(user != src)
 		user.do_attack_animation(src)
 		if(check_shields(I, I.force, "the [I.name]", MELEE_ATTACK, I.armour_penetration))
-			return 0
+			return FALSE
 
-	if(check_martial_art_defense(src, user, I, "<span class='warning'>[src] blocks [I]!</span>"))
+	if(check_martial_art_defense(src, user, I, span_warning("[src] blocks [I]!")))
 		return FALSE
 
 	if(istype(I,/obj/item/card/emag))
@@ -453,14 +454,14 @@ emp_act
 	var/weakness = check_weakness(I,user)
 
 	if(!I.force)
-		return 0 //item force is zero
+		return FALSE //item force is zero
 
-	var/armor = run_armor_check(affecting, "melee", "<span class='warning'>Your armour has protected your [hit_area].</span>", "<span class='warning'>Your armour has softened hit to your [hit_area].</span>", armour_penetration = I.armour_penetration)
+	var/armor = run_armor_check(affecting, "melee", span_warning("Your armour has protected your [hit_area]."), span_warning("Your armour has softened hit to your [hit_area]."), armour_penetration = I.armour_penetration)
 	var/weapon_sharp = is_sharp(I)
 	if(weapon_sharp && prob(getarmor(user.zone_selected, "melee")))
-		weapon_sharp = 0
+		weapon_sharp = FALSE
 	if(armor >= 100)
-		return 0
+		return FALSE
 	var/Iforce = I.force //to avoid runtimes on the forcesay checks at the bottom. Some items might delete themselves if you drop them. (stunning yourself, ninja swords)
 
 	apply_damage(I.force * weakness, I.damtype, affecting, armor, sharp = weapon_sharp, used_weapon = I)
@@ -471,11 +472,11 @@ emp_act
 			if(mind == objective.target)
 				objective.take_damage(I.force * weakness, I.damtype)
 
-	var/bloody = 0
+	var/bloody = FALSE
 	if(I.damtype == BRUTE && I.force && prob(25 + I.force * 2))
 		I.add_mob_blood(src)	//Make the weapon bloody, not the person.
 		if(prob(I.force * 2)) //blood spatter!
-			bloody = 1
+			bloody = TRUE
 			var/turf/location = loc
 			if(istype(location, /turf/simulated))
 				add_splatter_floor(location)
@@ -489,8 +490,8 @@ emp_act
 				if(BODY_ZONE_HEAD)//Harder to score a stun but if you do it lasts a bit longer
 					if(stat == CONSCIOUS && armor < 50)
 						if(prob(I.force))
-							visible_message("<span class='combat danger'>[src] has been knocked down!</span>", \
-											"<span class='combat userdanger'>[src] has been knocked down!</span>")
+							visible_message(span_combatdanger("[src] has been knocked down!"), \
+											span_combatuserdanger("[src] has been knocked down!"))
 							apply_effect(4 SECONDS, WEAKEN, armor)
 							AdjustConfused(30 SECONDS)
 						if(mind && mind.special_role == SPECIAL_ROLE_REV && prob(I.force + ((100 - health)/2)) && src != user && I.damtype == BRUTE)
@@ -510,8 +511,8 @@ emp_act
 
 				if(BODY_ZONE_CHEST)//Easier to score a stun but lasts less time
 					if(stat == CONSCIOUS && I.force && prob(I.force + 10))
-						visible_message("<span class='combat danger'>[src] has been knocked down!</span>", \
-										"<span class='combat userdanger'>[src] has been knocked down!</span>")
+						visible_message(span_combatdanger("[src] has been knocked down!"), \
+										span_combatuserdanger("[src] has been knocked down!"))
 						apply_effect(4 SECONDS, WEAKEN, armor)
 
 					if(bloody)
@@ -528,7 +529,7 @@ emp_act
 		forcesay(GLOB.hit_appends)	//forcesay checks stat already
 
 	dna.species.spec_attacked_by(I, user, affecting, user.a_intent, src)
-
+	return TRUE
 
 /**
  * This proc handles being hit by a thrown atom.


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
- **Вроде бы** заставляет прокать шанс на разваливание стульев об ударяемый атом только при реально ударе стула об атом.
- Убирает недоработанный дубль этого механа у табуреток, который остался после древнего рефактора, спасшего нас от `/табуретка/кровать/стул`.
- Возвращает стульям потерянное когда-то там (возможно при том же рефакторе) влияние параметра комфорта на сон персонажа. И всё же да, я там понакидывал комфорта капельку стульям, основываясь на их описании, всё же в кресле реально удобнее спать, чем на полу.
- Дефайники-Проки.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылки не будет, замечено и "зарепорчено" внутрираундово
Ну буквально, на брифинге офицер все стульчики из брифинг рума сломал себе об сумку, просто спамя попытками положить стул в сумку. Меня потом ещё ГСБ уволил по итогу такого фокуса.<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
