### PR TITLE
bugfix: (i think) No more cluwnes in crew manifest

### DIFF
--- a/code/datums/spells/cluwne.dm
+++ b/code/datums/spells/cluwne.dm
@@ -33,7 +33,7 @@
 	mutations.Add(NERVOUS)
 	dna.SetSEState(GLOB.nervousblock, 1, 1)
 	genemutcheck(src, GLOB.nervousblock, null, MUTCHK_FORCED)
-	rename_character(real_name, "cluwne")
+	rename_character(newname = "cluwne")
 
 	drop_item_ground(w_uniform, force = TRUE)
 	drop_item_ground(shoes, force = TRUE)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Теперь клувни не будут появляться в манифесте. Их можно уничтожать по правилам, зачем лазейка с манифестом?
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

