### PR TITLE
Bugfix: Spacehotel shard steal

### DIFF
--- a/_maps/map_files/RandomZLevels/spacehotel.dmm
+++ b/_maps/map_files/RandomZLevels/spacehotel.dmm
@@ -3372,7 +3372,7 @@
 /turf/simulated/floor/indestructible/plating,
 /area/awaymission/spacehotel)
 "iL" = (
-/obj/machinery/power/supermatter_shard,
+/obj/machinery/power/supermatter_shard/anchored,
 /turf/simulated/floor/indestructible/plating,
 /area/awaymission/spacehotel)
 "iM" = (

--- a/code/modules/awaymissions/mission_code/ruins/crashedipcship.dm
+++ b/code/modules/awaymissions/mission_code/ruins/crashedipcship.dm
@@ -60,15 +60,3 @@
 	desc = "A small dead parasitic creature that would like to connect with your brain stem."
 	icon = 'icons/mob/headcrab.dmi'
 	icon_state = "headcrab_dead"
-
-// SM shard that can't be moved
-/obj/machinery/power/supermatter_shard/anchored
-	name = "Well anchored supermatter shard"
-	desc = "A strangely translucent and iridescent crystal that looks like it used to be part of a larger structure. Apparently the structure is attached to the surface with industrial equipment, it cannot be unanchored with simple equipment. <span class='danger'>You get headaches just from looking at it.</span>"
-	anchored = TRUE
-
-/obj/machinery/power/supermatter_shard/anchored/attackby(obj/item/W as obj, mob/living/user as mob, params)
-	if(istype(W,/obj/item/wrench))
-		user.visible_message("<span class='danger'>As [user] tries to loose bolts of \the [src] with \a [W] but the tool disappears</span>")
-	consume_wrench(W)
-	user.apply_effect(150, IRRADIATE)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -519,3 +519,15 @@
 /obj/machinery/power/supermatter_shard/proc/supermatter_zap()
 	playsound(src.loc, 'sound/magic/lightningshock.ogg', 100, 1, extrarange = 5)
 	tesla_zap(src, 10, max(1000,power * damage / explosion_point))
+
+// SM shard that can't be moved for ruins and gates
+/obj/machinery/power/supermatter_shard/anchored
+	name = "Well anchored supermatter shard"
+	desc = "A strangely translucent and iridescent crystal that looks like it used to be part of a larger structure. Apparently the structure is attached to the surface with industrial equipment, it cannot be unanchored with simple equipment. <span class='danger'>You get headaches just from looking at it.</span>"
+	anchored = TRUE
+
+/obj/machinery/power/supermatter_shard/anchored/attackby(obj/item/W as obj, mob/living/user as mob, params)
+	if(istype(W,/obj/item/wrench))
+		user.visible_message("<span class='danger'>As [user] tries to loose bolts of \the [src] with \a [W] but the tool disappears</span>")
+	consume_wrench(W)
+	user.apply_effect(150, IRRADIATE)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Как выяснилось, кристалл в спейсхотеле можно двигать, более того грифознчать им и выполнять цель на кражу куска кристалла в обход задумки цели на кражу.
ПР заменяет кристалл в гейте на недвижимый, исключая возможность выполнить через него цель и украсть этот кристалл для грифа.
