### PR TITLE
bugfix: TeleKinesis no longer drops on ground

### DIFF
--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -91,7 +91,7 @@
 /obj/item/tk_grab/equipped(mob/user, slot, initial = FALSE)
 	SHOULD_CALL_PARENT(FALSE)
 	if(slot & ITEM_SLOT_HANDS)
-		return
+		return TRUE
 	qdel(src)
 
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
ПР меняет у телекинеза в проке `/equipped(` значение, что оно возвращает на `TRUE`, если ТК в слоте руки.

## Ссылка на предложение/Причина создания ПР
[Ментор тикет.](https://discord.com/channels/617003227182792704/780332672253558854/1247227497578233957)
Игроки жаловались, что ТК ничего не делает. Локалка повторила, что этот баг существует.
Из-за того, что ТК возвращал `null` - прок `/put_in_hand(` некорректно думал, что ТК нельзя одеть. Баг появился после #5044