### PR TITLE
tweak: Vision And Emotes Fixes

### DIFF
--- a/code/__DEFINES/organ_defines.dm
+++ b/code/__DEFINES/organ_defines.dm
@@ -54,3 +54,6 @@
 #define ORGAN_MANIPULATION_NOEFFECT 1
 #define ORGAN_MANIPULATION_ABDUCTOR 2
 
+/// used for species that can see without eyes
+#define NO_VISION_ORGAN "no_vision_organ"
+

--- a/code/datums/emote/emote.dm
+++ b/code/datums/emote/emote.dm
@@ -220,10 +220,10 @@
 			for(var/mob/dead/observer/ghost in viewers(user))
 				ghost.show_message(span_deadsay("[displayed_msg]"), EMOTE_VISIBLE)
 
-		else if((emote_type & (EMOTE_AUDIBLE|EMOTE_SOUND)) && !user.mind?.miming)
+		else if((emote_type & (EMOTE_AUDIBLE|EMOTE_SOUND)) && user.mind && !user.mind.miming)
 			user.audible_message(displayed_msg, deaf_message = span_italics("You see how <b>[user]</b> [msg]"))
 		else
-			user.visible_message(displayed_msg, blind_message = span_italics("You hear how someone [msg]"))
+			user.visible_message(displayed_msg)
 
 		if(!(emote_type & (EMOTE_FORCE_NO_RUNECHAT|EMOTE_SOUND)) && !isobserver(user))
 			runechat_emote(user, msg)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -764,11 +764,10 @@
 /datum/status_effect/transient/eye_blurry/calc_decay()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
+		var/obj/item/organ/vision = H.dna?.species?.get_vision_organ(H)
 
-		if(isnull(H.dna.species.vision_organ)) //species has no eyes
+		if(vision && vision == NO_VISION_ORGAN) //species has no eyes
 			return ..()
-
-		var/obj/item/organ/vision = H.get_int_organ(H.dna.species.vision_organ)
 
 		if(!vision || vision.is_bruised() || vision.is_traumatized()) // doesn't decay if you have damaged eyesight.
 			return 0
@@ -794,10 +793,10 @@
 		if((BLINDNESS in H.mutations))
 			return 0
 
-		if(isnull(H.dna.species.vision_organ)) // species that have no eyes
-			return ..()
+		var/obj/item/organ/vision = H.dna?.species?.get_vision_organ(H)
 
-		var/obj/item/organ/vision = H.get_int_organ(H.dna.species.vision_organ)
+		if(vision && vision == NO_VISION_ORGAN) // species that have no eyes
+			return ..()
 
 		if(!vision || vision.is_traumatized() || vision.is_bruised()) //got no eyes or broken eyes
 			return 0

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -92,15 +92,13 @@
 			to_chat(user, span_warning("You can't trigger [src] with a custom emote."))
 		return FALSE
 
-	if(!(emote_key in user.usable_emote_keys(trigger_causes & BIOCHIP_EMOTE_TRIGGER_INTENTIONAL)))
+	var/intentional_cause = (trigger_causes & BIOCHIP_EMOTE_TRIGGER_INTENTIONAL) && !(trigger_causes & BIOCHIP_EMOTE_TRIGGER_UNINTENTIONAL)
+	if(!(emote_key in user.usable_emote_keys(intentional_cause)))
 		if(!silent)
-			to_chat(user, span_warning("You can't trigger [src] with that emote! Try *help to see emotes you can use."))
+			to_chat(user, span_warning("You can't trigger [src] with that emote [intentional_cause ? "intentionally" : "unintentionally"]! Try *help to see emotes you can use."))
 		return FALSE
 
-	if(!(emote_key in user.usable_emote_keys(trigger_causes & BIOCHIP_EMOTE_TRIGGER_UNINTENTIONAL)))
-		CRASH("User was given an bio-chip for an unintentional emote that they can't use.")
-
-	LAZYADD(trigger_emotes, emote_key)
+	LAZYADDOR(trigger_emotes, emote_key)
 	RegisterSignal(user, COMSIG_MOB_EMOTED(emote_key), PROC_REF(on_emote))
 
 
