### PR TITLE
bugfix: glands names was the same

### DIFF
--- a/code/modules/economy/quests/thing_quests.dm
+++ b/code/modules/economy/quests/thing_quests.dm
@@ -124,13 +124,14 @@
 		/obj/item/organ/internal/heart/cursed = 550,
 		/obj/item/organ/internal/xenos/plasmavessel/hunter = 550,
 		/obj/item/organ/internal/xenos/plasmavessel/drone = 550,
-		/obj/item/organ/internal/xenos/neurotoxin = 650,
+		/obj/item/organ/internal/xenos/neurotoxin/sentinel = 650,
 		/obj/item/organ/internal/wryn/glands = 700,
 		/obj/item/organ/internal/xenos/hivenode = 700,
 		/obj/item/organ/internal/heart/plasmaman = 750,
 		/obj/item/organ/internal/xenos/acidgland/sentinel = 750,
 		/obj/item/organ/internal/xenos/acidgland/praetorian = 750,
 		/obj/item/organ/internal/xenos/resinspinner = 750,
+		/obj/item/organ/internal/xenos/neurotoxin = 850,
 		/obj/item/organ/internal/xenos/acidgland/queen = 900,
 		/obj/item/organ/internal/xenos/plasmavessel/queen = 900
 	)

--- a/code/modules/surgery/organs/subtypes/xenos.dm
+++ b/code/modules/surgery/organs/subtypes/xenos.dm
@@ -196,7 +196,7 @@
 
 
 /obj/item/organ/internal/xenos/neurotoxin
-	name = "xeno neurotoxin gland"
+	name = "Large xeno neurotoxin gland"
 	icon_state = "neurotox"
 	parent_organ_zone = BODY_ZONE_HEAD
 	slot = INTERNAL_ORGAN_NEUROTOXIN_GLAND
@@ -204,6 +204,7 @@
 	alien_powers = list(/obj/effect/proc_holder/spell/alien_spell/neurotoxin)
 
 /obj/item/organ/internal/xenos/neurotoxin/sentinel
+	name = "Medium xeno neurotoxin gland"
 	alien_powers = list(/obj/effect/proc_holder/spell/alien_spell/neurotoxin/sentinel)
 
 /obj/item/organ/internal/xenos/resinspinner

--- a/code/modules/surgery/organs/subtypes/xenos.dm
+++ b/code/modules/surgery/organs/subtypes/xenos.dm
@@ -196,7 +196,7 @@
 
 
 /obj/item/organ/internal/xenos/neurotoxin
-	name = "Large xeno neurotoxin gland"
+	name = "large xeno neurotoxin gland"
 	icon_state = "neurotox"
 	parent_organ_zone = BODY_ZONE_HEAD
 	slot = INTERNAL_ORGAN_NEUROTOXIN_GLAND

--- a/code/modules/surgery/organs/subtypes/xenos.dm
+++ b/code/modules/surgery/organs/subtypes/xenos.dm
@@ -204,7 +204,7 @@
 	alien_powers = list(/obj/effect/proc_holder/spell/alien_spell/neurotoxin)
 
 /obj/item/organ/internal/xenos/neurotoxin/sentinel
-	name = "Medium xeno neurotoxin gland"
+	name = "medium xeno neurotoxin gland"
 	alien_powers = list(/obj/effect/proc_holder/spell/alien_spell/neurotoxin/sentinel)
 
 /obj/item/organ/internal/xenos/resinspinner


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
В карго квест на xeno neurotoxin gland требуется часть квины, у которой одно название органа с сентинелем, исправляем путаницу. 
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Путаться плохо.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
