### PR TITLE
bugfix: Taperoll and Persistent Overlay Fix

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -117,10 +117,6 @@
 	else
 		return ..()
 
-// Proximity_flag is 1 if this afterattack was called on something adjacent, in your square, or on your person.
-// Click parameters is the params string from byond Click() code, see that documentation.
-/obj/item/proc/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
-	return
 
 /obj/item/proc/get_clamped_volume()
 	if(w_class)

--- a/code/datums/components/ducttape.dm
+++ b/code/datums/components/ducttape.dm
@@ -1,59 +1,76 @@
 /datum/component/ducttape
-	var/x_offset = 0
-	var/y_offset = 0
-	var/icon/tape_overlay = null
+	var/mutable_appearance/tape_overlay
 	var/hide_tape = FALSE
 
-/datum/component/ducttape/Initialize(obj/item/I, mob/user, x, y, hide_tape)
-	if(!istype(I)) //Something went wrong
-		return
+
+/datum/component/ducttape/Initialize(x_offset = 0, y_offset = 0, hide_tape = FALSE)
+	if(!isitem(parent)) //Something went wrong
+		return COMPONENT_INCOMPATIBLE
+	src.hide_tape = hide_tape
 	if(!hide_tape) //if TRUE this hides the tape overlay and added examine text
+		tape_overlay = mutable_appearance('icons/obj/bureaucracy.dmi', "tape")
+		tape_overlay.pixel_x = x_offset - 2
+		tape_overlay.pixel_y = y_offset - 2
 		RegisterSignal(parent, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(add_tape_overlay))
 		RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(add_tape_text))
-	x_offset = x
-	y_offset = y
-	RegisterSignal(parent, COMSIG_ITEM_AFTERATTACK, PROC_REF(afterattack))
-	RegisterSignal(parent, COMSIG_ITEM_PICKUP, PROC_REF(pick_up))
+	var/obj/item/I = parent
 	I.set_anchored(TRUE)
 	I.update_icon() //Do this first so the action button properly shows the icon
 	if(!hide_tape) //the tape can no longer be removed if TRUE
-		var/datum/action/item_action/remove_tape/RT = new(I)
-		if(I.loc == user)
-			RT.Grant(user)
+		var/datum/action/item_action/remove_tape/remove_action = new(I)
+		if(ismob(I.loc))
+			remove_action.Grant(I.loc)
 	I.add_tape()
 
 
