### PR TITLE
bugfix: Removed corrupted floor apprearances from Terror Spider gate 

### DIFF
--- a/_maps/map_files/RandomZLevels/terrorspiders.dmm
+++ b/_maps/map_files/RandomZLevels/terrorspiders.dmm
@@ -3443,7 +3443,6 @@
 /area/awaymission/UO71/centralhall)
 "iX" = (
 /obj/structure/closet/secure_closet{
-	icon_state = "secure";
 	locked = 0;
 	name = "kitchen Cabinet";
 	req_access = list(271)
@@ -4873,7 +4872,7 @@
 /area/awaymission/UO71/science)
 "lY" = (
 /obj/structure/sign/directions/medical{
-	pixel_y = -12
+	pixel_y = -20
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplecorner"
@@ -6941,7 +6940,6 @@
 /area/awaymission/UO71/medical)
 "qf" = (
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Medical Storage"
 	},
 /turf/simulated/floor/plasteel{
@@ -9269,8 +9267,7 @@
 /obj/machinery/atmospherics/trinary/filter{
 	dir = 4;
 	filter_type = 2;
-	on = 1;
-	req_access = null
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -9325,8 +9322,7 @@
 /obj/machinery/atmospherics/trinary/filter{
 	dir = 4;
 	filter_type = 1;
-	on = 1;
-	req_access = null
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -9337,11 +9333,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 9
 	},
-/turf/simulated/floor/plasteel{
-	burnt = 1;
-	dir = 8;
-	icon_state = "floorscorched2"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/UO71/eng)
 "uU" = (
 /obj/structure/cable{
@@ -10136,11 +10128,7 @@
 /obj/structure/sign/poster/official/build{
 	pixel_y = -32
 	},
-/turf/simulated/floor/plasteel{
-	burnt = 1;
-	dir = 8;
-	icon_state = "floorscorched2"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/UO71/eng)
 "wL" = (
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -10972,11 +10960,7 @@
 	},
 /obj/item/gun/energy/kinetic_accelerator,
 /obj/item/borg/upgrade/modkit/tracer,
-/turf/simulated/floor/plasteel{
-	burnt = 1;
-	dir = 8;
-	icon_state = "floorscorched2"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/UO71/mining)
 "yx" = (
 /turf/simulated/floor/plasteel,


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Исправляет баг отображения пола в Террорспайдер гейте

## Ссылка на багрепорт
https://discord.com/channels/617003227182792704/943940908162875473/1236703242100936855