### PR TITLE
bugfix: Autofire Fix

### DIFF
--- a/code/datums/components/fullauto.dm
+++ b/code/datums/components/fullauto.dm
@@ -303,7 +303,7 @@
 	if(semicd || shooter.incapacitated() || !can_trigger_gun(shooter))
 		return FALSE
 
-	if(!can_shoot())
+	if(!can_shoot(shooter))
 		shoot_with_empty_chamber(shooter)
 		return FALSE
 
@@ -328,7 +328,7 @@
 	if(semicd || shooter.incapacitated())
 		return NONE
 
-	if(!can_shoot())
+	if(!can_shoot(shooter))
 		shoot_with_empty_chamber(shooter)
 		return NONE
 

--- a/code/modules/antagonists/space_ninja/ninja_borg_module.dm
+++ b/code/modules/antagonists/space_ninja/ninja_borg_module.dm
@@ -60,7 +60,7 @@
 /obj/item/gun/energy/shuriken_emitter/borg/equip_to_best_slot(mob/M)
 	return
 
-/obj/item/gun/energy/shuriken_emitter/borg/can_shoot()
+/obj/item/gun/energy/shuriken_emitter/borg/can_shoot(mob/user)
 	return TRUE
 
 /obj/item/ammo_casing/energy/shuriken/borg

--- a/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_energy_stars.dm
+++ b/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_energy_stars.dm
@@ -62,7 +62,7 @@
 	qdel(src)
 
 
-/obj/item/gun/energy/shuriken_emitter/can_shoot()
+/obj/item/gun/energy/shuriken_emitter/can_shoot(mob/user)
 	return !my_suit.ninjacost(cost*burst_size)
 
 /obj/item/ammo_casing/energy/shuriken

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -147,12 +147,12 @@
 
 
 /obj/item/gun/proc/process_chamber()
-	return 0
+	return FALSE
 
 //check if there's enough ammo/energy/whatever to shoot one time
 //i.e if clicking would make it shoot
-/obj/item/gun/proc/can_shoot()
-	return 1
+/obj/item/gun/proc/can_shoot(mob/user)
+	return TRUE
 
 /obj/item/gun/proc/shoot_with_empty_chamber(mob/living/user)
 	to_chat(user, span_danger("*click*"))

--- a/code/modules/projectiles/guns/dartgun.dm
+++ b/code/modules/projectiles/guns/dartgun.dm
@@ -107,11 +107,10 @@
 	else
 		return ..()
 
-/obj/item/gun/dartgun/can_shoot()
+/obj/item/gun/dartgun/can_shoot(mob/user)
 	if(!cartridge)
-		return 0
-	else
-		return cartridge.darts
+		return FALSE
+	return cartridge.darts
 
 /obj/item/gun/dartgun/proc/has_selected_beaker_reagents()
 	return 0

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -183,13 +183,14 @@
 
 
 /obj/item/gun/energy/attack_self(mob/living/user)
-	if(length(ammo_type) > 1)
+	. = ..()
+	if(!. && length(ammo_type) > 1)
 		select_fire(user)
 		update_icon()
 
 
 /obj/item/gun/energy/can_shoot(mob/living/user)
-	if(sibyl_mod && !sibyl_mod.check_auth(user))
+	if(user && sibyl_mod && !sibyl_mod.check_auth(user))
 		return FALSE
 
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -148,7 +148,7 @@
 
 /obj/item/gun/energy/kinetic_accelerator/equipped(mob/user, slot, initial)
 	. = ..()
-	if(!can_shoot())
+	if(!can_shoot(user))
 		attempt_reload()
 
 

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -61,12 +61,13 @@
 	ammo_x_offset = 1
 	shaded_charge = TRUE
 
