### PR TITLE
bugfix: Space dragon now also restarts event if there are few people

### DIFF
--- a/code/game/gamemodes/miniantags/space_dragon/space_dragon.dm
+++ b/code/game/gamemodes/miniantags/space_dragon/space_dragon.dm
@@ -14,18 +14,21 @@
 
 
 /datum/event/space_dragon/start()
+	var/player_count = num_station_players()
+	if(player_count < SPACE_DRAGON_SPAWN_THRESHOLD)
+		log_and_message_admins("Random event attempted to spawn a space dragon, but there were only [player_count]/[SPACE_DRAGON_SPAWN_THRESHOLD] players.")
+		var/datum/event_container/EC = SSevents.event_containers[EVENT_LEVEL_MAJOR]
+		EC.next_event_time = world.time + (60 * 10)
+		return
 	// It is necessary to wrap this to avoid the event triggering repeatedly.
 	INVOKE_ASYNC(src, PROC_REF(wrapped_start))
 
 
 /datum/event/space_dragon/proc/wrapped_start()
-	var/player_count = num_station_players()
-	if(player_count < SPACE_DRAGON_SPAWN_THRESHOLD)
-		log_and_message_admins("Random event attempted to spawn a space dragon, but there were only [player_count]/[SPACE_DRAGON_SPAWN_THRESHOLD] players.")
-		return
 	var/list/candidates = SSghost_spawns.poll_candidates("Вы хотите занять роль Космического Дракона?", ROLE_SPACE_DRAGON, TRUE, source = /mob/living/simple_animal/hostile/space_dragon)
 	if(!length(candidates))
 		log_and_message_admins("Warning: nobody volunteered to become a Space Dragon!")
+		kill()
 		return
 	var/mob/living/simple_animal/hostile/space_dragon/space_dragon = new (pick(GLOB.carplist))
 	var/mob/candidate = pick(candidates)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Демоны, другие ивенты которые также имеют колво людей необходимое для запуска, перезапускают себя при малом онлайне. Делаем тоже самое с космодраконом.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->


