### PR TITLE
refactor: Allowed usage of GLOB.all_areas before atoms subsystem initialize

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -87,10 +87,10 @@
 /area/New(loc, ...)
 	if(!there_can_be_many) // Has to be done in New else the maploader will fuck up and find subtypes for the parent
 		GLOB.all_unique_areas[type] = src
+	GLOB.all_areas += src
 	..()
 
 /area/Initialize(mapload)
-	GLOB.all_areas += src
 	icon_state = ""
 	layer = AREA_LAYER
 	uid = ++global_uid


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Обновление, позволяющее пользоваться глобальным списком зон перед их инициализацией подсистемой атомов.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Основа под оптимизацию использования зон, предполагающих их перебирание по всему миру.
