### PR TITLE
refactor: Opacity Standartisation

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -61,6 +61,8 @@
 #define COMSIG_ATOM_ATTACK "atom_attack"
 ///called when the atom sucessfully has it's density var changed, from base atom/set_density(): (value)
 #define COMSIG_ATOM_SET_DENSITY "atom_set_density"
+///from base of atom/set_opacity(): (new_opacity)
+#define COMSIG_ATOM_SET_OPACITY "atom_set_opacity"
 ///from base of atom/experience_pressure_difference(): (pressure_difference, direction, pressure_resistance_prob_delta)
 #define COMSIG_ATOM_PRE_PRESSURE_PUSH "atom_pre_pressure_push"
 	///prevents pressure movement

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -242,8 +242,8 @@
 			Y1+=s
 			while(Y1!=Y2)
 				T=locate(X1,Y1,Z)
-				if(T.opacity)
-					return 0
+				if(IS_OPAQUE_TURF(T))
+					return FALSE
 				Y1+=s
 	else
 		var/m=(32*(Y2-Y1)+(PY2-PY1))/(32*(X2-X1)+(PX2-PX1))
@@ -258,16 +258,16 @@
 			else
 				X1+=signX //Line exits tile horizontally
 			T=locate(X1,Y1,Z)
-			if(T.opacity)
-				return 0
-	return 1
+			if(IS_OPAQUE_TURF(T))
+				return FALSE
+	return TRUE
 
-/proc/isInSight(var/atom/A, var/atom/B)
+/proc/isInSight(atom/A, atom/B)
 	var/turf/Aturf = get_turf(A)
 	var/turf/Bturf = get_turf(B)
 
 	if(!Aturf || !Bturf)
-		return 0
+		return FALSE
 
 	return inLineOfSight(Aturf.x, Aturf.y, Bturf.x, Bturf.y, Aturf.z)
 

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -506,27 +506,28 @@ Returns 1 if the chain up to the area contains the given typepath
 		weight += I.w_class
 	return weight
 
-//Step-towards method of determining whether one atom can see another. Similar to viewers()
-/proc/can_see(var/atom/source, var/atom/target, var/length=5) // I couldnt be arsed to do actual raycasting :I This is horribly inaccurate.
-	var/turf/current = get_turf(source)
+
+///Step-towards method of determining whether one atom can see another. Similar to viewers()
+///note: this is a line of sight algorithm, view() does not do any sort of raycasting and cannot be emulated by it accurately
+/proc/can_see(atom/source, atom/target, length = 5) // I couldnt be arsed to do actual raycasting :I This is horribly inaccurate.
+	var/turf/current_turf = get_turf(source)
 	var/turf/target_turf = get_turf(target)
+	if(!current_turf || !target_turf)	// nullspace
+		return FALSE
+	if(get_dist(current_turf, target_turf) > length)
+		return FALSE
+	if(current_turf == target_turf)//they are on the same turf, source can see the target
+		return TRUE
 	var/steps = 1
-
-	if(current != target_turf)
-		current = get_step_towards(current, target_turf)
-		while(current != target_turf)
-			if(steps > length)
-				return 0
-			if(current.opacity)
-				return 0
-			for(var/thing in current)
-				var/atom/A = thing
-				if(A.opacity)
-					return 0
-			current = get_step_towards(current, target_turf)
-			steps++
-
-	return 1
+	current_turf = get_step_towards(current_turf, target_turf)
+	while(current_turf != target_turf)
+		if(steps > length)
+			return FALSE
+		if(IS_OPAQUE_TURF(current_turf))
+			return FALSE
+		current_turf = get_step_towards(current_turf, target_turf)
+		steps++
+	return TRUE
 
 
 //Returns: all the areas in the world

--- a/code/datums/elements/light_blocking.dm
+++ b/code/datums/elements/light_blocking.dm
@@ -1,0 +1,47 @@
+/**
+ * Attached to movable atoms with opacity. Listens to them move and updates their old and new turf loc's opacity accordingly.
+ */
+/datum/element/light_blocking
+	element_flags = ELEMENT_DETACH
+
+
+/datum/element/light_blocking/Attach(datum/target)
+	. = ..()
+	if(!ismovable(target))
+		return ELEMENT_INCOMPATIBLE
+	RegisterSignal(target, COMSIG_MOVABLE_MOVED, PROC_REF(on_target_move))
+	var/atom/movable/movable_target = target
+	if(!isturf(movable_target.loc))
+		return
+	for(var/turf/turf_loc as anything in movable_target.locs)
+		turf_loc.add_opacity_source(target)
+
+
+/datum/element/light_blocking/Detach(datum/target)
+	. = ..()
+	var/atom/movable/movable_target = target
+	UnregisterSignal(movable_target, COMSIG_MOVABLE_MOVED)
+	if(!isturf(movable_target.loc))
+		return
+	for(var/turf/turf_loc as anything in movable_target.locs)
+		turf_loc.remove_opacity_source(target)
+
+
+///Updates old and new turf loc opacities.
+/datum/element/light_blocking/proc/on_target_move(atom/movable/source, atom/old_loc, dir, forced, list/old_locs)
+	SIGNAL_HANDLER
+	if(isturf(old_loc))
+		var/turf/old_turf = old_loc
+		old_turf.remove_opacity_source(source)
+		/*
+		if(old_locs)
+			for(var/turf/old_turf as anything in old_locs)			// after movement refactor
+				old_turf.remove_opacity_source(source)
+		else
+			var/turf/old_turf = old_loc
+			old_turf.remove_opacity_source(source)
+		*/
+	if(isturf(source.loc))
+		for(var/turf/new_turf as anything in source.locs)
+			new_turf.add_opacity_source(source)
+

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -148,10 +148,6 @@
 	if(light_system == STATIC_LIGHT && light_power && light_range)
 		update_light()
 
-	if(opacity && isturf(loc))
-		var/turf/T = loc
-		T.has_opaque_atom = TRUE // No need to recalculate it in this case, it's guranteed to be on afterwards anyways.
-
 	if(loc)
 		loc.InitializedOn(src) // Used for poolcontroller / pool to improve performance greatly. However it also open up path to other usage of observer pattern on turfs.
 
@@ -1574,13 +1570,27 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 
 
 ///Setter for the `density` variable to append behavior related to its changing.
-/atom/proc/set_density(new_value)
+/atom/proc/set_density(new_density)
 	SHOULD_CALL_PARENT(TRUE)
-	if(density == new_value)
+	if(density == new_density)
 		return
