### PR TITLE
refactor: now using forcemove instead of loc= for mobs mostly

### DIFF
--- a/code/datums/diseases/viruses/wizarditis.dm
+++ b/code/datums/diseases/viruses/wizarditis.dm
@@ -118,6 +118,6 @@ STI KALY - blind
 
 	if(is_teleport_allowed(target_turf.z))
 		affected_mob.say("SCYAR NILA [uppertext(thearea.name)]!")
-		affected_mob.loc = target_turf
+		affected_mob.forceMove(target_turf)
 
 	return

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -2849,7 +2849,7 @@
 		SSticker.mode.forge_syndicate_objectives(src)
 		SSticker.mode.greet_syndicate(src)
 
-		current.loc = get_turf(locate("landmark*Syndicate-Spawn"))
+		current.forceMove(get_turf(locate("landmark*Syndicate-Spawn")))
 
 		var/mob/living/carbon/human/H = current
 		qdel(H.belt)
@@ -2879,10 +2879,10 @@
 		assigned_role = SPECIAL_ROLE_WIZARD
 		//ticker.mode.learn_basic_spells(current)
 		if(!GLOB.wizardstart.len)
-			current.loc = pick(GLOB.latejoin)
+			current.forceMove(pick(GLOB.latejoin))
 			to_chat(current, "HOT INSERTION, GO GO GO")
 		else
-			current.loc = pick(GLOB.wizardstart)
+			current.forceMove(pick(GLOB.wizardstart))
 
 		SSticker.mode.equip_wizard(current)
 		for(var/obj/item/spellbook/S in current.contents)
@@ -2903,10 +2903,10 @@
 	add_antag_datum(ninja_datum)
 
 	if(!length(GLOB.ninjastart))
-		current.loc = pick(GLOB.latejoin)
+		current.forceMove(pick(GLOB.latejoin))
 		to_chat(current, "HOT INSERTION, GO GO GO")
 	else
-		current.loc = pick(GLOB.ninjastart)
+		current.forceMove(pick(GLOB.ninjastart))
 
 	//"generic" only, we don't want to spawn other antag's
 	ninja_datum.make_objectives_generate_antags(NINJA_TYPE_GENERIC, custom_objective)

--- a/code/game/gamemodes/antag_paradise/antag_paradise.dm
+++ b/code/game/gamemodes/antag_paradise/antag_paradise.dm
@@ -110,7 +110,7 @@
 			if(length(GLOB.ninjastart))
 				var/datum/mind/special_antag = safepick(get_players_for_role(ROLE_NINJA))
 				if(special_antag)
-					special_antag.current.loc = pick(GLOB.ninjastart)
+					special_antag.current.forceMove(pick(GLOB.ninjastart))
 					special_antag.assigned_role = SPECIAL_ROLE_SPACE_NINJA // assigned role and special role must be the same so they aren't chosen for other jobs.
 					special_antag.special_role = SPECIAL_ROLE_SPACE_NINJA
 					special_antag.offstation_role = TRUE // ninja can't be targeted as a victim for some pity traitors

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -433,7 +433,7 @@
 
 	var/key_of_revenant
 	message_admins("Revenant ectoplasm was left undestroyed for [reform_time/10] seconds and is reforming into a new revenant.")
-	loc = get_turf(src) //In case it's in a backpack or someone's hand
+	forceMove_turf() //In case it's in a backpack or someone's hand
 	var/mob/living/simple_animal/revenant/new_revenant = new(get_turf(src))
 
 	if(client_to_revive)

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -714,7 +714,7 @@ GLOBAL_LIST_EMPTY(multiverse)
 	if(user.zone_selected == BODY_ZONE_CHEST)
 		if(link)
 			target = null
-			link.loc = get_turf(src)
+			link.forceMove(get_turf(src))
 			to_chat(user, "<span class='notice'>You remove the [link] from the doll.</span>")
 			link = null
 			update_targets()

--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -518,7 +518,7 @@
 		if(G.state<2)
 			to_chat(user, span_warning("You need a better grip to do that!"))
 			return
