### PR TITLE
feat: Remove Mr.Cheng Technique from melee thunderdome

### DIFF
--- a/code/modules/mini_games/thunderdome/gamemodes/gamemode.dm
+++ b/code/modules/mini_games/thunderdome/gamemodes/gamemode.dm
@@ -39,8 +39,6 @@
 		/obj/item/CQC_manual = 1,
 		/obj/item/sleeping_carp_scroll = 1,
 		/obj/item/clothing/gloves/fingerless/rapid = 1,
-		/obj/item/storage/box/thunderdome/mr_chang_technique = 1,
-		/obj/item/storage/box/thunderdome/mr_chang_technique/spicy = 1,
 		/obj/item/storage/box/thunderdome/spears = 1,
 		/obj/item/storage/box/thunderdome/maga = 1,
 		/obj/item/storage/box/thunderdome/singulatiry = 1,


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Убирает из пула мили оружия для тандера искусство маркетинга Ченга

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1204293998114508811/1204303597228134473
Владисвелл разрешил
Сей предмет превращает мили тандер в долгое и унылое закидывание монетками и битьё по жопе(эмоуты этой фигнёй не блочатся).
