### PR TITLE
refactor: Dropped Proc Refactor

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -480,7 +480,7 @@
 	var/image/item_overlay = image(holding)
 	item_overlay.alpha = 92
 
-	if(!holding.mob_can_equip(user, slot_id, disable_warning = TRUE, bypass_equip_delay_self = TRUE, bypass_obscured = FALSE))
+	if(!holding.mob_can_equip(user, slot_id, disable_warning = TRUE, bypass_equip_delay_self = TRUE, bypass_obscured = FALSE, bypass_incapacitated = TRUE))
 		item_overlay.color = "#ff0000"
 	else
 		item_overlay.color = "#00ff00"

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -80,7 +80,7 @@
 	host = null
 	return ..()
 
-/obj/item/tk_grab/dropped(mob/user, silent = FALSE)
+/obj/item/tk_grab/dropped(mob/user, slot, silent = FALSE)
 	if(focus && user && loc != user && loc != user.loc) // drop_from_active_hand() gets called when you tk-attack a table/closet with an item
 		if(focus.Adjacent(loc))
 			focus.forceMove(loc)

--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -87,9 +87,9 @@
 		equip_item(H, suit_store, SLOT_HUD_SUIT_STORE)
 
 	if(l_hand)
-		H.equip_to_slot_if_possible(new l_hand(H.loc), SLOT_HUD_LEFT_HAND, TRUE, FALSE, TRUE, TRUE, TRUE, TRUE)
+		H.equip_to_slot_if_possible(new l_hand(H.loc), SLOT_HUD_LEFT_HAND, TRUE, FALSE, TRUE, TRUE, TRUE, TRUE, TRUE)
 	if(r_hand)
-		H.equip_to_slot_if_possible(new r_hand(H.loc), SLOT_HUD_RIGHT_HAND, TRUE, FALSE, TRUE, TRUE, TRUE, TRUE)
+		H.equip_to_slot_if_possible(new r_hand(H.loc), SLOT_HUD_RIGHT_HAND, TRUE, FALSE, TRUE, TRUE, TRUE, TRUE, TRUE)
 
 	if(pda)
 		equip_item(H, pda, SLOT_HUD_WEAR_PDA)

--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -559,7 +559,7 @@
 	trashtype = /obj/item/restraints/handcuffs/energy/used
 	flags = DROPDEL
 
-/obj/item/restraints/handcuffs/energy/cult/used/dropped(mob/user, silent = FALSE)
+/obj/item/restraints/handcuffs/energy/cult/used/dropped(mob/user, slot, silent = FALSE)
 	user.visible_message("<span class='danger'>[user]'s shackles shatter in a discharge of dark magic!</span>", \
 	"<span class='userdanger'>Your [name] shatter in a discharge of dark magic!</span>")
 	. = ..()

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -247,7 +247,7 @@
 		user.add_movespeed_modifier(/datum/movespeed_modifier/cult_robe)
 
 
-/obj/item/clothing/suit/hooded/cultrobes/flagellant_robe/dropped(mob/user, silent = FALSE)
+/obj/item/clothing/suit/hooded/cultrobes/flagellant_robe/dropped(mob/user, slot, silent = FALSE)
 	. = ..()
 	user?.remove_movespeed_modifier(/datum/movespeed_modifier/cult_robe)
 

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -588,7 +588,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	desc = "energy discharge"
 	flags = DROPDEL
 
-/obj/item/restraints/handcuffs/energy/used/dropped(mob/user, silent = FALSE)
+/obj/item/restraints/handcuffs/energy/used/dropped(mob/user, slot, silent = FALSE)
 	user.visible_message("<span class='danger'>[src] restraining [user] breaks in a discharge of energy!</span>", \
 							"<span class='userdanger'>[src] restraining [user] breaks in a discharge of energy!</span>")
 	do_sparks(4, 0, user.loc)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -545,7 +545,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 /**
  * When item is officially left user
  */
-/obj/item/proc/dropped(mob/user, silent = FALSE)
+/obj/item/proc/dropped(mob/user, slot, silent = FALSE)
 	SHOULD_CALL_PARENT(TRUE)
 
 	// Remove any item actions we temporary gave out
@@ -763,9 +763,10 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
  * * 'slot' is the slot we are trying to equip to
  * * 'bypass_equip_delay_self' for whether we want to bypass the equip delay
  * * 'bypass_obscured' for whether we want to ignore clothing obscuration
+ * * 'bypass_incapacitated' wheter we are ignoring user's incapacitated status (uded only for hands currently)
  */
-/obj/item/proc/mob_can_equip(mob/M, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE, bypass_obscured = FALSE)
-	return M.can_equip(src, slot, disable_warning, bypass_equip_delay_self, bypass_obscured)
+/obj/item/proc/mob_can_equip(mob/M, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE, bypass_obscured = FALSE, bypass_incapacitated = FALSE)
+	return M.can_equip(src, slot, disable_warning, bypass_equip_delay_self, bypass_obscured, bypass_incapacitated)
 
 
 /obj/item/verb/verb_pickup()

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -192,8 +192,8 @@
 	if(message)
 		to_chat(user, message)
 
-/obj/item/areaeditor/blueprints/dropped(mob/user, silent = FALSE)
-	..()
+/obj/item/areaeditor/blueprints/dropped(mob/user, slot, silent = FALSE)
+	. = ..()
 	clear_viewer()
 
 /obj/item/areaeditor/proc/get_area_type(area/A)

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -18,7 +18,7 @@
 	var/saved_overlays = null
 	var/saved_underlays = null
 
-/obj/item/chameleon/dropped(mob/user, silent = FALSE)
+/obj/item/chameleon/dropped(mob/user, slot, silent = FALSE)
 	. = ..()
 	disrupt()
 
@@ -200,7 +200,7 @@
 		S.cham_proj = null
 	return ..()
 
-/obj/item/borg_chameleon/dropped(mob/user, silent = FALSE)
+/obj/item/borg_chameleon/dropped(mob/user, slot, silent = FALSE)
 	. = ..()
 	disrupt(user)
 

--- a/code/game/objects/items/weapons/RCL.dm
+++ b/code/game/objects/items/weapons/RCL.dm
@@ -105,8 +105,8 @@
 		return 1
 	return 0
 
-/obj/item/twohanded/rcl/dropped(mob/user, silent = FALSE)
-	..()
+/obj/item/twohanded/rcl/dropped(mob/user, slot, silent = FALSE)
+	. = ..()
 	active = 0
 	last = null
 

--- a/code/game/objects/items/weapons/chrono_eraser.dm
+++ b/code/game/objects/items/weapons/chrono_eraser.dm
@@ -16,24 +16,21 @@
 /obj/item/chrono_eraser/proc/pass_mind(var/datum/mind/M)
 	erased_minds += M
 
-/obj/item/chrono_eraser/dropped(mob/user, silent = FALSE)
-	..()
-	if(PA)
-		qdel(PA)
+/obj/item/chrono_eraser/dropped(mob/user, slot, silent = FALSE)
+	. = ..()
+	QDEL_NULL(PA)
 
 /obj/item/chrono_eraser/Destroy()
-	dropped()
+	QDEL_NULL(PA)
 	return ..()
 
 /obj/item/chrono_eraser/ui_action_click(mob/user)
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
 		if(C.back == src)
-			if(PA)
-				qdel(PA)
-			else
-				PA = new(user, src)
-				user.put_in_hands(PA)
+			QDEL_NULL(PA)
+			PA = new(user, src)
+			user.put_in_hands(PA)
 
 /obj/item/chrono_eraser/item_action_slot_check(slot, mob/user)
 	if(slot == SLOT_HUD_BACK)

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -413,7 +413,7 @@
 	return OXYLOSS
 
 
-/obj/item/twohanded/shockpaddles/dropped(mob/user, silent = FALSE)
+/obj/item/twohanded/shockpaddles/dropped(mob/user, slot, silent = FALSE)
 	. = ..()
 	if(defib)
 		defib.toggle_paddles(user)
@@ -445,7 +445,7 @@
 	var/safety = TRUE
 	var/heart_attack_probability = 10
 
-/obj/item/twohanded/shockpaddles/borg/dropped(mob/user, silent = FALSE)
+/obj/item/twohanded/shockpaddles/borg/dropped(mob/user, slot, silent = FALSE)
 	SHOULD_CALL_PARENT(FALSE)
 	// No-op.
 

--- a/code/game/objects/items/weapons/highlander_swords.dm
+++ b/code/game/objects/items/weapons/highlander_swords.dm
@@ -42,7 +42,7 @@
 			//if we have a highlander sword in the other hand, relearn the style from that sword.
 			sword.style.teach(H, 1)
 
-/obj/item/claymore/highlander/dropped(mob/user, silent = FALSE)
+/obj/item/claymore/highlander/dropped(mob/user, slot, silent = FALSE)
 	. = ..()
 
 	if(!ishuman(user))

--- a/code/game/objects/items/weapons/legcuffs.dm
+++ b/code/game/objects/items/weapons/legcuffs.dm
@@ -326,11 +326,11 @@
 	reusable = FALSE
 
 
-/obj/item/restraints/legcuffs/bola/sinew/dropped(mob/living/carbon/user, silent = FALSE)
+/obj/item/restraints/legcuffs/bola/sinew/dropped(mob/living/carbon/user, slot, silent = FALSE)
 	. = ..()
 
-	if(!istype(user) || user.legcuffed != src)
-		return
+	if(!istype(user) || slot != SLOT_HUD_LEGCUFFED)
+		return .
 
 	user.apply_damage(10, BRUTE, (pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)))
 	new /obj/item/restraints/handcuffs/sinew(user.loc)

--- a/code/game/objects/items/weapons/lighters.dm
+++ b/code/game/objects/items/weapons/lighters.dm
@@ -346,7 +346,7 @@
 		return TRUE
 
 
-/obj/item/match/dropped(mob/user, silent = FALSE)
+/obj/item/match/dropped(mob/user, slot, silent = FALSE)
 	matchburnout()
 	. = ..()
 

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -102,7 +102,7 @@
 	cant_hold = list(/obj/item/disk/nuclear)
 
 
-/obj/item/storage/bag/plasticbag/mob_can_equip(mob/M, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE, bypass_obscured = FALSE)
+/obj/item/storage/bag/plasticbag/mob_can_equip(mob/M, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE, bypass_obscured = FALSE, bypass_incapacitated = FALSE)
 	if(slot==SLOT_HUD_HEAD && contents.len)
 		if(!disable_warning)
 			to_chat(M, "<span class='warning'>You need to empty the bag first!</span>")

