### PR TITLE
bugfix: correct flags check for items in safe

### DIFF
--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -184,7 +184,7 @@ GLOBAL_LIST_EMPTY(safes)
 
 /obj/structure/safe/attackby(obj/item/item, mob/user, params)
 	if(open)
-		if(item.flags && ABSTRACT)
+		if(item.flags & ABSTRACT)
 			return
 		if(broken && istype(item, /obj/item/safe_internals) && do_after(user, 2 SECONDS, target = src))
 			to_chat(user, span_notice("You replace the broken mechanism."))


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Чинит баг, из-за которого некоторые вещи нельзя было положить обратно в сейф после извлечения
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багфикс https://discord.com/channels/617003227182792704/1233377153815416902
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->