### PR TITLE
bugfix: Toggling thunderdome enrolling state no longer causes runtimes

### DIFF
--- a/code/modules/tgui/modules/minigames_explorer.dm
+++ b/code/modules/tgui/modules/minigames_explorer.dm
@@ -43,7 +43,7 @@
 			if(ROLE_THUNDERDOME in GLOB.special_roles)
 				owner.client?.prefs?.be_special ^= ROLE_THUNDERDOME
 				if(CONFIG_GET(flag/sql_enabled))
-					owner.client?.prefs?.save_preferences()
+					owner.client?.prefs?.save_preferences(owner.client)
 				return
 
 		if("toggle_notifications")


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление рантайма при переключении желаемости участвовать в играх на тандердоме.

