### PR TITLE
bugfix: dual shooting bypasses the gun's "ability to shoot" check. Sibyl sounds corrections.

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -235,9 +235,12 @@
 			if(G == src || G.weapon_weight >= WEAPON_MEDIUM)
 				continue
 			else if(G.can_trigger_gun(user))
-				bonus_spread += 24 * G.weapon_weight
-				loop_counter++
-				addtimer(CALLBACK(G, PROC_REF(process_fire), target, user, 1, params, null, bonus_spread), loop_counter)
+				if(!G.can_shoot(user)) //Just because you can pull the trigger doesn't mean it can't shoot.
+					G.shoot_with_empty_chamber(user)
+				else
+					bonus_spread += 24 * G.weapon_weight
+					loop_counter++
+					addtimer(CALLBACK(G, PROC_REF(process_fire), target, user, 1, params, null, bonus_spread), loop_counter)
 
 	process_fire(target,user,1,params, null, bonus_spread)
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -240,9 +240,11 @@
 	if(istype(user))
 		if(!user.can_use_guns(src))
 			return FALSE
+
 		if(restricted_species && restricted_species.len && !is_type_in_list(user.dna.species, restricted_species))
 			to_chat(user, span_danger("[src] is incompatible with your biology!"))
 			return FALSE
+
 	if(!can_shoot(user)) //Just because you can pull the trigger doesn't mean it can't shoot.
 		shoot_with_empty_chamber(user)
 		return FALSE

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -197,13 +197,7 @@
 		if(target == user && user.zone_selected != "mouth") //so we can't shoot ourselves (unless mouth selected)
 			return
 
-	if(istype(user))//Check if the user can use the gun, if the user isn't alive(turrets) assume it can.
-		var/mob/living/L = user
-		if(!can_trigger_gun(L))
-			return
-
-	if(!can_shoot(user)) //Just because you can pull the trigger doesn't mean it can't shoot.
-		shoot_with_empty_chamber(user)
+	if(!can_trigger_gun(user))
 		return
 
 	if(flag)
@@ -235,22 +229,25 @@
 			if(G == src || G.weapon_weight >= WEAPON_MEDIUM)
 				continue
 			else if(G.can_trigger_gun(user))
-				if(!G.can_shoot(user)) //Just because you can pull the trigger doesn't mean it can't shoot.
-					G.shoot_with_empty_chamber(user)
-				else
-					bonus_spread += 24 * G.weapon_weight
-					loop_counter++
-					addtimer(CALLBACK(G, PROC_REF(process_fire), target, user, 1, params, null, bonus_spread), loop_counter)
+				bonus_spread += 24 * G.weapon_weight
+				loop_counter++
+				addtimer(CALLBACK(G, PROC_REF(process_fire), target, user, 1, params, null, bonus_spread), loop_counter)
 
 	process_fire(target,user,1,params, null, bonus_spread)
 
+
 /obj/item/gun/proc/can_trigger_gun(mob/living/user)
-	if(!user.can_use_guns(src))
-		return 0
-	if(restricted_species && restricted_species.len && !is_type_in_list(user.dna.species, restricted_species))
-		to_chat(user, "<span class='danger'>[src] is incompatible with your biology!</span>")
-		return 0
-	return 1
+	if(istype(user))
+		if(!user.can_use_guns(src))
+			return FALSE
+		if(restricted_species && restricted_species.len && !is_type_in_list(user.dna.species, restricted_species))
+			to_chat(user, span_danger("[src] is incompatible with your biology!"))
+			return FALSE
+	if(!can_shoot(user)) //Just because you can pull the trigger doesn't mean it can't shoot.
+		shoot_with_empty_chamber(user)
+		return FALSE
+	return TRUE
+
 
 /obj/item/gun/proc/newshot()
 	return

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -188,12 +188,18 @@
 		update_icon()
 
 
+/obj/item/gun/energy/can_trigger_gun(mob/living/user)
+	. = ..()
+	if(. && sibyl_mod && !sibyl_mod.check_auth(user))
+		. = FALSE
+
+
 /obj/item/gun/energy/can_shoot(mob/living/user)
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
-	var/check_charge = cell.charge >= shot.e_cost
-	if(sibyl_mod && !sibyl_mod.check_auth(check_charge, user))
-		return FALSE
-	return check_charge
+	. = cell.charge >= shot.e_cost
+	if(!. && sibyl_mod?.voice_is_enabled)
+		sibyl_mod.play_sound(user)
+
 
 /obj/item/gun/energy/newshot()
 	if(!ammo_type || !cell)
