### PR TITLE
bugfix: Standardization and action desc fix

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -99,7 +99,9 @@
 //Hide/Show Action Buttons ... Button
 /obj/screen/movable/action_button/hide_toggle
 	name = "Hide Buttons"
-	desc = "Shift-click any button to reset its position, and Control-click it to lock/unlock its position. Alt-click this button to reset all buttons to their default positions. Control-Shift-click on any button to bind it to a hotkey."
+	desc = "Shift-click any button to reset its position, and Control-click it to lock/unlock its position. \
+	<br> Alt-click this button to reset all buttons to their default positions. \
+	<br> Control-Shift-click on any button to bind it to a hotkey."
 	icon = 'icons/mob/actions/actions.dmi'
 	icon_state = "bg_default"
 	var/hidden = FALSE

--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -1,5 +1,4 @@
 /obj/screen/movable/action_button
-	desc = "CTRL-Shift click on this button to bind it to a hotkey."
 	var/datum/action/linked_action
 	var/actiontooltipstyle = ""
 	screen_loc = null
@@ -100,7 +99,7 @@
 //Hide/Show Action Buttons ... Button
 /obj/screen/movable/action_button/hide_toggle
 	name = "Hide Buttons"
-	desc = "Shift-click any button to reset its position, and Control-click it to lock/unlock its position. Alt-click this button to reset all buttons to their default positions."
+	desc = "Shift-click any button to reset its position, and Control-click it to lock/unlock its position. Alt-click this button to reset all buttons to their default positions. Control-Shift-click on any button to bind it to a hotkey."
 	icon = 'icons/mob/actions/actions.dmi'
 	icon_state = "bg_default"
 	var/hidden = FALSE

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -19,10 +19,7 @@
 	button.linked_action = src
 	button.name = name
 	button.actiontooltipstyle = buttontooltipstyle
-	var/list/our_description = list()
-	our_description += desc
-	our_description += button.desc
-	button.desc = our_description.Join(" ")
+	button.desc = desc
 
 /datum/action/Destroy()
 	if(owner)
@@ -138,10 +135,7 @@
 				button.icon = button_icon
 			button.icon_state = background_icon_state
 		button.name = name
-		var/list/our_description = list()
-		our_description += desc
-		our_description += initial(button.desc)
-		button.desc = our_description.Join(" ")
+		button.desc = desc
 
 		ApplyIcon(button)
 
@@ -633,10 +627,7 @@
 	var/obj/effect/proc_holder/spell/spell = target
 	spell.action = src
 	name = spell.name
-	var/list/our_description = list()
-	our_description += spell.desc
-	our_description += button.desc
-	button.desc = our_description.Join(" ")
+	desc = spell.desc
 	button_icon = spell.action_icon
 	background_icon = spell.action_background_icon
 	button_icon_state = spell.action_icon_state


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Подчищает #4420

Убирает 
```var/list/our_description = list()
		our_description += desc
		our_description += initial(button.desc)
		button.desc = our_description.Join(" ")
```
, что по моим наблюдениям, ничего не делало или ломалось? По крайней мере, так кажется со способностями, что получаются в раунде. Возвращая к тому, что было. `button.desc = action.desc`

Помещает полезную подсказку по CTRL-SHFT-Click к другим подсказкам, а точней к той стрелке.

Делает пробелы между предложениями в этих подсказках.
## Ссылка на предложение/Причина создания ПР
### По описаниям ничего не ясно, что делает способность.
![image](https://github.com/ss220-space/Paradise/assets/87372121/6d12520a-f5fe-43bd-b293-5cf4c3f19196)
Такое видеть у КАЖДОЙ способности - not good.

Мем ниже - важная часть ПРа, что поймут РнДшники.
![image](https://github.com/ss220-space/Paradise/assets/87372121/66213a56-209f-443d-a80d-caa05f34e2f9)

## Демонстрация изменений
![image](https://github.com/ss220-space/Paradise/assets/87372121/458d892c-3807-41ab-bf50-a850a0bdab7d)
![image](https://github.com/ss220-space/Paradise/assets/87372121/8d2ef310-d237-453b-8bdc-e90a93959999)


Если человек забиндит способность, то вот так будет выглядеть.
![image](https://github.com/ss220-space/Paradise/assets/87372121/ca74a257-c897-492c-b4ce-23bef853fa92)

