### PR TITLE
bugfix: infinity wethersound in gate level.

### DIFF
--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -4,21 +4,21 @@
 	var/name = "space wind"
 	var/desc = "Heavy gusts of wind blanket the area, periodically knocking down anyone caught in the open."
 
-	var/telegraph_message = "<span class='warning'>The wind begins to pick up.</span>" //The message displayed in chat to foreshadow the weather's beginning
-	var/telegraph_duration = 300 //In deciseconds, how long from the beginning of the telegraph until the weather begins
+	var/telegraph_message = span_warning("The wind begins to pick up.") //The message displayed in chat to foreshadow the weather's beginning
+	var/telegraph_duration = 30 SECONDS //In deciseconds, how long from the beginning of the telegraph until the weather begins
 	var/telegraph_sound //The sound file played to everyone on an affected z-level
 	var/telegraph_overlay //The overlay applied to all tiles on the z-level
 
-	var/weather_message = "<span class='userdanger'>The wind begins to blow ferociously!</span>" //Displayed in chat once the weather begins in earnest
-	var/weather_duration = 1200 //In deciseconds, how long the weather lasts once it begins
-	var/weather_duration_lower = 1200 //See above - this is the lowest possible duration
-	var/weather_duration_upper = 1500 //See above - this is the highest possible duration
+	var/weather_message = span_userdanger("The wind begins to blow ferociously!") //Displayed in chat once the weather begins in earnest
+	var/weather_duration = 120 SECONDS //In deciseconds, how long the weather lasts once it begins
+	var/weather_duration_lower = 120 SECONDS //See above - this is the lowest possible duration
+	var/weather_duration_upper = 150 SECONDS //See above - this is the highest possible duration
 	var/weather_sound
 	var/weather_overlay
 	var/weather_color = null
 
-	var/end_message = "<span class='danger'>The wind relents its assault.</span>" //Displayed once the wather is over
-	var/end_duration = 300 //In deciseconds, how long the "wind-down" graphic will appear before vanishing entirely
+	var/end_message = span_danger("The wind relents its assault.") //Displayed once the wather is over
+	var/end_duration = 30 SECONDS //In deciseconds, how long the "wind-down" graphic will appear before vanishing entirely
 	var/end_sound
 	var/end_overlay
 
@@ -58,7 +58,7 @@
 
 /datum/weather/proc/telegraph()
 	if(stage == STARTUP_STAGE)
-		return TRUE
+		return TRUE	// If weather already active, don't need to mark it as invalid. More at `/datum/controller/subsystem/weather/fire()`
 	generate_area_list()
 	if(!impacted_areas.len)
 		return FALSE
@@ -106,7 +106,7 @@
 
 /datum/weather/proc/end()
 	if(stage == END_STAGE)
-		return 1
+		return TRUE
 	stage = END_STAGE
 	STOP_PROCESSING(SSweather, src)
 	update_areas()
@@ -114,14 +114,14 @@
 /datum/weather/proc/can_weather_act(mob/living/L) //Can this weather impact a mob?
 	var/turf/mob_turf = get_turf(L)
 	if(!istype(L))
-		return
+		return FALSE
 	if(mob_turf && !(mob_turf.z in impacted_z_levels))
-		return
+		return FALSE
 	if(immunity_type in L.weather_immunities)
-		return
+		return FALSE
 	if(!(get_area(L) in impacted_areas))
-		return
-	return 1
+		return FALSE
+	return TRUE
 
 /datum/weather/proc/weather_act(mob/living/L) //What effect does this weather have on the hapless mob?
 	return

--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -59,10 +59,10 @@
 /datum/weather/proc/telegraph()
 	if(stage == STARTUP_STAGE)
 		return TRUE
-	stage = STARTUP_STAGE
 	generate_area_list()
 	if(!impacted_areas.len)
 		return FALSE
+	stage = STARTUP_STAGE
 	weather_duration = rand(weather_duration_lower, weather_duration_upper)
 	START_PROCESSING(SSweather, src)
 	update_areas()

--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -3,17 +3,17 @@
 	name = "ash storm"
 	desc = "An intense atmospheric storm lifts ash off of the planet's surface and billows it down across the area, dealing intense fire damage to the unprotected."
 
-	telegraph_message = "<span class='boldwarning'>An eerie moan rises on the wind. Sheets of burning ash blacken the horizon. Seek shelter.</span>"
-	telegraph_duration = 300
+	telegraph_message = span_boldwarning("An eerie moan rises on the wind. Sheets of burning ash blacken the horizon. Seek shelter.")
+	telegraph_duration = 30 SECONDS
 	telegraph_overlay = "light_ash"
 
-	weather_message = "<span class='userdanger'><i>Smoldering clouds of scorching ash billow down around you! Get inside!</i></span>"
-	weather_duration_lower = 600
-	weather_duration_upper = 1200
+	weather_message = span_userdanger("<i>Smoldering clouds of scorching ash billow down around you! Get inside!</i>")
+	weather_duration_lower = 60 SECONDS
+	weather_duration_upper = 120 SECONDS
 	weather_overlay = "ash_storm"
 
-	end_message = "<span class='boldannounce'>The shrieking wind whips away the last of the ash and falls to its usual murmur. It should be safe to go outside now.</span>"
-	end_duration = 300
+	end_message = span_boldannounce("The shrieking wind whips away the last of the ash and falls to its usual murmur. It should be safe to go outside now.")
+	end_duration = 30 SECONDS
 	end_overlay = "light_ash"
 
 	area_type = /area/lavaland/surface/outdoors
@@ -128,10 +128,10 @@
 	name = "emberfall"
 	desc = "A passing ash storm blankets the area in harmless embers."
 
