### PR TITLE
bugfix: fix runtime to_chat called with invalid message

### DIFF
--- a/code/game/objects/items/tools/tool_behaviour.dm
+++ b/code/game/objects/items/tools/tool_behaviour.dm
@@ -43,7 +43,7 @@
 	return tool_use_check(user, amount)
 
 // A check called by tool_start_check once, and by use_tool on every tick of delay.
-/obj/item/proc/tool_use_check(mob/living/user, amount)
+/obj/item/proc/tool_use_check(mob/living/user, amount, silent = FALSE)
 	return !amount
 
 /obj/item/proc/play_tool_sound(atom/target, volume = tool_volume)

--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -115,14 +115,16 @@
 		M.update_inv_l_hand()
 
 // If welding tool ran out of fuel during a construction task, construction fails.
-/obj/item/weldingtool/tool_use_check(mob/living/user, amount)
+/obj/item/weldingtool/tool_use_check(mob/living/user, amount, silent = FALSE)
 	if(!tool_enabled)
-		to_chat(user, "<span class='notice'>[src] has to be on to complete this task!</span>")
+		if(!silent)
+			to_chat(user, "<span class='notice'>[src] has to be on to complete this task!</span>")
 		return FALSE
 	if(GET_FUEL >= amount * requires_fuel)
 		return TRUE
 	else
-		to_chat(user, "<span class='warning'>You need more welding fuel to complete this task!</span>")
+		if(!silent)
+			to_chat(user, "<span class='warning'>You need more welding fuel to complete this task!</span>")
 		return FALSE
 
 // When welding is about to start, run a normal tool_use_check, then flash a mob if it succeeds.

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -114,7 +114,7 @@
 	to_chat(user, span_notice("You tickled a makeshift wick made of wires, it looks like it needs to be set on fire."))
 
 /obj/item/grenade/iedsatchel/attackby(obj/item/W, user)
-	if(active == 1)
+	if(active)
 		return
 	if(istype(W, /obj/item/lighter))
 		var/obj/item/lighter/I = W
@@ -126,7 +126,7 @@
 		var/obj/item/match/I = W
 		if(!I.lit)
 			return
-		trigger()
+		trigger(user)
 		return
 	if(istype(W, /obj/item/weldingtool))
 		var/obj/item/weldingtool/I = W

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -376,7 +376,7 @@
 	return 1
 
 /mob/living/welder_act(mob/user, obj/item/I)
-	if(!I.tool_use_check(null, 0)) //Don't need the message, just if it succeeded
+	if(!I.tool_use_check(user, 0, silent = TRUE)) //Don't need the message, just if it succeeded
 		return
 	if(IgniteMob())
 		message_admins("[key_name_admin(user)] set [key_name_admin(src)] on fire with [I]")


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Чинит рантайм с нулевой целью to_chat если бить сваркой по мобу или если зажигать самодельную бомбу спичкой.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
![image](https://github.com/ss220-space/Paradise/assets/120549107/39320e7c-16b6-4d95-8162-5ed0ccda5ee2)
![Снимок экрана 2024-02-10 154918](https://github.com/ss220-space/Paradise/assets/120549107/8945c262-f47d-4098-8e58-6b9e7f4821f0)

<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

