### PR TITLE
tweak: added Show/Hide MC Tabs for people with access to runtimes view

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -283,6 +283,7 @@ GLOBAL_LIST_INIT(admin_verbs_ticket, list(
 		if(holder.rights & R_VIEWRUNTIMES)
 			verbs += /client/proc/view_runtimes
 			verbs += /client/proc/ss_breakdown
+			verbs += /client/proc/toggle_mctabs
 			spawn(1) // This setting exposes the profiler for people with R_VIEWRUNTIMES. They must still have it set in cfg/admin.txt
 				control_freak = 0
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Позволяет людям с правами на просмотр рантаймов переключать преф на показ MC табов. 
MC табы и так имели возможность показываться по коду, но преф на их переключения был дан только админам, исправляем это. 
