### PR TITLE
bugfix: BaseturfForPirateship

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_pirateship.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_pirateship.dmm
@@ -102,8 +102,8 @@
 "cZ" = (
 /obj/item/stack/sheet/mineral/plastitanium{
 	amount = 7;
-	pixel_y = -1;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = -1
 	},
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
@@ -138,8 +138,8 @@
 /area/ruin/powered/pirateship)
 "em" = (
 /obj/effect/decal/cleanable/blood/drip{
-	pixel_y = 38;
-	pixel_x = -13
+	pixel_x = -13;
+	pixel_y = 38
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/safe_cave)
@@ -199,8 +199,8 @@
 "fC" = (
 /obj/effect/spawner/window/shuttle/gray,
 /obj/machinery/door/poddoor/shutters{
-	id_tag = "pcarrier_windows";
-	dir = 1
+	dir = 1;
+	id_tag = "pcarrier_windows"
 	},
 /turf/simulated/floor{
 	nitrogen = 23;
@@ -371,16 +371,16 @@
 	pixel_y = 9
 	},
 /obj/machinery/door_control{
-	pixel_x = -7;
-	pixel_y = -3;
+	id = "pcarrier_windows";
 	name = "Window Lockdown";
-	id = "pcarrier_windows"
+	pixel_x = -7;
+	pixel_y = -3
 	},
 /obj/machinery/door_control{
-	pixel_y = -3;
-	pixel_x = 4;
+	id = "pcarrier_bridge";
 	name = "Bridge lockdown";
-	id = "pcarrier_bridge"
+	pixel_x = 4;
+	pixel_y = -3
 	},
 /obj/effect/decal/cleanable/dust,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -454,8 +454,8 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
-	pixel_y = 3;
-	pixel_x = -1
+	pixel_x = -1;
+	pixel_y = 3
 	},
 /obj/machinery/power/port_gen/pacman,
 /obj/structure/cable{
@@ -470,6 +470,11 @@
 	temperature = 300
 	},
 /area/ruin/powered/pirateship)