-/obj/item/gun/energy/gun/blueshield/can_shoot()
-    . = ..()
-    if(. && !isertmindshielded(usr))
-        to_chat(usr, span_warning("ЕРТ имплант «Защита разума» не обнаружен!"))
-        return FALSE
-    return .
+
+/obj/item/gun/energy/gun/blueshield/can_shoot(mob/user)
+	. = ..()
+	if(. && !isertmindshielded(user))
+		to_chat(user, span_warning("ЕРТ имплант «Защита разума» не обнаружен!"))
+		return FALSE
+
 
 /obj/item/gun/energy/gun/pdw9
 	name = "PDW-9 taser pistol"
@@ -80,12 +81,12 @@
 
 /obj/item/gun/energy/gun/pdw9/ert
 
-/obj/item/gun/energy/gun/pdw9/ert/can_shoot()
-    . = ..()
-    if(. && !isertmindshielded(usr))
-        to_chat(usr, span_warning("ЕРТ имплант «Защита разума» не обнаружен!"))
-        return FALSE
-    return .
+/obj/item/gun/energy/gun/pdw9/ert/can_shoot(mob/user)
+	. = ..()
+	if(. && !isertmindshielded(user))
+		to_chat(user, span_warning("ЕРТ имплант «Защита разума» не обнаружен!"))
+		return FALSE
+
 
 /obj/item/gun/energy/gun/turret
 	name = "hybrid turret gun"

--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -34,7 +34,7 @@
 			no_den_usage = 0
 	..()
 
-/obj/item/gun/magic/can_shoot()
+/obj/item/gun/magic/can_shoot(mob/user)
 	return charges
 
 /obj/item/gun/magic/newshot(params)

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -75,7 +75,7 @@
 		chambered.loc = src
 	return
 
-/obj/item/gun/projectile/can_shoot()
+/obj/item/gun/projectile/can_shoot(mob/user)
 	if(!magazine || !magazine.ammo_count(FALSE))
 		return FALSE
 	return TRUE

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -76,7 +76,7 @@
 		var/datum/action/A = X
 		A.UpdateButtonIcon()
 
-/obj/item/gun/projectile/automatic/can_shoot()
+/obj/item/gun/projectile/automatic/can_shoot(mob/user)
 	return get_ammo()
 
 /obj/item/gun/projectile/automatic/proc/empty_alarm()

--- a/code/modules/projectiles/guns/projectile/bombarda.dm
+++ b/code/modules/projectiles/guns/projectile/bombarda.dm
@@ -40,7 +40,7 @@
 /obj/item/gun/projectile/bombarda/chamber_round()
 	return
 
-/obj/item/gun/projectile/bombarda/can_shoot()
+/obj/item/gun/projectile/bombarda/can_shoot(mob/user)
 	if(!chambered)
 		return FALSE
 	return (chambered.BB ? TRUE : FALSE)

--- a/code/modules/projectiles/guns/projectile/bow.dm
+++ b/code/modules/projectiles/guns/projectile/bow.dm
@@ -68,7 +68,7 @@
 		chamber_round()
 		update_state()
 
-/obj/item/gun/projectile/bow/can_shoot()
+/obj/item/gun/projectile/bow/can_shoot(mob/user)
 	. = ..()
 	if(!ready_to_fire)
 		return FALSE

--- a/code/modules/projectiles/guns/projectile/launchers.dm
+++ b/code/modules/projectiles/guns/projectile/launchers.dm
@@ -149,7 +149,7 @@
 
 /obj/item/gun/projectile/revolver/rocketlauncher/suicide_act(mob/user)
 	user.visible_message("<span class='warning'>[user] aims [src] at the ground! It looks like [user.p_theyre()] performing a sick rocket jump!<span>")
-	if(can_shoot())
+	if(can_shoot(user))
 		user.notransform = TRUE
 		playsound(src, 'sound/weapons/rocketlaunch.ogg', 80, 1, 5)
 		animate(user, pixel_z = 300, time = 3 SECONDS, easing = LINEAR_EASING)

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -76,7 +76,7 @@
 		verbs -= /obj/item/gun/projectile/revolver/verb/spin
 
 
