### PR TITLE
bugfix: no more real cryopod in lavaland ruins

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_pirateship.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_pirateship.dmm
@@ -1752,7 +1752,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dust,
-/obj/machinery/cryopod,
+/obj/structure/showcase/machinery/oldpod,
 /turf/simulated/floor/wood/fancy/oak{
 	nitrogen = 23;
 	oxygen = 14;


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Заменяет настоящий рабочий криопод в руине подбитого корабля на подделку. 
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
![image](https://github.com/ss220-space/Paradise/assets/116907157/e8ba330e-928c-4371-be21-eb1ae3740f33)

<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->