### PR TITLE
bugfix: circuits of mapping vendors with custom names broken

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -257,7 +257,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/vending/boozeomat
 	req_components = list(/obj/item/vending_refill/boozeomat = 1)
 
-	var/static/list/vending_names_paths = list(
+	var/static/list/station_vendors = list(
 		"Booze-O-Mat" =							/obj/machinery/vending/boozeomat,
 		"Solar's Best Hot Drinks" =				/obj/machinery/vending/coffee,
 		"Getmore Chocolate Corp" =				/obj/machinery/vending/snack,
@@ -294,17 +294,24 @@ to destroy them and players will be able to make replacements.
 		"Service Departament ClothesMate Chaplain" 	= /obj/machinery/vending/clothing/departament/service/chaplain,
 		"RoboFriends" =                         /obj/machinery/vending/pai,)
 
+	var/static/list/unique_vendors = list(
+		"ShadyCigs Ultra" =						/obj/machinery/vending/cigarette/beach,
+		"SyndiWallMed" =						/obj/machinery/vending/wallmed/syndicate,
+		"SyndiMed Plus" =						/obj/machinery/vending/medical/syndicate_access,
+	)
+
 /obj/item/circuitboard/vendor/screwdriver_act(mob/user, obj/item/I)
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-	var/choice = tgui_input_list(user, "Choose a new brand", "Select an Item", vending_names_paths)
+	var/choice = tgui_input_list(user, "Choose a new brand", "Select an Item", station_vendors)
 	if(!choice)
 		return
 	set_type(choice)
 
 /obj/item/circuitboard/vendor/proc/set_type(type)
-	var/obj/machinery/vending/typepath = vending_names_paths[type]
+	var/static/list/buildable_vendors = station_vendors + unique_vendors
+	var/obj/machinery/vending/typepath = buildable_vendors[type]
 	build_path = typepath
 	board_name = "[type] Vendor"
 	format_board_name()

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -108,7 +108,7 @@
 	else
 		component_parts = list()
 		var/obj/item/circuitboard/vendor/V = new
-		V.set_type(replacetext(name, "\improper", ""))
+		V.set_type(replacetext(initial(name), "\improper", ""))
 		component_parts += V
 		component_parts += new refill_canister
 		RefreshParts()
@@ -1184,7 +1184,7 @@
 	refill_canister = /obj/item/vending_refill/wallmed
 
 /obj/machinery/vending/wallmed/syndicate
-	name = "\improper SyndiMed Plus"
+	name = "\improper SyndiWallMed"
 	desc = "<b>EVIL</b> wall-mounted Medical Equipment dispenser."
 	icon_state = "syndimed"
 	icon_deny = "syndimed-deny"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Теперь платы настенных наномедов на картах не будут ломаться оттого что названы emergency. Также дал возможность восстановить настенный автомат синдиката.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багрепорт: https://discord.com/channels/617003227182792704/1204043044836478996
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

