### PR TITLE
bugfix: Return flags after unsuccessful buckling

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -73,6 +73,7 @@
 		var/old_flags = target.pass_flags
 		target.pass_flags = PASSEVERYTHING
 		if(!target.Move(loc) || target.loc != loc)	// no move or still the same loc, even after move
+			target.pass_flags = old_flags
 			return FALSE
 		target.pass_flags = old_flags
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Если при перемещении на стул моб не менял позицию - у него не отбирался флаг "пройти всё".
ПР при неуспешной попытке сесть возвращает мобу его старые флаги.

## Ссылка на предложение/Причина создания ПР
[Ссылка на баг-репорт](https://discord.com/channels/617003227182792704/1253397945244450856/1253397945244450856).