--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -23,7 +23,7 @@
 	return		//make sure this is never picked up
 
 
-/obj/item/storage/internal/mob_can_equip(mob/M, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE, bypass_obscured = FALSE)
+/obj/item/storage/internal/mob_can_equip(mob/M, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE, bypass_obscured = FALSE, bypass_incapacitated = FALSE)
 	return FALSE	//make sure this is never picked up
 
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -421,7 +421,6 @@
 	if(usr)
 		if(usr.client && usr.s_active != src)
 			usr.client.screen -= W
-		W.dropped(usr)
 		add_fingerprint(usr)
 
 		if(!prevent_warning && !istype(W, /obj/item/gun/energy/kinetic_accelerator/crossbow))
@@ -449,22 +448,14 @@
 	if(!istype(W))
 		return FALSE
 
-	if(istype(src, /obj/item/storage/fancy))
-		var/obj/item/storage/fancy/F = src
-		F.update_icon()
-
 	for(var/_M in mobs_viewing)
 		var/mob/M = _M
 		if((M.s_active == src) && M.client)
 			M.client.screen -= W
 
 	if(new_location)
-		var/is_on_mob = get(loc, /mob)
-		if(is_on_mob)
-			W.dropped(usr)
-
 		if(ismob(new_location) || get(new_location, /mob))
-			if(usr && !is_on_mob && CONFIG_GET(flag/item_animations_enabled))
+			if(usr && !get(loc, /mob) && CONFIG_GET(flag/item_animations_enabled))
 				W.loc = get_turf(src)	// This bullshit is required since /image/ registered in turf contents only
 				W.pixel_x = pixel_x
 				W.pixel_y = pixel_y
@@ -476,6 +467,9 @@
 		else
 			W.layer = initial(W.layer)
 			W.plane = initial(W.plane)
+			W.mouse_opacity = initial(W.mouse_opacity)
+			W.in_inventory = FALSE
+			W.remove_outline()
 
 		W.forceMove(new_location)
 

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -116,8 +116,8 @@
 		loc = tank
 	return
 
-/obj/item/reagent_containers/spray/mister/dropped(mob/user, silent = FALSE)
-	..()
+/obj/item/reagent_containers/spray/mister/dropped(mob/user, slot, silent = FALSE)
+	. = ..()
 	to_chat(user, "<span class='notice'>The mister snaps back onto the watertank.</span>")
 	tank.on = 0
 	loc = tank
@@ -204,7 +204,7 @@
 			icon_state = "waterbackpackatmos"
 
 
-/obj/item/watertank/atmos/dropped(mob/user, silent = FALSE)
+/obj/item/watertank/atmos/dropped(mob/user, slot, silent = FALSE)
 	. = ..()
 	if(!noz)
 		return
@@ -264,8 +264,8 @@
 	tank.update_icon(UPDATE_ICON_STATE)
 
 
-/obj/item/extinguisher/mini/nozzle/dropped(mob/user, silent = FALSE)
-	..()
+/obj/item/extinguisher/mini/nozzle/dropped(mob/user, slot, silent = FALSE)
+	. = ..()
 	to_chat(user, "<span class='notice'>The nozzle snaps back onto the tank!</span>")
 	tank.on = 0
 	loc = tank

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -304,8 +304,8 @@
 	I.override = 1
 	user.add_alt_appearance("sneaking_mission", I, GLOB.player_list)
 
-/obj/item/twohanded/required/kirbyplants/dropped(mob/living/user, silent = FALSE)
-	..()
+/obj/item/twohanded/required/kirbyplants/dropped(mob/living/user, slot, silent = FALSE)
+	. = ..()
 	user.remove_alt_appearance("sneaking_mission")
 
 /obj/item/twohanded/required/kirbyplants/dead

--- a/code/modules/antagonists/space_ninja/energy_katana.dm
+++ b/code/modules/antagonists/space_ninja/energy_katana.dm
@@ -78,7 +78,7 @@
 			playsound(src, 'sound/weapons/bladeslice.ogg', 100, 1)
 
 
-/obj/item/melee/energy_katana/dropped(mob/user, silent = FALSE)
+/obj/item/melee/energy_katana/dropped(mob/user, slot, silent = FALSE)
 	. = ..()
 	if(user && user.client)
 		jaunt.Remove(user)

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -77,7 +77,7 @@
 		time = 10
 
 
-/obj/item/assembly/prox_sensor/dropped(mob/user, silent = FALSE)
+/obj/item/assembly/prox_sensor/dropped(mob/user, slot, silent = FALSE)
 	. = ..()
 	INVOKE_ASYNC(src, PROC_REF(sense), user)
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -94,7 +94,7 @@
 	return FALSE
 
 
-/obj/item/clothing/mob_can_equip(mob/M, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE, bypass_obscured = FALSE)
+/obj/item/clothing/mob_can_equip(mob/M, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE, bypass_obscured = FALSE, bypass_incapacitated = FALSE)
 	. = ..()
 	if(!.)
 		return FALSE
@@ -106,7 +106,7 @@
 		return FALSE
 
 
-/obj/item/clothing/dropped(mob/living/user, silent = FALSE)
+/obj/item/clothing/dropped(mob/living/user, slot, silent = FALSE)
 	. = ..()
 	if(!istype(user))
 		return
@@ -548,7 +548,7 @@ BLIND     // can't see anything
 			playsound(user.loc, 'sound/goonstation/misc/matchstick_light.ogg', 50, 1)
 		else
 			user.visible_message("<span class='warning'>[user] crushes the [M] into the bottom of [src], extinguishing it.</span>","<span class='warning'>You crush the [M] into the bottom of [src], extinguishing it.</span>")
-			M.dropped()
+			user.drop_item_ground(I)
 		return
 
 	if(I.tool_behaviour == TOOL_WIRECUTTER)
@@ -773,7 +773,7 @@ BLIND     // can't see anything
 			action.Grant(user)
 
 
-/obj/item/clothing/suit/space/dropped(mob/user, silent = FALSE)
+/obj/item/clothing/suit/space/dropped(mob/user, slot, silent = FALSE)
 	. = ..()
 	if(jetpack)
 		for(var/datum/action/action as anything in jetpack.actions)
@@ -850,23 +850,24 @@ BLIND     // can't see anything
 	return ..()
 
 
-/obj/item/clothing/under/dropped(mob/user, silent = FALSE)
-	..()
-	if(!ishuman(user))
-		return
-	var/mob/living/carbon/human/H = user
-	if(H.get_item_by_slot(SLOT_HUD_JUMPSUIT) == src)
-		for(var/obj/item/clothing/accessory/A in accessories)
-			A.attached_unequip()
+/obj/item/clothing/under/dropped(mob/user, slot, silent = FALSE)
+	. = ..()
+	if(!ishuman(user) || slot != SLOT_HUD_JUMPSUIT)
+		return .
+
+	for(var/obj/item/clothing/accessory/accessory in accessories)
+		accessory.attached_unequip()
+
 
 /obj/item/clothing/under/equipped(mob/user, slot, initial)
 	. = ..()
 
