### PR TITLE
bugfix: correct view range calculating and examine corrections.

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1408,8 +1408,7 @@
 
 /// Returns the biggest number from client.view so we can do easier maths
 /client/proc/maxview()
-	var/list/screensize = getviewsize(view)
-	return max(screensize[1], screensize[2])
+	return round(max(screensize[1], screensize[2]) / 2)
 
 
 #undef LIMITER_SIZE

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1408,6 +1408,7 @@
 
 /// Returns the biggest number from client.view so we can do easier maths
 /client/proc/maxview()
+	var/list/screensize = getviewsize(view)
 	return round(max(screensize[1], screensize[2]) / 2)
 
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -399,11 +399,6 @@
 				mind.disrupt_spells(0)
 
 
-
-/mob/living/carbon/proc/tintcheck()
-	return 0
-
-
 /mob/living/carbon/proc/create_dna()
 	if(!dna)
 		dna = new()
@@ -807,8 +802,13 @@ so that different stomachs can handle things in different ways VB*/
 		clear_fullscreen("tint", 0)
 
 
-/mob/living/carbon/proc/get_total_tint()
+/// Checks eye covering items for visually impairing tinting, such as welding masks. 0 & 1 = no impairment, 2 = welding mask overlay, 3 = casual blindness.
+/mob/living/proc/get_total_tint()
 	. = 0
+
+
+/mob/living/carbon/get_total_tint()
+	. = ..()
 	if(istype(head, /obj/item/clothing/head))
 		var/obj/item/clothing/head/HT = head
 		. += HT.tint

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -987,24 +987,6 @@
 		return HEARING_PROTECTION_MINOR
 
 
-///tintcheck()
-///Checks eye covering items for visually impairing tinting, such as welding masks
-///Checked in life.dm. 0 & 1 = no impairment, 2 = welding mask overlay, 3 = You can see jack, but you can't see shit.
-/mob/living/carbon/human/tintcheck()
-	var/tinted = 0
-	if(istype(src.head, /obj/item/clothing/head))
-		var/obj/item/clothing/head/HT = src.head
-		tinted += HT.tint
-	if(istype(src.glasses, /obj/item/clothing/glasses))
-		var/obj/item/clothing/glasses/GT = src.glasses
-		tinted += GT.tint
-	if(istype(src.wear_mask, /obj/item/clothing/mask))
-		var/obj/item/clothing/mask/MT = src.wear_mask
-		tinted += MT.tint
-
-	return tinted
-
-
 /mob/living/carbon/human/abiotic(var/full_body = 0)
 	if(full_body && ((src.l_hand && !(src.l_hand.flags & ABSTRACT)) || (src.r_hand && !(src.r_hand.flags & ABSTRACT)) || (src.back || src.wear_mask || src.head || src.shoes || src.w_uniform || src.wear_suit || src.glasses || src.l_ear || src.r_ear || src.gloves)))
 		return 1

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1417,8 +1417,9 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 /mob/living/proc/hindered_inspection(atom/target)
 	if(QDELETED(src) || QDELETED(target))
 		return TRUE
+	if(!(target in view(client.maxview(), client.eye)))
+		return TRUE
 	if(!has_vision(information_only = TRUE))
 		to_chat(src, span_notice("Здесь что-то есть, но вы не видите — что именно."))
 		return TRUE
 	return FALSE
-

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1398,6 +1398,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 		var/visible_species = "Unknown"
 
 		if(isliving(target))
+			to_chat(user, span_notice("You begin to examine [target]."))
 			var/mob/living/target_living = target
 			visible_species = target_living.get_visible_species()
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1388,11 +1388,12 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 
 /mob/living/run_examinate(atom/target)
 	var/datum/status_effect/staring/user_staring_effect = has_status_effect(STATUS_EFFECT_STARING)
+	face_atom(target)
+
 	if(user_staring_effect || hindered_inspection(target))
 		return
 
 	var/examine_time = target.get_examine_time()
-	face_atom(target)
 	if(examine_time && target != src)
 		var/visible_gender = target.get_visible_gender()
 		var/visible_species = "Unknown"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1398,7 +1398,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 		var/visible_species = "Unknown"
 
 		if(isliving(target))
-			to_chat(user, span_notice("You begin to examine [target]."))
+			to_chat(src, span_notice("You begin to examine [target]."))
 			var/mob/living/target_living = target
 			visible_species = target_living.get_visible_species()
 

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -470,7 +470,7 @@
 		..()
 
 
-/mob/living/simple_animal/bot/medbot/examinate(atom/A as mob|obj|turf in view(client.maxview()))
+/mob/living/simple_animal/bot/medbot/examinate(atom/A as mob|obj|turf in view(client.maxview(), client.eye))
 	..()
 	if(has_vision(information_only = TRUE))
 		chemscan(src, A)

--- a/code/modules/mob/living/update_status.dm
+++ b/code/modules/mob/living/update_status.dm
@@ -52,7 +52,7 @@
 // `information_only` is for stuff that's purely informational - like blindness overlays
 // This flag exists because certain things like angel statues expect this to be false for dead people
 /mob/living/has_vision(information_only = FALSE)
-	return (information_only && stat == DEAD) || !(AmountBlinded() || (BLINDNESS in mutations) || stat)
+	return (information_only && stat == DEAD) || !(AmountBlinded() || (BLINDNESS in mutations) || stat || get_total_tint() >= 3)
 
 // Whether the mob is capable of talking
 /mob/living/can_speak()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -299,7 +299,7 @@
 	popup.open()
 
 //mob verbs are faster than object verbs. See http://www.byond.com/forum/?post=1326139&page=2#comment8198716 for why this isn't atom/verb/examine()
-/mob/verb/examinate(atom/A as mob|obj|turf in view(client.maxview()))
+/mob/verb/examinate(atom/A as mob|obj|turf in view(client.maxview(), client.eye))
 	set name = "Examine"
 	set category = "IC"
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
- Меняет у верба `Examinate` поиск целей из видимости смотрящего на видимость "глаза" смотрящего, это даст ИИшке возможность юзать этот верб летая по станции глазом.
- Добавляет юзеру уведомление о начале длительного осмотра (секундного осмотра хуманов).
- Исправляет неправильное вычисление дальности виденья персонажа через `maxview()` прок, который выдавал полную длину экрана, вместо отрезка от персонажа до края экрана.
- Осмотр теперь прерывается, если цель осмотра выходит за дальность виденья персонажа.
- Убирает дубль прока по высчитыванию `tint` моба. Теперь мобы с чрезмерным затемнением зрения от одежды (от 3, что равно повязке на глаза) не могут осматривать.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на баг-репорт
https://discord.com/channels/617003227182792704/1205599870220501022<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## 2/3/4 пункты были оплачены фуллами @WolfLox
![изображение](https://github.com/ss220-space/Paradise/assets/115735095/b2fb447f-622d-47c3-acb0-565489ae3afc)
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
