### PR TITLE
bugfix: Vehicles Speed Boost Fix / No Glide Size Defaults To 8 / High RP Curse Fix

### DIFF
--- a/code/__DEFINES/movement.dm
+++ b/code/__DEFINES/movement.dm
@@ -3,6 +3,8 @@
 /// The maximum for glide_size to be clamped to.
 /// This shouldn't be higher than the icon size, and generally you shouldn't be changing this, but it's here just in case.
 #define MAX_GLIDE_SIZE 32
+/// Default glide size for movables.
+#define DEFAULT_GLIDE_SIZE 8
 
 /// Compensating for time dilation
 GLOBAL_VAR_INIT(glide_size_multiplier, 1.0)

--- a/code/__DEFINES/organ_defines.dm
+++ b/code/__DEFINES/organ_defines.dm
@@ -48,6 +48,7 @@
 #define INTERNAL_ORGAN_HAIR "hair_organ"	// yeah thats a thing
 #define INTERNAL_ORGAN_HONK_BLADDER "honk_bladder"
 #define INTERNAL_ORGAN_BRAIN_TUMOR "brain_tumor"
+#define INTERNAL_ORGAN_HIGHRP_TUMOR "highrp_tumor"
 
 
 // insert/remove organ special defines

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -143,6 +143,7 @@
 		return
 
 	if(flags & MOVEMENT_LOOP_IGNORE_GLIDE)
+		moving.set_glide_size(DEFAULT_GLIDE_SIZE)
 		return
 
 	moving.set_glide_size(MOVEMENT_ADJUSTED_GLIDE_SIZE(delay, visual_delay))

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -143,7 +143,8 @@
 		return
 
 	if(flags & MOVEMENT_LOOP_IGNORE_GLIDE)
-		moving.set_glide_size(DEFAULT_GLIDE_SIZE)
+		if(moving.glide_size != DEFAULT_GLIDE_SIZE)
+			moving.set_glide_size(DEFAULT_GLIDE_SIZE)
 		return
 
 	moving.set_glide_size(MOVEMENT_ADJUSTED_GLIDE_SIZE(delay, visual_delay))

--- a/code/datums/spells/high_rp.dm
+++ b/code/datums/spells/high_rp.dm
@@ -1,45 +1,56 @@
 /obj/item/organ/internal/high_rp_tumor
+	slot = INTERNAL_ORGAN_HIGHRP_TUMOR
+	unremovable = TRUE
 	actions_types = list(/datum/action/item_action/organ_action/manual_breath)
 	var/last_pump = 0
-	var/pump_delay = 300
+	var/pump_delay = 30 SECONDS
+	var/pump_window = 1 SECONDS
 	var/oxy_loss = 45
-	var/pump_window = 10
-	var/warned = 0
-	unremovable = TRUE
+	var/warned = FALSE
 
-/obj/item/organ/internal/high_rp_tumor/insert(mob/living/target, special = ORGAN_MANIPULATION_DEFAULT)
-	..(target, special)
-	if(target)
-		to_chat(target, "<span class='userdanger'>Я должен дышать, иначе просто задохнусь!</span>")
 
-/mob/living/carbon/human/proc/curse_high_rp(delay = 300, oxyloss = 45)
-	var/mob/living/carbon/human/H = src
+/obj/item/organ/internal/high_rp_tumor/insert(mob/living/carbon/target, special = ORGAN_MANIPULATION_DEFAULT)
+	. = ..()
+	if(. && target)
+		to_chat(target, span_userdanger("Вы чувствуете неприятное шевеление в груди... Внутренний голос подсказывает, что теперь придётся дышать самостоятельно!"))
+
+
+/obj/item/organ/internal/high_rp_tumor/remove(mob/living/carbon/target, special = ORGAN_MANIPULATION_DEFAULT)
+	. = ..()
+	if(. && target)
+		to_chat(target, span_userdanger("Вы чувствуете, что Вам более не требуется дышать самостоятельно!"))
+
+
+
+/mob/living/carbon/human/proc/curse_high_rp(delay = 30 SECONDS, oxyloss = 45)
 	var/obj/item/organ/internal/high_rp_tumor/hrp_tumor = new
 	hrp_tumor.last_pump = world.time
 	hrp_tumor.pump_delay = delay
 	hrp_tumor.oxy_loss = oxyloss
 	hrp_tumor.pump_window = delay/5
