### PR TITLE
bugfix: healtouch MAGEEEE Slomalsa pizdec

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -318,7 +318,7 @@
 
 /datum/spellbook_entry/healtouch
 	name = "Healing Touch"
-	spell_type = /obj/effect/proc_holder/spell/touch/healtouch
+	spell_type = /obj/effect/proc_holder/spell/touch/healtouch/advanced
 	category = "Assistance"
 	cost = 1
 


### PR DESCRIPTION


## Описание
Целительное касание мага не работало само на себя, хотя должно работать как у ученика мага.
Ну поторох когда апал ученика забыл поставить дописать в спел бук слово адвансед. Бывает.

## Ссылка на багрепорт
Нету на локалке заметил.
