### PR TITLE
bugfix: Bunch of bugfixes

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -295,15 +295,12 @@
  * * extra_checks - Additional checks to perform before the action is executed.
  * * interaction_key - The assoc key under which the do_after is capped, with max_interact_count being the cap. Interaction key will default to target if not set.
  * * max_interact_count - The maximum amount of interactions allowed.
- * * cancel_message - Message shown to the user if they exceeds max interaction count. Use NO_CANCEL_MESSAGE to remove it.
+ * * cancel_message - Message shown to the user if they exceeds max interaction count. Use "" to remove it.
  *
  * Returns `TRUE` on success, `FALSE` on failure.
  */
 
-#define NO_CANCEL_MESSAGE "no_message"
-#define DEFAULT_CANCEL_MESSAGE span_warning("Attempt cancelled.")
-
-/proc/do_after(mob/user, delay, atom/target, timed_action_flags = DEFAULT_DOAFTER_IGNORE, progress = TRUE, datum/callback/extra_checks, interaction_key, max_interact_count = INFINITY, cancel_message = DEFAULT_CANCEL_MESSAGE)
+/proc/do_after(mob/user, delay, atom/target, timed_action_flags = DEFAULT_DOAFTER_IGNORE, progress = TRUE, datum/callback/extra_checks, interaction_key, max_interact_count = INFINITY, cancel_message = span_warning("Attempt cancelled."))
 	if(!user)
 		return FALSE
 
@@ -315,7 +312,7 @@
 	if(interaction_key) //Do we have a interaction_key now?
 		var/current_interaction_count = LAZYACCESS(user.do_afters, interaction_key) || 0
 		if(current_interaction_count >= max_interact_count) //We are at our peak
-			if(cancel_message != NO_CANCEL_MESSAGE)
+			if(cancel_message)
 				to_chat(user, "[cancel_message]")
 			return FALSE
 		LAZYSET(user.do_afters, interaction_key, current_interaction_count + 1)

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -295,11 +295,15 @@
  * * extra_checks - Additional checks to perform before the action is executed.
  * * interaction_key - The assoc key under which the do_after is capped, with max_interact_count being the cap. Interaction key will default to target if not set.
  * * max_interact_count - The maximum amount of interactions allowed.
- * * cancel_message - Message shown to the user if they exceeds max interaction count.
+ * * cancel_message - Message shown to the user if they exceeds max interaction count. Use NO_CANCEL_MESSAGE to remove it.
  *
  * Returns `TRUE` on success, `FALSE` on failure.
  */
-/proc/do_after(mob/user, delay, atom/target, timed_action_flags = DEFAULT_DOAFTER_IGNORE, progress = TRUE, datum/callback/extra_checks, interaction_key, max_interact_count = INFINITY, cancel_message = span_warning("Attempt cancelled."))
+
+#define NO_CANCEL_MESSAGE "no_message"
+#define DEFAULT_CANCEL_MESSAGE span_warning("Attempt cancelled.")
+
+/proc/do_after(mob/user, delay, atom/target, timed_action_flags = DEFAULT_DOAFTER_IGNORE, progress = TRUE, datum/callback/extra_checks, interaction_key, max_interact_count = INFINITY, cancel_message = DEFAULT_CANCEL_MESSAGE)
 	if(!user)
 		return FALSE
 
@@ -311,7 +315,7 @@
 	if(interaction_key) //Do we have a interaction_key now?
 		var/current_interaction_count = LAZYACCESS(user.do_afters, interaction_key) || 0
 		if(current_interaction_count >= max_interact_count) //We are at our peak
-			if(cancel_message)
+			if(cancel_message != NO_CANCEL_MESSAGE)
 				to_chat(user, "[cancel_message]")
 			return FALSE
 		LAZYSET(user.do_afters, interaction_key, current_interaction_count + 1)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -62,7 +62,6 @@
 
 /obj/machinery/camera/Destroy()
 	SStgui.close_uis(wires)
-	toggle_cam(null, FALSE) //kick anyone viewing out
 	QDEL_NULL(assembly)
 	QDEL_NULL(wires)
 	GLOB.cameranet.removeCamera(src) //Will handle removal from the camera network and the chunks, so we don't need to worry about that

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -148,6 +148,7 @@
 	anchored = TRUE
 	resistance_flags = FIRE_PROOF
 	power_channel = ENVIRON
