### PR TITLE
bugfix: Cards Shuffle Fix

### DIFF
--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -133,7 +133,7 @@
 /datum/action/item_action/deal_card/Trigger(left_click = TRUE)
 	if(istype(target, /obj/item/deck))
 		var/obj/item/deck/D = target
-		return D.deal_card()
+		return D.deal_card(usr)
 	return ..()
 
 
@@ -146,7 +146,7 @@
 /datum/action/item_action/deal_card_multi/Trigger(left_click = TRUE)
 	if(istype(target, /obj/item/deck))
 		var/obj/item/deck/D = target
-		return D.deal_card_multi()
+		return D.deal_card_multi(usr)
 	return ..()
 
 
@@ -159,7 +159,7 @@
 /datum/action/item_action/shuffle/Trigger(left_click = TRUE)
 	if(istype(target, /obj/item/deck))
 		var/obj/item/deck/D = target
-		return D.deckshuffle()
+		return D.deckshuffle(usr)
 	return ..()
 
 
@@ -192,46 +192,65 @@
 	to_chat(user, span_notice("It's the [play_card]."))
 
 
-/obj/item/deck/proc/deal_card(mob/user = usr)
+/obj/item/deck/proc/deal_card(mob/user)
 	if(user.incapacitated() || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || !Adjacent(user))
 		return
 
 	if(!length(cards))
-		to_chat(usr, span_notice("There are no cards in the deck."))
+		to_chat(user, span_warning("There are no cards in the deck!"))
 		return
 
 	var/list/players = list()
-	for(var/mob/living/player in viewers(3))
+	for(var/mob/living/carbon/player in viewers(3, user))
 		if(!player.incapacitated() && !HAS_TRAIT(player, TRAIT_HANDS_BLOCKED))
 			players += player
 
-	var/mob/living/target = tgui_input_list(user, "Who do you wish to deal a card to?", "Deal Card", players)
-	if(!user || !src || !target || !Adjacent(user) || target.incapacitated() || HAS_TRAIT(target, TRAIT_HANDS_BLOCKED))
+	if(!length(players))
+		to_chat(user, span_warning("There are no players around!"))
+		return
+
+	var/mob/living/carbon/target = tgui_input_list(user, "Who do you wish to deal a card to?", "Deal Card", players)
+	if(!user || !src || !target || !Adjacent(user) || get_dist(user, target) > 3 || target.incapacitated() || HAS_TRAIT(target, TRAIT_HANDS_BLOCKED))
+		return
+
+	if(!length(cards))
+		to_chat(user, span_warning("Deck is empty!"))
 		return
 
 	deal_at(user, target, 1)
 
 
-/obj/item/deck/proc/deal_card_multi(mob/user = usr)
+/obj/item/deck/proc/deal_card_multi(mob/user)
 	if(user.incapacitated() || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || !Adjacent(user))
 		return
 
 	if(!length(cards))
-		to_chat(user, span_notice("There are no cards in the deck."))
+		to_chat(user, span_warning("There are no cards in the deck!"))
 		return
 
 	var/maxcards = clamp(length(cards), 1, 10)
