### PR TITLE
bugfix: beepskysmash permastun

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol.dm
@@ -546,9 +546,8 @@
 	taste_description = "THE LAW"
 
 /datum/reagent/consumable/ethanol/beepsky_smash/on_mob_life(mob/living/M)
-	var/update_flag = STATUS_UPDATE_NONE
 	M.drop_from_hands()
-	return ..() | update_flag
+	return ..()
 
 /datum/reagent/consumable/ethanol/irish_cream
 	name = "Irish Cream"

--- a/code/modules/reagents/chemistry/reagents/alcohol.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol.dm
@@ -547,7 +547,7 @@
 
 /datum/reagent/consumable/ethanol/beepsky_smash/on_mob_life(mob/living/M)
 	var/update_flag = STATUS_UPDATE_NONE
-	M.Stun(2 SECONDS)
+	M.drop_from_hands()
 	return ..() | update_flag
 
 /datum/reagent/consumable/ethanol/irish_cream


### PR DESCRIPTION
## Описание
Вернул для Beepsky smash дроп предметов из рук, как это работало до рефактора https://github.com/ss220-space/Paradise/pull/3135 , вместо пермастана
А вот баг ли это был изначально, лучше решайте с Eshi, это его просьба

## Ссылка на предложение/Причина создания ПР
![image](https://github.com/ss220-space/Paradise/assets/156955117/3ab1cd06-1f7e-4530-9797-9287c0336662)

