### PR TITLE
bugfix: PAI HUD fix

### DIFF
--- a/code/modules/mob/living/silicon/pai/software/pai_toggles.dm
+++ b/code/modules/mob/living/silicon/pai/software/pai_toggles.dm
@@ -7,8 +7,8 @@
 	toggle_software = TRUE
 
 /datum/pai_software/sec_hud/toggle(mob/living/silicon/pai/user)
-	user.secHUD = !user.secHUD
 	user.remove_med_sec_hud()
+	user.secHUD = !user.secHUD
 	if(user.secHUD)
 		user.add_sec_hud()
 
@@ -24,8 +24,8 @@
 	toggle_software = TRUE
 
 /datum/pai_software/med_hud/toggle(mob/living/silicon/pai/user)
-	user.medHUD = !user.medHUD
 	user.remove_med_sec_hud()
+	user.medHUD = !user.medHUD
 	if(user.medHUD)
 		user.add_med_hud()
 
@@ -133,8 +133,8 @@
 	only_syndi = TRUE
 
 /datum/pai_software/adv_sec_hud/toggle(mob/living/silicon/pai/user)
-	user.adv_secHUD = !user.adv_secHUD
 	user.remove_med_sec_hud()
+	user.adv_secHUD = !user.adv_secHUD
 	if(user.adv_secHUD)
 		user.add_sec_hud()
 

--- a/code/modules/mob/living/silicon/pai/software/pai_toggles.dm
+++ b/code/modules/mob/living/silicon/pai/software/pai_toggles.dm
@@ -11,6 +11,8 @@
 	user.secHUD = !user.secHUD
 	if(user.secHUD)
 		user.add_sec_hud()
+		user.medHUD = FALSE
+		user.adv_secHUD = FALSE
 
 /datum/pai_software/sec_hud/is_active(mob/living/silicon/pai/user)
 	return user.secHUD
@@ -28,6 +30,8 @@
 	user.medHUD = !user.medHUD
 	if(user.medHUD)
 		user.add_med_hud()
+		user.secHUD = FALSE
+		user.adv_secHUD = FALSE
 
 /datum/pai_software/med_hud/is_active(mob/living/silicon/pai/user)
 	return user.medHUD
@@ -137,6 +141,8 @@
 	user.adv_secHUD = !user.adv_secHUD
 	if(user.adv_secHUD)
 		user.add_sec_hud()
+		user.medHUD = FALSE
+		user.secHUD = FALSE
 
 /datum/pai_software/adv_sec_hud/is_active(mob/living/silicon/pai/user)
 	return user.adv_secHUD

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -346,11 +346,6 @@
 		diagsensor.remove_hud_from(src)
 	secsensor.remove_hud_from(src)
 	medsensor.remove_hud_from(src)
-	if (src.type == /mob/living/silicon/pai)
-		var/mob/living/silicon/pai/P = src
-		P.adv_secHUD = FALSE
-		P.secHUD = FALSE
-		P.medHUD = FALSE
 
 
 

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -348,7 +348,6 @@
 	medsensor.remove_hud_from(src)
 
 
-
 /mob/living/silicon/proc/add_sec_hud()
 	var/datum/atom_hud/secsensor = GLOB.huds[sec_hud]
 	secsensor.add_hud_to(src)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -346,6 +346,12 @@
 		diagsensor.remove_hud_from(src)
 	secsensor.remove_hud_from(src)
 	medsensor.remove_hud_from(src)
+	if (src.type == /mob/living/silicon/pai)
+		var/mob/living/silicon/pai/P = src
+		P.adv_secHUD = FALSE
+		P.secHUD = FALSE
+		P.medHUD = FALSE
+
 
 
 /mob/living/silicon/proc/add_sec_hud()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Худы ПИИ работали непонятно, так как задумывалось, что больше одного нельзя иметь разом (судя по коду), однако кнопки не переставали быть активными, из-за чего худ активной кнопки мог быть неактивен и для включения на неё надо было жать дважды. Теперь не больше одной кнопки худа будет активно одновременно, исправляя недоразумение.
## Ссылка на предложение/Причина создания ПР
Багфикс
