### PR TITLE
bugfix: missed value returning in `user_buckle_mob()`.

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -140,6 +140,7 @@
 				M.visible_message(span_warning("[user] buckles [M] to [src]!"),\
 					span_warning("[user] buckles you to [src]!"),\
 					span_italics("You hear metal clanking."))
+				return TRUE
 		else
 			to_chat(user, span_warning("You fail to buckle [M]."))
 	else
@@ -147,6 +148,7 @@
 			M.visible_message(span_notice("[M] buckles [M.p_them()]self to [src]."),\
 				span_notice("You buckle yourself to [src]."),\
 				span_italics("You hear metal clanking."))
+			return TRUE
 
 /atom/movable/proc/user_unbuckle_mob(mob/living/buckled_mob, mob/user)
 	var/mob/living/M = unbuckle_mob(buckled_mob)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
В ПРе чётырёхмесячной давности какой-то @0x0v3rfl0w убрал возврат значения через `.`<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## 4 месяца багу Ya Pierdole
Если коротко, то `MouseDrop` в баклинге не получал свой ретурн ТРУ, когда мы удачно садимся в, например, стул и проигрывает `MouseDrop` от родителя, что вызывает ненужные проверки и появление в чате лишнего текста.<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
