### PR TITLE
bugfix: Localhost-configured admin access is now working

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -439,8 +439,8 @@
 		message_admins("Panic bunker has been automatically disabled due to playercount dropping below [threshold]")
 
 /client/proc/is_connecting_from_localhost()
-	var/localhost_addresses = list("127.0.0.1", "::1") // Adresses
-	if(!isnull(address) && (address in localhost_addresses))
+	var/localhost_addresses = list("127.0.0.1", "::1", "0.0.0.0") // Adresses
+	if(!isnull(address) && (address in localhost_addresses) || !address)
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
ПР исправляет ошибку, при которой подключение из dreamseeker напрямую к dmb файлу не давало админских прав при отключенном конфиге DISABLE_LOCALHOST_ADMIN 