+	SEND_SIGNAL(src, COMSIG_ATOM_SET_DENSITY, new_density)
 	. = density
-	density = new_value
-	SEND_SIGNAL(src, COMSIG_ATOM_SET_DENSITY, new_value)
+	density = new_density
+
+
+/**
+ * Updates the atom's opacity value.
+ *
+ * This exists to act as a hook for associated behavior.
+ * It notifies (potentially) affected light sources so they can update (if needed).
+ */
+/atom/proc/set_opacity(new_opacity)
+	if(new_opacity == opacity)
+		return
+	SEND_SIGNAL(src, COMSIG_ATOM_SET_OPACITY, new_opacity)
+	. = opacity
+	opacity = new_opacity
 
 
 ///Setter for the `base_pixel_x` variable to append behavior related to its changing.

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -126,6 +126,9 @@
 			else
 				managed_overlays = em_block
 
+	if(opacity)
+		AddElement(/datum/element/light_blocking)
+
 	switch(light_system)
 		if(MOVABLE_LIGHT)
 			AddComponent(/datum/component/overlay_lighting)
@@ -136,6 +139,9 @@
 /atom/movable/Destroy(force)
 	unbuckle_all_mobs(force = TRUE)
 	QDEL_NULL(em_block)
+
+	if(opacity)
+		RemoveElement(/datum/element/light_blocking)
 
 	. = ..()
 	if(loc)
@@ -1079,4 +1085,14 @@
 	if(anchored && pulledby)
 		pulledby.stop_pulling()
 	SEND_SIGNAL(src, COMSIG_MOVABLE_SET_ANCHORED, anchorvalue)
+
+
+/atom/movable/set_opacity(new_opacity)
+	. = ..()
+	if(isnull(.) || !isturf(loc))
+		return .
+	if(opacity)
+		AddElement(/datum/element/light_blocking)
+	else
+		RemoveElement(/datum/element/light_blocking)
 

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -115,7 +115,7 @@
 
 /obj/machinery/camera/proc/setViewRange(num = 7)
 	view_range = num
-	GLOB.cameranet.updateVisibility(src, 0)
+	GLOB.cameranet.updateVisibility(src, opacity_check = FALSE)
 
 /obj/machinery/camera/singularity_pull(S, current_size)
 	if (status && current_size >= STAGE_FIVE) // If the singulo is strong enough to pull anchored objects and the camera is still active, turn off the camera as it gets ripped off the wall.
@@ -234,7 +234,7 @@
 	..()
 	target.update_icon(UPDATE_ICON_STATE)
 	//Update what it can see.
-	GLOB.cameranet.updateVisibility(target, FALSE)
+	GLOB.cameranet.updateVisibility(target, opacity_check = FALSE)
 
 
 /obj/item/assembly/prox_sensor/camera_upgrade(obj/machinery/camera/target, power_use_update = TRUE)

--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -56,26 +56,28 @@
 	detectTime = -1
 	return TRUE
 
-/// Returns TRUE if the camera can see the target.
-/obj/machinery/camera/proc/can_see(atom/target, length=7) // I stole this from global and modified it to work with Xray cameras.
-	var/turf/current = get_turf(src)
-	var/turf/target_turf = get_turf(target)
-	if(target.invisibility > SEE_INVISIBLE_LIVING || target.alpha == NINJA_ALPHA_INVISIBILITY)
-		return FALSE
-	if(get_dist(current, target_turf) > length)
-		return FALSE
-	if(current == target_turf || isXRay())
-		return TRUE
 
-	var/list/line_of_sight = get_line(src, target)
-	line_of_sight = line_of_sight.Cut(1, 2)
-	for(var/turf/current_turf as anything in line_of_sight)
-		if(current_turf.opacity)
+/// Returns TRUE if the camera can see the target.
+/obj/machinery/camera/proc/can_see(atom/target, length = 7) // I stole this from global and modified it to work with Xray cameras.
+	if(!target || target.invisibility > SEE_INVISIBLE_LIVING || target.alpha == NINJA_ALPHA_INVISIBILITY)
+		return FALSE
+	var/turf/current_turf = get_turf(src)
+	var/turf/target_turf = get_turf(target)
+	if(!current_turf || !target_turf || get_dist(current_turf, target_turf) > length)
+		return FALSE
+	if(current_turf == target_turf || isXRay())
+		return TRUE
+	var/steps = 1
+	current_turf = get_step_towards(current_turf, target_turf)
+	while(current_turf != target_turf)
+		if(steps > length)
 			return FALSE
-		for(var/atom/movable/thing as anything in current_turf)
-			if(thing.opacity)
-				return FALSE
+		if(IS_OPAQUE_TURF(current_turf))
+			return FALSE
+		current_turf = get_step_towards(current_turf, target_turf)
+		steps++
 	return TRUE
+
 
 /obj/machinery/camera/HasProximity(atom/movable/AM)
 	if(isliving(AM))

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -60,49 +60,49 @@
 */
 
 /obj/machinery/door/airlock/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 
 /obj/machinery/door/airlock/command/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 	normal_integrity = 400
 
 /obj/machinery/door/airlock/engineering/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 
 /obj/machinery/door/airlock/security/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 	normal_integrity = 400
 
 /obj/machinery/door/airlock/medical/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 
 /obj/machinery/door/airlock/research/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 
 /obj/machinery/door/airlock/mining/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 
 /obj/machinery/door/airlock/atmos/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 
 /obj/machinery/door/airlock/science/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 
 /obj/machinery/door/airlock/maintenance/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 
 /obj/machinery/door/airlock/maintenance/external/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 	normal_integrity = 200
 
@@ -118,7 +118,7 @@
 	paintable = FALSE
 
 /obj/machinery/door/airlock/gold/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 
 /obj/machinery/door/airlock/silver
@@ -128,7 +128,7 @@
 	paintable = FALSE
 
 /obj/machinery/door/airlock/silver/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 
 /obj/machinery/door/airlock/diamond
@@ -141,7 +141,7 @@
 
 /obj/machinery/door/airlock/diamond/glass
 	normal_integrity = 950
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 
 /obj/machinery/door/airlock/uranium
@@ -162,7 +162,7 @@
 	)
 
 /obj/machinery/door/airlock/uranium/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 
 /obj/machinery/door/airlock/plasma
@@ -206,7 +206,7 @@
 	return 0
 
 /obj/machinery/door/airlock/plasma/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 
 /obj/machinery/door/airlock/bananium
@@ -219,7 +219,7 @@
 	paintable = FALSE
 
 /obj/machinery/door/airlock/bananium/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 
 /obj/machinery/door/airlock/tranquillite
