### PR TITLE
tweak: Events and cargo quests now count alive station players for scaling

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -363,7 +363,7 @@
 		if(player.client && player.ready)
 			.++
 
-/datum/game_mode/proc/num_station_players()
+/proc/num_station_players()
 	. = 0
 	for(var/mob/living/carbon/human/player in GLOB.player_list)
 		if(!player)

--- a/code/game/gamemodes/miniantags/changeling_slug/changeling_slug_event.dm
+++ b/code/game/gamemodes/miniantags/changeling_slug/changeling_slug_event.dm
@@ -43,7 +43,7 @@
 			log_game("[new_slug.key] has become Changeling Headslug.")
 
 /datum/event/headslug_infestation/proc/eventcheck()
-	if(((length(GLOB.clients)) <= HI_MINPLAYERS_TRIGGER) ||GAMEMODE_IS_CULTS || GAMEMODE_IS_NUCLEAR || GAMEMODE_IS_SHADOWLING)
+	if((num_station_players() <= HI_MINPLAYERS_TRIGGER) ||GAMEMODE_IS_CULTS || GAMEMODE_IS_NUCLEAR || GAMEMODE_IS_SHADOWLING)
 		return TRUE
 
 

--- a/code/game/gamemodes/miniantags/demons/pulse_demon/pulse_demon_event.dm
+++ b/code/game/gamemodes/miniantags/demons/pulse_demon/pulse_demon_event.dm
@@ -46,7 +46,7 @@
 	return pick(spawn_centers)
 
 /datum/event/spawn_pulsedemon/start()
-	if((length(GLOB.clients)) <= minplayers)
+	if(num_station_players() <= minplayers)
 		var/datum/event_container/EC = SSevents.event_containers[EVENT_LEVEL_MODERATE]
 		EC.next_event_time = world.time + (60 * 10)
 		return	//we don't spawn demons on lowpop. Instead, we reroll!

--- a/code/game/gamemodes/miniantags/space_dragon/space_dragon.dm
+++ b/code/game/gamemodes/miniantags/space_dragon/space_dragon.dm
@@ -19,8 +19,9 @@
 
 
 /datum/event/space_dragon/proc/wrapped_start()
-	if(length(GLOB.clients) < SPACE_DRAGON_SPAWN_THRESHOLD)
-		log_and_message_admins("Random event attempted to spawn a space dragon, but there were only [length(GLOB.clients)]/[SPACE_DRAGON_SPAWN_THRESHOLD] players.")
+	var/player_count = num_station_players()
+	if(player_count < SPACE_DRAGON_SPAWN_THRESHOLD)
+		log_and_message_admins("Random event attempted to spawn a space dragon, but there were only [player_count]/[SPACE_DRAGON_SPAWN_THRESHOLD] players.")
 		return
 	var/list/candidates = SSghost_spawns.poll_candidates("Вы хотите занять роль Космического Дракона?", ROLE_SPACE_DRAGON, TRUE, source = /mob/living/simple_animal/hostile/space_dragon)
 	if(!length(candidates))

--- a/code/modules/economy/quests/_base_quests.dm
+++ b/code/modules/economy/quests/_base_quests.dm
@@ -63,7 +63,7 @@
 
 	if(!quest_type)
 		var/list/possible_types = list()
-		if((length(GLOB.clients) < MIN_PLAYERS_FOR_MIX) && (length(current_quests) == 2))
+		if((num_station_players() < MIN_PLAYERS_FOR_MIX) && (length(current_quests) == 2))
 			for(var/datum/cargo_quest/quest as anything in current_quests)
 				possible_types += quest.type
 		else

--- a/code/modules/events/abductor.dm
+++ b/code/modules/events/abductor.dm
@@ -19,7 +19,7 @@
 		else
 			temp = new
 
-		var/num_teams = min(round(length(GLOB.clients) / for_players) + 1, temp.max_teams)
+		var/num_teams = min(round(num_station_players() / for_players) + 1, temp.max_teams)
 		for(var/i in 1 to num_teams)
 			//Oh god why we can't have static functions
 			if (length(candidates) < 2)

