### PR TITLE
bugfix: Sleeping patients staying sleepy during surgery

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -409,15 +409,6 @@
 	var/mob/living/carbon/human/H = target
 	var/pain_mod = get_pain_modifier(H)
 
-	// don't let people sit on the optable and sleep verb
-	var/datum/status_effect/incapacitating/sleeping/S = H.IsSleeping()
-	if(S)
-		H.SetSleeping(0) // wake up people who are napping through the surgery
-		if(pain_mod < 0.95)
-			to_chat(H, span_danger("The surgery on your [parse_zone(target_zone)] is agonizingly painful, and rips you out of your shallow slumber!"))
-		else
-			// Still wake people up, but they shouldn't be as alarmed.
-			to_chat(H, span_warning("The surgery being performed on your [parse_zone(target_zone)] wakes you up."))
 	return pain_mod //operating on conscious people is hard.
 
 /**

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -409,6 +409,17 @@
 	var/mob/living/carbon/human/H = target
 	var/pain_mod = get_pain_modifier(H)
 
+/* this is broken, uncomment after separation IC-SLEEP from other method's sleep (like ether)
+	// don't let people sit on the optable and sleep verb
+	var/datum/status_effect/incapacitating/sleeping/S = H.IsSleeping()
+	if(S)
+		H.SetSleeping(0) // wake up people who are napping through the surgery
+		if(pain_mod < 0.95)
+			to_chat(H, span_danger("The surgery on your [parse_zone(target_zone)] is agonizingly painful, and rips you out of your shallow slumber!"))
+		else
+			// Still wake people up, but they shouldn't be as alarmed.
+			to_chat(H, span_warning("The surgery being performed on your [parse_zone(target_zone)] wakes you up."))
+*/
 	return pain_mod //operating on conscious people is hard.
 
 /**


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Убирает строчку в операции "если человек спит - разбудить его"

## Ссылка на предложение/Причина создания ПР
Рефактор #4436 занёс "фичу", которая убирала сон у пациента, если операция была на органическом теле.
Этой фичи до рефактора не было и сейчас она вызывает проблемы. К примеру, если цель усыпить морфином (те же воксы, у которых нельзя поставить обычный баллон с анестетиком) или другим усыпляющим средством - она просыпается из-за данной фичи.
[Слова Рерика](https://discord.com/channels/617003227182792704/734823601110515882/1240987569252991006) по этому поводу.
