### PR TITLE
bugfix: no more invisible seedstorage with seeds

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -559,7 +559,7 @@ to destroy them and players will be able to make replacements.
 							/obj/item/stock_parts/matter_bin = 1)
 	var/static/list/fridge_names_paths = list(
 							"SmartFridge" = /obj/machinery/smartfridge,
-							"MegaSeed Servitor" = /obj/machinery/smartfridge/seeds,
+							"Seed Storage" = /obj/machinery/smartfridge/seeds,
 							"Refrigerated Medicine Storage" = /obj/machinery/smartfridge/medbay,
 							"Slime Extract Storage" = /obj/machinery/smartfridge/secure/extract,
 							"Secure Refrigerated Medicine Storage" = /obj/machinery/smartfridge/secure/medbay/organ,

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -396,8 +396,7 @@
 /obj/machinery/smartfridge/seeds
 	name = "\improper Seed Storage"
 	desc = "When you need seeds fast!"
-	icon = 'icons/obj/machines/vending.dmi'
-	icon_state = "seeds"
+	icon_state = "smartfridge"
 
 /obj/machinery/smartfridge/seeds/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Исправляет баг, при котором холодильник для семян при добавлении в него семян становился невидимым. Также, вместо копии спрайта вендора семян, приводит спрайт холодильника к общему для всех смартфриджей.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
![Безымянный](https://github.com/ss220-space/Paradise/assets/139886553/adb4177a-b366-427a-a4ad-de0f0358c476)

<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
![изображение_2024-01-30_013206391](https://github.com/ss220-space/Paradise/assets/139886553/bfd20f52-e772-453e-a122-83a6e9d07f12)

<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