--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -1,4 +1,4 @@
-#define ALIEN_HIGHPOP_TRIGGER 80
+#define ALIEN_HIGHPOP_TRIGGER 60
 #define ALIEN_MIDPOP_TRIGGER 40
 
 /datum/event/alien_infestation
@@ -23,7 +23,7 @@
 
 /datum/event/alien_infestation/proc/wrappedstart()
 	var/list/vents = get_valid_vent_spawns(exclude_mobs_nearby = TRUE, exclude_visible_by_mobs = TRUE)
-	playercount = length(GLOB.clients)//grab playercount when event starts not when game starts
+	playercount = num_station_players() //grab playercount when event starts not when game starts
 	if(playercount <= ALIEN_MIDPOP_TRIGGER)
 		spawn_vectors(vents, playercount)
 		return

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -2,7 +2,7 @@
 	announceWhen	= 180
 	endWhen			= 240
 	var/successSpawn = FALSE	//So we don't make a command report if nothing gets spawned.
-	var/for_players = 40 		//Количество людей для спавна доп. мыши
+	var/for_players = 30 		//Количество людей для спавна доп. мыши
 
 /datum/event/blob/announce()
 	if(successSpawn)

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -26,7 +26,7 @@
 	if(!length(vents))
 		return
 
-	var/num_blobs = round((length(GLOB.clients) / for_players)) + 1
+	var/num_blobs = round((num_station_players() / for_players)) + 1
 	for(var/i in 1 to num_blobs)
 		if (length(candidates))
 			var/obj/vent = pick(vents)

--- a/code/modules/events/slaughterevent.dm
+++ b/code/modules/events/slaughterevent.dm
@@ -56,7 +56,7 @@
 
 
 /datum/event/spawn_slaughter/start()
-	if((length(GLOB.clients)) <= minplayers)
+	if(num_station_players() <= minplayers)
 		var/datum/event_container/EC = SSevents.event_containers[EVENT_LEVEL_MAJOR]
 		EC.next_event_time = world.time + (60 * 10)
 		return	//we don't spawn demons on lowpop. Instead, we reroll!

--- a/code/modules/events/spider_terror.dm
+++ b/code/modules/events/spider_terror.dm
@@ -1,4 +1,4 @@
-#define TS_HIGHPOP_TRIGGER 80
+#define TS_HIGHPOP_TRIGGER 60
 #define TS_MIDPOP_TRIGGER 50
 #define TS_MINPLAYERS_TRIGGER 35
 
@@ -25,13 +25,14 @@
 /datum/event/spider_terror/proc/wrappedstart()
 	var/spider_type
 	var/infestation_type
-	if((length(GLOB.clients)) <= TS_MINPLAYERS_TRIGGER)
+	var/player_count = num_station_players()
+	if(player_count <= TS_MINPLAYERS_TRIGGER)
 		var/datum/event_container/EC = SSevents.event_containers[EVENT_LEVEL_MAJOR]
 		EC.next_event_time = world.time + (60 * 10)
 		return	//we don't spawn spiders on lowpop. Instead, we reroll!
-	else if((length(GLOB.clients)) >= TS_HIGHPOP_TRIGGER)
+	else if(player_count >= TS_HIGHPOP_TRIGGER)
 		infestation_type = pick(5, 6)
-	else if((length(GLOB.clients)) >= TS_MIDPOP_TRIGGER)
+	else if(player_count >= TS_MIDPOP_TRIGGER)
 		infestation_type = pick(3, 4)
 	else
 		infestation_type = pick(1, 2)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Правка, позволяющая ориентироваться более точно по количеству игроков. Теперь например соотношение 60/20 призраков/живых не будет провоцировать спавн мажоров / их сильной версии.
Главные мажоры понизили свою планку для спавна с учетом этой правки.
