### PR TITLE
bugfix: megafauna are no longer afraid of chasms & normal pathing for shitspawn species & plasma golems now have normal explode ability

### DIFF
--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -27,7 +27,8 @@
 		/obj/effect/ebeam,
 		/obj/effect/spawner,
 		/obj/structure/railing,
-		/obj/machinery/atmospherics/pipe/simple
+		/obj/machinery/atmospherics/pipe/simple,
+		/mob/living/simple_animal/hostile/megafauna //failsafe
 		))
 	var/drop_x = 1
 	var/drop_y = 1
@@ -42,6 +43,12 @@
 	..()
 	START_PROCESSING(SSprocessing, src)
 	drop_stuff(AM)
+
+/turf/simulated/floor/chasm/CanPathfindPass(obj/item/card/id/ID, to_dir, caller, no_id = FALSE)
+	if(!isliving(caller))
+		return TRUE
+	var/mob/living/L = caller
+	return (L.flying || ismegafauna(caller))
 
 /turf/simulated/floor/chasm/process()
 	if(!drop_stuff())

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -66,13 +66,13 @@
 /mob/living/carbon/human/unathi/Initialize(mapload)
 	. = ..(mapload, /datum/species/unathi)
 
-/mob/living/carbon/human/unathi/draconid/Initialize(mapload)
+/mob/living/carbon/human/unathi_draconid/Initialize(mapload)
 	. = ..(mapload, /datum/species/unathi/draconid)
 
-/mob/living/carbon/human/unathi/ashwalker/Initialize(mapload)
+/mob/living/carbon/human/unathi_ashwalker/Initialize(mapload)
 	. = ..(mapload, /datum/species/unathi/ashwalker)
 
-/mob/living/carbon/human/unathi/ashwalker/shaman/Initialize(mapload)
+/mob/living/carbon/human/unathi_ashwalker_shaman/Initialize(mapload)
 	. = ..(mapload, /datum/species/unathi/ashwalker/shaman)
 
 /mob/living/carbon/human/vox/Initialize(mapload)
@@ -137,58 +137,58 @@
 /mob/living/carbon/human/golem/Initialize(mapload)
 	. = ..(mapload, /datum/species/golem)
 
-/mob/living/carbon/human/golem/random/Initialize(mapload)
+/mob/living/carbon/human/golem_random/Initialize(mapload)
 	. = ..(mapload, /datum/species/golem/random)
 
-/mob/living/carbon/human/golem/adamantine/Initialize(mapload)
+/mob/living/carbon/human/golem_adamantine/Initialize(mapload)
 	. = ..(mapload, /datum/species/golem/adamantine)
 
-/mob/living/carbon/human/golem/plasma/Initialize(mapload)
+/mob/living/carbon/human/golem_plasma/Initialize(mapload)
 	. = ..(mapload, /datum/species/golem/plasma)
 
-/mob/living/carbon/human/golem/diamond/Initialize(mapload)
+/mob/living/carbon/human/golem_diamond/Initialize(mapload)
 	. = ..(mapload, /datum/species/golem/diamond)
 
-/mob/living/carbon/human/golem/gold/Initialize(mapload)
+/mob/living/carbon/human/golem_gold/Initialize(mapload)
 	. = ..(mapload, /datum/species/golem/gold)
 
-/mob/living/carbon/human/golem/silver/Initialize(mapload)
+/mob/living/carbon/human/golem_silver/Initialize(mapload)
 	. = ..(mapload, /datum/species/golem/silver)
 
-/mob/living/carbon/human/golem/plasteel/Initialize(mapload)
+/mob/living/carbon/human/golem_plasteel/Initialize(mapload)
 	. = ..(mapload, /datum/species/golem/plasteel)
 
-/mob/living/carbon/human/golem/titanium/Initialize(mapload)
+/mob/living/carbon/human/golem_titanium/Initialize(mapload)
 	. = ..(mapload, /datum/species/golem/titanium)
 
-/mob/living/carbon/human/golem/plastitanium/Initialize(mapload)
+/mob/living/carbon/human/golem_plastitanium/Initialize(mapload)
 	. = ..(mapload, /datum/species/golem/plastitanium)
 
-/mob/living/carbon/human/golem/alien_alloy/Initialize(mapload)
+/mob/living/carbon/human/golem_alien_alloy/Initialize(mapload)
 	. = ..(mapload, /datum/species/golem/alloy)
 
