### PR TITLE
tweak: Need both hands to shoot AS-12 Minotaur

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -376,6 +376,7 @@
 	icon_state = "minotaur"
 	item_state = "minotaur"
 	w_class = WEIGHT_CLASS_NORMAL
+	weapon_weight = WEAPON_HEAVY
 	origin_tech = "combat=6;materials=4;syndicate=6"
 	mag_type = /obj/item/ammo_box/magazine/m12g
 	fire_sound = 'sound/weapons/gunshots/minotaur.ogg'


### PR DESCRIPTION


## Описание
Теперь для стрельбы с минотавра вторая рука должна быть свободной

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1210510401964343367

