### PR TITLE
bugfix: Immovable rods are no longer dealing insane amounts of damage

### DIFF
--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -66,26 +66,27 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 /obj/effect/immovablerod/singularity_pull()
 	return
 
-/obj/effect/immovablerod/Bump(atom/clong)
+/obj/effect/immovablerod/Bump(atom/clong, yes)
+	if(!yes)
+		return
 	if(prob(10))
 		playsound(src, 'sound/effects/bang.ogg', 50, 1)
 		audible_message("ЛЯЗГ")
 
-	if(clong && prob(25))
-		x = clong.x
-		y = clong.y
+	x = clong.x
+	y = clong.y
 
 	if(istype(clong, /turf) || isobj(clong))
 		if(clong.density)
-			clong.ex_act(2)
+			clong.ex_act(EXPLODE_HEAVY)
 
 	else if(istype(clong, /mob))
 		if(ishuman(clong))
 			var/mob/living/carbon/human/H = clong
-			H.visible_message("<span class='danger'>[H.name] пронизан незыблемым стержнем!</span>" , "<span class='userdanger'>Стержень пронзает тебя!</span>" , "<span class ='danger'>Вы слышите ЛЯЗГ!</span>")
+			H.visible_message(span_danger("[H.name] пронизан незыблемым стержнем!") , span_userdanger("Стержень пронзает тебя!") , span_danger("Вы слышите ЛЯЗГ!"))
 			H.adjustBruteLoss(160)
 		if(clong.density || prob(10))
-			clong.ex_act(2)
+			clong.ex_act(EXPLODE_HEAVY)
 
 /obj/effect/immovablerod/event
 	var/tiles_moved = 0


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление ошибки, при которой недвижимый стержень наносил чрезвычайно большой урон по жертвам.

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
Теперь палка не пробивает одну и ту же жертву дважды

https://github.com/ss220-space/Paradise/assets/73733747/0f612235-ea9d-44b6-bc30-057bd428e68e

