### PR TITLE
tweak: Antag Paradise Autotraitor Update

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -406,6 +406,13 @@
 	return ishuman(target) && target.dna.species.is_monkeybasic	// we deserve a runtime if a human has no DNA
 
 
+/proc/is_evolvedslime(mob/living/carbon/human/target)
+	if(!ishuman(target) || !istype(target.dna.species, /datum/species/slime))
+		return FALSE
+	var/datum/species/slime/species = target.dna.species
+	return species.evolved_slime
+
+
 /proc/spawn_atom_to_turf(spawn_type, target, amount, admin_spawn=FALSE, list/extra_args)
 	var/turf/T = get_turf(target)
 	if(!T)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -326,10 +326,7 @@
 		if(!player.client \
 			|| jobban_isbanned(player, "Syndicate") || jobban_isbanned(player, role) \
 			|| !player_old_enough_antag(player.client, role, req_job_rank) || player.client.prefs?.skip_antag \
-			|| !(role in player.client.prefs.be_special))
-			continue
-
-		if(player.mind.has_antag_datum(/datum/antagonist) || player.mind.offstation_role || player.mind.special_role)
+			|| !(role in player.client.prefs.be_special) || !is_player_station_relevant(player))
 			continue
 
 		players += player
@@ -356,34 +353,67 @@
 
 	return candidates
 
+
+/datum/game_mode/proc/get_alive_AIs_for_role(role)
+	. = list()
+	for(var/mob/living/silicon/ai/AI in GLOB.alive_mob_list)
+		if(!AI.client || !AI.mind \
+			|| jobban_isbanned(AI, "Syndicate") || jobban_isbanned(AI, role) \
+			|| !player_old_enough_antag(AI.client, role, JOB_TITLE_AI) || AI.client.prefs?.skip_antag \
+			|| !(role in AI.client.prefs.be_special) || AI.stat == DEAD || AI.control_disabled \
+			|| AI.mind.offstation_role || AI.mind.special_role)
+			continue
+		. += AI.mind
+
+
+/// All the checks required to find baseline human being
+/proc/is_player_station_relevant(mob/living/carbon/human/player)
+	if(QDELING(player))
+		return FALSE
+	if(!player.client)
+		return FALSE
+	if(!player.mind)
+		return FALSE
+	if(player.mind.special_role)	// already "special"
+		return FALSE
+	if(player.mind.offstation_role)	// spawned mobs
+		return FALSE
+	if(player.stat == DEAD)	// no zombies
+		return FALSE
+	var/turf/player_turf = get_turf(player)
+	if(!player_turf)	// nullspace, eh?
+		return FALSE
+	if(!is_level_reachable(player_turf.z) && !is_away_level(player_turf.z))	// taipan is not available, mkay?
+		return FALSE
+	if(is_monkeybasic(player))	// no monkas
+		return FALSE
+	if(isgolem(player))	// get out of here
+		return FALSE
+	if(is_evolvedslime(player))	// no evolved slimes please
+		return FALSE
+	return TRUE	// congratulations, you are normal!
+
+
 /datum/game_mode/proc/latespawn(mob/player)
 
 
 /datum/game_mode/proc/num_players()
 	. = 0
-
 	for(var/mob/new_player/player in GLOB.player_list)
-
 		if(player.client && player.ready)
 			.++
+
 
 /proc/num_station_players()
 	. = 0
 	for(var/mob/living/carbon/human/player in GLOB.player_list)
-		if(!player)
-			continue
-
-		if(player.client && player.mind && !player.mind.offstation_role && !player.mind.special_role)
+		if(is_player_station_relevant(player))
 			.++
 
 
 /datum/game_mode/proc/num_players_started()
 	. = 0
-
 	for(var/mob/living/carbon/human/player in GLOB.player_list)
-		if(!player)
-			continue
-
 		if(player.client)
 			.++
 

--- a/code/modules/mob/living/carbon/human/species/slime.dm
+++ b/code/modules/mob/living/carbon/human/species/slime.dm
@@ -72,6 +72,8 @@
 
 	disliked_food = SUGAR | FRIED
 	liked_food = MEAT | TOXIC | RAW
+	/// Special flag used for slimeperson evolved from the slime.
+	var/evolved_slime = FALSE
 
 /datum/species/slime/on_species_gain(mob/living/carbon/human/H)
 	..()

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -165,7 +165,9 @@
 			new_slime.update_hair()
 			new_slime.update_body()
 			new_slime.blood_color = new_colour
-			new_slime.dna.species.blood_color = new_slime.blood_color
+			new_slime.dna.species.blood_color = new_slime.dna.species
+			var/datum/species/slime/species = new_slime.dna.species
+			species.evolved_slime = TRUE
 		else
 			to_chat(src, "<i>I am not ready to evolve yet...</i>")
 


### PR DESCRIPTION
## Описание
Исправления для ролей, которые могут считаться станционными для подсчёта и выбора антагониста. Исключены монке, големы, эволюционировавшие слаймы, игроки вне сектора станции, в нуллспейсе.

Также починен спавн специальных антагусов, через авто-трейтор.