### PR TITLE
bugfix: Disable Tech Opat slomalsa syka

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -1199,7 +1199,7 @@
 
 /obj/item/spellbook/oneuse/random/Initialize()
 	. = ..()
-	var/static/banned_spells = list(/obj/item/spellbook/oneuse/mime, /obj/item/spellbook/oneuse/mime/fingergun, /obj/item/spellbook/oneuse/mime/fingergun/fake, /obj/item/spellbook/oneuse/mime/greaterwall, /obj/item/spellbook/oneuse/fake_gib)
+	var/static/banned_spells = list(/obj/item/spellbook/oneuse/mime, /obj/item/spellbook/oneuse/mime/fingergun, /obj/item/spellbook/oneuse/mime/fingergun/fake, /obj/item/spellbook/oneuse/mime/greaterwall, /obj/item/spellbook/oneuse/fake_gib, /obj/item/spellbook/oneuse/emp/used)
 	var/real_type = pick(subtypesof(/obj/item/spellbook/oneuse) - banned_spells)
 	new real_type(loc)
 	qdel(src)


### PR DESCRIPTION


## Описание
Опять библиотекарь, опять ебаный дизейбл теч.

**Использованная** книга заклинаний дизейбл теча не может выпасть в рандом спел бук и наборе книг мага.

## Ссылка на багрепорт
Добрые люди написали
![image](https://github.com/ss220-space/Paradise/assets/42041683/cdcd75ca-6561-4dd4-a591-a8f737e7c89c)