-	if(!ishuman(user))
-		return
-	if(slot == SLOT_HUD_JUMPSUIT)
-		for(var/obj/item/clothing/accessory/A in accessories)
-			A.attached_equip()
+	if(!ishuman(user) || slot != SLOT_HUD_JUMPSUIT)
+		return .
+
+	for(var/obj/item/clothing/accessory/accessory in accessories)
+		accessory.attached_equip()
+
 
 /*
   * # can_attach_accessory

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -12,19 +12,21 @@
 
 /obj/item/clothing/glasses/hud/equipped(mob/living/carbon/human/user, slot, initial)
 	. = ..()
+	if(!istype(user) || !HUDType || (slot != SLOT_HUD_GLASSES && slot != SLOT_HUD_HEAD))
+		return .
 
-	if(HUDType && slot == SLOT_HUD_GLASSES)
-		var/datum/atom_hud/H = GLOB.huds[HUDType]
-		H.add_hud_to(user)
-	if(HUDType && slot == SLOT_HUD_HEAD)
-		var/datum/atom_hud/H = GLOB.huds[HUDType]
-		H.add_hud_to(user)
+	var/datum/atom_hud/hud = GLOB.huds[HUDType]
+	hud.add_hud_to(user)
 
-/obj/item/clothing/glasses/hud/dropped(mob/living/carbon/human/user, silent = FALSE)
-	..()
-	if(HUDType && istype(user) && user.glasses == src)
-		var/datum/atom_hud/H = GLOB.huds[HUDType]
-		H.remove_hud_from(user)
+
+/obj/item/clothing/glasses/hud/dropped(mob/living/carbon/human/user, slot, silent = FALSE)
+	. = ..()
+	if(!istype(user) || !HUDType || (slot != SLOT_HUD_GLASSES && slot != SLOT_HUD_HEAD))
+		return .
+
+	var/datum/atom_hud/hud = GLOB.huds[HUDType]
+	hud.remove_hud_from(user)
+
 
 /obj/item/clothing/glasses/hud/emp_act(severity)
 	if(!emagged)

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -19,33 +19,34 @@
 	var/shock_delay = 40
 	var/unlimited_power = FALSE // Does this really need explanation?
 
-/obj/item/clothing/gloves/color/yellow/power/equipped(mob/user, slot, initial)
+
+/obj/item/clothing/gloves/color/yellow/power/equipped(mob/living/carbon/human/user, slot, initial)
 	. = ..()
 
-	if(!ishuman(user))
-		return
-	var/mob/living/carbon/human/H = user
-	if(slot == SLOT_HUD_GLOVES)
-		if(H.middleClickOverride)
-			old_mclick_override = H.middleClickOverride
-		H.middleClickOverride = mclick_override
-		if(!unlimited_power)
-			to_chat(H, "<span class='notice'>You feel electricity begin to build up in [src].</span>")
-		else
-			to_chat(H, "<span class='biggerdanger'>You feel like you have UNLIMITED POWER!!</span>")
+	if(!ishuman(user) || slot != SLOT_HUD_GLOVES)
+		return .
 
-/obj/item/clothing/gloves/color/yellow/power/dropped(mob/user, silent = FALSE)
+	if(user.middleClickOverride)
+		old_mclick_override = user.middleClickOverride
+	user.middleClickOverride = mclick_override
+	if(!unlimited_power)
+		to_chat(user, span_notice("You feel electricity begin to build up in [src]."))
+	else
+		to_chat(user, span_dangerbigger("You feel like you have UNLIMITED POWER!!!"))
+
+
+/obj/item/clothing/gloves/color/yellow/power/dropped(mob/living/carbon/human/user, slot, silent = FALSE)
 	. = ..()
 
-	if(!ishuman(user))
-		return
-	var/mob/living/carbon/human/H = user
-	if(H.get_item_by_slot(SLOT_HUD_GLOVES) == src && H.middleClickOverride == mclick_override)
-		if(old_mclick_override)
-			H.middleClickOverride = old_mclick_override
-			old_mclick_override = null
-		else
-			H.middleClickOverride = null
+	if(!ishuman(user) || slot != SLOT_HUD_GLOVES || user.middleClickOverride != mclick_override)
+		return .
+
+	if(old_mclick_override)
+		user.middleClickOverride = old_mclick_override
+		old_mclick_override = null
+	else
+		user.middleClickOverride = null
+
 
 /obj/item/clothing/gloves/color/yellow/power/unlimited
 	name = "UNLIMITED POWER gloves"

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -185,7 +185,7 @@
 		owner.verbs += /obj/item/clothing/gloves/fingerless/rapid/proc/dirslash_enabling
 	. = ..()
 
-/obj/item/clothing/gloves/fingerless/rapid/dropped(mob/user, silent)
+/obj/item/clothing/gloves/fingerless/rapid/dropped(mob/user, slot, silent = FALSE)
 	owner.verbs -= /obj/item/clothing/gloves/fingerless/rapid/proc/dirslash_enabling
 	owner.dirslash_enabled = initial(owner.dirslash_enabled)
 	. = ..()

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -322,7 +322,7 @@
 		user_suit.disguise(user, src)
 
 
-/obj/item/clothing/head/cardborg/dropped(mob/living/user, silent = FALSE)
+/obj/item/clothing/head/cardborg/dropped(mob/living/user, slot, silent = FALSE)
 	. = ..()
 	user.remove_alt_appearance("standard_borg_disguise")
 

--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -23,7 +23,7 @@
 	update_equipped_item()
 
 
-/obj/item/clothing/head/soft/dropped(mob/user, silent = FALSE)
+/obj/item/clothing/head/soft/dropped(mob/user, slot, silent = FALSE)
 	. = ..()
 	if(flipped)
 		flipped = FALSE

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -238,10 +238,10 @@
 	user.mind.AddSpell(new /obj/effect/proc_holder/spell/mime/speak/mask)
 
 
-/obj/item/clothing/mask/gas/mime/dropped(mob/user, silent = FALSE)
+/obj/item/clothing/mask/gas/mime/dropped(mob/user, slot, silent = FALSE)
 	. = ..()
 
-	if(!user?.mind)
+	if(!user?.mind || slot != SLOT_HUD_WEAR_MASK)
 		return
 
 	var/obj/effect/proc_holder/spell/mime/speak/mask/spell = locate() in user.mind.spell_list
@@ -314,6 +314,7 @@
 	item_state = "sechailer"
 	flags_inv = HIDENAME
 	flags_cover = MASKCOVERSMOUTH
+	clothing_traits = list(TRAIT_SECDEATH)
 	var/phrase = 1
 	var/aggressiveness = 1
 	var/safety = 1
@@ -341,14 +342,6 @@
 								"dredd"			= "I am, the LAW!"
 								)
 
-/obj/item/clothing/mask/gas/sechailer/equipped(mob/user, slot, initial)
-	. = ..()
-	if(slot == SLOT_HUD_WEAR_MASK && !HAS_TRAIT(user, TRAIT_SECDEATH))
-		ADD_TRAIT(user, TRAIT_SECDEATH, src)
-
-/obj/item/clothing/mask/gas/sechailer/dropped(mob/user, silent = FALSE)
-	. = ..()
-	REMOVE_TRAIT(user, TRAIT_SECDEATH, src)
 
 /obj/item/clothing/mask/gas/sechailer/hos
 	name = "\improper HOS SWAT mask"

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -113,14 +113,18 @@
 		SPECIES_STOK = 'icons/mob/clothing/species/monkey/mask.dmi'
 		)
 
-/obj/item/clothing/mask/muzzle/tapegag/dropped(mob/user, silent = FALSE)
-	var/obj/item/trash/tapetrash/TT = new trashtype
-	transfer_fingerprints_to(TT)
-	user.transfer_fingerprints_to(TT)
-	user.put_in_active_hand(TT)
-	playsound(src, 'sound/items/poster_ripped.ogg', 40, 1)
+
+/obj/item/clothing/mask/muzzle/tapegag/dropped(mob/user, slot, silent = FALSE)
+	. = ..()
+	if(slot != SLOT_HUD_WEAR_MASK)
+		return .
+	var/obj/item/trash/tapetrash/trash_gag = new trashtype(get_turf(src))
+	transfer_fingerprints_to(trash_gag)
+	user.transfer_fingerprints_to(trash_gag)
+	user.put_in_active_hand(trash_gag, ignore_anim = FALSE)
+	playsound(user, 'sound/items/poster_ripped.ogg', 40, TRUE)
 	user.emote("scream")
-	..()
+
 
 /obj/item/clothing/mask/muzzle/tapegag/thick
 	name = "thick tape gag"
@@ -376,10 +380,10 @@
 		else
 			user.real_name = "[user.name][temporaryname]"
 
-/obj/item/clothing/mask/horsehead/dropped(mob/user, silent = FALSE) //this really shouldn't happen, but call it extreme caution
-	if(flags & NODROP)
+/obj/item/clothing/mask/horsehead/dropped(mob/user, slot, silent = FALSE) //this really shouldn't happen, but call it extreme caution
+	if(slot == SLOT_HUD_WEAR_MASK && (flags & NODROP))
 		goodbye_horses(loc)
-	..()
+	. = ..()
 
 /obj/item/clothing/mask/horsehead/Destroy()
 	if(flags & NODROP)

--- a/code/modules/clothing/neck/ponchos.dm
+++ b/code/modules/clothing/neck/ponchos.dm
@@ -49,8 +49,8 @@
 		return
 	flip(user)
 
-/obj/item/clothing/neck/poncho/dropped(mob/user, silent = FALSE)
-	..()
+/obj/item/clothing/neck/poncho/dropped(mob/user, slot, silent = FALSE)
+	. = ..()
 	if(flipped)
 		flipped = FALSE
 		update_icon(UPDATE_ICON_STATE)

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -130,9 +130,10 @@
 	if(slot == SLOT_HUD_SHOES && enabled_waddle)
 		user.AddElement(/datum/element/waddling)
 
-/obj/item/clothing/shoes/magboots/clown/dropped(mob/user, silent = FALSE)
+/obj/item/clothing/shoes/magboots/clown/dropped(mob/user, slot, silent = FALSE)
 	. = ..()
-	user.RemoveElement(/datum/element/waddling)
+	if(slot == SLOT_HUD_SHOES && enabled_waddle)
+		user.RemoveElement(/datum/element/waddling)
 
 /obj/item/clothing/shoes/magboots/clown/CtrlClick(mob/living/user)
 	if(!isliving(user))
@@ -299,17 +300,18 @@
 	if(slot == SLOT_HUD_SHOES && cell && core)
 		style.teach(user, TRUE)
 
-/obj/item/clothing/shoes/magboots/gravity/dropped(mob/living/carbon/human/user, silent = FALSE)
-	. = ..()
-	if(!ishuman(user))
-		return
 
-	if(user.get_item_by_slot(SLOT_HUD_SHOES) == src)
-		style.remove(user)
-		if(magpulse)
-			if(!silent)
-				to_chat(user, "<span class='notice'>As [src] are removed, they deactivate.</span>")
-			toggle_magpulse(user, silent = TRUE)
+/obj/item/clothing/shoes/magboots/gravity/dropped(mob/living/carbon/human/user, slot, silent = FALSE)
+	. = ..()
+	if(!ishuman(user) || slot != SLOT_HUD_SHOES)
+		return .
+
+	style.remove(user)
+	if(magpulse)
+		if(!silent)
+			to_chat(user, "<span class='notice'>As [src] are removed, they deactivate.</span>")
+		toggle_magpulse(user, silent = TRUE)
+
 
 /obj/item/clothing/shoes/magboots/gravity/item_action_slot_check(slot)
 	if(slot == SLOT_HUD_SHOES)

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -87,9 +87,10 @@
 	if(slot == SLOT_HUD_SHOES && enabled_waddle)
 		user.AddElement(/datum/element/waddling)
 
-/obj/item/clothing/shoes/clown_shoes/dropped(mob/user, silent = FALSE)
+/obj/item/clothing/shoes/clown_shoes/dropped(mob/user, slot, silent = FALSE)
 	. = ..()
-	user.RemoveElement(/datum/element/waddling)
+	if(slot == SLOT_HUD_SHOES && enabled_waddle)
+		user.RemoveElement(/datum/element/waddling)
 
 /obj/item/clothing/shoes/clown_shoes/CtrlClick(mob/living/user)
 	if(!isliving(user))

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -226,9 +226,9 @@
 
 
 //In case they somehow come off while enabled.
-/obj/item/clothing/shoes/magboots/vox/dropped(mob/user, silent = FALSE)
+/obj/item/clothing/shoes/magboots/vox/dropped(mob/user, slot, silent = FALSE)
 	. = ..()
-	if(magpulse)
+	if(slot == SLOT_HUD_SHOES && magpulse)
 		if(!silent)
 			user.visible_message("The [src] go limp as they are removed from [usr]'s feet.", "The [src] go limp as they are removed from your feet.")
 		toggle_magpulse(user, silent = TRUE)

--- a/code/modules/clothing/spacesuits/chronosuit.dm
+++ b/code/modules/clothing/spacesuits/chronosuit.dm
@@ -8,13 +8,14 @@
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	var/obj/item/clothing/suit/space/chronos/suit = null
 
-/obj/item/clothing/head/helmet/space/chronos/dropped(mob/user, silent = FALSE)
-	if(suit)
+/obj/item/clothing/head/helmet/space/chronos/dropped(mob/user, slot, silent = FALSE)
+	if(suit && slot == SLOT_HUD_HEAD)
 		suit.deactivate()
-	..()
+	. = ..()
+
 
 /obj/item/clothing/head/helmet/space/chronos/Destroy()
-	dropped()
+	suit?.deactivate()
 	return ..()
 
 
@@ -48,13 +49,13 @@
 		else
 			deactivate()
 
-/obj/item/clothing/suit/space/chronos/dropped(mob/user, silent = FALSE)
-	if(activated)
+/obj/item/clothing/suit/space/chronos/dropped(mob/user, slot, silent = FALSE)
+	if(slot == SLOT_HUD_OUTER_SUIT && activated)
 		deactivate()
-	..()
+	. = ..()
 
 /obj/item/clothing/suit/space/chronos/Destroy()
-	dropped()
+	deactivate()
 	return ..()
 
 /obj/item/clothing/suit/space/chronos/emp_act(severity)

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -4,11 +4,11 @@
 	desc = "A special helmet designed for work in a hazardous, low-pressure environment."
     //alt_desc =
 	icon_state = "hardsuit0-engineering"
+	base_icon_state = "hardsuit"
 	item_state = "eng_helm"
 	armor = list("melee" = 10, "bullet" = 5, "laser" = 10, "energy" = 15, "bomb" = 10, "bio" = 100, "rad" = 75, "fire" = 50, "acid" = 75)
 	item_color = "engineering" //Determines used sprites: hardsuit[on]-[color] and hardsuit[on]-[color]2 (lying down sprite)
 	max_integrity = 300
-	var/basestate = "hardsuit"
 	allowed = list(/obj/item/flashlight)
 	light_power = 1
 	light_range = 4
@@ -46,25 +46,34 @@
 
 
 /obj/item/clothing/head/helmet/space/hardsuit/update_icon_state()
-	icon_state = "[basestate][light_on]-[item_color]"
+	icon_state = "[base_icon_state][light_on]-[item_color]"
+
+
+/obj/item/clothing/head/helmet/space/hardsuit/attack_hand(mob/user, pickupfireoverride = FALSE)
+	if(suit)
+		suit.RemoveHelmet(user)
+	else
+		qdel(src)
+		stack_trace("Investigate hardsuit helmet attackhand of type: [type]")
 
 
 /obj/item/clothing/head/helmet/space/hardsuit/equipped(mob/living/carbon/user, slot, initial = FALSE)
 	. = ..(user, slot, TRUE)
-	if(!suit)
-		qdel(src)
-		return FALSE
-	if(slot != SLOT_HUD_HEAD || user.wear_suit != suit)
-		user.drop_item_ground(src, force = TRUE, silent = TRUE)
+	if(!suit || slot != SLOT_HUD_HEAD || user.wear_suit != suit)
+		if(!QDELING(src))
+			qdel(src)
+		stack_trace("Investigate hardsuit helmet equip of type: [type]")
 		return FALSE
 
 
-/obj/item/clothing/head/helmet/space/hardsuit/dropped(mob/user, silent = FALSE)
-	. = ..(user, TRUE)
-	if(suit)
-		suit.RemoveHelmet(user)
-	else if(!QDELETED(src))
-		qdel(src)
+/obj/item/clothing/head/helmet/space/hardsuit/dropped(mob/living/carbon/user, slot, silent = FALSE)
+	. = ..(user, slot, TRUE)
+	if(!suit || slot != SLOT_HUD_HEAD || user.wear_suit != suit)
+		if(!QDELING(src))
+			qdel(src)
+		stack_trace("Investigate hardsuit helmet drop of type: [type]")
+		return FALSE
+	suit.RemoveHelmet(user)
 
 
 /obj/item/clothing/head/helmet/space/hardsuit/MouseDrop(atom/over_object, src_location, over_location, src_control, over_control, params)
@@ -72,18 +81,17 @@
 		suit.RemoveHelmet(usr)
 	else
 		qdel(src)
+		stack_trace("Investigate hardsuit helmet mousedrop of type: [type]")
 
 
 /obj/item/clothing/head/helmet/space/hardsuit/attack_self(mob/user)
+	toggle_light()
+
+
+/obj/item/clothing/head/helmet/space/hardsuit/proc/toggle_light(update_buttons = TRUE)
 	set_light_on(!light_on)
-	toggle_light(light_on)
-
-
-/obj/item/clothing/head/helmet/space/hardsuit/proc/toggle_light(enable = TRUE, update_buttons = TRUE)
-	light_on = enable
 	update_icon(UPDATE_ICON_STATE)
 	update_equipped_item(update_buttons)
-	set_light_on(enable)
 
 
 /obj/item/clothing/head/helmet/space/hardsuit/item_action_slot_check(slot)
@@ -104,7 +112,7 @@
 
 /obj/item/clothing/head/helmet/space/hardsuit/extinguish_light(force = FALSE)
 	if(light_on)
-		toggle_light(enable = FALSE)
+		toggle_light()
 		visible_message(span_danger("[src]'s light fades and turns off."))
 
 
@@ -169,7 +177,7 @@
 	RemoveHelmet(user)
 
 
-/obj/item/clothing/suit/space/hardsuit/dropped(mob/user, silent = FALSE)
+/obj/item/clothing/suit/space/hardsuit/dropped(mob/user, slot, silent = FALSE)
 	. = ..()
 	RemoveHelmet(user)
 
@@ -231,13 +239,11 @@
 	if(!helmet)
 		return FALSE
 	if(!suit_adjusted)
-		if(helmet.loc != src)	// in case helmet was dropped on equip and hardsuit is already adjusted
-			helmet.forceMove(src)
 		return FALSE
 	. = TRUE
 	suit_adjusted = FALSE
 	if(helmet.light_on)
-		helmet.toggle_light(enable = FALSE, update_buttons = FALSE)
+		helmet.toggle_light(update_buttons = FALSE)
 	if(ishuman(user))
 		user.temporarily_remove_item_from_inventory(helmet, force = TRUE)
 		user.update_inv_wear_suit()
@@ -384,7 +390,8 @@
 		return
 	if(toggle)
 		on = !on
-		toggle_light(enable = on, update_buttons = FALSE)
+		if(on != light_on)
+			toggle_light(update_buttons = FALSE)
 	if(user)
 		to_chat(user, span_notice("You switch your hardsuit to [on ? "EVA mode, sacrificing speed for space protection." : "combat mode and can now run at full speed."]"))
 		playsound(loc, 'sound/items/rig_deploy.ogg', 110, TRUE)
@@ -469,8 +476,8 @@
 
 /obj/item/clothing/suit/space/hardsuit/syndi/EngageHelmet(mob/living/carbon/human/user)
 	. = ..()
-	if(. && on)
-		helmet?.toggle_light(enable = TRUE, update_buttons = FALSE)
+	if(. && on && !light_on)
+		helmet.toggle_light()
 
 
 //Elite Syndie suit
@@ -711,15 +718,15 @@
 	var/explosion_detection_dist = 40
 
 
-/obj/item/clothing/head/helmet/space/hardsuit/rd/equipped(mob/living/carbon/human/user, slot, initial)
+/obj/item/clothing/head/helmet/space/hardsuit/rd/equipped(mob/living/carbon/human/user, slot, initial = FALSE)
 	. = ..()
 	if(slot == SLOT_HUD_HEAD)
 		GLOB.doppler_arrays += src //Needed to sense the kabooms
 
 
-/obj/item/clothing/head/helmet/space/hardsuit/rd/dropped(mob/living/carbon/human/user, silent = FALSE)
+/obj/item/clothing/head/helmet/space/hardsuit/rd/dropped(mob/living/carbon/human/user, slot, silent = FALSE)
 	. = ..()
-	if(!user || user.head != src)
+	if(slot == SLOT_HUD_HEAD)
 		GLOB.doppler_arrays -= src
 
 

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -40,8 +40,19 @@
 		)
 
 
+/obj/item/clothing/head/helmet/space/hardsuit/Initialize(mapload, obj/item/clothing/suit/space/hardsuit/parent)
+	. = ..()
+	if(istype(parent))
+		suit = parent
+	else
+		stack_trace("Investigate hardsuit helmet ([type]). Initialized without proper suit.")
+
+
 /obj/item/clothing/head/helmet/space/hardsuit/Destroy()
-	suit = null
+	if(suit)
+		suit.RemoveHelmet(loc)
+		suit.helmet = null
+		suit = null
 	return ..()
 
 
@@ -166,8 +177,7 @@
 	if(!helmettype || helmet)
 		return
 
-	var/obj/item/clothing/head/helmet/space/hardsuit/new_helmet = new helmettype(src)
-	new_helmet.suit = src
+	var/obj/item/clothing/head/helmet/space/hardsuit/new_helmet = new helmettype(src, src)
 	helmet = new_helmet
 	helmet.update_appearance(UPDATE_ICON_STATE|UPDATE_NAME|UPDATE_DESC)
 
@@ -202,7 +212,10 @@
 
 
 /obj/item/clothing/suit/space/hardsuit/proc/ToggleHelmet(mob/living/carbon/human/user)
-	if(!helmet || !ishuman(user))
+	if(!ishuman(user))
+		return
+	if(!helmet)
+		to_chat(user, span_warning("[src] has no helmet anymore!"))
 		return
 	if(taser_proof?.ert_mindshield_locked)
 		if(isertmindshielded(user))

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -116,9 +116,9 @@
 		H.add_hud_to(user)
 
 
-/obj/item/clothing/head/helmet/space/plasmaman/dropped(mob/living/carbon/human/user, silent = FALSE)
+/obj/item/clothing/head/helmet/space/plasmaman/dropped(mob/living/carbon/human/user, slot, silent = FALSE)
 	. = ..()
-	if(HUDType && istype(user) && user.head == src)
+	if(HUDType && istype(user) && slot == SLOT_HUD_HEAD)
 		var/datum/atom_hud/H = GLOB.huds[HUDType]
 		H.remove_hud_from(user)
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -646,14 +646,14 @@
 	magical = TRUE
 
 //mob_size using for crusher mark
-/obj/item/clothing/suit/hooded/goliath/wizard/equipped(mob/living/user, slot, initial)
+/obj/item/clothing/suit/hooded/goliath/wizard/equipped(mob/living/user, slot, initial = FALSE)
 	. = ..()
-	if(istype(user))
+	if(istype(user) && slot == SLOT_HUD_HEAD)
 		user.mob_size = MOB_SIZE_LARGE
 
-/obj/item/clothing/suit/hooded/goliath/wizard/dropped(mob/living/user, silent)
+/obj/item/clothing/suit/hooded/goliath/wizard/dropped(mob/living/user, slot, silent = FALSE)
 	. = ..()
-	if(istype(user))
+	if(istype(user)&& slot == SLOT_HUD_HEAD)
 		user.mob_size = MOB_SIZE_HUMAN
 
 /obj/item/clothing/suit/armor/bone

--- a/code/modules/clothing/suits/hood.dm
+++ b/code/modules/clothing/suits/hood.dm
@@ -47,7 +47,7 @@
 	RemoveHood(user)
 
 
-/obj/item/clothing/suit/hooded/dropped(mob/user, silent = FALSE)
+/obj/item/clothing/suit/hooded/dropped(mob/user, slot, silent = FALSE)
 	. = ..()
 	RemoveHood(user)
 
@@ -113,22 +113,31 @@
 	return ..()
 
 
-/obj/item/clothing/head/hooded/equipped(mob/living/carbon/user, slot, initial = FALSE)
-	. = ..()
-	if(!suit)
-		qdel(src)
-		return FALSE
-	if(slot != SLOT_HUD_HEAD || user.wear_suit != suit)
-		user.drop_item_ground(src, force = TRUE, silent = TRUE)
-		return FALSE
-
-
-/obj/item/clothing/head/hooded/dropped(mob/user, silent = FALSE)
-	. = ..()
+/obj/item/clothing/head/hooded/attack_hand(mob/user, pickupfireoverride = FALSE)
 	if(suit)
 		suit.RemoveHood(user)
-	else if(!QDELETED(src))
+	else
 		qdel(src)
+		stack_trace("Investigate suit hood attackhand of type: [type]")
+
+
+/obj/item/clothing/head/hooded/equipped(mob/living/carbon/user, slot, initial = FALSE)
+	. = ..()
+	if(!suit || slot != SLOT_HUD_HEAD || user.wear_suit != suit)
+		if(!QDELING(src))
+			qdel(src)
+		stack_trace("Investigate suit hood equip of type: [type]")
+		return FALSE
+
+
+/obj/item/clothing/head/hooded/dropped(mob/living/carbon/user, slot, silent = FALSE)
+	. = ..()
+	if(!suit || slot != SLOT_HUD_HEAD || user.wear_suit != suit)
+		if(!QDELING(src))
+			qdel(src)
+		stack_trace("Investigate suit hood drop of type: [type]")
+		return FALSE
+	suit.RemoveHood(user)
 
 
 /obj/item/clothing/head/hooded/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
@@ -136,4 +145,5 @@
 		suit.RemoveHood(usr)
 	else
 		qdel(src)
+		stack_trace("Investigate suit hood mousedrop of type: [type]")
 

--- a/code/modules/clothing/suits/hood.dm
+++ b/code/modules/clothing/suits/hood.dm
@@ -19,8 +19,7 @@
 /obj/item/clothing/suit/hooded/proc/MakeHood()
 	item_color = initial(icon_state)
 	if(!hood)
-		var/obj/item/clothing/head/hooded/new_hood = new hoodtype(src)
-		new_hood.suit = src
+		var/obj/item/clothing/head/hooded/new_hood = new hoodtype(src, src)
 		hood = new_hood
 
 
@@ -58,7 +57,10 @@
 
 
 /obj/item/clothing/suit/hooded/proc/ToggleHood(mob/living/carbon/human/user)
-	if(!ishuman(user) || !hood)
+	if(!ishuman(user))
+		return
+	if(!hood)
+		to_chat(user, span_warning("[src] has no head gear anymore!"))
 		return
 	if(suit_adjusted)
 		RemoveHood(user)
@@ -89,8 +91,6 @@
 	if(!hood)
 		return FALSE
 	if(!suit_adjusted)
-		if(hood.loc != src)	// in case hood was dropped on equip and suit is already adjusted
-			hood.forceMove(src)
 		return FALSE
 	. = TRUE
 	suit_adjusted = FALSE
@@ -108,8 +108,19 @@
 	var/obj/item/clothing/suit/hooded/suit
 
 
+/obj/item/clothing/head/hooded/Initialize(mapload, obj/item/clothing/suit/hooded/parent)
+	. = ..()
+	if(istype(parent))
+		suit = parent
+	else
+		stack_trace("Investigate suit hood ([type]). Initialized without proper suit.")
+
+
 /obj/item/clothing/head/hooded/Destroy()
-	suit = null
+	if(suit)
+		suit.RemoveHood(loc)
+		suit.hood = null
+		suit = null
 	return ..()
 
 

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -273,15 +273,18 @@
 	species_disguise = "High-tech robot"
 	dog_fashion = /datum/dog_fashion/back
 
-/obj/item/clothing/suit/cardborg/equipped(mob/living/user, slot, initial)
-	. = ..()
 
+/obj/item/clothing/suit/cardborg/equipped(mob/living/user, slot, initial = FALSE)
+	. = ..()
 	if(slot == SLOT_HUD_OUTER_SUIT)
 		disguise(user)
 
-/obj/item/clothing/suit/cardborg/dropped(mob/living/user, silent = FALSE)
-	..()
-	user.remove_alt_appearance("standard_borg_disguise")
+
+/obj/item/clothing/suit/cardborg/dropped(mob/living/user, slot, silent = FALSE)
+	. = ..()
+	if(slot == SLOT_HUD_OUTER_SUIT)
+		user.remove_alt_appearance("standard_borg_disguise")
+
 
 /obj/item/clothing/suit/cardborg/proc/disguise(mob/living/carbon/human/H, obj/item/clothing/head/cardborg/borghead)
 	if(istype(H))

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -52,7 +52,7 @@
 		to_chat(user, "<span class='notice'>You attach [src] to [has_suit].</span>")
 	src.add_fingerprint(user)
 
-/obj/item/clothing/accessory/proc/on_removed(mob/user)
+/obj/item/clothing/accessory/proc/on_removed(mob/user, silent = FALSE)
 	if(!has_suit)
 		return
 	has_suit.cut_overlay(inv_overlay)
@@ -68,8 +68,9 @@
 
 	has_suit = null
 	if(user)
-		user.put_in_hands(src)
-		add_fingerprint(user)
+		forceMove_turf()
+		user.put_in_hands(src, ignore_anim = !silent, silent = silent)
+
 
 /obj/item/clothing/accessory/attack(mob/living/carbon/human/H, mob/living/user)
 	// This code lets you put accessories on other people by attacking their sprite with the accessory
@@ -413,7 +414,7 @@
 	. = ..()
 	has_suit.verbs += /obj/item/clothing/accessory/holobadge/verb/holobadge_verb
 
-/obj/item/clothing/accessory/holobadge/on_removed(mob/user as mob)
+/obj/item/clothing/accessory/holobadge/on_removed(mob/user, silent = FALSE)
 	has_suit.verbs -= /obj/item/clothing/accessory/holobadge/verb/holobadge_verb
 	. = ..()
 
@@ -877,13 +878,13 @@
 	if(access_id)
 		. += "<span class='notice'>There is [bicon(access_id)] \a [access_id] clipped onto it.</span>"
 
-/obj/item/clothing/accessory/petcollar/equipped(mob/living/simple_animal/user)
+/obj/item/clothing/accessory/petcollar/equipped(mob/living/simple_animal/user, slot, initial = FALSE)
 	. = ..()
 
 	if(istype(user))
 		START_PROCESSING(SSobj, src)
 
-/obj/item/clothing/accessory/petcollar/dropped(mob/living/simple_animal/user, silent = FALSE)
+/obj/item/clothing/accessory/petcollar/dropped(mob/living/simple_animal/user, slot, silent = FALSE)
 	STOP_PROCESSING(SSobj, src)
 	. = ..()
 
@@ -958,7 +959,7 @@
 		cached_bubble_icon = M.bubble_icon
 		M.bubble_icon = strip_bubble_icon
 
-/obj/item/clothing/accessory/head_strip/on_removed(mob/user)
+/obj/item/clothing/accessory/head_strip/on_removed(mob/user, silent = FALSE)
 	if(has_suit && ismob(has_suit.loc))
 		var/mob/M = has_suit.loc
 		M.bubble_icon = cached_bubble_icon

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -119,7 +119,7 @@
 	..()
 	has_suit.verbs += /obj/item/clothing/accessory/holster/verb/holster_verb
 
-/obj/item/clothing/accessory/holster/on_removed(mob/user)
+/obj/item/clothing/accessory/holster/on_removed(mob/user, silent = FALSE)
 	has_suit.verbs -= /obj/item/clothing/accessory/holster/verb/holster_verb
 	..()
 

--- a/code/modules/clothing/under/accessories/jewelry.dm
+++ b/code/modules/clothing/under/accessories/jewelry.dm
@@ -107,7 +107,7 @@
 		var/mob/living/M = user
 		M.apply_status_effect(STATUS_EFFECT_DRAGON_STRENGTH)
 
-/obj/item/clothing/accessory/necklace/gem/on_removed(mob/user)
+/obj/item/clothing/accessory/necklace/gem/on_removed(mob/user, silent = FALSE)
 	. = ..()
 	if(isliving(user) && dragon_power)
 		var/mob/living/M = user
@@ -125,17 +125,15 @@
 		M.apply_status_effect(STATUS_EFFECT_DRAGON_STRENGTH)
 	return ..()
 
-/obj/item/clothing/accessory/necklace/gem/equipped(mob/user, slot, initial)
+/obj/item/clothing/accessory/necklace/gem/equipped(mob/living/user, slot, initial = FALSE)
 	. = ..()
 	if(isliving(user) && dragon_power && slot == SLOT_HUD_NECK)
-		var/mob/living/M = user
-		M.apply_status_effect(STATUS_EFFECT_DRAGON_STRENGTH)
+		user.apply_status_effect(STATUS_EFFECT_DRAGON_STRENGTH)
 
-/obj/item/clothing/accessory/necklace/gem/dropped(mob/user)
+/obj/item/clothing/accessory/necklace/gem/dropped(mob/living/user, slot, silent = FALSE)
 	. = ..()
-	var/mob/living/M = user
-	if(isliving(user) && dragon_power && M.get_item_by_slot(SLOT_HUD_NECK) == src)
-		M.remove_status_effect(STATUS_EFFECT_DRAGON_STRENGTH)
+	if(isliving(user) && dragon_power && slot == SLOT_HUD_NECK)
+		user.remove_status_effect(STATUS_EFFECT_DRAGON_STRENGTH)
 
 //bracers
 /obj/item/clothing/gloves/jewelry_bracers

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -865,17 +865,17 @@
 	item_color = "atmos"
 	resistance_flags = FIRE_PROOF
 
-/obj/item/clothing/under/contortionist/equipped(mob/living/carbon/human/user, slot, initial)
+
+/obj/item/clothing/under/contortionist/equipped(mob/living/carbon/human/user, slot, initial = FALSE)
 	. = ..()
+	if(slot == SLOT_HUD_JUMPSUIT && !user.ventcrawler)
+		user.ventcrawler = 1
 
-	if(slot == SLOT_HUD_JUMPSUIT)
-		if(!user.ventcrawler)
-			user.ventcrawler = 1
 
-/obj/item/clothing/under/contortionist/dropped(mob/living/carbon/human/user, silent = FALSE)
-	if(!user.get_int_organ(/obj/item/organ/internal/heart/gland/ventcrawling))
+/obj/item/clothing/under/contortionist/dropped(mob/living/carbon/human/user, slot, silent = FALSE)
+	if(slot == SLOT_HUD_JUMPSUIT && !user.get_int_organ(/obj/item/organ/internal/heart/gland/ventcrawling))
 		user.ventcrawler = 0
-	..()
+	. = ..()
 
 
 /obj/item/clothing/under/contortionist/proc/check_clothing(mob/user)

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -620,7 +620,7 @@
 	return I
 
 
-/obj/item/cardhand/dropped(mob/user, silent = FALSE)
+/obj/item/cardhand/dropped(mob/user, slot, silent = FALSE)
 	. = ..()
 	if(user)
 		direction = user.dir

--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -185,11 +185,21 @@
 	filling_color = "#FFA500"
 	distill_reagent = "lsd"
 	tastes = list("polygons" = 1, "oranges" = 1)
+	var/big_icon = TRUE
 
-/obj/item/reagent_containers/food/snacks/grown/citrus/orange_3d/pickup(mob/user)
-	. = ..()
-	icon_state = "orange"
 
-/obj/item/reagent_containers/food/snacks/grown/citrus/orange_3d/dropped(mob/user, silent = FALSE)
+/obj/item/reagent_containers/food/snacks/grown/citrus/orange_3d/equipped(mob/user, slot, initial = FALSE)
+	big_icon = TRUE
+	update_icon(UPDATE_ICON_STATE)
 	. = ..()
-	icon_state = "orang"
+
+
+/obj/item/reagent_containers/food/snacks/grown/citrus/orange_3d/dropped(mob/user, slot, silent = FALSE)
+	. = ..()
+	big_icon = FALSE
+	update_icon(UPDATE_ICON_STATE)
+
+
+/obj/item/reagent_containers/food/snacks/grown/citrus/orange_3d/update_icon_state()
+	icon_state = big_icon ? "orang" : "orange"
+

--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -189,14 +189,14 @@
 
 
 /obj/item/reagent_containers/food/snacks/grown/citrus/orange_3d/equipped(mob/user, slot, initial = FALSE)
-	big_icon = TRUE
+	big_icon = FALSE
 	update_icon(UPDATE_ICON_STATE)
 	. = ..()
 
 
 /obj/item/reagent_containers/food/snacks/grown/citrus/orange_3d/dropped(mob/user, slot, silent = FALSE)
 	. = ..()
-	big_icon = FALSE
+	big_icon = TRUE
 	update_icon(UPDATE_ICON_STATE)
 
 

--- a/code/modules/martial_arts/krav_maga.dm
+++ b/code/modules/martial_arts/krav_maga.dm
@@ -152,23 +152,20 @@
 /obj/item/clothing/gloves/color/black/krav_maga/check_item_eat(mob/target, mob/user)
 	return FALSE
 
-/obj/item/clothing/gloves/color/black/krav_maga/equipped(mob/user, slot, initial)
+
+/obj/item/clothing/gloves/color/black/krav_maga/equipped(mob/user, slot, initial = FALSE)
 	. = ..()
+	if(!ishuman(user) || slot != SLOT_HUD_GLOVES)
+		return .
+	style.teach(user, TRUE)
 
-	if(!ishuman(user))
-		return
-	if(slot == SLOT_HUD_GLOVES)
-		var/mob/living/carbon/human/H = user
-		style.teach(H,1)
 
-/obj/item/clothing/gloves/color/black/krav_maga/dropped(mob/user, silent = FALSE)
+/obj/item/clothing/gloves/color/black/krav_maga/dropped(mob/user, slot, silent = FALSE)
 	. = ..()
+	if(!ishuman(user) || slot != SLOT_HUD_GLOVES)
+		return .
+	style.remove(user)
 
-	if(!ishuman(user))
-		return
-	var/mob/living/carbon/human/H = user
-	if(H.get_item_by_slot(SLOT_HUD_GLOVES) == src)
-		style.remove(H)
 
 /obj/item/clothing/gloves/color/black/krav_maga/sec//more obviously named, given to sec
 	name = "krav maga gloves"

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -280,23 +280,20 @@
 /obj/item/clothing/gloves/boxing
 	var/datum/martial_art/boxing/style = new
 
-/obj/item/clothing/gloves/boxing/equipped(mob/user, slot, initial)
+
+/obj/item/clothing/gloves/boxing/equipped(mob/user, slot, initial = FALSE)
 	. = ..()
+	if(!ishuman(user) || slot != SLOT_HUD_GLOVES)
+		return .
+	style.teach(user, TRUE)
 
-	if(!ishuman(user))
-		return
-	if(slot == SLOT_HUD_GLOVES)
-		var/mob/living/carbon/human/H = user
-		style.teach(H, TRUE)
 
-/obj/item/clothing/gloves/boxing/dropped(mob/user, silent = FALSE)
+/obj/item/clothing/gloves/boxing/dropped(mob/user, slot, silent = FALSE)
 	. = ..()
+	if(!ishuman(user) || slot != SLOT_HUD_GLOVES)
+		return .
+	style.remove(user)
 
-	if(!ishuman(user))
-		return
-	var/mob/living/carbon/human/H = user
-	if(H.get_item_by_slot(SLOT_HUD_GLOVES) == src)
-		style.remove(H)
 
 /obj/item/storage/belt/champion/wrestling
 	name = "Wrestling Belt"
@@ -306,28 +303,25 @@
 	name = "Пояс Истинного Чемпиона"
 	desc = "Вы - лучший! и Вы это знаете!"
 
-/obj/item/storage/belt/champion/wrestling/equipped(mob/user, slot, initial)
+
+/obj/item/storage/belt/champion/wrestling/equipped(mob/user, slot, initial = FALSE)
 	. = ..()
+	if(!ishuman(user) || slot != SLOT_HUD_BELT)
+		return .
+	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+		to_chat(user, span_warning("In spite of the grandiosity of the belt, you don't feel like getting into any fights."))
+		return .
+	style.teach(user, TRUE)
+	to_chat(user, span_sciradio("You have an urge to flex your muscles and get into a fight. You have the knowledge of a thousand wrestlers before you. You can remember more by using the show info verb in the martial arts tab."))
 
-	if(!ishuman(user))
-		return
-	if(slot == SLOT_HUD_BELT)
-		var/mob/living/carbon/human/H = user
-		if(HAS_TRAIT(user, TRAIT_PACIFISM))
-			to_chat(user, "<span class='warning'>In spite of the grandiosity of the belt, you don't feel like getting into any fights.</span>")
-			return
-		style.teach(H, TRUE)
-		to_chat(user, "<span class='sciradio'>You have an urge to flex your muscles and get into a fight. You have the knowledge of a thousand wrestlers before you. You can remember more by using the show info verb in the martial arts tab.</span>")
 
-/obj/item/storage/belt/champion/wrestling/dropped(mob/user, silent = FALSE)
+/obj/item/storage/belt/champion/wrestling/dropped(mob/user, slot, silent = FALSE)
 	. = ..()
+	if(!ishuman(user) || slot != SLOT_HUD_BELT)
+		return .
+	style.remove(user)
+	to_chat(user, span_sciradio("You no longer have an urge to flex your muscles."))
 
-	if(!ishuman(user))
-		return
-	var/mob/living/carbon/human/H = user
-	if(H.get_item_by_slot(SLOT_HUD_BELT) == src)
-		style.remove(H)
-		to_chat(user, "<span class='sciradio'>You no longer have an urge to flex your muscles.</span>")
 
 /obj/item/plasma_fist_scroll
 	name = "frayed scroll"

--- a/code/modules/mining/lavaland/loot/hierophant_loot.dm
+++ b/code/modules/mining/lavaland/loot/hierophant_loot.dm
@@ -518,7 +518,7 @@
 		spell_teleport.action.Grant(slave)
 		spell_message.action.Grant(slave)
 
-/obj/item/clothing/accessory/necklace/hierophant_talisman/on_removed(mob/user)
+/obj/item/clothing/accessory/necklace/hierophant_talisman/on_removed(mob/user, silent = FALSE)
 	. = ..()
 	if(!ishuman(user) || !slave)
 		return

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -76,7 +76,7 @@
 	)
 
 	for(var/slot in priority_list)
-		if(equip_to_slot_if_possible(I, slot, FALSE, FALSE, force, force, TRUE))
+		if(equip_to_slot_if_possible(I, slot, FALSE, FALSE, force, force, force, TRUE))
 			return TRUE
 
 	if(drop_on_fail)
@@ -137,7 +137,7 @@
  * Used in job equipping so shit doesn't pile up at the start loc.
  */
 /mob/proc/equip_or_collect(obj/item/I, slot)
