### PR TITLE
bugfix: returns mage-simplemob spells

### DIFF
--- a/code/datums/spells/charge.dm
+++ b/code/datums/spells/charge.dm
@@ -4,6 +4,7 @@
 	school = "transmutation"
 	base_cooldown = 1 MINUTES
 	clothes_req = FALSE
+	human_req = FALSE
 	invocation = "DIRI CEL"
 	invocation_type = "whisper"
 	cooldown_min = 40 SECONDS //50 deciseconds reduction per rank

--- a/code/datums/spells/horsemask.dm
+++ b/code/datums/spells/horsemask.dm
@@ -5,6 +5,7 @@
 	base_cooldown = 15 SECONDS
 	cooldown_min = 3 SECONDS //30 deciseconds reduction per rank
 	clothes_req = FALSE
+	human_req = FALSE
 	stat_allowed = CONSCIOUS
 	invocation = "KN'A FTAGHU, PUCK 'BTHNK!"
 	invocation_type = "shout"

--- a/code/datums/spells/knock.dm
+++ b/code/datums/spells/knock.dm
@@ -6,6 +6,7 @@
 	base_cooldown = 10 SECONDS
 	cooldown_min = 2 SECONDS //20 deciseconds reduction per rank
 	clothes_req = FALSE
+	human_req = FALSE
 	invocation = "AULIE OXIN FIERA"
 	invocation_type = "whisper"
 

--- a/code/datums/spells/lichdom.dm
+++ b/code/datums/spells/lichdom.dm
@@ -5,6 +5,7 @@
 	base_cooldown = 1 SECONDS
 	cooldown_min = 1 SECONDS
 	clothes_req = FALSE
+	human_req = FALSE
 	centcom_cancast = FALSE
 	invocation = "NECREM IMORTIUM!"
 	invocation_type = "shout"

--- a/code/datums/spells/mind_transfer.dm
+++ b/code/datums/spells/mind_transfer.dm
@@ -5,6 +5,7 @@
 	school = "transmutation"
 	base_cooldown = 60 SECONDS
 	clothes_req = FALSE
+	human_req = FALSE
 	invocation = "GIN'YU CAPAN"
 	invocation_type = "whisper"
 	selection_activated_message = "<span class='notice'>You prepare to transfer your mind. Click on a target to cast the spell.</span>"

--- a/code/datums/spells/summonitem.dm
+++ b/code/datums/spells/summonitem.dm
@@ -5,6 +5,7 @@
 	base_cooldown = 10 SECONDS
 	cooldown_min = 10 SECONDS
 	clothes_req = FALSE
+	human_req = FALSE
 	invocation = "GAR YOK"
 	invocation_type = "whisper"
 	level_max = 0 //cannot be improved

--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -129,7 +129,7 @@
 	base_cooldown = 12 SECONDS
 	cooldown_min = 2 SECONDS //25 deciseconds reduction per rank
 	clothes_req = FALSE
-
+	human_req = FALSE
 	smoke_type = SMOKE_COUGHING
 	smoke_amt = 10
 
@@ -208,6 +208,7 @@
 	base_cooldown = 10 SECONDS
 	cooldown_min = 5 SECONDS //12 deciseconds reduction per rank
 	clothes_req = FALSE
+	human_req = FALSE
 	invocation = "TARCOL MINTI ZHERI"
 	invocation_type = "whisper"
 	sound = 'sound/magic/forcewall.ogg'
@@ -311,6 +312,7 @@
 	school = "transmutation"
 	action_icon_state = "blind"
 	clothes_req = FALSE
+	human_req = FALSE
 	invocation = "STI KALY"
 	invocation_type = "whisper"
 	message = "<span class='notice'>Your eyes cry out in pain!</span>"
@@ -357,6 +359,7 @@
 	base_cooldown = 6 SECONDS
 	cooldown_min = 2 SECONDS //10 deciseconds reduction per rank
 	clothes_req = FALSE
+	human_req = FALSE
 	invocation = "ONI SOMA"
 	invocation_type = "shout"
 
@@ -458,6 +461,7 @@
 	desc = "Makes everyone around you more flammable, and lights yourself on fire."
 	base_cooldown = 6 SECONDS
 	clothes_req = FALSE
+	human_req = FALSE
 	invocation = "FI'RAN DADISKO"
 	invocation_type = "shout"
 	action_icon_state = "sacredflame"


### PR DESCRIPTION
## Описание
Многие спеллы мага не работали в форме животного после рефактора спеллов. Возвращена возможность использовать все спеллы, что работали в симплмобах у мага ранее


## Ссылка на предложение/Причина создания ПР
Предложки на убирание "мышемагов" и прочих симпло-магов не нашёл, значит баг, ПР с рефактором:
https://github.com/ss220-space/Paradise/pull/3168