@@ -290,13 +296,14 @@
 /obj/item/gun/energy/ui_action_click()
 	toggle_gunlight()
 
+
 /obj/item/gun/energy/suicide_act(mob/user)
-	if(can_shoot())
+	if(can_trigger_gun(user))
 		user.visible_message(span_suicide("[user] is putting the barrel of the [name] in [user.p_their()] mouth.  It looks like [user.p_theyre()] trying to commit suicide."))
 		sleep(25)
 		if(user.l_hand == src || user.r_hand == src)
 			user.visible_message(span_suicide("[user] melts [user.p_their()] face off with the [name]!"))
-			playsound(loc, fire_sound, 50, 1, -1)
+			playsound(loc, fire_sound, 50, TRUE, -1)
 			var/obj/item/ammo_casing/energy/shot = ammo_type[select]
 			cell.use(shot.e_cost)
 			update_icon()
@@ -306,8 +313,9 @@
 			return OXYLOSS
 	else
 		user.visible_message(span_suicide("[user] is pretending to blow [user.p_their()] brains out with the [name]! It looks like [user.p_theyre()] trying to commit suicide!"))
-		playsound(loc, 'sound/weapons/empty.ogg', 50, 1, -1)
+		playsound(loc, 'sound/weapons/empty.ogg', 50, TRUE, -1)
 		return OXYLOSS
+
 
 /obj/item/gun/energy/vv_edit_var(var_name, var_value)
 	switch(var_name)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -195,8 +195,8 @@
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
 	. = cell.charge >= shot.e_cost
 
-	if(!. && sibyl_mod?.voice_is_enabled)
-		sibyl_mod.play_sound(user, 'sound/voice/dominator/battery.ogg', 5 SECONDS)
+	if(!.)
+		sibyl_mod?.sibyl_sound(user, 'sound/voice/dominator/battery.ogg', 5 SECONDS)
 
 
 /obj/item/gun/energy/newshot()

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -188,15 +188,13 @@
 		update_icon()
 
 
-/obj/item/gun/energy/can_trigger_gun(mob/living/user)
-	. = ..()
-	if(. && sibyl_mod && !sibyl_mod.check_auth(user))
-		. = FALSE
-
-
 /obj/item/gun/energy/can_shoot(mob/living/user)
+	if(!sibyl_mod?.check_auth(user))
+		return FALSE
+
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
 	. = cell.charge >= shot.e_cost
+
 	if(!. && sibyl_mod?.voice_is_enabled)
 		sibyl_mod.play_sound(user)
 

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -189,14 +189,14 @@
 
 
 /obj/item/gun/energy/can_shoot(mob/living/user)
-	if(!sibyl_mod?.check_auth(user))
+	if(sibyl_mod && !sibyl_mod.check_auth(user))
 		return FALSE
 
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
 	. = cell.charge >= shot.e_cost
 
 	if(!. && sibyl_mod?.voice_is_enabled)
-		sibyl_mod.play_sound(user)
+		sibyl_mod.play_sound(user, 'sound/voice/dominator/battery.ogg', 5 SECONDS)
 
 
 /obj/item/gun/energy/newshot()

--- a/code/modules/projectiles/sibyl/sibyl_system_mod.dm
+++ b/code/modules/projectiles/sibyl/sibyl_system_mod.dm
@@ -53,8 +53,8 @@ GLOBAL_VAR_INIT(sibsys_automode, TRUE)
 /obj/item/sibyl_system_mod/proc/register(mob/user)
 	GLOB.sybsis_registry += list(src)
 
-	if(!auth_id && voice_is_enabled)
-		play_sound(user, 'sound/voice/dominator/link.ogg', 10 SECONDS)
+	if(!auth_id)
+		sibyl_sound(user, 'sound/voice/dominator/link.ogg', 10 SECONDS)
 
 	return TRUE
 
