### PR TITLE
tweak: Tables Flip Hotkey Change

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -51,9 +51,9 @@
 	. += deconstruction_hints(user)
 	if(can_be_flipped)
 		if(flipped)
-			. += span_info("<b>Alt-Click</b> to right the table again.")
+			. += span_info("<b>Alt-Shift-Click</b> to right the table again.")
 		else
-			. += span_info("<b>Alt-Click</b> to flip over the table.")
+			. += span_info("<b>Alt-Shift-Click</b> to flip over the table.")
 
 
 /obj/structure/table/proc/deconstruction_hints(mob/user)
@@ -326,7 +326,7 @@
 	return check_table.straight_table_check(direction)
 
 
-/obj/structure/table/AltClick(mob/user)
+/obj/structure/table/AltShiftClick(mob/user)
 	actual_flip(user)
 
 


### PR DESCRIPTION
## Описание
Меняем хоткей для быстрого переворачивания столов с Alt-Click на Alt-Shift-Click, чтобы можно было спокойно осматривать содержимое турфа.