### PR TITLE
bugfix: Remove telebacon from cargo

### DIFF
--- a/code/modules/economy/quests/thing_quests.dm
+++ b/code/modules/economy/quests/thing_quests.dm
@@ -178,7 +178,6 @@
 		/obj/item/reagent_containers/food/snacks/meatsteak/drask = 70,
 		/obj/item/reagent_containers/food/snacks/meatsteak/grey = 70,
 		/obj/item/reagent_containers/food/snacks/candy/jawbreaker = 70,
-		/obj/item/reagent_containers/food/snacks/telebacon = 70,
 		/obj/item/reagent_containers/food/snacks/plov = 70,
 		/obj/item/reagent_containers/food/snacks/weirdoliviersalad = 70,
 		/obj/item/reagent_containers/food/snacks/doner_mushroom = 70,


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Убирает телебекон из пулла реквестов в карго.

## Ссылка на предложение/Причина создания ПР
[Ссылка](https://discord.com/channels/617003227182792704/1216620779031105639/1216620779031105639) говорит, что там телебекона не должно быть.

## Изменения
+0-1
