### PR TITLE
bugfix: some cargo fixes and tweaks/ part 2

### DIFF
--- a/code/controllers/subsystem/non-firing/cargo_quests.dm
+++ b/code/controllers/subsystem/non-firing/cargo_quests.dm
@@ -79,7 +79,7 @@ SUBSYSTEM_DEF(cargo_quests)
 			cargo_announcer.print_report(quest, complete, modificators, old_reward)
 
 	if(!reroll && (quest.customer in plasma_departaments))
-		addtimer(CALLBACK(src, PROC_REF(create_new_quest), pick(get_customer_list(quest.customer))), 25 MINUTES)
+		addtimer(CALLBACK(src, PROC_REF(create_new_quest), pick(get_customer_list(quest.customer))), 10 MINUTES)
 	else
 		create_new_quest(pick(get_customer_list(quest.customer)), reroll, quest.quest_difficulty)
 	qdel(quest)

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1019,7 +1019,7 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 ///////////// High-Tech Disks
 
 /datum/supply_packs/misc/htdisk
-	name = "Empty High-Tech Disk Crate"
+	name = "HEADER"
 	cost = 1
 	special = TRUE
 	containername = "htdisk crate"

--- a/code/modules/economy/quests/quest_console.dm
+++ b/code/modules/economy/quests/quest_console.dm
@@ -27,11 +27,6 @@
 	return attack_hand(user)
 
 /obj/machinery/computer/supplyquest/attack_hand(mob/user)
-	if(!allowed(user) && !isobserver(user))
-		to_chat(user, span_warning("Access denied."))
-		playsound(src, pick('sound/machines/button.ogg', 'sound/machines/button_alternate.ogg', 'sound/machines/button_meloboom.ogg'), 20)
-		return TRUE
-
 	add_fingerprint(user)
 	ui_interact(user)
 	return
@@ -80,6 +75,8 @@
 		if(for_active_quests && !quest_storage.active)
 			continue
 		var/timeleft_sec = round((quest_storage.time_start + quest_storage.quest_time - world.time) / 10)
+		if(quest_storage.active)
+			timeleft_sec += 180
 		var/list/quests_items = list()
 		for(var/datum/cargo_quest/cargo_quest as anything in quest_storage.current_quests)
 			var/image_index = rand(1, length(cargo_quest.interface_icons))
@@ -264,7 +261,7 @@
 		paper.info += "content mismatch (-30%) x[modificators["content_mismatch"]]<br>"
 		phrases += pick_list(QUEST_NOTES_STRINGS, "content_mismatch_phrases")
 	if(modificators["content_missing"])
-		paper.info += "content missing (-50%) x[modificators["content_missing"]]<br>"
+		paper.info += "content missing (-[round(modificators["content_missing"] * 100/modificators["quest_len"])]%)<br>"
 		phrases += pick_list(QUEST_NOTES_STRINGS, "content_missing_phrases")
 	if(!complete)
 		paper.info += "time expired (-100%)<br>"

--- a/code/modules/economy/quests/thing_quests.dm
+++ b/code/modules/economy/quests/thing_quests.dm
@@ -178,25 +178,27 @@
 	)
 	normal_items = list(
 		/obj/item/gem/rupee = 130,
-		/obj/item/crusher_trophy/vortex_talisman = 145,
 		/obj/item/borg/upgrade/modkit/lifesteal = 145,
-		/obj/item/crusher_trophy/tail_spike = 200,
+		/obj/item/voodoo = 180,
 		/obj/item/gem/magma = 220
 	)
 	hard_items = list(
 		/obj/item/crusher_trophy/blaster_tubes = 260,
-		/obj/item/crusher_trophy/adaptive_intelligence_core = 350,
+		/obj/item/grenade/clusterbuster/inferno = 270,
 		/obj/item/gem/phoron = 350,
 		/obj/item/gem/purple = 400,
 		/obj/item/gem/amber = 400,
-		/obj/item/crusher_trophy/demon_claws = 400,
 	)
 
 	very_hard_items = list(
 		/obj/item/gem/data = 450,
 		/obj/item/gem/void = 500,
 		/obj/effect/mob_spawn/human/ash_walker = 550,
-		/obj/item/gem/bloodstone = 650
+		/obj/item/gem/bloodstone = 650,
+		/obj/item/crusher_trophy/vortex_talisman = 700,
+		/obj/item/crusher_trophy/tail_spike = 750,
+		/obj/item/crusher_trophy/adaptive_intelligence_core = 850,
+		/obj/item/crusher_trophy/demon_claws = 1000,
 	)
 	difficultly_flags = (QUEST_DIFFICULTY_EASY|QUEST_DIFFICULTY_NORMAL|QUEST_DIFFICULTY_HARD|QUEST_DIFFICULTY_VERY_HARD)
 
