### PR TITLE
bugfix: Space Turfs Has No Gravity

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -109,6 +109,9 @@
 	if(opacity)
 		has_opaque_atom = TRUE
 
+	if(istype(loc, /area/space))
+		force_no_gravity = TRUE
+
 	return INITIALIZE_HINT_NORMAL
 
 /turf/Destroy(force)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -170,6 +170,6 @@
 	if(m_intent != MOVE_INTENT_RUN)
 		return
 
-	Weaken(10 SECONDS)
+	Weaken(4 SECONDS)
 	to_chat(src, "Gravity!")
 


### PR DESCRIPTION
## Описание
Присвоение всем турфам находящимся в дефолтной зоне /area/space статуса отсутствующей гравитации. Также зарезал ослабление, от перехода из среды без гравитации с 10с. до 4с.