-/mob/living/carbon/human/golem/uranium/Initialize(mapload)
+/mob/living/carbon/human/golem_uranium/Initialize(mapload)
 	. = ..(mapload, /datum/species/golem/uranium)
 
-/mob/living/carbon/human/golem/plastic/Initialize(mapload)
+/mob/living/carbon/human/golem_plastic/Initialize(mapload)
 	. = ..(mapload, /datum/species/golem/plastic)
 
-/mob/living/carbon/human/golem/sand/Initialize(mapload)
+/mob/living/carbon/human/golem_sand/Initialize(mapload)
 	. = ..(mapload, /datum/species/golem/sand)
 
-/mob/living/carbon/human/golem/glass/Initialize(mapload)
+/mob/living/carbon/human/golem_glass/Initialize(mapload)
 	. = ..(mapload, /datum/species/golem/glass)
 
-/mob/living/carbon/human/golem/bluespace/Initialize(mapload)
+/mob/living/carbon/human/golem_bluespace/Initialize(mapload)
 	. = ..(mapload, /datum/species/golem/bluespace)
 
-/mob/living/carbon/human/golem/bananium/Initialize(mapload)
+/mob/living/carbon/human/golem_bananium/Initialize(mapload)
 	. = ..(mapload, /datum/species/golem/bananium)
 
-/mob/living/carbon/human/golem/tranquillite/Initialize(mapload)
+/mob/living/carbon/human/golem_tranquillite/Initialize(mapload)
 	. = ..(mapload, /datum/species/golem/tranquillite)
 
-/mob/living/carbon/human/golem/clockwork/Initialize(mapload)
+/mob/living/carbon/human/golem_clockwork/Initialize(mapload)
 	. = ..(mapload, /datum/species/golem/clockwork)
 
 /mob/living/carbon/human/wryn/Initialize(mapload)

--- a/code/modules/mob/living/carbon/human/species/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/unathi.dm
@@ -169,7 +169,7 @@
 
 /datum/species/unathi/ashwalker/on_species_gain(mob/living/carbon/human/H)
 	..()
-	var/datum/action/innate/ignite/fire = locate() in H.actions
+	var/datum/action/innate/ignite_unathi/fire = locate() in H.actions
 	if(!fire)
 		fire = new
 		fire.Grant(H)
@@ -178,7 +178,7 @@
 
 /datum/species/unathi/ashwalker/on_species_loss(mob/living/carbon/human/H)
 	..()
-	var/datum/action/innate/ignite/fire = locate() in H.actions
+	var/datum/action/innate/ignite_unathi/fire = locate() in H.actions
 	if(fire)
 		fire.Remove(H)
 	UnregisterSignal(H, COMSIG_MOVABLE_Z_CHANGED)
@@ -211,7 +211,7 @@
 	if(!finder)
 		finder = new
 		finder.Grant(C)
-	var/datum/action/innate/ignite/fire = locate() in C.actions
+	var/datum/action/innate/ignite_unathi/fire = locate() in C.actions
 	if(!fire)
 		fire = new
 		fire.Grant(C)
@@ -224,7 +224,7 @@
 	var/datum/action/innate/anvil_finder/finder = locate() in C.actions
 	if(finder)
 		finder.Remove(C)
-	var/datum/action/innate/ignite/fire = locate() in C.actions
+	var/datum/action/innate/ignite_unathi/fire = locate() in C.actions
 	if(fire)
 		fire.Remove(C)
 
@@ -351,7 +351,7 @@ They're basically just lizards with all-around marginally better stats and fire 
 	C.update_inv_head()
 	C.update_inv_wear_suit() //update sprites for digi legs
 	C.weather_immunities |= "ash"
-	var/datum/action/innate/ignite/fire = locate() in C.actions
+	var/datum/action/innate/ignite_unathi/fire = locate() in C.actions
 	if(!fire)
 		fire = new
 		fire.Remove(C)
@@ -362,12 +362,12 @@ They're basically just lizards with all-around marginally better stats and fire 
 	C.update_inv_head()
 	C.update_inv_wear_suit()
 	C.weather_immunities -= "ash"
-	var/datum/action/innate/ignite/fire = locate() in C.actions
+	var/datum/action/innate/ignite_unathi/fire = locate() in C.actions
 	if(fire)
 		fire.Grant(C)
 
 //igniter. only for ashwalkers and drakonids because of """lore"""
-/datum/action/innate/ignite
+/datum/action/innate/ignite_unathi
 	name = "Ignite"
 	desc = "You form a fire in your mouth, fierce enough to... light a cigarette."
 	icon_icon = 'icons/obj/cigarettes.dmi'