-	hrp_tumor.insert(H)
+	hrp_tumor.insert(src)
+
 
 /obj/item/organ/internal/high_rp_tumor/on_life()
 	if(world.time > (last_pump + (pump_delay - pump_window)))
-		to_chat(owner, "Мне начинает не хватать воздуха.")
-		warned = 1
+		to_chat(owner, span_userdanger("Я долж[genderize_ru(owner.gender, "ен", "на", "но", "ны")] дышать, иначе просто задохн[pluralize_ru(owner.gender, "усь", "ёмся")]!"))
+		warned = TRUE
 
 	if(world.time > (last_pump + pump_delay))
 		var/mob/living/carbon/human/H = owner
 		H.setOxyLoss(H.oxyloss + oxy_loss)
-		H.custom_emote(EMOTE_VISIBLE, "задыха%(ет,ют)%ся!")
-		to_chat(H, "<span class='userdanger'>Я должен дышать, иначе просто задохнусь!</span>")
+		H.emote("gasp", ignore_cooldowns = TRUE)
 		last_pump = world.time
-		warned = 0
+		warned = FALSE
+
 
 /datum/action/item_action/organ_action/manual_breath
 	name = "Дышать"
 	use_itemicon = FALSE
 	icon_icon = 'icons/obj/surgery.dmi'
 	button_icon_state = "lungs"
-	check_flags = null
+	check_flags = NONE
+
 
 /datum/action/item_action/organ_action/manual_breath/Trigger(left_click = TRUE)
 	. = ..()
@@ -47,10 +58,10 @@
 		var/obj/item/organ/internal/high_rp_tumor/hrp_tumor = target
 
 		if(world.time < (hrp_tumor.last_pump + (hrp_tumor.pump_delay - hrp_tumor.pump_window))) //no spam
-			to_chat(owner, "<span class='userdanger'>Слишком рано!</span>")
+			to_chat(owner, span_userdanger("Слишком рано!"))
 			hrp_tumor.owner.setOxyLoss(hrp_tumor.owner.oxyloss + hrp_tumor.oxy_loss/5)
 			return
 
 		hrp_tumor.last_pump = world.time
-		to_chat(owner, "<span class = 'notice'>Вы дышите.</span>")
 		owner.custom_emote(EMOTE_VISIBLE, "дыш%(ит,ат)%.")
+

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1,7 +1,7 @@
 /atom/movable
 	layer = OBJ_LAYER
 	appearance_flags = TILE_BOUND|PIXEL_SCALE|LONG_GLIDE
-	glide_size = 8 // Default, adjusted when mobs move based on their movement delays
+	glide_size = DEFAULT_GLIDE_SIZE // Default, adjusted when mobs move based on their movement delays
 	var/last_move = null
 	var/anchored = FALSE
 	var/move_resist = MOVE_RESIST_DEFAULT
@@ -328,8 +328,9 @@
 	loc = T
 
 
-/atom/movable/proc/set_glide_size(target = 8)
+/atom/movable/proc/set_glide_size(target = DEFAULT_GLIDE_SIZE)
 	if(HAS_TRAIT(src, TRAIT_NO_GLIDE))
+		glide_size = DEFAULT_GLIDE_SIZE
 		return
 	SEND_SIGNAL(src, COMSIG_MOVABLE_UPDATE_GLIDE_SIZE, target)
 	glide_size = target

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -171,8 +171,10 @@
 		var/datum/disease/D = new disease
 		D.Contract(M)
 	M.adjustOxyLoss(oxy_damage)
-	M.adjustBruteLoss(brute_damage)
-	M.adjustFireLoss(burn_damage)
+	if(brute_damage)
+		M.apply_damage(brute_damage, BRUTE)
+	if(burn_damage)
+		M.apply_damage(burn_damage, BURN)
 	if(death)
 		M.death() //Kills the new mob
 	M.color = mob_color

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -242,7 +242,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	return TRUE
 
 
-/mob/dead/observer/Move(atom/newloc, direct = NONE, glide_size_override = 8)
+/mob/dead/observer/Move(atom/newloc, direct = NONE, glide_size_override = DEFAULT_GLIDE_SIZE)
 	setDir(direct)
 	ghostimage.setDir(dir)
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -139,6 +139,10 @@
 		face_atom(target) //Looks better if they keep looking at you when dodging
 
 
