### PR TITLE
Fix: Ninja gravity bug

### DIFF
--- a/code/modules/antagonists/space_ninja/suit/shoes.dm
+++ b/code/modules/antagonists/space_ninja/suit/shoes.dm
@@ -25,3 +25,4 @@
 	permeability_coefficient = 0.01
 	strip_delay = 120
 	slowdown = 0
+	clothing_traits = list(TRAIT_NEGATES_GRAVITY)


### PR DESCRIPTION
## Описание
После мощного рефактора гравитации, при телепортации с космоса на станцию ниндзя получал стан от появления гравитации, отличный нерф, спасибо. Добавляем вечный трейт магбутсов к ботинкам. (Нельзя выключить, не замедляет)

## Ссылка на предложение/Причина создания ПР
Фиксим баг после рефактора (почему)