### PR TITLE
bugfix: Fixed black tiles issue on ruins and gate levels.

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_althland_facility.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_althland_facility.dmm
@@ -15,7 +15,7 @@
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -31,7 +31,7 @@
 	dir = 8;
 	id = "mining_internal"
 	},
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -42,7 +42,7 @@
 	desc = "A computer long since rendered non-functional due to lack of maintenance. Spitting out error messages.";
 	name = "Broken Computer"
 	},
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -51,7 +51,7 @@
 "ba" = (
 /obj/effect/landmark/tiles/burnturf,
 /obj/effect/decal/cleanable/glass,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -75,7 +75,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -121,7 +121,7 @@
 "cg" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -147,7 +147,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -165,7 +165,7 @@
 /obj/structure/closet/crate/secure/loot,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -174,7 +174,7 @@
 "eX" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -200,7 +200,7 @@
 	dir = 8;
 	id = "mining_internal"
 	},
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -210,7 +210,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
 /obj/item/clothing/under/rank/miner,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -219,7 +219,7 @@
 "fG" = (
 /obj/effect/landmark/tiles/damageturf,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -228,7 +228,7 @@
 "fI" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -237,7 +237,7 @@
 "fU" = (
 /obj/machinery/atmospherics/unary/tank/oxygen_agent_b,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -260,7 +260,7 @@
 /obj/structure/ore_box,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -269,7 +269,7 @@
 "iv" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -281,7 +281,7 @@
 /obj/item/bedsheet,
 /obj/structure/bed,
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -294,7 +294,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/tiles/damageturf,
 /obj/item/stack/sheet/metal/fifty,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -317,7 +317,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -327,7 +327,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -392,7 +392,7 @@
 /obj/effect/landmark/tiles/damageturf,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -403,7 +403,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -415,7 +415,7 @@
 /area/lavaland/surface/outdoors)
 "kK" = (
 /obj/effect/landmark/tiles/burnturf,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -426,7 +426,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/tiles/damageturf,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -439,7 +439,7 @@
 /area/lavaland/surface/outdoors)
 "mP" = (
 /obj/structure/girder,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -494,7 +494,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -516,7 +516,7 @@
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -529,7 +529,7 @@
 	},
 /obj/item/clothing/under/rank/miner,
 /obj/effect/decal/remains/human,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -540,7 +540,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -551,7 +551,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
 /obj/item/clothing/under/rank/miner,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -561,7 +561,7 @@
 /obj/structure/door_assembly/door_assembly_ext,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -571,7 +571,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille,
 /obj/item/shard,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -610,7 +610,7 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -620,7 +620,7 @@
 /obj/structure/door_assembly/door_assembly_mhatch,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -630,7 +630,7 @@
 /obj/effect/turf_decal/caution/stand_clear/white,
 /obj/effect/turf_decal/box/white,
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -638,14 +638,14 @@
 /area/ruin/unpowered)
 "sp" = (
 /obj/effect/decal/cleanable/glass,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors)
 "sD" = (
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -676,7 +676,7 @@
 	id = "mining_internal"
 	},
 /obj/item/stack/sheet/mineral/silver,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -687,7 +687,7 @@
 	dir = 8;
 	id = "mining_internal"
 	},
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -701,7 +701,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -722,7 +722,7 @@
 /area/ruin/unpowered)
 "uq" = (
 /obj/effect/decal/warning_stripes/white,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -739,7 +739,7 @@
 /obj/item/clothing/shoes/workboots/mining,
 /obj/item/clothing/shoes/workboots/mining,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -748,7 +748,7 @@
 "uL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -763,7 +763,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -775,7 +775,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -807,7 +807,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -841,7 +841,7 @@
 "xl" = (
 /obj/effect/landmark/tiles/burnturf,
 /obj/item/stack/sheet/metal/fifty,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -855,7 +855,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -872,7 +872,7 @@
 /obj/structure/disposalpipe/broken,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -890,7 +890,7 @@
 /area/lavaland/surface/outdoors)
 "yL" = (
 /obj/structure/door_assembly/door_assembly_ext,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -920,7 +920,7 @@
 /obj/effect/landmark/tiles/burnturf,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -932,7 +932,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -954,7 +954,7 @@
 "zy" = (
 /obj/effect/landmark/tiles/damageturf,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -964,7 +964,7 @@
 /obj/effect/landmark/tiles/damageturf,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1015,7 +1015,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1025,7 +1025,7 @@
 /obj/effect/landmark/tiles/damageturf,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/marker_beacon,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1043,7 +1043,7 @@
 "Cf" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1056,7 +1056,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1066,7 +1066,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/door_assembly/door_assembly_mhatch,
 /obj/effect/landmark/tiles/damageturf,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1074,7 +1074,7 @@
 /area/ruin/unpowered)
 "CF" = (
 /obj/effect/landmark/tiles/damageturf,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1098,7 +1098,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/chinese,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1134,7 +1134,7 @@
 /area/ruin/unpowered)
 "EP" = (
 /obj/structure/door_assembly/door_assembly_ext,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1182,7 +1182,7 @@
 /obj/structure/closet/crate/secure/loot,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1192,7 +1192,7 @@
 /obj/item/stack/ore/plasma,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1201,7 +1201,7 @@
 "It" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/marker_beacon,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1214,7 +1214,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1225,7 +1225,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1235,7 +1235,7 @@
 /obj/machinery/constructable_frame/machine_frame,
 /obj/item/stack/cable_coil,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1247,7 +1247,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1267,7 +1267,7 @@
 /area/ruin/unpowered)
 "JF" = (
 /obj/machinery/vending/cigarette,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1277,7 +1277,7 @@
 /obj/item/pickaxe,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1288,7 +1288,7 @@
 	dir = 5
 	},
 /obj/structure/plasticflaps,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1307,7 +1307,7 @@
 "Lq" = (
 /obj/item/chair,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1317,7 +1317,7 @@
 /obj/machinery/mech_bay_recharge_port,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1328,7 +1328,7 @@
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1353,7 +1353,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1363,7 +1363,7 @@
 /obj/machinery/light_construct/small,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1373,7 +1373,7 @@
 /obj/effect/landmark/tiles/burnturf,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/tiles/damageturf,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1382,7 +1382,7 @@
 "NJ" = (
 /obj/machinery/power/smes,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1413,7 +1413,7 @@
 /obj/structure/table,
 /obj/machinery/light_construct/small,
 /obj/item/storage/belt/mining/alt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1422,7 +1422,7 @@
 "OU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1433,7 +1433,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
 /obj/item/clothing/under/rank/miner,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1446,7 +1446,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1454,7 +1454,7 @@
 /area/ruin/unpowered)
 "Po" = (
 /obj/structure/grille,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1502,7 +1502,7 @@
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
 /obj/item/shard,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1529,7 +1529,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1561,7 +1561,7 @@
 /obj/effect/landmark/tiles/burnturf,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1571,7 +1571,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1590,7 +1590,7 @@
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1598,7 +1598,7 @@
 /area/ruin/unpowered)
 "TT" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1608,7 +1608,7 @@
 /obj/structure/girder,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1627,7 +1627,7 @@
 "Uu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1635,7 +1635,7 @@
 /area/lavaland/surface/outdoors)
 "Uy" = (
 /obj/machinery/mech_bay_recharge_port,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1646,7 +1646,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1677,7 +1677,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1689,7 +1689,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1708,7 +1708,7 @@
 /obj/structure/mecha_wreckage/ripley,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1720,7 +1720,7 @@
 	name = "Broken Computer"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1730,7 +1730,7 @@
 /obj/effect/landmark/tiles/damageturf,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1740,7 +1740,7 @@
 /obj/effect/landmark/tiles/damageturf,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1763,7 +1763,7 @@
 "ZJ" = (
 /obj/structure/grille,
 /obj/item/shard,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1773,7 +1773,7 @@
 /obj/structure/door_assembly/door_assembly_ext,
 /obj/effect/landmark/tiles/damageturf,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1790,7 +1790,7 @@
 	dir = 8;
 	id = "mining_internal"
 	},
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_pirateship.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_pirateship.dmm
@@ -202,7 +202,7 @@
 	dir = 1;
 	id_tag = "pcarrier_windows"
 	},
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300

--- a/_maps/map_files/RandomRuins/SpaceRuins/abandoned_banya.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/abandoned_banya.dmm
@@ -873,7 +873,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/smes/vintage,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ruin/USSP_SpaceBanya)
 "Lj" = (
 /obj/machinery/computer/monitor,
@@ -980,7 +980,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ruin/USSP_SpaceBanya)
 "RV" = (
 /obj/effect/decal/cleanable/flour,

--- a/_maps/map_files/RandomRuins/SpaceRuins/anomalyship.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/anomalyship.dmm
@@ -15,7 +15,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
 /mob/living/simple_animal/hostile/poison/giant_spider,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/medbay)
 "at" = (
 /turf/simulated/mineral/plasma,
@@ -39,7 +39,7 @@
 "bi" = (
 /obj/effect/landmark/tiles/damageturf,
 /obj/effect/decal/cleanable/insectguts,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/epicenter)
 "bG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -51,7 +51,7 @@
 "bM" = (
 /obj/effect/landmark/tiles/damageturf,
 /obj/item/stack/cable_coil,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/epicenter)
 "cI" = (
 /turf/simulated/wall/shuttle/onlyselfsmooth/nodiagonal,
@@ -92,7 +92,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/command)
 "do" = (
 /turf/simulated/wall/shuttle/nosmooth{
@@ -112,7 +112,7 @@
 	dir = 6
 	},
 /obj/structure/spider/stickyweb,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/medbay)
 "dR" = (
 /turf/simulated/mineral/iron,
@@ -186,7 +186,7 @@
 	dir = 1
 	},
 /obj/structure/spider/stickyweb,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/medbay)
 "fN" = (
 /turf/simulated/wall/shuttle/onlyselfsmooth/nodiagonal,
@@ -254,7 +254,7 @@
 "gM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/energy)
 "gO" = (
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -296,14 +296,14 @@
 	},
 /area/ae13/energy)
 "hy" = (
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/miner)
 "hV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /obj/machinery/door/airlock/external,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/hall)
 "ib" = (
 /obj/item/storage/belt/utility{
@@ -335,7 +335,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/command)
 "ik" = (
 /turf/simulated/wall/shuttle/onlyselfsmooth/nodiagonal,
@@ -357,12 +357,12 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/hall)
 "iU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/tiles/damageturf,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/epicenter)
 "iV" = (
 /obj/structure/chair/comfy/shuttle{
@@ -391,7 +391,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/contractor_flare,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/command)
 "jT" = (
 /obj/effect/landmark/tiles/damageturf,
@@ -545,16 +545,16 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/medbay)
 "nV" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/miner)
 "nX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/airlock/external,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/hall)
 "ok" = (
 /obj/structure/cable{
@@ -564,7 +564,7 @@
 	tag = ""
 	},
 /obj/effect/landmark/tiles/damageturf,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/hall)
 "oB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -578,7 +578,7 @@
 	start_charge = 0
 	},
 /obj/structure/cable,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/energy)
 "oD" = (
 /obj/effect/decal/cleanable/dirt,
@@ -589,7 +589,7 @@
 	tag = ""
 	},
 /obj/effect/decal/cleanable/blood/writing,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/hall)
 "oQ" = (
 /obj/structure/alien/weeds,
@@ -677,7 +677,7 @@
 "pW" = (
 /obj/structure/grille,
 /obj/structure/window/full/shuttle,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/energy)
 "qe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -685,12 +685,12 @@
 	icon_state = "1-8"
 	},
 /obj/effect/landmark/tiles/damageturf,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/medbay)
 "qj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/medbay)
 "qk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -711,7 +711,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/energy)
 "qM" = (
 /obj/structure/rack,
@@ -735,7 +735,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/energy)
 "ru" = (
 /turf/simulated/floor/plasteel{
@@ -758,7 +758,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/medbay)
 "sc" = (
 /obj/structure/cable{
@@ -767,7 +767,7 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/hall)
 "si" = (
 /obj/structure/closet/crate/secure/unknownchemicals,
@@ -818,7 +818,7 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /obj/effect/gluttony,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/hall)
 "tt" = (
 /obj/structure/alien/weeds,
@@ -833,7 +833,7 @@
 /obj/item/stack/sheet/metal{
 	amount = 2
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/miner)
 "tx" = (
 /obj/effect/spawner/lootdrop/bluespace_tap/organic,
@@ -948,7 +948,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/cable_coil,
 /obj/structure/spider/stickyweb,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/medbay)
 "uS" = (
 /obj/structure/table/reinforced,
@@ -976,7 +976,7 @@
 /area/ae13/command)
 "vf" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/command)
 "vo" = (
 /obj/effect/decal/cleanable/dirt,
@@ -990,13 +990,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/built,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/miner)
 "vw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/secure/engineering,
 /obj/item/clothing/gloves/color/yellow/fake,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/epicenter)
 "vx" = (
 /turf/simulated/floor/plating/asteroid/airless,
@@ -1035,7 +1035,7 @@
 /obj/item/stack/sheet/metal{
 	amount = 2
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/epicenter)
 "wy" = (
 /obj/structure/alien/weeds,
@@ -1146,7 +1146,7 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/hall)
 "yD" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1266,12 +1266,12 @@
 "Aw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/contractor_flare,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/miner)
 "Az" = (
 /obj/structure/ore_box,
 /obj/effect/turf_decal/stripes/box,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/miner)
 "AB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1294,7 +1294,7 @@
 /area/ae13/hall)
 "AE" = (
 /obj/item/stack/cable_coil,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/miner)
 "AF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1304,7 +1304,7 @@
 /turf/simulated/floor/indestructible/plating,
 /area/ae13/energy)
 "AR" = (
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/energy)
 "AT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1330,7 +1330,7 @@
 	frequency = 1331;
 	id_tag = "syndie_cargo_left_shuttle_pump"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/hall)
 "BN" = (
 /turf/simulated/wall/shuttle/nodiagonal,
@@ -1338,7 +1338,7 @@
 "BT" = (
 /obj/effect/contractor_flare,
 /obj/structure/spider/stickyweb,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/medbay)
 "Ca" = (
 /obj/structure/alien/weeds,
@@ -1349,19 +1349,19 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
 /obj/structure/spider/stickyweb,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/medbay)
 "Ck" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/hall)
 "Cz" = (
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 8
 	},
 /obj/effect/contractor_flare,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/hall)
 "CG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1376,7 +1376,7 @@
 	tag = ""
 	},
 /obj/effect/landmark/tiles/damageturf,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/hall)
 "Db" = (
 /obj/structure/cable,
@@ -1407,11 +1407,11 @@
 	tag = ""
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/energy)
 "Dq" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/medbay)
 "DH" = (
 /obj/machinery/bodyscanner,
@@ -1463,7 +1463,7 @@
 /obj/structure/shuttle/engine/large{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/medbay)
 "EE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1471,7 +1471,7 @@
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/energy)
 "EM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1531,18 +1531,18 @@
 /obj/effect/landmark/tiles/damageturf,
 /obj/structure/grille,
 /obj/structure/window/full/shuttle,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/epicenter)
 "FN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/metal{
 	amount = 2
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/medbay)
 "FR" = (
 /obj/machinery/door/airlock/external,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/hall)
 "FZ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1562,12 +1562,12 @@
 "Gc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/cable_coil,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/hall)
 "Ge" = (
 /obj/structure/grille,
 /obj/structure/window/full/shuttle,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/medbay)
 "Gp" = (
 /obj/structure/alien/weeds,
@@ -1587,7 +1587,7 @@
 	},
 /area/ae13/energy)
 "GP" = (
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/hall)
 "GW" = (
 /obj/item/stack/sheet/bluespace_crystal,
@@ -1668,7 +1668,7 @@
 /obj/item/stack/sheet/metal{
 	amount = 2
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/miner)
 "JN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -1700,7 +1700,7 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/hall)
 "Kd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1740,7 +1740,7 @@
 "Kw" = (
 /obj/structure/grille,
 /obj/structure/window/full/shuttle,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/command)
 "Ky" = (
 /obj/effect/landmark/tiles/damageturf,
@@ -1824,12 +1824,12 @@
 /area/ae13/miner)
 "Mf" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/hall)
 "Mp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/cable_coil,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/energy)
 "Mq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1858,7 +1858,7 @@
 	tag = ""
 	},
 /obj/effect/decal/cleanable/blood/writing,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/hall)
 "MB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1875,7 +1875,7 @@
 "Ni" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/medbay)
 "No" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -1883,7 +1883,7 @@
 	frequency = 1331;
 	id_tag = "syndie_cargo_right_shuttle_pump"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/hall)
 "Nr" = (
 /obj/structure/alien/weeds,
@@ -1984,7 +1984,7 @@
 	icon_state = "2-8";
 	tag = ""
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/energy)
 "Pf" = (
 /turf/simulated/wall/shuttle,
@@ -2040,7 +2040,7 @@
 /area/ae13/miner)
 "Qg" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/energy)
 "Qi" = (
 /obj/structure/ore_box,
@@ -2091,7 +2091,7 @@
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/hall)
 "Ru" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2172,7 +2172,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/tiles/damageturf,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/epicenter)
 "Sr" = (
 /obj/effect/landmark/tiles/damageturf,
@@ -2183,7 +2183,7 @@
 /obj/item/stack/sheet/metal{
 	amount = 2
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/hall)
 "SK" = (
 /obj/structure/chair/comfy/shuttle{
@@ -2256,7 +2256,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/secure/engineering,
 /obj/item/clothing/gloves/color/yellow,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/epicenter)
 "Tk" = (
 /obj/effect/landmark/tiles/damageturf,
@@ -2366,7 +2366,7 @@
 "TM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/gibs/body,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/medbay)
 "TO" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -2374,7 +2374,7 @@
 	frequency = 1331;
 	id_tag = "synd_pump_bottom"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/hall)
 "TU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2391,7 +2391,7 @@
 	icon_state = "portal";
 	name = "bluespace portal"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/hall)
 "Us" = (
 /obj/effect/decal/cleanable/blood/writing{
@@ -2400,7 +2400,7 @@
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/hall)
 "UA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2411,7 +2411,7 @@
 	tag = ""
 	},
 /obj/effect/mob_spawn/headcrab,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/hall)
 "UW" = (
 /obj/machinery/light{
@@ -2426,7 +2426,7 @@
 /area/ae13/epicenter)
 "UY" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/epicenter)
 "Va" = (
 /obj/structure/sign/poster/official/state_laws,
@@ -2440,16 +2440,16 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/miner)
 "VG" = (
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/medbay)
 "VJ" = (
 /obj/structure/shuttle/engine/large{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/energy)
 "VX" = (
 /obj/structure/alien/weeds,
@@ -2465,7 +2465,7 @@
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/blood/gibs/old,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/command)
 "Wh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2482,7 +2482,7 @@
 	tag = ""
 	},
 /obj/effect/decal/cleanable/blood/writing,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/hall)
 "Wy" = (
 /turf/simulated/wall/shuttle/nosmooth{
@@ -2495,7 +2495,7 @@
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/hall)
 "WM" = (
 /turf/simulated/wall/shuttle/nodiagonal,
@@ -2553,12 +2553,12 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/epicenter)
 "Ye" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/flamethrower/full/tank,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/miner)
 "Yg" = (
 /obj/structure/rack,
@@ -2582,7 +2582,7 @@
 "Yq" = (
 /obj/structure/grille,
 /obj/structure/window/full/shuttle,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/miner)
 "Yy" = (
 /turf/simulated/wall/shuttle/nodiagonal,
@@ -2595,7 +2595,7 @@
 "YV" = (
 /obj/structure/grille,
 /obj/structure/window/full/shuttle,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ae13/epicenter)
 "Zc" = (
 /obj/structure/alien/weeds,

--- a/_maps/map_files/RandomRuins/SpaceRuins/lonelypod.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/lonelypod.dmm
@@ -199,7 +199,7 @@
 "DL" = (
 /obj/structure/window/full/shuttle,
 /obj/structure/grille,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ruin/unpowered)
 "Et" = (
 /obj/machinery/door/airlock/public/glass{
@@ -402,7 +402,7 @@
 "QK" = (
 /obj/effect/decal/cleanable/dust,
 /obj/effect/spawner/window/reinforced,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ruin/powered)
 "Ry" = (
 /obj/structure/sign/vacuum/external,
@@ -496,7 +496,7 @@
 "Yf" = (
 /obj/effect/decal/cleanable/dust,
 /obj/effect/spawner/window/reinforced,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ruin/unpowered)
 "YP" = (
 /obj/structure/reagent_dispensers/watertank,

--- a/_maps/map_files/RandomRuins/SpaceRuins/spaceprison.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/spaceprison.dmm
@@ -925,7 +925,7 @@
 	d2 = 4;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ruin/spaceprison)
 "cB" = (
 /obj/machinery/light/small,
@@ -1128,7 +1128,7 @@
 /obj/machinery/door/poddoor/multi_tile/two_tile_ver{
 	id_tag = "spaceprisonpod"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ruin/spaceprison)
 "eG" = (
 /turf/simulated/floor/plasteel{
@@ -1287,7 +1287,7 @@
 /area/ruin/spaceprison)
 "gD" = (
 /obj/structure/door_assembly/door_assembly_ext,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ruin/spaceprison)
 "gE" = (
 /obj/structure/table/reinforced,
@@ -1462,7 +1462,7 @@
 	d2 = 4;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ruin/spaceprison)
 "kP" = (
 /obj/structure/window/reinforced{
@@ -1546,7 +1546,7 @@
 /area/ruin/spaceprison)
 "np" = (
 /obj/machinery/door/airlock/external,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ruin/spaceprison)
 "nS" = (
 /obj/machinery/suit_storage_unit/security,
@@ -1643,7 +1643,7 @@
 	amount = 2
 	},
 /obj/structure/cable,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ruin/spaceprison)
 "pW" = (
 /obj/machinery/teleport/station,
@@ -1685,7 +1685,7 @@
 	d2 = 4;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ruin/spaceprison)
 "rh" = (
 /obj/structure/window/reinforced{
@@ -1827,7 +1827,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ruin/spaceprison)
 "vk" = (
 /obj/structure/table/reinforced,
@@ -2030,7 +2030,7 @@
 	pixel_y = 0
 	},
 /obj/structure/cable,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ruin/spaceprison)
 "zr" = (
 /obj/machinery/door/window/brigdoor{
@@ -2077,7 +2077,7 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ruin/spaceprison)
 "An" = (
 /obj/effect/landmark/tiles/damageturf,
@@ -2340,7 +2340,7 @@
 "GQ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ruin/spaceprison)
 "GZ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -2486,7 +2486,7 @@
 	d2 = 4;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ruin/spaceprison)
 "Ko" = (
 /obj/structure/window/reinforced,
@@ -2517,7 +2517,7 @@
 	d2 = 4;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ruin/spaceprison)
 "KD" = (
 /turf/simulated/floor/plasteel{
@@ -2593,7 +2593,7 @@
 	d2 = 4;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ruin/spaceprison)
 "MG" = (
 /obj/effect/decal/warning_stripes/west,
@@ -2959,7 +2959,7 @@
 /turf/simulated/floor/plating/airless,
 /area/ruin/spaceprison)
 "Vt" = (
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ruin/spaceprison)
 "VC" = (
 /obj/structure/window/reinforced{
@@ -2997,7 +2997,7 @@
 "WF" = (
 /obj/effect/landmark/tiles/damageturf,
 /obj/structure/inflatable,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ruin/spaceprison)
 "Xe" = (
 /obj/machinery/light{
@@ -3019,7 +3019,7 @@
 /area/ruin/spaceprison)
 "Xy" = (
 /obj/structure/spacepoddoor,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ruin/spaceprison)
 "XX" = (
 /obj/structure/chair/office/light{

--- a/_maps/map_files/RandomZLevels/spacebattle.dmm
+++ b/_maps/map_files/RandomZLevels/spacebattle.dmm
@@ -3561,7 +3561,7 @@
 /obj/machinery/door/poddoor/shutters{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/awaymission/spacebattle/syndicate3)
 "kf" = (
 /obj/machinery/computer{
@@ -3585,7 +3585,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/awaymission/spacebattle/hallway11)
 "kj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4012,7 +4012,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/transit_tube,
 /obj/structure/window/full/shuttle,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/awaymission/spacebattle/cruiser)
 "lq" = (
 /obj/machinery/light/small{
@@ -4077,7 +4077,7 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/sec_storage)
 "lD" = (
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/awaymission/spacebattle/storage)
 "lF" = (
 /obj/effect/landmark/tiles/damageturf,
@@ -6003,7 +6003,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/awaymission/spacebattle/storage)
 "rn" = (
 /obj/machinery/door/airlock/highsecurity,
@@ -7409,7 +7409,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/transit_tube,
 /obj/structure/window/full/shuttle,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/awaymission/spacebattle/hallway11)
 "uW" = (
 /obj/structure/window/plasmareinforced{
@@ -7903,7 +7903,7 @@
 	icon_state = "TheSingGen";
 	layer = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/awaymission/spacebattle/hallway3)
 "wo" = (
 /obj/structure/cable{
@@ -8386,7 +8386,7 @@
 	name = "Blast Shutters"
 	},
 /obj/machinery/door/poddoor/shutters,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/awaymission/spacebattle/syndicate3)
 "xu" = (
 /obj/item/wirecutters,
@@ -11226,7 +11226,7 @@
 	icon_state = "TheSingGen";
 	layer = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/awaymission/spacebattle/hallway11)
 "Fg" = (
 /obj/structure/cable{
@@ -15562,7 +15562,7 @@
 "QQ" = (
 /obj/structure/grille,
 /obj/structure/window/full/shuttle/gray,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/awaymission/spacebattle/syndicate3)
 "QR" = (
 /obj/machinery/door/airlock/engineering,
@@ -17126,7 +17126,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/trunk,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/awaymission/spacebattle/hallway3)
 "Vm" = (
 /obj/structure/cable{
@@ -18282,7 +18282,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/awaymission/spacebattle/storage)
 "YC" = (
 /obj/effect/decal/syndie_logo{


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление ошибок с чёрными тайлами в руинах заменой неиспользуемого /turf/simulated/floor на /turf/simulated/floor/plating.

