### PR TITLE
refactor: moving lava generation to a datum system

### DIFF
--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -107,8 +107,11 @@
 		var/animate_time = 0
 		for(var/thing in C.parallax_layers)
 			var/obj/screen/parallax_layer/L = thing
-			L.icon_state = initial(L.icon_state)
-			L.update_o(C.view)
+			if(istype(L, /obj/screen/parallax_layer/planet) && SSmapping.lavaland_theme?.planet_icon_state)
+				L.icon_state = SSmapping.lavaland_theme.planet_icon_state
+			else
+				L.icon_state = initial(L.icon_state)
+				L.update_o(C.view)
 			var/T = PARALLAX_LOOP_TIME / L.speed
 			if(T > animate_time)
 				animate_time = T
@@ -339,13 +342,8 @@
 
 /obj/screen/parallax_layer/planet/Initialize(mapload)
 	. = ..()
-	switch(SSmapping.lavaland_theme)
-		if(/turf/simulated/floor/plating/lava/smooth/lava_land_surface)
-			icon_state = "planet"
-		if(/turf/simulated/floor/plating/lava/smooth/lava_land_surface/plasma)
-			icon_state = "planet_plasma"
-		if(/turf/simulated/floor/chasm/straight_down/lava_land_surface)
-			icon_state = "planet_canyon"
+	if(SSmapping.lavaland_theme?.planet_icon_state)
+		icon_state = SSmapping.lavaland_theme.planet_icon_state
 
 /obj/screen/parallax_layer/planet/update_status(mob/M)
 	var/turf/T = get_turf(M)

--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -111,7 +111,7 @@
 				L.icon_state = SSmapping.lavaland_theme.planet_icon_state
 			else
 				L.icon_state = initial(L.icon_state)
-				L.update_o(C.view)
+			L.update_o(C.view)
 			var/T = PARALLAX_LOOP_TIME / L.speed
 			if(T > animate_time)
 				animate_time = T

--- a/code/controllers/subsystem/non-firing/mapping.dm
+++ b/code/controllers/subsystem/non-firing/mapping.dm
@@ -10,7 +10,7 @@ SUBSYSTEM_DEF(mapping)
 	/// Waht map to fallback
 	var/datum/map/fallback_map = new /datum/map/delta
 	///What do we have as the lavaland theme today?
-	var/turf/simulated/floor/lavaland_theme
+	var/datum/lavaland_theme/lavaland_theme
 	///What primary cave theme we have picked for cave generation today.
 	var/cave_theme
 
@@ -38,7 +38,9 @@ SUBSYSTEM_DEF(mapping)
 		F << next_map.type
 
 /datum/controller/subsystem/mapping/Initialize()
-	lavaland_theme = pick(/turf/simulated/floor/plating/lava/smooth/lava_land_surface, /turf/simulated/floor/plating/lava/smooth/lava_land_surface/plasma, /turf/simulated/floor/chasm/straight_down/lava_land_surface)
+	var/datum/lavaland_theme/lavaland_theme_type = pick(subtypesof(/datum/lavaland_theme))
+	ASSERT(lavaland_theme_type)
+	lavaland_theme = new lavaland_theme_type
 	log_startup_progress("We're in the mood for [initial(lavaland_theme.name)] today...") //We load this first. In the event some nerd ever makes a surface map, and we don't have it in lavaland in the event lavaland is disabled.
 	cave_theme = pick(BLOCKED_BURROWS, CLASSIC_CAVES, DEADLY_DEEPROCK)
 	log_startup_progress("We feel like [cave_theme] today...")
@@ -70,14 +72,8 @@ SUBSYSTEM_DEF(mapping)
 		log_startup_progress("Populating lavaland...")
 		var/lavaland_setup_timer = start_watch()
 		seedRuins(list(level_name_to_num(MINING)), CONFIG_GET(number/lavaland_budget), /area/lavaland/surface/outdoors/unexplored, GLOB.lava_ruins_templates)
-		switch(lavaland_theme)
-			if(/turf/simulated/floor/plating/lava/smooth/lava_land_surface)
-				spawn_rivers(level_name_to_num(MINING)) //Default spawn, no tweaks needed
-			if(/turf/simulated/floor/plating/lava/smooth/lava_land_surface/plasma) //More rivers, smaller
-				spawn_rivers(level_name_to_num(MINING), nodes = 2)
-				spawn_rivers(level_name_to_num(MINING), nodes = 2)
-			if(/turf/simulated/floor/chasm/straight_down/lava_land_surface) //Thiner chasms, bridges, reaches to edge of map.
-				spawn_rivers(level_name_to_num(MINING), nodes = 6, turf_type = /turf/simulated/floor/plating/lava/smooth/mapping_lava, whitelist_area = /area/lavaland/surface/outdoors, min_x = 50, min_y = 7, max_x = 250, max_y = 225, prob = 10, prob_loss = 5)
+		if(lavaland_theme)
+			lavaland_theme.setup()
 		var/time_spent = stop_watch(lavaland_setup_timer)
 		log_startup_progress("Successfully populated lavaland in [time_spent]s.")
 		if(time_spent >= 10)

