### PR TITLE
tweak: New Gravity Effect

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -1,7 +1,7 @@
 /mob/living/carbon/human/Moved(atom/OldLoc, Dir, Forced = FALSE)
 	. = ..()
-	//if((!OldLoc || !OldLoc.has_gravity()) && has_gravity()) //Temporary disable stun when gravity change
-	//	thunk()
+	if(!Forced && (!OldLoc || !OldLoc.has_gravity()) && has_gravity())
+		thunk()
 
 
 /mob/living/carbon/human/get_movespeed_modifiers()
@@ -159,9 +159,9 @@
 		*/
 
 
-/// Proc used to weaken the user when moving from no gravity to positive gravity.
+/// Proc used to inflict stamina damage when user is moving from no gravity to positive gravity.
 /mob/living/carbon/human/proc/thunk()
-	if(buckled || mob_negates_gravity() || incorporeal_move)
+	if(buckled || incorporeal_move || mob_negates_gravity())
 		return
 
 	if(dna?.species.spec_thunk(src)) //Species level thunk overrides
@@ -170,6 +170,6 @@
 	if(m_intent != MOVE_INTENT_RUN)
 		return
 
-	Weaken(4 SECONDS)
-	to_chat(src, "Gravity!")
+	to_chat(src, span_userdanger("Gravity exhausts you!"))
+	adjustStaminaLoss(35)
 


### PR DESCRIPTION
## Описание
Изменяет механ воздействия гравитации, при переходе из зоны без гравитации, в зону с гравитацией.

Было: 10с. ослабления.

Стало: 35 урона выносливости. Понизил изначальные 40, из предложки, чтобы избежать замедления, после первого срабатывания. Три срабатывания всё так же отправят в стаминакрит.

Форсмувы больше не провоцируют данный эффект, потому что не являются клиентским передвижением.


## Ссылка на предложение/Причина создания ПР
В процессе.
