### PR TITLE
Feat: syndiebase griefsky autopatrol

### DIFF
--- a/_maps/map_files/generic/syndicatebase.dmm
+++ b/_maps/map_files/generic/syndicatebase.dmm
@@ -16093,7 +16093,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/mob/living/simple_animal/bot/secbot/griefsky/syndicate,
 /turf/simulated/floor/carpet/black,
 /area/syndicate/unpowered/syndicate_space_base/main/north)
 "okK" = (
@@ -19766,6 +19765,9 @@
 "qQJ" = (
 /obj/effect/decal/syndie_logo{
 	icon_state = "logo11"
+	},
+/mob/living/simple_animal/bot/secbot/griefsky/syndicate{
+	auto_patrol = 0
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/syndicate/unpowered/syndicate_space_base/main/north)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Отключает автопартуль грифски на тайпайне, что бы сэкономить 4 мс памяти. 
На пустующем большую часть времени z уровне кому надо, тот включит, и никакого функционала патрулирование квадрата 8х9 не несёт.
