### PR TITLE
bugfix: AI can't see roundstart `restricted_camera_networks` and normal borg accessability for malf hacked APC.

### DIFF
--- a/code/_globalvars/lists/misc.dm
+++ b/code/_globalvars/lists/misc.dm
@@ -33,10 +33,17 @@ GLOBAL_LIST_INIT(restricted_camera_networks, list(
 	"UO45",
 	"UO45R",
 	"UO71",
+	"MO19",
+	"MO19X",
+	"MO19R",
 	"Xeno",
 	"Hotel",
+	"spacehotel",
+	"spacebar",
+	"USSP",
 	"USSP_LAB",
-	"USSP_gorky17"
+	"USSP_gorky17",
+	"Bunker1"
 	)) //Those networks can only be accessed by preexisting terminals. AIs and new terminals can't use them.
 
 GLOBAL_LIST_INIT(ruin_landmarks, list())

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -35,7 +35,7 @@
 	var/in_use_lights = 0 // TO BE IMPLEMENTED
 	var/toggle_sound = 'sound/items/wirecutter.ogg'
 
-/obj/machinery/camera/Initialize(mapload)
+/obj/machinery/camera/Initialize(mapload, list/networks)
 	. = ..()
 	wires = new(src)
 	assembly = new(src)
@@ -44,7 +44,13 @@
 	assembly.update_icon()
 
 	GLOB.cameranet.cameras += src
-	GLOB.cameranet.addCamera(src)
+	if(networks)
+		network = networks
+	var/list/tempnetwork = difflist(network, GLOB.restricted_camera_networks)
+	if(tempnetwork.len)
+		GLOB.cameranet.addCamera(src)
+	else
+		GLOB.cameranet.removeCamera(src)
 	if(isturf(loc))
 		LAZYADD(myArea.cameras, UID())
 	if(is_station_level(z) && prob(3) && !start_active)

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -81,17 +81,11 @@
 	var/temptag = "[sanitize(camera_area.name)] ([rand(1, 999)])"
 	input = strip_html(input(usr, "How would you like to name the camera?", "Set Camera Name", temptag))
 	state = ASSEMBLY_BUILT
-	var/obj/machinery/camera/C = new(loc)
+	var/obj/machinery/camera/C = new(loc, uniquelist(tempnetwork))
 	loc = C
 	C.assembly = src
 
 	C.auto_turn()
-
-	C.network = uniquelist(tempnetwork)
-	tempnetwork = difflist(C.network,GLOB.restricted_camera_networks)
-	if(!tempnetwork.len) // Camera isn't on any open network - remove its chunk from AI visibility.
-		GLOB.cameranet.removeCamera(C)
-
 	C.c_tag = input
 
 	for(var/i = 5; i >= 0; i -= 1)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1015,14 +1015,7 @@
 	if(istype(user, /mob/living/silicon))
 		var/mob/living/silicon/ai/AI = user
 		var/mob/living/silicon/robot/robot = user
-		if(                                                             \
-			aidisabled ||                                            \
-			malfhack && istype(malfai) &&                                \
-			(                                                            \
-				(istype(AI) && (malfai!=AI && malfai != AI.parent)) ||   \
-				(istype(robot) && (robot in malfai.connected_robots))    \
-			)                                                            \
-		)
+		if(aidisabled || malfhack && istype(malfai) && ((istype(AI) && (malfai!=AI && malfai != AI.parent)) || (istype(robot) && !(robot in malfai.connected_robots))))
 			if(!loud)
 				to_chat(user, "<span class='danger'>\The [src] has AI control disabled!</span>")
 				user << browse(null, "window=apc")


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
- Перекидывает проверку списка сети камер из прока создания камеры вручную на просто прок появления камеры в мире, что убирает у ИИ возможность видеть камеры из "чёрного списка".
- Убирает ошибку возможности управления АПЦ после взлома малфом, при которой управлять этим АПЦ из силиконов мог только взломавший его малф и все **НЕ** привязанные к нему киборги.
- Заполняет список `restricted_camera_networks` сетями внестанционных камер.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Баг сам попался под руку
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
