### PR TITLE
balance: antag paradise mode tweaks

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -304,6 +304,13 @@
 		return picked
 	return null
 
+//Pick a random element by weight from the list and remove it from the list.
+/proc/pick_weight_n_take(list/listfrom)
+	if(listfrom.len > 0)
+		var/picked = pick_weight_classic(listfrom)
+		listfrom -= picked
+		return picked
+	return null
 
 /**
  * Picks multiple unique elements from the suplied list.

--- a/code/controllers/configuration/entries/config.dm
+++ b/code/controllers/configuration/entries/config.dm
@@ -419,13 +419,14 @@
 	min_val = 0
 
 
-/datum/config_entry/str_list/antag_paradise_main_antags
+/datum/config_entry/keyed_list/antag_paradise_main_antags
+	key_mode = KEY_MODE_TEXT
+	value_mode = VALUE_MODE_NUM
 	default = list(
-		ROLE_TRAITOR,
-		ROLE_VAMPIRE,
-		ROLE_CHANGELING,
+		ROLE_TRAITOR = 60,
+		ROLE_VAMPIRE = 20,
+		ROLE_CHANGELING = 20,
 	)
-	lowercase = TRUE
 
 /datum/config_entry/keyed_list/antag_paradise_special_antags_weights
 	key_mode = KEY_MODE_TEXT

--- a/code/game/gamemodes/antag_paradise/antag_paradise.dm
+++ b/code/game/gamemodes/antag_paradise/antag_paradise.dm
@@ -60,7 +60,6 @@
 	pre_double_antags = list()
 
 	var/players = roundstart ? num_players() : num_station_players()
-	calculate_antags(players)
 	var/scale = CONFIG_GET(number/traitor_scaling) ? CONFIG_GET(number/traitor_scaling) : 10
 	var/antags_amount
 	var/special_antag_amount
@@ -94,7 +93,7 @@
 					special_antag.special_role = SPECIAL_ROLE_THIEF
 					special_antag.restricted_roles = restricted_jobs
 					pre_antags[special_antag] = ROLE_THIEF
-					antags_amount--
+					//antags_amount--
 
 		if(ROLE_MALF_AI)
 			if(special_antag_amount)
@@ -210,9 +209,12 @@
 	antag_possibilities[ROLE_TRAITOR] =	get_players_for_role(ROLE_TRAITOR)
 	antag_possibilities[ROLE_THIEF] = get_players_for_role(ROLE_THIEF, list("Vox" = 4))
 
+	calculate_antags()
+
 	return roll_antagonists(antag_possibilities, TRUE)
 
-/datum/game_mode/antag_paradise/proc/calculate_antags(players)
+/datum/game_mode/antag_paradise/proc/calculate_antags()
+	var/players = num_players()
 	var/list/special_antags_list
 	if(GLOB.antag_paradise_special_weights)
 		special_antags_list = GLOB.antag_paradise_special_weights
@@ -231,7 +233,7 @@
 
 	antags_weights = list()
 
-	var/list/antag_weight_config = CONFIG_GET(str_list/antag_paradise_main_antags)
+	var/list/antag_weight_config = CONFIG_GET(keyed_list/antag_paradise_main_antags)
 	antag_weight_config = antag_weight_config.Copy()
 
 	for(var/antag in antag_weight_config)
@@ -248,13 +250,13 @@
 		return
 
 	var/list/subtype_weights = CONFIG_GET(keyed_list/antag_paradise_subtype_weights)
-	antags_weights[pick_n_take(antag_weight_config)] = subtype_weights[ANTAG_SINGLE]
+	antags_weights[pick_weight_n_take(antag_weight_config)] = subtype_weights[ANTAG_SINGLE]
 	if(!length(antag_weight_config) || mode_type == ANTAG_SINGLE)
 		return
-	antags_weights[pick_n_take(antag_weight_config)] = subtype_weights[ANTAG_DOUBLE]
+	antags_weights[pick_weight_n_take(antag_weight_config)] = subtype_weights[ANTAG_DOUBLE]
 	if(!length(antag_weight_config) || mode_type == ANTAG_DOUBLE)
 		return
-	antags_weights[pick_n_take(antag_weight_config)] = subtype_weights[ANTAG_TRIPPLE]
+	antags_weights[pick_weight_n_take(antag_weight_config)] = subtype_weights[ANTAG_TRIPPLE]
 
 
 /datum/game_mode/antag_paradise/post_setup()

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1253,7 +1253,7 @@
 		if(GLOB.antag_paradise_weights)
 			antags_list = GLOB.antag_paradise_weights
 		else
-			antags_list = CONFIG_GET(str_list/antag_paradise_main_antags)
+			antags_list = CONFIG_GET(keyed_list/antag_paradise_main_antags)
 			antags_list = antags_list.Copy()
 			for(var/key in list(ROLE_TRAITOR, ROLE_VAMPIRE, ROLE_CHANGELING, ROLE_THIEF))
 				antags_list[key] = !!(key in antags_list)
@@ -1299,7 +1299,7 @@
 
 		else if(findtext(command, "weights_normal_"))
 			if(!GLOB.antag_paradise_weights)
-				var/list/antags_list = CONFIG_GET(str_list/antag_paradise_main_antags)
+				var/list/antags_list = CONFIG_GET(keyed_list/antag_paradise_main_antags)
 				antags_list = antags_list.Copy()
 				for(var/key in list(ROLE_TRAITOR, ROLE_VAMPIRE, ROLE_CHANGELING, ROLE_THIEF))
 					antags_list[key] = !!(key in antags_list)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Трейторы теперь спавнятся чаще чем другие миноры, вор теперь не занимает слоты остальных антагов