### PR TITLE
tweak: Unnecessary Lights Removed

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -246,7 +246,7 @@
 	if(!firedoors)
 		return
 	firedoors_last_closed_on = world.time
-	for(var/obj/machinery/door/firedoor/firedoor in firedoors)
+	for(var/obj/machinery/door/firedoor/firedoor as anything in firedoors)
 		if(!firedoor.is_operational())
 			continue
 		var/valid = TRUE
@@ -285,9 +285,6 @@
 	if(!fire)
 		set_fire_alarm_effect()
 		ModifyFiredoors(FALSE)
-		for(var/item in firealarms)
-			var/obj/machinery/firealarm/F = item
-			F.update_icon()
 
 	for(var/thing in cameras)
 		var/obj/machinery/camera/C = locateUID(thing)
@@ -310,9 +307,6 @@
 	if(fire)
 		unset_fire_alarm_effects()
 		ModifyFiredoors(TRUE)
-		for(var/item in firealarms)
-			var/obj/machinery/firealarm/F = item
-			F.update_icon()
 
 	for(var/thing in cameras)
 		var/obj/machinery/camera/C = locateUID(thing)
@@ -371,7 +365,8 @@
 	fire = TRUE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	for(var/obj/machinery/firealarm/alarm as anything in firealarms)
-		alarm.update_fire_light(fire)
+		alarm.update_fire_light()
+		alarm.update_icon()
 	if(area_emergency_mode) //Fires are not legally allowed if the power is off
 		return
 	for(var/obj/machinery/light/light as anything in lights_cache)
@@ -383,7 +378,8 @@
 	fire = FALSE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	for(var/obj/machinery/firealarm/alarm as anything in firealarms)
-		alarm.update_fire_light(fire)
+		alarm.update_fire_light()
+		alarm.update_icon()
 	if(area_emergency_mode) //The lights stay red until the crisis is resolved
 		return
 	for(var/obj/machinery/light/light as anything in lights_cache)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -42,9 +42,6 @@ GLOBAL_VAR(bomb_set)
 	///How many sheets of various metals we need to fix it
 	var/sheets_to_fix = 5
 
-	light_system = MOVABLE_LIGHT
-	light_power = LIGHTING_MINIMUM_POWER
-	light_range = 1
 
 /obj/machinery/nuclearbomb/syndicate
 	is_syndicate = TRUE
@@ -120,10 +117,7 @@ GLOBAL_VAR(bomb_set)
 		. += mutable_appearance(icon, "npanel_open")
 
 	if(!lighthack)
-		set_light_on(TRUE)
 		underlays += emissive_appearance(icon, "nuclearbomb_lightmask")
-	else if(light)
-		set_light_on(FALSE)
 
 
 /obj/machinery/nuclearbomb/process()

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -235,13 +235,15 @@
 	GLOB.air_alarm_repository.update_cache(src)
 
 /obj/machinery/alarm/Initialize()
-	..()
+	. = ..()
 	set_frequency(frequency)
 	if(is_taipan(z)) // Синдидоступ при сборке на тайпане
 		req_access = list(ACCESS_SYNDICATE)
 
 	if(!master_is_operating())
 		elect_master()
+
+	update_icon()
 
 /obj/machinery/alarm/proc/master_is_operating()
 	if(!alarm_area)
@@ -1069,12 +1071,9 @@
 
 
 /obj/machinery/alarm/power_change(forced = FALSE)
-	..() //we don't check return here because we also care about the BROKEN flag
-	if(stat & NOPOWER)
-		set_light_on(FALSE)
-	else
-		set_light(1, LIGHTING_MINIMUM_POWER)
-	update_icon()
+	. = ..()
+	if(.)
+		update_icon()
 
 
 /obj/machinery/alarm/obj_break(damage_flag)

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -33,7 +33,7 @@
 	return TRUE
 
 /obj/machinery/computer/extinguish_light(force = FALSE)
-	if(light_range)
+	if(light_on)
 		set_light_on(FALSE)
 		underlays.Cut()
 		visible_message(span_danger("[src] grows dim, its screen barely readable."))
