### PR TITLE
bugfix: slimeman and diona initialised with wrong hud.

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -21,6 +21,8 @@
 		tts_seed = SStts.get_random_seed(src)
 
 	setup_dna(new_species)
+	med_hud_set_health()	// Updating med huds is necessary after `setup_dna()` due to the fact that while
+	med_hud_set_status()	// a human does not have a heart, the hud status is displayed incorrectly.
 
 	create_reagents(330)
 
@@ -35,8 +37,6 @@
 	handcrafting.ui_interact(src)
 
 /mob/living/carbon/human/prepare_data_huds()
-	//Update med hud images...
-	..()
 	//...sec hud images...
 	sec_hud_set_ID()
 	sec_hud_set_implants()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Для хуманов вытаскивает обновление медицинского худа из общего корневого прока обновления худов, который вызывается вначале инициализации (и который ничего нам не даёт в том месте, ибо всё равно мы доспавниваем внутренние и внешние органы потом), в конец инициализаии.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Зарепорчено в раунде
Дионы и Слаймолюди имеют у себя в списке `has_organ` мозги прописанные выше, чем сердце, так что при впихивании мозга в тело, что провоцирует обновление медхудов, мы получаем сломанный медхуд, считающий, что у нас нету сердца.<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
