### PR TITLE
bugfix: Make very clear, what tiles we DONT use

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -23,7 +23,7 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 /turf/simulated/floor
 	name = "floor"
 	icon = 'icons/turf/floors.dmi'
-	icon_state = "dont_use_this_floor"
+	icon_state = "dont_use_this_tile"
 	plane = FLOOR_PLANE
 	var/icon_regular_floor = "floor" //used to remember what icon the tile should have by default
 	var/floor_regular_dir = SOUTH  //used to remember what dir the tile should have by default


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Меняет иконку неиспользоваемого пола с "dont_use_this_floor" на "dont_use_this_tile"

## Ссылка на предложение/Причина создания ПР
Мапперы путают их с обычными тайлами при создании карты
Игрокам легче находить такие тайлы и говорить о проблемах карты
Выглядело как опечатка

## Демонстрация изменений
![image](https://github.com/ss220-space/Paradise/assets/87372121/221ed2cd-25ea-4c3a-b425-944476e91ca2)