### PR TITLE
qol: keybinds for tail and wings

### DIFF
--- a/code/datums/keybindings/mob.dm
+++ b/code/datums/keybindings/mob.dm
@@ -131,6 +131,14 @@
 	. = ..()
 	C.body_toggle_head()
 
+/datum/keybinding/mob/target_cycle/chest
+	name = "Выбрать грудь/крылья"
+	keys = list("Numpad5")
+
+/datum/keybinding/mob/target_cycle/chest/down(client/C)
+	. = ..()
+	C.body_chest()
+
 /datum/keybinding/mob/target_cycle/r_arm
 	name = "Выбрать правую руку/кисть"
 	keys = list("Numpad4")
@@ -146,6 +154,14 @@
 /datum/keybinding/mob/target_cycle/l_arm/down(client/C)
 	. = ..()
 	C.body_l_arm()
+
+/datum/keybinding/mob/target_cycle/groin
+	name = "Выбрать пах/хвост"
+	keys = list("Numpad2")
+
+/datum/keybinding/mob/target_cycle/groin/down(client/C)
+	. = ..()
+	C.body_groin()
 
 /datum/keybinding/mob/target_cycle/r_leg
 	name = "Выбрать правую ногу/ступню"
@@ -191,12 +207,10 @@
 /datum/keybinding/mob/target/chest
 	name = "Выбрать грудь"
 	body_part = BODY_ZONE_CHEST
-	keys = list("Numpad5")
 
-/datum/keybinding/mob/target/groin
-	name = "Выбрать пах"
-	body_part = BODY_ZONE_PRECISE_GROIN
-	keys = list("Numpad2")
+/datum/keybinding/mob/target/wing
+	name = "Выбрать крылья"
+	body_part = BODY_ZONE_WING
 
 /datum/keybinding/mob/target/r_arm
 	name = "Выбрать правую руку"
@@ -213,6 +227,14 @@
 /datum/keybinding/mob/target/l_hand
 	name = "Выбрать левую кисть"
 	body_part = BODY_ZONE_PRECISE_L_HAND
+
+/datum/keybinding/mob/target/groin
+	name = "Выбрать пах"
+	body_part = BODY_ZONE_PRECISE_GROIN
+
+/datum/keybinding/mob/target/tail
+	name = "Выбрать хвост"
+	body_part = BODY_ZONE_TAIL
 
 /datum/keybinding/mob/target/r_leg
 	name = "Выбрать правую ногу"

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -380,6 +380,7 @@
 /client/verb/body_r_arm()
 	set name = "body-r-arm"
 	set hidden = 1
+
 	if(!check_has_body_select())
 		return
 
@@ -398,11 +399,13 @@
 
 	if(!check_has_body_select())
 		return
+
 	var/next_in_line
 	if(mob.zone_selected == BODY_ZONE_CHEST)
 		next_in_line = BODY_ZONE_WING
 	else
 		next_in_line = BODY_ZONE_CHEST
+
 	var/obj/screen/zone_sel/selector = mob.hud_used.zone_select
 	selector.set_selected_zone(next_in_line)
 
@@ -444,9 +447,15 @@
 
 	if(!check_has_body_select())
 		return
+	
+	var/next_in_line
+	if(mob.zone_selected == BODY_ZONE_PRECISE_GROIN)
+		next_in_line = BODY_ZONE_TAIL
+	else
+		next_in_line = BODY_ZONE_PRECISE_GROIN
 
 	var/obj/screen/zone_sel/selector = mob.hud_used.zone_select
-	selector.set_selected_zone(BODY_ZONE_PRECISE_GROIN)
+	selector.set_selected_zone(next_in_line)
 
 /client/verb/body_tail()
 	set name = "body-tail"


### PR DESCRIPTION
Now, using the numpad, you can select any part of the body, except for the tail and wings. This corrects this issue.

## Описание
Немного накосячил с комитами, поэтому пересоздал запрос.

Добавилась возможность выбирать хвост и крылья на клавиши Numlock и переназначать эти клавиши в настройках персонажа.

Принцип работы. По умолчанию, как с текущими частями куклы при многократном нажатии кнопок идёт переключение. Если Num5, то Торс/Крылья. Если Num2, то Пах/Хвост. Но если игрока это не устраивает, то в настройках управления можно поменять клавиши и поставить кнопку на каждую часть тела отдельно. Даже вернуть "текущий" вариант управления.

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/618952559607939072/1200411376254976080

## Демонстрация изменений
![301117489-0f2440ea-cedc-4bd3-8b0d-d8122c18448c](https://github.com/ss220-space/Paradise/assets/25286304/adaef5cb-9d62-4a2e-affa-c08ed93fde2a)
