### PR TITLE
bugfix: emagged CMO defib don't stop hearts

### DIFF
--- a/code/datums/components/defibrillator.dm
+++ b/code/datums/components/defibrillator.dm
@@ -5,8 +5,8 @@
 	/// If this is being used by a borg or not, with necessary safeties applied if so.
 	var/robotic
 	/// If it should penetrate space suits
-	var/combat
-	/// If combat is true, this determines whether or not it should always cause a heart attack.
+	var/ignore_hardsuits
+	/// If ignore_hardsuits is true, this determines whether or not it should always cause a heart attack.
 	var/heart_attack_chance
 	/// Whether the safeties are enabled or not
 	var/safety
@@ -32,21 +32,21 @@
  * * robotic - whether this should be treated like a borg module.
  * * cooldown - Minimum time possible between shocks.
  * * speed_multiplier - Speed multiplier for defib do-afters.
- * * combat - If true, the defib can zap through hardsuits.
- * * heart_attack_chance - If combat and safeties are off, the % chance for this to cause a heart attack on harm intent.
+ * * ignore_hardsuits - If true, the defib can zap through hardsuits.
+ * * heart_attack_chance - If safeties are off, the % chance for this to cause a heart attack on harm intent.
  * * safe_by_default - If true, safety will be enabled by default.
  * * emp_proof - If true, safety won't be switched by emp. Note that the device itself can still have behavior from it, it's just that the component will not.
  * * emag_proof - If true, safety won't be switched by emag. Note that the device itself can still have behavior from it, it's just that the component will not.
  * * actual_unit - Unit which the component's parent is based from, such as a large defib unit or a borg. The actual_unit will make the sounds and be the "origin" of visible messages, among other things.
  */
-/datum/component/defib/Initialize(robotic, cooldown = 5 SECONDS, speed_multiplier = 1, combat = FALSE, heart_attack_chance = 100, safe_by_default = TRUE, emp_proof = FALSE, emag_proof = FALSE, obj/item/actual_unit = null)
+/datum/component/defib/Initialize(robotic, cooldown = 5 SECONDS, speed_multiplier = 1, ignore_hardsuits = FALSE, heart_attack_chance = 100, safe_by_default = TRUE, emp_proof = FALSE, emag_proof = FALSE, obj/item/actual_unit = null)
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
 
 	src.robotic = robotic
 	src.speed_multiplier = speed_multiplier
 	src.cooldown = cooldown
-	src.combat = combat
+	src.ignore_hardsuits = ignore_hardsuits
 	src.heart_attack_chance = heart_attack_chance
 	safety = safe_by_default
 	src.emp_proof = emp_proof
@@ -151,15 +151,10 @@
 			to_chat(user, span_notice("The instructions on [defib_ref] don't mention how to defibrillate that..."))
 		return
 
-	if(should_cause_harm && combat && heart_attack_chance == 100)
+	if(should_cause_harm)
 		combat_fibrillate(user, target)
 		SEND_SIGNAL(parent, COMSIG_DEFIB_SHOCK_APPLIED, user, target, should_cause_harm, TRUE)
 		busy = FALSE
-		return
-
-	if(should_cause_harm)
-		fibrillate(user, target)
-		SEND_SIGNAL(parent, COMSIG_DEFIB_SHOCK_APPLIED, user, target, should_cause_harm, TRUE)
 		return
 
 	user.visible_message(
@@ -192,7 +187,7 @@
 		busy = FALSE
 		return
 
-	if(istype(target.wear_suit, /obj/item/clothing/suit/space) && !combat)
+	if(istype(target.wear_suit, /obj/item/clothing/suit/space) && !ignore_hardsuits)
 		user.visible_message(span_notice("[defib_ref] buzzes: Patient's chest is obscured. Operation aborted."))
 		playsound(get_turf(defib_ref), 'sound/machines/defib_failed.ogg', 50, 0)
 		busy = FALSE
@@ -310,7 +305,7 @@
  * * user - wielder of the defib
  * * target - person getting shocked
  */
-/datum/component/defib/proc/fibrillate(mob/user, mob/living/carbon/human/target)
+/datum/component/defib/proc/combat_fibrillate(mob/user, mob/living/carbon/human/target)
 	if(!istype(target))
 		return
 	busy = TRUE
@@ -320,9 +315,10 @@
 	)
 	target.adjustStaminaLoss(50)
 	target.Weaken(4 SECONDS)
-	playsound(get_turf(parent), 'sound/machines/defib_zap.ogg', 50, 1, -1)
+	playsound(get_turf(parent), 'sound/machines/defib_zap.ogg', 50, TRUE, -1)
 	target.emote("gasp")
-	if(combat && prob(heart_attack_chance))
+	if(prob(heart_attack_chance))
+		add_attack_logs(user, target, "Gave a heart attack with [parent]")
 		target.set_heartattack(TRUE)
 	SEND_SIGNAL(target, COMSIG_LIVING_MINOR_SHOCK, 100)
 	add_attack_logs(user, target, "Stunned with [parent]")
