### PR TITLE
bugfix: Incorrect display of ammo in the clip

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -1030,7 +1030,7 @@
             gun.attackby(MA, user)
             if(magazine)
                 magazine.loc = src
-                magazine.update_icon()
+                magazine.update_appearance(UPDATE_ICON | UPDATE_DESC)
             return
 
 /obj/item/storage/box/sec

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -109,8 +109,7 @@
 			else
 				to_chat(user, span_notice("You perform a tactical reload on \the [src], replacing the magazine."))
 				magazine.loc = get_turf(loc)
-				magazine.update_icon()
-				magazine.update_desc()
+				magazine.update_appearance(UPDATE_ICON | UPDATE_DESC)
 				magazine = null
 				reload(AM, user)
 				return TRUE
@@ -163,8 +162,7 @@
 	if(magazine)
 		magazine.loc = get_turf(loc)
 		user.put_in_hands(magazine)
-		magazine.update_desc()
-		magazine.update_icon()
+		magazine.update_appearance(UPDATE_ICON | UPDATE_DESC)
 		magazine = null
 		update_weight()
 		to_chat(user, span_notice("You pull the magazine out of \the [src]!"))

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -110,6 +110,7 @@
 				to_chat(user, span_notice("You perform a tactical reload on \the [src], replacing the magazine."))
 				magazine.loc = get_turf(loc)
 				magazine.update_icon()
+				magazine.update_desc()
 				magazine = null
 				reload(AM, user)
 				return TRUE
@@ -162,6 +163,7 @@
 	if(magazine)
 		magazine.loc = get_turf(loc)
 		user.put_in_hands(magazine)
+		magazine.update_desc()
 		magazine.update_icon()
 		magazine = null
 		update_weight()

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -41,6 +41,7 @@
 				to_chat(user, "<span class='notice'>You perform a tactical reload on \the [src], replacing the magazine.</span>")
 				magazine.loc = get_turf(loc)
 				magazine.update_icon()
+				magazine.update_desc()
 				magazine = null
 			else
 				to_chat(user, "<span class='notice'>You insert the magazine into \the [src].</span>")

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -40,8 +40,7 @@
 			if(magazine)
 				to_chat(user, "<span class='notice'>You perform a tactical reload on \the [src], replacing the magazine.</span>")
 				magazine.loc = get_turf(loc)
-				magazine.update_icon()
-				magazine.update_desc()
+				magazine.update_appearance(UPDATE_ICON | UPDATE_DESC)
 				magazine = null
 			else
 				to_chat(user, "<span class='notice'>You insert the magazine into \the [src].</span>")

--- a/code/modules/projectiles/guns/projectile/saw.dm
+++ b/code/modules/projectiles/guns/projectile/saw.dm
@@ -46,8 +46,7 @@
 		..()
 	else if(cover_open && magazine)
 		//drop the mag
-		magazine.update_icon()
-		magazine.update_desc()
+		magazine.update_appearance(UPDATE_ICON | UPDATE_DESC)
 		magazine.loc = get_turf(loc)
 		user.put_in_hands(magazine)
 		magazine = null

--- a/code/modules/projectiles/guns/projectile/saw.dm
+++ b/code/modules/projectiles/guns/projectile/saw.dm
@@ -47,6 +47,7 @@
 	else if(cover_open && magazine)
 		//drop the mag
 		magazine.update_icon()
+		magazine.update_desc()
 		magazine.loc = get_turf(loc)
 		user.put_in_hands(magazine)
 		magazine = null


### PR DESCRIPTION

## Описание
Описание количества пуль в магазине не обновлялось при ручном вынимании магазина/тактической перезарядке баллистического оружия, потому что не вызывался update_desc() магазина. Скрин 1 - до. Скрин 2 - после фикса

Баг от PR https://github.com/ss220-space/Paradise/pull/4170 или его первой части

## Демонстрация изменений

![image](https://github.com/ss220-space/Paradise/assets/156955117/2d2db2d2-36f2-4bca-8331-085cb6d4c4f7)

![image](https://github.com/ss220-space/Paradise/assets/156955117/c35e8e4d-3210-4ae8-808d-b7feeaab7bb3)
