### PR TITLE
bugfix: trying remove some lags by meteor sat console

### DIFF
--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -111,7 +111,7 @@ GLOBAL_LIST_INIT(meteor_shields, list())
 	desc = ""
 	icon = 'icons/obj/machines/satellite.dmi'
 	icon_state = "sat_inactive"
-	density = FALSE
+	density = TRUE
 	use_power = FALSE
 	var/mode = "NTPROBEV0.8"
 	var/active = FALSE

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -1,9 +1,12 @@
+GLOBAL_LIST_INIT(meteor_shields, list())
+
 // Щиты станции
 // Цепь спутников, окружающих станцию
 // Спутники активируются, создавая щит, который будет препятствовать прохождению неорганической материи.
 /datum/station_goal/station_shield
 	name = "Station Shield"
-	var/coverage_goal = 12500
+	VAR_PRIVATE/cached_coverage_length
+	var/coverage_goal = 10000
 
 /datum/station_goal/station_shield/get_report()
 	return {"<b>Сооружение щитов станции</b><br>
@@ -24,17 +27,22 @@
 /datum/station_goal/station_shield/check_completion()
 	if(..())
 		return TRUE
-	if(get_coverage() >= coverage_goal)
+	update_coverage()
+	if(cached_coverage_length >= coverage_goal)
 		return TRUE
 	return FALSE
 
-/datum/station_goal/proc/get_coverage()
+/datum/station_goal/station_shield/proc/get_coverage()
+	return cached_coverage_length
+
+/datum/station_goal/station_shield/proc/update_coverage()
 	var/list/coverage = list()
-	for(var/obj/machinery/satellite/meteor_shield/A in GLOB.machines)
-		if(!A.active || !is_station_level(A.z))
+	for(var/obj/machinery/satellite/meteor_shield/shield_satt as anything in GLOB.meteor_shields)
+		if(!shield_satt.active || !is_station_level(shield_satt.z))
 			continue
-		coverage |= view(A.kill_range, A)
-	return coverage.len
+		for(var/turf/covered in view(shield_satt.kill_range, shield_satt))
+			coverage |= covered
+	cached_coverage_length = length(coverage)
 
 /obj/item/circuitboard/computer/sat_control
 	board_name = "Контроллер сети спутников"
@@ -51,7 +59,7 @@
 
 /obj/machinery/computer/sat_control/attack_hand(mob/user)
 	if(..())
-		return 1
+		return TRUE
 	ui_interact(user)
 
 /obj/machinery/computer/sat_control/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)
@@ -103,36 +111,45 @@
 	desc = ""
 	icon = 'icons/obj/machines/satellite.dmi'
 	icon_state = "sat_inactive"
+	density = FALSE
+	use_power = FALSE
 	var/mode = "NTPROBEV0.8"
 	var/active = FALSE
-	density = 1
-	use_power = FALSE
-	var/static/gid = 0
+	/// global counter of IDs
+	var/static/global_id = 0
+	/// id number for this satellite
 	var/id = 0
+	/// toggle cooldown
+	COOLDOWN_DECLARE(toggle_sat_cooldown)
 
-/obj/machinery/satellite/New()
-	..()
-	id = gid++
+/obj/machinery/satellite/Initialize(mapload)
+	. = ..()
+	id = global_id++
 
 /obj/machinery/satellite/attack_hand(mob/user)
 	if(..())
-		return 1
+		return TRUE
 	interact(user)
 
 /obj/machinery/satellite/interact(mob/user)
 	toggle(user)
 
 /obj/machinery/satellite/proc/toggle(mob/user)
+	if(!COOLDOWN_FINISHED(src, toggle_sat_cooldown))
+		return FALSE
 	if(!active && !isinspace())
 		if(user)
-			to_chat(user, "<span class='warning'>Вы можете активировать только находящиеся в космосе спутники.</span>")
+			to_chat(user, span_warning("Вы можете активировать только находящиеся в космосе спутники."))
 		return FALSE
 	if(user)
-		to_chat(user, "<span class='notice'>Вы [active ? "деактивировали": "активировали"] [src]</span>")
+		to_chat(user, span_notice("Вы [active ? "деактивировали": "активировали"] [src]"))
 	active = !active
+	COOLDOWN_START(src, toggle_sat_cooldown, 1 SECONDS)
 	if(active)
-		animate(src, pixel_y = 2, time = 10, loop = -1)
 		anchored = TRUE
+		if(pulledby)
+			pulledby.stop_pulling()
+		animate(src, pixel_y = 2, time = 10, loop = -1)
 	else
 		animate(src, pixel_y = 0, time = 10)
 		anchored = FALSE
@@ -142,12 +159,11 @@
 /obj/machinery/satellite/update_icon_state()
 	icon_state = active ? "sat_active" : "sat_inactive"
 
