### PR TITLE
bugfix: Takes pre-nerf taser away from 100yos

### DIFF
--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -114,8 +114,8 @@
 	delay = 15
 	harmful = FALSE
 
-/obj/item/ammo_casing/energy/electrode/old
-	projectile_type = /obj/item/projectile/energy/electrode/old
+/obj/item/ammo_casing/energy/electrode/advanced //admin-bus only, k? dont give this thing to 100 year old Charlie crew or other ghost role
+	projectile_type = /obj/item/projectile/energy/electrode/advanced
 
 /obj/item/ammo_casing/energy/electrode/gun
 	fire_sound = 'sound/weapons/gunshots/gunshot.ogg'

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -8,7 +8,7 @@
 	force = 10
 	flags =  CONDUCT
 	slot_flags = SLOT_BACK
-	ammo_type = list(/obj/item/ammo_casing/energy/electrode/old, /obj/item/ammo_casing/energy/laser/pulse , /obj/item/ammo_casing/energy/laser)
+	ammo_type = list(/obj/item/ammo_casing/energy/electrode/advanced, /obj/item/ammo_casing/energy/laser/pulse , /obj/item/ammo_casing/energy/laser)
 	cell_type = /obj/item/stock_parts/cell/pulse
 
 /obj/item/gun/energy/pulse/emp_act(severity)

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -40,7 +40,7 @@
 /obj/item/projectile/energy/electrode/dominator
 	color = LIGHT_COLOR_LIGHT_CYAN
 
-/obj/item/projectile/energy/electrode/old
+/obj/item/projectile/energy/electrode/advanced
 	stun = 10 SECONDS
 	weaken =  10 SECONDS
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Отделяет электрод дедов и Тэты.

## Ссылка на предложение/Причина создания ПР
`/obj/item/ammo_casing/energy/electrode/old` использовался в коде, для обозначения хреного пистолета с Тэты.
![image](https://github.com/ss220-space/Paradise/assets/87372121/2ee28f10-d5c3-4b62-885c-a30ef053390b)
#4577 по [незнанию дал](https://discord.com/channels/617003227182792704/734823601110515882/1219323718262587523) тазер с пульсовки дедов обычной гост роли.

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
