### PR TITLE
balance: Vending capitalism update

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -2324,7 +2324,7 @@
 		/obj/item/toy/crayon/rainbow = 1,
 		/obj/item/weaponcrafting/receiver = 1
 )
-	premium = list(/obj/item/poster/random_contraband = 5)
+	premium = list(/obj/item/poster/random_contraband = 5
 	)
 	prices = list(
 		/obj/item/toy/crayon/spraycan = 50,

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1029,11 +1029,18 @@
 		/obj/item/reagent_containers/food/drinks/chocolate = 10,
 		/obj/item/reagent_containers/food/drinks/chicken_soup = 10,
 		/obj/item/reagent_containers/food/drinks/weightloss = 10,
-		/obj/item/reagent_containers/food/drinks/mug = 15)
+		/obj/item/reagent_containers/food/drinks/mug = 15,
+		/obj/item/reagent_containers/food/drinks/mug/novelty = 5)
 	contraband = list(/obj/item/reagent_containers/food/drinks/ice = 10)
-	premium = list(/obj/item/reagent_containers/food/drinks/mug/novelty = 5)
-	prices = list(/obj/item/reagent_containers/food/drinks/coffee = 25, /obj/item/reagent_containers/food/drinks/tea = 25, /obj/item/reagent_containers/food/drinks/h_chocolate = 25, /obj/item/reagent_containers/food/drinks/chocolate = 25,
-				  /obj/item/reagent_containers/food/drinks/chicken_soup = 30,/obj/item/reagent_containers/food/drinks/weightloss = 50, /obj/item/reagent_containers/food/drinks/mug = 50)
+	prices = list(/obj/item/reagent_containers/food/drinks/coffee = 25, 
+		/obj/item/reagent_containers/food/drinks/tea = 25, 
+		/obj/item/reagent_containers/food/drinks/h_chocolate = 25, 
+		/obj/item/reagent_containers/food/drinks/chocolate = 25,		  
+		/obj/item/reagent_containers/food/drinks/chicken_soup = 30,
+		/obj/item/reagent_containers/food/drinks/weightloss = 50, 
+		/obj/item/reagent_containers/food/drinks/mug = 50, 
+		/obj/item/reagent_containers/food/drinks/mug/novelty = 100, 
+		/obj/item/reagent_containers/food/drinks/ice = 40)
 	refill_canister = /obj/item/vending_refill/coffee
 
 /obj/machinery/vending/coffee/free
@@ -1092,13 +1099,31 @@
 	broken_overlay = "snack_broken"
 	broken_lightmask_overlay = "snack_broken_lightmask"
 
-	products = list(/obj/item/reagent_containers/food/snacks/candy/candybar = 6,/obj/item/reagent_containers/food/drinks/dry_ramen = 6,/obj/item/reagent_containers/food/snacks/doshik = 6,/obj/item/reagent_containers/food/snacks/doshik_spicy = 6,/obj/item/reagent_containers/food/snacks/chips =6,
-					/obj/item/reagent_containers/food/snacks/sosjerky = 6,/obj/item/reagent_containers/food/snacks/no_raisin = 6,/obj/item/reagent_containers/food/snacks/pistachios =6,
-					/obj/item/reagent_containers/food/snacks/spacetwinkie = 6,/obj/item/reagent_containers/food/snacks/cheesiehonkers = 6,/obj/item/reagent_containers/food/snacks/tastybread = 6)
+	products = list(/obj/item/reagent_containers/food/snacks/candy/candybar = 6,
+					/obj/item/reagent_containers/food/drinks/dry_ramen = 6,
+					/obj/item/reagent_containers/food/snacks/doshik = 6,
+					/obj/item/reagent_containers/food/snacks/doshik_spicy = 6,
+					/obj/item/reagent_containers/food/snacks/chips =6,
+					/obj/item/reagent_containers/food/snacks/sosjerky = 6,
+					/obj/item/reagent_containers/food/snacks/no_raisin = 6,
+					/obj/item/reagent_containers/food/snacks/pistachios =6,
+					/obj/item/reagent_containers/food/snacks/spacetwinkie = 6,
+					/obj/item/reagent_containers/food/snacks/cheesiehonkers = 6,
+					/obj/item/reagent_containers/food/snacks/tastybread = 6
+					)
 	contraband = list(/obj/item/reagent_containers/food/snacks/syndicake = 6)