-/obj/machinery/satellite/attackby(obj/item/I, mob/user, params)
-	if(I.tool_behaviour == TOOL_MULTITOOL)
-		add_fingerprint(user)
-		to_chat(user, "<span class='notice'>// NTSAT-[id] // Режим : [active ? "ОСНОВНОЙ" : "ОЖИДАНИЕ"] //[emagged ? "ОТЛАДКА //" : ""]</span>")
-	else
-		return ..()
+/obj/machinery/satellite/multitool_act(mob/living/user, obj/item/I)
+	..()
+	add_fingerprint(user)
+	to_chat(user, span_notice("// NTSAT-[id] // Режим : [active ? "ОСНОВНОЙ" : "ОЖИДАНИЕ"] //[emagged ? "ОТЛАДКА //" : ""]"))
+	return TRUE
 
 /obj/machinery/satellite/meteor_shield
 	name = "Спутник метеорного щита"
@@ -156,8 +172,21 @@
 	speed_process = TRUE
 	var/kill_range = 14
 
+/obj/machinery/satellite/meteor_shield/examine(mob/user)
+	. = ..()
+	if(active)
+		. += span_notice("It is currently active. You can interact with it to shut it down.")
+		if(emagged)
+			. += span_warning("Rather than the usual sounds of beeps and pings, it produces a weird and constant hiss of white noise…")
+		else
+			. += span_notice("It emits periodic beeps and pings as it communicates with the satellite network.")
+	else
+		. += span_notice("It is currently disabled. You can interact with it to set it up.")
+		if(emagged)
+			. += span_warning("But something seems off about it...?")
+
 /obj/machinery/satellite/meteor_shield/proc/space_los(meteor)
-	for(var/turf/T in getline(src,meteor))
+	for(var/turf/T as anything in getline(src, meteor))
 		if(!isspaceturf(T))
 			return FALSE
 	return TRUE
@@ -165,23 +194,31 @@
 /obj/machinery/satellite/meteor_shield/process()
 	if(!active)
 		return
-	for(var/obj/effect/meteor/M in GLOB.meteor_list)
-		if(M.z != z)
+	for(var/obj/effect/meteor/meteor_to_destroy as anything in GLOB.meteor_list)
+		if(meteor_to_destroy.z != z)
 			continue
-		if(get_dist(M, src) > kill_range)
+		if(get_dist(meteor_to_destroy, src) > kill_range)
 			continue
-		if(!emagged && space_los(M))
-			Beam(get_turf(M), icon_state = "sat_beam", time = 5, maxdistance = kill_range)
-			qdel(M)
+		if(!emagged && space_los(meteor_to_destroy))
+			Beam(get_turf(meteor_to_destroy), icon_state = "sat_beam", time = 5, maxdistance = kill_range)
+			qdel(meteor_to_destroy)
+
+/obj/machinery/satellite/meteor_shield/Process_Spacemove(movement_dir)
+	return active
 
 /obj/machinery/satellite/meteor_shield/toggle(user)
-	if(..(user))
-		return TRUE
+	. = ..()
+	if(!.)
+		return
 	if(emagged)
 		if(active)
 			change_meteor_chance(2)
 		else
 			change_meteor_chance(0.5)
+
+	var/datum/station_goal/station_shield/shield_goal = locate() in SSticker.mode.station_goals
+	if(shield_goal)
+		shield_goal.update_coverage()
 
 /obj/machinery/satellite/meteor_shield/proc/change_meteor_chance(mod)
 	for(var/datum/event_container/container in SSevents.event_containers)
@@ -189,16 +226,25 @@
 			if(M.event_type == /datum/event/meteor_wave)
 				M.weight_mod *= mod
 
+/obj/machinery/satellite/meteor_shield/Initialize(mapload)
+	. = ..()
+	GLOB.meteor_shields += src
+
 /obj/machinery/satellite/meteor_shield/Destroy()
 	. = ..()
 	if(active && emagged)
 		change_meteor_chance(0.5)
+	GLOB.meteor_shields -= src
+	var/datum/station_goal/station_shield/shield_goal = locate() in SSticker.mode.station_goals
+	if(shield_goal)
+		shield_goal.update_coverage()
 
 /obj/machinery/satellite/meteor_shield/emag_act(mob/user)
-	if(!emagged)
-		add_attack_logs(user, src, "emagged")
-		if(user)
-			to_chat(user, "<span class='danger'>Вы переписали схемы метеорного щита, заставив его привлекать метеоры, а не уничтожать их.</span>")
-		emagged = 1
-		if(active)
-			change_meteor_chance(2)
+	if(emagged)
+		return
+	add_attack_logs(user, src, "emagged")
+	if(user)
+		to_chat(user, span_danger("Вы переписали схемы метеорного щита, заставив его привлекать метеоры, а не уничтожать их."))
+	emagged = TRUE
+	if(active)
+		change_meteor_chance(2)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Сейчас, когда вы смотрите в консоль щитов, каждое обновление тгуи высчитывается покрытие. А высчитывается оно каждым атомом в зоне дальности щита(щит у мусорки будет сильно увеличивать вам прогресс) через |=. Это очень медленно.
Взял с тг их реализацию щитов пока.
А именно:
 1. Теперь мы кэшируем покрытие и изменяем его только когда переключаем/уничтожаем щит. И при подсчёте цели. 
 2. Только видимые турфы дают покрытие. 
Из-за этого снизил цель покрытия с 12500 до 10000, чтобы не заказывать по 30 щитов каждый раунд. 
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Когда в консоль щитов смотрят двое:
![Снимок экрана 2024-03-01 203623](https://github.com/ss220-space/Paradise/assets/120549107/9ef83890-5057-456b-aa0a-44a2097c755a)

<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
