### PR TITLE
bugfix: You can change AI laws

### DIFF
--- a/code/modules/antagonists/space_ninja/drain_act/ai_upload.dm
+++ b/code/modules/antagonists/space_ninja/drain_act/ai_upload.dm
@@ -33,7 +33,7 @@
 		if(src.stat & BROKEN)
 			to_chat(usr, "The upload computer is broken!")
 			return
-		for(var/mob/living/silicon/ai/currentAI in GLOB.alive_mob_list)
+		for(var/mob/living/silicon/ai/currentAI as anything in GLOB.ai_list)
 			if(currentAI.stat != DEAD && currentAI.nightvision != 0)
 				currentAI.laws.clear_inherent_laws()
 				SSticker?.score?.save_silicon_laws(currentAI, ninja, "AI upload hacked by ninja, all inherent laws were deleted", log_all_laws = TRUE)

--- a/code/modules/antagonists/space_ninja/drain_act/ai_upload.dm
+++ b/code/modules/antagonists/space_ninja/drain_act/ai_upload.dm
@@ -34,7 +34,7 @@
 			to_chat(usr, "The upload computer is broken!")
 			return
 		for(var/mob/living/silicon/ai/currentAI in GLOB.alive_mob_list)
-			if(currentAI.stat != DEAD && currentAI.see_in_dark != FALSE)
+			if(currentAI.stat != DEAD && currentAI.nightvision != 0)
 				currentAI.laws.clear_inherent_laws()
 				SSticker?.score?.save_silicon_laws(currentAI, ninja, "AI upload hacked by ninja, all inherent laws were deleted", log_all_laws = TRUE)
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -45,6 +45,7 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 	status_flags = CANSTUN|CANPARALYSE|CANPUSH
 	mob_size = MOB_SIZE_LARGE
 	sight = SEE_TURFS | SEE_MOBS | SEE_OBJS
+	nightvision = 8
 	can_strip = 0
 	var/list/network = list("SS13","Telecomms","Research Outpost","Mining Outpost")
 	var/obj/machinery/camera/current = null


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Возвращает ночное зрение у ИИ, которое убрали после #4685.
Меняет у аплоуда ИИ (взлом через прикосновение паука) переменную, чтобы работало как и было задумано.
(Как потом узанлось, отсутствие ночного зрения не давал взломать ИИшку.)

## Ссылка на предложение/Причина создания ПР
[Почему убрали ночное зрение](https://discord.com/channels/617003227182792704/734823601110515882/1221814053404672040).
[Баг-репорт](https://discord.com/channels/617003227182792704/1221510730239574156/1221510730239574156)

