### PR TITLE
bugfix: Shuttle Smash Skips Silicon Search

### DIFF
--- a/code/modules/shuttle/shuttle_smash.dm
+++ b/code/modules/shuttle/shuttle_smash.dm
@@ -66,11 +66,22 @@
 	gib()
 
 
+/mob/living/silicon/shuttle_crush_react(turf/stationary_turf, mobile_dir, skip_ungibable_search = TRUE)
+	. = ..()	// we are skipping ungibable search, since silicons have no valuables to drop and this only cause bugs with brain removal
+
+
+/mob/living/silicon/robot/shuttle_crush_react(turf/stationary_turf, mobile_dir, skip_ungibable_search = TRUE)
+	if(module)
+		var/obj/item/gripper/our_gripper = locate() in module.modules
+		our_gripper?.drop_ungibbable_items(stationary_turf)
+	return ..()
+
+
 /mob/living/silicon/ai/shuttle_crush_react(turf/stationary_turf, mobile_dir, skip_ungibable_search = FALSE)
 	return FALSE
 
 
-/mob/living/carbon/brain/shuttle_crush_react(turf/stationary_turf, mobile_dir)
+/mob/living/carbon/brain/shuttle_crush_react(turf/stationary_turf, mobile_dir, skip_ungibable_search = FALSE)
 	return FALSE
 
 

--- a/code/modules/shuttle/shuttle_smash.dm
+++ b/code/modules/shuttle/shuttle_smash.dm
@@ -62,7 +62,7 @@
 	if(!skip_ungibable_search)
 		drop_ungibbable_items(stationary_turf)
 	for(var/mob/living/victim in contents)
-		victim.shuttle_crush_react(stationary_turf, mobile_dir, skip_ungibable_search)
+		victim.shuttle_crush_react(stationary_turf, mobile_dir)
 	gib()
 
 
@@ -122,7 +122,7 @@
 	var/atom/movable/user = master?.loc
 	master?.disrupt()
 	if(ismovable(user))
-		user.shuttle_crush_react(stationary_turf, mobile_dir, skip_ungibable_search)
+		user.shuttle_crush_react(stationary_turf, mobile_dir)
 
 
 /obj/effect/shuttle_crush_react(turf/stationary_turf, mobile_dir, skip_ungibable_search = FALSE)


### PR DESCRIPTION
## Описание
Гиб шаттлом скипает поиск ценных вещей у силиконов, поскольку таковых вещей попросту нет. У киборгов добавлена проверка на содержимое гриппера.

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1245428131855335544