### PR TITLE
bugfix: Brig doors now use a proper font

### DIFF
--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -195,7 +195,7 @@
 		var/disp2 = "[add_zero(num2text((timeleft / 60) % 60),2)]:[add_zero(num2text(timeleft % 60), 2)]"
 		if(length(disp2) > DISPLAY_CHARS_PER_LINE)
 			disp2 = "Error"
-		var/new_text = {"<div style="font-size:[DISPLAY_FONT_SIZE];color:[DISPLAY_FONT_COLOR];font:'[DISPLAY_FONT_SIZE]';text-align:center;" valign="top">[uppertext(disp1)]<br>[uppertext(disp2)]</div>"}
+		var/new_text = {"<div style="font-size:[DISPLAY_FONT_SIZE];color:[DISPLAY_FONT_COLOR];font:'[DISPLAY_FONT_STYLE]';text-align:center;" valign="top">[uppertext(disp1)]<br>[uppertext(disp2)]</div>"}
 		if(maptext != new_text)
 			maptext = new_text
 	else if(maptext)

--- a/code/modules/power/treadmill.dm
+++ b/code/modules/power/treadmill.dm
@@ -199,7 +199,7 @@
 /obj/machinery/treadmill_monitor/proc/update_display(var/line1, var/line2)
 	line1 = uppertext(line1)
 	line2 = uppertext(line2)
-	var/new_text = {"<div style="font-size:[DISPLAY_FONT_SIZE];color:[DISPLAY_FONT_COLOR];font:'[DISPLAY_FONT_SIZE]';text-align:center;" valign="top">[line1]<br>[line2]</div>"}
+	var/new_text = {"<div style="font-size:[DISPLAY_FONT_SIZE];color:[DISPLAY_FONT_COLOR];font:'[DISPLAY_FONT_STYLE]';text-align:center;" valign="top">[line1]<br>[line2]</div>"}
 	if(maptext != new_text)
 		maptext = new_text
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Меняет в `/obj/machinery/door_timer`, в проке `update_display()` параметр `font`, чтобы там был не размер пикселей, а шрифт.

## Ссылка на предложение/Причина создания ПР
Выглядело как опечатка.
![image](https://github.com/ss220-space/Paradise/assets/87372121/f55d35f4-74ac-42a5-b669-3d0ffb913f6d)
--
![image](https://github.com/ss220-space/Paradise/assets/87372121/1faded24-6f01-4f11-8dd6-588d84d88e8a)


## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
