### PR TITLE
bugfix: arrival shuttle zone.

### DIFF
--- a/code/game/area/ss13_areas.dm
+++ b/code/game/area/ss13_areas.dm
@@ -70,11 +70,11 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	dynamic_lighting = DYNAMIC_LIGHTING_FORCED
 	parallax_movedir = NORTH
 	sound_environment = SOUND_ENVIRONMENT_ROOM
-/*
-/area/shuttle/arrival //dont have this, but at once...
-	name = "\improper Arrival Shuttle"
 
-/area/shuttle/arrival/pre_game
+/area/shuttle/arrival
+	name = "\improper Arrival Shuttle"
+/*
+/area/shuttle/arrival/pre_game //dont have this, but at once...
 	icon_state = "shuttle2"
 */
 /area/shuttle/arrival/station


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Раскомменчивает ступень зоны шаттла прибытия, в которой хранится имя зоны.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР
10 месяцев, как Момо по ошибке закомментила (не напрямую, но) используемую зону. Это заставило зону шаттла прибытия отображаться везде, как "Space".<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
