### PR TITLE
balance: Explosion effect tweaks

### DIFF
--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -191,17 +191,17 @@
 							var/atom/AM = atom
 							if(!QDELETED(AM) && AM.simulated)
 								if(AM.level >= affecting_level)
-									AM.ex_act(dist)
+									AM.ex_act(dist, epicenter)
 					else
 						for(var/atom in T.contents)	//see above
 							var/atom/AM = atom
 							if(!QDELETED(AM) && AM.simulated)
-								AM.ex_act(dist)
+								AM.ex_act(dist, epicenter)
 							CHECK_TICK
 					if(breach)
-						T.ex_act(dist)
+						T.ex_act(dist, epicenter)
 					else
-						T.ex_act(3)
+						T.ex_act(3, epicenter)
 
 			CHECK_TICK
 
@@ -225,7 +225,7 @@
 
 /proc/secondaryexplosion(turf/epicenter, range)
 	for(var/turf/tile in spiral_range_turfs(range, epicenter))
-		tile.ex_act(2)
+		tile.ex_act(2, epicenter)
 
 /client/proc/check_bomb_impacts()
 	set name = "Check Bomb Impact"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -260,7 +260,7 @@
 	var/burnloss = 0
 
 	if(status_flags & GODMODE)
-		return 0
+		return FALSE
 
 	var/armor = getarmor(null, "bomb")	//Average bomb protection
 	var/limb_loss_reduction = FLOOR(armor / 25, 1) //It's guaranteed that every 25th armor point will protect from one delimb
@@ -270,7 +270,7 @@
 		if(1)
 			if(prob(ex_armor_reduction(100, armor)) && armor < 100)
 				gib()
-				return 0
+				return FALSE
 			else
 				bruteloss += 500
 				limbs_affected = pick(2,3,4)
@@ -295,8 +295,8 @@
 
 	limbs_affected = max(limbs_affected - limb_loss_reduction, 0)
 	if(epicenter)
-		var/throw_distance = round(3 - severity + ex_armor_reduction(4, armor))
-		var/throw_speed = 14 - severity * 4 + ex_armor_reduction(4, armor)
+		var/throw_distance = round(4 - severity + ex_armor_reduction(4 - severity, armor))
+		var/throw_speed = 14 - severity * 4 + ex_armor_reduction(4 - severity, armor)
 		var/dir_if_centered = epicenter == get_turf(src) ? rand(0, 10) : null
 		var/turf/turf_to_land
 		if(!dir_if_centered)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Небольшой ребаланс взрывов на основе фидбека игроков
Убран эффект сна, теперь он заменён отталкиванием.
Теперь воздействие взрыва отталкивает кукол от эпицентра взрыва.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
:clueless:
## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->


https://github.com/ss220-space/Paradise/assets/73733747/46005d59-09b8-4301-8e2a-8d327dbf1414



