### PR TITLE
bugfix: Ambient Occlusion updates real time

### DIFF
--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -2507,7 +2507,7 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 				if("ambientocclusion")
 					toggles ^= PREFTOGGLE_AMBIENT_OCCLUSION
 					if(length(parent?.screen))
-						for(var/atom/movable/screen/plane_master/plane_master as anything in parent.mob?.hud_used?.get_true_plane_masters(GAME_PLANE))
+						for(var/atom/movable/screen/plane_master/plane_master as anything in parent.mob?.hud_used?.get_true_plane_masters(RENDER_PLANE_GAME_WORLD))
 							plane_master.show_to(parent.mob)
 
 				if("parallax")


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Меняет плейн, что обновляется при изменении преференсов, на RENDER_PLANE_GAME_WORLD, вместо GAME_PLANE.

## Ссылка на предложение/Причина создания ПР
[Ссылка](https://discord.com/channels/617003227182792704/734823601110515882/1255556378551124090).
В прошлом, для обновления `Ambient Occlusion` нужно просто нажать кнопку. После переделки плейнов, там обновляется не тот плейн.
Попросту выглядело как очепятка.

https://github.com/ss220-space/Paradise/assets/87372121/9b19dece-b0f5-4f5d-8edf-76b45e2de18f


## Демонстрация изменений

https://github.com/ss220-space/Paradise/assets/87372121/742cad41-29b0-490e-aa2b-cb84b7d251e7


