### PR TITLE
tweak: adrenaline for changelings

### DIFF
--- a/code/modules/antagonists/changeling/powers/epinephrine.dm
+++ b/code/modules/antagonists/changeling/powers/epinephrine.dm
@@ -26,6 +26,7 @@
 	user.resting = FALSE
 	user.update_canmove()
 	user.reagents.add_reagent("synaptizine", 20)
+	user.reagents.add_reagent("adrenaline", 2)
 	user.adjustStaminaLoss(-95)
 
 	SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]"))


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Теперь способность генокрадов "epinephrine overdose" вводит 2 юнита реагента "адреналин", увеличивающего порог боли и дающего неуязвимость к станам
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1187385034706001950
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
