### PR TITLE
add: new resonators

### DIFF
--- a/code/modules/mining/equipment/resonator.dm
+++ b/code/modules/mining/equipment/resonator.dm
@@ -55,7 +55,7 @@
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "shield1"
 	layer = ABOVE_ALL_MOB_LAYER
-	duration = 50 SECONDS
+	duration = 5 SECONDS
 	/// the amount of damage living beings will take whilst inside the field during its burst
 	var/resonance_damage = 20
 	/// the modifier to resonance_damage; affected by the quick_burst_mod from the resonator

--- a/code/modules/mining/equipment/resonator.dm
+++ b/code/modules/mining/equipment/resonator.dm
@@ -1,3 +1,7 @@
+#define RESONATOR_MODE_AUTO   1
+#define RESONATOR_MODE_MANUAL 2
+#define RESONATOR_MODE_MATRIX 3
+
 /**********************Resonator**********************/
 /obj/item/resonator
 	name = "resonator"
@@ -5,45 +9,43 @@
 	icon_state = "resonator"
 	item_state = "resonator"
 	origin_tech = "magnets=3;engineering=3"
-	desc = "A handheld device that creates small fields of energy that resonate until they detonate, crushing rock. It can also be activated without a target to create a field at the user's location, to act as a delayed time trap. It's more effective in a vaccuum."
+	desc = "A handheld device that creates small fields of energy that resonate until they detonate, crushing rock. It does increased damage in low pressure. It has two modes: Automatic and manual detonation."
 	w_class = WEIGHT_CLASS_NORMAL
 	force = 15
 	throwforce = 10
-	var/burst_time = 30
-	var/fieldlimit = 4
-	var/list/fields = list()
+	/// the mode of the resonator; has three modes: auto (1), manual (2), and matrix (3)
+	var/mode = RESONATOR_MODE_AUTO
+	/// How efficient it is in manual mode. Yes, we lower the damage cuz it's gonna be used for mobhunt
 	var/quick_burst_mod = 0.8
-
-/obj/item/resonator/upgraded
-	name = "upgraded resonator"
-	desc = "An upgraded version of the resonator that can produce more fields at once."
-	icon_state = "resonator_u"
-	origin_tech = "materials=4;powerstorage=3;engineering=3;magnets=3"
-	fieldlimit = 6
-	quick_burst_mod = 1
+	/// the number of fields the resonator is allowed to have at once
+	var/fieldlimit = 4
+	/// the list of currently active fields from this resonator
+	var/list/fields = list()
+	/// the number that is added to the failure_prob, which is the probability of whether it will spread or not
+	var/adding_failure = 50
 
 /obj/item/resonator/attack_self(mob/user)
-	if(burst_time == 50)
-		burst_time = 30
-		to_chat(user, "<span class='info'>You set the resonator's fields to detonate after 3 seconds.</span>")
+	if(mode == RESONATOR_MODE_AUTO)
+		to_chat(user, "<span class='info'>You set the resonator's fields to detonate only after you hit one with it.</span>")
+		mode = RESONATOR_MODE_MANUAL
 	else
-		burst_time = 50
-		to_chat(user, "<span class='info'>You set the resonator's fields to detonate after 5 seconds.</span>")
+		to_chat(user, "<span class='info'>You set the resonator's fields to automatically detonate after 2 seconds.</span>")
+		mode = RESONATOR_MODE_AUTO
 
-/obj/item/resonator/proc/CreateResonance(target, mob/user)
-	var/turf/T = get_turf(target)
-	var/obj/effect/temp_visual/resonance/R = locate(/obj/effect/temp_visual/resonance) in T
-	if(R)
-		R.damage_multiplier = quick_burst_mod
-		R.burst()
+/obj/item/resonator/proc/create_resonance(target, mob/user)
+	var/turf/target_turf = get_turf(target)
+	var/obj/effect/temp_visual/resonance/resonance_field = locate(/obj/effect/temp_visual/resonance) in target_turf
+	if(resonance_field)
+		resonance_field.damage_multiplier = quick_burst_mod
+		resonance_field.burst()
 		return
 	if(LAZYLEN(fields) < fieldlimit)
-		new /obj/effect/temp_visual/resonance(T, user, src, burst_time)
+		new /obj/effect/temp_visual/resonance(target_turf, user, src, mode, adding_failure)
 		user.changeNext_move(CLICK_CD_MELEE)
 
 /obj/item/resonator/pre_attackby(atom/target, mob/user, params)
-	if(check_allowed_items(target, 1))
-		CreateResonance(target, user)
+	if(check_allowed_items(target, TRUE))
+		create_resonance(target, user)
 	return TRUE
 
 //resonance field, crushes rock, damages mobs
@@ -53,29 +55,46 @@
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "shield1"
 	layer = ABOVE_ALL_MOB_LAYER
-	duration = 50
+	duration = 60 SECONDS
+	/// the amount of damage living beings will take whilst inside the field during its burst
 	var/resonance_damage = 20