@@ -113,7 +111,7 @@
 	if(!(intentional && (trigger_causes & BIOCHIP_EMOTE_TRIGGER_INTENTIONAL)) && !(!intentional && (trigger_causes & BIOCHIP_EMOTE_TRIGGER_UNINTENTIONAL)))
 		return
 
-	add_attack_logs(user, user, "[intentional ? "intentionally" : "unintentionally"] [src] was [intentional ? "intentionally" : "unintentionally"] triggered with the emote [fired_emote].")
+	add_attack_logs(user, user, "[src] was [intentional ? "intentionally" : "unintentionally"] triggered with the emote [fired_emote].")
 	emote_trigger(key, user, intentional)
 
 
@@ -136,7 +134,7 @@
 	death_trigger(source, gibbed)
 
 
-/obj/item/implant/proc/emote_trigger(emote, mob/source, force)
+/obj/item/implant/proc/emote_trigger(emote, mob/source, intentional)
 	return
 
 
@@ -183,13 +181,13 @@
 	if(trigger_emotes)
 		if(!(trigger_causes & BIOCHIP_EMOTE_TRIGGER_INTENTIONAL|BIOCHIP_EMOTE_TRIGGER_UNINTENTIONAL))
 			CRASH("Bio-chip [src] has trigger emotes defined but no trigger cause with which to use them!")
-		if(!activated && (trigger_causes & BIOCHIP_EMOTE_TRIGGER_INTENTIONAL))
+		if(activated == BIOCHIP_ACTIVATED_PASSIVE && (trigger_causes & BIOCHIP_EMOTE_TRIGGER_INTENTIONAL))
 			CRASH("Bio-chip [src] has intentional emote triggers on a passive bio-chip")
 		// If you can't activate the implant manually, you shouldn't be able to deliberately activate it with an emote
 		for(var/emote in trigger_emotes)
 			set_trigger(source, emote, on_implant = TRUE)
 
-	if(activated)
+	if(activated == BIOCHIP_ACTIVATED_ACTIVE)
 		for(var/datum/action/action as anything in actions)
 			action.Grant(source)
 			update_button(action)

--- a/code/game/objects/items/weapons/implants/implant_sad_trombone.dm
+++ b/code/game/objects/items/weapons/implants/implant_sad_trombone.dm
@@ -8,15 +8,15 @@
 	implant_state = "implant-honk"
 
 
-/obj/item/implant/sad_trombone/emote_trigger(emote, mob/source, force)
-	activate(emote)
+/obj/item/implant/sad_trombone/emote_trigger(emote, mob/source, intentional)
+	activate()
 
 
 /obj/item/implant/sad_trombone/death_trigger(mob/user, gibbed)
-	activate(gibbed)
+	activate()
 
 
-/obj/item/implant/sad_trombone/activate()
+/obj/item/implant/sad_trombone/activate(cause)
 	playsound(loc, 'sound/misc/sadtrombone.ogg', 50, FALSE)
 
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -99,16 +99,12 @@
 
 /mob/living/carbon/human/handle_disabilities()
 	//Vision //god knows why this is here
-	var/obj/item/organ/vision
-	if(dna.species.vision_organ)
-		vision = get_int_organ(dna.species.vision_organ)
-
-	if(!dna.species.vision_organ) // Presumably if a species has no vision organs, they see via some other means.
+	var/obj/item/organ/vision = dna?.species?.get_vision_organ(src)
+	if(vision == NO_VISION_ORGAN)
 		SetEyeBlind(0)
 		SetEyeBlurry(0)
