### PR TITLE
Bugfix: old arcades on station

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -19163,7 +19163,7 @@
 /obj/machinery/newscaster{
 	pixel_x = -28
 	},
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/battle,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "darkred"
@@ -20458,7 +20458,7 @@
 /obj/machinery/newscaster{
 	pixel_x = 28
 	},
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/orion_trail,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar/atrium)
 "cmo" = (
@@ -84904,13 +84904,13 @@
 	},
 /area/maintenance/electrical)
 "ofo" = (
-/obj/machinery/computer/arcade,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/computer/arcade/orion_trail,
 /turf/simulated/floor/plasteel{
 	icon_state = "bcarpet05"
 	},
@@ -95797,13 +95797,13 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
 "qwX" = (
-/obj/machinery/computer/arcade,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/computer/arcade/battle,
 /turf/simulated/floor/plasteel{
 	icon_state = "bcarpet05"
 	},
@@ -100759,7 +100759,7 @@
 /obj/machinery/newscaster{
 	pixel_x = 28
 	},
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/orion_trail,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "darkred"
@@ -118616,7 +118616,7 @@
 	},
 /area/atmos/control)
 "vLQ" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/battle,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar/atrium)
 "vLR" = (

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -8794,7 +8794,7 @@
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
 "boA" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/orion_trail,
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
@@ -45917,8 +45917,7 @@
 	dir = 4
 	},
 /obj/item/lighter/zippo/qm{
-	pixel_x = -12;
-	pixel_y = 0
+	pixel_x = -12
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
@@ -49525,7 +49524,7 @@
 	c_tag = "Brig General Population West";
 	dir = 1
 	},
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/battle,
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
@@ -82052,10 +82051,10 @@
 	},
 /area/security/hos)
 "tOx" = (
-/obj/machinery/computer/arcade,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/machinery/computer/arcade/orion_trail,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "tOz" = (
@@ -90276,11 +90275,11 @@
 	dir = 4;
 	pixel_x = 32
 	},
-/obj/machinery/computer/arcade,
 /obj/machinery/camera{
 	c_tag = "Bar East";
 	dir = 8
 	},
+/obj/machinery/computer/arcade/battle,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "woJ" = (

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -13667,7 +13667,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
 "aKh" = (
-/obj/structure/chair/office/dark,
+/obj/machinery/computer/arcade,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "aKi" = (
@@ -18539,10 +18539,10 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "aXt" = (
-/obj/machinery/computer/arcade,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/computer/arcade/orion_trail,
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "aXu" = (
@@ -25384,6 +25384,7 @@
 "bnv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
+/obj/machinery/computer/arcade,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bnw" = (
@@ -30825,7 +30826,7 @@
 	},
 /area/turret_protected/ai_upload)
 "bBC" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/orion_trail,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "bBD" = (
@@ -39382,7 +39383,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
 "bWT" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/orion_trail,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "bWV" = (
@@ -74851,6 +74852,12 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
+"jIs" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint)
 "jJj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -74874,8 +74881,8 @@
 	},
 /area/security/main)
 "jMn" = (
-/obj/machinery/computer/arcade,
 /obj/effect/decal/cleanable/dust,
+/obj/machinery/computer/arcade/battle,
 /turf/simulated/floor/wood,
 /area/security/permabrig)
 "jPN" = (
@@ -84441,13 +84448,13 @@
 	},
 /area/maintenance/port)
 "urb" = (
-/obj/machinery/computer/arcade,
 /obj/machinery/camera{
 	c_tag = "Prison Library";
 	dir = 6;
 	network = list("Prison","SS13")
 	},
 /obj/effect/decal/cleanable/dust,
+/obj/machinery/computer/arcade/orion_trail,
 /turf/simulated/floor/wood,
 /area/security/permabrig)
 "utk" = (
@@ -87160,6 +87167,10 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/mrchangs)
+"xga" = (
+/obj/machinery/computer/arcade,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "xgd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -112108,7 +112119,7 @@ aGp
 aHv
 aGb
 aKi
-aPi
+jIs
 aQg
 aMQ
 aMQ
@@ -128898,7 +128909,7 @@ cyJ
 wUz
 chf
 cIn
-csL
+xga
 cIj
 cKS
 cMb


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Согласно [анонимным источникам](https://discord.com/channels/617003227182792704/1147631959254765679/1220623494749093898) в ходе расследования было выявлено, что рандомные аркады могут быть старыми после введения https://github.com/ss220-space/Paradise/pull/4648
![image](https://github.com/ss220-space/Paradise/assets/110329212/739e87a3-69c2-462d-b95e-0f2a50b84553)


Так что рандомные автоматы будут только в техах, где старые могут смотреться лаконично, все прочие заменены на нерандомные. 
На кибериаде тыкнула три рандомных в техах, ибо их всего 5 на карте.
