### PR TITLE
bugfix: alphabet sorting for chem dispensers on spawn.

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks/cans.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/cans.dm
@@ -185,7 +185,7 @@
 	name = "non-alcoholic beer"
 	desc = "A favorite thing of all students and those who drive."
 	icon_state = "alcoholfreebeercan"
-	list_reagents = list("alcohol_free_beer" = 30)
+	list_reagents = list("noalco_beer" = 30)
 
 
 /obj/item/reagent_containers/food/drinks/cans/adminbooze

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -44,6 +44,7 @@
 	component_parts += new /obj/item/stock_parts/manipulator(null)
 	component_parts += new /obj/item/stack/sheet/glass(null)
 	component_parts += new cell_type(null)
+	dispensable_reagents = sortAssoc(dispensable_reagents)
 	RefreshParts()
 
 /obj/machinery/chem_dispenser/upgraded/New()
@@ -420,7 +421,7 @@
 	desc = "A technological marvel, supposedly able to mix just the mixture you'd like to drink the moment you ask for one."
 	dispensable_reagents = list("ice", "cream", "cider", "beer", "kahlua", "whiskey", "wine", "vodka", "gin", "rum", "tequila", "vermouth", "cognac", "ale", "mead", "synthanol", "jagermeister", "bluecuracao", "sambuka", "schnaps", "sheridan")
 	upgrade_reagents = list("iced_beer", "irishcream", "manhattan", "antihol", "synthignon", "bravebull")
-	hacked_reagents = list("goldschlager", "patron", "absinthe", "ethanol", "nothing", "sake", "bitter", "champagne", "aperol", "alcohol_free_beer")
+	hacked_reagents = list("goldschlager", "patron", "absinthe", "ethanol", "nothing", "sake", "bitter", "champagne", "aperol", "noalco_beer")
 	hack_message = "You disable the 'nanotrasen-are-cheap-bastards' lock, enabling hidden and very expensive boozes."
 	unhack_message = "You re-enable the 'nanotrasen-are-cheap-bastards' lock, disabling hidden and very expensive boozes."
 	is_drink = TRUE
@@ -668,7 +669,7 @@
 	dispensable_reagents = list("ice", "cream", "cider", "beer", "kahlua", "whiskey", "wine", "vodka", "gin", "rum", "tequila",
 	"vermouth", "cognac", "ale", "mead", "synthanol", "jagermeister", "bluecuracao", "sambuka", "schnaps", "sheridan", "iced_beer",
 	"irishcream", "manhattan", "antihol", "synthignon", "bravebull", "goldschlager", "patron", "absinthe", "ethanol", "nothing",
-	"sake", "bitter", "champagne", "aperol", "alcohol_free_beer")
+	"sake", "bitter", "champagne", "aperol", "noalco_beer")
 
 /obj/item/handheld_chem_dispenser/soda
 	name = "handheld soda fountain"

--- a/code/modules/reagents/chemistry/reagents/drinks.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks.dm
@@ -536,7 +536,7 @@
 
 /datum/reagent/consumable/drink/non_alcoholic_beer
 	name = "Non-alcoholic beer"
-	id = "alcohol_free_beer"
+	id = "noalco_beer"
 	description = "The most meaningless thing."
 	drink_icon = "alcohol_free_beer"
 	drink_name = "Non-alcoholic beer"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Вернул сортировку реагентов химдиспенсеров по алфавиту в их `New()`. Провафлял, признаю
## Ссылка на баг-репорт
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
https://discord.com/channels/617003227182792704/1208204640785535026