### PR TITLE
FIX: Blueshield gun duplicates

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -254,6 +254,7 @@
 	// These items will NOT be preserved
 	var/list/do_not_preserve_items = list (
 		/obj/item/mmi/robotic_brain
+		/obj/item/gun/energy/gun/blueshield
 	)
 
 //////

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -253,7 +253,7 @@
 	)
 	// These items will NOT be preserved
 	var/list/do_not_preserve_items = list (
-		/obj/item/mmi/robotic_brain
+		/obj/item/mmi/robotic_brain,
 		/obj/item/gun/energy/gun/blueshield
 	)
 


### PR DESCRIPTION
## Описание
Добавляет пистолет БШ в исключения крио, чтобы БШ после ухода одного не лутали себе второй, поскольку они все прилетают с ним.

## Ссылка на предложение/Причина создания ПР
Эээ фикс.
