### PR TITLE
bugfix: IV drip can now be used again to collect or inject reagents.

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -34,7 +34,7 @@
 	if(!bag)
 		to_chat(usr, span_warning("There's no IV bag connected to [src]!"))
 		return FALSE
-	bag.afterattack(over_object, usr, TRUE)
+	bag.attack(over_object, usr)
 	START_PROCESSING(SSmachines, src)
 
 


### PR DESCRIPTION
## Описание
Капельница была сломана после одного твика и последующих баг фиксов. 
Теперь почти неиспользуемый предмет снова работает!

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1241829168891564073