-	if(I.mob_can_equip(src, slot, disable_warning = TRUE, bypass_equip_delay_self = TRUE, bypass_obscured = TRUE))
+	if(I.mob_can_equip(src, slot, disable_warning = TRUE, bypass_equip_delay_self = TRUE, bypass_obscured = TRUE, bypass_incapacitated = TRUE))
 		//Mob can equip.  Equip it.
 		equip_to_slot(I, slot, initial = TRUE)
 	else
@@ -158,7 +158,7 @@
  * Used to equip people when the rounds starts and when events happen and such.
  */
 /mob/proc/equip_to_slot_or_del(obj/item/I, slot)
-	return equip_to_slot_if_possible(I, slot, qdel_on_fail = TRUE, bypass_equip_delay_self = TRUE, bypass_obscured = TRUE, disable_warning = TRUE, initial = TRUE)
+	return equip_to_slot_if_possible(I, slot, qdel_on_fail = TRUE, bypass_equip_delay_self = TRUE, bypass_obscured = TRUE, bypass_incapacitated = TRUE, disable_warning = TRUE, initial = TRUE)
 
 
 /**
@@ -171,11 +171,11 @@
  * * 'bypass_obscured' - set `TRUE` if you want to ignore clothing obscuration
  * * 'initial' - used to indicate whether our items is initial equipment (job datums etc) or just a player doing it
  */
