### PR TITLE
bugfix: airlock access deny sound with no power 

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -551,7 +551,7 @@ About the new airlock wires panel:
 		if("closing")
 			update_icon(AIRLOCK_CLOSING)
 		if("deny")
-			if(!stat && arePowerSystemsOn())
+			if(arePowerSystemsOn())
 				update_icon(AIRLOCK_DENY)
 				playsound(src,doorDeni,50,0,3)
 				sleep(6)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -551,7 +551,7 @@ About the new airlock wires panel:
 		if("closing")
 			update_icon(AIRLOCK_CLOSING)
 		if("deny")
-			if(!stat)
+			if(!stat && arePowerSystemsOn())
 				update_icon(AIRLOCK_DENY)
 				playsound(src,doorDeni,50,0,3)
 				sleep(6)


### PR DESCRIPTION
## Описание
Убирает  проигрывание звука "доступ запрещён" у аирлока без питания при взаимодействии с ним(без доступа к нему, очевидно)