-	weather_message = "<span class='notice'>Gentle embers waft down around you like grotesque snow. The storm seems to have passed you by...</span>"
+	weather_message = span_notice("Gentle embers waft down around you like grotesque snow. The storm seems to have passed you by...")
 	weather_overlay = "light_ash"
 
-	end_message = "<span class='notice'>The emberfall slows, stops. Another layer of hardened soot to the basalt beneath your feet.</span>"
+	end_message = span_notice("The emberfall slows, stops. Another layer of hardened soot to the basalt beneath your feet.")
 	end_sound = null
 
 	aesthetic = TRUE

--- a/code/datums/weather/weather_types/snow_storm.dm
+++ b/code/datums/weather/weather_types/snow_storm.dm
@@ -21,14 +21,14 @@
 
 	immunity_type = "snow"
 
+	var/list/inside_areas = list()
+	var/list/outside_areas = list()
 	var/datum/looping_sound/active_outside_ashstorm/sound_ao = new(list(), FALSE, TRUE)
 	var/datum/looping_sound/active_inside_ashstorm/sound_ai = new(list(), FALSE, TRUE)
 	var/datum/looping_sound/weak_outside_ashstorm/sound_wo = new(list(), FALSE, TRUE)
 	var/datum/looping_sound/weak_inside_ashstorm/sound_wi = new(list(), FALSE, TRUE)
 
 /datum/weather/snow_storm/proc/update_eligible_areas()
-	var/list/inside_areas = list()
-	var/list/outside_areas = list()
 	var/list/eligible_areas = list()
 	for(var/z in impacted_z_levels)
 		eligible_areas += GLOB.space_manager.areas_in_z["[z]"]
@@ -36,47 +36,40 @@
 	for(var/i in 1 to eligible_areas.len)
 		var/area/place = eligible_areas[i]
 		if(place.outdoors)
-			outside_areas += place
+			outside_areas |= place
 		else
-			inside_areas += place
+			inside_areas |= place
 		CHECK_TICK
-
-	sound_ao.output_atoms = outside_areas
-	sound_ai.output_atoms = inside_areas
-	sound_wo.output_atoms = outside_areas
-	sound_wi.output_atoms = inside_areas
-
-	sound_wo.start()
-	sound_wi.start()
 
 /datum/weather/snow_storm/proc/update_audio()
 	switch(stage)
 		if(STARTUP_STAGE)
-			sound_wo.start()
-			sound_wi.start()
+			sound_wo.start(outside_areas)
+			sound_wi.start(inside_areas)
 
 		if(MAIN_STAGE)
-			sound_wo.stop()
-			sound_wi.stop()
+			sound_wo.stop(outside_areas, TRUE)
+			sound_wi.stop(inside_areas, TRUE)
 
-			sound_ao.start()
-			sound_ai.start()
+			sound_ao.start(outside_areas)
+			sound_ai.start(inside_areas)
 
 		if(WIND_DOWN_STAGE)
-			sound_ao.stop()
-			sound_ai.stop()
+			sound_ao.stop(outside_areas, TRUE)
+			sound_ai.stop(inside_areas, TRUE)
 
-			sound_wo.start()
-			sound_wi.start()
+			sound_wo.start(outside_areas)
+			sound_wi.start(inside_areas)
 
 		if(END_STAGE)
-			sound_wo.stop()
-			sound_wi.stop()
+			sound_wo.stop(outside_areas, TRUE)
+			sound_wi.stop(inside_areas, TRUE)
 
 /datum/weather/snow_storm/telegraph()
 	. = ..()
-	update_eligible_areas()
-	update_audio()
+	if(.)
+		update_eligible_areas()
+		update_audio()
 
 /datum/weather/snow_storm/wind_down()
 	. = ..()

--- a/code/datums/weather/weather_types/snow_storm.dm
+++ b/code/datums/weather/weather_types/snow_storm.dm
@@ -3,17 +3,17 @@
 	desc = "Harsh snowstorms roam the topside of this arctic planet, burying any area unfortunate enough to be in its path."
 	probability = 99
 
-	telegraph_message = "<span class='warning'>Drifting particles of snow begin to dust the surrounding area..</span>"
-	telegraph_duration = 400
+	telegraph_message = span_warning("Drifting particles of snow begin to dust the surrounding area...")
+	telegraph_duration = 40 SECONDS
 	telegraph_overlay = "light_snow"
 
-	weather_message = "<span class='userdanger'><i>Harsh winds pick up as dense snow begins to fall from the sky! Seek shelter!</i></span>"
+	weather_message = span_userdanger("<i>Harsh winds pick up as dense snow begins to fall from the sky! Seek shelter!</i>")
 	weather_overlay = "snow_storm"
-	weather_duration_lower = 600
-	weather_duration_upper = 1200
+	weather_duration_lower = 60 SECONDS
+	weather_duration_upper = 120 SECONDS
 
-	end_duration = 100
-	end_message = "<span class='boldannounce'>The snowfall dies down, it should be safe to go outside again.</span>"
+	end_duration = 10 SECONDS
+	end_message = span_boldannounce("The snowfall dies down, it should be safe to go outside again.")
 	end_overlay = "light_snow"
 
 	area_type = /area/vision_change_area/awaymission/evil_santa_storm


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Во-первых, теперь не проходит "регистрация" зон для заполнения атомов в датуме звука, если погода не нашла для себя подходящих зон.
Во-вторых, у пыльной и снежной бури их "внешние/внутренние" зоны добавляются и убираются из списка атомов в датуме звука при каждом изменении стадии погоды. Теперь обе бури могут душить звуком там, где работают, независимо друг от друга.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР
Система была немного недоработана и её косяки вскрылись после обновления новогоднего гейта. Это всё.<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