@@ -114,8 +114,7 @@ GLOBAL_VAR_INIT(sibsys_automode, TRUE)
 	if(!auth_id)
 		unlock(user, ID)
 		to_chat(user, span_notice("Вы авторизировали [weapon] в системе Sibyl System под именем [auth_id.registered_name]."))
-		if(voice_is_enabled)
-			play_sound(user, 'sound/voice/dominator/user.ogg', 10 SECONDS)
+		sibyl_sound(user, 'sound/voice/dominator/user.ogg', 10 SECONDS)
 	else if(auth_id == ID)
 		lock(user)
 		to_chat(user, span_notice("Вы деавторизировали [weapon] в системе Sibyl System."))
@@ -207,8 +206,8 @@ GLOBAL_VAR_INIT(sibsys_automode, TRUE)
 	return names.Join(", ")
 
 
-/obj/item/sibyl_system_mod/proc/play_sound(mob/living/user, sound, time)
-	if(!voice_cd && user)
+/obj/item/sibyl_system_mod/proc/sibyl_sound(mob/living/user, sound, time)
+	if(user && voice_is_enabled && !voice_cd)
 		user.playsound_local(get_turf(user), sound, 50, FALSE)
 		voice_cd = addtimer(VARSET_CALLBACK(src, voice_cd, null), time)
 

--- a/code/modules/projectiles/sibyl/sibyl_system_mod.dm
+++ b/code/modules/projectiles/sibyl/sibyl_system_mod.dm
@@ -16,7 +16,7 @@ GLOBAL_VAR_INIT(sibsys_automode, TRUE)
 	var/limit = SIBYL_NONLETHAL
 	var/emagged = FALSE
 
-	var/voice_is_enabled = FALSE
+	var/voice_is_enabled = TRUE
 	var/voice_cd = null
 
 	var/list/available = list()
@@ -72,10 +72,17 @@ GLOBAL_VAR_INIT(sibsys_automode, TRUE)
 	W.update_icon()
 	return state
 
+
+/obj/item/sibyl_system_mod/attack_self(mob/user)
+	..()
+	toggle_voice(user)
+
+
 /obj/item/sibyl_system_mod/proc/toggle_voice(mob/user)
 	voice_is_enabled = !voice_is_enabled
 	if(user)
-		to_chat(user,span_notice("Голосовая подсистема [voice_is_enabled ? "включена" : "отключена"]."))
+		to_chat(user, span_notice("Голосовая подсистема [voice_is_enabled ? "включена" : "отключена"]."))
+
 
 /obj/item/sibyl_system_mod/proc/lock(mob/user, silent = FALSE)
 	if(emagged)

--- a/code/modules/projectiles/sibyl/sibyl_system_mod.dm
+++ b/code/modules/projectiles/sibyl/sibyl_system_mod.dm
@@ -124,7 +124,7 @@ GLOBAL_VAR_INIT(sibsys_automode, TRUE)
 		check_unknown_names()
 	return FALSE
 
-/obj/item/sibyl_system_mod/proc/check_auth(check_charge, mob/living/user)
+/obj/item/sibyl_system_mod/proc/check_auth(mob/living/user)
 	if(!weapon)
 		return FALSE
 	if(!emagged)
@@ -134,11 +134,8 @@ GLOBAL_VAR_INIT(sibsys_automode, TRUE)
 		if(!find_and_compare_id_cards(user, auth_id))
 			to_chat(user, span_warning("Ваша ID-карта не совпадает с авторизованной."))
 			return FALSE
-	if(!check_charge)
-		if(user && voice_is_enabled && !voice_cd)
-			voice_cd = addtimer(CALLBACK(src, PROC_REF(play_sound), user, 'sound/voice/dominator/battery.ogg'), 10 SECONDS)
-		return FALSE
 	return TRUE
+
 
 /obj/item/sibyl_system_mod/proc/find_and_compare_id_cards(mob/user, obj/item/card/id/registered_id)
 	for(var/obj/item/card/id/found_id in user.get_all_id_cards())
@@ -199,9 +196,13 @@ GLOBAL_VAR_INIT(sibsys_automode, TRUE)
 			names += list(ammo.select_name)
 	return names.Join(", ")
 
