### PR TITLE
Add: Secbot and ED209 detainment speech cooldown

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -1,4 +1,5 @@
 #define BATON_COOLDOWN 3.5 SECONDS
+#define SPEAK_COOLDOWN 10 SECONDS
 
 /mob/living/simple_animal/bot/ed209
 	name = "\improper ED-209 Security Robot"
@@ -55,7 +56,7 @@
 	var/projectile = /obj/item/projectile/energy/electrode
 	var/shoot_sound = 'sound/weapons/taser.ogg'
 	var/baton_delayed = FALSE
-
+	var/speak_cooldown = FALSE
 
 /mob/living/simple_animal/bot/ed209/New(loc, created_name, created_lasercolor)
 	..()
@@ -628,9 +629,13 @@
 	add_attack_logs(src, C, "stunned")
 	if(declare_arrests)
 		var/area/location = get_area(src)
-		speak("[arrest_type ? "Detaining" : "Arresting"] level [threat] scumbag <b>[C]</b> in [location].", radio_channel)
+		if(!speak_cooldown)
+			speak("[arrest_type ? "Detaining" : "Arresting"] level [threat] scumbag <b>[C]</b> in [location].", radio_channel)
+			speak_cooldown = TRUE
+			addtimer(VARSET_CALLBACK(src, speak_cooldown, FALSE), SPEAK_COOLDOWN)
 	C.visible_message(span_danger("[src] has stunned [C]!"),
 					span_userdanger("[src] has stunned you!"))
+
 
 
 /mob/living/simple_animal/bot/ed209/proc/start_cuffing(mob/living/carbon/C)
@@ -652,5 +657,6 @@
 	back_to_idle()
 
 
-#undef BATON_COOLDOWN
 
+#undef SPEAK_COOLDOWN
+#undef BATON_COOLDOWN

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -1,4 +1,5 @@
 #define BATON_COOLDOWN 3.5 SECONDS
+#define SPEAK_COOLDOWN 10 SECONDS
 
 /mob/living/simple_animal/bot/secbot
 	name = "\improper Securitron"
@@ -49,6 +50,7 @@
 	var/flashing_lights = FALSE
 	var/baton_delayed = FALSE
 	var/prev_flashing_lights = FALSE
+	var/speak_cooldown = FALSE
 
 
 /mob/living/simple_animal/bot/secbot/beepsky
@@ -317,7 +319,10 @@
 	add_attack_logs(src, C, "stunned")
 	if(declare_arrests)
 		var/area/location = get_area(src)
-		speak("[arrest_type ? "Detaining" : "Arresting"] level [threat] scumbag <b>[C]</b> in [location].", radio_channel)
+		if(!speak_cooldown)
+			speak("[arrest_type ? "Detaining" : "Arresting"] level [threat] scumbag <b>[C]</b> in [location].", radio_channel)
+			speak_cooldown = TRUE
+			addtimer(VARSET_CALLBACK(src, speak_cooldown, FALSE), SPEAK_COOLDOWN)
 	C.visible_message(span_danger("[src] has [harmbaton ? "beaten" : "stunned"] [C]!"),
 					span_userdanger("[src] has [harmbaton ? "beaten" : "stunned"] you!"))
 
@@ -531,5 +536,6 @@
 	req_access = list(ACCESS_SECURITY)
 
 
-#undef BATON_COOLDOWN
 
+#undef SPEAK_COOLDOWN
+#undef BATON_COOLDOWN


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет Секьюритронам и ED209 задержку перед отправкой повторного сообщения о задержании преступника. 
Секьюритроны и ED209 ранее спамили фразой о задержании преступника через каждый удар, но теперь только спустя 10 секунд после первого удара. 
Меньше запросов ТТС, меньше спама в канал СБ, меньше боли ушам.
(Честно? Я не знаю что я делаю!)
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1221813158746914908
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->