-	var/dcard = input("How many card(s) do you wish to deal? You may deal up to [maxcards] cards.") as num|null
-	if(!dcard || dcard > maxcards || dcard < 1 || !Adjacent(user) || user.incapacitated() || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
+	var/dcard = input("How many card(s) do you wish to deal? You may deal up to [maxcards] cards.", "Card Dealing", 1) as num|null
+	if(!dcard || !length(cards) || !Adjacent(user) || user.incapacitated() || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 		return
 
+	dcard = clamp(min(round(abs(dcard)), length(cards)), 1, 10)	// we absolutely trust our players
+
 	var/list/players = list()
-	for(var/mob/living/player in viewers(3))
+	for(var/mob/living/carbon/player in viewers(3, user))
 		if(!player.incapacitated() && !HAS_TRAIT(player, TRAIT_HANDS_BLOCKED))
 			players += player
 
-	var/mob/living/target = tgui_input_list(user, "Who do you wish to deal [dcard] card(s)?", "Deal Card", players)
-	if(!user || !src || !target || !Adjacent(user) || target.incapacitated() || HAS_TRAIT(target, TRAIT_HANDS_BLOCKED))
+	if(!length(players))
+		to_chat(user, span_warning("You decide to deal <b>[dcard]</b> card\s, but there are no players around!"))
+		return
+	to_chat(user, span_notice("You decide to deal <b>[dcard]</b> card\s."))
+
+	var/mob/living/carbon/target = tgui_input_list(user, "Who do you wish to deal [dcard] card(s)?", "Deal Card", players)
+	if(!user || !src || !target || !Adjacent(user) || get_dist(user, target) > 3 || target.incapacitated() || HAS_TRAIT(target, TRAIT_HANDS_BLOCKED))
+		return
+
+	if(length(cards) < dcard)
+		to_chat(user, span_warning("The deck has no sufficient amount of cards anymore!"))
 		return
 
 	deal_at(user, target, dcard)
@@ -248,10 +267,10 @@
 		cardhand.concealed = TRUE
 		cardhand.update_appearance(UPDATE_NAME|UPDATE_DESC|UPDATE_OVERLAYS)
 	if(user == target)
-		user.visible_message(span_notice("[user] deals [dcard] card(s) to [user.p_themselves()]."))
+		user.visible_message(span_notice("[user] deals <b>[dcard]</b> card\s to [user.p_themselves()]."))
 	else
-		user.visible_message(span_notice("[user] deals [dcard] card(s) to [target]."))
-	cardhand.throw_at(get_step(target,target.dir), 3, 1, cardhand)
+		user.visible_message(span_notice("[user] deals <b>[dcard]</b> card\s to [target]."))
+	INVOKE_ASYNC(cardhand, TYPE_PROC_REF(/atom/movable, throw_at), get_step(target, target.dir), 3, 1, user)
 
 
 /obj/item/deck/attack_self(mob/user)
@@ -279,7 +298,7 @@
 		return FALSE
 
 	var/mob/user = usr
-	if(over_object != user || user.incapacitated() || !ishuman(user))
+	if(over_object != user || user.incapacitated() || !iscarbon(user))
 		return FALSE
 
 	if(user.put_in_hands(src, ignore_anim = FALSE))

--- a/code/modules/games/tarot.dm
+++ b/code/modules/games/tarot.dm
@@ -22,12 +22,11 @@
 	COOLDOWN_START(src, shuffle_cooldown, 1 SECONDS)
 	var/list/newcards = list()
 	while(cards.len)
-		var/datum/playingcard/card = pick(cards)
-		card.name = replacetext(card.name," reversed","")
+		var/datum/playingcard/card = pick_n_take(cards)
+		card.name = replacetext(card.name," reversed", "")
 		if(prob(50))
 			card.name += " reversed"
 		newcards += card
-		cards -= card
 	cards = newcards
 	playsound(user, 'sound/items/cardshuffle.ogg', 50, TRUE)
 	user.visible_message(span_notice("[user] shuffles [src]."), span_notice("You shuffle [src]."))

--- a/code/modules/games/tarot.dm
+++ b/code/modules/games/tarot.dm
@@ -15,19 +15,20 @@
 			cards += new /datum/playingcard("[number] of [suit]", "tarot_[suit]", "card_back_tarot")
 
 
-/obj/item/deck/tarot/deckshuffle()
-	var/mob/living/user = usr
-	if(cooldown < world.time - 1 SECONDS)
-		var/list/newcards = list()
-		while(cards.len)
-			var/datum/playingcard/card = pick(cards)
-			card.name = replacetext(card.name," reversed","")
-			if(prob(50))
-				card.name += " reversed"
-			newcards += card
-			cards -= card
-		cards = newcards
-		playsound(user, 'sound/items/cardshuffle.ogg', 50, 1)
-		user.visible_message(span_notice("[user] shuffles [src]."), span_notice("You shuffle [src]."))
-		cooldown = world.time
+/obj/item/deck/tarot/deckshuffle(mob/user)
+	if(!COOLDOWN_FINISHED(src, shuffle_cooldown) || !iscarbon(user) || user.incapacitated() || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
+		return
+
+	COOLDOWN_START(src, shuffle_cooldown, 1 SECONDS)
+	var/list/newcards = list()
+	while(cards.len)
+		var/datum/playingcard/card = pick(cards)
+		card.name = replacetext(card.name," reversed","")
+		if(prob(50))
+			card.name += " reversed"
+		newcards += card
+		cards -= card
+	cards = newcards
+	playsound(user, 'sound/items/cardshuffle.ogg', 50, TRUE)
+	user.visible_message(span_notice("[user] shuffles [src]."), span_notice("You shuffle [src]."))
 


### PR DESCRIPTION
## Описание
Исправляет невозможность перетасовать колоду карта, а также добавление большего количества проверок на возможность взаимодействия с колодой.

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1248173922017480735
