### PR TITLE
bugfix: Emotes check stat before show runechat

### DIFF
--- a/code/datums/emote/emote.dm
+++ b/code/datums/emote/emote.dm
@@ -298,7 +298,7 @@
 			for(var/mob/living/M in O.contents)
 				M.show_message(text, EMOTE_VISIBLE)
 
-		if(O.client?.prefs.toggles2 & PREFTOGGLE_2_RUNECHAT)
+		if(O.stat == CONSCIOUS && O.client?.prefs.toggles2 & PREFTOGGLE_2_RUNECHAT)
 			O.create_chat_message(user, runechat_text, emote = TRUE)
 
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Рунчат от эмоутов проверяют, спит ли человек, прежде чем показать эмоут.

## Ссылка на предложение/Причина создания ПР
[Ссылка на жалобу](https://discord.com/channels/617003227182792704/734823601110515882/1247259791458439248).
Немного стандарта?