+	layer = BELOW_OBJ_LAYER + 0.01
 
 	var/id_tag
 	var/master_tag
@@ -229,6 +230,7 @@
 	name = "access button"
 	anchored = TRUE
 	power_channel = ENVIRON
+	layer = BELOW_OBJ_LAYER + 0.01
 
 	var/master_tag
 	frequency = AIRLOCK_FREQ

--- a/code/game/machinery/embedded_controller/embedded_controller_base.dm
+++ b/code/game/machinery/embedded_controller/embedded_controller_base.dm
@@ -7,6 +7,8 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 10
 
+	layer = BELOW_OBJ_LAYER + 0.01
+
 	var/on = 1
 
 /obj/machinery/embedded_controller/proc/post_signal(datum/signal/signal, comm_line)

--- a/code/game/machinery/tcomms/core.dm
+++ b/code/game/machinery/tcomms/core.dm
@@ -125,6 +125,8 @@
   *
   */
 /obj/machinery/tcomms/core/proc/refresh_zlevels()
+	if(QDELING(src))
+		return
 	// Refresh the list
 	reachable_zlevels = list()
 	// Add itself as a reachable Z-level

--- a/code/game/turfs/simulated/floor/asteroid.dm
+++ b/code/game/turfs/simulated/floor/asteroid.dm
@@ -96,6 +96,8 @@
 
 		playsound(src, I.usesound, 50, TRUE)
 		if(do_after(user, 4 SECONDS * I.toolspeed * gettoolspeedmod(user), src))
+			if(!istype(src, /turf/simulated/floor/plating/asteroid))
+				return TRUE //Turf has been changed in process, prevents can_dig() runtime
 			if(!can_dig(user))
 				return TRUE
 			to_chat(user, span_notice("You dig a hole."))

--- a/code/modules/antagonists/vampire/vampire_powers/bestia_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/bestia_powers.dm
@@ -1414,7 +1414,7 @@
 	name = "Flying vampire..."
 	invisibility = 0
 	layer = LOW_LANDMARK_LAYER
-	light_system = MOVABLE_LIGHT
+	light_system = STATIC_LIGHT
 
 
 /**

--- a/code/modules/atmospherics/machinery/atmospherics.dm
+++ b/code/modules/atmospherics/machinery/atmospherics.dm
@@ -219,7 +219,7 @@ Pipelines + Other Objects -> Pipe network
 			to_chat(user, span_warning("As you begin unwrenching \the [src] a gust of air blows in your face... maybe you should reconsider?"))
 			unsafe_wrenching = TRUE //Oh dear oh dear
 
-		if(do_after(user, 4 SECONDS * W.toolspeed * gettoolspeedmod(user), src) && !QDELETED(src))
+		if(do_after(user, 4 SECONDS * W.toolspeed * gettoolspeedmod(user), src, max_interact_count = 1, cancel_message = NO_CANCEL_MESSAGE) && !QDELETED(src))
 			user.visible_message( \
 				"[user] unfastens \the [src].", \
 				span_notice("You have unfastened \the [src]."), \

--- a/code/modules/atmospherics/machinery/atmospherics.dm
+++ b/code/modules/atmospherics/machinery/atmospherics.dm
@@ -219,7 +219,7 @@ Pipelines + Other Objects -> Pipe network
 			to_chat(user, span_warning("As you begin unwrenching \the [src] a gust of air blows in your face... maybe you should reconsider?"))
 			unsafe_wrenching = TRUE //Oh dear oh dear
 
-		if(do_after(user, 4 SECONDS * W.toolspeed * gettoolspeedmod(user), src, max_interact_count = 1, cancel_message = NO_CANCEL_MESSAGE) && !QDELETED(src))
+		if(do_after(user, 4 SECONDS * W.toolspeed * gettoolspeedmod(user), src, max_interact_count = 1, cancel_message = "") && !QDELETED(src))
 			user.visible_message( \
 				"[user] unfastens \the [src].", \
 				span_notice("You have unfastened \the [src]."), \


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
ПР исправляет следующие ошибки:
- Рантайм при вскапывании пепла и превращении его в чазм.
- Теперь в do_after можно убрать сообщение о "переборе" по попыткам.
- Эффект "летающего вампира" больше не рантаймит.
- Телекомы теперь удаляются корректно.
- Камеры теперь удаляются корректно, в том числе при их уничтожении.
- Исправлена ошибка с отображением контроллеров шлюзов при их нахождении на решётке.