-/mob/proc/equip_to_slot_if_possible(obj/item/I, slot, drop_on_fail = FALSE, qdel_on_fail = FALSE, bypass_equip_delay_self = FALSE, bypass_obscured = FALSE, disable_warning = FALSE, initial = FALSE)
+/mob/proc/equip_to_slot_if_possible(obj/item/I, slot, drop_on_fail = FALSE, qdel_on_fail = FALSE, bypass_equip_delay_self = FALSE, bypass_obscured = FALSE, bypass_incapacitated = FALSE, disable_warning = FALSE, initial = FALSE)
 	if(!istype(I) || QDELETED(I)) //This qdeleted is to prevent stupid behavior with things that qdel during init
 		return FALSE
 
-	if(!I.mob_can_equip(src, slot, disable_warning, bypass_equip_delay_self, bypass_obscured))
+	if(!I.mob_can_equip(src, slot, disable_warning, bypass_equip_delay_self, bypass_obscured, bypass_incapacitated))
 		if(drop_on_fail)
 			if(I in get_equipped_items(include_pockets = TRUE, include_hands = TRUE))
 				drop_item_ground(I)
@@ -207,7 +207,7 @@
  * Returns if a certain item can be equipped to a certain slot.
  * Always call [obj/item/mob_can_equip()] instead of this proc.
  */
