### PR TITLE
bugfix: VTEC Ignores Speed Penalties

### DIFF
--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -108,8 +108,6 @@
 
 /datum/movespeed_modifier/robot_vtec_upgrade
 	multiplicative_slowdown = -1
-	movetypes = GROUND
-	blacklisted_movetypes = (FLOATING|FLYING)
 
 
 /datum/movespeed_modifier/slime_health_mod


### PR DESCRIPTION
## Описание
Витёк игнорирует типы передвижения и применяется всегда.