### PR TITLE
bugfix: event station lavaland path.

### DIFF
--- a/code/modules/map_fluff/event.dm
+++ b/code/modules/map_fluff/event.dm
@@ -2,7 +2,7 @@
 /datum/map/event
 	name = "Station Name"
 	map_path = "_maps/map_files/event/Station/yourstation.dmm"
-	Lavaland_path = "_maps/map_files/delta/Lavaland.dmm"
+	Lavaland_path = "_maps/map_files/Delta/Lavaland.dmm"
 
 	station_name = "Ingame Station name"
 	station_short = "Ingame Station name short"
@@ -17,7 +17,7 @@
 /datum/map/towerstation
 	name = "Towerstation"
 	map_path = "_maps/map_files/event/Station/towerstation.dmm"
-	lavaland_path = "_maps/map_files/delta/Lavaland.dmm"
+	lavaland_path = "_maps/map_files/Delta/Lavaland.dmm"
 	traits = list(
 		list(MAIN_STATION, STATION_LEVEL = "Main Floor", STATION_CONTACT, REACHABLE, AI_OK, ZTRAIT_UP),
 		list(STATION_LEVEL = "Second Floor", STATION_CONTACT, REACHABLE, AI_OK, ZTRAIT_UP, ZTRAIT_DOWN, ZTRAIT_BASETURF = /turf/simulated/openspace),


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->У нас папка с Керберосом с заглавной буквы прописана, но менять название папки с `Delta` на `delta` немного проблематично, так что в пути лаваленда ивентовых карт просто поменял эту гадскую букву.

## Скрин баг-репорта от таинственного незнакомца
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
![image](https://github.com/ss220-space/Paradise/assets/115735095/1e1261c3-7f1b-4c52-ac89-558d939f58b6)