@@ -91,7 +91,7 @@
 	else
 		if(icon_screen)
 			. += "[icon_screen]"
-		if(light)
+		if(light_on)
 			underlays += emissive_appearance(icon, "[icon_state]_lightmask")
 
 	if(icon_keyboard && abductor)

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -46,7 +46,7 @@
 	var/datum/track/T = new /datum/track(name, file, length, beat)
 	songs += T
 
-/obj/machinery/disco/New()
+/obj/machinery/disco/Initialize(mapload)
 	. = ..()
 	selection = songs[1]
 
@@ -137,7 +137,6 @@
 					return
 				active = TRUE
 				update_icon()
-				set_light(1, LIGHTING_MINIMUM_POWER) //for emmisive appearance
 				dance_setup()
 				START_PROCESSING(SSobj, src)
 				lights_spin()
@@ -491,7 +490,6 @@
 		dance_over()
 		playsound(src,'sound/machines/terminal_off.ogg',50,1)
 		update_icon()
-		set_light_on(FALSE)
 		stop = world.time + 100
 
 

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -42,13 +42,12 @@
 
 /obj/machinery/door_control/Initialize(mapload, direction = null, building = FALSE)
 	. = ..()
-	power_change(forced = TRUE)
 	if(building)
 		open = TRUE
 		constructed = TRUE
 		setDir(direction)
 		set_pixel_offsets_from_dir(26, -26, 26, -26)
-		update_icon(UPDATE_ICON_STATE|UPDATE_OVERLAYS)
+	update_icon()
 
 
 /obj/machinery/door_control/attack_ai(mob/user)
@@ -120,7 +119,7 @@
 		SCREWDRIVER_CLOSE_PANEL_MESSAGE
 		open = FALSE
 		update_access()
-		update_icon(UPDATE_ICON_STATE|UPDATE_OVERLAYS)
+		update_icon()
 		return
 
 	// Open the panel
@@ -132,7 +131,7 @@
 	SCREWDRIVER_OPEN_PANEL_MESSAGE
 	open = TRUE
 	constructed = TRUE
-	update_icon(UPDATE_ICON_STATE|UPDATE_OVERLAYS)
+	update_icon()
 
 /obj/machinery/door_control/wrench_act(mob/living/user, obj/item/I)
 	if(!open)
@@ -261,13 +260,9 @@
 
 
 /obj/machinery/door_control/power_change(forced = FALSE)
-	if(!..())
-		return
-	if(stat & NOPOWER)
-		set_light_on(FALSE)
-	else
-		set_light(1, LIGHTING_MINIMUM_POWER)
-	update_icon()
+	. = ..()
+	if(.)
+		update_icon()
 
 
 /obj/machinery/door_control/update_icon_state()
@@ -294,7 +289,7 @@
 		else if(device)
 			. += "doorctrl-overlay-device"
 
-	if(stat & NOPOWER)
+	if(open || (stat & NOPOWER))
 		return
 
 	underlays += emissive_appearance(icon, "[base_icon_state]_lightmask")

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -9,8 +9,12 @@
 	desc = "A convenable firelock. Equipped with a manual lever for operating in case of emergency."
 	icon = 'icons/obj/doors/doorfireglass.dmi'
 	icon_state = "door_open"
-	opacity = 0
+	opacity = FALSE
 	density = FALSE
+	light_on = FALSE
+	light_range = 1.4
+	light_power = 0.3
+	light_color = COLOR_RED_LIGHT
 	max_integrity = 300
 	resistance_flags = FIRE_PROOF
 	heat_proof = TRUE
@@ -32,9 +36,11 @@
 	var/active_alarm = FALSE
 	var/list/affecting_areas
 
+
 /obj/machinery/door/firedoor/Initialize(mapload)
 	. = ..()
 	CalculateAffectingAreas()
+
 
 /obj/machinery/door/firedoor/examine(mob/user)
 	. = ..()
@@ -85,14 +91,13 @@
 	if(stat & (NOPOWER|BROKEN))
 		set_light_on(FALSE)
 		return
