### PR TITLE
refactor: reduce list count for floor turfs

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -68,9 +68,9 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 	var/min_cold_protection_temperature //Set this variable to determine down to which temperature (IN KELVIN) the item protects against cold damage. 0 is NOT an acceptable number due to if(varname) tests!! Keep at null to disable protection. Only protects areas set by cold_protection flags
 
 	var/list/actions = list() //list of /datum/action's that this item has.
-	var/list/actions_types = list() //list of paths of action datums to give to the item on New().
-	var/list/action_icon = list() //list of icons-sheets for a given action to override the icon.
-	var/list/action_icon_state = list() //list of icon states for a given action to override the icon_state.
+	var/list/actions_types = null //list of paths of action datums to give to the item on New().
+	var/list/action_icon = null //list of icons-sheets for a given action to override the icon.
+	var/list/action_icon_state = null //list of icon states for a given action to override the icon_state.
 
 	var/list/materials = list()
 	var/materials_coeff = 1
@@ -171,7 +171,10 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 /obj/item/New()
 	..()
 	for(var/path in actions_types)
-		new path(src, action_icon[path], action_icon_state[path])
+		if(action_icon && action_icon_state)
+			new path(src, action_icon[path], action_icon_state[path])
+		else
+			new path(src)
 
 	if(!hitsound)
 		if(damtype == "fire")

--- a/code/game/objects/items/devices/voice.dm
+++ b/code/game/objects/items/devices/voice.dm
@@ -65,7 +65,7 @@
 /obj/item/voice_changer/ninja
 	name = "ninja voice changer"
 	desc = "A voice scrambling module."
-	actions_types = list()
+	actions_types = null
 	inform_about_toggle = FALSE
 
 /obj/item/voice_changer/ninja/set_voice(mob/user, chosen_voice)

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -35,9 +35,7 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 	var/burnt = 0
 	var/current_overlay = null
 	var/floor_tile = null //tile that this floor drops
-	var/list/broken_states = list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
-	var/list/burnt_states = list("floorscorched1", "floorscorched2")
-	var/list/prying_tool_list = list(TOOL_CROWBAR) //What tool/s can we use to pry up the tile?
+	var/prying_tool = TOOL_CROWBAR //What tool/s can we use to pry up the tile?
 	var/keep_dir = TRUE //When false, resets dir to default on changeturf()
 
 	footstep = FOOTSTEP_FLOOR
@@ -58,6 +56,16 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 //		if(!( locate(/obj/machinery/mass_driver, src) ))
 //			return 0
 //	return ..()
+
+/// Returns a list of every turf state considered "broken".
+/// Will be randomly chosen if a turf breaks at runtime.
+/turf/simulated/floor/proc/broken_states()
+	return list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
+
+/// Returns a list of every turf state considered "burnt".
+/// Will be randomly chosen if a turf is burnt at runtime.
+/turf/simulated/floor/proc/burnt_states()
+	return list("floorscorched1", "floorscorched2")
 
 /turf/simulated/floor/ex_act(severity)
 	if(is_shielded())
@@ -131,14 +139,14 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 /turf/simulated/floor/break_tile()
 	if(broken)
 		return
-	current_overlay = pick(broken_states)
+	current_overlay = pick(broken_states())
 	broken = TRUE
 	update_icon()
 
 /turf/simulated/floor/burn_tile()
 	if(burnt)
 		return
-	current_overlay = pick(burnt_states)
+	current_overlay = pick(burnt_states())
 	burnt = TRUE
 	update_icon()
 
@@ -233,7 +241,7 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 	if(T.turf_type == type)
 		return
 	var/obj/item/thing = user.get_inactive_hand()
-	if(!thing || !prying_tool_list.Find(thing.tool_behaviour))
+	if(!thing || prying_tool != thing.tool_behaviour)
 		return
 	var/turf/simulated/floor/plating/P = pry_tile(thing, user, TRUE)
 	if(!istype(P))