-/obj/item/gun/projectile/revolver/can_shoot()
+/obj/item/gun/projectile/revolver/can_shoot(mob/user)
 	return get_ammo(FALSE, FALSE)
 
 
@@ -243,7 +243,7 @@
 	return
 
 /obj/item/gun/projectile/revolver/russian/attack_self(mob/user)
-	if(!spun && can_shoot())
+	if(!spun && can_shoot(user))
 		user.visible_message("[user] spins the chamber of the revolver.", span_notice("You spin the revolver's chamber."))
 		Spin()
 	else

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -32,10 +32,10 @@
 /obj/item/gun/projectile/shotgun/chamber_round()
 	return
 
-/obj/item/gun/projectile/shotgun/can_shoot()
+/obj/item/gun/projectile/shotgun/can_shoot(mob/user)
 	if(!chambered)
-		return 0
-	return (chambered.BB ? 1 : 0)
+		return FALSE
+	return (chambered.BB ? TRUE : FALSE)
 
 /obj/item/gun/projectile/shotgun/attack_self(mob/living/user)
 	if(recentpump)

--- a/code/modules/projectiles/guns/rocket.dm
+++ b/code/modules/projectiles/guns/rocket.dm
@@ -42,7 +42,7 @@
 	else
 		return ..()
 
-/obj/item/gun/rocketlauncher/can_shoot()
+/obj/item/gun/rocketlauncher/can_shoot(mob/user)
 	return rockets.len
 
 /obj/item/gun/rocketlauncher/process_fire(atom/target as mob|obj|turf, mob/living/user as mob|obj, message = 1, params, zone_override = "")

--- a/code/modules/projectiles/guns/throw.dm
+++ b/code/modules/projectiles/guns/throw.dm
@@ -62,10 +62,9 @@
 		loaded_projectiles -= to_launch
 	return
 
-/obj/item/gun/throw/can_shoot()
-	if(to_launch)
-		return 1
-	return 0
+/obj/item/gun/throw/can_shoot(mob/user)
+	return to_launch
+
 
 /obj/item/gun/throw/process_fire(atom/target as mob|obj|turf, mob/living/user as mob|obj, message = 1, params, zone_override)
 	add_fingerprint(user)

--- a/code/modules/projectiles/sibyl/sibyl_system_mod.dm
+++ b/code/modules/projectiles/sibyl/sibyl_system_mod.dm
@@ -140,15 +140,15 @@ GLOBAL_VAR_INIT(sibsys_automode, TRUE)
 		if(!auth_id)
 			to_chat(user, span_warning("Требуется авторизация! Приложите ID-карту."))
 			return FALSE
-		if(!find_and_compare_id_cards(user, auth_id))
+		if(!find_and_compare_id_cards(user))
 			to_chat(user, span_warning("Ваша ID-карта не совпадает с авторизованной."))
 			return FALSE
 	return TRUE
 
 
-/obj/item/sibyl_system_mod/proc/find_and_compare_id_cards(mob/user, obj/item/card/id/registered_id)
+/obj/item/sibyl_system_mod/proc/find_and_compare_id_cards(mob/user)
 	for(var/obj/item/card/id/found_id in user.get_all_id_cards())
-		if(found_id == registered_id)
+		if(found_id == auth_id)
 			return TRUE
 	return FALSE
 


### PR DESCRIPTION
## Описание
Фикс компонента автоогня, для работы с сибилами.

Также теперь до энергетического оружия будет доходить сигнал ATTACK_SELF, что позволяет использовать его с компонентом двуручного оружия. Здесь правда будут конфликты с оружием, которое имеет несколько режимов стрельбы и переключается через то же действие (attack_self). Возможно есть смысл вынести переключение режимов для всего оружия на кнопку интерфейса.