### PR TITLE
bugfix: Light fixes: Patch 1

### DIFF
--- a/code/datums/components/overlay_lighting.dm
+++ b/code/datums/components/overlay_lighting.dm
@@ -494,6 +494,19 @@
 			translate_x += 32 * final_distance
 		if(WEST)
 			translate_x += -32 * final_distance
+		if(SOUTHEAST)
+			translate_x += 32 * final_distance
+			translate_y += -32 * final_distance
+		if(SOUTHWEST)
+			translate_x += -32 * final_distance
+			translate_y += -32 * final_distance
+		if(NORTHEAST)
+			translate_x += 32 * final_distance
+			translate_y += 32 * final_distance
+		if(NORTHWEST)
+			translate_x += -32 * final_distance
+			translate_y += 32 * final_distance
+
 	if((directional_offset_x != translate_x) || (directional_offset_y != translate_y))
 		directional_offset_x = translate_x
 		directional_offset_y = translate_y

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -384,7 +384,7 @@
 	if(on)
 		set_light(AI_CAMERA_LUMINOSITY, l_on = TRUE)
 	else
-		set_light_on(FALSE)
+		set_light(0)
 
 /obj/machinery/camera/proc/nano_structure()
 	var/cam[0]

--- a/code/game/objects/effects/temporary_visuals/muzzle_flashes.dm
+++ b/code/game/objects/effects/temporary_visuals/muzzle_flashes.dm
@@ -2,6 +2,8 @@
 	icon = 'icons/effects/projectile.dmi'
 	icon_state = "firing_effect"
 	duration = 0.2
+	light_system = MOVABLE_LIGHT
+	light_on = TRUE
 
 /obj/effect/temp_visual/target_angled/muzzle_flash/Initialize(mapload, atom/target, duration_override = null)
 	if(duration_override)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -110,6 +110,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	slot_flags = SLOT_BELT | SLOT_EARS
 	flags = CONDUCT
+	light_system = MOVABLE_LIGHT
 	light_range = 2
 
 /obj/item/flashlight/seclite

--- a/code/modules/food_and_drinks/drinks/drinks/shotglass.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/shotglass.dm
@@ -63,7 +63,8 @@
 	if(!isShotFlammable() || (resistance_flags & ON_FIRE)) //You can't light a shot that's not flammable!
 		return
 	..()
-	set_light(light_intensity, null, light_color)
+	set_light_range_power_color(light_intensity, 1, light_color)
+	set_light_on(TRUE)
 	visible_message("<span class = 'notice'>[src] begins to burn with a blue hue!</span>")
 	update_appearance(UPDATE_NAME|UPDATE_OVERLAYS)
 

--- a/code/modules/food_and_drinks/food.dm
+++ b/code/modules/food_and_drinks/food.dm
@@ -28,6 +28,8 @@
 	resistance_flags = FLAMMABLE
 	container_type = INJECTABLE
 	var/log_eating = FALSE // do we log if someone eats us?
+	light_system = MOVABLE_LIGHT
+	light_on = FALSE
 
 /obj/item/reagent_containers/food/Initialize(mapload)
 	. = ..()

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -280,8 +280,8 @@
 
 /datum/plant_gene/trait/glow/on_new(obj/item/reagent_containers/food/snacks/grown/G)
 	..()
-	G.light_system = MOVABLE_LIGHT
-	G.AddComponent(/datum/component/overlay_lighting, glow_range(G.seed), glow_power(G.seed), glow_color)
+	G.set_light_range_power_color(glow_range(G.seed), glow_power(G.seed), glow_color)
+	G.set_light_on(TRUE)
 
 /datum/plant_gene/trait/glow/blue
 	name = "Blue Bioluminescence"

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -149,6 +149,9 @@
 /atom/proc/set_light_power(new_power)
 	if(new_power == light_power)
 		return
+	if(light_system == STATIC_LIGHT)
+		set_light(l_power = new_power)
+		return
 	if(SEND_SIGNAL(src, COMSIG_ATOM_SET_LIGHT_POWER, new_power) & COMPONENT_BLOCK_LIGHT_UPDATE)
 		return
 	. = light_power
@@ -158,6 +161,9 @@
 /// Setter for the light range of this atom.
 /atom/proc/set_light_range(new_range)
 	if(new_range == light_range)
+		return
+	if(light_system == STATIC_LIGHT)
+		set_light(l_range = new_range)
 		return
 	if(SEND_SIGNAL(src, COMSIG_ATOM_SET_LIGHT_RANGE, new_range) & COMPONENT_BLOCK_LIGHT_UPDATE)
 		return
@@ -169,6 +175,9 @@
 /atom/proc/set_light_color(new_color)
 	if(new_color == light_color)
 		return