-/obj/item/sibyl_system_mod/proc/play_sound(mob/living/user, sound)
-	user.playsound_local(get_turf(user), sound, 50, FALSE)
-	voice_cd = null
+
+/obj/item/sibyl_system_mod/proc/play_sound(mob/living/user)
+	if(!voice_cd && user)
+		voice_cd = TRUE
+		user.playsound_local(get_turf(user), 'sound/voice/dominator/battery.ogg', 50, FALSE)
+		addtimer(VARSET_CALLBACK(src, voice_cd, FALSE), 10 SECONDS)
+
 
 /obj/item/sibyl_system_mod/Destroy()
 	GLOB.sybsis_registry -= list(src)

--- a/code/modules/projectiles/sibyl/sibyl_system_mod.dm
+++ b/code/modules/projectiles/sibyl/sibyl_system_mod.dm
@@ -52,9 +52,12 @@ GLOBAL_VAR_INIT(sibsys_automode, TRUE)
 
 /obj/item/sibyl_system_mod/proc/register(mob/user)
 	GLOB.sybsis_registry += list(src)
-	if(!auth_id && user && voice_is_enabled && !voice_cd)
-		voice_cd = addtimer(CALLBACK(src, PROC_REF(play_sound), user, 'sound/voice/dominator/link.ogg'), 4 SECONDS)
+
+	if(!auth_id && voice_is_enabled)
+		play_sound(user, 'sound/voice/dominator/link.ogg', 10 SECONDS)
+
 	return TRUE
+
 
 /obj/item/sibyl_system_mod/proc/uninstall(obj/item/gun/energy/W)
 	GLOB.sybsis_registry -= list(src)
@@ -104,8 +107,8 @@ GLOBAL_VAR_INIT(sibsys_automode, TRUE)
 	if(!auth_id)
 		unlock(user, ID)
 		to_chat(user, span_notice("Вы авторизировали [weapon] в системе Sibyl System под именем [auth_id.registered_name]."))
-		if(user && voice_is_enabled && !voice_cd)
-			voice_cd = addtimer(CALLBACK(src, PROC_REF(play_sound), user, 'sound/voice/dominator/user.ogg'), 2 SECONDS)
+		if(voice_is_enabled)
+			play_sound(user, 'sound/voice/dominator/user.ogg', 10 SECONDS)
 	else if(auth_id == ID)
 		lock(user)
 		to_chat(user, span_notice("Вы деавторизировали [weapon] в системе Sibyl System."))
@@ -197,11 +200,10 @@ GLOBAL_VAR_INIT(sibsys_automode, TRUE)
 	return names.Join(", ")
 
 
-/obj/item/sibyl_system_mod/proc/play_sound(mob/living/user)
+/obj/item/sibyl_system_mod/proc/play_sound(mob/living/user, sound, time)
 	if(!voice_cd && user)
-		voice_cd = TRUE
-		user.playsound_local(get_turf(user), 'sound/voice/dominator/battery.ogg', 50, FALSE)
-		addtimer(VARSET_CALLBACK(src, voice_cd, FALSE), 10 SECONDS)
+		user.playsound_local(get_turf(user), sound, 50, FALSE)
+		voice_cd = addtimer(VARSET_CALLBACK(src, voice_cd, null), time)
 
 
 /obj/item/sibyl_system_mod/Destroy()

--- a/code/modules/projectiles/sibyl/sibyl_weapons.dm
+++ b/code/modules/projectiles/sibyl/sibyl_weapons.dm
@@ -1,5 +1,6 @@
 /obj/item/gun/energy/proc/install_sibyl()
 	var/obj/item/sibyl_system_mod/M = new /obj/item/sibyl_system_mod
+	M.voice_is_enabled = FALSE
 	M.install(src)
 
 /obj/item/gun/energy/dominator/sibyl/Initialize(mapload)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
- Отделяет из проверки автентификации сибила проигрывание мелодии "оружие разряжено".
- Проверка возможности оружия к стрельбе теперь включена в проверку возможности моба стрелять.
- Суицид еганами проверяет, может ли выстрелить человек, а не только может ли стрелять оружие.
- Озвучка сибила теперь проигрывается СРАЗУ и тогда создаёт таймер, а не проигрывается после таймера.
- Озвучка сибила выключена только у пушек, что спавнятся с сибилом.
- Озвучку сибила можно переключать прожав сибил в руке.
## Ссылка на баг-репорт
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
https://discord.com/channels/617003227182792704/1218729221338169364
