### PR TITLE
bugfix: Human Overlays Fix

### DIFF
--- a/code/__DEFINES/overlays.dm
+++ b/code/__DEFINES/overlays.dm
@@ -1,6 +1,6 @@
 // A reasonable number of maximum overlays an object needs
 // If you think you need more, rethink it
-#define MAX_ATOM_OVERLAYS 150
+#define MAX_ATOM_OVERLAYS 100
 
 
 /// Checks if an atom has reached the overlay limit, and make a loud error if it does.

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -80,8 +80,7 @@
 		M.icon_state = disguise.icon_state
 		M.cut_overlays()
 		M.add_overlay(disguise.overlays)
-		M.update_inv_r_hand()
-		M.update_inv_l_hand()
+		M.update_inv_hands()
 
 /obj/item/clothing/suit/armor/abductor/vest/proc/DeactivateStealth()
 	if(!stealth_active)
@@ -91,7 +90,6 @@
 		var/mob/living/carbon/human/M = loc
 		new /obj/effect/temp_visual/dir_setting/ninja(get_turf(M), M.dir)
 		M.name_override = null
-		M.cut_overlays()
 		M.regenerate_icons()
 
 /obj/item/clothing/suit/armor/abductor/vest/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)

--- a/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_chameleon.dm
+++ b/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_chameleon.dm
@@ -166,6 +166,8 @@
 			ninja_action.action_ready = TRUE
 			ninja_action.use_action()
 		ninja.cut_overlays()
+	else
+		ninja.cut_overlay(disguise.overlays)
 
 	//Disguise
 	ninja.name_override = disguise.name

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -518,6 +518,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 /mob/living/carbon/human/regenerate_icons()
 	if(notransform)
 		return
+	cut_overlays()
 	update_mutations()
 	update_body(TRUE) //Update the body and force limb icon regeneration.
 	update_hair()
@@ -547,9 +548,9 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	force_update_limbs()
 	update_tail_layer()
 	update_wing_layer()
-	update_halo_layer()
 	if(blocks_emissive)
 		add_overlay(get_emissive_block())
+	update_halo_layer()
 	update_fire()
 	update_hands_HUD()
 


### PR DESCRIPTION
## Описание
Исправление работы с оверлеями у хамелеона ниндзя, а также добавление полного обрезания оверлеев, перед регенерацией иконок у хуманов, чтобы оверлеи не накапливались.

Также возвращено старое значение для лимита оверлеев на атом - до 100.
