### PR TITLE
Fix: beds and chairs obj layer

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -18,6 +18,7 @@
 	anchored = TRUE
 	buckle_lying = TRUE
 	resistance_flags = FLAMMABLE
+	layer = BELOW_OBJ_LAYER
 	max_integrity = 100
 	integrity_failure = 30
 	var/buildstacktype = /obj/item/stack/sheet/metal

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -3,11 +3,10 @@
 	desc = "You sit in this. Either by will or force."
 	icon = 'icons/obj/chairs.dmi'
 	icon_state = "chair"
-	layer = OBJ_LAYER
+	layer = BELOW_OBJ_LAYER
 	can_buckle = TRUE
 	buckle_lying = FALSE // you sit in a chair, not lay
 	resistance_flags = NONE
-	layer = BELOW_OBJ_LAYER
 	max_integrity = 250
 	integrity_failure = 25
 	buckle_offset = 0
@@ -117,7 +116,7 @@
 	if(has_buckled_mobs() && dir == NORTH)
 		layer = ABOVE_MOB_LAYER
 	else
-		layer = OBJ_LAYER
+		layer = initial(layer)
 
 
 /obj/structure/chair/post_buckle_mob(mob/living/M)

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -7,6 +7,7 @@
 	can_buckle = TRUE
 	buckle_lying = FALSE // you sit in a chair, not lay
 	resistance_flags = NONE
+	layer = BELOW_OBJ_LAYER
 	max_integrity = 250
 	integrity_failure = 25
 	buckle_offset = 0


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Снижает "слой" стульев и кроватей во избежание абуза который возможен из-за того, что сейчас у шкафов слой ниже.

## Ссылка на предложение/Причина создания ПР
Абузить плохо. Кто-то давно об этом не подумал. Не выглядит как фича, не интересно, хуево.
https://discord.com/channels/617003227182792704/918070331716010014/1234706192727674920

## Демонстрация изменений
![image](https://github.com/ss220-space/Paradise/assets/88409706/e2a2e062-c650-4c5c-8a34-d3aa059bc0eb)

