### PR TITLE
QoL: Special role now visible in TP

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -696,6 +696,7 @@
 	var/out = {"<meta charset="UTF-8"><B>[name]</B>[(current && (current.real_name != name))?" (as [current.real_name])" : ""]<br>"}
 	out += "Mind currently owned by key: [key] [active ? "(synced)" : "(not synced)"]<br>"
 	out += "Assigned role: [assigned_role]. <a href='?src=[UID()];role_edit=1'>Edit</a><br>"
+	out += "Special role: [special_role].<br>" //better to change this through /datum/antag
 	out += "Factions and special roles:<br>"
 
 	var/list/sections = list(

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -696,7 +696,7 @@
 	var/out = {"<meta charset="UTF-8"><B>[name]</B>[(current && (current.real_name != name))?" (as [current.real_name])" : ""]<br>"}
 	out += "Mind currently owned by key: [key] [active ? "(synced)" : "(not synced)"]<br>"
 	out += "Assigned role: [assigned_role]. <a href='?src=[UID()];role_edit=1'>Edit</a><br>"
-	out += "Special role: [special_role].<br>" //better to change this through /datum/antag
+	out += "Special role: [special_role].<br>" //better to change this through /datum/antagonist/, some code uses this var and can break if something goes wrong
 	out += "Factions and special roles:<br>"
 
 	var/list/sections = list(


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет в TP строку с названием роли, для дебага и для быстрого поиска проблемы в выдаче антагов.

## Ссылка на предложение/Причина создания ПР
Вроде, не в первый раз говорят про то, что роль выдаётся некорректно, но что именно не так - не говорят. Это решение должно помочь уменьшить круг поисков.
Сейчас, если стоит не "обычная" роль, по тип помощника контрактора или космического дракона - оно просто не [показывается админам](https://discord.com/channels/617003227182792704/1233545869970767965/1233545869970767965).
![image](https://github.com/ss220-space/Paradise/assets/87372121/36944fa8-d322-469d-8fad-602c96d9e682)

## Демонстрация изменений
![image](https://github.com/ss220-space/Paradise/assets/87372121/1fb1ecca-bb5b-4c0e-9f11-f488007c7e78)
