### PR TITLE
bugfix: Fixed runtime on unequipping clothing with accessories attached

### DIFF
--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -31,7 +31,8 @@
 	has_suit = S
 	loc = has_suit
 	has_suit.overlays += inv_overlay
-	LAZYADD(has_suit.actions, actions)
+	if(actions)
+		LAZYADD(has_suit.actions, actions)
 
 	for(var/X in actions)
 		var/datum/action/A = X


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление ошибки, при которой аксессуар давал одежде, на которую прикреплялся, null'евой actions, который в последствие вызывал рантаймы при взаимодействии с одеждой.

