### PR TITLE
butgfix: Additional Can Equip Check

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -689,7 +689,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 	if(user.equip_to_appropriate_slot(src, force, silent = TRUE))
 		return TRUE
 
-	if(equip_delay_self)
+	if(equip_delay_self > 0)
 		if(!silent)
 			to_chat(user, span_warning("Вы должны экипировать [src] вручную!"))
 		return FALSE
@@ -728,6 +728,18 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 		to_chat(user, span_warning("Вы не можете надеть [src]!"))
 
 	return FALSE
+
+
+/**
+ * Additional can equip checks when equipping is done by the user, and not by the code: [/mob/verb/quick_equip]
+ */
+/obj/item/proc/user_can_equip(mob/user, silent = FALSE)
+	// if an item is already on user you cannot reequip it anywhere if it has NODROP trait
+	if(loc == user && HAS_TRAIT(src, TRAIT_NODROP))
+		if(!silent)
+			to_chat(user, span_warning("Неведомая сила не позволяет Вам надеть [name]."))
+		return FALSE
+	return TRUE
 
 
 /**

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -44,7 +44,7 @@
 		to_chat(src, span_warning("Вы ничего не держите в руке!"))
 		return
 
-	if(!QDELETED(I))
+	if(!QDELETED(I) && I.user_can_equip(src))
 		I.equip_to_best_slot(src)
 
 

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -908,8 +908,6 @@
 
 		// POCKETS
 		if(ITEM_SLOT_POCKET_LEFT)
-			if(HAS_TRAIT(I, TRAIT_NODROP)) //Pockets aren't visible, so you can't move NODROP items into them.
-				return FALSE
 			if(user.l_store)
 				return FALSE
 
@@ -922,8 +920,6 @@
 			return TRUE
 
 		if(ITEM_SLOT_POCKET_RIGHT)
-			if(HAS_TRAIT(I, TRAIT_NODROP))
-				return FALSE
 			if(user.r_store)
 				return FALSE
 


### PR DESCRIPTION
## Описание
Дополнительная проверка для эквипа айтема, когда этим занимается непосредственно юзер, а не код. Устраняет возможность манипулировать предметами с ноудропом внутри инвентаря.

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1248659054637617213