-	if(active_alarm)
-		set_light(1, 0.5, COLOR_RED_LIGHT, l_on = TRUE)
-	else
-		set_light(1, LIGHTING_MINIMUM_POWER, l_on = TRUE)
+	set_light_on(active_alarm)
+
 
 /obj/machinery/door/firedoor/extinguish_light(force = FALSE)
-	set_light_on(FALSE)
-	update_icon(UPDATE_OVERLAYS)
+	if(light_on)
+		set_light_on(FALSE)
+		update_icon(UPDATE_OVERLAYS)
 
 
 /obj/machinery/door/firedoor/power_change(forced = FALSE)
@@ -232,7 +237,7 @@
 	if(welded)
 		. += "welded[density ? "" : "_open"]"
 	if(active_alarm && hasPower())
-		if(light)
+		if(light_on)
 			. += emissive_appearance('icons/obj/doors/doorfire.dmi', "alarmlights_lightmask")
 		. += image('icons/obj/doors/doorfire.dmi', "alarmlights")
 

--- a/code/game/machinery/dye_generator.dm
+++ b/code/game/machinery/dye_generator.dm
@@ -7,7 +7,7 @@
 	anchored = TRUE
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 40
-	var/dye_color = "#FFFFFF"
+	light_range = 2
 
 
 /obj/machinery/dye_generator/Initialize(mapload)
@@ -43,16 +43,13 @@
 
 /obj/machinery/dye_generator/power_change(forced = FALSE)
 	. = ..()
-	if(stat & NOPOWER)
-		set_light_on(FALSE)
-	else
-		set_light(1, LIGHTING_MINIMUM_POWER, dye_color)
 	if(.)
+		set_light_on(!(stat & NOPOWER))
 		update_icon(UPDATE_OVERLAYS)
 
 
 /obj/machinery/dye_generator/extinguish_light(force = FALSE)
-	if(light)
+	if(light_on)
 		set_light_on(FALSE)
 		underlays.Cut()
 
@@ -61,9 +58,10 @@
 	..()
 	if(stat & (BROKEN|NOPOWER))
 		return
-	var/temp = input(usr, "Choose a dye color", "Dye Color") as color
-	dye_color = temp
-	set_light(1, LIGHTING_MINIMUM_POWER, temp)
+	var/temp = input(usr, "Choose a dye color", "Dye Color") as color|null
+	if(!temp)
+		return
+	set_light_color(temp)
 
 
 /obj/machinery/dye_generator/attackby(obj/item/I, mob/user, params)
@@ -76,7 +74,7 @@
 		add_fingerprint(user)
 		var/obj/item/hair_dye_bottle/HD = I
 		user.visible_message(span_notice("[user] fills the [HD] up with some dye."),span_notice("You fill the [HD] up with some hair dye."))
-		HD.dye_color = dye_color
+		HD.dye_color = light_color
 		HD.update_icon(UPDATE_OVERLAYS)
 		return
 	return ..()

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -23,10 +23,6 @@ GLOBAL_LIST_EMPTY(firealarms)
 	power_channel = ENVIRON
 	resistance_flags = FIRE_PROOF
 
-	light_power = LIGHTING_MINIMUM_POWER
-	light_range = 7
-	light_color = "#ff3232"
-
 	var/buildstage = FIRE_ALARM_READY
 	var/wiresexposed = FALSE
 	var/detecting = TRUE
@@ -52,7 +48,7 @@ GLOBAL_LIST_EMPTY(firealarms)
 
 	myArea = get_area(src)
 	LAZYADD(myArea.firealarms, src)
-	set_light(1, LIGHTING_MINIMUM_POWER) //for emissives
+	update_fire_light()
 	update_icon()
 
 
@@ -256,27 +252,27 @@ GLOBAL_LIST_EMPTY(firealarms)
 		new /obj/item/stack/cable_coil(loc, 3)
 	qdel(src)
 
-/obj/machinery/firealarm/proc/update_fire_light(fire)
+
+/obj/machinery/firealarm/proc/update_fire_light()
 	if(stat & NOPOWER)
 		set_light_on(FALSE)
 		return
-	else if(GLOB.security_level == SEC_LEVEL_EPSILON)
-		set_light(2, 1, COLOR_WHITE)
-		return
-	else if(fire == !!light_power || fire == !!(light_power - 0.1))
-		return  // do nothing if we're already active
 