+/mob/living/simple_animal/hostile/step_with_glide(atom/newloc, direction, speed_override)
+	return ..(newloc, direction, move_to_delay)
+
+
 /mob/living/simple_animal/hostile/attacked_by(obj/item/I, mob/living/user)
 	if(stat == CONSCIOUS && !target && AIStatus != AI_OFF && !client && user)
 		FindTarget(list(user), 1)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -764,4 +764,6 @@
 	. = Move(newloc, direction)
 	if(adjusted_delay <= END_GLIDE_SPEED)
 		set_glide_size(DELAY_TO_GLIDE_SIZE(adjusted_delay))
+	else
+		set_glide_size(DEFAULT_GLIDE_SIZE)
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -747,7 +747,7 @@
 		REMOVE_TRAIT(src, TRAIT_NO_GLIDE, SPEED_TRAIT)
 
 
-/mob/living/simple_animal/proc/step_with_glide(atom/newloc, direction)
+/mob/living/simple_animal/proc/step_with_glide(atom/newloc, direction, speed_override)
 	if(client)
 		return FALSE
 	if(!direction && !newloc)
@@ -758,7 +758,7 @@
 		newloc = get_step(src, direction)
 		if(!newloc)
 			return FALSE
-	var/adjusted_delay = cached_multiplicative_slowdown
+	var/adjusted_delay = isnull(speed_override) ? cached_multiplicative_slowdown : speed_override
 	if(ISDIAGONALDIR(direction))
 		adjusted_delay *= sqrt(2)
 	. = Move(newloc, direction)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -764,6 +764,6 @@
 	. = Move(newloc, direction)
 	if(adjusted_delay <= END_GLIDE_SPEED)
 		set_glide_size(DELAY_TO_GLIDE_SIZE(adjusted_delay))
-	else
+	else if(glide_size != DEFAULT_GLIDE_SIZE)
 		set_glide_size(DEFAULT_GLIDE_SIZE)
 

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -500,19 +500,19 @@
 		I.item_flags |= IGNORE_SLOWDOWN
 		I.update_equipped_item()
 
-	if(istype(O, /obj/vehicle))
-		var/obj/vehicle/V = O
-		var/vehicle_speed_mod = CONFIG_GET(number/movedelay/run_delay)
-		if(V.vehicle_move_delay <= vehicle_speed_mod)
-			to_chat(user, "<span class='warning'>[V] can't be made any faster!</span>")
-			return ..()
-		V.vehicle_move_delay = vehicle_speed_mod
+	else if(istype(O, /obj/vehicle))
+		var/obj/vehicle/vehicle = O
+		if(vehicle.check_potion(src, user))
+			return
+		return ..()
+
 	else if (!drop && istype(O, /obj/machinery/smartfridge))
 		// apply speed potion to smart fridge only if the potions drag'n'drop onto it
 		return ..()
 
+	O.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
+	O.add_atom_colour(COLOR_RED, WASHABLE_COLOUR_PRIORITY)
 	to_chat(user, "<span class='notice'>You slather the red gunk over [O], making it faster.</span>")
-	O.add_atom_colour("#FF0000", WASHABLE_COLOUR_PRIORITY)
 	qdel(src)
 
 

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -23,7 +23,9 @@
 
 /obj/item/organ/internal/proc/insert(mob/living/carbon/target, special = ORGAN_MANIPULATION_DEFAULT)
 	if(!iscarbon(target) || owner == target)
-		return
+		return FALSE
+
+	. = TRUE
 
 	do_pickup_animation(src, target)
 


### PR DESCRIPTION
## Описание
- исправление некорректной скорости, при нанесении на транспорт красного зелья из ксено
- введение дефолтного глайдинга, равному числу 8, если объект передвигается слишком медленно
- поменял прок нанесения урона у моб спавнера трупов, чтобы не ломались все кости и игра не провисала
- исправлена двойная атака голиафа после чарджа
- исправлено проклятие High RP
- поправлен глайдинг стелс-коробоки

