### PR TITLE
tweak: gamemodes says station names

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -19,7 +19,7 @@
 
 /datum/game_mode/abduction/announce()
 	to_chat(world, "<B>The current game mode is - Abduction!</B>")
-	to_chat(world, "There are alien <b>abductors</b> sent to [world.name] to perform nefarious experiments!")
+	to_chat(world, "There are alien <b>abductors</b> sent to [station_name()] to perform nefarious experiments!")
 	to_chat(world, "<b>Abductors</b> - kidnap the crew and replace their organs with experimental ones.")
 	to_chat(world, "<b>Crew</b> - don't get abducted and stop the abductors.")
 

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -126,7 +126,7 @@ Made by Xhuis
 
 /datum/game_mode/proc/greet_shadow(var/datum/mind/shadow)
 	var/list/messages = list()
-	messages.Add("<b>Currently, you are disguised as an employee aboard [world.name].</b>")
+	messages.Add("<b>Currently, you are disguised as an employee aboard [station_name()].</b>")
 	messages.Add("<b>In your limited state, you have two abilities: Hatch and Shadowling Hivemind '[get_language_prefix(LANGUAGE_HIVE_SHADOWLING)]'.</b>")
 	messages.Add("<b>Any other shadowlings are your allies. You must assist them as they shall assist you.</b>")
 	messages.Add("<b>С полной информацией вы можете ознакомиться на вики: <a href=\"https://wiki.ss220.space/index.php/Shadowling\">Тенеморф</a></b><br>")


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Убирает `world.name` (название сервера), ставит `station_name()` (название станции) вместо него.

## Ссылка на предложение/Причина создания ПР
[Ссылка](https://discord.com/channels/617003227182792704/734823601110515882/1226223461819617290)
![image](https://github.com/ss220-space/Paradise/assets/87372121/f1752c9c-1273-42ca-b393-eddde523bff7)
