### PR TITLE
tweak: Slightly Improved UID

### DIFF
--- a/code/__HELPERS/unique_ids.dm
+++ b/code/__HELPERS/unique_ids.dm
@@ -16,22 +16,38 @@
 
 /// The next UID to be used (Increments by 1 for each UID)
 GLOBAL_VAR_INIT(next_unique_datum_id, 1)
+/// Every time GLOB.next_unique_datum_id goes above 16777215, we will add new letter and reset the counter.
+GLOBAL_VAR_INIT(unique_datum_id_letters, "")
 /// Log of all UIDs created in the round. Assoc list with type as key and amount as value
 GLOBAL_LIST_EMPTY(uid_log)
 
 /**
   * Gets or creates the UID of a datum
   *
-  * BYOND refs are recycled, so this system prevents that. If a datum does not have a UID when this proc is ran, one will be created
+  * BYOND refs are recycled, so this system prevents that. If a datum does not have a UID when this proc is ran, one will be created.
+  * If we go above 54 * 16777216 UIDs in a round shit breaks.
+  *
   * Returns the UID of the datum
   */
 /datum/proc/UID()
 	if(!unique_datum_id)
 		var/tag_backup = tag
-		tag = null // Grab the raw ref, not the tag
-		// num2text can output 8 significant figures max. If we go above 10 million UIDs in a round, shit breaks
-		unique_datum_id = "\ref[src]_[num2text(GLOB.next_unique_datum_id++, 8)]"
+		// Grab the raw ref, not the tag
+		tag = null
+		var/new_ref = "\ref[src]"
 		tag = tag_backup
+		GLOB.next_unique_datum_id++
+		if(GLOB.next_unique_datum_id >= (SHORT_REAL_LIMIT - 1))
+			var/static/list/free_unique_letters = GLOB.alphabet.Copy() + GLOB.alphabet_uppercase.Copy()
+			if(!free_unique_letters.len)
+				stack_trace("UID is out of unique strings. Time to switch on weakrefs.")
+				return
+			var/new_letter = pick(free_unique_letters)
+			free_unique_letters -= new_letter
+			GLOB.unique_datum_id_letters = "[GLOB.unique_datum_id_letters][new_letter]"
+			GLOB.next_unique_datum_id = 1
+		// we nee to use num2text since BYOND will print a number in scientific notation if its big enough, breaking the refs
+		unique_datum_id = "[new_ref]_[GLOB.unique_datum_id_letters]|[num2text(GLOB.next_unique_datum_id, 8)]"
 		GLOB.uid_log[type]++
 	return unique_datum_id
 
@@ -45,8 +61,8 @@ GLOBAL_LIST_EMPTY(uid_log)
 /**
   * Locates a datum based off of the UID
   *
-  * Replacement for locate() which takes a UID instead of a ref
-  * Returns the datum, if found
+  * Replacement for locate() which takes a UID instead of a ref.
+  * This will return `null` if the datum was deleted. This MUST be respected.
   */
 /proc/locateUID(uid)
 	if(!istext(uid))
@@ -57,10 +73,33 @@ GLOBAL_LIST_EMPTY(uid_log)
 	if(!splitat)
 		return null
 
-	var/datum/D = locate(copytext(uid, 1, splitat))
+	var/datum/found = locate(copytext(uid, 1, splitat))
 
-	if(D && D.unique_datum_id == uid)
-		return D
+	if(!QDELETED(found) && found.unique_datum_id == uid)
+		return found
+
+	return null
+
+
+/**
+ * Like locateUID, but doesn't care if the datum is being qdeleted but hasn't been deleted yet.
+ *
+ * Just use locateUID, unless you specifically know what you are doing.
+ */
+/proc/hardlocateUID(uid)
+	if(!istext(uid))
+		return null
+
+	var/splitat = findlasttext(uid, "_")
+
+	if(!splitat)
+		return null
+
+	var/datum/found = locate(copytext(uid, 1, splitat))
+
+	if(found && found.unique_datum_id == uid)
+		return found
+
 	return null
 
 
@@ -78,7 +117,7 @@ GLOBAL_LIST_EMPTY(uid_log)
 
 
 /**
-  * Opens a lof of UIDs
+  * Opens a lot of UIDs
   *
   * In-round ability to view what has created a UID, and how many times a UID for that path has been declared
   */
@@ -91,7 +130,8 @@ GLOBAL_LIST_EMPTY(uid_log)
 		return
 
 	var/list/sorted = sortTim(GLOB.uid_log, cmp = /proc/cmp_numeric_dsc, associative = TRUE)
-	var/list/text = list("<h1>UID Log</h1>", "<p>Current UID: [GLOB.next_unique_datum_id]</p>", "<ul>")
+	var/stringlen = length(GLOB.unique_datum_id_letters)
+	var/list/text = list("<h1>UID Log</h1>", "<p>Current UID: [stringlen ? "[num2text(stringlen * SHORT_REAL_LIMIT, 100)] + " : ""][GLOB.next_unique_datum_id]</p>", "<ul>")
 	for(var/key in sorted)
 		text += "<li>[key] - [sorted[key]]</li>"
 


### PR DESCRIPTION
## Описание
Ранее мы были ограничены 16777216 уникальными идентификаторами для получения UID из-за ограничений бульона на целые числа. Теперь же при достижении данного лимита счётчик сбрасывается и просто появляется одна буква из латинского алафавита. Всего букв 54  - нижний и верхний регистр. Итого максимально допустимое число UID на раунд повышается до 54 * 16777216 = 905 969 664, почти миллиарда. Впрочем стоит отметить, что мы никогда не достигали даже первого потолка.

Также теперь будет учитываться статус QDELING, при резолве UID, в случае его наличия всегда будет возвращаться null. Обойти это ограничение можно используя новый прок hardlocateUID, но в 99.99% случаев вам нужно использовать locateUID.