### PR TITLE
tweak/bugfix:  Disable Tech requires a magician's robe from a librarian

### DIFF
--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -145,7 +145,7 @@
 	desc = "This spell disables all weapons, cameras and most other technology in range."
 	base_cooldown = 40 SECONDS
 	cooldown_min = 20 SECONDS //50 deciseconds reduction per rank
-	clothes_req = TRUE
+	clothes_req = FALSE
 	invocation = "NEC CANTIO"
 	invocation_type = "shout"
 


### PR DESCRIPTION
## Описание
Дизейбл теч выпадает книгами заклинаний. Соответственно выпадает у библиотекаря. Библиотекарь пользоваться не может, хотя потратил свои кровные 25 ТК.

Все заклинания из книг не требуют робы, ибо это изначально не для магов сделано. А тут же роба требуется что не должно быть так.

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1253808785949065318
## Демонстрация изменений

![image](https://github.com/ss220-space/Paradise/assets/42041683/35b4f03a-d2d2-4228-af58-a8fa539465aa)
