### PR TITLE
bugfix: Fixed wrong machinery cache initialization

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -149,11 +149,10 @@ Class Procs:
 	. = ..()
 	GLOB.machines += src
 
-	if(use_power)
-		myArea = get_area(src)
-		if(myArea)
-			RegisterSignal(myArea, COMSIG_AREA_EXITED, PROC_REF(onAreaExited))
-			LAZYADD(myArea.machinery_cache, src)
+	myArea = get_area(src)
+	if(myArea)
+		RegisterSignal(myArea, COMSIG_AREA_EXITED, PROC_REF(onAreaExited))
+		LAZYADD(myArea.machinery_cache, src)
 
 	if(!speed_process)
 		START_PROCESSING(SSmachines, src)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление неправильного заполенния кэша машинерии зоны.
Идеологически, кэш машинерии не предполагает, что в нём будут содержаться только машины, потребляющие энергию.
Например исправляет работоспособность управлением турелей на Тайпане, которые не потребляют энергию.