+	if(light_system == STATIC_LIGHT)
+		set_light(l_color = new_color)
+		return
 	if(SEND_SIGNAL(src, COMSIG_ATOM_SET_LIGHT_COLOR, new_color) & COMPONENT_BLOCK_LIGHT_UPDATE)
 		return
 	. = light_color
@@ -178,6 +187,9 @@
 /// Setter for whether or not this atom's light is on.
 /atom/proc/set_light_on(new_value)
 	if(new_value == light_on)
+		return
+	if(light_system == STATIC_LIGHT)
+		set_light(l_on = new_value)
 		return
 	if(SEND_SIGNAL(src, COMSIG_ATOM_SET_LIGHT_ON, new_value) & COMPONENT_BLOCK_LIGHT_UPDATE)
 		return

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -109,6 +109,12 @@
 				set_light_color(var_value)
 			datum_flags |= DF_VAR_EDITED
 			return TRUE
+		if (NAMEOF(src, light_on))
+			if(light_system == STATIC_LIGHT)
+				set_light(l_on = var_value)
+			else
+				set_light_on(var_value)
+			return TRUE
 
 	return ..()
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1177,7 +1177,7 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 		to_chat(src, "Camera lights deactivated.")
 
 		for(var/obj/machinery/camera/C in lit_cameras)
-			C.set_light(0)
+			C.set_light(l_on = FALSE)
 			lit_cameras = list()
 
 		return

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1177,7 +1177,7 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 		to_chat(src, "Camera lights deactivated.")
 
 		for(var/obj/machinery/camera/C in lit_cameras)
-			C.set_light_on(FALSE)
+			C.set_light(0)
 			lit_cameras = list()
 
 		return
@@ -1239,9 +1239,9 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 
 	for(var/obj/machinery/camera/C in remove)
 		lit_cameras -= C //Removed from list before turning off the light so that it doesn't check the AI looking away.
-		C.Togglelight(0)
+		C.Togglelight(FALSE)
 	for(var/obj/machinery/camera/C in add)
-		C.Togglelight(1)
+		C.Togglelight(TRUE)
 		lit_cameras |= C
 
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -180,7 +180,7 @@
 		effect.alpha = min(255, muzzle_strength * 255)
 		if(chambered.muzzle_flash_color)
 			effect.color = chambered.muzzle_flash_color
-			effect.set_light(muzzle_range, muzzle_strength, chambered.muzzle_flash_color)
+			effect.set_light_range_power_color(muzzle_range, muzzle_strength, chambered.muzzle_flash_color)
 		else
 			effect.color = LIGHT_COLOR_TUNGSTEN
 

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -101,6 +101,9 @@
 	/// Descriptive string used in amputation
 	var/amputation_point
 
+	light_system = MOVABLE_LIGHT
+	light_on = FALSE
+
 
 /obj/item/organ/external/New(mob/living/carbon/holder)
 	..()

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -8,6 +8,8 @@
 	/// Whether it shows up as an option to remove during surgery.
 	var/unremovable = FALSE
 	var/can_see_food = FALSE
+	light_system = MOVABLE_LIGHT
+	light_on = FALSE
 
 
 /obj/item/organ/internal/New(mob/living/carbon/holder)

--- a/code/modules/surgery/organs/subtypes/kidan.dm
+++ b/code/modules/surgery/organs/subtypes/kidan.dm
@@ -77,6 +77,7 @@
 		var/light = calculate_glow(KIDAN_LANTERN_LIGHT)
 		var/obj/item/organ/external/groin/lbody = owner.get_organ(check_zone(parent_organ_zone))
 		lbody.set_light_range_power_color(light, color = colour)
+		lbody.set_light_on(TRUE)
 		glowing = light
 		return 1
 

--- a/code/modules/surgery/organs/subtypes/nucleation.dm
+++ b/code/modules/surgery/organs/subtypes/nucleation.dm
@@ -24,8 +24,8 @@
 	species_type = /datum/species/nucleation
 	name = "luminescent eyes"
 	icon_state = "crystal-eyes"
-	light_color = "#c9c918"
-	light_system = MOVABLE_LIGHT_DIRECTIONAL
+	light_color = "#f7f792"
+	light_system = MOVABLE_LIGHT
 	light_power = 1
 	light_range = 2
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление освещения, часть 1:
- Исправлена ошибка, при которой лампы на камерах ИИ не затухали
- Поправлен свет от глаз нуклеации
- Пенлайт теперь светит вокруг себя
- Поправлен свет от гроинов киданов
- Исправлено поведение направленного света при диагональном осмотре/передвижении
![изображение](https://github.com/ss220-space/Paradise/assets/73733747/fa5d4e2c-4642-41b2-905a-c330a72ef6ce)
