### PR TITLE
add: shuttle now gibs objects and mobs 

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -615,13 +615,11 @@
 			continue
 
 		for(var/obj/things in T1)
-			if(istype(things, /obj/docking_port)) //prevent from qdel docking port
+			if(is_type_in_list(things, GLOB.ungibbable_items_types) || istype(things, /obj/docking_port) || istype(things, /obj/effect))
 				continue
 			else
-				if(!(istype(things, /obj/effect)) || istype(things, /obj/effect/decal)) //and any effects other than decals (dels only blood, gibs, remains etc.)
-					things.visible_message(span_warning("\The [things] gets crushed to dust!"))
-					qdel(things)
-				continue
+				things.visible_message(span_warning("\The [things] gets crushed to dust!"))
+				qdel(things)
 
 		for(var/atom/movable/AM in T1)
 			if(AM.pulledby)
@@ -635,6 +633,7 @@
 					living_things.stop_pulling()
 					living_things.visible_message(span_warning("[living_things] is hit by a hyperspace ripple!"),
 						span_userdanger("You feel an immense crushing pressure as the space around you ripples."))
+					living_things.drop_ungibbable_items(T1)
 					living_things.gib()
 
 			// Move unanchored atoms


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Теперь шаттлы гибают всех гуманоидов в зоне своего прилёта, также закрывает дыру, из-за которой сидя в шкафу или мехе можно было выжить под прилетающим шаттлом (мех ломался, человек выпадал живым и здоровым)
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1187384861493829733 и здравый смысл
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений

https://github.com/ss220-space/Paradise/assets/139886553/6db30227-6499-4d92-a29e-b1a986d8aa02


<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
