### PR TITLE
Tweak: Remove extra atmos different turfes and useless dirs and tags

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -37538,7 +37538,6 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "darkredfull"
 	},
 /area/security/securearmory)
@@ -47808,7 +47807,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "darkredfull"
 	},
 /area/security/interrogation)
@@ -53735,8 +53733,7 @@
 "gKd" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency/old,
-/turf/simulated/floor/plasteel{
-	dir = 10;
+/turf/simulated/floor/plasteel/airless{
 	icon_state = "darkredfull"
 	},
 /area/space)
@@ -56340,7 +56337,6 @@
 	},
 /obj/effect/landmark/start/warden,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "darkredfull"
 	},
 /area/security/warden)
@@ -59445,9 +59441,9 @@
 /area/chapel/office)
 "icl" = (
 /obj/effect/landmark/tiles/burnturf,
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "darkred"
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "darkred";
+	dir = 9
 	},
 /area/space)
 "icp" = (
@@ -66323,7 +66319,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "darkredfull"
 	},
 /area/security/warden)
@@ -66747,7 +66742,7 @@
 /area/bridge/vip)
 "jPC" = (
 /obj/effect/landmark/tiles/burnturf,
-/turf/simulated/floor/plasteel{
+/turf/simulated/floor/plasteel/airless{
 	icon_state = "darkred"
 	},
 /area/space)
@@ -68548,11 +68543,6 @@
 	icon_state = "darkblue"
 	},
 /area/construction/hallway)
-"kna" = (
-/turf/simulated/floor/greengrid{
-	temperature = 80
-	},
-/area/toxins/xenobiology)
 "knb" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -75853,7 +75843,6 @@
 	},
 /obj/effect/landmark/start/warden,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "darkredfull"
 	},
 /area/security/warden)
@@ -92751,7 +92740,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "darkredfull"
 	},
 /area/security/warden)
@@ -111640,7 +111628,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "darkredfull"
 	},
 /area/security/evidence)
@@ -114786,7 +114773,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "darkredfull"
 	},
 /area/security/visiting_room)
@@ -119554,7 +119540,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "darkredfull"
 	},
 /area/security/securearmory)
@@ -119576,7 +119561,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "darkredfull"
 	},
 /area/security/securearmory)
@@ -158271,7 +158255,7 @@ sHq
 tNx
 jfk
 wBr
-kna
+wMW
 iRu
 oOo
 fvu
@@ -158528,7 +158512,7 @@ mkL
 lGo
 mZA
 oKx
-kna
+wMW
 rbA
 oOo
 fvu
@@ -158785,7 +158769,7 @@ gsc
 jhm
 feg
 cTz
-kna
+wMW
 iRu
 oOo
 ksG

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -47,7 +47,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "hydrofloor"
+	icon_state = "neutralfull"
 	},
 /area/crew_quarters/serviceyard)
 "aah" = (
@@ -3918,7 +3918,7 @@
 	tag = "icon-pipe-j1 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "hydrofloor"
+	icon_state = "neutralfull"
 	},
 /area/crew_quarters/serviceyard)
 "aEp" = (
@@ -6833,8 +6833,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/crew_quarters/fitness)
 "aWY" = (
@@ -7736,7 +7735,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	icon_state = "hydrofloor"
+	icon_state = "neutralfull"
 	},
 /area/crew_quarters/serviceyard)
 "bck" = (
@@ -21434,8 +21433,7 @@
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/maintenance/banya)
 "crF" = (
@@ -24468,7 +24466,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "hydrofloor"
+	icon_state = "neutralfull"
 	},
 /area/crew_quarters/serviceyard)
 "cEE" = (
@@ -24680,7 +24678,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "hydrofloor"
+	icon_state = "neutralfull"
 	},
 /area/crew_quarters/serviceyard)
 "cFE" = (
@@ -24790,7 +24788,7 @@
 	pixel_y = -25
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "hydrofloor"
+	icon_state = "neutralfull"
 	},
 /area/crew_quarters/serviceyard)
 "cFW" = (
@@ -27823,7 +27821,7 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel{
-	icon_state = "hydrofloor"
+	icon_state = "neutralfull"
 	},
 /area/crew_quarters/serviceyard)
 "cTl" = (
@@ -32900,7 +32898,7 @@
 	name = "Toilet"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "hydrofloor"
+	icon_state = "neutralfull"
 	},
 /area/crew_quarters/serviceyard)
 "doi" = (
@@ -32977,7 +32975,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "hydrofloor"
+	icon_state = "neutralfull"
 	},
 /area/crew_quarters/serviceyard)
 "doy" = (
@@ -33036,7 +33034,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "hydrofloor"
+	icon_state = "neutralfull"
 	},
 /area/crew_quarters/serviceyard)
 "doP" = (
@@ -40800,7 +40798,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "hydrofloor"
+	icon_state = "neutralfull"
 	},
 /area/crew_quarters/serviceyard)
 "dVy" = (
@@ -51413,8 +51411,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/medical/research)
 "gio" = (
@@ -57159,7 +57156,6 @@
 	},
 /obj/machinery/computer/card,
 /turf/simulated/floor/plasteel{
-	dir = 6;
 	icon_state = "bluefull"
 	},
 /area/bridge/checkpoint/south)
