### PR TITLE
bugfix: set disco light as static

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -426,6 +426,7 @@
 	name = "disco light"
 	desc = "Groovy..."
 	icon_state = null
+	light_system = STATIC_LIGHT
 	light_color = null
 	light_range = 0
 	light_power = 10


### PR DESCRIPTION
## Описание
Была проблема, что свет излучаемых источников дискомашины являлись MOVABLE_LIGHT_DIRECTIONAL и в них вызывался update_light() на каждый разноцветный источник. Исправил на источники STATIC_LIGHT.
Возможно стоит переделать дискомашину под динамичный свет.

## Ссылка на предложение/Причина создания ПР
![image](https://github.com/ss220-space/Paradise/assets/8555356/ec3b1167-c824-489a-bbee-9abbbd42040c)
![image](https://github.com/ss220-space/Paradise/assets/8555356/087a3a96-7f59-42bd-9bf3-4e13cbb950ff)

## Демонстрация изменений

