### PR TITLE
bugfix: tail implants bugfix bugfix

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1942,7 +1942,7 @@
 	item = /obj/item/autoimplanter/oneuse/razorblade
 	cost = 42
 	surplus = 0
-	excludefrom = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
+	uplinktypes = list(UPLINK_TYPE_TRAITOR)
 
 /datum/uplink_item/cyber_implants/laserblade
 	name = "Overcharged Tail Laserblade"
@@ -1950,7 +1950,7 @@
 	item = /obj/item/autoimplanter/oneuse/laserblade
 	cost = 38
 	surplus = 0
-	excludefrom = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
+	uplinktypes = list(UPLINK_TYPE_TRAITOR)
 
 // POINTLESS BADASSERY
 


### PR DESCRIPTION
## Описание
Благодаря багфиксу https://github.com/ss220-space/Paradise/pull/4717 импланты лезвия были удалены вообще из всех аплинков, даже триторского. Вернул их в триторский/админский аплинк. В нюкерском и ССТ их более нет