-/mob/proc/can_equip(obj/item/I, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE, bypass_obscured = FALSE)
+/mob/proc/can_equip(obj/item/I, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE, bypass_obscured = FALSE, bypass_incapacitated = FALSE)
 	return FALSE
 
 
@@ -543,6 +543,8 @@
 	if(!can_unEquip(I, force, silent, newloc, no_move, invdrop))
 		return FALSE
 
+	var/slot = get_slot_by_item(I)
+
 	if(I == r_hand)
 		r_hand = null
 		update_inv_r_hand()
@@ -563,7 +565,7 @@
 				I.move_to_null_space()
 			else
 				I.forceMove(newloc)
-		I.dropped(src, silent)
+		I.dropped(src, slot, silent)
 
 	return TRUE
 

--- a/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
@@ -65,14 +65,14 @@
 	return I.equipped(src, slot, initial)
 
 
-/mob/living/carbon/alien/humanoid/can_equip(obj/item/I, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE, bypass_obscured = FALSE)
+/mob/living/carbon/alien/humanoid/can_equip(obj/item/I, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE, bypass_obscured = FALSE, bypass_incapacitated = FALSE)
 	switch(slot)
 		if(SLOT_HUD_LEFT_HAND)
 			if(l_hand)
 				return FALSE
 			if(!I.allowed_for_alien())
 				return FALSE
