### PR TITLE
bugfix: Change ninjas species separatly from applying antag datum

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -2407,6 +2407,7 @@
 				if(!ninja_datum)
 					return
 
+				ninja_datum.change_species(current)
 				ninja_datum.equip_ninja()
 				log_admin("[key_name(usr)] has equipped [key_name(current)] as a ninja")
 				message_admins("[key_name_admin(usr)] has equipped [key_name_admin(current)] as a ninja")

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -2902,6 +2902,7 @@
 	var/datum/antagonist/ninja/ninja_datum = new
 	ninja_datum.give_objectives = FALSE
 	ninja_datum.generate_antags = FALSE
+	ninja_datum.change_species(current)
 	add_antag_datum(ninja_datum)
 
 	if(!length(GLOB.ninjastart))

--- a/code/game/gamemodes/antag_paradise/antag_paradise.dm
+++ b/code/game/gamemodes/antag_paradise/antag_paradise.dm
@@ -285,6 +285,7 @@
 		if(pre_antags[antag] == ROLE_NINJA)
 			var/datum/antagonist/ninja/ninja_datum = new
 			ninja_datum.antag_paradise_mode_chosen = TRUE
+			ninja_datum.change_species(antag.current)
 			antag.add_antag_datum(ninja_datum)
 
 	addtimer(CALLBACK(src, PROC_REF(initiate_antags)), rand(1 SECONDS, 10 SECONDS))

--- a/code/game/gamemodes/spaceninja/space_ninja.dm
+++ b/code/game/gamemodes/spaceninja/space_ninja.dm
@@ -42,7 +42,9 @@
 
 
 /datum/game_mode/space_ninja/post_setup()
-	pre_ninja?.add_antag_datum(/datum/antagonist/ninja)
+	var/datum/antagonist/ninja/ninja_datum = new
+	ninja_datum.change_species(pre_ninja.current)
+	pre_ninja?.add_antag_datum(ninja_datum)
 	..()
 
 

--- a/code/modules/antagonists/space_ninja/machinery/ninja_cloning.dm
+++ b/code/modules/antagonists/space_ninja/machinery/ninja_cloning.dm
@@ -68,6 +68,7 @@
 	ninja_ghost.forceMove(src.loc)
 	ninja = ninja_ghost.incarnate_ghost()
 	var/datum/antagonist/ninja/ninja_datum = ninja.mind.has_antag_datum(/datum/antagonist/ninja)
+	ninja_datum.change_species(ninja)
 	ninja_datum.equip_ninja()
 	ninja.forceMove(src)
 	ninja.Sleeping(15 SECONDS)

--- a/code/modules/antagonists/space_ninja/ninja_datum.dm
+++ b/code/modules/antagonists/space_ninja/ninja_datum.dm
@@ -113,7 +113,10 @@
 /datum/antagonist/ninja/apply_innate_effects(mob/living/mob_override)
 	var/mob/living/user = ..()
 	user.faction = list(ROLE_NINJA)
-	human_ninja = ishuman(user) ? user : null
+
+
+/datum/antagonist/ninja/proc/change_species(mob/living/mob_to_change = null) // This should be used to fully to remove robo-limbs & change species for lack of sprites
+	human_ninja = ishuman(mob_to_change) ? mob_to_change : null
 	if(human_ninja)
 		human_ninja.set_species(/datum/species/human)	// only human ninjas for now
 		human_ninja.revive()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Меняет код ниндзи, чтобы он не возраждал при каждом смене тела.
Добавлен прок изменения расы и вызыв его перед каждым одеванием ниндзи (иначе не работает).

## Ссылка на предложение/Причина создания ПР
[Ссылка на баг репорт](https://discord.com/channels/617003227182792704/1250153821683060777/1250153821683060777).

https://github.com/ss220-space/Paradise/assets/87372121/d554fcf9-6de1-4139-953b-6319e1542cc8

Ниндзя способен вернуться к жизни, просто подождав пересадки. Даже меняет расу на другую.

## Демонстрация изменений

https://github.com/ss220-space/Paradise/assets/87372121/ba64ba86-844c-4f35-a1f5-35040d49b496

