### PR TITLE
feat: add wrench action to raise bolt on unpowered airlock

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1067,6 +1067,23 @@ About the new airlock wires panel:
 		return
 	interact_with_panel(user)
 
+/obj/machinery/door/airlock/wrench_act(mob/user, obj/item/I)
+	if(!headbutt_shock_check(user))
+		return
+	. = TRUE
+	if(!I.tool_use_check(user, 0))
+		return
+	if(!panel_open||!locked||emagged)
+		to_chat(user, span_notice("You can't reach bolt reducer."))
+		return
+	if(isAllPowerLoss())
+		to_chat(user, span_notice("You start wrenching bolt reducer."))
+		if(I.use_tool(src, user, 300, volume = I.tool_volume))
+			user.visible_message(span_notice("[user] raise \the [src]'s bolt manually."),
+								span_notice("You raise \the [src]'s bolt manually."))
+			unlock(TRUE)
+		return
+
 /obj/machinery/door/airlock/welder_act(mob/user, obj/item/I) //This is god awful but I don't care
 	if(!headbutt_shock_check(user))
 		return


### PR DESCRIPTION
## Описание
Добавил в `airlock.dm` возможность поднять болты у обесточенного шлюза с помощью разводного ключа. Действие длится 30 секунд с обычным инструментом. На емагнутых дверях не работает.

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1200755592038465546

## Демонстрация изменений
Сегодня без скриншотов. 