-	prices = list(/obj/item/reagent_containers/food/snacks/candy/candybar = 20,/obj/item/reagent_containers/food/drinks/dry_ramen = 30,/obj/item/reagent_containers/food/snacks/doshik = 30,/obj/item/reagent_containers/food/snacks/doshik_spicy = 150,
-					/obj/item/reagent_containers/food/snacks/chips =25,/obj/item/reagent_containers/food/snacks/sosjerky = 30,/obj/item/reagent_containers/food/snacks/no_raisin = 20,
-					/obj/item/reagent_containers/food/snacks/pistachios = 35, /obj/item/reagent_containers/food/snacks/spacetwinkie = 30,/obj/item/reagent_containers/food/snacks/cheesiehonkers = 25,/obj/item/reagent_containers/food/snacks/tastybread = 30)
+	prices = list(/obj/item/reagent_containers/food/snacks/candy/candybar = 20,
+					/obj/item/reagent_containers/food/drinks/dry_ramen = 30,
+					/obj/item/reagent_containers/food/snacks/doshik = 30,
+					/obj/item/reagent_containers/food/snacks/doshik_spicy = 150,
+					/obj/item/reagent_containers/food/snacks/chips =25,
+					/obj/item/reagent_containers/food/snacks/sosjerky = 30,
+					/obj/item/reagent_containers/food/snacks/no_raisin = 20,
+					/obj/item/reagent_containers/food/snacks/pistachios = 35, 
+					/obj/item/reagent_containers/food/snacks/spacetwinkie = 30,
+					/obj/item/reagent_containers/food/snacks/cheesiehonkers = 25,
+					/obj/item/reagent_containers/food/snacks/tastybread = 30, 
+					/obj/item/reagent_containers/food/snacks/syndicake = 50)
 	refill_canister = /obj/item/vending_refill/snack
 
 /obj/machinery/vending/snack/free
@@ -1184,6 +1209,7 @@
 		/obj/item/reagent_containers/food/drinks/cans/energy/trop = 40,
 		/obj/item/reagent_containers/food/drinks/cans/energy/milk = 40,
 		/obj/item/reagent_containers/food/drinks/cans/energy/grey = 40,
+		/obj/item/reagent_containers/food/drinks/cans/thirteenloko = 80
 		/obj/item/reagent_containers/food/drinks/zaza = 200)
 	refill_canister = /obj/item/vending_refill/cola
 
@@ -1289,10 +1315,33 @@
 	broken_overlay = "cigs_broken"
 	broken_lightmask_overlay = "cigs_broken_lightmask"
 
-	products = list(/obj/item/storage/fancy/cigarettes/cigpack_robust = 12, /obj/item/storage/fancy/cigarettes/cigpack_uplift = 6, /obj/item/storage/fancy/cigarettes/cigpack_random = 6, /obj/item/reagent_containers/food/pill/patch/nicotine = 10, /obj/item/storage/box/matches = 10,/obj/item/lighter/random = 4,/obj/item/storage/fancy/rollingpapers = 5)
-	contraband = list(/obj/item/lighter/zippo = 4, /obj/item/clothing/mask/cigarette/pipe/oldpipe = 3)
-	premium = list(/obj/item/clothing/mask/cigarette/cigar/havana = 2, /obj/item/storage/fancy/cigarettes/cigpack_robustgold = 1)
-	prices = list(/obj/item/storage/fancy/cigarettes/cigpack_robust = 180, /obj/item/storage/fancy/cigarettes/cigpack_uplift = 240, /obj/item/storage/fancy/cigarettes/cigpack_random = 360, /obj/item/reagent_containers/food/pill/patch/nicotine = 70, /obj/item/storage/box/matches = 10,/obj/item/lighter/random = 60, /obj/item/storage/fancy/rollingpapers = 20, /obj/item/clothing/mask/cigarette/pipe/oldpipe = 250)
+	products = list(/obj/item/storage/fancy/cigarettes/cigpack_robust = 12, 
+					/obj/item/storage/fancy/cigarettes/cigpack_uplift = 6, 
+					/obj/item/storage/fancy/cigarettes/cigpack_random = 6, 
+					/obj/item/reagent_containers/food/pill/patch/nicotine = 10, 
+					/obj/item/storage/box/matches = 10,
+					/obj/item/lighter/random = 4,
+					/obj/item/storage/fancy/rollingpapers = 5, 
+					/obj/item/lighter/zippo = 4,
+					/obj/item/clothing/mask/cigarette/cigar/havana = 2, 
+					/obj/item/storage/fancy/cigarettes/cigpack_robustgold = 1
+					)
+	contraband = list( /obj/item/clothing/mask/cigarette/pipe/oldpipe = 3, 
+					/obj/item/storage/fancy/cigarettes/cigpack_med = 1
+					)
+	prices = list(/obj/item/storage/fancy/cigarettes/cigpack_robust = 180, 
+					/obj/item/storage/fancy/cigarettes/cigpack_uplift = 240, 
+					/obj/item/storage/fancy/cigarettes/cigpack_random = 360, 
+					/obj/item/reagent_containers/food/pill/patch/nicotine = 70, 
+					/obj/item/storage/box/matches = 10,
+					/obj/item/lighter/random = 60,
+					/obj/item/storage/fancy/rollingpapers = 20,
+					/obj/item/clothing/mask/cigarette/pipe/oldpipe = 250,
+					/obj/item/lighter/zippo = 250,
+					/obj/item/clothing/mask/cigarette/cigar/havana = 1000,
+					/obj/item/storage/fancy/cigarettes/cigpack_robustgold = 700,
+					/obj/item/storage/fancy/cigarettes/cigpack_med = 500
+					)
 	refill_canister = /obj/item/vending_refill/cigarette
 
 /obj/machinery/vending/cigarette/free
