### PR TITLE
tweak: progressbar for examining and possibility to examine items in storages.

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1418,8 +1418,9 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 	if(QDELETED(src) || QDELETED(target))
 		return TRUE
 	if(!(target in view(client.maxview(), client.eye)))
-		if(!(target in GetAllContents()))
-			return TRUE
+		for(var/obj/screen/storage/box in client.screen)
+			if(!box.is_item_accessible(target, src))
+				return TRUE
 	if(!has_vision(information_only = TRUE))
 		to_chat(src, span_notice("Здесь что-то есть, но вы не видите — что именно."))
 		return TRUE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1399,7 +1399,6 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 		var/visible_species = "Unknown"
 
 		if(isliving(target))
-			to_chat(src, span_notice("You begin to examine [target]."))
 			var/mob/living/target_living = target
 			visible_species = target_living.get_visible_species()
 
@@ -1409,7 +1408,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 					target_staring_effect.catch_look(src)
 
 		user_staring_effect = apply_status_effect(STATUS_EFFECT_STARING, examine_time, target, visible_gender, visible_species)
-		if(do_mob(src, target, examine_time, FALSE, list(CALLBACK(src, PROC_REF(hindered_inspection), target)), TRUE))
+		if(do_mob(src, src, examine_time, TRUE, list(CALLBACK(src, PROC_REF(hindered_inspection), target)), TRUE))
 			..()
 	else
 		..()
@@ -1419,7 +1418,8 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 	if(QDELETED(src) || QDELETED(target))
 		return TRUE
 	if(!(target in view(client.maxview(), client.eye)))
-		return TRUE
+		if(!(target in GetAllContents()))
+			return TRUE
 	if(!has_vision(information_only = TRUE))
 		to_chat(src, span_notice("Здесь что-то есть, но вы не видите — что именно."))
 		return TRUE


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
- Для эксперимента решил попробовать видимый прогрессбар для секундного экзамайна. Люди не любят читать текст в игре про текст.
- Фикс "дальности виденья" сломал возможность осматривать вещи внутри ёмкостей. Вообще, получилось логично, но такая фича пока опережает наше время.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на баг-репорт
https://discord.com/channels/617003227182792704/1207094377160384512<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