@@ -239,7 +239,7 @@
 	paintable = FALSE
 
 /obj/machinery/door/airlock/sandstone/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 
 /obj/machinery/door/airlock/wood
@@ -249,7 +249,7 @@
 	paintable = FALSE
 
 /obj/machinery/door/airlock/wood/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 
 /obj/machinery/door/airlock/titanium
@@ -262,7 +262,7 @@
 
 /obj/machinery/door/airlock/titanium/glass
 	normal_integrity = 350
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 
 //////////////////////////////////
@@ -276,7 +276,7 @@
 	assemblytype = /obj/structure/door_assembly/door_assembly_public
 
 /obj/machinery/door/airlock/public/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 
 //////////////////////////////////
@@ -294,7 +294,7 @@
 	doorClose = 'sound/machines/airlock_ext_close.ogg'
 
 /obj/machinery/door/airlock/external/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 
 //////////////////////////////////
@@ -305,7 +305,7 @@
 /obj/machinery/door/airlock/centcom
 	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/centcom/overlays.dmi'
-	opacity = 0
+	opacity = FALSE
 	explosion_block = 2
 	assemblytype = /obj/structure/door_assembly/door_assembly_centcom
 	normal_integrity = 1000
@@ -487,7 +487,7 @@
 	paintable = FALSE
 
 /obj/machinery/door/airlock/shuttle/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 
 /obj/machinery/door/airlock/abductor
@@ -578,7 +578,7 @@
 /obj/machinery/door/airlock/cult/cult_conceal()
 	icon = stealth_icon
 	overlays_file = stealth_overlays
-	opacity = stealth_opacity
+	set_opacity(stealth_opacity)
 	glass = stealth_glass
 	airlock_material = stealth_airlock_material
 	name = "airlock"
@@ -589,7 +589,7 @@
 /obj/machinery/door/airlock/cult/cult_reveal()
 	icon = SSticker.cultdat?.airlock_runed_icon_file
 	overlays_file = SSticker.cultdat?.airlock_runed_overlays_file
-	opacity = initial(opacity)
+	set_opacity(initial(opacity))
 	glass = initial(glass)
 	airlock_material = initial(airlock_material)
 	name = initial(name)
@@ -609,11 +609,11 @@
 
 /obj/machinery/door/airlock/cult/glass
 	glass = TRUE
-	opacity = 0
+	opacity = FALSE
 
 /obj/machinery/door/airlock/cult_fake/glass
 	glass = TRUE
-	opacity = 0
+	opacity = FALSE
 
 /obj/machinery/door/airlock/cult/glass/Initialize()
 	. = ..()
@@ -639,7 +639,7 @@
 
 /obj/machinery/door/airlock/cult/unruned/glass
 	glass = TRUE
-	opacity = 0
+	opacity = FALSE
 
 /obj/machinery/door/airlock/cult/unruned/glass/Initialize()
 	. = ..()
@@ -705,7 +705,7 @@
 
 /obj/machinery/door/airlock/clockwork/glass
 	glass = TRUE
-	opacity = 0
+	opacity = FALSE
 
 /obj/machinery/door/airlock/clockwork/glass/friendly
 	friendly = TRUE
@@ -741,7 +741,7 @@
 	normal_integrity = 500
 
 /obj/machinery/door/airlock/syndicate/security/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 	normal_integrity = 450
 
@@ -752,7 +752,7 @@
 	normal_integrity = 350
 
 /obj/machinery/door/airlock/syndicate/public/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 	normal_integrity = 300
 
@@ -762,7 +762,7 @@
 	assemblytype = /obj/structure/door_assembly/syndicate/door_assembly_syndie_atmos
 	normal_integrity = 400
 /obj/machinery/door/airlock/syndicate/atmos/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 	normal_integrity = 350
 
@@ -773,7 +773,7 @@
 	normal_integrity = 300
 
 /obj/machinery/door/airlock/syndicate/maintenance/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 	normal_integrity = 250
 
@@ -785,7 +785,7 @@
 
 
 /obj/machinery/door/airlock/syndicate/medical/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 	normal_integrity = 350
 
@@ -796,7 +796,7 @@
 	normal_integrity = 400
 
 /obj/machinery/door/airlock/syndicate/cargo/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 	normal_integrity = 350
 
@@ -807,7 +807,7 @@
 	normal_integrity = 400
 
 /obj/machinery/door/airlock/syndicate/research/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 	normal_integrity = 350
 
@@ -818,7 +818,7 @@
 	normal_integrity = 450
 
 /obj/machinery/door/airlock/syndicate/engineering/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 	normal_integrity = 400
 
@@ -829,7 +829,7 @@
 	normal_integrity = 500
 
 /obj/machinery/door/airlock/syndicate/command/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 	normal_integrity = 450
 
@@ -841,7 +841,7 @@
 	normal_integrity = 350
 
 /obj/machinery/door/airlock/syndicate/freezer/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 	normal_integrity = 300
 
@@ -852,7 +852,7 @@
 	normal_integrity = 350
 
 /obj/machinery/door/airlock/syndicate/extmai/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE
 	normal_integrity = 300
 
@@ -890,5 +890,5 @@
 	return
 
 /obj/machinery/door/airlock/multi_tile/glass
-	opacity = 0
+	opacity = FALSE
 	glass = TRUE

--- a/code/game/machinery/doors/alarmlock.dm
+++ b/code/game/machinery/doors/alarmlock.dm
@@ -2,9 +2,9 @@
 	name = "glass alarm airlock"
 	icon = 'icons/obj/doors/airlocks/station2/glass.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/station2/overlays.dmi'
-	opacity = 0
-	glass = 1
-	autoclose = 0
+	opacity = FALSE
+	glass = TRUE
+	autoclose = FALSE
 	var/datum/radio_frequency/air_connection
 	var/air_frequency = ATMOS_FIRE_FREQ
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/doors/doorint.dmi'
 	icon_state = "door1"
 	anchored = TRUE
-	opacity = 1
+	opacity = TRUE
 	density = TRUE
 	layer = OPEN_DOOR_LAYER
 	power_channel = ENVIRON
@@ -487,12 +487,12 @@
 
 /obj/machinery/door/proc/update_freelook_sight()
 	if(!glass && GLOB.cameranet)
