### PR TITLE
bugfix: locked R&D designs now really locked.

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -147,6 +147,7 @@
 	modkit_design = /datum/design/unique_modkit/bounty
 
 /datum/design/unique_modkit
+	req_tech = null	// Unreachable by tech researching.
 	build_type = PROTOLATHE | MECHFAB
 
 /datum/design/unique_modkit/offensive_turf_aoe

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -29,19 +29,35 @@ other types of metals and chemistry for reagents).
 
 */
 
-/datum/design						//Datum for object designs, used in construction
-	var/name = "Name"					//Name of the created object.
-	var/desc = "Desc"					//Description of the created object.
-	var/id = "id"						//ID of the created object for easy refernece. Alphanumeric, lower-case, no symbols
-	var/list/req_tech = list()			//IDs of that techs the object originated from and the minimum level requirements.
-	var/build_type = null				//Flag as to what kind machine the design is built in. See defines.
-	var/list/materials = list()			//List of materials. Format: "id" = amount.
-	var/construction_time				//Amount of time required for building the object
-	var/build_path = null				//The file path of the object that gets created
-	var/list/make_reagents = list()			//Reagents produced. Format: "id" = amount. Currently only supported by the biogenerator.
-	var/locked = FALSE						//If true it will spawn inside a lockbox with currently sec access
-	var/access_requirement = list(ACCESS_ARMORY) //What special access requirements will the lockbox have? Defaults to armory.
-	var/category = null //Primarily used for Mech Fabricators, but can be used for anything
-	var/list/reagents_list = list()			//List of reagents. Format: "id" = amount.
+// Datum for object designs, used in construction
+/datum/design
+	/// Name of the created object.
+	var/name = "Name"
+	/// Description of the created object.
+	var/desc = "Desc"
+	/// ID of the created object for easy refernece. Alphanumeric, lower-case, no symbols.
+	var/id = "id"
+	/// IDs of that techs the object originated from and the minimum level requirements. Leave 'null' here to block the design from appearing regularly in the R&D consoles.
+	var/list/req_tech = list()
+	/// Flag as to what kind machine the design is built in. See defines.
+	var/build_type = null
+	/// List of materials. Format: "id" = amount.
+	var/list/materials = list()
+	/// Amount of time required for building the object.
+	var/construction_time
+	/// The file path of the object that gets created.
+	var/build_path = null
+	/// Reagents produced. Format: "id" = amount. Currently only supported by the biogenerator.
+	var/list/make_reagents = list()
+	/// If true it will spawn inside a lockbox with currently sec access.
+	var/locked = FALSE
+	/// What special access requirements will the lockbox have? Defaults to armory.
+	var/access_requirement = list(ACCESS_ARMORY)
+	/// Primarily used for Mech Fabricators, but can be used for anything.
+	var/category = null
+	/// List of reagents. Format: "id" = amount.
+	var/list/reagents_list = list()
+	/// Max number of items in stack by build on the autolathe.
 	var/maxstack = 1
-	var/lathe_time_factor = 1			//How many times faster than normal is this to build on the protolathe
+	/// How many times faster than normal is this to build on the protolathe.
+	var/lathe_time_factor = 1

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -1047,6 +1047,7 @@
 	name = "Golem Shell Construction"
 	desc = "Allows for the construction of a Golem Shell."
 	id = "golem"
+	req_tech = null	// Unreachable by tech researching.
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 40000)
 	build_path = /obj/item/golem_shell

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -566,7 +566,7 @@
 	name = "Machine Design (Rift Scan Server)"
 	desc = "Плата сервера сканирования и изучения блюспейс разлома."
 	id = "brs_server"
-	req_tech = list("bluespace" = 20) // unreachable
+	req_tech = null	// Unreachable by tech researching.
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, MAT_BLUESPACE = 100)
 	build_path = /obj/item/circuitboard/brs_server
@@ -576,7 +576,7 @@
 	name = "Machine Design (Portable Rift Scanner)"
 	desc = "Плата портативного сканера блюспейс разлома."
 	id = "brs_portable_scanner"
-	req_tech = list("bluespace" = 20) // unreachable
+	req_tech = null	// Unreachable by tech researching.
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, MAT_BLUESPACE = 200)
 	build_path = /obj/item/circuitboard/brs_portable_scanner
@@ -586,7 +586,7 @@
 	name = "Machine Design (Stationary Rift Scanner)"
 	desc = "Плата стационарного сканера блюспейс разлома."
 	id = "brs_stationary_scanner"
-	req_tech = list("bluespace" = 20) // unreachable
+	req_tech = null	// Unreachable by tech researching.
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, MAT_BLUESPACE = 500)
 	build_path = /obj/item/circuitboard/brs_stationary_scanner

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -81,8 +81,10 @@ research holder datum.
 
 //Checks to see if design has all the required pre-reqs.
 //Input: datum/design; Output: 0/1 (false/true)
-/datum/research/proc/DesignHasReqs(var/datum/design/D)
-	if(D.req_tech.len == 0)
+/datum/research/proc/DesignHasReqs(datum/design/D)
+	if(!islist(D.req_tech))
+		return FALSE
+	if(!D.req_tech.len)
 		return TRUE
 	for(var/req in D.req_tech)
 		var/datum/tech/known = known_tech[req]


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Разминочный +1-1 (почти), убирающий из меню протолата дизайн "Name" и в целом все дизайны, что по логике должны загружаться только из дисков. Теперь для подобных дизайнов можно просто вписать нулль в `req_tech`, а не шизовать с `"bluespace"=20` и прочими прелестями. Лучше заливать после #4600.<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на баг-репорт
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
https://discord.com/channels/617003227182792704/1217595064084332644