-	if(fire)
-		set_light(l_power = 0.8)
+	if(GLOB.security_level == SEC_LEVEL_EPSILON)
+		set_light(2, 1, COLOR_WHITE, TRUE)
+		return
+
+	if(myArea?.fire)
+		set_light(3, 1, "#ff3232", TRUE)
 	else
-		set_light(l_power = LIGHTING_MINIMUM_POWER)
+		set_light_on(FALSE)
 
 
-/obj/machinery/firealarm/power_change()
-	if(!..())
-		return
-	update_fire_light()
-	update_icon()
+/obj/machinery/firealarm/power_change(forced = FALSE)
+	. = ..()
+	if(.)
+		update_fire_light()
+		update_icon()
 
 
 /obj/machinery/firealarm/attack_hand(mob/user)

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -39,13 +39,9 @@
 
 
 /obj/machinery/flasher/power_change(forced = FALSE)
-	if(!..())
-		return
-	if(stat & NOPOWER)
-		set_light_on(FALSE)
-	else
-		set_light(1, LIGHTING_MINIMUM_POWER)
-	update_icon()
+	. = ..()
+	if(.)
+		update_icon()
 
 
 /obj/machinery/flasher/update_icon_state()

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -46,6 +46,8 @@ GLOBAL_LIST_EMPTY(holopads)
 	layer = HOLOPAD_LAYER //Preventing mice and drones from sneaking under them.
 	plane = FLOOR_PLANE
 	max_integrity = 300
+	light_on = FALSE
+	light_range = 2
 	armor = list(melee = 50, bullet = 20, laser = 20, energy = 20, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 0)
 	var/list/masters = list()//List of living mobs that use the holopad
 	var/list/holorays = list()//Holoray-mob link.
@@ -90,8 +92,6 @@ GLOBAL_LIST_EMPTY(holopads)
 		if(outgoing_call)
 			outgoing_call.ConnectionFailure(src)
 		set_light_on(FALSE)
-	else
-		set_light(1, LIGHTING_MINIMUM_POWER, l_on = TRUE)
 	update_icon(UPDATE_OVERLAYS)
 
 
@@ -323,7 +323,7 @@ GLOBAL_LIST_EMPTY(holopads)
 				playsound(src, 'sound/machines/twobeep.ogg', 100)	//bring, bring!
 				ringing = TRUE
 
-	update_icon(UPDATE_ICON_STATE)
+	update_icon()
 
 
 //Try to transfer hologram to another pad that can project on T
@@ -437,7 +437,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	use_power = total_users > 0 ? ACTIVE_POWER_USE : IDLE_POWER_USE
 	active_power_usage = HOLOPAD_PASSIVE_POWER_USAGE + (HOLOGRAM_POWER_USAGE * total_users)
 	if(total_users)
-		set_light(2, l_on = TRUE)
+		set_light_on(TRUE)
 	else
 		set_light_on(FALSE)
 	update_icon()

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -42,7 +42,6 @@
 		name = "light switch([area.name])"
 
 	on = area.lightswitch
-	light_switch_light()
 	update_icon()
 
 
@@ -57,13 +56,6 @@
 		SSradio.remove_object(src, frequency)
 	radio_connection = null
 	return ..()
-
-
-/obj/machinery/light_switch/proc/light_switch_light()
-	if(stat & (NOPOWER|BROKEN))
-		set_light_on(FALSE)
-		return
-	set_light(1, LIGHTING_MINIMUM_POWER, on ? COLOR_APC_GREEN : COLOR_APC_RED, TRUE)
 
 
 /obj/machinery/light_switch/update_icon_state()
@@ -96,7 +88,6 @@
 	playsound(src, 'sound/machines/lightswitch.ogg', 10, TRUE)
 	add_fingerprint(user)
 	on = !on
-	light_switch_light()
 	update_icon()
 
 
@@ -108,9 +99,8 @@
 		handle_output()
 
 	if(light_connect)
