### PR TITLE
tweak: Changed BFL goal crate cost and its content, decreased BSH goal points

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -2324,6 +2324,12 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 
 	containername = "patriotic crate"
 
+/datum/supply_packs/misc/golden_toilet
+	name = "Golden Toilet"
+	cost = 500
+	contains = list(/obj/structure/toilet/golden_toilet)
+	containername = "golden toilet"
+
 
 ///////////// Paper Work
 

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -58,9 +58,9 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 	var/special_enabled = FALSE
 
 	/// The number of times one can order a cargo crate, before it becomes restricted. -1 for infinite
-//	var/order_limit = -1
+//	var/order_limit = -1	// Unused for now (Crate limit #3056).
 	/// Number of times a crate has been ordered in a shift
-//	var/times_ordered = 0	// Unused for now (Crate limit #3056).
+	var/times_ordered = 0
 
 	/// List of names for being done in TGUI
 	var/list/ui_manifest = list()
@@ -1098,9 +1098,23 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 
 /datum/supply_packs/misc/station_goal/bfl_goal
 	name = "BFL Mission goal"
-	cost = 6500
+	cost = 3000
 	contains = list(
-					/obj/structure/toilet/golden_toilet/bfl_goal
+					/obj/item/paper/researchnotes,
+					/obj/item/paper/researchnotes,
+					/obj/item/paper/researchnotes,
+					/obj/item/paper/researchnotes,
+					/obj/item/paper/researchnotes,
+					/obj/item/paper/researchnotes,
+					/obj/item/paper/researchnotes,
+					/obj/item/paper/researchnotes,
+					/obj/item/paper/researchnotes,
+					/obj/item/paper/researchnotes,
+					/obj/item/paper/researchnotes,
+					/obj/item/paper/researchnotes,
+					/obj/item/paper/researchnotes,
+					/obj/item/paper/researchnotes,
+					/obj/item/paper/researchnotes // 15 random research notes
 					)
 	containername = "Goal crate"
 

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -215,7 +215,7 @@
 
 /obj/structure/toilet/golden_toilet
 	name = "Золотой унитаз"
-	desc = "Поговаривают, что 7 веков назад у каждого арабского шейха был такой унитаз."
+	desc = "Поговаривают, что 7 веков назад у каждого арабского шейха был такой унитаз. Им явно кто-то пользовался..."
 	icon_state = "gold_toilet00"
 
 /obj/structure/toilet/golden_toilet/update_icon_state()

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -572,7 +572,7 @@
 						if(P.credits_cost)
 							SSshuttle.cargo_money_account.money -= P.credits_cost
 						SSshuttle.shoppinglist += O
-//						P.times_ordered += 1	// Unused for now (Crate limit #3056).
+						P.times_ordered += 1
 						investigate_log("[key_name_log(usr)] has authorized an order for [P.name]. Remaining points: [SSshuttle.points].", INVESTIGATE_CARGO)
 					break
 

--- a/code/modules/station_goals/bfl.dm
+++ b/code/modules/station_goals/bfl.dm
@@ -38,9 +38,9 @@
 /datum/station_goal/bfl/check_completion()
 	if(..())
 		return TRUE
-	for(var/datum/supply_packs/misc/station_goal/bfl_goal/B)
-		if(B.times_ordered >= 1)
-			return TRUE
+	var/datum/supply_packs/misc/station_goal/bfl_goal/goal_pack = SSshuttle.supply_packs["[/datum/supply_packs/misc/station_goal/bfl_goal]"]
+	if(goal_pack.times_ordered >= 1)
+		return TRUE
 	return FALSE
 
 /datum/station_goal/bfl/Destroy()

--- a/code/modules/station_goals/bfl.dm
+++ b/code/modules/station_goals/bfl.dm
@@ -10,7 +10,7 @@
 	<br>
 	Its base parts should be available for shipping by your cargo shuttle.
 	<br>
-	In order to complete the mission, you must to order a special pack in cargo called BFL Mission goal, and install it content anywhere on the station.
+	In order to complete the mission, you must to order a special pack in cargo called BFL Mission goal, and enjoy your reward.
 	<br><br>
 	-Nanotrasen Naval Command"}
 
@@ -38,8 +38,8 @@
 /datum/station_goal/bfl/check_completion()
 	if(..())
 		return TRUE
-	for(var/obj/structure/toilet/golden_toilet/bfl_goal/B)
-		if(B && is_station_contact(B.z))
+	for(var/datum/supply_packs/misc/station_goal/bfl_goal/B)
+		if(B.times_ordered >= 1)
 			return TRUE
 	return FALSE
 

--- a/code/modules/station_goals/bfl.dm
+++ b/code/modules/station_goals/bfl.dm
@@ -529,8 +529,6 @@
 /obj/item/gps/internal/bfl_crack
 	gpstag = "NT signal"
 
-/obj/structure/toilet/golden_toilet/bfl_goal
-	name = "\[NT REDACTED\]"
 /obj/singularity/bfl_red
 	name = "BFL"
 	desc = "Giant laser, which is supposed for mining"

--- a/code/modules/station_goals/bluespace_tap.dm
+++ b/code/modules/station_goals/bluespace_tap.dm
@@ -2,7 +2,7 @@
 /datum/station_goal/bluespace_tap
 	name = "Bluespace Harvester"
 	gamemode_blacklist = list("extended")
-	var/goal = 45000
+	var/goal = 25000
 
 /datum/station_goal/bluespace_tap/get_report()
 	return {"<b>Bluespace Harvester Experiment</b><br>


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание

- Цена финального ящика с целью БФЛ теперь 3000 очков карго (было 6500)
- Ящик с целью БФЛ теперь содержит 15 случайных бумажек с уровнями исследований для РНД (был золотой сортир)
- Для завершения цели харвестера нужно 25000 очков (было 45000)
- Для заказа в карго отдельно доступен золотой сортир за 500 очков

<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
БФЛ - https://discord.com/channels/617003227182792704/755125334097133628/1214616428213309461 и https://discord.com/channels/617003227182792704/755125334097133628/1216130279245222039
Харвестер - https://discord.com/channels/617003227182792704/755125334097133628/1215920136360300557
Сортир за 500 - https://discord.com/channels/617003227182792704/755125334097133628/1216130227126800426
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->