### PR TITLE
fix: Event files architecture improvement

### DIFF
--- a/_maps/map_files/event/ReadMe.txt
+++ b/_maps/map_files/event/ReadMe.txt
@@ -1,2 +1,5 @@
 This folder is intended for storing event station maps.
 Don't forget to write your map into the \code\modules\map_fluff\event.dm
+
+If you want to add ruin, you need to write your map into the \_maps\map_files\templates
+DON'T CREATE NEW FOLDER IN templates!

--- a/_maps/map_files/event/Ruins/ReadMe.txt
+++ b/_maps/map_files/event/Ruins/ReadMe.txt
@@ -1,2 +1,0 @@
-This folder is intended for storing event Ruins maps.
-Don't forget to write your map into the \code\modules\map_fluff\event.dm


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
**Довёл архитектуру хранения и использования ивент карт до ума.
Удалил папку Ruins из Event. Теперь педали льют ивентовые руины в templates и используют в раундах после залива.
Всё расписано в ReadMe.**

## Ссылка на предложение/Причина создания ПР
_Мой недосмотр_

## Демонстрация изменений
![image](https://github.com/ss220-space/Paradise/assets/127967350/4bc60ed2-d30c-4fe2-b709-901f178717a3)