+"iT" = (
+/obj/effect/mapping_helpers/no_lava,
+/obj/effect/baseturf_helper/lava_land/surface/basalt,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "iX" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
@@ -509,15 +514,15 @@
 /area/lavaland/surface/outdoors)
 "jn" = (
 /obj/effect/decal/cleanable/blood/drip{
-	pixel_y = 1;
-	pixel_x = 19
+	pixel_x = 19;
+	pixel_y = 1
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/safe_cave)
 "jt" = (
 /obj/effect/decal/cleanable/glass{
-	pixel_y = 5;
-	pixel_x = -16
+	pixel_x = -16;
+	pixel_y = 5
 	},
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor{
@@ -560,8 +565,8 @@
 /area/lavaland/surface/outdoors)
 "kj" = (
 /obj/effect/decal/cleanable/blood/drip{
-	pixel_y = 35;
-	pixel_x = -15
+	pixel_x = -15;
+	pixel_y = 35
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/safe_cave)
@@ -613,12 +618,12 @@
 /obj/structure/table,
 /obj/structure/grille/broken,
 /obj/machinery/cell_charger{
-	pixel_y = 4;
-	pixel_x = -1
+	pixel_x = -1;
+	pixel_y = 4
 	},
 /obj/item/stock_parts/cell/high{
-	pixel_y = 7;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = 7
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/powered/pirateship)
@@ -641,8 +646,8 @@
 /area/ruin/powered/pirateship)
 "ll" = (
 /obj/effect/decal/cleanable/blood/drip{
-	pixel_y = 20;
-	pixel_x = 11
+	pixel_x = 11;
+	pixel_y = 20
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/safe_cave)
@@ -798,8 +803,8 @@
 /obj/effect/mob_spawn/human/corpse/pirate/ranged,
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/reagent_containers/food/drinks/bottle/rum{
-	pixel_y = -14;
-	pixel_x = 16
+	pixel_x = 16;
+	pixel_y = -14
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/safe_cave)
@@ -891,16 +896,16 @@
 /area/lavaland/surface/outdoors)
 "nT" = (
 /obj/item/reagent_containers/food/snacks/goliath_steak{
-	pixel_y = -7;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = -7
 	},
 /obj/item/reagent_containers/food/snacks/goliath_steak{
-	pixel_y = 4;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 4
 	},
 /obj/item/reagent_containers/food/snacks/goliath_steak{
-	pixel_y = 14;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 14
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/safe_cave)
@@ -1001,9 +1006,9 @@
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel/stairs{
 	color = "493116";
-	temperature = 300;
 	nitrogen = 23;
-	oxygen = 14
+	oxygen = 14;
+	temperature = 300
 	},
 /area/ruin/powered/pirateship)
 "po" = (
@@ -1152,8 +1157,8 @@
 "sG" = (
 /obj/item/stack/sheet/mineral/plastitanium{
 	amount = 7;
-	pixel_y = 10;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 10
 	},
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor{
@@ -1186,8 +1191,8 @@
 /area/ruin/unpowered/safe_cave)
 "tv" = (
 /obj/effect/decal/cleanable/blood/drip{
-	pixel_y = 20;
-	pixel_x = -13
+	pixel_x = -13;
+	pixel_y = 20
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
@@ -1333,8 +1338,8 @@
 	dir = 4
 	},
 /obj/item/trash/waffles{
-	pixel_y = -3;
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = -3
 	},
 /obj/item/trash/fried_vox{
 	pixel_y = 7
@@ -1395,8 +1400,8 @@
 	dir = 4
 	},
 /obj/item/extinguisher{
-	pixel_y = 5;
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = 5
 	},
 /obj/item/ammo_casing/shotgun/buckshot{
 	pixel_x = -5;
@@ -1519,8 +1524,8 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
-	pixel_y = -4;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = -4
 	},
 /obj/structure/table/reinforced,
 /obj/structure/cable{
@@ -1842,8 +1847,8 @@
 /area/ruin/powered/pirateship)
 "EZ" = (
 /obj/effect/decal/cleanable/blood/drip{
-	pixel_y = 20;
-	pixel_x = -15
+	pixel_x = -15;
+	pixel_y = 20
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/safe_cave)
@@ -1999,8 +2004,8 @@
 /area/ruin/powered/pirateship)
 "Ik" = (
 /obj/machinery/atmospherics/pipe/simple/visible/supply{
-	pixel_x = -2;
-	dir = 4
+	dir = 4;
+	pixel_x = -2
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
 	dir = 5
@@ -2148,8 +2153,8 @@
 	pixel_y = 38
 	},
 /obj/effect/decal/cleanable/blood/drip{
-	pixel_y = 38;
-	pixel_x = -13
+	pixel_x = -13;
+	pixel_y = 38
 	},
 /turf/simulated/floor/engine{
 	nitrogen = 23;
@@ -2188,8 +2193,8 @@
 /area/lavaland/surface/outdoors)
 "Lg" = (
 /obj/effect/decal/cleanable/blood/drip{
-	pixel_y = 20;
-	pixel_x = -10
+	pixel_x = -10;
+	pixel_y = 20
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/safe_cave)
@@ -2208,6 +2213,19 @@
 /obj/structure/flora/ash/cacti,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/safe_cave)
+"LT" = (
+/obj/effect/decal/warning_stripes/yellow/partial,
+/obj/effect/decal/warning_stripes/arrow{
+	color = "EDCBFF"
+	},
+/obj/effect/decal/cleanable/dust,
+/obj/effect/baseturf_helper/lava_land/surface/basalt,
+/turf/simulated/floor/plasteel/dark{
+	nitrogen = 23;
+	oxygen = 14;
+	temperature = 300
+	},
+/area/ruin/powered/pirateship)
 "LZ" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -2229,8 +2247,8 @@
 /area/ruin/powered/pirateship)
 "Mc" = (
 /obj/item/clothing/suit/hooded/goliath{
-	pixel_y = -6;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -6
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
@@ -2252,12 +2270,12 @@
 /area/ruin/unpowered/safe_cave)
 "MP" = (
 /obj/effect/decal/cleanable/blood/drip{
-	pixel_y = 1;
-	pixel_x = 19
+	pixel_x = 19;
+	pixel_y = 1
 	},
 /obj/effect/decal/cleanable/blood/drip{
-	pixel_y = 20;
-	pixel_x = -13
+	pixel_x = -13;
+	pixel_y = 20
 	},
 /turf/simulated/floor/engine{
 	nitrogen = 23;
@@ -2294,8 +2312,8 @@
 "Ng" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/pill/zoom{
-	pixel_y = -3;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = -3
 	},
 /obj/item/trash/spentcasing{
 	pixel_x = 7;
@@ -2310,8 +2328,8 @@
 	pixel_y = 9
 	},
 /obj/item/reagent_containers/food/pill/zoom{
-	pixel_y = -3;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -3
 	},
 /obj/machinery/light_switch{
 	pixel_x = 22;
@@ -2325,8 +2343,8 @@
 "Nt" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/item/extinguisher{
-	pixel_y = 5;
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = 5
 	},
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel/dark{
@@ -2338,8 +2356,8 @@
 "NH" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
-	pixel_y = -4;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = -4
 	},
 /obj/item/reagent_containers/syringe{
 	pixel_y = -11
@@ -2381,8 +2399,8 @@
 	icon_state = "4-8"
 	},
 /obj/item/pickaxe/drill{
-	pixel_y = 1;
-	pixel_x = -1
+	pixel_x = -1;
+	pixel_y = 1
 	},
 /obj/effect/decal/cleanable/dust,
 /obj/item/pickaxe/drill{
@@ -2456,8 +2474,8 @@
 	pixel_y = -6
 	},
 /obj/structure/fermenting_barrel{
-	pixel_y = 3;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 3
 	},
 /obj/item/reagent_containers/food/drinks/bottle/absinthe/premium{
 	pixel_x = 3;
@@ -2561,12 +2579,12 @@
 	},
 /obj/structure/rack,
 /obj/item/storage/pill_bottle/random_drug_bottle{
-	pixel_y = 3;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 3
 	},
 /obj/item/storage/pill_bottle/random_drug_bottle{
-	pixel_y = -2;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = -2
 	},
 /obj/item/storage/pill_bottle/random_drug_bottle,
 /obj/machinery/vending/wallmed{
@@ -2589,8 +2607,8 @@
 	pixel_y = 9
 	},
 /obj/item/reagent_containers/food/drinks/bottle/rum{
-	pixel_y = 9;
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = 9
 	},
 /turf/simulated/floor/plasteel/dark{
 	nitrogen = 23;
@@ -2757,9 +2775,10 @@
 /area/ruin/unpowered/safe_cave)
 "SH" = (
 /obj/effect/decal/cleanable/blood/drip{
-	pixel_y = 20;
-	pixel_x = 10
+	pixel_x = 10;
+	pixel_y = 20
 	},
+/obj/effect/baseturf_helper/lava_land/surface/basalt,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/safe_cave)
 "Tl" = (
@@ -2923,12 +2942,12 @@
 	},
 /obj/effect/decal/warning_stripes/west,
 /obj/item/mop{
-	pixel_y = -17;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = -17
 	},
 /obj/item/reagent_containers/glass/bucket{
-	pixel_y = -7;
-	pixel_x = -9
+	pixel_x = -9;
+	pixel_y = -7
 	},
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel/dark{
@@ -3073,8 +3092,8 @@
 /area/ruin/powered/pirateship)
 "XF" = (
 /obj/effect/decal/cleanable/blood/drip{
-	pixel_y = 38;
-	pixel_x = -13
+	pixel_x = -13;
+	pixel_y = 38
 	},
 /turf/simulated/floor/engine{
 	nitrogen = 23;
@@ -3100,8 +3119,8 @@
 /area/lavaland/surface/outdoors)
 "XV" = (
 /obj/item/cigbutt/cigarbutt{
-	pixel_y = 10;
-	pixel_x = 9
+	pixel_x = 9;
+	pixel_y = 10
 	},
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
@@ -3124,8 +3143,8 @@
 /area/ruin/powered/pirateship)
 "Ym" = (
 /obj/item/stack/rods/ten{
-	pixel_y = 15;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 15
 	},
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
@@ -3140,8 +3159,8 @@
 "Yw" = (
 /obj/machinery/atmospherics/binary/pump,
 /obj/machinery/atmospherics/pipe/simple/visible/supply{
-	pixel_x = -2;
-	dir = 5
+	dir = 5;
+	pixel_x = -2
 	},
 /obj/structure/cable/green{
 	icon_state = "1-4"
@@ -3178,8 +3197,8 @@
 /area/lavaland/surface/outdoors)
 "YY" = (
 /obj/item/stack/ore/gold{
-	pixel_y = -7;
-	pixel_x = -10
+	pixel_x = -10;
+	pixel_y = -7
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/safe_cave)
@@ -4295,7 +4314,7 @@ aw
 KA
 wS
 ls
-Md
+LT
 oG
 aO
 bK
@@ -4375,7 +4394,7 @@ XL
 QL
 QL
 QL
-QL
+iT
 QL
 QL
 QL


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
**Добавил бейзтурф на pirateship, дабы не было космоса в планете.**

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1220739276040442048

## Демонстрация изменений
![image](https://github.com/ss220-space/Paradise/assets/127967350/e3b3a38f-13d7-4feb-a6ce-bc08723f0135)

