### PR TITLE
bugfix: fix possible softlock in tutorial

### DIFF
--- a/code/game/objects/training/basic_tasks.dm
+++ b/code/game/objects/training/basic_tasks.dm
@@ -97,7 +97,7 @@
 		"Возьмите :tr ПДА :9 в вашу руку нажатием на него :tr ЛКМ")
 
 /datum/training_task/basic_3_2/init_task()
-	user.equip_to_slot_if_possible(new /obj/item/pda, slot_wear_pda)
+	user.equip_to_slot_if_possible(new /obj/item/pda, slot_wear_pda, drop_on_fail = TRUE)
 	..()
 
 /datum/training_task/basic_3_2/check_func()
@@ -134,7 +134,7 @@
 		"Возьмите ID карту в руку так, чтобы в активной руке лежала ваша ID карта, а в неактивной - ПДА")
 
 /datum/training_task/basic_3_4/init_task()
-	user.equip_to_slot_if_possible(new /obj/item/card/id/captains_spare, slot_wear_id)
+	user.equip_to_slot_if_possible(new /obj/item/card/id/captains_spare, slot_wear_id, drop_on_fail = TRUE)
 	..()
 
 /datum/training_task/basic_3_4/check_func()
@@ -190,7 +190,7 @@
 	oxygen = new()
 	backpack = new()
 	backpack.block_unequip = TRUE
-	user.equip_to_slot_if_possible(backpack, slot_back)
+	user.equip_to_slot_if_possible(backpack, slot_back, drop_on_fail = TRUE)
 	backpack.contents.Add(mask)
 	backpack.contents.Add(oxygen)
 	. = ..()
@@ -513,8 +513,8 @@
 	oxygen = new(vulpkanin.loc)
 
 	vulpkanin.delete_equipment()
-	vulpkanin.equip_to_slot_if_possible(new /obj/item/clothing/shoes/orange, slot_shoes)
-	vulpkanin.equip_to_slot_if_possible(new /obj/item/clothing/under/color/orange, slot_w_uniform)
+	vulpkanin.equip_to_slot_if_possible(new /obj/item/clothing/shoes/orange, slot_shoes, drop_on_fail = TRUE)
+	vulpkanin.equip_to_slot_if_possible(new /obj/item/clothing/under/color/orange, slot_w_uniform, drop_on_fail = TRUE)
 
 	vulpkanin.equip_to_appropriate_slot(eva_helmet)
 	vulpkanin.equip_to_appropriate_slot(eva_suit)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -83,7 +83,7 @@
 		if(I in get_equipped_items(include_pockets = TRUE, include_hands = TRUE))
 			drop_item_ground(I)
 		else
-			forceMove(drop_location())
+			I.forceMove(drop_location())
 		return FALSE
 
 	if(qdel_on_fail)
@@ -121,7 +121,7 @@
 		if(I in get_equipped_items(include_pockets = TRUE, include_hands = TRUE))
 			drop_item_ground(I)
 		else
-			forceMove(drop_location())
+			I.forceMove(drop_location())
 		return FALSE
 
 	if(qdel_on_fail)
@@ -180,7 +180,7 @@
 			if(I in get_equipped_items(include_pockets = TRUE, include_hands = TRUE))
 				drop_item_ground(I)
 			else
-				forceMove(drop_location())
+				I.forceMove(drop_location())
 			return FALSE
 
 		if(qdel_on_fail)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Если вы положите пда в слот карты, то в одном из шагов обучения карта не сможет экипироваться и заспавнится в нуллспейсе, что засофтлочит вам процесс обучения до следующего рестарта... Теперь мы будем кидать под себя предметы в обучении если их не получилось экипировать. 

Здесь для этого починена логика drop_on_fail. Для мастера был также сделан этот фикс https://github.com/ss220-space/Paradise/pull/4524
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Репорт: https://discord.com/channels/617003227182792704/756409070721957918/1212689971086098452
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
