### PR TITLE
bugfix: autoimplanter missing limb

### DIFF
--- a/code/modules/surgery/organs/autoimplanter.dm
+++ b/code/modules/surgery/organs/autoimplanter.dm
@@ -15,6 +15,10 @@
 	if(!storedorgan)
 		to_chat(user, "<span class='notice'>[src] currently has no implant stored.</span>")
 		return FALSE
+	var/mob/living/carbon/human/patient = user
+	if(!patient.bodyparts_by_name[storedorgan.parent_organ_zone])
+		to_chat(user, span_warning("Missing limb!"))
+		return FALSE
 	storedorgan.insert(user)//insert stored organ into the user
 	user.visible_message("<span class='notice'>[user] presses a button on [src], and you hear a short mechanical noise.</span>", "<span class='notice'>You feel a sharp sting as [src] plunges into your body.</span>")
 	playsound(get_turf(user), usesound, 50, 1)


### PR DESCRIPTION


## Описание
Добавил проверку, чтобы автоимлантер не мог поставить имплант в часть тела, которой у куклы нет
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
