### PR TITLE
bugfix: added absorption instead status flags in adrenaline reagent

### DIFF
--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -68,7 +68,7 @@
 	name = "Syndicate Infiltrator"
 
 /datum/outfit/admin/syndicate_infiltrator/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	. = H.equip_syndicate_infiltrator(0, 20, FALSE)
+	. = H.equip_syndicate_infiltrator(0, 100, FALSE)
 	H.sec_hud_set_ID()
 	if(!visualsOnly)
 		H.faction += "syndicate"

--- a/code/modules/admin/verbs/infiltratorteam_syndicate.dm
+++ b/code/modules/admin/verbs/infiltratorteam_syndicate.dm
@@ -32,7 +32,7 @@ GLOBAL_VAR_INIT(sent_syndicate_infiltration_team, 0)
 		if(!input)
 			alert("No mission specified. Aborting.")
 			return
-	var/tctext = input(src, "How much TC do you want to give each team member? Suggested: 20-30. They cannot trade TC.") as num
+	var/tctext = input(src, "How much TC do you want to give each team member? Suggested: 100-150. They cannot trade TC.") as num
 	var/tcamount = text2num(tctext)
 	tcamount = between(0, tcamount, 1000)
 	if(GLOB.sent_syndicate_infiltration_team == 1)
@@ -109,7 +109,7 @@ GLOBAL_VAR_INIT(sent_syndicate_infiltration_team, 0)
 
 // ---------------------------------------------------------------------------------------------------------
 
-/client/proc/create_syndicate_infiltrator(obj/spawn_location, syndicate_leader_selected = 0, uplink_tc = 20, is_mgmt = 0)
+/client/proc/create_syndicate_infiltrator(obj/spawn_location, syndicate_leader_selected = 0, uplink_tc = 100, is_mgmt = 0)
 	var/mob/living/carbon/human/new_syndicate_infiltrator = new(spawn_location.loc)
 
 	var/syndicate_infiltrator_name = random_name(pick(MALE,FEMALE))

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -377,6 +377,8 @@
 /mob/living/proc/Paralyse(amount, ignore_canparalyse = FALSE)
 	if(IS_PARALYZE_IMMUNE(src, ignore_canparalyse))
 		return
+	if(absorb_status_effect(amount, ignore_canparalyse, PARALYZE))
+		return
 	var/datum/status_effect/incapacitating/paralyzed/P = IsParalyzed()
 	if(P)
 		P.duration = max(world.time + amount, P.duration)
@@ -386,6 +388,8 @@
 
 /mob/living/proc/SetParalysis(amount, ignore_canparalyse = FALSE)
 	if(IS_PARALYZE_IMMUNE(src, ignore_canparalyse))
+		return
+	if(absorb_status_effect(amount, ignore_canparalyse, PARALYZE))
 		return
 	var/datum/status_effect/incapacitating/paralyzed/P = IsParalyzed()
 	if(P)

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -1467,13 +1467,13 @@
 /datum/reagent/medicine/adrenaline/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	update_flags |= M.setStaminaLoss(0, FALSE)
-	var/status = CANSTUN | CANWEAKEN | CANPARALYSE
-	M.status_flags &= ~status
-
+	M.add_status_effect_absorption("adrenaline_weaken", INFINITY, 4, status_effect = WEAKEN)
+	M.add_status_effect_absorption("adrenaline_stun", INFINITY, 4, status_effect = STUN)
+	M.add_status_effect_absorption("adrenaline_paralyse", INFINITY, 4, status_effect = PARALYZE)
 	return ..() | update_flags
 
 /datum/reagent/medicine/adrenaline/on_mob_delete(mob/living/M)
-	M.status_flags |= CANSTUN | CANWEAKEN | CANPARALYSE
+	M.status_effect_absorption -= list("adrenaline_weaken", "adrenaline_stun", "adrenaline_paralyse")
 	..()
 
 /datum/reagent/medicine/adrenaline/overdose_process(mob/living/M, severity)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Адреналин при выветривании из организма добавляет вам флаги canweaken и т.д. даже если их у вас не было. Заменяем это.
Также сделал актуальное колво тк у админского оутфита инфилтрейтора.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
небольшой фикс
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
