### PR TITLE
bugfix: airlock electronics null fix

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1476,15 +1476,7 @@ About the new airlock wires panel:
 			else
 				ae = new/obj/item/airlock_electronics(loc)
 			check_access()
-
-			// Doors without access control set (aka public doors) have req_acess variable as null and upon deconstruction that variable overwrites airlock electronics selected_accesses variable data making it null as well.
-			// This breaks airlock electronics GUI as it relies on selected_accesses variable to show what accesses are enabled/disabled.
-			// We reset variable to the default airlock settings if it happened to be null one.
-			if (req_access)
-				ae.selected_accesses = req_access
-			else
-				ae.selected_accesses = list()
-
+			ae.selected_accesses = length(req_access) ? req_access  : list()
 			ae.one_access = check_one_access
 		else
 			ae = electronics

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1476,7 +1476,15 @@ About the new airlock wires panel:
 			else
 				ae = new/obj/item/airlock_electronics(loc)
 			check_access()
-			ae.selected_accesses = req_access
+
+			// Doors without access control set (aka public doors) have req_acess variable as null and upon deconstruction that variable overwrites airlock electronics selected_accesses variable data making it null as well.
+			// This breaks airlock electronics GUI as it relies on selected_accesses variable to show what accesses are enabled/disabled.
+			// We reset variable to the default airlock settings if it happened to be null one.
+			if (req_access)
+				ae.selected_accesses = req_access
+			else
+				ae.selected_accesses = list()
+
 			ae.one_access = check_one_access
 		else
 			ae = electronics


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

При активации UI настройки платы шлюза иногда появляется ошибка ntos.

При разборе аирлока с общим доступом, в момент "типа вытаскивания платы", создается с нуля плата аирлока с дефолтным selected_accesses.

Потом в эту плату записываются данные доступа с аирлока из req_access переменной, которая на таких аирлоках = null.

Если аирлок с настроенным доступом, то проблем нет, т.к. данные имеются и записываются корректно.

Соответственно плата сама по себе рабочая, но в момент ее настройки, GUI обращается в уже несуществующие данные в selected_accesses и выбрасывает ошибку.

Теперь в случае разбора или уничтожения аирлока общего доступа, создаваемая плата имеет пустой список как и положено, а список создается по необходимости.
см. https://github.com/ss220-space/Paradise/pull/4313

Справка:
selected_accesses - доступы выбранные на плате и они записываются в req_access на аирлоке когда она вставляется.
req_access - данные на аирлоке и при вытаскивании записываются в selected_accesses на плате.

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

https://discord.com/channels/617003227182792704/1206012302051254272

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