-		G.affecting.loc = src.loc
+		G.affecting.forceMove(loc)
 		G.affecting.Weaken(10 SECONDS)
 		visible_message(span_warning("[G.assailant] dunks [G.affecting] into [src]!"))
 		qdel(W)

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -31,7 +31,7 @@
 		new prize(get_turf(src), prize_amount)
 	else
 		var/atom/movable/prize = pick(contents)
-		prize.loc = get_turf(src)
+		prize.forceMove(get_turf(src))
 
 /obj/machinery/computer/arcade/emp_act(severity)
 	..(severity)

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -150,7 +150,7 @@
 	playsound(loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
 	emergency_mode = TRUE
 	update_icon(UPDATE_ICON_STATE)
-	L.loc = loc
+	L.forceMove(loc)
 	addtimer(CALLBACK(src, PROC_REF(reboot)), SAFETY_COOLDOWN)
 
 /obj/machinery/recycler/proc/reboot()
@@ -160,7 +160,7 @@
 
 /obj/machinery/recycler/proc/crush_living(mob/living/L)
 
-	L.loc = loc
+	L.forceMove(loc)
 
 	if(issilicon(L))
 		playsound(loc, 'sound/items/welder.ogg', 50, 1)

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -214,7 +214,7 @@
 
 	sleep(20)
 	if(state in list(1,3,6) )
-		usr.loc = src.loc
+		usr.forceMove(loc)
 
 
 /obj/machinery/washing_machine/update_icon_state()
@@ -244,7 +244,7 @@
 			var/obj/item/grab/G = W
 			if(ishuman(G.assailant) && iscorgi(G.affecting))
 				add_fingerprint(user)
-				G.affecting.loc = src
+				G.affecting.forceMove(src)
 				qdel(G)
 				state = 3
 			update_icon()
@@ -325,13 +325,13 @@
 		if(2)
 			state = 1
 			for(var/atom/movable/O in contents)
-				O.loc = src.loc
+				O.forceMove(loc)
 		if(3)
 			state = 4
 		if(4)
 			state = 3
 			for(var/atom/movable/O in contents)
-				O.loc = src.loc
+				O.forceMove(loc)
 			crayon = null
 			state = 1
 		if(5)
@@ -345,7 +345,7 @@
 					var/mob/M = locate(/mob,contents)
 					M.gib()
 			for(var/atom/movable/O in contents)
-				O.loc = src.loc
+				O.forceMove(loc)
 			crayon = null
 			state = 1
 

--- a/code/game/objects/effects/bump_teleporter.dm
+++ b/code/game/objects/effects/bump_teleporter.dm
@@ -36,7 +36,7 @@ GLOBAL_LIST_EMPTY(bump_teleporters)
 	for(var/bt in GLOB.bump_teleporters)
 		var/obj/effect/bump_teleporter/teleporter = bt
 		if(teleporter.id == id_target)
-			moving_atom.loc = teleporter.loc
+			moving_atom.forceMove(teleporter.loc)
 			process_special_effects(moving_atom)
 			return
 

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -92,10 +92,7 @@
 
 /obj/item/chameleon/proc/eject_all()
 	for(var/atom/movable/A in active_dummy)
-		A.loc = active_dummy.loc
-		if(ismob(A))
-			var/mob/M = A
-			M.reset_perspective(null)
+		A.forceMove(active_dummy.loc)
 
 /obj/effect/dummy/chameleon
 	name = ""
@@ -113,7 +110,7 @@
 	overlays = new_overlays
 	underlays = new_underlays
 	dir = O.dir
-	M.loc = src
+	M.forceMove(src)
 	master = C
 	master.active_dummy = src
 

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -58,15 +58,16 @@
 			to_chat(user, "<span class='notice'>You install a [diode.name] in [src].</span>")
 		else
 			to_chat(user, "<span class='notice'>[src] already has a cell.</span>")
+		return
 
-	else if(W.tool_behaviour == TOOL_SCREWDRIVER)
-		if(diode)
-			to_chat(user, "<span class='notice'>You remove the [diode.name] from the [src].</span>")
-			diode.loc = get_turf(src.loc)
-			diode = null
-			return
-		..()
-	return
+	return ..()
+
+/obj/item/laser_pointer/screwdriver_act(mob/living/user, obj/item/I)
+	. = TRUE
+	if(diode)
+		to_chat(user, "<span class='notice'>You remove the [diode.name] from the [src].</span>")
+		diode.forceMove(get_turf(loc))
+		diode = null
 
 /obj/item/laser_pointer/afterattack(atom/target, mob/living/user, flag, params)
 	if(flag)	//we're placing the object on a table or in backpack

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -111,7 +111,7 @@
 	if(!T || !istype(T))
 		return FALSE
 
-	usr.visible_message("<span class='warning'>[user] starts climbing onto \the [src]!</span>")
+	user.visible_message("<span class='warning'>[user] starts climbing onto \the [src]!</span>")
 	climber = user
 	if(!do_after(user, 50, target = src))
 		climber = null
@@ -121,9 +121,9 @@
 		climber = null
 		return FALSE
 
-	usr.loc = get_turf(src)
+	user.forceMove(get_turf(src))
 	if(get_turf(user) == get_turf(src))
-		usr.visible_message("<span class='warning'>[user] climbs onto \the [src]!</span>")
+		user.visible_message("<span class='warning'>[user] climbs onto \the [src]!</span>")
 
 	clumse_stuff(climber)
 

--- a/code/game/objects/structures/transit_tubes/transit_tube.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube.dm
@@ -38,7 +38,7 @@
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
 			for(var/atom/movable/AM in contents)
-				AM.loc = loc
+				AM.forceMove(loc)
 				AM.ex_act(severity++)
 
 			qdel(src)
@@ -46,7 +46,7 @@
 		if(EXPLODE_HEAVY)
 			if(prob(50))
 				for(var/atom/movable/AM in contents)
-					AM.loc = loc
+					AM.forceMove(loc)
 					AM.ex_act(severity++)
 
 				qdel(src)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1381,7 +1381,7 @@
 		if(!M)
 			return
 
-		M.loc = prison_cell
+		M.forceMove(prison_cell)
 		if(ishuman(M))
 			var/mob/living/carbon/human/prisoner = M
 			prisoner.equip_to_slot_or_del(new /obj/item/clothing/under/color/orange(prisoner), ITEM_SLOT_CLOTH_INNER)
@@ -1573,7 +1573,7 @@
 			var/mob/living/L = M
 			L.Paralyse(10 SECONDS)
 		sleep(5)
-		M.loc = pick(GLOB.tdome1)
+		M.forceMove(pick(GLOB.tdome1))
 		spawn(50)
 			to_chat(M, "<span class='notice'>You have been sent to the Thunderdome.</span>")
 		log_and_message_admins("has sent [key_name_admin(M)] to the thunderdome. (Team 1)")
@@ -1599,7 +1599,7 @@
 			var/mob/living/L = M
 			L.Paralyse(10 SECONDS)
 		sleep(5)
-		M.loc = pick(GLOB.tdome2)
+		M.forceMove(pick(GLOB.tdome2))
 		spawn(50)
 			to_chat(M, "<span class='notice'>You have been sent to the Thunderdome.</span>")
 		log_and_message_admins("has sent [key_name_admin(M)] to the thunderdome. (Team 2)")
@@ -1622,7 +1622,7 @@
 			var/mob/living/L = M
 			L.Paralyse(10 SECONDS)
 		sleep(5)
-		M.loc = pick(GLOB.tdomeadmin)
+		M.forceMove(pick(GLOB.tdomeadmin))
 		spawn(50)
 			to_chat(M, "<span class='notice'>You have been sent to the Thunderdome.</span>")
 		log_and_message_admins("has sent [key_name_admin(M)] to the thunderdome. (Admin.)")
@@ -1652,7 +1652,7 @@
 			var/mob/living/L = M
 			L.Paralyse(10 SECONDS)
 		sleep(5)
-		M.loc = pick(GLOB.tdomeobserve)
+		M.forceMove(pick(GLOB.tdomeobserve))
 		spawn(50)
 			to_chat(M, "<span class='notice'>You have been sent to the Thunderdome.</span>")
 		log_and_message_admins("has sent [key_name_admin(M)] to the thunderdome. (Observer.)")
@@ -1746,7 +1746,7 @@
 			var/mob/living/L = M
 			L.Paralyse(10 SECONDS)
 		sleep(5)
-		M.loc = pick(GLOB.aroomwarp)
+		M.forceMove(pick(GLOB.aroomwarp))
 		spawn(50)
 			to_chat(M, "<span class='notice'>You have been sent to the <b>Admin Room!</b>.</span>")
 		log_and_message_admins("has sent [key_name_admin(M)] to the Admin Room")
@@ -3072,12 +3072,12 @@
 								//don't strip organs
 							H.drop_item_ground(W)
 						//teleport person to cell
-						H.loc = pick(GLOB.prisonwarp)
+						H.forceMove(pick(GLOB.prisonwarp))
 						H.equip_to_slot_or_del(new /obj/item/clothing/under/color/orange(H), ITEM_SLOT_CLOTH_INNER)
 						H.equip_to_slot_or_del(new /obj/item/clothing/shoes/orange(H), ITEM_SLOT_FEET)
 					else
 						//teleport security person
-						H.loc = pick(GLOB.prisonsecuritywarp)
+						H.forceMove(pick(GLOB.prisonsecuritywarp))
 					GLOB.prisonwarped += H
 			if("traitor_all")
 				if(!SSticker)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -34,7 +34,7 @@
 			var/mob/living/L = M
 			L.Paralyse(10 SECONDS)
 		sleep(5)	//so they black out before warping
-		M.loc = pick(GLOB.prisonwarp)
+		M.forceMove(pick(GLOB.prisonwarp))
 		if(ishuman(M))
 			var/mob/living/carbon/human/prisoner = M
 			prisoner.equip_to_slot_or_del(new /obj/item/clothing/under/color/orange(prisoner), ITEM_SLOT_CLOTH_INNER)
@@ -462,13 +462,13 @@ Traitors and the like can also be revived with the previous role mostly intact.
 			else
 				new_character.mind.add_antag_datum(/datum/antagonist/traitor)
 		if("Wizard")
-			new_character.loc = pick(GLOB.wizardstart)
+			new_character.forceMove(pick(GLOB.wizardstart))
 			//ticker.mode.learn_basic_spells(new_character)
 			SSticker.mode.equip_wizard(new_character)
 		if("Syndicate")
 			var/obj/effect/landmark/synd_spawn = locate("landmark*Syndicate-Spawn")
 			if(synd_spawn)
-				new_character.loc = get_turf(synd_spawn)
+				new_character.forceMove(get_turf(synd_spawn))
 			call(/datum/game_mode/proc/equip_syndicate)(new_character)
 
 		if("Death Commando")//Leaves them at late-join spawn.

--- a/code/modules/clothing/spacesuits/chronosuit.dm
+++ b/code/modules/clothing/spacesuits/chronosuit.dm
@@ -97,7 +97,7 @@
 					sleep(7)
 			if(holder)
 				if(user && (user in holder.contents))
-					user.loc = to_turf
+					user.forceMove(to_turf)
 					if(user.client)
 						if(camera)
 							user.client.eye = camera
@@ -105,12 +105,12 @@
 							user.client.eye = user
 				qdel(holder)
 			else if(user)
-				user.loc = from_turf
+				user.forceMove(from_turf)
 			if(phaseanim)
 				qdel(phaseanim)
 			teleporting = 0
 			if(user && !user.loc) //ubersanity
-				user.loc = locate(0,0,1)
+				user.forceMove(locate(0,0,1))
 				user.gib()
 
 /obj/item/clothing/suit/space/chronos/process()

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -33,7 +33,7 @@
 /obj/machinery/gibber/Destroy()
 	if(contents.len)
 		for(var/atom/movable/A in contents)
-			A.loc = get_turf(src)
+			A.forceMove(get_turf(src))
 	if(occupant)
 		occupant = null
 	return ..()
@@ -182,7 +182,7 @@
 		return
 
 	for(var/obj/O in src)
-		O.loc = loc
+		O.forceMove(loc)
 
 	occupant.forceMove(get_turf(src))
 	occupant = null
@@ -393,16 +393,14 @@
 			continue
 		if(O.flags & NODROP || stealthmode)
 			qdel(O) //they are already dead by now
-		H.drop_item_ground(O)
-		O.loc = loc
+		H.drop_transfer_item_to_loc(O, loc)
 		O.throw_at(get_edge_target_turf(src, gib_throw_dir), rand(1, 5), 15)
 		sleep(1)
 
 	for(var/obj/item/clothing/C in H)
 		if(C.flags & NODROP || stealthmode)
 			qdel(C)
-		H.drop_item_ground(C)
-		C.loc = loc
+		H.drop_transfer_item_to_loc(C, loc)
 		C.throw_at(get_edge_target_turf(src, gib_throw_dir), rand(1, 5), 15)
 		sleep(1)
 
@@ -414,7 +412,7 @@
 		if(stealthmode)
 			qdel(O)
 		else if(istype(O))
-			O.loc = loc
+			O.forceMove(loc)
 			O.throw_at(get_edge_target_turf(src, gib_throw_dir), rand(1, 5), 15)
 			spats++
 			sleep(1)

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -129,7 +129,7 @@
 /datum/food_processor_process/mob/monkey/process_food(loc, what, processor)
 	var/mob/living/carbon/human/lesser/monkey/O = what
 	if(O.client) //grief-proof
-		O.loc = loc
+		O.forceMove(loc)
 		O.visible_message("<span class='notice'>Suddenly [O] jumps out from the processor!</span>", \
 				"<span class='notice'>You jump out of \the [src].</span>", \
 				"<span class='notice'>You hear a chimp.</span>")

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -226,7 +226,7 @@
 						if(L.stat != DEAD)
 							continue
 						large_cocoon = 1
-						L.loc = C
+						L.forceMove(C)
 						C.pixel_x = L.pixel_x
 						C.pixel_y = L.pixel_y
 						fed++

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -99,7 +99,7 @@
 /mob/living/simple_animal/hostile/headcrab/Destroy()
 	if(contents)
 		for(var/mob/M in contents)
-			M.loc = get_turf(src)
+			M.forceMove(get_turf(src))
 	return ..()
 
 /mob/living/simple_animal/hostile/headcrab/update_icons()

--- a/code/modules/mob/living/simple_animal/hostile/spaceworms.dm
+++ b/code/modules/mob/living/simple_animal/hostile/spaceworms.dm
@@ -183,7 +183,7 @@
 				src.visible_message("<span class='userdanger'>\the [src] eats \the [noms]!</span>","<span class='notice'>You eat \the [noms]!</span>","<span class='userdanger'>You hear gnashing.</span>") //inform everyone what the fucking worm is doing.
 				if(ismob(noms))
 					var/mob/M = noms //typecast because noms isn't movable
-					M.loc = src //because just setting a mob loc to null breaks the camera and such
+					M.forceMove(src) //because just setting a mob loc to null breaks the camera and such
 		else
 			currentlyEating = null
 	else

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/actions.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/actions.dm
@@ -283,7 +283,7 @@
 							visible_message("<span class='danger'>[src] wraps [L] in a web.</span>")
 						large_cocoon = 1
 						last_cocoon_object = 0
-						L.loc = C
+						L.forceMove(C)
 						C.pixel_x = L.pixel_x
 						C.pixel_y = L.pixel_y
 						break

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -42,7 +42,7 @@
 	var/turf/T = get_turf(src)
 	for(var/atom/movable/AM in src)
 		AM.add_fingerprint(user)
-		AM.loc = T
+		AM.forceMove(T)
 
 	qdel(src)
 
@@ -130,7 +130,7 @@
 		if(ishuman(user))
 			user.put_in_hands(wrapped)
 		else
-			wrapped.loc = get_turf(src)
+			wrapped.forceMove(get_turf(src))
 	playsound(src.loc, 'sound/items/poster_ripped.ogg', 50, 1)
 	qdel(src)
 

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -517,7 +517,7 @@
 			throwSmoke(src.loc)
 			if(trackedIan)
 				throwSmoke(trackedIan.loc)
-				trackedIan.loc = src.loc
+				trackedIan.forceMove(loc)
 				investigate_log("Experimentor has stolen Ian!", INVESTIGATE_EXPERIMENTOR) //...if anyone ever fixes it...
 			else
 				new /mob/living/simple_animal/pet/dog/corgi(src.loc)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Используем forceMove вместо loc =  в основном для мобов. Сделано для того чтобы вызывалось moved и корректно обновлялись статусы, например гравитация.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