-		GLOB.cameranet.updateVisibility(src, 0)
+		GLOB.cameranet.updateVisibility(src, opacity_check = FALSE)
 
 /obj/machinery/door/BlockSuperconductivity() // All non-glass airlocks block heat, this is intended.
 	if(opacity || heat_proof)
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 /obj/machinery/door/morgue
 	icon = 'icons/obj/doors/doormorgue.dmi'

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -18,7 +18,7 @@
 /obj/machinery/door/poddoor/preopen
 	icon_state = "open"
 	density = FALSE
-	opacity = 0
+	opacity = FALSE
 
 /obj/machinery/door/poddoor/impassable
 	name = "reinforced blast door"
@@ -33,7 +33,7 @@
 /obj/machinery/door/poddoor/impassable/preopen
 	icon_state = "open"
 	density = FALSE
-	opacity = 0
+	opacity = FALSE
 
 //"BLAST" doors are obviously stronger than regular doors when it comes to BLASTS.
 /obj/machinery/door/poddoor/ex_act(severity)
@@ -91,15 +91,13 @@
 		apply_opacity_to_my_turfs(opacity)
 
 /obj/machinery/door/poddoor/multi_tile/Destroy()
-	apply_opacity_to_my_turfs(0)
+	apply_opacity_to_my_turfs(FALSE)
 	return ..()
 
 //Multi-tile poddoors don't turn invisible automatically, so we change the opacity of the turfs below instead one by one.
-/obj/machinery/door/poddoor/multi_tile/proc/apply_opacity_to_my_turfs(var/new_opacity)
-	for(var/turf/T in locs)
-		T.opacity = new_opacity
-		T.has_opaque_atom = new_opacity
-		T.reconsider_lights()
+/obj/machinery/door/poddoor/multi_tile/proc/apply_opacity_to_my_turfs(new_opacity)
+	for(var/turf/turf as anything in locs)
+		turf.set_opacity(new_opacity)
 	update_freelook_sight()
 
 /obj/machinery/door/poddoor/multi_tile/four_tile_ver

--- a/code/game/machinery/doors/shutters.dm
+++ b/code/game/machinery/doors/shutters.dm
@@ -15,7 +15,7 @@
 /obj/machinery/door/poddoor/shutters/preopen
 	icon_state = "open"
 	density = FALSE
-	opacity = 0
+	opacity = FALSE
 
 /obj/machinery/door/poddoor/shutters/preopen/invincible
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -10,7 +10,7 @@
 	flags = ON_BORDER
 	obj_flags = BLOCKS_CONSTRUCTION_DIR
 	pass_flags_self = PASSGLASS
-	opacity = 0
+	opacity = FALSE
 	dir = EAST
 	max_integrity = 150 //If you change this, consider changing ../door/window/brigdoor/ max_integrity at the bottom of this .dm file
 	integrity_failure = 0

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -18,7 +18,7 @@
 	..()
 
 /obj/machinery/shield/Destroy()
-	opacity = FALSE
+	set_opacity(FALSE)
 	set_density(FALSE)
 	air_update_turf(1)
 	return ..()

--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -9,7 +9,7 @@
 	icon = 'icons/obj/mecha/mecha.dmi'
 	density = TRUE
 	anchored = FALSE
-	opacity = 0
+	opacity = FALSE
 	var/list/welder_salvage = list(/obj/item/stack/sheet/plasteel, /obj/item/stack/sheet/metal, /obj/item/stack/rods)
 	var/salvage_num = 5
 	var/list/crowbar_salvage = list()

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -101,7 +101,7 @@
 	initial_icon = "deathripley"
 	step_in = 3
 	slow_pressure_step_in = 3
-	opacity=0
+	opacity = FALSE
 	max_temperature = 65000
 	max_integrity = 300
 	lights_power = 7

--- a/code/game/objects/effects/alien_acid.dm
+++ b/code/game/objects/effects/alien_acid.dm
@@ -4,7 +4,7 @@
 	desc = "Burbling corrosive stuff."
 	icon_state = "acid"
 	density = FALSE
-	opacity = 0
+	opacity = FALSE
 	anchored = TRUE
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	layer = ABOVE_NORMAL_TURF_LAYER

--- a/code/game/objects/effects/bump_teleporter.dm
+++ b/code/game/objects/effects/bump_teleporter.dm
@@ -9,7 +9,7 @@ GLOBAL_LIST_EMPTY(bump_teleporters)
 	invisibility = INVISIBILITY_ABSTRACT	// nope, can't see this
 	anchored = TRUE
 	density = TRUE
-	opacity = 0
+	opacity = FALSE
 
 /obj/effect/bump_teleporter/New()
 	..()

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -5,7 +5,7 @@
 /obj/effect/particle_effect/foam
 	name = "foam"
 	icon_state = "foam"
-	opacity = 0
+	opacity = FALSE
 	anchored = TRUE
 	density = FALSE
 	layer = OBJ_LAYER + 0.9

--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -10,7 +10,7 @@
 	icon = 'icons/effects/96x96.dmi'
 	pixel_x = -32
 	pixel_y = -32
-	opacity = 1
+	opacity = TRUE
 	anchored = FALSE
 	var/steps = 0
 	var/lifetime = 5
@@ -25,7 +25,7 @@
 	for(var/i = 0, i < frames, i++)
 		alpha -= step
 		if(alpha < 160)
-			set_opacity(0)
+			set_opacity(FALSE)
 		stoplag()
 
 /obj/effect/particle_effect/smoke/New()
@@ -148,7 +148,7 @@
 /obj/effect/particle_effect/smoke/freezing
 	name = "nanofrost smoke"
 	color = "#B2FFFF"
-	opacity = 0
+	opacity = FALSE
 
 /datum/effect_system/smoke_spread/freezing
 	effect_type = /obj/effect/particle_effect/smoke/freezing

--- a/code/game/objects/effects/forcefields.dm
+++ b/code/game/objects/effects/forcefields.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "m_shield"
 	anchored = TRUE
-	opacity = 0
+	opacity = FALSE
 	density = TRUE
 	var/lifetime = 30 SECONDS
 

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -8,7 +8,7 @@
 	name = "glowshroom"
 	desc = "Mycena Bregprox, a species of mushroom that glows in the dark."
 	anchored = TRUE
-	opacity = 0
+	opacity = FALSE
 	density = FALSE
 	icon = 'icons/obj/lighting.dmi'
 	//replaced in Initialize()

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -455,9 +455,6 @@
 	icon = 'icons/obj/weapons/ammo.dmi'
 	icon_state = "rcd"
 	item_state = "rcdammo"
-	opacity = FALSE
-	density = FALSE
-	anchored = FALSE
 	origin_tech = "materials=3"
 	materials = list(MAT_METAL=16000, MAT_GLASS=8000)
 	var/ammoamt = 20

