### PR TITLE
revert: area has gravity by default

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -32,7 +32,7 @@
 	var/static_environ = 0
 
 	/// Whether this area has a gravity by default.
-	var/has_gravity = TRUE
+	var/has_gravity = STANDARD_GRAVITY
 	var/list/apc = list()
 	var/no_air = null
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -32,7 +32,7 @@
 	var/static_environ = 0
 
 	/// Whether this area has a gravity by default.
-	var/has_gravity = FALSE
+	var/has_gravity = TRUE
 	var/list/apc = list()
 	var/no_air = null
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Возвращает area гравитацию в по умолчанию убранную в рефакторе https://github.com/ss220-space/Paradise/pull/4783
## Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Очень приятно получить везде где по умолчанию стоит гравитация ее отсутствие без каких либо обсуждений.
