### PR TITLE
bugfix: outfit inhand items disappearing.

### DIFF
--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -87,9 +87,9 @@
 		equip_item(H, suit_store, slot_s_store)
 
 	if(l_hand)
-		H.put_in_l_hand(new l_hand(H))
+		H.equip_to_slot_if_possible(new l_hand(H.loc), slot_l_hand, TRUE, FALSE, TRUE, TRUE, TRUE, TRUE)
 	if(r_hand)
-		H.put_in_r_hand(new r_hand(H))
+		H.equip_to_slot_if_possible(new r_hand(H.loc), slot_r_hand, TRUE, FALSE, TRUE, TRUE, TRUE, TRUE)
 
 	if(pda)
 		equip_item(H, pda, slot_wear_pda)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Спавнит вещи, которые должны попасть в руки персонажа при одевании аутфита, под персонажем и одевает проком `equip_to_slot_if_possible`. Это, в случае, если у персонажа нету рук, либо он заспавнился капитаном на Дельте прямо на мыле, поможет ему не потерять свои драгоценные баллоны с плазмой или что-то типо того. Ну и, если попытка взять что-то в руку при спавне аутфита провалилась, то это что-то не будет мёртвым грузом лежать в контентах моба. Просто форсированный спавн в руку лепить не стал, ибо тогда получается, что человек без рук мог получить в эту несуществующую руку что-то.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на баг-репорт
https://discord.com/channels/617003227182792704/1172619892395089990<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