-			if(incapacitated())
+			if(!bypass_incapacitated && incapacitated())
 				return FALSE
 			return TRUE
 
@@ -81,7 +81,7 @@
 				return FALSE
 			if(!I.allowed_for_alien())
 				return FALSE
-			if(incapacitated())
+			if(!bypass_incapacitated && incapacitated())
 				return FALSE
 			return TRUE
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -682,12 +682,12 @@
 					if(pocket_item == (pocket_id == SLOT_HUD_RIGHT_STORE ? r_store : l_store)) //item still in the pocket we search
 						if(drop_item_ground(pocket_item))
 							if(thief_mode)
-								usr.put_in_hands(pocket_item)
+								usr.put_in_hands(pocket_item, silent = TRUE)
 							add_attack_logs(usr, src, "Stripped of [pocket_item]")
 				else
 					if(place_item)
-						usr.drop_item_ground(place_item)
-						equip_to_slot_if_possible(place_item, pocket_id, disable_warning = TRUE)
+						usr.drop_item_ground(place_item, silent = thief_mode)
+						equip_to_slot_if_possible(place_item, pocket_id, disable_warning = TRUE, initial = thief_mode)
 						add_attack_logs(usr, src, "Equipped with [place_item]")
 
 				// Update strip window
@@ -727,7 +727,7 @@
 						if(!thief_mode)
 							usr.visible_message("<span class='danger'>\The [usr] takes \the [A] off of \the [src]'s [U]!</span>", \
 												"<span class='danger'>You take \the [A] off of \the [src]'s [U]!</span>")
-						A.on_removed(usr)
+						A.on_removed(usr, thief_mode)
 						U.accessories -= A
 						update_inv_w_uniform()
 
@@ -1307,15 +1307,25 @@
 	if(!(dna.species.bodyflags & HAS_SKIN_TONE))
 		s_tone = 0
 
-	var/list/thing_to_check = list(SLOT_HUD_WEAR_MASK, SLOT_HUD_HEAD, SLOT_HUD_SHOES, SLOT_HUD_GLOVES, SLOT_HUD_LEFT_EAR, SLOT_HUD_RIGHT_EAR, SLOT_HUD_GLASSES, SLOT_HUD_LEFT_HAND, SLOT_HUD_RIGHT_HAND, SLOT_HUD_NECK)
-	var/list/kept_items = list()
-	var/list/item_flags = list()
-	for(var/thing in thing_to_check)
-		var/obj/item/I = get_item_by_slot(thing)
-		if(I)
-			kept_items[I] = thing
-			item_flags[I] = I.flags
-			I.flags = NONE // Temporary set the flags to NONE
+	var/list/slots_to_check = list(
+		"[SLOT_HUD_WEAR_MASK]",
+		"[SLOT_HUD_HEAD]",
+		"[SLOT_HUD_SHOES]",
+		"[SLOT_HUD_GLOVES]",
+		"[SLOT_HUD_LEFT_EAR]",
+		"[SLOT_HUD_RIGHT_EAR]",
+		"[SLOT_HUD_GLASSES]",
+		"[SLOT_HUD_LEFT_HAND]",
+		"[SLOT_HUD_RIGHT_HAND]",
+		"[SLOT_HUD_NECK]",
+	)
+	for(var/slot in slots_to_check)
+		var/obj/item/item = get_item_by_slot(text2num(slot))
+		if(item)
+			var/has_drop_del = item.flags & DROPDEL
+			slots_to_check[slot] = list(item, has_drop_del)
+			if(has_drop_del)			// we are interested only in dropdel flag
+				item.flags &= ~DROPDEL	// to prevent items deletion on limbs regrowth
 
 	if(!transformation) //Distinguish between creating a mob and switching species
 		dna.species.on_species_gain(src)
@@ -1415,15 +1425,18 @@
 	else
 		dna.species.create_organs(src, missing_bodyparts, additional_organs)
 
-	for(var/obj/item/thing in kept_items)
-		var/equipped = equip_to_slot(thing, kept_items[thing], initial = TRUE)	// we can skip [mob_can_equip()] checks here
-		thing.flags = item_flags[thing] // Reset the flags to the original ones
-		if(!equipped)
-			thing.dropped() // Ensures items know they are dropped. Using their original flags
+	for(var/slot in slots_to_check)
+		var/list/item_params = slots_to_check[slot]
+		if(!item_params)
+			continue
+		var/obj/item/item = item_params[1]
+		if(item_params[2])	// has dropdel flag previously
+			item.flags |= DROPDEL
+		equip_to_slot_if_possible(item, text2num(slot), drop_on_fail = TRUE, bypass_equip_delay_self = TRUE, bypass_obscured = TRUE, bypass_incapacitated = TRUE, initial = TRUE)
 
 	//Handle hair/head accessories for created mobs.
 	var/obj/item/organ/external/head/H = get_organ(BODY_ZONE_HEAD)
-	if(save_appearance && old_bodyparts)
+	if(H && save_appearance && old_bodyparts)
 		var/obj/item/organ/external/head/old_head = old_bodyparts[BODY_ZONE_HEAD]
 		if(istype(old_head))
 			if(old_head.h_style)
@@ -1439,7 +1452,7 @@
 			if(old_head.headacc_colour)
 				H.headacc_colour = old_head.headacc_colour
 
-	else if(istype(H))
+	else if(H)
 		if(dna.species.default_hair)
 			H.h_style = dna.species.default_hair
 		else

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -250,8 +250,8 @@
 	update_equipment_speed_mods()
 
 