@@ -444,6 +446,29 @@
 
 	req_items = list(/obj/item/dnainjector)
 	var/list/required_blocks = list()
+	normal_items = list(
+		"LISP" = 100,
+		"MUTE" = 100,
+		"RAD" = 100,
+		"FAT" = 100,
+		"SWEDE" = 100,
+		"SCRAMBLE" = 100,
+		"WEAK" = 100,
+		"HORNS" = 100,
+		"COMIC" = 100,
+		"SOBER" = 150,
+		"PSYRESIST" = 150,
+		"SHADOW" = 150,
+		"CHAMELEON" = 150,
+		"CRYO" = 150,
+		"EAT" = 150,
+		"JUMP" = 150,
+		"IMMOLATE" = 150,
+		"EMPATH" = 150,
+		"POLYMORPH" = 150,
+		"STRONG" = 150,
+	)
+
 	hard_items = list(
 		"BLINDNESS" = 200,
 		"COLOURBLIND" = 200,
@@ -469,7 +494,7 @@
 		"SHOCKIMMUNITY" = 200,
 		"SMALLSIZE" = 250
 	)
-	difficultly_flags = (QUEST_DIFFICULTY_HARD)
+	difficultly_flags = (QUEST_DIFFICULTY_NORMAL|QUEST_DIFFICULTY_HARD)
 
 /datum/cargo_quest/thing/genes/update_interface_icon()
 	return

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -52,12 +52,16 @@
 
 		if(sortTag != tagger.currTag || cc_tag != tagger.currcc_tag)
 			add_fingerprint(user)
-			var/tag = uppertext(GLOB.TAGGERLOCATIONS[tagger.currTag])
-			var/cctag = uppertext(tagger.currcc_tag)
-			to_chat(user, span_notice("*[tag]*"))
-			to_chat(user, span_notice("*[cctag]*"))
-			sortTag = tagger.currTag
-			cc_tag = tagger.currcc_tag
+
+			if(tagger.currcc_tag)
+				var/cctag = uppertext(tagger.currcc_tag)
+				to_chat(user, span_notice("*[cctag]*"))
+				cc_tag = tagger.currcc_tag
+			else
+				var/tag = uppertext(GLOB.TAGGERLOCATIONS[tagger.currTag])
+				to_chat(user, span_notice("*[tag]*"))
+				sortTag = tagger.currTag
+
 			if(iconLabeled)
 				icon_state = iconLabeled
 			playsound(loc, 'sound/machines/twobeep.ogg', 100, 1)
@@ -356,6 +360,8 @@
 			if(currTag != destination_id)
 				currTag = destination_id
 				playsound(src, "terminal_type", 25, TRUE)
+			currcc_tag = null
+
 		if("select_cc_destination")
 			if(currcc_tag != params["destination"])
 				currcc_tag = params["destination"]


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Фиксы и изменения для #4047

Теперь раундстартом не будет самых сложных квестов.
Теперь когда вы берёте заказ к нему добавляется 3 минуты.
Теперь не будет лишнего штрафа за недоставленные вещи, сам штраф снижен с 50% за каждую вещь до 25% если вещей должно было быть 4 и 33% если 3.
Теперь таггер не будет ставить и станционную и цк точку одновременно, только последнюю выбранную.
Теперь люди без доступа смогут смотреть в консоль кма(не пользоваться)
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Уменьшение сложности/фиксы.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