-		for(var/obj/machinery/light_switch/light_switch in area.machinery_cache)
+		for(var/obj/machinery/light_switch/light_switch in (area.machinery_cache - src))
 			light_switch.on = on
-			light_switch.light_switch_light()
 			light_switch.update_icon()
 		area?.power_change()
 
@@ -148,8 +138,6 @@
 /obj/machinery/light_switch/power_change(forced = FALSE)
 	if(!..() || !otherarea)
 		return
-
-	light_switch_light()
 	update_icon()
 
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -602,5 +602,5 @@ Class Procs:
 
 
 /obj/machinery/extinguish_light(force = FALSE)
-	if(light_range)
-		remove_light()
+	if(light_on)
+		set_light_on(FALSE)

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -28,6 +28,7 @@
 	component_parts += new /obj/item/circuitboard/recharger(null)
 	component_parts += new /obj/item/stock_parts/capacitor(null)
 	RefreshParts()
+	update_icon()
 
 
 /obj/machinery/recharger/RefreshParts()
@@ -159,14 +160,11 @@
 			B.cell.charge = 0
 	..(severity)
 
+
 /obj/machinery/recharger/power_change(forced = FALSE)
-	if(!..())
-		return
-	if(stat & NOPOWER)
-		set_light_on(FALSE)
-	else
-		set_light(1, LIGHTING_MINIMUM_POWER, l_on = TRUE)
-	update_icon()
+	. = ..()
+	if(.)
+		update_icon()
 
 
 /obj/machinery/recharger/update_icon_state()

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -125,13 +125,9 @@ GLOBAL_LIST_EMPTY(allRequestConsoles)
 
 
 /obj/machinery/requests_console/power_change(forced = FALSE)
