### PR TITLE
tweak: no sanitize for area `name` in crew monitor's.

### DIFF
--- a/code/datums/cache/crew.dm
+++ b/code/datums/cache/crew.dm
@@ -64,7 +64,7 @@ GLOBAL_DATUM_INIT(crew_repository, /datum/repository/crew, new())
 
 		if(C.sensor_mode >= SUIT_SENSOR_TRACKING)
 			var/area/A = get_area(H)
-			crewmemberData["area"] = sanitize(A.name)
+			crewmemberData["area"] = A.name
 			crewmemberData["x"] = pos.x
 			crewmemberData["y"] = pos.y
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Названия зон не кодируются и игрокам в лицо больше не вылезают всякие #%34% и прочие радости ХТМЛьки при использовании монитора экипажа. "Опасные" названия зон итак не допускаются при использовании чертежей ингейм.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на баг-репорт (Да-да)
https://discord.com/channels/617003227182792704/1196688167697383465<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
