### PR TITLE
bugfix: Chameleon mask is now can be removed

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -423,7 +423,7 @@
 	resistance_flags = NONE
 	armor = list("melee" = 5, "bullet" = 5, "laser" = 5, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 	clothing_flags = AIRTIGHT|BLOCK_GAS_SMOKE_EFFECT
-	flags_inv = HIDEMASK|HIDEHEADSETS|HIDEGLASSES|HIDENAME
+	flags_inv = HIDEHEADSETS|HIDEGLASSES|HIDENAME
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.01
 	flags_cover = MASKCOVERSEYES | MASKCOVERSMOUTH


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Убирает у маски флаг "скрыть маску", что не позволяло её снять.

## Ссылка на предложение/Причина создания ПР
[А-чат](https://discord.com/channels/617003227182792704/617003951606333442/1252593796022276157) тикет.
После надевания маски из-за этого флага нельзя было снять эту маску. Ещё этот флаг скрывал эту же маску.