-	if(!..())
-		return
-	if(stat & NOPOWER)
-		set_light_on(FALSE)
-	else
-		set_light(1, LIGHTING_MINIMUM_POWER, l_on = TRUE)
-	update_icon(UPDATE_OVERLAYS)
+	. = ..()
+	if(.)
+		update_icon(UPDATE_OVERLAYS)
 
 
 /obj/machinery/requests_console/update_overlays()

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -255,9 +255,8 @@ GLOBAL_LIST_INIT(statdisp_picture_colors, list(
 
 
 /obj/machinery/status_display/proc/update_display_light()
-	if(light)
-		set_light_on(FALSE)
 	if(stat & (NOPOWER|BROKEN))
+		set_light_on(FALSE)
 		return
 
 	if(mode == STATUS_DISPLAY_ALERT)
@@ -302,21 +301,16 @@ GLOBAL_LIST_EMPTY(ai_displays)
 
 
 /obj/machinery/ai_status_display/emp_act(severity)
-	if(stat & (BROKEN|NOPOWER))
-		..(severity)
-		return
-	mode = AI_DISPLAY_MODE_BSOD
-	update_icon()
+	if(!(stat & (BROKEN|NOPOWER)))
+		mode = AI_DISPLAY_MODE_BSOD
+	update_icon(UPDATE_OVERLAYS)
 	..(severity)
 
 
 /obj/machinery/ai_status_display/power_change(forced = FALSE)
-	if(!..())
-		return
-	if(stat & NOPOWER)
-		set_light_on(FALSE)
-	else
-		set_light(1, LIGHTING_MINIMUM_POWER, GLOB.statdisp_picture_colors[picture_state], l_on = TRUE)
+	. = ..()
+	if(.)
+		update_icon(UPDATE_OVERLAYS)
 
 
 /obj/machinery/ai_status_display/flicker()
@@ -324,7 +318,7 @@ GLOBAL_LIST_EMPTY(ai_displays)
 		return FALSE
 
 	emotion = "Tribunal Malf"
-	update_icon()
+	update_icon(UPDATE_OVERLAYS)
 	return TRUE
 
 

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -322,10 +322,14 @@
 	var/accurate = FALSE
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 10
+	light_range = 2
+	light_color = "#f1f1bd"
+	light_on = FALSE
 	active_power_usage = 2000
 	var/obj/machinery/teleport/station/power_station
 	var/calibrated //Calibration prevents mutation
 	var/admin_usage = FALSE // if 1, works on z2. If 0, doesn't. Used for admin room teleport.
+
 
 /obj/machinery/teleport/hub/New()
 	..()
@@ -347,6 +351,7 @@
 /obj/machinery/teleport/hub/Initialize()
 	..()
 	link_power_station()
+	update_icon()
 
 /obj/machinery/teleport/hub/Destroy()
 	if(power_station)
@@ -433,9 +438,16 @@
 		underlays += emissive_appearance(icon, "tele1_lightmask")
 
 
+/obj/machinery/teleport/hub/power_change(forced = FALSE)
+	. = ..()
+	if(.)
+		update_lighting()
+		update_icon(UPDATE_OVERLAYS)
+
+
 /obj/machinery/teleport/hub/proc/update_lighting()
 	if(power_station && power_station.engaged && !panel_open)
-		set_light(2, 1, "#f1f1bd", l_on = TRUE)
+		set_light_on(TRUE)
 	else
 		set_light_on(FALSE)
 
@@ -571,11 +583,13 @@
 	component_parts += new /obj/item/stock_parts/capacitor(null)
 	component_parts += new /obj/item/stack/sheet/glass(null)
 	RefreshParts()
-	link_console_and_hub()
 
-/obj/machinery/teleport/station/Initialize()
-	..()
+
+/obj/machinery/teleport/station/Initialize(mapload)
+	. = ..()
 	link_console_and_hub()
+	update_icon()
+
 
 /obj/machinery/teleport/station/RefreshParts()
 	var/E
@@ -684,19 +698,9 @@
 
 
 /obj/machinery/teleport/station/power_change(forced = FALSE)
-	if(!..())
-		return
-
-	if(stat & NOPOWER)
-		set_light_on(FALSE)
-	else
-		set_light(1, LIGHTING_MINIMUM_POWER, l_on = TRUE)
-
-	update_icon()
-
-	if(teleporter_hub)
-		teleporter_hub.update_icon()
-		teleporter_hub.update_lighting()
+	. = ..()
+	if(.)
+		update_icon()
 
 
 /obj/machinery/teleport/station/update_icon_state()

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -251,7 +251,7 @@
 
 
 /obj/machinery/vending/extinguish_light(force = FALSE)
-	if(light)
+	if(light_on)
 		set_light_on(FALSE)
 		underlays.Cut()
 

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -45,7 +45,6 @@
 
 	creation_mob_ckey = creation_mob?.ckey
 
-	set_light(1, LIGHTING_MINIMUM_POWER, l_on = TRUE)
 	update_icon(UPDATE_OVERLAYS)
 
 	for(var/obj/effect/portal/other_portal in loc)

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -227,10 +227,8 @@
 	if(!current_area)
 		return
 	if(on)
-		set_light(1, LIGHTING_MINIMUM_POWER)
 		RegisterSignal(current_area, COMSIG_AREA_POWER_CHANGE, PROC_REF(AreaPowerCheck))
 	else
-		set_light(0)
 		UnregisterSignal(current_area, COMSIG_AREA_POWER_CHANGE)
 
 /**
@@ -245,10 +243,8 @@
 	var/area/current_area = get_area(src)
 	if(!current_area)
 		on = FALSE
-		set_light_on(FALSE)
 	else
 		on = current_area.powered(EQUIP) // set "on" to the equipment power status of our area.
-		set_light(1, LIGHTING_MINIMUM_POWER, l_on = TRUE)
 	update_icon()
 
 /obj/item/intercom_electronics

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -261,8 +261,8 @@
 
 
 /obj/structure/extinguish_light(force = FALSE)
-	if(light_range)
-		set_light(0, 0)
+	if(light_on)
+		set_light_on(FALSE)
 		name = "dimmed [name]"
 		desc = "Something shadowy moves to cover the object. Perhaps shining a light will force it to clear?"
 		extinguish_timer_id = addtimer(CALLBACK(src, PROC_REF(extinguish_light_check)), 2 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_LOOP|TIMER_DELETE_ME|TIMER_STOPPABLE)
@@ -282,7 +282,7 @@
 
 /obj/structure/proc/reset_light()
 	light_process = 0
-	set_light(initial(light_range), initial(light_power))
+	set_light_on(TRUE)
 	name = initial(name)
 	desc = initial(desc)
 	deltimer(extinguish_timer_id)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -41,8 +41,7 @@
 
 /obj/structure/morgue/Initialize(mapload)
 	. = ..()
-	update_icon(update_state())
-	set_light(1, LIGHTING_MINIMUM_POWER)
+	update_state()
 
 
 /obj/structure/morgue/Destroy()
@@ -106,7 +105,7 @@
 			return update_icon(UPDATE_OVERLAYS)
 
 	status = UNREVIVABLE
-	update_icon(UPDATE_OVERLAYS)
+	return update_icon(UPDATE_OVERLAYS)
 
 
 /obj/structure/morgue/update_overlays()
@@ -397,11 +396,6 @@ GLOBAL_LIST_EMPTY(crematoriums)
 /obj/machinery/crematorium/update_overlays()
 	. = ..()
 	underlays.Cut()
-	if(cremating)
-		set_light(1, LIGHTING_MINIMUM_POWER, l_on = TRUE)
-		underlays += emissive_appearance(icon, "crema_active_lightmask")
-	else
-		set_light_on(FALSE)
 
 	if(connected)
 		return
@@ -410,6 +404,7 @@ GLOBAL_LIST_EMPTY(crematoriums)
 
 	if(cremating)
 		. += "crema_active"
+		underlays += emissive_appearance(icon, "crema_active_lightmask")
 		return
 
 	if(length(contents))

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -14,7 +14,6 @@
 	. = ..()
 	if(does_emissive)
 		update_icon(UPDATE_OVERLAYS)
-		set_light(1, LIGHTING_MINIMUM_POWER)
 
 
 /obj/structure/sign/update_overlays()

--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -40,7 +40,7 @@ log transactions
 	machine_id = "[station_name()] RT #[GLOB.num_financial_terminals++]"
 
 /obj/machinery/atm/Initialize()
-	..()
+	. = ..()
 	reconnect_database()
 	update_icon()
 
@@ -91,13 +91,9 @@ log transactions
 
 
 /obj/machinery/atm/power_change(forced = FALSE)
-	if(!..())
-		return
-	if(stat & NOPOWER)
-		set_light_on(FALSE)
-	else
-		set_light(1, LIGHTING_MINIMUM_POWER)
-	update_icon()
+	. = ..()
+	if(.)
+		update_icon()
 
 
 /obj/machinery/atm/update_overlays()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -993,7 +993,7 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 
 	for(var/obj/machinery/ai_status_display/display as anything in GLOB.ai_displays) //change status
 		display.emotion = emote
-		display.update_icon()
+		display.update_icon(UPDATE_OVERLAYS)
 
 	for(var/obj/machinery/machine in GLOB.machines) //change status
 		if(istype(machine, /obj/machinery/ai_status_display))

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -39,6 +39,7 @@
 
 	for(var/obj/machinery/ai_status_display/display as anything in GLOB.ai_displays) //change status
 		display.mode = AI_DISPLAY_MODE_BSOD
+		display.update_icon(UPDATE_OVERLAYS)
 
 	if(istype(loc, /obj/item/aicard))
 		loc.icon_state = "aicard-404"

--- a/code/modules/mob/living/silicon/ai/login.dm
+++ b/code/modules/mob/living/silicon/ai/login.dm
@@ -10,5 +10,6 @@
 		for(var/obj/machinery/ai_status_display/display as anything in GLOB.ai_displays) //change status
 			display.mode = AI_DISPLAY_MODE_EMOTE
 			display.emotion = "Neutral"
+			display.update_icon(UPDATE_OVERLAYS)
 
 	view_core()

--- a/code/modules/mob/living/silicon/ai/logout.dm
+++ b/code/modules/mob/living/silicon/ai/logout.dm
@@ -2,5 +2,6 @@
 	..()
 	for(var/obj/machinery/ai_status_display/display as anything in GLOB.ai_displays) //change status
 		display.mode = AI_DISPLAY_MODE_BLANK
+		display.update_icon(UPDATE_OVERLAYS)
 	src.view_core()
 	return

--- a/code/modules/mob/living/silicon/decoy/death.dm
+++ b/code/modules/mob/living/silicon/decoy/death.dm
@@ -7,4 +7,5 @@
 	for(var/obj/machinery/ai_status_display/display as anything in GLOB.ai_displays) //change status
 		if(atoms_share_level(display, src))
 			display.mode = AI_DISPLAY_MODE_BSOD
+			display.update_icon(UPDATE_OVERLAYS)
 	gib()

--- a/code/modules/newscaster/obj/newscaster.dm
+++ b/code/modules/newscaster/obj/newscaster.dm
@@ -113,29 +113,25 @@
 
 	var/hp_percent = round(obj_integrity * 100 / max_integrity)
 	switch(hp_percent)
-		if(76 to INFINITY)
-			return
-		if(51 to 75)
-			. += "crack1"
+		if(-INFINITY to 25)
+			. += "crack3"
 		if(26 to 50)
 			. += "crack2"
-		if(1 to 25)
-			. += "crack3"
+		if(51 to 75)
+			. += "crack1"
 
 
 /obj/machinery/newscaster/power_change(forced = FALSE)
-	if(!..())
-		return
-	if(stat & NOPOWER)
-		set_light_on(FALSE)
-	else
-		set_light(1, LIGHTING_MINIMUM_POWER, l_on = TRUE)
-	update_icon(UPDATE_OVERLAYS)
-
-
-/obj/machinery/newscaster/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = TRUE, attack_dir)
 	. = ..()
-	update_icon(UPDATE_OVERLAYS)
+	if(.)
+		update_icon(UPDATE_OVERLAYS)
+
+
+/obj/machinery/newscaster/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = TRUE, attack_dir, armour_penetration = 0)
+	. = ..()
+	if(.)
+		update_icon(UPDATE_OVERLAYS)
+
 
 /obj/machinery/newscaster/wrench_act(mob/user, obj/item/I)
 	. = TRUE

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -529,13 +529,9 @@
 
 // called when area power changes
 /obj/machinery/disposal/power_change(forced = FALSE)
-	if(!..())
-		return	// do default setting/reset of stat NOPOWER bit
-	update()	// update icon
-	if(stat & NOPOWER)
-		set_light_on(FALSE)
-	else
-		set_light(1, LIGHTING_MINIMUM_POWER, l_on = TRUE)
+	. = ..()
+	if(.)
+		update()	// do default setting/reset of stat NOPOWER bit
 
 
 // called when holder is expelled from a disposal

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -135,13 +135,11 @@
 	event_triggered_by = null
 	event_confirmed_by = null
 	busy = FALSE
-	set_light_on(FALSE)
 	update_icon()
 
 
 /obj/machinery/keycard_auth/proc/broadcast_request()
 	update_icon()
-	set_light(1, LIGHTING_MINIMUM_POWER, l_on = TRUE)
 	for(var/obj/machinery/keycard_auth/KA in GLOB.machines)
 		if(KA == src)
 			continue
@@ -163,7 +161,6 @@
 		return
 	reset()
 
-	set_light(1, LIGHTING_MINIMUM_POWER, l_on = TRUE)
 	event_source = source
 	busy = TRUE
 	active = TRUE

--- a/code/modules/security_levels/security_levels.dm
+++ b/code/modules/security_levels/security_levels.dm
@@ -102,8 +102,8 @@ GLOBAL_DATUM_INIT(security_announcement_down, /datum/announcement/priority/secur
 /proc/update_station_firealarms()
 	for(var/obj/machinery/firealarm/alarm as anything in GLOB.firealarms)
 		if(is_station_contact(alarm.z))
-			alarm.update_icon()
 			alarm.update_fire_light()
+			alarm.update_icon()
 
 
 /proc/get_security_level()


### PR DESCRIPTION
## Описание
Удаление источников света у объектов с эмиссивами. Ранее они были необходимы, поскольку при отсутствии минимального света на турфе, тот бы становился полностью чёрным, и игрок бы такой эмиссив не видел. После изменений, связанных с оверлейным светом, данный костыль более не нужен.