--- a/code/game/objects/items/weapons/RCL.dm
+++ b/code/game/objects/items/weapons/RCL.dm
@@ -4,7 +4,6 @@
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "rcl-0"
 	item_state = "rcl-0"
-	opacity = 0
 	force = 5 //Plastic is soft
 	throwforce = 5
 	throw_speed = 1

--- a/code/game/objects/items/weapons/RLF.dm
+++ b/code/game/objects/items/weapons/RLF.dm
@@ -8,9 +8,6 @@ RLF
 	desc = "A device used to rapidly deploy lollipop."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "rlf"
-	opacity = 0
-	density = FALSE
-	anchored = FALSE
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	w_class = WEIGHT_CLASS_NORMAL
 

--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -9,9 +9,6 @@ RSF
 	desc = "A device used to rapidly deploy service items."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "rsf"
-	opacity = 0
-	density = FALSE
-	anchored = FALSE
 	var/matter = 0
 	var/mode = 1
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)

--- a/code/game/objects/items/weapons/rpd.dm
+++ b/code/game/objects/items/weapons/rpd.dm
@@ -14,9 +14,6 @@
 	desc = "This device can rapidly dispense atmospherics and disposals piping, manipulate loose piping, and recycle any detached pipes it is applied to."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "rpd"
-	opacity = 0
-	density = FALSE
-	anchored = FALSE
 	flags = CONDUCT
 	force = 10
 	throwforce = 10

--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -96,7 +96,7 @@
 	desc = "Resin just thin enough to let light pass through."
 	icon = 'icons/obj/smooth_structures/alien/resin_membrane.dmi'
 	icon_state = "membrane0"
-	opacity = 0
+	opacity = FALSE
 	max_integrity = 160
 	resintype = "membrane"
 	pass_flags_self = PASSGLASS
@@ -293,7 +293,7 @@
 
 /obj/structure/alien/resin/door/proc/update_freelook_sight()
 	if(GLOB.cameranet)
-		GLOB.cameranet.updateVisibility(src, FALSE)
+		GLOB.cameranet.updateVisibility(src, opacity_check = FALSE)
 
 
 #undef RESIN_DOOR_CLOSED

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -6,13 +6,15 @@
 	name = "curtain"
 	icon_state = "closed"
 	layer = SHOWER_CLOSED_LAYER
-	opacity = 1
+	opacity = TRUE
 	density = FALSE
+
 
 /obj/structure/curtain/open
 	icon_state = "open"
 	layer = SHOWER_OPEN_LAYER
-	opacity = 0
+	opacity = FALSE
+
 
 /obj/structure/curtain/attack_hand(mob/user)
 	playsound(get_turf(loc), "rustle", 15, 1, -5)
@@ -29,14 +31,16 @@
 		if(BURN)
 			playsound(loc, 'sound/items/welder.ogg', 80, TRUE)
 
+
 /obj/structure/curtain/proc/toggle()
 	set_opacity(!opacity)
-	if(opacity)
-		icon_state = "closed"
-		layer = SHOWER_CLOSED_LAYER
-	else
-		icon_state = "open"
-		layer = SHOWER_OPEN_LAYER
+	layer = opacity ? SHOWER_CLOSED_LAYER : SHOWER_OPEN_LAYER
+	update_icon(UPDATE_ICON_STATE)
+
+
+/obj/structure/curtain/update_icon_state()
+	icon_state = opacity ? "closed" : "open"
+
 
 /obj/structure/curtain/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/toy/crayon))

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -399,14 +399,16 @@
 	icon_state = "bush1"
 	density = TRUE
 	anchored = TRUE
-	layer = 3.2
+	layer = ABOVE_OBJ_LAYER
 	var/indestructable = 0
 	var/stump = 0
+
 
 /obj/structure/bush/Initialize(mapload)
 	. = ..()
 	if(prob(20))
-		opacity = 1
+		set_opacity(TRUE)
+
 
 /obj/structure/bush/attackby(var/obj/I as obj, var/mob/user as mob, params)
 	//hatchets can clear away undergrowth

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -7,7 +7,7 @@
 	icon_state = "minibar"
 	anchored = TRUE
 	density = FALSE
-	opacity = 0
+	opacity = FALSE
 	var/deconstructible = TRUE
 
 /obj/structure/fluff/attackby(obj/item/I, mob/living/user, params)

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -3,7 +3,7 @@
 	name = "metal door"
 	density = TRUE
 	anchored = TRUE
-	opacity = 1
+	opacity = TRUE
 
 	icon = 'icons/obj/doors/mineral_doors.dmi'
 	icon_state = "metal"
@@ -20,6 +20,7 @@
 	var/openSound = 'sound/effects/stonedoor_openclose.ogg'
 	var/closeSound = 'sound/effects/stonedoor_openclose.ogg'
 	var/damageSound = null
+	var/is_opaque = TRUE
 
 /obj/structure/mineral_door/Initialize()
 	. = ..()
@@ -97,7 +98,8 @@
 	flick("[initial_state]opening",src)
 	sleep(10)
 	set_density(FALSE)
-	set_opacity(FALSE)
+	if(is_opaque)
+		set_opacity(FALSE)
 	state = 1
 	air_update_turf(1)
 	update_icon(UPDATE_ICON_STATE)
@@ -109,16 +111,18 @@
 
 /obj/structure/mineral_door/proc/Close()
 	if(isSwitchingStates || state != 1)
-		return
+		return FALSE
 	var/turf/T = get_turf(src)
 	for(var/mob/living/L in T)
-		return
+		return FALSE
+	. = TRUE
 	isSwitchingStates = 1
 	playsound(loc, closeSound, 100, 1)
 	flick("[initial_state]closing",src)
 	sleep(10)
 	set_density(TRUE)
-	set_opacity(TRUE)
+	if(is_opaque)
+		set_opacity(TRUE)
 	state = 0
 	air_update_turf(1)
 	update_icon(UPDATE_ICON_STATE)
@@ -181,11 +185,8 @@
 	max_integrity = 100
 
 /obj/structure/mineral_door/transparent
-	opacity = 0
-
-/obj/structure/mineral_door/transparent/Close()
-	..()
-	set_opacity(0)
+	opacity = FALSE
+	is_opaque = FALSE
 
 /obj/structure/mineral_door/transparent/plasma
 	name = "plasma door"

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -1,9 +1,9 @@
 /obj/structure/sign
 	icon = 'icons/obj/decals.dmi'
 	anchored = TRUE
