### PR TITLE
bugfix: Clean up after rock resprite

### DIFF
--- a/code/game/turfs/simulated/walls_indestructible.dm
+++ b/code/game/turfs/simulated/walls_indestructible.dm
@@ -259,7 +259,7 @@
 
 /turf/simulated/wall/indestructible/mineral_rock/Initialize(mapload)
 	var/matrix/M = new
-	M.Translate(-4, -4)
+	//M.Translate(-4, -4)
 	transform = M
 	icon = smooth_icon
 	. = ..()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Убирает у фальшстен и у нерушимых стен сдвиг в сторону.
В общем, что использует `'icons/turf/smoothrocks.dmi'` больше не двигается.

## Ссылка на предложение/Причина создания ПР
![image](https://github.com/ss220-space/Paradise/assets/87372121/9dcf1936-a1fa-457d-b3d9-8a9b640ddde0)
[Ссылка](https://discord.com/channels/617003227182792704/943940908162875473/1255223544468607086)

## Демонстрация изменений
Нету