+	/// the modifier to resonance_damage; affected by the quick_burst_mod from the resonator
 	var/damage_multiplier = 1
+	/// the parent creator (user) of this field
 	var/creator
-	var/obj/item/resonator/res
+	/// the parent resonator of this field
+	var/obj/item/resonator/parent_resonator
+	/// whether the field is rupturing currently or not (to prevent recursion)
+	var/rupturing = FALSE
+	/// the probability that the field will not be able to spread
+	var/failure_prob = 0
+	/// the number that is added to the failure_prob. Will default to 40
+	var/adding_failure
 
-/obj/effect/temp_visual/resonance/New(loc, set_creator, set_resonator, set_duration)
-	duration = set_duration
+/obj/effect/temp_visual/resonance/Initialize(mapload, set_creator, set_resonator, mode, set_failure = 40)
+	if(mode == RESONATOR_MODE_AUTO)
+		duration = 2 SECONDS
+	if(mode == RESONATOR_MODE_MATRIX)
+		icon_state = "shield2"
+		name = "resonance matrix"
+		RegisterSignal(src, list(COMSIG_MOVABLE_CROSSED, COMSIG_ATOM_ENTERED), PROC_REF(burst))
 	. = ..()
 	creator = set_creator
-	res = set_resonator
-	if(res)
-		res.fields += src
+	parent_resonator = set_resonator
+	if(parent_resonator)
+		parent_resonator.fields += src
+	adding_failure = set_failure
 	playsound(src,'sound/weapons/resonator_fire.ogg',50,1)
-	transform = matrix() * 0.75
-	animate(src, transform = matrix() * 1.5, time = duration)
+	if(mode == RESONATOR_MODE_AUTO)
+		transform = matrix()*0.75
+		animate(src, transform = matrix()*1.5, time = duration)
 	deltimer(timerid)
 	timerid = addtimer(CALLBACK(src, PROC_REF(burst)), duration, TIMER_STOPPABLE)
 
 /obj/effect/temp_visual/resonance/Destroy()
-	if(res)
-		res.fields -= src
-		res = null
+	if(parent_resonator)
+		parent_resonator.fields -= src
+		parent_resonator = null
 	creator = null
 	return ..()
 
@@ -91,21 +110,32 @@
 	resonance_damage *= damage_multiplier
 
 /obj/effect/temp_visual/resonance/proc/burst()
-	var/turf/T = get_turf(src)
-	new /obj/effect/temp_visual/resonance_crush(T)
-	if(ismineralturf(T))
-		if(isancientturf(T))
+	rupturing = TRUE
+	var/turf/src_turf = get_turf(src)
+	new /obj/effect/temp_visual/resonance_crush(src_turf)
+	if(ismineralturf(src_turf))
+		if(isancientturf(src_turf))
 			visible_message("<span class='notice'>This rock appears to be resistant to all mining tools except pickaxes!</span>")
 		else
-			var/turf/simulated/mineral/M = T
+			var/turf/simulated/mineral/M = src_turf
 			M.attempt_drill(creator)
-	check_pressure(T)
-	playsound(T,'sound/weapons/resonator_blast.ogg',50,1)
-	for(var/mob/living/L in T)
+	check_pressure(src_turf)
+	playsound(src_turf,'sound/weapons/resonator_blast.ogg',50,1)
+	for(var/mob/living/L in src_turf)
 		if(creator)
 			add_attack_logs(creator, L, "Resonance field'ed")
 		to_chat(L, "<span class='userdanger'>[src] ruptured with you in it!</span>")
 		L.apply_damage(resonance_damage, BRUTE)
+	for(var/obj/effect/temp_visual/resonance/field in orange(1, src))
+		if(field.rupturing)
+			continue
+		field.burst()
+	if(!prob(failure_prob) && parent_resonator)
+		for(var/turf/simulated/mineral/mineral_spread in orange(1, src))
+			if(locate(/obj/effect/temp_visual/resonance) in mineral_spread)
+				continue
+			var/obj/effect/temp_visual/resonance/new_field = new(mineral_spread, creator, parent_resonator, parent_resonator.mode)
+			new_field.failure_prob = failure_prob + adding_failure
 	qdel(src)
 
 /obj/effect/temp_visual/resonance_crush
@@ -115,5 +145,29 @@
 
 /obj/effect/temp_visual/resonance_crush/New()
 	..()
-	transform = matrix()*1.5
+	transform = matrix() * 1.5
 	animate(src, transform = matrix() * 0.1, alpha = 50, time = 4)
