### PR TITLE
tweak: Areas Can Ignore Gravgen Effects

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -33,6 +33,9 @@
 
 	/// Whether this area has a gravity by default.
 	var/has_gravity = FALSE
+	/// If `TRUE` this area will skip gravity generator's effect in its Z-level.
+	var/ignore_gravgen = FALSE
+
 	var/list/apc = list()
 	var/no_air = null
 

--- a/code/game/area/areas/mining.dm
+++ b/code/game/area/areas/mining.dm
@@ -41,6 +41,7 @@
 
 /area/mine/unexplored/cere
 	sound_environment = SOUND_AREA_ASTEROID
+	ignore_gravgen = TRUE
 
 /area/mine/unexplored/cere/ai
 	name = "AI Asteroid"

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1474,5 +1474,5 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 
 	var/area/turf_area = gravity_turf.loc
 
-	return !gravity_turf.force_no_gravity && (turf_area.has_gravity || length(GLOB.gravity_generators["[gravity_turf.z]"]))
+	return !gravity_turf.force_no_gravity && (turf_area.has_gravity || (!turf_area.ignore_gravgen && length(GLOB.gravity_generators["[gravity_turf.z]"])))
 


### PR DESCRIPTION
## Описание
Добавляет зонам флаг, позволяющий намеренно игнорировать наличие генератора гравитации на Z-уровне. Сделано по больше части для окрестностей Церы.