### PR TITLE
bugfix: smart viro fridge added missed overlay

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -635,6 +635,15 @@
 	else
 		icon_state = "[prefix]"
 
+/obj/machinery/smartfridge/secure/chemistry/virology/screwdriver_act(mob/living/user, obj/item/I)
+	. = default_deconstruction_screwdriver(user, icon_state, icon_state, I)
+	if(!.)
+		return
+
+	overlays.Cut()
+	if(panel_open)
+		overlays += image(icon, "smartfridge-panel")
+
 /**
   * # Smart Virus Storage (Preloaded)
   *


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Открытая панель на холодильнике вирусолога отображается корректно.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

https://discord.com/channels/617003227182792704/1201646256771055847