### PR TITLE
bugfix: Incorrect starting loc for weapon's shot by telekinesis

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -853,6 +853,7 @@
 	if(O.loc != src.loc)
 		add_fingerprint(user)
 		var/obj/item/gun/our_gun = O
+		our_gun.reset_direction()
 		our_gun.place_on_rack()
 		our_gun.do_drop_animation(src)
 		our_gun.Move(loc)

--- a/code/modules/projectiles/firing.dm
+++ b/code/modules/projectiles/firing.dm
@@ -75,13 +75,11 @@
 	var/turf/curloc = get_turf(user)
 
 	/*
-	 * If the user is not holding a weapon in hand,
-	 * use a starting location from the firer source (telekinesis fix)
-	 * TODO: update this code after rework telekinesis for weapons
+	 * If the user is holding a weapon in telekinesis grab,
+	 * use a starting location from the firer source
 	*/
-	var/turf/source_loc = get_turf(firer_source_atom)
-	if (curloc != source_loc)
-		curloc = source_loc
+	if (!isnull(firer_source_atom) && user.tkgrabbed_objects[firer_source_atom])
+		curloc = get_turf(firer_source_atom)
 
 	loc = curloc
 	starting = curloc

--- a/code/modules/projectiles/firing.dm
+++ b/code/modules/projectiles/firing.dm
@@ -73,8 +73,18 @@
 
 /obj/item/projectile/proc/preparePixelProjectile(atom/target, turf/targloc, mob/living/user, params, spread)
 	var/turf/curloc = get_turf(user)
-	loc = get_turf(user)
-	starting = get_turf(user)
+
+	/*
+	 * If the user is not holding a weapon in hand,
+	 * use a starting location from the firer source (telekinesis fix)
+	 * TODO: update this code after rework telekinesis for weapons
+	*/
+	var/turf/source_loc = get_turf(firer_source_atom)
+	if (curloc != source_loc)
+		curloc = source_loc
+
+	loc = curloc
+	starting = curloc
 	current = curloc
 	yo = targloc.y - curloc.y
 	xo = targloc.x - curloc.x

--- a/code/modules/projectiles/firing.dm
+++ b/code/modules/projectiles/firing.dm
@@ -78,7 +78,8 @@
 	 * If the user is holding a weapon in telekinesis grab,
 	 * use a starting location from the firer source
 	*/
-	if (!isnull(firer_source_atom) && user.tkgrabbed_objects[firer_source_atom])
+	var/fire_from_tk_grab = !isnull(firer_source_atom) && user.tkgrabbed_objects[firer_source_atom]
+	if (fire_from_tk_grab)
 		curloc = get_turf(firer_source_atom)
 
 	loc = curloc

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -41,6 +41,7 @@
 	var/bolt_open = FALSE
 	var/spread = 0
 	var/randomspread = 1
+	var/barrel_dir = EAST // barel direction need for a rotate gun with telekinesis for shot to target (default: matched with tile direction)
 
 	var/unique_rename = TRUE //allows renaming with a pen
 	var/unique_reskin = FALSE //allows reskinning
@@ -223,7 +224,8 @@
 	return
 
 /obj/item/gun/proc/process_fire(atom/target as mob|obj|turf, mob/living/user as mob|obj, message = 1, params, zone_override, bonus_spread = 0)
-	if (user.tkgrabbed_objects[src]) // don't add fingerprints if gun is hold by telekinesis grab
+	var/is_tk_grab = !isnull(user.tkgrabbed_objects[src])
+	if (is_tk_grab) // don't add fingerprints if gun is hold by telekinesis grab
 		add_fingerprint(user)
 
 	if(chambered)
@@ -237,6 +239,9 @@
 	if(spread)
 		randomized_gun_spread =	rand(0,spread)
 	var/randomized_bonus_spread = rand(0, bonus_spread)
+
+	if (is_tk_grab)
+		rotate_to_target(target)
 
 	if(burst_size > 1)
 		if(chambered && chambered.harmful)
@@ -326,7 +331,6 @@
 			to_chat(user, "<span class='userdanger'>[src] blows up in your face!</span>")
 			user.take_organ_damage(0,10)
 			return FALSE
-
 
 /obj/item/gun/attack(mob/M, mob/user)
 	if(user.a_intent == INTENT_HARM) //Flogging
@@ -600,13 +604,43 @@
 	var/matrix/M = matrix()
 	M.Turn(-90)
 	transform = M
+	barrel_dir = NORTH
 
 /obj/item/gun/proc/remove_from_rack()
-	if(on_rack)
-		var/matrix/M = matrix()
-		transform = M
-		on_rack = FALSE
+	var/matrix/M = matrix()
+	transform = M
+	on_rack = FALSE
+	barrel_dir = EAST
+
+// rotating the gun to targer for a shot with telekinesis
+/obj/item/gun/proc/rotate_to_target(atom/target)
+	setDir(barrel_dir)
+	var/upd_dir = get_dir(src, target)
+	if (barrel_dir == upd_dir)
+		return
+	var/angle = dir2angle(upd_dir) - dir2angle(barrel_dir)
+	if (angle > 180)
+		angle -= 360
+	var/matrix/M = matrix(transform)
+	M.Turn(angle)
+	animate(src, transform = M, time = 2)
+	barrel_dir = upd_dir
+
+// if the gun have rotate transformation - reset it
+/obj/item/gun/proc/reset_direction()
+	if (barrel_dir == EAST)
+		return
+	var/matrix/M = matrix()
+	transform = M
+	barrel_dir = EAST
 
 /obj/item/gun/pickup(mob/user)
 	. = ..()
-	remove_from_rack()
+	if (on_rack)
+		remove_from_rack()
+	else
+		reset_direction()
+
+/obj/item/gun/equipped(mob/user, slot, initial)
+	reset_direction()
+	return ..()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -223,7 +223,9 @@
 	return
 
 /obj/item/gun/proc/process_fire(atom/target as mob|obj|turf, mob/living/user as mob|obj, message = 1, params, zone_override, bonus_spread = 0)
-	add_fingerprint(user)
+	if (user.tkgrabbed_objects[src]) // don't add fingerprints if gun is hold by telekinesis grab
+		add_fingerprint(user)
+
 	if(chambered)
 		chambered.leave_residue(user)
 
@@ -301,6 +303,16 @@
 
 	if(rusted_weapon)
 		malf_counter -= burst_size
+		// if the gun grabbed by telekinesis, it's can exploise but without damage for user
+		if (user.tkgrabbed_objects[src])
+			if (malf_counter <= 0 && prob(50))
+				user.drop_item_ground(user.tkgrabbed_objects[src])
+				new /obj/effect/decal/cleanable/ash(loc)
+				to_chat(user, "<span class='userdanger'>WOAH! [src] blows up!</span>")
+				playsound(user, 'sound/effects/explosion1.ogg', 30, 1)
+				qdel(src)
+				return FALSE
+			return TRUE
 		if(malf_counter <= 0 && prob(50))
 			new /obj/effect/decal/cleanable/ash(user.loc)
 			user.take_organ_damage(0,30)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Поправлен баг, когда при выстреле из оружия с помощью телекинеза проджектайл вылетает из персонажа вместо оружия.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Воспроизводится стабильно.
https://discord.com/channels/617003227182792704/1193998010003247104
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
## Демонстрация изменений
Теперь при использовании телекинеза проджектайл использует стартовую локацию оружия.
Реализован поворот оружия к цели при стрельбе с помощью телекинеза и при выстреле не остается отпечатков пальцев. Оружие не может нанести урон при взрыве, когда удерживается телекинезом
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->