### PR TITLE
Fix: bed layers

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -18,6 +18,7 @@
 	anchored = TRUE
 	buckle_lying = TRUE
 	resistance_flags = FLAMMABLE
+	layer = BELOW_OBJ_LAYER
 	max_integrity = 100
 	integrity_failure = 30
 	var/buildstacktype = /obj/item/stack/sheet/metal


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Теперь слой кроватей будет ниже чем слой ящиков/обьектов во избежание абузов с прятками

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1234775026818089030/1234775026818089030
Становление невидимым при помощи мешка не круто

## Демонстрация изменений
![image](https://github.com/ss220-space/Paradise/assets/88409706/5bc899c4-3841-47ae-9955-462c0ffdd748)
