### PR TITLE
bugfix: SP8 no longer gives illegal techs

### DIFF
--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -94,6 +94,7 @@
 	force = 10
 	mag_type = /obj/item/ammo_box/magazine/sp8
 	fire_sound = 'sound/weapons/gunshots/sp8.ogg'
+	origin_tech = "combat=5;materials=2"
 	can_suppress = TRUE
 	unique_reskin = TRUE
 	can_flashlight = TRUE


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
При наследовании от стечкина варденский СП-8 получил нелегальные технологии при разборе в РНД, что автором было не предусмотрено.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Закрытие дыры, позволяющей станции достать нелегальные технологии... при разборе НТшного пистолета.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->