--- a/code/game/turfs/simulated/floor/asteroid.dm
+++ b/code/game/turfs/simulated/floor/asteroid.dm
@@ -433,8 +433,10 @@ GLOBAL_LIST_INIT(megafauna_spawn_list, list(/mob/living/simple_animal/hostile/me
 	slowdown = 2
 	environment_type = "snow"
 	planetary_atmos = TRUE
-	burnt_states = list("snow_dug")
 	digResult = /obj/item/stack/sheet/mineral/snow
+
+/turf/simulated/floor/plating/asteroid/snow/broken_states()
+	return list("snow_dug")
 
 /turf/simulated/floor/plating/asteroid/snow/burn_tile()
 	if(!burnt)

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -1,12 +1,14 @@
 /turf/simulated/floor/wood
 	icon_state = "wood"
 	floor_tile = /obj/item/stack/tile/wood
-	prying_tool_list = list(TOOL_SCREWDRIVER)
-	broken_states = list("wood-broken", "wood-broken2", "wood-broken3", "wood-broken4", "wood-broken5", "wood-broken6", "wood-broken7")
+	prying_tool = TOOL_SCREWDRIVER
 	footstep = FOOTSTEP_WOOD
 	barefootstep = FOOTSTEP_WOOD_BAREFOOT
 	clawfootstep = FOOTSTEP_WOOD_CLAW
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
+
+/turf/simulated/floor/wood/broken_states()
+	return list("wood-broken", "wood-broken2", "wood-broken3", "wood-broken4", "wood-broken5", "wood-broken6", "wood-broken7")
 
 /turf/simulated/floor/wood/screwdriver_act(mob/user, obj/item/I)
 	. = TRUE
@@ -44,48 +46,64 @@
 /turf/simulated/floor/wood/oak
 	icon_state = "wood-oak"
 	floor_tile = /obj/item/stack/tile/wood/oak
-	broken_states = list("wood-oak-broken", "wood-oak-broken2", "wood-oak-broken3", "wood-oak-broken4", "wood-oak-broken5", "wood-oak-broken6", "wood-oak-broken7")
+
+/turf/simulated/floor/wood/oak/broken_states()
+	return list("wood-oak-broken", "wood-oak-broken2", "wood-oak-broken3", "wood-oak-broken4", "wood-oak-broken5", "wood-oak-broken6", "wood-oak-broken7")
 
 /turf/simulated/floor/wood/birch
 	icon_state = "wood-birch"
 	floor_tile = /obj/item/stack/tile/wood/birch
-	broken_states = list("wood-birch-broken", "wood-birch-broken2", "wood-birch-broken3", "wood-birch-broken4", "wood-birch-broken5", "wood-birch-broken6", "wood-birch-broken7")
+
+/turf/simulated/floor/wood/birch/broken_states()
+	return list("wood-birch-broken", "wood-birch-broken2", "wood-birch-broken3", "wood-birch-broken4", "wood-birch-broken5", "wood-birch-broken6", "wood-birch-broken7")
 
 /turf/simulated/floor/wood/cherry
 	icon_state = "wood-cherry"
 	floor_tile = /obj/item/stack/tile/wood/cherry
-	broken_states = list("wood-cherry-broken", "wood-cherry-broken2", "wood-cherry-broken3", "wood-cherry-broken4", "wood-cherry-broken5", "wood-cherry-broken6", "wood-cherry-broken7")
+
+/turf/simulated/floor/wood/cherry/broken_states()
+	return list("wood-cherry-broken", "wood-cherry-broken2", "wood-cherry-broken3", "wood-cherry-broken4", "wood-cherry-broken5", "wood-cherry-broken6", "wood-cherry-broken7")
 
 /turf/simulated/floor/wood/fancy/oak
 	icon_state = "fancy-wood-oak"
 	floor_tile = /obj/item/stack/tile/wood/fancy/oak
-	broken_states = list("fancy-wood-oak-broken", "fancy-wood-oak-broken2", "fancy-wood-oak-broken3", "fancy-wood-oak-broken4", "fancy-wood-oak-broken5", "fancy-wood-oak-broken6", "fancy-wood-oak-broken7")
+
+/turf/simulated/floor/wood/fancy/oak/broken_states()
+	return list("fancy-wood-oak-broken", "fancy-wood-oak-broken2", "fancy-wood-oak-broken3", "fancy-wood-oak-broken4", "fancy-wood-oak-broken5", "fancy-wood-oak-broken6", "fancy-wood-oak-broken7")
 
 /turf/simulated/floor/wood/fancy/birch
 	icon_state = "fancy-wood-birch"
 	floor_tile = /obj/item/stack/tile/wood/fancy/birch
-	broken_states = list("fancy-wood-birch-broken", "fancy-wood-birch-broken2", "fancy-wood-birch-broken3", "fancy-wood-birch-broken4", "fancy-wood-birch-broken5", "fancy-wood-birch-broken6", "fancy-wood-birch-broken7")
+
+/turf/simulated/floor/wood/fancy/birch/broken_states()
+	return list("fancy-wood-birch-broken", "fancy-wood-birch-broken2", "fancy-wood-birch-broken3", "fancy-wood-birch-broken4", "fancy-wood-birch-broken5", "fancy-wood-birch-broken6", "fancy-wood-birch-broken7")
 
 /turf/simulated/floor/wood/fancy/cherry
 	icon_state = "fancy-wood-cherry"
 	floor_tile = /obj/item/stack/tile/wood/fancy/cherry
-	broken_states = list("fancy-wood-cherry-broken", "fancy-wood-cherry-broken2", "fancy-wood-cherry-broken3", "fancy-wood-cherry-broken4", "fancy-wood-cherry-broken5", "fancy-wood-cherry-broken6", "fancy-wood-cherry-broken7")
+
+/turf/simulated/floor/wood/fancy/cherry/broken_states()
+	return list("fancy-wood-cherry-broken", "fancy-wood-cherry-broken2", "fancy-wood-cherry-broken3", "fancy-wood-cherry-broken4", "fancy-wood-cherry-broken5", "fancy-wood-cherry-broken6", "fancy-wood-cherry-broken7")
 
 /turf/simulated/floor/wood/fancy/light
 	icon_state = "light-fancy-wood"
 	floor_tile = /obj/item/stack/tile/wood/fancy/light
-	broken_states = list("light-fancy-wood-broken", "light-fancy-wood-broken2", "light-fancy-wood-broken3", "light-fancy-wood-broken4", "light-fancy-wood-broken5", "light-fancy-wood-broken6", "light-fancy-wood-broken7")
+
+/turf/simulated/floor/wood/fancy/light/broken_states()
+	return list("light-fancy-wood-broken", "light-fancy-wood-broken2", "light-fancy-wood-broken3", "light-fancy-wood-broken4", "light-fancy-wood-broken5", "light-fancy-wood-broken6", "light-fancy-wood-broken7")
 
 // GRASS
 /turf/simulated/floor/grass
 	name = "grass patch"
 	icon_state = "grass1"
 	floor_tile = /obj/item/stack/tile/grass
-	broken_states = list("sand")
 	footstep = FOOTSTEP_GRASS
 	barefootstep = FOOTSTEP_GRASS
 	clawfootstep = FOOTSTEP_GRASS
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
+
+/turf/simulated/floor/grass/broken_states()
+	return list("sand")
 
 /turf/simulated/floor/grass/Initialize(mapload)
 	. = ..()
@@ -120,7 +138,6 @@
 	icon = 'icons/turf/floors/carpet.dmi'
 	icon_state = "carpet"
 	floor_tile = /obj/item/stack/tile/carpet
-	broken_states = list("damaged")
 	smooth = SMOOTH_TRUE
 	canSmoothWith = null
 	footstep = FOOTSTEP_CARPET
@@ -131,6 +148,9 @@
 /turf/simulated/floor/carpet/Initialize(mapload)
 	. = ..()
 	update_icon()
+
+/turf/simulated/floor/carpet/broken_states()
+	return list("damaged")
 
 /turf/simulated/floor/carpet/update_icon()
 	if(!..())
@@ -205,12 +225,14 @@
 	icon = 'icons/turf/space.dmi'
 	icon_state = "0"
 	floor_tile = /obj/item/stack/tile/fakespace
-	broken_states = list("damaged")
 	plane = PLANE_SPACE
 
 /turf/simulated/floor/fakespace/Initialize(mapload)
 	. = ..()
 	icon_state = SPACE_ICON_STATE
+
+/turf/simulated/floor/fakespace/broken_states()
+	return list("damaged")
 
 /turf/simulated/floor/fakespace/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
 	underlay_appearance.icon = 'icons/turf/space.dmi'

--- a/code/game/turfs/simulated/floor/light_floor.dm
+++ b/code/game/turfs/simulated/floor/light_floor.dm
@@ -15,7 +15,6 @@
 	light_range = 5
 	icon_state = "light_on"
 	floor_tile = /obj/item/stack/tile/light
-	broken_states = list("light_broken")
 	var/on = TRUE
 	var/state = LIGHTFLOOR_ON
 	var/can_modify_colour = TRUE
@@ -23,6 +22,9 @@
 /turf/simulated/floor/light/Initialize(mapload)
 	. = ..()
 	update_icon()
+
+/turf/simulated/floor/light/broken_states()
+	return list("light_broken")
 
 /turf/simulated/floor/light/update_icon()
 	..()

--- a/code/game/turfs/simulated/floor/mineral.dm
+++ b/code/game/turfs/simulated/floor/mineral.dm
@@ -14,9 +14,8 @@
 	icon_state = ""
 	var/list/icons = list()
 
-/turf/simulated/floor/mineral/Initialize(mapload)
-	. = ..()
-	broken_states = list("[initial(icon_state)]_dam")
+/turf/simulated/floor/mineral/broken_states()
+	return list("[initial(icon_state)]_dam")
 
 /turf/simulated/floor/mineral/update_icon()
 	if(!..())
@@ -92,7 +91,9 @@
 	name = "shuttle floor"
 	icon_state = "titanium"
 	floor_tile = /obj/item/stack/tile/mineral/titanium
-	broken_states = list("titanium_dam1","titanium_dam2","titanium_dam3","titanium_dam4","titanium_dam5")
+
+/turf/simulated/floor/mineral/titanium/broken_states()
+	return list("titanium_dam1","titanium_dam2","titanium_dam3","titanium_dam4","titanium_dam5")
 
 /turf/simulated/floor/mineral/titanium/airless
 	oxygen = 0
@@ -129,7 +130,9 @@
 	name = "shuttle floor"
 	icon_state = "plastitanium"
 	floor_tile = /obj/item/stack/tile/mineral/plastitanium
-	broken_states = list("plastitanium_dam1","plastitanium_dam2","plastitanium_dam3","plastitanium_dam4","plastitanium_dam5")
+
+/turf/simulated/floor/mineral/plastitanium/broken_states()
+	return list("plastitanium_dam1","plastitanium_dam2","plastitanium_dam3","plastitanium_dam4","plastitanium_dam5")
 
 /turf/simulated/floor/mineral/plastitanium/red
 	icon_state = "plastitanium_red"

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -159,9 +159,13 @@
 	name = "high-traction floor"
 	icon_state = "noslip"
 	floor_tile = /obj/item/stack/tile/noslip
-	broken_states = list("noslip-damaged1","noslip-damaged2","noslip-damaged3")
-	burnt_states = list("noslip-scorched1","noslip-scorched2")
 	slowdown = -0.3
+
+/turf/simulated/floor/noslip/broken_states()
+	return list("noslip-damaged1","noslip-damaged2","noslip-damaged3")
+
+/turf/simulated/floor/noslip/burnt_states()
+	return list("noslip-scorched1","noslip-scorched2")
 
 /turf/simulated/floor/noslip/MakeSlippery()
 	return

--- a/code/game/turfs/simulated/floor/plasteel_floor.dm
+++ b/code/game/turfs/simulated/floor/plasteel_floor.dm
@@ -1,8 +1,12 @@
 /turf/simulated/floor/plasteel
 	icon_state = "floor"
 	floor_tile = /obj/item/stack/tile/plasteel
-	broken_states = list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
-	burnt_states = list("floorscorched1", "floorscorched2")
+
+/turf/simulated/floor/plasteel/broken_states()
+	return list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
+
+/turf/simulated/floor/plasteel/burnt_states()
+	return list("floorscorched1", "floorscorched2")
 
 /turf/simulated/floor/plasteel/update_icon()
 	if(!..())

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -4,8 +4,6 @@
 	icon = 'icons/turf/floors/plating.dmi'
 	intact = FALSE
 	floor_tile = null
-	broken_states = list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
-	burnt_states = list("floorscorched1", "floorscorched2")
 
 	var/unfastened = FALSE
 
@@ -19,6 +17,12 @@
 	. = ..()
 	icon_plating = icon_state
 	update_icon()
+
+/turf/simulated/floor/plating/broken_states()
+	return list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
+
+/turf/simulated/floor/plating/burnt_states()
+	return list("floorscorched1", "floorscorched2")
 
 /turf/simulated/floor/plating/damaged/Initialize(mapload)
 	. = ..()

--- a/code/modules/awaymissions/mission_code/spacebattle.dm
+++ b/code/modules/awaymissions/mission_code/spacebattle.dm
@@ -705,7 +705,6 @@
 	.=..()
 
 /obj/item/clothing/head/helmet/space/hardsuit/syndi/damaged
-	actions_types = list()
 	on = 1
 	icon_state = "hardsuit1-syndi"
 	item_state = "syndie_helm"

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -664,7 +664,7 @@
 	permeability_coefficient = 0.01
 	armor = list("melee" = 30, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 20, "bio" = 100, "rad" = 0, "fire" = 100, "acid" = 100)
 	resistance_flags = FIRE_PROOF | ACID_PROOF
-	actions_types = list()
+	actions_types = null
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
 

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -55,7 +55,7 @@
 	item_state = "voxmask"
 	permeability_coefficient = 0.01
 	species_restricted = list("Vox", "Vox Armalis") //These should fit the "Mega Vox" just fine.
-	actions_types = list()
+	actions_types = null
 
 /obj/item/clothing/mask/breath/vox/attack_self(var/mob/user)
 	return

--- a/code/modules/clothing/spacesuits/ert.dm
+++ b/code/modules/clothing/spacesuits/ert.dm
@@ -207,7 +207,7 @@
 	icon_state = "hardsuit0-ert_paranormal"
 	item_color = "ert_paranormal"
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
-	actions_types = list()
+	actions_types = null
 	resistance_flags = FIRE_PROOF
 	has_camera = FALSE
 	sprite_sheets = list(

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -826,7 +826,7 @@
 	icon_state = "militaryjacket"
 	item_state = "militaryjacket"
 	ignore_suitadjust = 1
-	actions_types = list()
+	actions_types = null
 	adjust_flavour = null
 	allowed = list(/obj/item/flashlight,/obj/item/tank/internals/emergency_oxygen,/obj/item/toy,/obj/item/storage/fancy/cigarettes,/obj/item/lighter,/obj/item/gun/projectile/automatic/pistol,/obj/item/gun/projectile/revolver,/obj/item/gun/projectile/revolver/detective)
 
@@ -962,7 +962,7 @@
 	desc = "Pompadour not included."
 	icon_state = "leatherjacket"
 	ignore_suitadjust = 1
-	actions_types = list()
+	actions_types = null
 	adjust_flavour = null
 	resistance_flags = NONE
 

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -233,7 +233,7 @@
 	min_cold_protection_temperature = ARMOR_MIN_TEMP_PROTECT
 	max_heat_protection_temperature = ARMOR_MAX_TEMP_PROTECT
 	resistance_flags = FIRE_PROOF | ACID_PROOF
-	actions_types = list() //No inbuilt light
+	actions_types = null //No inbuilt light
 	magical = TRUE
 
 /obj/item/clothing/head/helmet/space/hardsuit/wizard/attack_self(mob/user)

--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -732,7 +732,7 @@
 //////////// Suits ////////////
 /obj/item/clothing/suit/fluff
 	icon = 'icons/obj/custom_items.dmi'
-	actions_types = list()
+	actions_types = null
 	ignore_suitadjust = 1
 	adjust_flavour = null
 	sprite_sheets = null
@@ -744,7 +744,7 @@
 	icon_state = "pulsecoat"
 	item_state = "pulsecoat"
 	ignore_suitadjust = 1
-	actions_types = list()
+	actions_types = null
 
 /obj/item/clothing/suit/jacket/miljacket/patch // sniper_fairy : P.A.T.C.H.
 	name = "custom purple military jacket"
@@ -833,7 +833,7 @@
 	icon_state = "kidosvest"
 	item_state = "kidosvest"
 	ignore_suitadjust = 1
-	actions_types = list()
+	actions_types = null
 	adjust_flavour = null
 	sprite_sheets = null
 
@@ -843,7 +843,7 @@
 	icon = 'icons/obj/custom_items.dmi'
 	icon_state = "jacksvest"
 	ignore_suitadjust = TRUE
-	actions_types = list()
+	actions_types = null
 	adjust_flavour = null
 	sprite_sheets = null
 

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -104,12 +104,13 @@
 /turf/simulated/floor/vines
 	color = "#aa77aa"
 	icon_state = "vinefloor"
-	broken_states = list()
 	footstep = FOOTSTEP_GRASS
 	barefootstep = FOOTSTEP_GRASS
 	clawfootstep = FOOTSTEP_GRASS
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
 
+/turf/simulated/floor/vines/broken_states()
+	return list()
 
 //All of this shit is useless for vines
 

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -324,7 +324,7 @@
 	can_suppress = 0
 	burst_size = 1
 	fire_delay = 0
-	actions_types = list()
+	actions_types = null
 
 /obj/item/gun/projectile/automatic/shotgun/bulldog/New()
 	..()
@@ -441,7 +441,7 @@
 	magout_sound = 'sound/weapons/gun_interactions/batrifle_magout.ogg'
 	can_suppress = 0
 	burst_size = 1
-	actions_types = list()
+	actions_types = null
 
 /obj/item/gun/projectile/automatic/lr30/update_icon()
 	..()

--- a/code/modules/projectiles/guns/projectile/launchers.dm
+++ b/code/modules/projectiles/guns/projectile/launchers.dm
@@ -40,7 +40,7 @@
 	can_holster = TRUE // Override default automatic setting since it is a handgun sized gun
 	burst_size = 1
 	fire_delay = 0
-	actions_types = list()
+	actions_types = null
 
 
 /obj/item/gun/projectile/automatic/gyropistol/process_chamber(eject_casing = 0, empty_chamber = 1)
@@ -65,7 +65,7 @@
 	burst_size = 1
 	fire_delay = 0
 	select = 0
-	actions_types = list()
+	actions_types = null
 
 /obj/item/gun/projectile/automatic/speargun/update_icon()
 	return

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -13,7 +13,7 @@
 	can_suppress = 1
 	burst_size = 1
 	fire_delay = 0
-	actions_types = list()
+	actions_types = null
 
 /obj/item/gun/projectile/automatic/pistol/update_icon()
 	..()

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -18,7 +18,7 @@
 	zoomable = TRUE
 	zoom_amt = 7 //Long range, enough to see in front of you, but no tiles behind you.
 	slot_flags = SLOT_BACK
-	actions_types = list()
+	actions_types = null
 
 /obj/item/gun/projectile/automatic/sniper_rifle/syndicate
 	name = "syndicate sniper rifle"

--- a/code/modules/projectiles/guns/projectile/toy.dm
+++ b/code/modules/projectiles/guns/projectile/toy.dm
@@ -29,7 +29,7 @@
 	can_suppress = 0
 	burst_size = 1
 	fire_delay = 0
-	actions_types = list()
+	actions_types = null
 
 /obj/item/gun/projectile/automatic/toy/pistol/update_icon()
 	..()


### PR DESCRIPTION
Рефактор broken_states и burnt_states  с переменной на прок а также замена prying_tool_list  на обычный элемент т.к не было мест где было бы больше одного элемента.
Минус 2 переменных и минус три листа из /turf/simulated/floor что сокращает потребление памяти