### PR TITLE
tweak: dice of fate now gives syndie bundle beacon instead of empty box when roll "17"

### DIFF
--- a/code/game/objects/items/devices/radio/beacon.dm
+++ b/code/game/objects/items/devices/radio/beacon.dm
@@ -273,6 +273,11 @@
 								/obj/item/encryptionkey/syndicate = 1)										// 0-5 TK
 	)
 
+/obj/item/radio/beacon/syndicate/bundle/magical //for d20 dice of fate
+	used = TRUE
+	name = "suspicious 'magical' beacon"
+	desc = "It looks battered and old, as if someone tried to crack it with brute force."
+
 /obj/item/radio/beacon/syndicate/bundle/Initialize()
 	. = ..()
 	unselected = bundles.Copy()

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -384,7 +384,7 @@
 			user.mind.AddSpell(S)
 
 		if(17)
-			//Tator Kit
+			//Choose from 1 of 3 random syndie bundles
 			T.visible_message("<span class='userdanger'>A suspicious radio beacon appears!</span>")
 			new /obj/item/radio/beacon/syndicate/bundle/magical(drop_location())
 			create_smoke(2)

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -385,8 +385,8 @@
 
 		if(17)
 			//Tator Kit
-			T.visible_message("<span class='userdanger'>A suspicious box appears!</span>")
-			new /obj/item/storage/box/syndicate(drop_location())
+			T.visible_message("<span class='userdanger'>A suspicious radio beacon appears!</span>")
+			new /obj/item/radio/beacon/syndicate/bundle/magical(drop_location())
 			create_smoke(2)
 		if(18)
 			//Captain ID


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Чинит баг после вот этого ПРа (https://github.com/ss220-space/Paradise/pull/4263), из-за которого выпадение 17 на магических костях судьбы давало пустую коробку вместо случайного набора. Теперь выпадение 17 на костях даёт маячок, аналогичный маячку с выбором бандлов из аплинка. При этом этот маячок нельзя рефанднуть в аплинке.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР
Исправление бага, ну и раз уж трейторам больше не даётся простая скучная коробка со случайным набором, то и из костей пускай тоже падает маячок с возможностью выбора.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