+
+/obj/item/resonator/upgraded
+	name = "upgraded resonator"
+	desc = "An upgraded version of the resonator that can produce more fields at once, as well as having no damage penalty for bursting a resonance field early. It also allows you to set 'Resonance matrixes', that detonate after someone(or something) walks over it."
+	icon_state = "resonator_u"
+	fieldlimit = 6
+	quick_burst_mod = 1
+	adding_failure = 20
+	origin_tech = "materials=4;powerstorage=3;engineering=3;magnets=3"
+
+/obj/item/resonator/upgraded/attack_self(mob/user)
+	if(mode == RESONATOR_MODE_AUTO)
+		to_chat(user, "<span class='info'>You set the resonator's fields to detonate only after you hit one with it.</span>")
+		mode = RESONATOR_MODE_MANUAL
+	else if(mode == RESONATOR_MODE_MANUAL)
+		to_chat(user, "<span class='info'>You set the resonator's fields to work as matrix traps.</span>")
+		mode = RESONATOR_MODE_MATRIX
+	else
+		to_chat(user, "<span class='info'>You set the resonator's fields to automatically detonate after 2 seconds.</span>")
+		mode = RESONATOR_MODE_AUTO
+
+#undef RESONATOR_MODE_AUTO
+#undef RESONATOR_MODE_MANUAL
+#undef RESONATOR_MODE_MATRIX

--- a/code/modules/mining/equipment/resonator.dm
+++ b/code/modules/mining/equipment/resonator.dm
@@ -26,10 +26,10 @@
 
 /obj/item/resonator/attack_self(mob/user)
 	if(mode == RESONATOR_MODE_AUTO)
-		to_chat(user, "<span class='info'>You set the resonator's fields to detonate only after you hit one with it.</span>")
+		to_chat(user, span_info("You set the resonator's fields to detonate only after you hit one with it."))
 		mode = RESONATOR_MODE_MANUAL
 	else
-		to_chat(user, "<span class='info'>You set the resonator's fields to automatically detonate after 2 seconds.</span>")
+		to_chat(user, span_info("You set the resonator's fields to automatically detonate after 2 seconds."))
 		mode = RESONATOR_MODE_AUTO
 
 /obj/item/resonator/proc/create_resonance(target, mob/user)
@@ -55,7 +55,7 @@
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "shield1"
 	layer = ABOVE_ALL_MOB_LAYER
-	duration = 60 SECONDS
+	duration = 50 SECONDS
 	/// the amount of damage living beings will take whilst inside the field during its burst
 	var/resonance_damage = 20
 	/// the modifier to resonance_damage; affected by the quick_burst_mod from the resonator
@@ -115,7 +115,7 @@
 	new /obj/effect/temp_visual/resonance_crush(src_turf)
 	if(ismineralturf(src_turf))
 		if(isancientturf(src_turf))
-			visible_message("<span class='notice'>This rock appears to be resistant to all mining tools except pickaxes!</span>")
+			visible_message(span_notice("This rock appears to be resistant to all mining tools except pickaxes!"))
 		else
 			var/turf/simulated/mineral/M = src_turf
 			M.attempt_drill(creator)
@@ -124,7 +124,7 @@
 	for(var/mob/living/L in src_turf)
 		if(creator)
 			add_attack_logs(creator, L, "Resonance field'ed")
-		to_chat(L, "<span class='userdanger'>[src] ruptured with you in it!</span>")
+		to_chat(L, span_userdanger("[src] ruptured with you in it!"))
 		L.apply_damage(resonance_damage, BRUTE)
 	for(var/obj/effect/temp_visual/resonance/field in orange(1, src))
 		if(field.rupturing)
@@ -159,13 +159,13 @@
 
 /obj/item/resonator/upgraded/attack_self(mob/user)
 	if(mode == RESONATOR_MODE_AUTO)
-		to_chat(user, "<span class='info'>You set the resonator's fields to detonate only after you hit one with it.</span>")
+		to_chat(user, span_info("You set the resonator's fields to detonate only after you hit one with it."))
 		mode = RESONATOR_MODE_MANUAL
 	else if(mode == RESONATOR_MODE_MANUAL)
-		to_chat(user, "<span class='info'>You set the resonator's fields to work as matrix traps.</span>")
+		to_chat(user, span_info("You set the resonator's fields to work as matrix traps."))
 		mode = RESONATOR_MODE_MATRIX
 	else
-		to_chat(user, "<span class='info'>You set the resonator's fields to automatically detonate after 2 seconds.</span>")
+		to_chat(user,  span_info("You set the resonator's fields to automatically detonate after 2 seconds."))
 		mode = RESONATOR_MODE_AUTO
 
 #undef RESONATOR_MODE_AUTO


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Обновляет код резонаторов, портируя какой-то там ПР с ТГ
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Теперь у стандартного резонатора два режима использования - автоматическая детонация меток после двух секунд и ручная детонация меток после того как пользователь кликнет резонатором по метке. У продвинутого резонатора есть третий режим - ловушки, который наносит 20 урона пользователю как только тот наступит на метку резонатора.
Еще одно сильное изменение - при детонации метки детонируются все рядом находящиеся метки, тем самым облегчая работу с инструментом.
Другим важным отличием от старого резонатора является распространение. Принцип работы механики прост. После детонации метки на соседних от резонатора тайлах минералов с уменьшающимся шансом появляются новые метки. Изначально рассеивание равно 100%. Дальше оно уменьшается в зависимости от типа резонатора. Улучшенный резонатор покрывает достаточно большое расстояние и гораздо легче рубит породу.
## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1201217099838795887
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