@@ -61242,8 +61238,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/medical/reception)
 "ixu" = (
@@ -67268,14 +67263,6 @@
 	icon_state = "darkblue"
 	},
 /area/bridge)
-"jWl" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "ramptop";
-	tag = "icon-stage_stairs"
-	},
-/area/medical/reception)
 "jWn" = (
 /obj/structure/plasticflaps,
 /obj/effect/decal/warning_stripes/yellow,
@@ -73898,8 +73885,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/medical/research)
 "lGO" = (
@@ -74823,8 +74809,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/medical/reception)
 "lRk" = (
@@ -81476,7 +81461,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "hydrofloor"
+	icon_state = "neutralfull"
 	},
 /area/crew_quarters/serviceyard)
 "nqH" = (
@@ -81639,8 +81624,7 @@
 /obj/structure/delta_statue/nw,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/bridge/vip)
 "nsi" = (
@@ -83361,8 +83345,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/medical/research)
 "nMs" = (
@@ -83895,7 +83878,7 @@
 	name = "Toilet"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "hydrofloor"
+	icon_state = "neutralfull"
 	},
 /area/crew_quarters/serviceyard)
 "nSz" = (
@@ -84241,8 +84224,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/medical/virology/lab)
 "nXm" = (
@@ -91084,8 +91066,7 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "ramptop";
-	tag = "icon-stage_stairs"
+	icon_state = "ramptop"
 	},
 /area/crew_quarters/fitness)
 "pBl" = (
@@ -96751,7 +96732,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "hydrofloor"
+	icon_state = "neutralfull"
 	},
 /area/crew_quarters/serviceyard)
 "qKI" = (
@@ -102279,8 +102260,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/medical/research)
 "sbb" = (
@@ -105642,8 +105622,7 @@
 "sQt" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/medbay)
 "sQx" = (
@@ -127230,7 +127209,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
 	icon_state = "bluefull"
 	},
 /area/bridge/checkpoint/south)
@@ -167742,8 +167720,8 @@ xMi
 gZr
 uzj
 xYU
-jWl
-jWl
+hiQ
+hiQ
 xYU
 cNI
 xYU


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Изначально в ксенобиологии были тайлы, которые был ниже стандартной температуры на 190 кельвинов, что бы ей можно было пользоваться раундстартом, но тогда нет смысла в охладительной установке рядом, но с февральским патчем они частично были заменены на обычные, что вызывало взаимодействие атмоса до начала раунда, поэтому было принято решение избавиться от них вообще.
Так же в островке над бригом в космосе каким-то образом, то ли февральский патч(маловероятно), то ли изначально, были не безвоздушные полы, что так же вызывало взаимодействие атмоса.
Ну и убраны ненужные направления для фуллтайл плиток и остатков тэгов для тайлов пола,

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/943940908162875473/1206046663450558484