### PR TITLE
bugfix?: Mutation on thunderdome

### DIFF
--- a/code/modules/mini_games/thunderdome/brawlers/mob_spawns.dm
+++ b/code/modules/mini_games/thunderdome/brawlers/mob_spawns.dm
@@ -37,7 +37,8 @@
 	var/mob/living/created = ..()
 	thunderdome.fighters += created
 
-	created.mutations |= RUN
+	created.dna.SetSEState(GLOB.increaserunblock, TRUE)
+	genemutcheck(created, GLOB.increaserunblock, null, MUTCHK_FORCED)
 
 	created.AddComponent(/datum/component/thunderdome_death_signaler, thunderdome)
 	created.AddComponent(/datum/component/death_timer_reset, death_time_before)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Меняет `mutations |= RUN` на прок, что даёт ген скорости.

## Ссылка на предложение/Причина создания ПР
[Сломалось, судя по всему](https://discord.com/channels/617003227182792704/734823601110515882/1229872890229297172).
