### PR TITLE
bugfix: Vampires has hungriness

### DIFF
--- a/code/datums/diseases/critical.dm
+++ b/code/datums/diseases/critical.dm
@@ -145,7 +145,7 @@
 /datum/disease/critical/hypoglycemia/has_cure()
 	if(ishuman(affected_mob))
 		var/mob/living/carbon/human/H = affected_mob
-		if((NO_HUNGER in H.dna.species.species_traits) && !isvampire(src))
+		if((NO_HUNGER in H.dna.species.species_traits) && !isvampire(H))
 			return TRUE
 		if(ismachineperson(H))
 			return TRUE

--- a/code/datums/diseases/critical.dm
+++ b/code/datums/diseases/critical.dm
@@ -145,7 +145,7 @@
 /datum/disease/critical/hypoglycemia/has_cure()
 	if(ishuman(affected_mob))
 		var/mob/living/carbon/human/H = affected_mob
-		if(NO_HUNGER in H.dna.species.species_traits)
+		if((NO_HUNGER in H.dna.species.species_traits) && !isvampire(src))
 			return TRUE
 		if(ismachineperson(H))
 			return TRUE

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1970,7 +1970,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 
 
 /mob/living/carbon/human/set_nutrition(change)
-	if(NO_HUNGER in dna.species.species_traits)
+	if((NO_HUNGER in dna.species.species_traits) && !isvampire(src))
 		return FALSE
 	. = ..()
 	update_hunger_slowdown()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавлена проверка у `hypoglycemia` на вампира, чтобы он тоже болел, даже когда плазмамен.
У `set_nutrition` добавлена проверка на вампира, чтобы плазмамены могли пополнять свой голод.

## Ссылка на предложение/Причина создания ПР
Болезнь - [Запрос](https://discord.com/channels/617003227182792704/734823601110515882/1255791623036731503) и предоплата бупом.
`set_nutrition` - [Скрин админа](https://discord.com/channels/617003227182792704/734823601110515882/1255784560256483338).
