### PR TITLE
bugfix: Default Zone Selection

### DIFF
--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -12,7 +12,7 @@
 	var/stat = 0 //Whether a mob is alive or dead. TODO: Move this to living - Nodrak
 
 	/// The zone this mob is currently targeting
-	var/zone_selected = null
+	var/zone_selected = BODY_ZONE_CHEST
 
 	var/obj/screen/hands = null
 	var/obj/screen/pullin = null


### PR DESCRIPTION
## Описание
Устанавливает дефолтно выбранную зону (верхнюю часть туловища), по умолчанию для всех мобов. Устраняет проблемы с обращением к нулю, без переключения на другую часть тела.
