### PR TITLE
bugfix: Blob Nuclear Overlay Fix

### DIFF
--- a/code/game/gamemodes/blob/blobs/captured_nuke.dm
+++ b/code/game/gamemodes/blob/blobs/captured_nuke.dm
@@ -9,6 +9,7 @@
 	. = ..()
 	START_PROCESSING(SSobj, src)
 	N?.forceMove(src)
+	update_icon(UPDATE_OVERLAYS)
 
 
 /obj/structure/blob/captured_nuke/update_overlays()

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -19,8 +19,8 @@
 	var/mob/camera/blob/overmind
 	creates_cover = TRUE
 
-/obj/structure/blob/New(loc)
-	..()
+/obj/structure/blob/Initialize(mapload)
+	. = ..()
 	GLOB.blobs += src
 	setDir(pick(GLOB.cardinal))
 	check_integrity()


### PR DESCRIPTION
## Описание
Исправляет отсутствие соответствующего оверлея, у блоба, захватившего боеголовку.