### PR TITLE
bugfix: deleted lonely nun hoods from hotel templates

### DIFF
--- a/_maps/map_files/templates/spacehotel/s_01.dmm
+++ b/_maps/map_files/templates/spacehotel/s_01.dmm
@@ -38,7 +38,6 @@
 "f" = (
 /obj/structure/rack,
 /obj/item/clothing/head/collectable/police,
-/obj/item/clothing/head/hooded/nun_hood,
 /obj/item/clothing/head/mailman,
 /obj/item/clothing/head/nursehat,
 /obj/item/clothing/head/wizard/fake,
@@ -89,7 +88,6 @@
 /obj/machinery/button/windowtint{
 	id = "room_s";
 	pixel_x = -24;
-	pixel_y = 0;
 	range = 5
 	},
 /turf/simulated/floor/indestructible{
@@ -115,7 +113,6 @@
 /area/template_noop)
 "o" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2

--- a/_maps/map_files/templates/spacehotel/s_02.dmm
+++ b/_maps/map_files/templates/spacehotel/s_02.dmm
@@ -38,7 +38,6 @@
 "f" = (
 /obj/structure/rack,
 /obj/item/clothing/head/collectable/police,
-/obj/item/clothing/head/hooded/nun_hood,
 /obj/item/clothing/head/mailman,
 /obj/item/clothing/head/nursehat,
 /obj/item/clothing/head/wizard/fake,
@@ -90,7 +89,6 @@
 /obj/machinery/button/windowtint{
 	id = "room_s";
 	pixel_x = -24;
-	pixel_y = 0;
 	range = 5
 	},
 /turf/simulated/floor/indestructible{
@@ -116,7 +114,6 @@
 /area/template_noop)
 "o" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Из бдсм наборов в теплейтах отеля удалены капюшоны робы монашки; робы и так есть на соседнем тайле
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
![image](https://github.com/ss220-space/Paradise/assets/87157426/49048002-b295-4528-b6bc-108300572c8e)