@@ -359,26 +355,3 @@
 							span_userdanger("You feel a powerful shock travel up your [affecting.hand ? affecting.get_organ(BODY_ZONE_L_ARM) : affecting.get_organ(BODY_ZONE_R_ARM)] and back down your [affecting.hand ? affecting.get_organ(BODY_ZONE_R_ARM) : affecting.get_organ(BODY_ZONE_L_ARM)]!"))
 			affecting.set_heartattack(TRUE)
 
-
-/datum/component/defib/proc/combat_fibrillate(mob/user, mob/living/carbon/human/target)
-	if(!istype(target))
-		return
-	busy = TRUE
-	target.adjustStaminaLoss(60)
-	target.emote("gasp")
-	add_attack_logs(user, target, "Stunned with [parent]")
-	if(target.incapacitated())
-		add_attack_logs(user, target, "Gave a heart attack with [parent]")
-		target.set_heartattack(TRUE)
-		target.visible_message(
-			span_danger("[user] has touched [target.name] with [parent]!"),
-			span_userdanger("[user] has touched [target.name] with [parent]!"),
-		)
-		playsound(get_turf(parent), 'sound/machines/defib_zap.ogg', 50, TRUE, -1)
-		set_cooldown(cooldown)
-		target.Weaken(4 SECONDS)
-		return
-	target.Weaken(4 SECONDS)
-	target.shock_internal_organs(100)
-	target.visible_message(span_danger("[user] touches [target] lightly with [parent]!"))
-	set_cooldown(2.5 SECONDS)

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -26,8 +26,8 @@
 	var/obj/item/stock_parts/cell/high/cell = null
 	/// If false, using harm intent will let you zap people. Note that any updates to this after init will only impact icons.
 	var/safety = TRUE
-	/// If true, this can be used through hardsuits, and can cause heart attacks in harm intent.
-	var/combat = FALSE
+	/// If true, this can be used through hardsuits
+	var/ignore_hardsuits = FALSE
 	// If safety is false and combat is true, the chance that this will cause a heart attack.
 	var/heart_attack_probability = 30
 	/// If this is vulnerable to EMPs.
@@ -264,6 +264,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = ITEM_SLOT_BELT
 	origin_tech = "biotech=5"
+	heart_attack_probability = 10
 
 /obj/item/defibrillator/compact/item_action_slot_check(slot, mob/user)
 	if(slot == ITEM_SLOT_BELT)
@@ -280,7 +281,7 @@
 	icon_state = "defibcombat"
 	item_state = "defibcombat"
 	paddle_type = /obj/item/twohanded/shockpaddles/syndicate
-	combat = TRUE
+	ignore_hardsuits = TRUE
 	safety = FALSE
 	heart_attack_probability = 100
 
@@ -295,10 +296,10 @@
 	icon_state = "defibnt"
 	item_state = "defibnt"
 	paddle_type = /obj/item/twohanded/shockpaddles/advanced
-	combat = TRUE
+	ignore_hardsuits = TRUE
 	safety = TRUE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF //Objective item, better not have it destroyed.
-	heart_attack_probability = 10
+	heart_attack_probability = 100
 
 	var/next_emp_message //to prevent spam from the emagging message on the advanced defibrillator
 
@@ -360,7 +361,7 @@
 /obj/item/twohanded/shockpaddles/proc/add_defib_component(mainunit)
 	if(check_defib_exists(mainunit))
 		update_icon(UPDATE_ICON_STATE)
-		AddComponent(/datum/component/defib, actual_unit = defib, combat = defib.combat, safe_by_default = defib.safety, heart_attack_chance = defib.heart_attack_probability, emp_proof = defib.hardened, emag_proof = defib.emag_proof)
+		AddComponent(/datum/component/defib, actual_unit = defib, ignore_hardsuits = defib.ignore_hardsuits, safe_by_default = defib.safety, heart_attack_chance = defib.heart_attack_probability, emp_proof = defib.hardened, emag_proof = defib.emag_proof)
 	else
 		AddComponent(/datum/component/defib)
 	RegisterSignal(src, COMSIG_DEFIB_READY, PROC_REF(on_cooldown_expire))
@@ -459,7 +460,7 @@
 /obj/item/twohanded/shockpaddles/borg/add_defib_component(mainunit)
 	var/is_combat_borg = istype(loc, /obj/item/robot_module/syndicate_medical) || istype(loc, /obj/item/robot_module/ninja)
 
-	AddComponent(/datum/component/defib, robotic = TRUE, combat = is_combat_borg, safe_by_default = safety, emp_proof = TRUE, heart_attack_chance = heart_attack_probability)
+	AddComponent(/datum/component/defib, robotic = TRUE, ignore_hardsuits = is_combat_borg, safe_by_default = safety, emp_proof = TRUE, heart_attack_chance = heart_attack_probability)
 
 	RegisterSignal(src, COMSIG_DEFIB_READY, PROC_REF(on_cooldown_expire))
 	RegisterSignal(src, COMSIG_DEFIB_SHOCK_APPLIED, PROC_REF(after_shock))


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Исправляет логику работы дефибриляторов в соответствии с тем, как это было до [рефактора](https://github.com/ss220-space/Paradise/pull/4406)
СМОшный емагнутый и нюкерские дефибы вновь останавливают сердца с первого удара.
Шанс остановки компактного дефиба из РНД вновь 10%. 
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

