### PR TITLE
bugfix: Admin Move And Point Layer Fix

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -170,20 +170,24 @@
 		if(NAMEOF(src, x))
 			var/turf/T = locate(var_value, y, z)
 			if(T)
+				admin_teleport(T)
 				return TRUE
 			return FALSE
 		if(NAMEOF(src, y))
 			var/turf/T = locate(x, var_value, z)
 			if(T)
+				admin_teleport(T)
 				return TRUE
 			return FALSE
 		if(NAMEOF(src, z))
 			var/turf/T = locate(x, y, var_value)
 			if(T)
+				admin_teleport(T)
 				return TRUE
 			return FALSE
 		if(NAMEOF(src, loc))
 			if(isatom(var_value) || isnull(var_value))
+				admin_teleport(var_value)
 				return TRUE
 			return FALSE
 		if(NAMEOF(src, anchored))
@@ -195,6 +199,17 @@
 		return .
 
 	return ..()
+
+
+/// Proc to hook user-enacted teleporting behavior and keep logging of the event.
+/atom/movable/proc/admin_teleport(atom/new_location)
+	if(isnull(new_location))
+		log_admin("[key_name(usr)] teleported [key_name(src)] to nullspace")
+		move_to_null_space()
+	else
+		var/turf/location = get_turf(new_location)
+		log_admin("[key_name(usr)] teleported [key_name(src)] to [AREACOORD(location)]")
+		forceMove(new_location)
 
 
 //Returns an atom's power cell, if it has one. Overload for individual items.

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1100,6 +1100,7 @@
 			var/organ_path = species.has_organ[organ_slot]
 			new organ_path(src)
 
+	recalculate_limbs_status()
 	return TRUE
 
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -166,6 +166,26 @@
 		update_obesity_slowdown()
 
 
+/// Proc used to recalculate traits and slowdowns after species change.
+/mob/living/carbon/human/proc/recalculate_limbs_status()
+	if(usable_legs > 0) // gained leg usage
+		REMOVE_TRAIT(src, TRAIT_FLOORED, LACKING_LOCOMOTION_APPENDAGES_TRAIT)
+		REMOVE_TRAIT(src, TRAIT_IMMOBILIZED, LACKING_LOCOMOTION_APPENDAGES_TRAIT)
+	else if(usable_legs == 0 && !(movement_type & (FLYING|FLOATING))) // lost leg usage, not flying
+		ADD_TRAIT(src, TRAIT_FLOORED, LACKING_LOCOMOTION_APPENDAGES_TRAIT)
+		if(usable_hands == 0) // lost hand usage
+			ADD_TRAIT(src, TRAIT_IMMOBILIZED, LACKING_LOCOMOTION_APPENDAGES_TRAIT)
+
+	if(usable_hands > 0) // gained hand usage
+		REMOVE_TRAIT(src, TRAIT_HANDS_BLOCKED, LACKING_MANIPULATION_APPENDAGES_TRAIT)
+	else if(usable_hands == 0) // lost hand usage
+		ADD_TRAIT(src, TRAIT_HANDS_BLOCKED, LACKING_MANIPULATION_APPENDAGES_TRAIT)
+
+	update_limbless_slowdown()
+	update_fractures_slowdown()
+	update_hands_HUD()
+
+
 /// Proc used to inflict stamina damage when user is moving from no gravity to positive gravity.
 /mob/living/carbon/human/proc/thunk()
 	if(buckled || incorporeal_move || mob_negates_gravity())

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -281,6 +281,9 @@
 
 		new organ_path(target)
 
+	// and now we need to recheck our limbs conditions
+	target.recalculate_limbs_status()
+
 
 /datum/species/proc/breathe(mob/living/carbon/human/H)
 	if((NO_BREATHE in species_traits) || (BREATHLESS in H.mutations))

--- a/code/modules/point/point.dm
+++ b/code/modules/point/point.dm
@@ -64,6 +64,7 @@
 		var/mutable_appearance/point_visual = mutable_appearance(
 			'icons/mob/screen_gen.dmi',
 			"arrow",
+			thought_bubble.layer + 0.01
 		)
 
 		point_visual.pixel_y = 7


### PR DESCRIPTION
## Описание
Возобновляет перемещение через смену переменных x, y, z, loc в VV, а также повышает слой стрелки при указании на объекты в инвентаре, чтобы она снова была на переднем плане. Добавлен перерассчёт трейтов и замедления при регенерации конечностей.