### PR TITLE
bugfix: fixes unnecessary message about switching gunmode if the mode is one

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -183,7 +183,7 @@
 
 
 /obj/item/gun/energy/attack_self(mob/living/user)
-	if(length(ammo_type))
+	if(length(ammo_type) > 1)
 		select_fire(user)
 		update_icon()
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Возвращаем это: 
![Снимок экрана 2024-03-08 102031](https://github.com/ss220-space/Paradise/assets/120549107/fefa9098-113f-489f-8ea4-6089e34bb2fd)

<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