-	opacity = 0
+	opacity = FALSE
 	density = FALSE
-	layer = 3.5
+	layer = NOT_HIGH_OBJ_LAYER
 	max_integrity = 100
 	blocks_emissive = EMISSIVE_BLOCK_GENERIC
 	var/does_emissive = FALSE

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -555,7 +555,7 @@ GLOBAL_LIST_INIT(wcCommon, pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e",
 	name = "tinted window"
 	desc = "It looks rather strong and opaque. Might take a few good hits to shatter it."
 	icon_state = "twindow"
-	opacity = 1
+	opacity = TRUE
 
 /obj/structure/window/reinforced/tinted/frosted
 	name = "frosted window"
@@ -576,10 +576,10 @@ GLOBAL_LIST_INIT(wcCommon, pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e",
 		original_color = color
 	if(opacity)
 		animate(src, color="[original_color]", time=5)
-		set_opacity(0)
+		set_opacity(FALSE)
 	else
 		animate(src, color="#222222", time=5)
-		set_opacity(1)
+		set_opacity(TRUE)
 
 /obj/machinery/button/windowtint
 	name = "window tint control"
@@ -765,7 +765,7 @@ GLOBAL_LIST_INIT(wcCommon, pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e",
 	desc = "It looks rather strong and opaque. Might take a few good hits to shatter it."
 	icon = 'icons/obj/smooth_structures/tinted_window.dmi'
 	icon_state = "tinted_window"
-	opacity = 1
+	opacity = TRUE
 
 /obj/structure/window/full/reinforced/ice
 	icon = 'icons/obj/smooth_structures/rice_window.dmi'

--- a/code/game/objects/structures/wryn.dm
+++ b/code/game/objects/structures/wryn.dm
@@ -54,7 +54,7 @@
 	desc = "Wax just thin enough to let light pass through."
 	icon = 'icons/obj/smooth_structures/wryn/window.dmi'
 	icon_state = "window"
-	opacity = 0
+	opacity = FALSE
 	max_integrity = 20
 	canSmoothWith = list(/obj/structure/wryn/wax/wall, /obj/structure/wryn/wax/window)
 

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -31,7 +31,7 @@
 /obj/structure/shuttle/engine/propulsion
 	name = "propulsion"
 	icon_state = "propulsion"
-	opacity = 1
+	opacity = TRUE
 
 /obj/structure/shuttle/engine/propulsion/burst
 
@@ -48,7 +48,7 @@
 // Engines
 /obj/structure/shuttle/engine/large
 	name = "engine"
-	opacity = 1
+	opacity = TRUE
 	icon = 'icons/obj/2x2.dmi'
 	icon_state = "large_engine"
 	desc = "A very large bluespace engine used to propel very large ships."
@@ -69,7 +69,7 @@
 
 /obj/structure/shuttle/engine/huge
 	name = "engine"
-	opacity = 1
+	opacity = TRUE
 	icon = 'icons/obj/3x3.dmi'
 	icon_state = "huge_engine"
 	desc = "Almost gigantic bluespace engine used to propel very large ships at very high speed."

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -8,7 +8,7 @@
 	smooth = SMOOTH_MORE | SMOOTH_BORDER
 	canSmoothWith = null
 	baseturf = /turf/simulated/floor/plating/asteroid/airless
-	opacity = 1
+	opacity = TRUE
 	density = TRUE
 	blocks_air = TRUE
 	init_air = FALSE

--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -3,7 +3,7 @@
 	desc = "A huge chunk of reinforced metal used to separate rooms."
 	icon = 'icons/turf/walls/reinforced_wall.dmi'
 	icon_state = "r_wall"
-	opacity = 1
+	opacity = TRUE
 	density = TRUE
 	explosion_block = 2
 	explosion_vertical_block = 1

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -55,8 +55,8 @@
 	if (light_power && light_range)
 		update_light()
 
-	if (opacity)
-		has_opaque_atom = TRUE
+	if(opacity)
+		directional_opacity = ALL_CARDINALS
 
 	return INITIALIZE_HINT_NORMAL
 

--- a/code/modules/awaymissions/map_rng.dm
+++ b/code/modules/awaymissions/map_rng.dm
@@ -5,7 +5,7 @@
 	invisibility = INVISIBILITY_ABSTRACT
 	anchored = TRUE
 	density = FALSE
-	opacity = 0
+	opacity = FALSE
 	var/template_name = null
 	var/datum/map_template/template = null
 	var/centered = 1

--- a/code/modules/awaymissions/mission_code/beach.dm
+++ b/code/modules/awaymissions/mission_code/beach.dm
@@ -2,7 +2,7 @@
 	name = "waterfall effect"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "extinguish"
-	opacity = 0
+	opacity = FALSE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	density = FALSE
 	anchored = TRUE

--- a/code/modules/awaymissions/mission_code/spacehotel.dm
+++ b/code/modules/awaymissions/mission_code/spacehotel.dm
@@ -196,7 +196,7 @@
 	invisibility = INVISIBILITY_ABSTRACT
 	anchored = TRUE
 	density = FALSE
-	opacity = 0
+	opacity = FALSE
 	var/list/room_doors[0]			// assoc list of [room id]=hotel_door
 	var/list/vacant_rooms[0]		// list of vacant room doors
 	var/list/guests[0]				// assoc list of [guest mob]=room id

--- a/code/modules/awaymissions/zvis.dm
+++ b/code/modules/awaymissions/zvis.dm
@@ -192,7 +192,7 @@
 
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "loadingarea"
-	opacity = 1
+	opacity = TRUE
 	density = TRUE
 	invisibility = 0
 	appearance_flags = TILE_BOUND | KEEP_TOGETHER | LONG_GLIDE

--- a/code/modules/clothing/spacesuits/chronosuit.dm
+++ b/code/modules/clothing/spacesuits/chronosuit.dm
@@ -183,7 +183,7 @@
 	density = FALSE
 	anchored = TRUE
 	invisibility = INVISIBILITY_ABSTRACT
-	opacity = 0
+	opacity = FALSE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	var/mob/holder = null
 

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -459,7 +459,7 @@
 			qdel(master)
 	master = null
 	mutations.Cut()
-	set_opacity(0)
+	set_opacity(FALSE)
 	if(has_buckled_mobs())
 		unbuckle_all_mobs(force = TRUE)
 	return ..()
@@ -641,7 +641,7 @@
 	if(!energy)
 		icon_state = pick("Med1", "Med2", "Med3")
 		energy = 1
-		set_opacity(1)
+		set_opacity(TRUE)
 	else
 		icon_state = pick("Hvy1", "Hvy2", "Hvy3")
 		energy = 2

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -597,7 +597,7 @@ GLOBAL_LIST_INIT(major_hallutinations, list("fake"=20,"death"=10,"xeno"=10,"sing
 	desc = ""
 	density = FALSE
 	anchored = TRUE
-	opacity = 0
+	opacity = FALSE
 	var/mob/living/carbon/human/my_target = null
 	var/weapon_name = null
 	var/obj/item/weap = null

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -17,7 +17,7 @@
 	icon_state = "book-0"
 	anchored = TRUE
 	density = TRUE
-	opacity = FALSE
+	opacity = TRUE
 	resistance_flags = FLAMMABLE
 	max_integrity = 200
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 0)

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -17,7 +17,7 @@
 	icon_state = "book-0"
 	anchored = TRUE
 	density = TRUE
-	opacity = 1
+	opacity = FALSE
 	resistance_flags = FLAMMABLE
 	max_integrity = 200
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 0)

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -31,7 +31,8 @@
 // Will update the light (duh).
 // Creates or destroys it if needed, makes it update values, makes sure it's got the correct source turf...
 /atom/proc/update_light()
-	set waitfor = FALSE
+	SHOULD_NOT_SLEEP(TRUE)
+
 	if(QDELETED(src))
 		return
 
@@ -51,38 +52,9 @@
 		else
 			light = new/datum/light_source(src, .)
 
+
 /atom/proc/extinguish_light(force = FALSE)
 	return
-
-// If we have opacity, make sure to tell (potentially) affected light sources.
-/atom/movable/Destroy()
-	var/turf/T = loc
-	. = ..()
-	if(opacity && istype(T))
-		var/old_has_opaque_atom = T.has_opaque_atom
-		T.recalc_atom_opacity()
-		if(old_has_opaque_atom != T.has_opaque_atom)
-			T.reconsider_lights()
-
-// Should always be used to change the opacity of an atom.
-// It notifies (potentially) affected light sources so they can update (if needed).
-/atom/proc/set_opacity(new_opacity)
-	if(new_opacity == opacity)
-		return
-
-	opacity = new_opacity
-	var/turf/T = loc
-	if(!isturf(T))
-		return
-
-	if(new_opacity == TRUE)
-		T.has_opaque_atom = TRUE
-		T.reconsider_lights()
-	else
-		var/old_has_opaque_atom = T.has_opaque_atom
-		T.recalc_atom_opacity()
-		if(old_has_opaque_atom != T.has_opaque_atom)
-			T.reconsider_lights()
 
 
 /atom/proc/flash_lighting_fx(_range = FLASH_LIGHT_RANGE, _power = FLASH_LIGHT_POWER, _color = LIGHT_COLOR_WHITE, _duration = FLASH_LIGHT_DURATION, _reset_lighting = TRUE)

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -296,13 +296,13 @@
 				var/turf/above = GET_TURF_ABOVE(T)
 				while(above)
 					// If we find a non transparent turf, end
-					if(!above.transparent_floor || IS_OPAQUE_TURF(above) || T.has_opaque_atom)
+					if(!above.transparent_floor || IS_OPAQUE_TURF(above))
 						break
 					INSERT_CORNERS(corners, above)
 					above = GET_TURF_ABOVE(above)
 		else // Yes I know this could be acomplished with an if in the for loop, but it's fukin lighting code man
 			for(var/turf/T in view(CEILING(light_range, 1), source_turf))
-				if(IS_OPAQUE_TURF(T) || T.has_opaque_atom)
+				if(IS_OPAQUE_TURF(T))
 					continue
 				INSERT_CORNERS(corners, T)
 

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -1,18 +1,3 @@
-/turf
-	luminosity = 1
-	///Bool, whether this turf will always be illuminated no matter what area it is in
-	var/always_lit = FALSE
-
-	var/tmp/lighting_corners_initialised = FALSE
-
-	var/tmp/atom/movable/lighting_object/lighting_object // Our lighting object.
-	///Lighting Corner datums.
-	var/tmp/datum/lighting_corner/lighting_corner_NE
-	var/tmp/datum/lighting_corner/lighting_corner_SE
-	var/tmp/datum/lighting_corner/lighting_corner_SW
-	var/tmp/datum/lighting_corner/lighting_corner_NW
-	var/tmp/has_opaque_atom = FALSE // Not to be confused with opacity, this will be TRUE if there's any opaque atom on the tile.
-
 // Causes any affecting light sources to be queued for a visibility update, for example a door got opened.
 /turf/proc/reconsider_lights()
 	lighting_corner_NE?.vis_update()
@@ -69,21 +54,6 @@
 
 	return !(luminosity || dynamic_lumcount)
 
-// Can't think of a good name, this proc will recalculate the has_opaque_atom variable.
-/turf/proc/recalc_atom_opacity()
-	has_opaque_atom = opacity
-	if(!has_opaque_atom)
-		for(var/atom/A in contents) // Loop through every movable atom on our tile PLUS ourselves (we matter too...)
-			if(A.opacity)
-				has_opaque_atom = TRUE
-				break
-
-/turf/Exited(atom/movable/Obj, atom/newloc)
-	. = ..()
-
-	if(Obj && Obj.opacity)
-		recalc_atom_opacity() // Make sure to do this before reconsider_lights(), incase we're on instant updates.
-		reconsider_lights()
 
 /turf/proc/change_area(area/old_area, area/new_area)
 
@@ -118,6 +88,7 @@
 		if(new_area.lighting_effects)
 			add_overlay(new_area.lighting_effects[index])
 
+
 ///Proc to add movable sources of opacity on the turf and let it handle lighting code.
 /turf/proc/add_opacity_source(atom/movable/new_source)
 	LAZYADD(opacity_sources, new_source)
@@ -141,7 +112,7 @@
 		directional_opacity = ALL_CARDINALS
 		if(. != directional_opacity)
 			reconsider_lights()
-		return
+		return .
 	directional_opacity = NONE
 	if(opacity_sources)
 		for(var/atom/movable/opacity_source as anything in opacity_sources)
@@ -152,3 +123,11 @@
 				break
 	if(. != directional_opacity && (. == ALL_CARDINALS || directional_opacity == ALL_CARDINALS))
 		reconsider_lights() //The lighting system only cares whether the tile is fully concealed from all directions or not.
+
+
+/turf/set_opacity(new_opacity)
+	. = ..()
+	if(isnull(.))
+		return .
+	recalculate_directional_opacity()
+

--- a/code/modules/mini_games/mini_games.dm
+++ b/code/modules/mini_games/mini_games.dm
@@ -20,7 +20,7 @@
 	anchored = TRUE
 	density = FALSE
 	invisibility = INVISIBILITY_MAXIMUM
-	opacity = 0
+	opacity = FALSE
 	layer = BELOW_MOB_LAYER
 	resistance_flags = INDESTRUCTIBLE
 

--- a/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
@@ -96,8 +96,7 @@ GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new())
 
 // Updates the chunks that the turf is located in. Use this when obstacles are destroyed or	when doors open.
 
-/datum/cameranet/proc/updateVisibility(atom/A, opacity_check = 1)
-
+/datum/cameranet/proc/updateVisibility(atom/A, opacity_check = TRUE)
 	if(!SSticker || (opacity_check && !A.opacity))
 		return
 	majorChunkChange(A, 2)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -477,7 +477,7 @@ Difficulty: Medium
 	icon = 'icons/effects/fire.dmi'
 	icon_state = "1"
 	anchored = TRUE
-	opacity = 0
+	opacity = FALSE
 	density = TRUE
 	duration = 82
 	color = COLOR_DARK_ORANGE

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/builder.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/builder.dm
@@ -69,7 +69,7 @@
 
 /obj/structure/spider/terrorweb/queen/builder
 	max_integrity = 35
-	opacity = 1
+	opacity = TRUE
 	name = "drone web"
 	desc = "Extremely thick web."
 

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/guardian.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/guardian.dm
@@ -131,5 +131,5 @@
 /obj/structure/spider/terrorweb/purple
 	name = "thick web"
 	desc = "This web is so thick, most cannot see beyond it."
-	opacity = 1
+	opacity = TRUE
 	max_integrity = 40

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -5,8 +5,8 @@
 	desc = "A large pulsating plant..."
 	icon = 'icons/effects/spacevines.dmi'
 	icon_state = "flower_bud"
-	layer = MOB_LAYER + 0.9
-	opacity = 0
+	layer = SPACEVINE_MOB_LAYER
+	opacity = FALSE
 	canSmoothWith = list()
 	smooth = SMOOTH_FALSE
 	var/growth_time = 1200

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -165,11 +165,11 @@
 		if(T.x == 1 || T.x==world.maxx || T.y==1 || T.y==world.maxy)		// not obscured if we reach the edge
 			break
 
-		if(T.density)			// if we hit a solid turf, panel is obscured
-			obscured = 1
+		if(IS_OPAQUE_TURF(T))			// if we hit an opaque turf, panel is obscured
+			obscured = TRUE
 			return
 
-	obscured = 0		// if hit the edge or stepped 20 times, not obscured
+	obscured = FALSE		// if hit the edge or stepped 20 times, not obscured
 	update_solar_exposure()
 
 

--- a/code/modules/projectiles/guns/dartgun.dm
+++ b/code/modules/projectiles/guns/dartgun.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/weapons/ammo.dmi'
 	icon_state = "darts-5"
 	item_state = "rcdammo"
-	opacity = 0
+	opacity = FALSE
 	density = FALSE
 	anchored = FALSE
 	origin_tech = "materials=2"

--- a/code/modules/ruins/lavalandruin_code/necropolis_lavalend.dm
+++ b/code/modules/ruins/lavalandruin_code/necropolis_lavalend.dm
@@ -75,7 +75,7 @@
 /obj/machinery/door/poddoor/impassable/necropolisdoor/preopen
 	icon_state = "necropen"
 	density = FALSE
-	opacity = 0
+	opacity = FALSE
 
 /obj/machinery/door/poddoor/impassable/necropolisdoor/do_animate(animation)
 	switch(animation)
@@ -122,14 +122,12 @@
 		apply_opacity_to_my_turfs(opacity)
 
 /obj/machinery/door/poddoor/impassable/necropolisdoor/multi_tile/Destroy()
-	apply_opacity_to_my_turfs(0)
+	apply_opacity_to_my_turfs(FALSE)
 	return ..()
 
-/obj/machinery/door/poddoor/impassable/necropolisdoor/multi_tile/proc/apply_opacity_to_my_turfs(var/new_opacity)
-	for(var/turf/T in locs)
-		T.opacity = new_opacity
-		T.has_opaque_atom = new_opacity
-		T.reconsider_lights()
+/obj/machinery/door/poddoor/impassable/necropolisdoor/multi_tile/proc/apply_opacity_to_my_turfs(new_opacity)
+	for(var/turf/turf as anything in locs)
+		turf.set_opacity(new_opacity)
 	update_freelook_sight()
 
 /obj/machinery/door/poddoor/impassable/necropolisdoor/multi_tile/four_tile_hor

--- a/code/modules/spacepods/construction.dm
+++ b/code/modules/spacepods/construction.dm
@@ -1,6 +1,6 @@
 /obj/structure/spacepod_frame
 	density = TRUE
-	opacity = 0
+	opacity = FALSE
 
 	anchored = TRUE
 	layer = 3.9

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -19,13 +19,13 @@
 	desc = "A space pod meant for space travel."
 	icon = 'icons/goonstation/48x48/pods.dmi'
 	density = TRUE //Dense. To raise the heat.
-	opacity = 0
+	opacity = FALSE
 
 	move_resist = MOVE_FORCE_EXTREMELY_STRONG
 	move_force = MOVE_FORCE_VERY_STRONG
 	resistance_flags = ACID_PROOF
 
-	layer = 3.9
+	layer = BEHIND_MOB_LAYER
 	infra_luminosity = 15
 
 	var/mob/living/pilot	//There is only ever one pilot and he gets all the privledge

--- a/paradise.dme
+++ b/paradise.dme
@@ -498,6 +498,7 @@
 #include "code\datums\elements\_element.dm"
 #include "code\datums\elements\connect_loc.dm"
 #include "code\datums\elements\falling_hazard.dm"
+#include "code\datums\elements\light_blocking.dm"
 #include "code\datums\elements\movetype_handler.dm"
 #include "code\datums\elements\openspace_item_click_handler.dm"
 #include "code\datums\elements\simple_flying.dm"


### PR DESCRIPTION
## Описание
Доделываю работку за владом.

- прозрачность атомов (opacity) полностью стандартизирована (TRUE/FALSE)
- добавлен корректный сеттер для переменной прозрачности
- для /atom/movable работа с прозрачностью перенесена в элемент

В элементе нужно будет сделать небольшую правку для мультитайл объектов, когда зальют мои новые грабы.