### PR TITLE
bugfix: blobinfected mouse krytit jopoi

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -53,7 +53,8 @@
 			/mob/living/simple_animal/mouse,
 			/mob/living/simple_animal/mouse/brown,
 			/mob/living/simple_animal/mouse/gray,
-			/mob/living/simple_animal/mouse/white)
+			/mob/living/simple_animal/mouse/white,
+			/mob/living/simple_animal/mouse/blobinfected)
 
 /mob/living/simple_animal/mouse/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## Описание
Зараженная блобом **мышь** не могла юзать панель эмоутов **мыши**. Теперь может.

## Ссылка на багрепорт
https://discord.com/channels/617003227182792704/1253377248938168392


