### PR TITLE
bugfix: No Throw Impact Effects With Items

### DIFF
--- a/code/game/objects/effects/effects.dm
+++ b/code/game/objects/effects/effects.dm
@@ -45,6 +45,11 @@
 			if(prob(25))
 				qdel(src)
 
+
+/obj/effect/hit_by_thrown_carbon(mob/living/carbon/human/C, datum/thrownthing/throwingdatum, damage, mob_hurt, self_hurt)
+	return
+
+
 /**
  * # The abstract object
  *

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1311,3 +1311,8 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 /// Called on [/datum/element/openspace_item_click_handler/proc/on_afterattack]. Check the relative file for information.
 /obj/item/proc/handle_openspace_click(turf/target, mob/user, proximity_flag, click_parameters)
 	stack_trace("Undefined handle_openspace_click() behaviour. Ascertain the openspace_item_click_handler element has been attached to the right item and that its proc override doesn't call parent.")
+
+
+/obj/item/hit_by_thrown_carbon(mob/living/carbon/human/C, datum/thrownthing/throwingdatum, damage, mob_hurt, self_hurt)
+	return
+


### PR DESCRIPTION
## Описание
Исправляет эффекты, присущие объектам, в случае попадания по предметам и эффектам.


## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1237491048796786801
