### PR TITLE
refactor: Optimized cables performance

### DIFF
--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -239,7 +239,7 @@
 	var/index = 1
 	var/obj/P = null
 
-	worklist+=O //start propagating from the passed object
+	worklist[O] = TRUE //start propagating from the passed object
 
 	while(index<=worklist.len) //until we've exhausted all power objects
 		P = worklist[index] //get the next power object found
@@ -249,17 +249,19 @@
 			var/obj/structure/cable/C = P
 			if(C.powernet != PN) //add it to the powernet, if it isn't already there
 				PN.add_cable(C)
-			worklist |= C.get_connections() //get adjacents power objects, with or without a powernet
+			//worklist |= C.get_connections() //get adjacents power objects, with or without a powernet
+			for(var/i in C.get_connections())
+				worklist[i] = TRUE
 
 		else if(P.anchored && istype(P, /obj/machinery/power))
 			var/obj/machinery/power/M = P
-			found_machines |= M //we wait until the powernet is fully propagates to connect the machines
+			found_machines[P] = M //we wait until the powernet is fully propagates to connect the machines
 
 		else
 			continue
 
 	//now that the powernet is set, connect found machines to it
-	for(var/obj/machinery/power/PM in found_machines)
+	for(var/obj/machinery/power/PM as anything in found_machines)
 		if(!PM.connect_to_network()) //couldn't find a node on its turf...
 			PM.disconnect_from_network() //... so disconnect if already on a powernet
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Оптимизация прока propagate_network, отвечающего за построение сетей у кабелей.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
![изображение](https://github.com/ss220-space/Paradise/assets/73733747/0daca89e-8aae-4a69-81cf-3463fb4949e0)
Среднее время исполнения propagate_network до рефактора (42.64мс)
## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
![изображение](https://github.com/ss220-space/Paradise/assets/73733747/2a9bbf8a-4ef3-434c-8b33-5962b77d3f09)
Среднее время исполнения propagate_network после рефактора (4.73мс)
![изображение](https://github.com/ss220-space/Paradise/assets/73733747/3b99b9e1-e0f9-446b-a723-c8c4c7ca034b)
Уменьшение времени исполнения propagate_network с самыми тяжелыми сетями на 5000 кабелей, почти в четыре раза