### PR TITLE
refactor: Obscured Slots Refining

### DIFF
--- a/code/datums/spells/horsemask.dm
+++ b/code/datums/spells/horsemask.dm
@@ -34,7 +34,7 @@
 	var/obj/item/clothing/mask/horsehead/magichead = new /obj/item/clothing/mask/horsehead
 	magichead.item_flags |= DROPDEL	//curses!
 	ADD_TRAIT(magichead, TRAIT_NODROP, CURSED_ITEM_TRAIT(magichead.type))
-	magichead.flags_inv = NONE	//so you can still see their face
+	magichead.flags_inv &= ~HIDENAME	//so you can still see their face
 	magichead.voicechange = TRUE	//NEEEEIIGHH
 	target.visible_message(	"<span class='danger'>[target]'s face  lights up in fire, and after the event a horse's head takes its place!</span>", \
 							"<span class='danger'>Your face burns up, and shortly after the fire you realise you have the face of a horse!</span>")

--- a/code/game/gamemodes/clockwork/clockwork_items.dm
+++ b/code/game/gamemodes/clockwork/clockwork_items.dm
@@ -655,6 +655,7 @@
 	allowed = list(/obj/item/clockwork, /obj/item/twohanded/ratvarian_spear, /obj/item/twohanded/clock_hammer, /obj/item/melee/clock_sword)
 	armor = list("melee" = 40, "bullet" = 30, "laser" = 40, "energy" = 20, "bomb" = 25, "bio" = 10, "rad" = 0, "fire" = 10, "acid" = 10)
 	flags_inv = HIDEJUMPSUIT
