### PR TITLE
bugfix: Effects on_apply correctly sees this effect

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -917,8 +917,10 @@
 /datum/status_effect/transient/blindness
 	id = "blindness"
 
-/datum/status_effect/transient/blindness/on_apply()
+/datum/status_effect/transient/blindness/on_creation()
 	. = ..()
+	if(!.)
+		return
 	owner.update_blind_effects()
 
 /datum/status_effect/transient/blindness/on_remove()
@@ -943,8 +945,10 @@
 /datum/status_effect/transient/drugged
 	id = "drugged"
 
-/datum/status_effect/transient/drugged/on_apply()
+/datum/status_effect/transient/drugged/on_creation()
 	. = ..()
+	if(!.)
+		return
 	owner.update_druggy_effects()
 
 /datum/status_effect/transient/drugged/on_remove()
@@ -983,8 +987,10 @@
 			carbon.AdjustEyeBlurry(9 SECONDS)
 	carbon.update_disgust_alert()
 
-/datum/status_effect/transient/disgust/on_apply()
+/datum/status_effect/transient/disgust/on_creation()
 	. = ..()
+	if(!.)
+		return
 	owner.update_disgust_alert()
 
 /datum/status_effect/transient/disgust/on_remove()

--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -42,11 +42,14 @@
 /datum/status_effect/proc/on_creation(mob/living/new_owner, ...)
 	if(new_owner)
 		owner = new_owner
-	if(QDELETED(owner) || !on_apply())
+	if(QDELETED(owner))
 		qdel(src)
 		return FALSE
 	if(owner)
-		LAZYADD(owner.status_effects, src)
+		LAZYADD(owner.status_effects, src) //some effects' on_apply() has check if this effect in "status_effects"
+	if(!on_apply())
+		qdel(src)
+		return FALSE
 	if(duration != -1)
 		duration = world.time + duration
 	if(tick_interval != -1)

--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -42,14 +42,11 @@
 /datum/status_effect/proc/on_creation(mob/living/new_owner, ...)
 	if(new_owner)
 		owner = new_owner
-	if(QDELETED(owner))
+	if(QDELETED(owner) || !on_apply())
 		qdel(src)
 		return FALSE
 	if(owner)
-		LAZYADD(owner.status_effects, src) //some effects' on_apply() has check if this effect in "status_effects"
-	if(!on_apply())
-		qdel(src)
-		return FALSE
+		LAZYADD(owner.status_effects, src)
 	if(duration != -1)
 		duration = world.time + duration
 	if(tick_interval != -1)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Меняет у статусов on_apply на on_creation
Чинит `/datum/status_effect/transient/drugged` и `/datum/status_effect/transient/blindness`

## Ссылка на предложение/Причина создания ПР
[Ссылка на баг-репорт](https://discord.com/channels/617003227182792704/1252535450225213483/1252535450225213483).
Похожие эффекты с `/datum/status_effect/transient/drugged` применяли свой эффект на `on_apply()`, что требовал `AmountDruggy()`.
Поскольку этого эффекта на момент вызова прока не было в `status_effects` - он возвращал ноль и не применял ничего.
