### PR TITLE
tweak: Thunk Checks For Incorporeal Move

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -161,7 +161,7 @@
 
 /// Proc used to weaken the user when moving from no gravity to positive gravity.
 /mob/living/carbon/human/proc/thunk()
-	if(buckled || mob_negates_gravity())
+	if(buckled || mob_negates_gravity() || incorporeal_move)
 		return
 
 	if(dna?.species.spec_thunk(src)) //Species level thunk overrides


### PR DESCRIPTION
## Описание
Мобы которые находятся в состоянии бестелесного передвижения (тенелинги, маги) более не провоцируют эффект прока thunk().
