### PR TITLE
bugfix: ussp golem docking port size

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
@@ -8131,11 +8131,11 @@
 "zW" = (
 /obj/docking_port/stationary{
 	dir = 8;
-	dwidth = 8;
-	height = 20;
+	dwidth = 10;
+	height = 30;
 	id = "freegolem_ussp";
 	name = "Near USSP Station";
-	width = 16
+	width = 20
 	},
 /turf/space,
 /area/template_noop)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправляет размер зоны стыковочного порта для големов возле бублика сссп
## Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
![image](https://github.com/ss220-space/Paradise/assets/87157426/3f399429-a163-46e4-8a77-49b2a8bfec6b)
