### PR TITLE
bugfix: Nettle and deathnettle special effects now blocking

### DIFF
--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -106,9 +106,9 @@
 	return ..()
 
 /obj/item/grown/nettle/death/attack(mob/living/carbon/M, mob/user)
-	..()
-	if(isliving(M))
-		to_chat(M, "<span class='danger'>You are stunned by the powerful acid of the Deathnettle!</span>")
+	. = ..()
+	if(. && isliving(M))
+		to_chat(M, span_danger("You are stunned by the powerful acid of the Deathnettle!"))
 		add_attack_logs(user, M, "Hit with [src]")
 
 		M.AdjustEyeBlurry((force / 7) STATUS_EFFECT_CONSTANT)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Особые эффекты атаки крапивой теперь учитывают результат родительской функции и не применяются, когда атака промазала/была заблокирована и т.п.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
