### PR TITLE
QoL: PDA Shows Sent Messages

### DIFF
--- a/code/modules/pda/messenger.dm
+++ b/code/modules/pda/messenger.dm
@@ -187,6 +187,7 @@
 
 		SStgui.update_uis(src)
 		PM.notify("<b>Message from [pda.owner] ([pda.ownjob]), </b>\"[t]\" (<a href='?src=[PM.UID()];choice=Message;target=[pda.UID()]'>Reply</a>)")
+		to_chat(U, "[bicon(pda)] <b>Message to [P.owner] ([P.ownjob]), </b>\"[t]\" (<a href='?src=[UID()];choice=Message;target=[P.UID()]'>Send more</a>)")
 		log_pda("(PDA: [src.name]) sent \"[t]\" to [P.name]", U)
 		var/log_message = "sent PDA message \"[t]\" using [pda]"
 		var/receiver


### PR DESCRIPTION
## Описание
Отправка сообщений, через PDA, дублируется в чате. Плюс добавил возможность отправить ещё одно сообщение, через ссылку в конце, по аналогии с Reply.

## Демонстрация изменений
![ttCyDO3](https://github.com/ss220-space/Paradise/assets/35403274/7cf298e8-5256-4bd0-aecc-5f7eda51977d)