@@ -376,7 +376,7 @@ They're basically just lizards with all-around marginally better stats and fire 
 	var/cooldown_duration = 40 SECONDS
 	check_flags = AB_CHECK_RESTRAINED
 
-/datum/action/innate/ignite/Activate()
+/datum/action/innate/ignite_unathi/Activate()
 	var/mob/living/carbon/human/user = owner
 	if(world.time <= cooldown)
 		to_chat(user, span_warning("Your throat hurts too much to do it right now. Wait [round((cooldown - world.time) / 10)] seconds and try again."))

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -199,7 +199,8 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		var/icon/base_icon
 		//BEGIN CACHED ICON GENERATION.
 		var/obj/item/organ/external/chest = get_organ(BODY_ZONE_CHEST)
-		base_icon = chest.get_icon(skeleton)
+		if(chest) //I hate it.
+			base_icon = chest.get_icon(skeleton)
 
 		for(var/obj/item/organ/external/part as anything in bodyparts)
 			if(part.limb_zone == BODY_ZONE_TAIL || part.limb_zone == BODY_ZONE_WING)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
@@ -290,7 +290,6 @@ Difficulty: Very Hard
 
 /mob/living/simple_animal/hostile/megafauna/ancient_robot/Bump(atom/A)
 	if(charging)
-		DestroySurroundings()
 		if(isliving(A))
 			var/mob/living/L = A
 			if(!istype(A, /mob/living/simple_animal/hostile/ancient_robot_leg))
@@ -564,8 +563,6 @@ Difficulty: Very Hard
 	return
 
 /mob/living/simple_animal/hostile/megafauna/ancient_robot/Moved(atom/OldLoc, Dir, Forced = FALSE)
-	if(charging)
-		DestroySurroundings()
 	if(Dir)
 		leg_walking_controler(Dir)
 		if(charging)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -536,8 +536,6 @@ Difficulty: Hard
 /mob/living/simple_animal/hostile/megafauna/bubblegum/Moved(atom/OldLoc, Dir, Forced = FALSE)
 	if(Dir)
 		new /obj/effect/decal/cleanable/blood/bubblegum(loc)
-	if(charging)
-		DestroySurroundings()
 	playsound(src, 'sound/effects/meteorimpact.ogg', 200, TRUE, 2, TRUE)
 	return ..()
 
@@ -545,7 +543,6 @@ Difficulty: Hard
 	if(charging)
 		if(isturf(A) || isobj(A) && A.density)
 			A.ex_act(EXPLODE_HEAVY)
-		DestroySurroundings()
 		if(isliving(A))
 			var/mob/living/L = A
 			L.visible_message("<span class='danger'>[src] slams into [L]!</span>", "<span class='userdanger'>[src] tramples you into the ground!</span>")

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -58,6 +58,8 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/megafauna/Moved()
+	if(target)
+		DestroySurroundings() //So they can path through chasms.
 	if(nest && nest.parent && get_dist(nest.parent, src) > nest_range)
 		var/turf/closest = get_turf(nest.parent)
 		for(var/i = 1 to nest_range)
@@ -176,6 +178,12 @@
 		SSmedals.SetScore(BOSS_SCORE, C, 1)
 		SSmedals.SetScore(score_type, C, 1)
 	return TRUE
+
+/mob/living/simple_animal/hostile/megafauna/DestroySurroundings()
+	. = ..()
+	for(var/turf/simulated/floor/chasm/C in circlerangeturfs(src, 1))
+		C.density = FALSE //I hate it.
+		addtimer(VARSET_CALLBACK(C, density, TRUE), 2 SECONDS) // Needed to make them path. I hate it.
 
 /datum/action/innate/megafauna_attack
 	name = "Megafauna Attack"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Налепляем костыль на костыль, теперь мегафауна больше не боится чазмов
Сверху, убираем абъюз фауны стенками, теперь она чаще ломает окружение в битве, а не пытается его обойти. Мило, прикольно
И СВЕРХУ:
Нормальный спавн всех уникальных рас - подтипы унати (эшвалкеры, драконид) и големы.
И СВЕРХУ:
Меняет путь способности дыхания у унати на новый путь, потому что он совпадал с названием способности у плазма-големов. И вместо того, чтобы взрываться, плазмаголемы получили возможность использовать ротовую спичку. Мда.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багфикс + багфикс +багфикс
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