-/datum/component/proc/add_tape_text(datum/source, mob/user, list/examine_list)
+/datum/component/ducttape/Destroy()
+	tape_overlay = null
+	return ..()
+
+
+/datum/component/ducttape/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_ITEM_AFTERATTACK, PROC_REF(afterattack))
+	RegisterSignal(parent, COMSIG_ITEM_PICKUP, PROC_REF(pick_up))
+
+
+/datum/component/ducttape/UnregisterFromParent()
+	UnregisterSignal(parent, list(COMSIG_ITEM_AFTERATTACK, COMSIG_ITEM_PICKUP))
+
+
+/datum/component/ducttape/proc/add_tape_text(datum/source, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+
 	examine_list += span_notice("There's some sticky tape attached to [source].")
 
 
-/datum/component/ducttape/proc/add_tape_overlay(obj/item/O)
-	tape_overlay = new('icons/obj/bureaucracy.dmi', "tape")
-	tape_overlay.Shift(EAST, x_offset - 2)
-	tape_overlay.Shift(NORTH, y_offset - 2)
-	O.add_overlay(tape_overlay)
+/datum/component/ducttape/proc/add_tape_overlay(datum/source, list/overlays)
+	SIGNAL_HANDLER
+
+	overlays += tape_overlay
 
 
 /datum/component/ducttape/proc/remove_tape(obj/item/I, mob/user)
 	to_chat(user, span_notice("You tear the tape off [I]!"))
 	playsound(I, 'sound/items/poster_ripped.ogg', 50, 1)
 	new /obj/item/trash/tapetrash(user.loc)
-	I.update_icon()
 	I.set_anchored(initial(I.anchored))
+	if(!hide_tape)
+		UnregisterSignal(parent, list(COMSIG_ATOM_UPDATE_OVERLAYS, COMSIG_PARENT_EXAMINE))
+	I.update_icon()
 	for(var/datum/action/item_action/remove_tape/RT in I.actions)
 		RT.Remove(user)
 		qdel(RT)
-	I.cut_overlay(tape_overlay)
 	user.transfer_fingerprints_to(I)
 	I.remove_tape()
 	qdel(src)
 
 
 /datum/component/ducttape/proc/afterattack(obj/item/I, atom/target, mob/user, proximity, params)
-	if(!proximity)
+	SIGNAL_HANDLER
+
+	if(!proximity || !isturf(target) || !user.drop_item_ground(I))
 		return
-	if(!isturf(target))
-		return
+
 	var/turf/source_turf = get_turf(I)
 	var/turf/target_turf = target
 	var/x_offset
@@ -76,12 +93,14 @@
 		else if(target_direction & SOUTH)
 			x_offset = rand(-12, 12)
 			y_offset = -16
-	if(!user.drop_item_ground(I))
-		return
 	to_chat(user, span_notice("You stick [I] to [target_turf]."))
 	I.pixel_x = x_offset
 	I.pixel_y = y_offset
 
+
 /datum/component/ducttape/proc/pick_up(obj/item/I, mob/user)
+	SIGNAL_HANDLER
+
 	I.pixel_x = initial(I.pixel_x)
 	I.pixel_y = initial(I.pixel_y)
+

--- a/code/datums/components/persistent_overlay.dm
+++ b/code/datums/components/persistent_overlay.dm
@@ -1,32 +1,52 @@
+#define DEFAULT_DUPE_ID "default_dupe_ID"
+
 /datum/component/persistent_overlay
-	var/image/persistent_overlay
-	var/atom/target
+	dupe_mode = COMPONENT_DUPE_ALLOWED
+	var/dupe_id = DEFAULT_DUPE_ID
+	var/mutable_appearance/persistent_overlay
 
 
-/datum/component/persistent_overlay/Initialize(persistent_overlay, target, timer)
+/datum/component/persistent_overlay/Initialize(persistent_overlay, dupe_id = DEFAULT_DUPE_ID, timer)
+	if(!isatom(parent) || !istext(dupe_id) || dupe_id == DEFAULT_DUPE_ID)
+		return COMPONENT_INCOMPATIBLE
+
+	if(parent.datum_components && parent.datum_components[/datum/component/persistent_overlay])
+		var/list/all_persistent = parent.datum_components[/datum/component/persistent_overlay]
+		if(!islist(all_persistent))
+			all_persistent = list(all_persistent)
+		for(var/datum/component/persistent_overlay/existing as anything in all_persistent)
+			if(existing.dupe_id == dupe_id)
+				existing.remove_persistent_overlay()
+
+	src.dupe_id = dupe_id
 	src.persistent_overlay = persistent_overlay
-	src.target = target
-	if(timer)
-		addtimer(CALLBACK(src, PROC_REF(remove_persistent_overlay)), timer)
-	if(target)
-		RegisterSignal(target, COMSIG_PARENT_QDELETING, PROC_REF(remove_persistent_overlay))
 	RegisterSignal(parent, COMSIG_PARENT_QDELETING, PROC_REF(remove_persistent_overlay))
-	add_persistent_overlay()
+	RegisterSignal(parent, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(on_update_overlays))
+	var/atom/atom_parent = parent
+	atom_parent.update_icon()
+	if(!isnull(timer))
+		addtimer(CALLBACK(src, PROC_REF(remove_persistent_overlay)), timer)
 
 
 /datum/component/persistent_overlay/Destroy()
 	persistent_overlay = null
-	target = null
 	return ..()
 
 
+/datum/component/persistent_overlay/proc/on_update_overlays(datum/source, list/overlays)
+	SIGNAL_HANDLER
+
+	overlays += persistent_overlay
+
+
 /datum/component/persistent_overlay/proc/remove_persistent_overlay(datum/source)
-	var/atom/movable/our_target = target ? target : parent
-	our_target.cut_overlay(persistent_overlay)
+	SIGNAL_HANDLER
+
+	var/atom/atom_parent = parent
+	UnregisterSignal(atom_parent, COMSIG_ATOM_UPDATE_OVERLAYS)
+	atom_parent.update_icon()
 	qdel(src)
 
 
-/datum/component/persistent_overlay/proc/add_persistent_overlay(datum/source)
-	var/atom/movable/our_target = target ? target : parent
-	our_target.add_overlay(persistent_overlay)
+#undef DEFAULT_DUPE_ID
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -547,6 +547,40 @@
 	return
 
 
+/**
+ * Adds a special overlay to any atom.
+ * This overlay will always persist even when an atom is updating its overlays.
+ *
+ * Arguments:
+ * * overlay_to_add - should be an image, mutable_appearance or icon
+ * * id - string ID of our overlay, should be unique, otherwise it will remove all overlays with the same ID
+ * * timer (optional) - if set overlay will be removed after passed time
+ */
+/atom/proc/add_persistent_overlay(overlay_to_add, id, timer)
+	if(!istext(id))
+		CRASH("Non-text argument passed as an ID.")
+	AddComponent(/datum/component/persistent_overlay, overlay_to_add, id, timer)
+
+
+/**
+ * Removes a persistent overlay from an atom if it exists.
+ *
+ * Arguments:
+ * * id - string ID of the overlay we should remove
+ */
+/atom/proc/remove_persistent_overlay(id)
+	if(!istext(id))
+		CRASH("Non-text argument passed as an ID.")
+	if(!datum_components || !datum_components[/datum/component/persistent_overlay])
+		return
+	var/list/all_persistent = datum_components[/datum/component/persistent_overlay]
+	if(!islist(all_persistent))
+		all_persistent = list(all_persistent)
+	for(var/datum/component/persistent_overlay/existing as anything in all_persistent)
+		if(existing.dupe_id == id)
+			existing.remove_persistent_overlay()
+
+
 /atom/Topic(href, href_list)
 	. = ..()
 	if(.)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -328,9 +328,8 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 		..()
 
 
-/obj/item/afterattack(atom/target, mob/user, proximity, params)
+/obj/item/proc/afterattack(atom/target, mob/user, proximity, params)
 	SEND_SIGNAL(src, COMSIG_ITEM_AFTERATTACK, target, user, proximity, params)
-	..()
 
 	if(!proximity)
 		return
@@ -500,7 +499,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 			return
 		if(TR.use(1))
 			to_chat(user, "<span class='notice'>You apply some tape to [src].</span>")
-			AddComponent(/datum/component/ducttape, src, user, x_offset, y_offset)
+			AddComponent(/datum/component/ducttape, x_offset, y_offset)
 			user.transfer_fingerprints_to(src)
 		else
 			to_chat(user, "<span class='notice'>You don't have enough tape to do that!</span>")

--- a/code/game/objects/items/decorations.dm
+++ b/code/game/objects/items/decorations.dm
@@ -6,9 +6,10 @@
 /obj/item/decorations/sticky_decorations
 	w_class = WEIGHT_CLASS_TINY
 
+
 /obj/item/decorations/sticky_decorations/New()
 	. = ..()
-	AddComponent(/datum/component/ducttape, src, null, 0, 0, TRUE)//add this to something to make it sticky but without the tape overlay
+	AddComponent(/datum/component/ducttape, 0, 0, TRUE)//add this to something to make it sticky but without the tape overlay
 
 
 

--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -9,9 +9,6 @@
 	amount = 25
 	max_amount = 25
 
-/obj/item/stack/tape_roll/New(loc, amount=null)
-	..()
-	update_icon(UPDATE_ICON_STATE)
 
 /obj/item/stack/tape_roll/attack(mob/living/carbon/human/M, mob/living/user)
 	if(!istype(M)) //What good is a duct tape mask if you are unable to speak?

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -123,7 +123,9 @@
 	user.transfer_fingerprints_to(trash_gag)
 	user.put_in_active_hand(trash_gag, ignore_anim = FALSE)
 	playsound(user, 'sound/items/poster_ripped.ogg', 40, TRUE)
-	user.emote("scream")
+	if(user.has_pain())
+		// we have to use timer, since an item is still on user, while this proc is called
+		addtimer(CALLBACK(user, TYPE_PROC_REF(/mob, emote), "scream"), 0)
 
 
 /obj/item/clothing/mask/muzzle/tapegag/thick


### PR DESCRIPTION
## Описание
- убран дубликат прока afterattack
- древний компонент /datum/component/ducttape приведён в нормальный вид
- теперь тот, с кого содрали изоленту, будет кричать, как и задумано
- исправлена работа компонента /datum/component/persistent_overlay и кода, где он применялся