### PR TITLE
bugfix: Returned the "pAI suicide" button

### DIFF
--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -90,7 +90,7 @@
 		close_up()
 	card.removePersonality()
 	var/turf/T = get_turf(card.loc)
-	for(var/mob/M in viewers(T))
+	for(var/mob/M in viewers(7,T))
 		M.show_message(span_notice("[src] flashes a message across its screen, \"Wiping core files. Please acquire a new personality to continue using pAI device functions.\""), EMOTE_VISIBLE, span_notice("[src] bleeps electronically."), EMOTE_AUDIBLE)
 	death(gibbed = FALSE, cleanWipe = TRUE)
 

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -90,8 +90,7 @@
 		close_up()
 	card.removePersonality()
 	var/turf/T = get_turf(card.loc)
-	for(var/mob/M in viewers(7,T))
-		M.show_message(span_notice("[src] flashes a message across its screen, \"Wiping core files. Please acquire a new personality to continue using pAI device functions.\""), EMOTE_VISIBLE, span_notice("[src] bleeps electronically."), EMOTE_AUDIBLE)
+	visible_message(span_notice("[src] flashes a message across its screen, \"Wiping core files. Please acquire a new personality to continue using pAI device functions.\""), blind_message = span_notice("[src] bleeps electronically."))
 	death(gibbed = FALSE, cleanWipe = TRUE)
 
 

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -89,7 +89,6 @@
 	if(canmove || resting)
 		close_up()
 	card.removePersonality()
-	var/turf/T = get_turf(card.loc)
 	visible_message(span_notice("[src] flashes a message across its screen, \"Wiping core files. Please acquire a new personality to continue using pAI device functions.\""), blind_message = span_notice("[src] bleeps electronically."))
 	death(gibbed = FALSE, cleanWipe = TRUE)
 

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -416,6 +416,17 @@
 	update_icons()
 	update_canmove()
 
+/mob/living/silicon/pai/verb/pAI_suicide()
+	set category = "pAI Commands"
+	set name = "pAI Suicide"
+	set desc = "Kill yourself and become a ghost (You will recieve a confirmation prompt.)"
+
+	if(alert("REALLY kill yourself? This action can't be undone.", "Suicide", "No", "Suicide") == "Suicide")
+		do_suicide()
+
+	else
+		to_chat(src, "Aborting suicide attempt.")
+
 /mob/living/silicon/pai/update_sight()
 	if(!client)
 		return


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Возвращена кнопка выгрузки в меню "pAI Commands", которая была убрана одним из ПРов. Так же починено отображение текста для находящихся рядом при самовайпе пИИ.

<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Изначально эта кнопка у пИИ была, но во время рефактора код переместили, а кнопку вернуть забыли.  Вернул на место
![1](https://github.com/ss220-space/Paradise/assets/156955117/cc1ad388-c404-44de-9aca-b31953f43235)


<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