-
-	else if(!vision || vision.is_traumatized())   // Vision organs cut out or broken? Permablind.
-		EyeBlind(4 SECONDS)
+	else if(!vision || vision.is_traumatized())	// Vision organs cut out or broken? Permablind.
+		SetEyeBlind(4 SECONDS)
 
 	if(getBrainLoss() >= 60 && stat != DEAD)
 		if(prob(3))

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -192,9 +192,6 @@
 
 	var/meat_type = /obj/item/reagent_containers/food/snacks/meat/humanoid
 
-	/// If set, this organ is required for vision. Defaults to "eyes" if the species has them.
-	var/vision_organ
-
 	var/list/has_limbs = list(
 		BODY_ZONE_CHEST = list("path" = /obj/item/organ/external/chest),
 		BODY_ZONE_PRECISE_GROIN = list("path" = /obj/item/organ/external/groin),
@@ -225,10 +222,6 @@
 	var/list/autohiss_exempt = null
 
 /datum/species/New()
-	//If the species has eyes, they are the default vision organ
-	if(!vision_organ && has_organ[INTERNAL_ORGAN_EYES])
-		vision_organ = /obj/item/organ/internal/eyes
-
 	unarmed = new unarmed_type()
 
 /datum/species/proc/get_random_name(gender)
@@ -1161,6 +1154,19 @@ It'll return null if the organ doesn't correspond, so include null checks when u
 /datum/species/proc/can_hear(mob/living/carbon/human/user)
 	var/obj/item/organ/internal/ears/ears = user.get_organ_slot(INTERNAL_ORGAN_EARS)
 	return ears && !(DEAF in user.mutations) && !HAS_TRAIT(user, TRAIT_DEAF)
+
+
+/datum/species/proc/has_vision(mob/living/carbon/human/user, information_only = FALSE)
+	if(information_only && user.stat == DEAD)
+		return TRUE
+	if(user.AmountBlinded() || (BLINDNESS in user.mutations) || user.stat)
+		return FALSE
+	var/obj/item/organ/vision = get_vision_organ(user)
+	return vision && (vision == NO_VISION_ORGAN || !vision.is_traumatized())
+
+
+/datum/species/proc/get_vision_organ(mob/living/carbon/human/user)
+	return user.get_organ_slot(INTERNAL_ORGAN_EYES)
 
 
 /datum/species/proc/spec_Process_Spacemove(mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/species/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/golem.dm
@@ -162,6 +162,11 @@
 	H.name = H.real_name
 	to_chat(H, info_text)
 
+
+/datum/species/golem/get_vision_organ(mob/living/carbon/human/user)
+	return NO_VISION_ORGAN
+
+
 //Random Golem
 
 /datum/species/golem/random

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -56,8 +56,6 @@
 
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/humanoid/machine
 
-	vision_organ = /obj/item/organ/internal/eyes/optical_sensor
-
 	has_limbs = list(
 		BODY_ZONE_CHEST = list("path" = /obj/item/organ/external/chest/ipc),
 		BODY_ZONE_PRECISE_GROIN = list("path" = /obj/item/organ/external/groin/ipc),

--- a/code/modules/mob/living/carbon/human/species/nucleation.dm
+++ b/code/modules/mob/living/carbon/human/species/nucleation.dm
@@ -28,7 +28,7 @@
 		INTERNAL_ORGAN_STRANGE_CRYSTAL = /obj/item/organ/internal/nucleation/strange_crystal,
 		INTERNAL_ORGAN_RESONANT_CRYSTAL = /obj/item/organ/internal/nucleation/resonant_crystal,
 	)
-	vision_organ = /obj/item/organ/internal/eyes/luminescent_crystal
+
 
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/humanoid/nucleation
 

--- a/code/modules/mob/living/carbon/human/species/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/species/skeleton.dm
@@ -72,3 +72,8 @@
 		return TRUE
 
 	return ..()
+
+
+/datum/species/skeleton/get_vision_organ(mob/living/carbon/human/user)
+	return NO_VISION_ORGAN
+

--- a/code/modules/mob/living/carbon/human/species/slime.dm
+++ b/code/modules/mob/living/carbon/human/species/slime.dm
@@ -148,6 +148,10 @@
 	return !(DEAF in user.mutations) && !HAS_TRAIT(user, TRAIT_DEAF)
 
 
+/datum/species/slime/get_vision_organ(mob/living/carbon/human/user)
+	return NO_VISION_ORGAN
+
+
 /datum/action/innate/slimecolor
 	name = "Toggle Recolor"
 	check_flags = AB_CHECK_CONSCIOUS

--- a/code/modules/mob/living/carbon/human/update_stat.dm
+++ b/code/modules/mob/living/carbon/human/update_stat.dm
@@ -23,5 +23,11 @@
 	return ..() // Fallback if we don't have a species or DNA
 
 
+/mob/living/carbon/human/has_vision(information_only = FALSE)
+	if(dna?.species)
+		return dna.species.has_vision(src, information_only)
+	return ..()
+
+
 /mob/living/carbon/human/check_death_method()
 	return dna.species.dies_at_threshold

--- a/code/modules/mob/living/update_status.dm
+++ b/code/modules/mob/living/update_status.dm
@@ -1,12 +1,12 @@
 /mob/living/update_blind_effects()
-	if(!has_vision(information_only=TRUE))
-		overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
-		throw_alert("blind", /obj/screen/alert/blind)
-		return 1
-	else
+	if(has_vision(information_only = TRUE))
 		clear_fullscreen("blind")
 		clear_alert("blind")
-		return 0
+		return FALSE
+
+	overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
+	throw_alert("blind", /obj/screen/alert/blind)
+	return TRUE
 
 
 /mob/living/update_blurry_effects()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -79,26 +79,25 @@
 		return
 
 	if(type)
-		if((type & EMOTE_VISIBLE) && !has_vision(information_only = TRUE))	// Vision related
-			if(!(alt))
+		if((type & EMOTE_VISIBLE) && !has_vision(information_only = TRUE))	//Vision related
+			if(!alt)
 				return
-			else
-				msg = alt
-				type = alt_type
-		if((type & EMOTE_AUDIBLE) && !can_hear())	// Hearing related
-			if(!(alt))
+			msg = alt
+			type = alt_type
+
+		if(type & EMOTE_AUDIBLE && !can_hear())	//Hearing related
+			if(!alt)
 				return
-			else
-				msg = alt
-				type = alt_type
-				if((type & EMOTE_VISIBLE) && !has_vision(information_only=TRUE))
-					return
+			msg = alt
+			type = alt_type
+			if((type & EMOTE_VISIBLE) && !has_vision(information_only = TRUE))
+				return
+
 	// Added voice muffling for Issue 41.
 	if(stat == UNCONSCIOUS)
 		to_chat(src, "<I>…Вам почти удаётся расслышать чьи-то слова…</I>")
 	else
 		to_chat(src, msg)
-	return
 
 
 // Show a message to all mobs in sight of this one

--- a/code/modules/mob/mob_emote.dm
+++ b/code/modules/mob/mob_emote.dm
@@ -68,13 +68,13 @@
  *
  * * intentional_use: Whether or not to check based on if the action was intentional.
  */
-/mob/proc/usable_emote_keys(intentional_use = TRUE)
+/mob/proc/usable_emote_keys(intentional_use)
 	var/list/all_keys = list()
 	for(var/key in GLOB.emote_list)
 		for(var/datum/emote/P in GLOB.emote_list[key])
 			if(P.key in all_keys)
 				continue
-			if(P.can_run_emote(src, status_check = FALSE, intentional = null))
+			if(P.can_run_emote(src, status_check = FALSE, intentional = intentional_use))
 				all_keys += P.key
 				if(P.key_third_person)
 					all_keys += P.key_third_person


### PR DESCRIPTION
## Описание
Устранение ненужного сообщения для глухих, поскольку видимые эмоции не могут "слышать".

Добавил расовый прок на вижен по аналогии с can_hear.

Немного подкорректировал код имплантов.

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1197307783410876479
