### PR TITLE
tweak: People in softcrit are now examined as "barely conscious"

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -340,7 +340,7 @@
 		if(stat == CONSCIOUS)
 			if(getBrainLoss() >= 60)
 				msg += "[p_they(TRUE)] [p_have()] a stupid expression on [p_their()] face.\n"
-			if(health < HEALTH_THRESHOLD_CRIT && health > HEALTH_THRESHOLD_DEAD && stat != DEAD)
+			if(health < HEALTH_THRESHOLD_CRIT && health > HEALTH_THRESHOLD_DEAD)
 				msg += span_warning("[p_they(TRUE)] [p_are()] barely conscious.\n")
 
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -337,8 +337,12 @@
 	if(!appears_dead)
 		if(stat == UNCONSCIOUS)
 			msg += "[p_they(TRUE)] [p_are()]n't responding to anything around [p_them()] and seems to be asleep.\n"
-		else if(getBrainLoss() >= 60)
-			msg += "[p_they(TRUE)] [p_have()] a stupid expression on [p_their()] face.\n"
+		if(stat == CONSCIOUS)
+			if(getBrainLoss() >= 60)
+				msg += "[p_they(TRUE)] [p_have()] a stupid expression on [p_their()] face.\n"
+			if(health < HEALTH_THRESHOLD_CRIT && health > HEALTH_THRESHOLD_DEAD && stat != DEAD)
+				msg += span_warning("[p_they(TRUE)] [p_are()] barely conscious.\n")
+
 
 		if(get_int_organ(/obj/item/organ/internal/brain))
 			if(dna.species.show_ssd)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
В случае, если кукла вошла в крит (более чем 100 урона любого типа), у нее появляется новая строка в описании - "He (She/They) is (are) barely conscious."
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1196327495440547920
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