@@ -1871,10 +1920,30 @@
 	broken_lightmask_overlay = "tool_broken_lightmask"
 	deny_overlay = "tool_deny"
 
-	products = list(/obj/item/stack/cable_coil/random = 10,/obj/item/crowbar = 5,/obj/item/weldingtool = 3,/obj/item/wirecutters = 5,
-					/obj/item/wrench = 5,/obj/item/analyzer = 5,/obj/item/t_scanner = 5,/obj/item/screwdriver = 5)
-	contraband = list(/obj/item/weldingtool/hugetank = 2,/obj/item/clothing/gloves/color/fyellow = 2)
-	premium = list(/obj/item/clothing/gloves/color/yellow = 1)
+	products = list(/obj/item/stack/cable_coil/random = 10,
+					/obj/item/crowbar = 5,
+					/obj/item/weldingtool = 3,
+					/obj/item/wirecutters = 5,
+					/obj/item/wrench = 5,
+					/obj/item/analyzer = 5,
+					/obj/item/t_scanner = 5,
+					/obj/item/screwdriver = 5,
+					/obj/item/clothing/gloves/color/fyellow = 2
+					)
+	contraband = list(/obj/item/weldingtool/hugetank = 2,
+					/obj/item/clothing/gloves/color/yellow = 1
+					)
+	prices = list(/obj/item/stack/cable_coil/random = 30,
+					/obj/item/crowbar = 50,/obj/item/weldingtool = 50,
+					/obj/item/wirecutters = 50,
+					/obj/item/wrench = 50,
+					/obj/item/analyzer = 30,
+					/obj/item/t_scanner = 30,
+					/obj/item/screwdriver = 50,
+					/obj/item/clothing/gloves/color/fyellow = 250,
+					/obj/item/weldingtool/hugetank = 200,
+					/obj/item/clothing/gloves/color/yellow = 500
+	)
 	refill_canister = /obj/item/vending_refill/youtool
 	armor = list(melee = 50, bullet = 20, laser = 20, energy = 20, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 70)
 	resistance_flags = FIRE_PROOF
@@ -2250,9 +2319,34 @@
 		/obj/item/pen = 5,
 		/obj/item/pen/blue = 5,
 		/obj/item/pen/red = 5)
-	contraband = list(/obj/item/toy/crayon/mime = 1,/obj/item/toy/crayon/rainbow = 1)
+	contraband = list(
+		/obj/item/toy/crayon/mime = 1,
+		/obj/item/toy/crayon/rainbow = 1,
+		/obj/item/weaponcrafting/receiver = 1
+)
 	premium = list(/obj/item/poster/random_contraband = 5)
-
+	)
+	prices = list(
+		/obj/item/toy/crayon/spraycan = 50,
+		/obj/item/stack/cable_coil/random = 30,
+		/obj/item/camera = 20,
+		/obj/item/camera_film = 10,
+		/obj/item/storage/photo_album = 10,
+		/obj/item/stack/wrapping_paper = 20,
+		/obj/item/stack/tape_roll = 20,
+		/obj/item/stack/packageWrap = 10,
+		/obj/item/storage/fancy/crayons = 35,
+		/obj/item/storage/fancy/glowsticks_box = 100,
+		/obj/item/hand_labeler = 30,
+		/obj/item/paper = 5,
+		/obj/item/c_tube = 10,
+		/obj/item/pen = 5,
+		/obj/item/pen/blue = 10,
+		/obj/item/pen/red = 10,
+		/obj/item/toy/crayon/mime = 50,
+		/obj/item/toy/crayon/rainbow = 50,
+		/obj/item/weaponcrafting/receiver = 250
+	)
 
 /obj/machinery/vending/crittercare
 	name = "\improper CritterCare"

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1209,7 +1209,7 @@
 		/obj/item/reagent_containers/food/drinks/cans/energy/trop = 40,
 		/obj/item/reagent_containers/food/drinks/cans/energy/milk = 40,
 		/obj/item/reagent_containers/food/drinks/cans/energy/grey = 40,
-		/obj/item/reagent_containers/food/drinks/cans/thirteenloko = 80
+		/obj/item/reagent_containers/food/drinks/cans/thirteenloko = 80,
 		/obj/item/reagent_containers/food/drinks/zaza = 200)
 	refill_canister = /obj/item/vending_refill/cola
 


### PR DESCRIPTION
## Описание
Все теперь почти все вендоры в игре требуют денег за свои услуги, включая контрабандные итемы.
В артвенд добавлен ресивер, в сигаретный вендер сигареты с каннабиноидами.
Пару предметов из взлома переехали в стандарт, и наоборот. 
Монеты были выпилены из вендоров с функциональными предметами. Теперь они остались тока на визуалку типа постеров или одежды.
Чутка структурировал код в некоторых вендорах, ибо одной строкой все было читать неудобно пиздээээц.

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1250386652069888000

## Демонстрация изменений
![image](https://github.com/ss220-space/Paradise/assets/42041683/51124822-85f8-4892-9e05-2ec7e97628f9)
