### PR TITLE
balance: Combat Crawling Update N1

### DIFF
--- a/code/modules/martial_arts/cqc.dm
+++ b/code/modules/martial_arts/cqc.dm
@@ -81,7 +81,7 @@
 		playsound(get_turf(A), 'sound/effects/hit_kick.ogg', 50, 1, -1)
 		D.apply_damage(10, BRUTE)
 		objective_damage(A, D, 10, BRUTE)
-		D.Weaken(2 SECONDS)
+		D.Knockdown(1 SECONDS)
 		add_attack_logs(A, D, "Melee attacked with martial-art [src] : Leg sweep", ATKLOG_ALL)
 	return TRUE
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -186,7 +186,7 @@
 
 /// Proc used to inflict stamina damage when user is moving from no gravity to positive gravity.
 /mob/living/carbon/human/proc/thunk()
-	if(buckled || incorporeal_move || mob_negates_gravity())
+	if(buckled || incorporeal_move || body_position == LYING_DOWN || mob_negates_gravity())
 		return
 
 	if(dna?.species.spec_thunk(src)) //Species level thunk overrides


### PR DESCRIPTION
## Описание
Изменение старых эффектов в связи с введением ползания. Будет дополняться по ходу дела и когда накопится достаточное количество твиков, выведу из драфта.

- удар CQC из позиции лёжа: Weaken(2 SECONDS) -> Knockdown(1 SECONDS)
- переползание в зону с гравитацией не вызывает урона выносливости