### PR TITLE
bugfix: Atmos no longer divide by zero

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -81,7 +81,7 @@
     var/atox = 0
     var/asleep = 0
     var/ab = 0
-    var/atemp = 0
+    var/atemp = TCMB
 
     var/turf_count = 0
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Меняет в проке `assimilate_air(` изначальную температуру с 0 градуса на 2.7.

## Ссылка на предложение/Причина создания ПР
[Ссылка](https://discord.com/channels/617003227182792704/734823601110515882/1242102025429192744).
Если вокруг тайла нет воздуха, то и дальше температура присваивается нулевая. Что очень плохо сказывается на атмосе, когда он делит на ноль для давления (или когда там происходит деление).