### PR TITLE
bugfix: Now blood is unsafe

### DIFF
--- a/code/_globalvars/lists/reagents.dm
+++ b/code/_globalvars/lists/reagents.dm
@@ -50,7 +50,7 @@ GLOBAL_LIST_INIT(blocked_chems, list("polonium", "initropidril", "concentrated_i
 
 GLOBAL_LIST_INIT(safe_chem_list, list("antihol", "charcoal", "epinephrine", "insulin", "teporone","silver_sulfadiazine", "salbutamol",
 									  "omnizine", "stimulants", "synaptizine", "potass_iodide", "oculine", "mannitol", "styptic_powder",
-									  "spaceacillin", "salglu_solution", "sal_acid", "cryoxadone", "blood", "synthflesh", "hydrocodone",
+									  "spaceacillin", "salglu_solution", "sal_acid", "cryoxadone", "synthflesh", "hydrocodone",
 									  "mitocholide", "rezadone"))
 
 GLOBAL_LIST_INIT(safe_chem_applicator_list, list("silver_sulfadiazine", "styptic_powder", "synthflesh"))


### PR DESCRIPTION
## Описание
МикроПР, который удаляет кровь из списка безопасных реагентов. Теперь кровь не считается безопасным реагентом и патч будет накладываться с задержкой, предотвращая мгновенное заражение.

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1250428091767984188
Кровь должна считаться опасным веществом. Её нельзя заливать в гипоспрей, а патчи с ней должны лепиться с задержкой в три секунды.