-/mob/living/carbon/human/can_equip(obj/item/I, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE, bypass_obscured = FALSE)
-	return dna.species.can_equip(I, slot, disable_warning, src, disable_warning, bypass_equip_delay_self, bypass_obscured)
+/mob/living/carbon/human/can_equip(obj/item/I, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE, bypass_obscured = FALSE, bypass_incapacitated = FALSE)
+	return dna.species.can_equip(I, slot, disable_warning, src, disable_warning, bypass_equip_delay_self, bypass_obscured, bypass_incapacitated)
 
 
 /**

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -685,7 +685,7 @@
 	damage = 6
 
 
-/datum/species/proc/can_equip(obj/item/I, slot, disable_warning = FALSE, mob/living/carbon/human/user, bypass_equip_delay_self = FALSE, bypass_obscured = FALSE)
+/datum/species/proc/can_equip(obj/item/I, slot, disable_warning = FALSE, mob/living/carbon/human/user, bypass_equip_delay_self = FALSE, bypass_obscured = FALSE, bypass_incapacitated = FALSE)
 	if(slot in no_equip)
 		if(!I.species_exception || !is_type_in_list(src, I.species_exception))
 			return FALSE
@@ -713,14 +713,14 @@
 		if(SLOT_HUD_LEFT_HAND)
 			if(user.l_hand)
 				return FALSE
-			if(user.incapacitated())
+			if(!bypass_incapacitated && user.incapacitated())
 				return FALSE
 			return TRUE
 
 		if(SLOT_HUD_RIGHT_HAND)
 			if(user.r_hand)
 				return FALSE
-			if(user.incapacitated())
+			if(!bypass_incapacitated && user.incapacitated())
 				return FALSE
 			return TRUE
 

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -380,7 +380,7 @@
 		I.pixel_y = initial(I.pixel_y)
 		I.layer = initial(I.layer)
 		I.plane = initial(I.plane)
-		I.dropped(src, silent)
+		I.dropped(src, null, silent)
 		return TRUE
 
 	// If the item is a stack and we're already holding a stack then merge
@@ -419,7 +419,7 @@
 	I.forceMove(drop_location())
 	I.layer = initial(I.layer)
 	I.plane = initial(I.plane)
-	I.dropped(src, silent)
+	I.dropped(src, null, silent)
 
 	return FALSE
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1114,7 +1114,7 @@
 		if(what && what == who.get_item_by_slot(where) && Adjacent(who))
 			if(!who.drop_item_ground(what, silent = silent))
 				return
-			if(silent)
+			if(silent && !QDELETED(what) && isturf(what.loc))
 				put_in_hands(what, silent = TRUE)
 			add_attack_logs(src, who, "Stripped of [what]")
 

--- a/code/modules/mob/living/simple_animal/friendly/diona.dm
+++ b/code/modules/mob/living/simple_animal/friendly/diona.dm
@@ -277,7 +277,7 @@
 	I.pixel_y = initial(I.pixel_y)
 	I.layer = initial(I.layer)
 	I.plane = initial(I.plane)
-	I.dropped()
+	I.dropped(src, null, silent)
 
 
 /mob/living/simple_animal/diona/put_in_active_hand(obj/item/I, force = FALSE, ignore_anim = TRUE)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -130,22 +130,22 @@ Difficulty: Medium
 		user.Slowed(20 SECONDS)
 		user.Dizzy(20 SECONDS)
 
-/obj/item/clothing/suit/hooded/explorer/blood/equipped(mob/living/carbon/human/user, slot, initial)
-	. = ..()
-	if(!ishuman(user))
-		return
-	if(slot == SLOT_HUD_OUTER_SUIT)
-		LAZYADD(user.mob_spell_list, blood_spell)
-		blood_spell.action.Grant(user)
 
-/obj/item/clothing/suit/hooded/explorer/blood/dropped(mob/living/carbon/human/user)
+/obj/item/clothing/suit/hooded/explorer/blood/equipped(mob/living/carbon/human/user, slot, initial = FALSE)
 	. = ..()
+	if(!ishuman(user) || slot != SLOT_HUD_OUTER_SUIT)
+		return .
+	LAZYADD(user.mob_spell_list, blood_spell)
+	blood_spell.action.Grant(user)
 
-	if(!ishuman(user))
-		return
-	if(user.get_item_by_slot(SLOT_HUD_OUTER_SUIT) == src)
-		LAZYREMOVE(user.mob_spell_list, blood_spell)
-		blood_spell.action.Remove(user)
+
+/obj/item/clothing/suit/hooded/explorer/blood/dropped(mob/living/carbon/human/user, slot, silent = FALSE)
+	. = ..()
+	if(!ishuman(user) || slot != SLOT_HUD_OUTER_SUIT)
+		return .
+	LAZYREMOVE(user.mob_spell_list, blood_spell)
+	blood_spell.action.Remove(user)
+
 
 /mob/living/simple_animal/hostile/megafauna/blood_drunk_miner/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/pandora.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/pandora.dm
@@ -222,7 +222,7 @@
 		var/mob/living/M = user
 		M.apply_status_effect(STATUS_EFFECT_HOPE)
 
-/obj/item/clothing/accessory/necklace/pandora_hope/on_removed(mob/user)
+/obj/item/clothing/accessory/necklace/pandora_hope/on_removed(mob/user, silent = FALSE)
 	. = ..()
 	if(isliving(user))
 		var/mob/living/M = user

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -532,7 +532,7 @@
 			return pcollar
 	. = ..()
 
-/mob/living/simple_animal/can_equip(obj/item/I, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE, bypass_obscured = FALSE)
+/mob/living/simple_animal/can_equip(obj/item/I, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE, bypass_obscured = FALSE, bypass_incapacitated = FALSE)
 	// . = ..() // Do not call parent. We do not want animals using their hand slots.
 	switch(slot)
 		if(SLOT_HUD_COLLAR)

--- a/code/modules/mob/living/simple_animal/tribbles.dm
+++ b/code/modules/mob/living/simple_animal/tribbles.dm
@@ -102,7 +102,7 @@ GLOBAL_VAR_INIT(totaltribbles, 0)   //global variable so it updates for all trib
 	..()
 	to_chat(user, "<span class='notice'>You nuzzle the tribble and it trills softly.</span>")
 
-/obj/item/toy/tribble/dropped(mob/user, silent = FALSE) //now you can't item form them to get rid of them all so easily
+/obj/item/toy/tribble/dropped(mob/user, slot, silent = FALSE) //now you can't item form them to get rid of them all so easily
 	new /mob/living/simple_animal/tribble(user.loc)
 	for(var/mob/living/simple_animal/tribble/T in user.loc)
 		T.icon_state = src.icon_state

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -611,11 +611,10 @@ GLOBAL_LIST_INIT(SpookyGhosts, list("ghost","shade","shade2","ghost-narsie","hor
 	camera_state(user)
 
 
-/obj/item/videocam/dropped(mob/user, silent = FALSE)
+/obj/item/videocam/dropped(mob/user, slot, silent = FALSE)
 	. = ..()
-	if(!on)
-		return
-	camera_state()
+	if(on)
+		camera_state()
 
 
 /obj/item/videocam/examine(mob/user)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -500,9 +500,9 @@
 		visible_message(span_danger("[src]'s light fades and turns off."))
 
 
-/obj/item/gun/dropped(mob/user, silent = FALSE)
-	..()
-	zoom(user,FALSE)
+/obj/item/gun/dropped(mob/user, slot, silent = FALSE)
+	. = ..()
+	zoom(user, FALSE)
 	if(azoom)
 		azoom.Remove(user)
 

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -152,7 +152,7 @@
 		attempt_reload()
 
 
-/obj/item/gun/energy/kinetic_accelerator/dropped(mob/user, silent = FALSE)
+/obj/item/gun/energy/kinetic_accelerator/dropped(mob/user, slot, silent = FALSE)
 	. = ..()
 	if(!QDELING(src) && !holds_charge)
 		// Put it on a delay because moving item from slot to hand calls `dropped()`.

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -739,7 +739,7 @@
 	update_icon()
 
 
-/obj/item/gun/energy/dominator/dropped(mob/user, silent = FALSE)
+/obj/item/gun/energy/dominator/dropped(mob/user, slot, silent = FALSE)
 	. = ..()
 	update_icon()
 

--- a/code/modules/projectiles/guns/medbeam.dm
+++ b/code/modules/projectiles/guns/medbeam.dm
@@ -31,7 +31,7 @@
 	return
 
 
-/obj/item/gun/medbeam/dropped(mob/user, silent = FALSE)
+/obj/item/gun/medbeam/dropped(mob/user, slot, silent = FALSE)
 	. = ..()
 	LoseTarget()
 

--- a/code/modules/projectiles/guns/projectile/bow.dm
+++ b/code/modules/projectiles/guns/projectile/bow.dm
@@ -43,7 +43,7 @@
 	slowdown = ready_to_fire ? slowdown_when_ready : initial(slowdown)
 
 
-/obj/item/gun/projectile/bow/dropped(mob/user, silent = FALSE)
+/obj/item/gun/projectile/bow/dropped(mob/user, slot, silent = FALSE)
 	if(magazine && magazine.ammo_count())
 		magazine.empty_magazine()
 		ready_to_fire = FALSE

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -260,8 +260,8 @@
 	bolt_open = 1
 	pump()
 
-/obj/item/gun/projectile/shotgun/boltaction/enchanted/dropped(mob/user, silent = FALSE)
-	..()
+/obj/item/gun/projectile/shotgun/boltaction/enchanted/dropped(mob/user, slot, silent = FALSE)
+	. = ..()
 	guns_left = 0
 
 /obj/item/gun/projectile/shotgun/boltaction/enchanted/attack_self()

--- a/code/modules/reagents/reagent_containers/iv_bag.dm
+++ b/code/modules/reagents/reagent_containers/iv_bag.dm
@@ -28,12 +28,12 @@
 /obj/item/reagent_containers/iv_bag/on_reagent_change()
 	update_icon(UPDATE_OVERLAYS)
 
-/obj/item/reagent_containers/iv_bag/pickup(mob/user)
+/obj/item/reagent_containers/iv_bag/equipped(mob/user, slot, initial = FALSE)
 	. = ..()
 	update_icon(UPDATE_OVERLAYS)
 
-/obj/item/reagent_containers/iv_bag/dropped(mob/user, silent = FALSE)
-	..()
+/obj/item/reagent_containers/iv_bag/dropped(mob/user, slot, silent = FALSE)
+	. = ..()
 	update_icon(UPDATE_OVERLAYS)
 
 /obj/item/reagent_containers/iv_bag/attack_self(mob/user)

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -31,12 +31,12 @@
 /obj/item/reagent_containers/syringe/on_reagent_change()
 	update_icon()
 
-/obj/item/reagent_containers/syringe/pickup(mob/user)
+/obj/item/reagent_containers/syringe/equipped(mob/user, slot, initial = FALSE)
 	. = ..()
 	update_icon()
 
-/obj/item/reagent_containers/syringe/dropped(mob/user, silent = FALSE)
-	..()
+/obj/item/reagent_containers/syringe/dropped(mob/user, slot, silent = FALSE)
+	. = ..()
 	update_icon()
 
 /obj/item/reagent_containers/syringe/attack_self(mob/user)


### PR DESCRIPTION
## Описание
Небольшой рефактор прока dropped(). Теперь в него будет передаваться слот предмета, по аналогии с equipped(), что довольно удобно, если нам необходима информация откуда именно выпал предмет.

Также починил свет хардсьютов и добавил проверку на перчатки вора, при снимании аксессуаров - теперь данные действия будут полностью беззвучны.

Ну и последнее - добавил в прок equip_to_slot_if_possible() аргумент-флаг, позволяющий игнорировать статус incapacitated() у моба, при надевании предметов.