+	flags_inv_transparent = HIDEJUMPSUIT
 	magical = TRUE
 	sprite_sheets = list(
 		SPECIES_UNATHI = 'icons/mob/clothing/species/unathi/suit.dmi',
@@ -674,6 +675,7 @@
 	allowed = list(/obj/item/flashlight, /obj/item/tank, /obj/item/resonator, /obj/item/mining_scanner, /obj/item/t_scanner/adv_mining_scanner, /obj/item/gun/energy/kinetic_accelerator, /obj/item/pickaxe, /obj/item/twohanded/kinetic_crusher, /obj/item/hierophant_club, /obj/item/twohanded/fireaxe/boneaxe) // some miners stuff
 	armor = list("melee" = 40, "bullet" = 30, "laser" = 40, "energy" = 20, "bomb" = 25, "bio" = 10, "rad" = 0, "fire" = 10, "acid" = 10)
 	flags_inv = HIDEJUMPSUIT
+	flags_inv_transparent = HIDEJUMPSUIT
 	magical = TRUE
 	sprite_sheets = list(
 		SPECIES_UNATHI = 'icons/mob/clothing/species/unathi/suit.dmi'
@@ -782,6 +784,7 @@
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	armor = list("melee" = 50, "bullet" = 40, "laser" = 50, "energy" = 30, "bomb" = 50, "bio" = 30, "rad" = 30, "fire" = 100, "acid" = 100)
 	flags_inv = HIDEJUMPSUIT
+	flags_inv_transparent = HIDEGLOVES|HIDESHOES
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	allowed = list(/obj/item/clockwork, /obj/item/twohanded/ratvarian_spear, /obj/item/twohanded/clock_hammer, /obj/item/melee/clock_sword)
 	hide_tail_by_species = list(SPECIES_VULPKANIN)
@@ -806,6 +809,7 @@
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	allowed = list(/obj/item/flashlight, /obj/item/tank, /obj/item/resonator, /obj/item/mining_scanner, /obj/item/t_scanner/adv_mining_scanner, /obj/item/gun/energy/kinetic_accelerator, /obj/item/pickaxe, /obj/item/twohanded/kinetic_crusher, /obj/item/hierophant_club, /obj/item/twohanded/fireaxe/boneaxe) // some miners stuff
 	flags_inv = HIDEJUMPSUIT
+	flags_inv_transparent = HIDEGLOVES|HIDESHOES
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	allowed = list(/obj/item/clockwork, /obj/item/twohanded/ratvarian_spear, /obj/item/twohanded/clock_hammer, /obj/item/melee/clock_sword)
 	sprite_sheets = list(

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -151,6 +151,7 @@
 	slowdown = 1
 	armor = list("melee" = 70, "bullet" = 50, "laser" = 30,"energy" = 15, "bomb" = 30, "bio" = 30, "rad" = 30, "fire" = 40, "acid" = 75)
 	flags_inv = HIDEGLOVES|HIDEJUMPSUIT|HIDETAIL
+	flags_inv_transparent = HIDEJUMPSUIT
 	magical = TRUE
 	species_restricted = null
 	sprite_sheets = list(
@@ -164,6 +165,7 @@
 	item_state = "cult_armour"
 	w_class = WEIGHT_CLASS_BULKY
 	armor = list("melee" = 50, "bullet" = 40, "laser" = 50, "energy" = 30, "bomb" = 50, "bio" = 30, "rad" = 30, "fire" = 50, "acid" = 60)
+	flags_inv_transparent = HIDEGLOVES
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	allowed = list(/obj/item/tome, /obj/item/melee/cultblade)
 	hoodtype = /obj/item/clothing/head/hooded/cult_hoodie
@@ -207,7 +209,6 @@
 	desc = "Blood-soaked robes infused with dark magic; allows the user to move at inhuman speeds, but at the cost of increased damage."
 	icon_state = "flagellantrobe"
 	item_state = "flagellantrobe"
-	flags_inv = HIDEJUMPSUIT
 	allowed = list(/obj/item/tome, /obj/item/melee/cultblade)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	armor = list("melee" = -50, "bullet" = -50, "laser" = -50,"energy" = -50, "bomb" = -50, "bio" = -50, "rad" = -50, "fire" = 0, "acid" = 0)
@@ -439,7 +440,6 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	allowed = list(/obj/item/tome, /obj/item/melee/cultblade)
 	armor = list(melee = 50, bullet = 30, laser = 50, energy = 20, bomb = 25, bio = 10, rad = 0, fire = 10, acid = 10)
-	flags_inv = HIDEJUMPSUIT
 	item_flags = DROPDEL
 	hoodtype = /obj/item/clothing/head/hooded/culthood/alt/ghost
 
@@ -606,7 +606,6 @@
 	desc = "A sickening spear composed entirely of crystallized blood."
 	icon = 'icons/obj/cult.dmi'
 	icon_state = "bloodspear0"
-	slot_flags = 0
 	force = 17
 	force_unwielded = 17
 	force_wielded = 24

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -1139,7 +1139,7 @@
 		var/obj/item/clothing/mask/horsehead/magichead = new /obj/item/clothing/mask/horsehead
 		ADD_TRAIT(magichead, TRAIT_NODROP, CURSED_ITEM_TRAIT(magichead.type))
 		magichead.item_flags |= DROPDEL	//curses!
-		magichead.flags_inv = NONE	//so you can still see their face
+		magichead.flags_inv &= ~HIDENAME	//so you can still see their face
 		magichead.voicechange = TRUE	//NEEEEIIGHH
 		if(!user.drop_item_ground(user.wear_mask))
 			qdel(user.wear_mask)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -25,6 +25,10 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 	var/slot_flags_2 = NONE
 	/// This flag is used to determine when items in someone's inventory cover others. IE helmets making it so you can't see glasses, etc.
 	var/flags_inv = NONE
+	/// These flags will be added/removed (^=) to/from flags_inv in [/proc/check_obscured_slots()]
+	/// if check_transparent argument is set to `TRUE`. Used in carbon's update icons shenanigans.
+	/// Example: you can see someone's mask through their transparent visor, but you cannot reach it
+	var/flags_inv_transparent = NONE
 	/// Special cover flags used for protection calculations.
 	var/flags_cover = NONE
 
@@ -690,7 +694,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 
 	if(equip_delay_self > 0)
 		if(!silent)
-			to_chat(user, span_warning("Вы должны экипировать [src] вручную!"))
+			to_chat(user, span_warning("Вы должны экипировать [name] вручную!"))
 		return FALSE
 
 	//If storage is active - insert there
@@ -711,20 +715,21 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 		if(container.can_be_inserted(src, TRUE))
 			return container.handle_item_insertion(src)
 
+	var/our_name = name
+
 	if(drop_on_fail)
 		if(src in user.get_equipped_items(include_pockets = TRUE, include_hands = TRUE))
 			user.drop_item_ground(src)
 		else
 			forceMove(drop_location())
-		return FALSE
 
-	if(qdel_on_fail)
+	else if(qdel_on_fail)
 		if(src in user.get_equipped_items(include_pockets = TRUE, include_hands = TRUE))
 			user.temporarily_remove_item_from_inventory(src, force = TRUE)
 		qdel(src)
 
 	if(!silent)
-		to_chat(user, span_warning("Вы не можете надеть [src]!"))
+		to_chat(user, span_warning("Вы не можете надеть [our_name]!"))
 
 	return FALSE
 

--- a/code/modules/antagonists/space_ninja/suit/suit.dm
+++ b/code/modules/antagonists/space_ninja/suit/suit.dm
@@ -22,7 +22,8 @@
 	armor = list("melee" = 40, "bullet" = 30, "laser" = 20,"energy" = 30, "bomb" = 30, "bio" = 100, "rad" = 30, "fire" = 100, "acid" = 100)
 	strip_delay = 12
 	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
-	flags_inv = HIDEJUMPSUIT|HIDETAIL
+	flags_inv = HIDEGLOVES|HIDEJUMPSUIT|HIDETAIL
+	flags_inv_transparent = HIDEGLOVES|HIDEJUMPSUIT
 	actions = list()
 	action_icon = list()
 	action_icon_state = list()
@@ -651,9 +652,9 @@
 /obj/item/clothing/suit/space/space_ninja/proc/toggle_ninja_nodrop(obj/item/ninja_clothing)
 	var/prev_has = HAS_TRAIT_FROM(ninja_clothing, TRAIT_NODROP, NINJA_TRAIT)
 	if(prev_has)
-		REMOVE_TRAIT(src, TRAIT_NODROP, NINJA_TRAIT)
+		REMOVE_TRAIT(ninja_clothing, TRAIT_NODROP, NINJA_TRAIT)
 	else
-		ADD_TRAIT(src, TRAIT_NODROP, NINJA_TRAIT)
+		ADD_TRAIT(ninja_clothing, TRAIT_NODROP, NINJA_TRAIT)
 	current_initialisation_text = "[prev_has ? "Разблокировка" : "Блокировка"]: [ninja_clothing.name]... Успех"
 	playsound(ninja_clothing.loc, 'sound/items/piston.ogg', 10, TRUE)
 	sleep(10)

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -34,6 +34,7 @@
 	if(.)
 		clothing_flags ^= visor_clothing_flags
 		flags_inv ^= visor_flags_inv
+		flags_inv_transparent ^= visor_flags_inv_transparent
 
 /obj/item/clothing/head/helmet/detective
 	name = "olive helmet"

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -92,6 +92,11 @@
 		w_class = up ? WEIGHT_CLASS_SMALL : WEIGHT_CLASS_NORMAL
 
 
+/obj/item/clothing/mask/gas/explorer/force_adjust_mask()
+	. = ..()
+	w_class = WEIGHT_CLASS_SMALL
+
+
 /obj/item/clothing/mask/gas/explorer/folded/Initialize(mapload)
 	. = ..()
 	force_adjust_mask()
@@ -349,14 +354,22 @@
 								"dredd"			= "I am, the LAW!"
 								)
 
+
 /obj/item/clothing/mask/gas/sechailer/adjustmask(user)
 	. = ..()
 	if(.)
 		w_class = up ? WEIGHT_CLASS_SMALL : WEIGHT_CLASS_NORMAL
 
+
+/obj/item/clothing/mask/gas/sechailer/force_adjust_mask()
+	. = ..()
+	w_class = WEIGHT_CLASS_SMALL
+
+
 /obj/item/clothing/mask/gas/sechailer/folded/Initialize(mapload)
 	. = ..()
 	force_adjust_mask()
+
 
 /obj/item/clothing/mask/gas/sechailer/hos
 	name = "\improper HOS SWAT mask"

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -403,12 +403,14 @@
 		clothing_flags |= visor_clothing_flags
 		flags_cover |= (HEADCOVERSEYES|HEADCOVERSMOUTH)
 		flags_inv |= visor_flags_inv
+		flags_inv_transparent |= visor_flags_inv_transparent
 		cold_protection |= HEAD
 		armor.rad = 100
 	else
 		clothing_flags &= ~visor_clothing_flags
 		flags_cover &= ~(HEADCOVERSEYES|HEADCOVERSMOUTH)
 		flags_inv &= ~visor_flags_inv
+		flags_inv_transparent &= ~visor_flags_inv_transparent
 		cold_protection &= ~HEAD
 		armor.rad = combat_rad
 	update_appearance(UPDATE_ICON_STATE|UPDATE_NAME|UPDATE_DESC)

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -46,21 +46,23 @@
 	up = !up
 	clothing_flags ^= visor_clothing_flags
 	flags_inv ^= visor_flags_inv
+	flags_inv_transparent ^= visor_flags_inv_transparent
 	if(visor_vars_to_toggle & VISOR_FLASHPROTECT)
 		flash_protect ^= initial(flash_protect)
 	if(visor_vars_to_toggle & VISOR_TINT)
 		tint = up ? tint_up : initial(tint)
+
 
 /obj/item/clothing/head/helmet/space/plasmaman/proc/toggle_welding_screen(mob/living/user)
 	if(weldingvisortoggle(user))
 		if(on)
 			to_chat(user, "<span class='notice'>Your helmet's torch can't pass through your welding visor!</span>")
 			on = FALSE
-			playsound(src, 'sound/mecha/mechmove03.ogg', 50, 1) //Visors don't just come from nothing
+			playsound(src, 'sound/mecha/mechmove03.ogg', 50, TRUE) //Visors don't just come from nothing
 			update_icon(UPDATE_OVERLAYS)
 			actions_types = list(/datum/action/item_action/toggle_helmet_light)
 		else
-			playsound(src, 'sound/mecha/mechmove03.ogg', 50, 1) //Visors don't just come from nothing
+			playsound(src, 'sound/mecha/mechmove03.ogg', 50, TRUE) //Visors don't just come from nothing
 			update_icon(UPDATE_OVERLAYS)
 
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -144,7 +144,7 @@
 	desc = "A trenchcoat enhanced with a special lightweight kevlar. The epitome of tactical plainclothes."
 	icon_state = "hostrench_open"
 	item_state = "hostrench_open"
-	flags_inv = 0
+	flags_inv_transparent = HIDEJUMPSUIT
 	ignore_suitadjust = 0
 	suit_adjusted = 1
 	actions_types = list(/datum/action/item_action/openclose)
@@ -155,7 +155,7 @@
 	desc = "A trenchcoat augmented with a special alloy for some protection and style."
 	icon_state = "jensencoat"
 	item_state = "jensencoat"
-	flags_inv = 0
+	flags_inv_transparent = HIDEJUMPSUIT
 	sprite_sheets = null
 
 /obj/item/clothing/suit/armor/vest/warden
@@ -207,6 +207,7 @@
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	armor = list("melee" = 50, "bullet" = 10, "laser" = 10, "energy" = 20, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 80)
 	flags_inv = HIDEJUMPSUIT
+	flags_inv_transparent = HIDEJUMPSUIT
 	strip_delay = 80
 	put_on_delay = 60
 	hide_tail_by_species = list(SPECIES_VOX)

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -101,14 +101,16 @@
 	desc = "Made of real fur."
 	item_state = "cap_coat"
 	icon_state = "cap_coat"
+	flags_inv_transparent = HIDEJUMPSUIT
 
 /obj/item/clothing/suit/captunic/parade
 	name = "captain's parade jacket"
 	desc = "Worn by a Captain to show their class."
 	icon_state = "cap_jacket_black_open"
 	item_state = "cap_jacket_black_open"
-	ignore_suitadjust = 0
-	suit_adjusted = 1
+	ignore_suitadjust = FALSE
+	suit_adjusted = TRUE
+	flags_inv_transparent = HIDEJUMPSUIT
 	actions_types = list(/datum/action/item_action/button)
 	adjust_flavour = "unbutton"
 
@@ -121,8 +123,9 @@
 	desc = "Worn by a Captain to show their class."
 	icon_state = "cap_jacket_open"
 	item_state = "cap_jacket_open"
-	ignore_suitadjust = 0
-	suit_adjusted = 1
+	ignore_suitadjust = FALSE
+	suit_adjusted = TRUE
+	flags_inv_transparent = HIDEJUMPSUIT
 	actions_types = list(/datum/action/item_action/button)
 	adjust_flavour = "unbutton"
 
@@ -131,8 +134,9 @@
 	desc = "Worn by a Captain to show their class."
 	icon_state = "bomber_captain_open"
 	item_state = "bomber_captain_open"
-	ignore_suitadjust = 0
-	suit_adjusted = 1
+	ignore_suitadjust = FALSE
+	suit_adjusted = TRUE
+	flags_inv_transparent = HIDEJUMPSUIT
 	actions_types = list(/datum/action/item_action/button)
 	adjust_flavour = "unbutton"
 
@@ -425,6 +429,7 @@
 	item_state = "qm_jacket_open"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	flags_inv = HIDEJUMPSUIT
+	flags_inv_transparent = HIDEJUMPSUIT
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen, /obj/item/storage/fancy/cigarettes, /obj/item/clothing/mask/cigarette, /obj/item/lighter, /obj/item/rcs, /obj/item/stack/packageWrap, /obj/item/stack/wrapping_paper, /obj/item/destTagger, /obj/item/pen, /obj/item/paper, /obj/item/stamp, /obj/item/qm_quest_tablet)
 	ignore_suitadjust = 0
 	suit_adjusted = 1

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -92,6 +92,7 @@
 	icon_state = "hgpirate"
 	item_state = "hgpirate"
 	flags_inv = HIDEJUMPSUIT
+	flags_inv_transparent = HIDEJUMPSUIT
 
 
 /obj/item/clothing/suit/cyborg_suit

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -100,7 +100,6 @@
 	resistance_flags = NONE
 
 	sprite_sheets = list(
-		SPECIES_PLASMAMAN = 'icons/mob/clothing/species/plasmaman/suit.dmi',
 		SPECIES_VOX = 'icons/mob/clothing/species/vox/helmet.dmi',
 		SPECIES_GREY = 'icons/mob/clothing/species/grey/head.dmi',
 		SPECIES_MONKEY = 'icons/mob/clothing/species/monkey/head.dmi',
@@ -147,7 +146,6 @@
 	icon_state = "bombsuitsec"
 	item_state = "bombsuitsec"
 	sprite_sheets = list(
-		SPECIES_PLASMAMAN = 'icons/mob/clothing/species/plasmaman/suit.dmi',
 		SPECIES_VOX = 'icons/mob/clothing/species/vox/helmet.dmi',
 		SPECIES_VULPKANIN = 'icons/mob/clothing/species/vulpkanin/helmet.dmi'
 		)
@@ -155,6 +153,7 @@
 /obj/item/clothing/suit/bomb_suit/security
 	icon_state = "bombsuitsec"
 	item_state = "bombsuitsec"
+	flags_inv_transparent = HIDEGLOVES|HIDESHOES
 	allowed = list(/obj/item/gun/energy,/obj/item/melee/baton,/obj/item/restraints/handcuffs)
 	sprite_sheets = list(
 		SPECIES_PLASMAMAN = 'icons/mob/clothing/species/plasmaman/suit.dmi',
@@ -179,7 +178,6 @@
 	resistance_flags = NONE
 
 	sprite_sheets = list(
-		SPECIES_PLASMAMAN = 'icons/mob/clothing/species/plasmaman/suit.dmi',
 		SPECIES_VOX = 'icons/mob/clothing/species/vox/head.dmi',
 		SPECIES_GREY = 'icons/mob/clothing/species/grey/head.dmi',
 		SPECIES_MONKEY = 'icons/mob/clothing/species/monkey/head.dmi',

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -157,6 +157,7 @@
 	armor = list("melee" = 30, "bullet" = 20, "laser" = 20, "energy" = 30, "bomb" = 20, "bio" = 20, "rad" = 20, "fire" = 100, "acid" = 100)
 	allowed = list(/obj/item/teleportation_scroll)
 	flags_inv = HIDEJUMPSUIT
+	flags_inv_transparent = HIDEJUMPSUIT
 	strip_delay = 50
 	put_on_delay = 50
 	resistance_flags = FIRE_PROOF | ACID_PROOF

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -13,10 +13,19 @@
 	var/obj/item/clothing/under/has_suit
 	/// Allow accessories of the same type.
 	var/allow_duplicates = TRUE
+	/// Overlay used when the accessory is attached to the clothing.
+	var/mutable_appearance/acc_overlay
+
+
+/obj/item/clothing/accessory/Initialize(mapload)
+	. = ..()
+	if(icon_state in icon_states('icons/obj/clothing/ties_overlay.dmi'))
+		acc_overlay = mutable_appearance('icons/obj/clothing/ties_overlay.dmi', icon_state)
 
 
 /obj/item/clothing/accessory/Destroy()
 	on_removed()
+	acc_overlay = null
 	return ..()
 
 
@@ -35,6 +44,10 @@
 
 	has_suit = new_suit
 	LAZYADD(has_suit.accessories, src)
+
+	if(acc_overlay)
+		has_suit.update_icon(UPDATE_OVERLAYS)
+
 	if(loc != has_suit)
 		forceMove(new_suit)
 
@@ -73,6 +86,9 @@
 
 	LAZYREMOVE(has_suit.accessories, src)
 	LAZYREMOVE(has_suit.actions, actions)
+
+	if(acc_overlay)
+		has_suit.update_icon(UPDATE_OVERLAYS)
 
 	if(ismob(has_suit.loc))
 		var/mob/wearer = has_suit.loc

--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -435,6 +435,7 @@
 		sallet.flags_cover = helm.flags_cover
 		sallet.visor_clothing_flags = helm.visor_clothing_flags
 		sallet.visor_flags_inv = helm.visor_flags_inv
+		sallet.visor_flags_inv_transparent = helm.visor_flags_inv_transparent
 		sallet.flags_inv |= HIDEHAIR
 
 		sallet.add_fingerprint(H)

--- a/code/modules/holiday/christmas.dm
+++ b/code/modules/holiday/christmas.dm
@@ -101,5 +101,4 @@
 	name = "festive paper hat"
 	icon_state = "xmashat"
 	desc = "A crappy paper hat that you are REQUIRED to wear."
-	flags_inv = 0
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -604,10 +604,13 @@
 
 
 /**
- * Collects all the bitflags from the obscured slots.
- * Works only for humans and checks only suits, headgear and masks currently.
+ * Collects flags_inv bitflags from all equipped items and returns slots considered as obscure.
+ *
+ * Arguments:
+ * * check_transparent - If `TRUE` bitflags from var/flags_inv_transparent will be considered, works like a toggle (^=) for var/flags_inv.
+ * Used in overlay updates to properly cover or uncover certain zones.
  */
-/mob/proc/check_obscured_slots()
+/mob/proc/check_obscured_slots(check_transparent)
 	. = NONE
 
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1045,30 +1045,29 @@
 		to_chat(user, "<span class='alert'>[fail_msg]</span>")
 
 
-/mob/living/carbon/human/check_obscured_slots()
+/mob/living/carbon/human/check_obscured_slots(check_transparent)
 	. = ..()
 
-	if(wear_suit)
-		if(wear_suit.flags_inv & HIDEGLOVES)
-			. |= ITEM_SLOT_GLOVES
-		if(wear_suit.flags_inv & HIDEJUMPSUIT)
-			. |= ITEM_SLOT_CLOTH_INNER
-		if(wear_suit.flags_inv & HIDESHOES)
-			. |= ITEM_SLOT_FEET
+	var/hidden_flags = NONE
 
-	if(head)
-		if(head.flags_inv & HIDEMASK)
-			. |= ITEM_SLOT_MASK
-		if(head.flags_inv & HIDEGLASSES)
-			. |= ITEM_SLOT_EYES
-		if(head.flags_inv & HIDEHEADSETS)
-			. |= ITEM_SLOT_EARS
+	for(var/obj/item/equipped_item as anything in get_equipped_items())
+		var/item_flags = equipped_item.flags_inv
+		if(check_transparent && equipped_item.flags_inv_transparent)
+			item_flags ^= equipped_item.flags_inv_transparent
+		hidden_flags |= item_flags
 
-	if(wear_mask)
-		if(wear_mask.flags_inv & HIDEGLASSES)
-			. |= ITEM_SLOT_EYES
-		if(wear_mask.flags_inv & HIDEHEADSETS)
-			. |= ITEM_SLOT_EARS
+	if(hidden_flags & HIDEGLOVES)
+		. |= ITEM_SLOT_GLOVES
+	if(hidden_flags & HIDEJUMPSUIT)
+		. |= ITEM_SLOT_CLOTH_INNER
+	if(hidden_flags & HIDESHOES)
+		. |= ITEM_SLOT_FEET
+	if(hidden_flags & HIDEMASK)
+		. |= ITEM_SLOT_MASK
+	if(hidden_flags & HIDEGLASSES)
+		. |= ITEM_SLOT_EYES
+	if(hidden_flags & HIDEHEADSETS)
+		. |= ITEM_SLOT_EARS
 
 
 /mob/living/carbon/human/proc/check_has_mouth()
@@ -1080,7 +1079,7 @@
 
 /mob/living/carbon/human/get_visible_gender()
 	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDENAME)) || (head && (head.flags_inv & HIDENAME))
-	if(skipface && (ITEM_SLOT_CLOTH_INNER & check_obscured_slots()))
+	if(skipface && (check_obscured_slots() & ITEM_SLOT_CLOTH_INNER))
 		return PLURAL
 	return gender
 

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -54,7 +54,8 @@
 	if(istype(mask) && mask.tint || initial(mask.tint))
 		update_tint()
 
-	if((mask.flags_inv & (HIDEHAIR|HIDEHEADHAIR|HIDEFACIALHAIR)) || (initial(mask.flags_inv) & (HIDEHAIR|HIDEHEADHAIR|HIDEFACIALHAIR)))
+	if((mask.flags_inv & (HIDEHAIR|HIDEHEADHAIR|HIDEFACIALHAIR)) || \
+		(initial(mask.flags_inv) & (HIDEHAIR|HIDEHEADHAIR|HIDEFACIALHAIR)))
 		update_hair()	//rebuild hair
 		update_fhair()
 		update_head_accessory()
@@ -63,9 +64,16 @@
 		internal = null
 		update_action_buttons_icon()
 
-	if((mask.flags_inv & HIDEGLASSES) || (initial(mask.flags_inv) & HIDEGLASSES))
+	if((mask.flags_inv & HIDEGLASSES) || \
+		(mask.flags_inv_transparent & HIDEGLASSES) || \
+		(initial(mask.flags_inv) & HIDEGLASSES) || \
+		(initial(mask.flags_inv_transparent) & HIDEGLASSES))
 		update_inv_glasses()
-	if((mask.flags_inv & HIDEHEADSETS) || (initial(mask.flags_inv) & HIDEHEADSETS))
+
+	if((mask.flags_inv & HIDEHEADSETS) || \
+		(mask.flags_inv_transparent & HIDEHEADSETS) || \
+		(initial(mask.flags_inv) & HIDEHEADSETS) || \
+		(initial(mask.flags_inv_transparent) & HIDEHEADSETS))
 		update_inv_ears()
 
 	sec_hud_set_ID()
@@ -84,7 +92,9 @@
 		internal = null
 		update_action_buttons_icon()
 
-	if(forced || (check_item.flags_inv & (HIDEHAIR|HIDEHEADHAIR|HIDEFACIALHAIR)) || (initial(check_item.flags_inv) & (HIDEHAIR|HIDEHEADHAIR|HIDEFACIALHAIR)))
+	if(forced || \
+		(check_item.flags_inv & (HIDEHAIR|HIDEHEADHAIR|HIDEFACIALHAIR)) || \
+		(initial(check_item.flags_inv) & (HIDEHAIR|HIDEHEADHAIR|HIDEFACIALHAIR)))
 		update_hair()	//rebuild hair
 		update_fhair()
 		update_head_accessory()
@@ -98,11 +108,23 @@
 		if(forced || hat.vision_flags || hat.see_in_dark || !isnull(hat.lighting_alpha))
 			update_sight()
 
-	if(forced || (check_item.flags_inv & HIDEHEADSETS) || (initial(check_item.flags_inv) & HIDEHEADSETS))
+	if(forced || \
+		(check_item.flags_inv & HIDEHEADSETS) || \
+		(check_item.flags_inv_transparent & HIDEHEADSETS) || \
+		(initial(check_item.flags_inv) & HIDEHEADSETS) || \
+		(initial(check_item.flags_inv_transparent) & HIDEHEADSETS))
 		update_inv_ears()
-	if(forced || (check_item.flags_inv & HIDEMASK) || (initial(check_item.flags_inv) & HIDEMASK))
+	if(forced || \
+		(check_item.flags_inv & HIDEMASK) || \
+		(check_item.flags_inv_transparent & HIDEMASK) || \
+		(initial(check_item.flags_inv) & HIDEMASK) || \
+		(initial(check_item.flags_inv_transparent) & HIDEMASK))
 		update_inv_wear_mask()
-	if(forced || (check_item.flags_inv & HIDEGLASSES) || (initial(check_item.flags_inv) & HIDEGLASSES))
+	if(forced || \
+		(check_item.flags_inv & HIDEGLASSES) || \
+		(check_item.flags_inv_transparent & HIDEGLASSES) || \
+		(initial(check_item.flags_inv) & HIDEGLASSES) || \
+		(initial(check_item.flags_inv_transparent) & HIDEGLASSES))
 		update_inv_glasses()
 
 	sec_hud_set_ID()
@@ -113,11 +135,22 @@
  * Handles stuff to update when a mob equips/unequips a suit.
  */
 /mob/living/carbon/human/wear_suit_update(obj/item/clothing/suit)
-	if((suit.flags_inv & HIDEJUMPSUIT) || (initial(suit.flags_inv) & HIDEJUMPSUIT))
+	if((suit.flags_inv & HIDEJUMPSUIT) || \
+		(suit.flags_inv_transparent & HIDEJUMPSUIT) || \
+		(initial(suit.flags_inv) & HIDEJUMPSUIT) || \
+		(initial(suit.flags_inv_transparent) & HIDEJUMPSUIT))
 		update_inv_w_uniform()
-	if((suit.flags_inv & HIDESHOES) || (initial(suit.flags_inv) & HIDESHOES))
+
+	if((suit.flags_inv & HIDESHOES) || \
+		(suit.flags_inv_transparent & HIDESHOES) || \
+		(initial(suit.flags_inv) & HIDESHOES) || \
+		(initial(suit.flags_inv_transparent) & HIDESHOES))
 		update_inv_shoes()
-	if((suit.flags_inv & HIDEGLOVES) || (initial(suit.flags_inv) & HIDEGLOVES))
+
+	if((suit.flags_inv & HIDEGLOVES) || \
+		(suit.flags_inv_transparent & HIDEGLOVES) || \
+		(initial(suit.flags_inv) & HIDEGLOVES) || \
+		(initial(suit.flags_inv_transparent) & HIDEGLOVES))
 		update_inv_gloves()
 
 	update_inv_wear_suit()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -533,7 +533,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		var/atom/movable/screen/inventory/inv = hud_used.inv_slots[TOBITSHIFT(ITEM_SLOT_CLOTH_INNER) + 1]
 		inv?.update_icon()
 
-	if(ITEM_SLOT_CLOTH_INNER & check_obscured_slots())
+	if(check_obscured_slots(check_transparent = TRUE) & ITEM_SLOT_CLOTH_INNER)
 		return
 
 	if(istype(w_uniform, /obj/item/clothing/under))
@@ -618,7 +618,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		var/atom/movable/screen/inventory/inv = hud_used.inv_slots[TOBITSHIFT(ITEM_SLOT_GLOVES) + 1]
 		inv?.update_icon()
 
-	if(ITEM_SLOT_GLOVES & check_obscured_slots())
+	if(check_obscured_slots(check_transparent = TRUE) & ITEM_SLOT_GLOVES)
 		return
 
 	if(gloves)
@@ -662,7 +662,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	if(!head_organ)
 		return
 
-	if(ITEM_SLOT_EYES & check_obscured_slots())
+	if(check_obscured_slots(check_transparent = TRUE) & ITEM_SLOT_EYES)
 		return
 
 	if(glasses)
@@ -708,7 +708,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	if(!head_organ)
 		return
 
-	if(ITEM_SLOT_EARS & check_obscured_slots())
+	if(check_obscured_slots(check_transparent = TRUE) & ITEM_SLOT_EARS)
 		return
 
 	if(l_ear || r_ear)
@@ -746,7 +746,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		var/atom/movable/screen/inventory/inv = hud_used.inv_slots[TOBITSHIFT(ITEM_SLOT_FEET) + 1]
 		inv?.update_icon()
 
-	if(ITEM_SLOT_FEET & check_obscured_slots())
+	if(check_obscured_slots(check_transparent = TRUE) & ITEM_SLOT_FEET)
 		return
 
 	if(shoes)
@@ -887,7 +887,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	if(!head_organ)
 		return
 
-	if(ITEM_SLOT_MASK & check_obscured_slots())
+	if(check_obscured_slots(check_transparent = TRUE) & ITEM_SLOT_MASK)
 		return
 
 	if((istype(wear_mask, /obj/item/clothing/mask) || istype(wear_mask, /obj/item/clothing/accessory)))


### PR DESCRIPTION
## Описание
Переписал код закрытых слотов таким образом, что теперь его можно использовать для определения перекрытия или наоборот открытия других слотов исключительно при обновлении оверлеев на кукле персонажа.

Например это позволяет закрыть кукле возможность снять комбинезон, но в то же время комбинезон всё ещё будет видно на персонаже, ранее он бы просто пропал.

Также исправил отображение аксессуаров на комбинезонах.