### PR TITLE
bugfix: Fixed genetics getting wrong assignments

### DIFF
--- a/code/game/gamemodes/setupgame.dm
+++ b/code/game/gamemodes/setupgame.dm
@@ -22,7 +22,7 @@
 
 	// SE blocks to assign.
 	var/list/numsToAssign= list()
-	for(var/i in 1 to DNA_SE_LENGTH)
+	for(var/i in 1 to DNA_SE_LENGTH - 1) //Because it's inclusive
 		numsToAssign += i
 
 	// Standard muts


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление ошибки, при которой гены неправильно распределялись раундстартом, что иногда приводило к невозможности появления в раунде одного гена