--- a/code/game/turfs/simulated/floor/lava.dm
+++ b/code/game/turfs/simulated/floor/lava.dm
@@ -276,4 +276,5 @@
 
 /turf/simulated/floor/plating/lava/smooth/mapping_lava/LateInitialize()
 	. = ..()
-	ChangeTurf(SSmapping.lavaland_theme)
+	if(SSmapping.lavaland_theme?.primary_turf_type)
+		ChangeTurf(SSmapping.lavaland_theme.primary_turf_type, ignore_air = TRUE)

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -282,7 +282,7 @@ GLOBAL_DATUM_INIT(_preloader, /datum/dmm_suite/preloader, new())
 	var/turf/T
 	if(members[first_turf_index] != /turf/template_noop)
 		if(members[first_turf_index] == /turf/simulated/floor/plating/lava/smooth/lava_land_surface)
-			T = instance_atom(SSmapping.lavaland_theme, members_attributes[first_turf_index], xcrd, ycrd, zcrd)
+			T = instance_atom(SSmapping.lavaland_theme?.primary_turf_type, members_attributes[first_turf_index], xcrd, ycrd, zcrd)
 		else
 			T = instance_atom(members[first_turf_index], members_attributes[first_turf_index], xcrd, ycrd, zcrd)
 

--- a/code/modules/lavaland/lavaland_theme.dm
+++ b/code/modules/lavaland/lavaland_theme.dm
@@ -2,7 +2,7 @@
 	/// Name of lavaland theme
 	var/name = "Not Specified"
 	/// Typepath of turf the `/turf/simulated/floor/plating/lava/mapping_lava` will be changed to on Late Initialization
-	var/turf/simulated/floor/primary_turf_type
+	var/primary_turf_type
 	/// Icon state of planet present on background of station Z-level
 	var/planet_icon_state
 

--- a/code/modules/lavaland/lavaland_theme.dm
+++ b/code/modules/lavaland/lavaland_theme.dm
@@ -1,0 +1,59 @@
+/datum/lavaland_theme
+	/// Name of lavaland theme
+	var/name = "Not Specified"
+	/// Typepath of turf the `/turf/simulated/floor/plating/lava/mapping_lava` will be changed to on Late Initialization
+	var/turf/simulated/floor/primary_turf_type
+	/// Icon state of planet present on background of station Z-level
+	var/planet_icon_state
+
+
+/datum/lavaland_theme/New()
+	if(!primary_turf_type)
+		stack_trace("Turf type is `null` in `[type]` lavaland theme")
+	else if(!ispath(primary_turf_type))
+		stack_trace("Wrong turf type in `[type]` lavaland theme")
+
+/**
+ * This proc should do all theme specific thing.
+ * Now it only generates rivers, but it can do all stuff you desire.
+ */
+
+/datum/lavaland_theme/proc/setup()
+	return
+
+/datum/lavaland_theme/lava
+	name = "lava"
+	primary_turf_type = /turf/simulated/floor/plating/lava/smooth/lava_land_surface
+	planet_icon_state = "planet"
+
+/datum/lavaland_theme/lava/setup()
+	spawn_rivers(level_name_to_num(MINING))
+
+/datum/lavaland_theme/plasma
+	name = "plasma"
+	primary_turf_type = /turf/simulated/floor/plating/lava/smooth/lava_land_surface/plasma
+	planet_icon_state = "planet_plasma"
+
+/datum/lavaland_theme/plasma/setup()
+	spawn_rivers(level_name_to_num(MINING), nodes = 2)
+	spawn_rivers(level_name_to_num(MINING), nodes = 2)
+
+/datum/lavaland_theme/chasm
+	name = "chasm"
+	primary_turf_type = /turf/simulated/floor/chasm/straight_down/lava_land_surface
+	planet_icon_state = "planet_chasm"
+
+/datum/lavaland_theme/chasm/setup()
+	spawn_rivers(
+		level_name_to_num(MINING),
+		nodes = 6,
+		turf_type = /turf/simulated/floor/plating/lava/smooth/mapping_lava,
+		whitelist_area = /area/lavaland/surface/outdoors,
+		min_x = 50,
+		min_y = 7,
+		max_x = 250,
+		max_y = 225,
+		prob = 10,
+		prob_loss = 5
+	)
+

--- a/paradise.dme
+++ b/paradise.dme
@@ -2007,6 +2007,7 @@
 #include "code\modules\instruments\songs\play_legacy.dm"
 #include "code\modules\instruments\songs\play_synthesized.dm"
 #include "code\modules\karma\karma.dm"
+#include "code\modules\lavaland\lavaland_theme.dm"
 #include "code\modules\library\admin.dm"
 #include "code\modules\library\codex_gigas.dm"
 #include "code\modules\library\lib_items.dm"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Название говорит за себя. Теперь отдельный файл с датумами отвечает за генерацию лаваленда и всех смешных приколов. Позволяет впоследствии добавлять еще больше уникального механа каждому типу генерации лавы.
Так же фиксит баг, при котором при перемещении на шаттле внешний вид планеты сбрасывается до стандартной лавы.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Куол + багфикс
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->