### PR TITLE
add: alt-click on the damage zone will be equivalent to clicking on itself

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -279,7 +279,26 @@
 	if(!choice)
 		return TRUE
 
+	if(PL["alt"])
+		AltClick(usr, choice)
+		return
+
 	return set_selected_zone(choice)
+
+/obj/screen/zone_sel/AltClick(mob/user, choice)
+
+	if(user.next_click > world.time || user.next_move > world.time)
+		return FALSE
+	user.changeNext_click(1)
+
+	var/obj/item/holding_item = user.get_active_hand()
+	var/old_selecting = selecting
+	if(!istype(holding_item))
+		return FALSE
+	if(!set_selected_zone(choice, FALSE))
+		return FALSE
+	holding_item.melee_attack_chain(user, user)
+	set_selected_zone(old_selecting, FALSE)
 
 
 /obj/screen/zone_sel/MouseEntered(location, control, params)
@@ -378,7 +397,7 @@
 					return BODY_ZONE_WING
 
 
-/obj/screen/zone_sel/proc/set_selected_zone(choice)
+/obj/screen/zone_sel/proc/set_selected_zone(choice, update_overlay = TRUE)
 	if(!hud || !hud.mymob)
 		return FALSE
 
@@ -388,7 +407,8 @@
 	if(choice != selecting)
 		selecting = choice
 		hud.mymob.zone_selected = choice
-		update_icon(UPDATE_OVERLAYS)
+		if(update_overlay)
+			update_icon(UPDATE_OVERLAYS)
 	return TRUE
 
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Если сделать alt+click по damage zone панели (в нижнем правом углу экрана) то это будет эквивалентно клику по себе с выбранной зоной. При этом выделенная зона останется прежней.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1208044735676022815
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

