### PR TITLE
refactor: Swarming Component Rework

### DIFF
--- a/code/datums/components/connect_loc_behalf.dm
+++ b/code/datums/components/connect_loc_behalf.dm
@@ -1,0 +1,72 @@
+/// This component behaves similar to connect_loc, hooking into a signal on a tracked object's turf
+/// It has the ability to react to that signal on behalf of a separate listener however
+/// This has great use, primarily for components, but it carries with it some overhead
+/// So we do it separately as it needs to hold state which is very likely to lead to bugs if it remains as an element.
+/datum/component/connect_loc_behalf
+	dupe_mode = COMPONENT_DUPE_UNIQUE
+	/// An assoc list of signal -> procpath to register to the loc this object is on.
+	var/list/connections
+	var/atom/movable/tracked
+	var/atom/tracked_loc
+
+
+/datum/component/connect_loc_behalf/Initialize(atom/movable/tracked, list/connections)
+	if(!istype(tracked))
+		return COMPONENT_INCOMPATIBLE
+	src.connections = connections
+	src.tracked = tracked
+
+
+/datum/component/connect_loc_behalf/RegisterWithParent()
+	RegisterSignal(tracked, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
+	RegisterSignal(tracked, COMSIG_QDELETING, PROC_REF(handle_tracked_qdel))
+	update_signals()
+
+
+/datum/component/connect_loc_behalf/UnregisterFromParent()
+	unregister_signals()
+	UnregisterSignal(tracked, list(
+		COMSIG_MOVABLE_MOVED,
+		COMSIG_QDELETING,
+	))
+	tracked = null
+
+
+/datum/component/connect_loc_behalf/proc/handle_tracked_qdel()
+	SIGNAL_HANDLER
+	qdel(src)
+
+
+/datum/component/connect_loc_behalf/proc/update_signals()
+	unregister_signals()
+	//You may ask yourself, isn't this just silencing an error?
+	//The answer is yes, but there's no good cheap way to fix it
+	//What happens is the tracked object or hell the listener gets say, deleted, which makes targets[old_loc] return a null
+	//The null results in a bad index, because of course it does
+	//It's not a solvable problem though, since both actions, the destroy and the move, are sourced from the same signal send
+	//And sending a signal should be agnostic of the order of listeners
+	//So we need to either pick the order agnositic, or destroy safe
+	//And I picked destroy safe. Let's hope this is the right path!
+	if(isnull(tracked.loc))
+		return
+
+	tracked_loc = tracked.loc
+
+	for(var/signal in connections)
+		parent.RegisterSignal(tracked_loc, signal, connections[signal])
+
+
+/datum/component/connect_loc_behalf/proc/unregister_signals()
+	if(isnull(tracked_loc))
+		return
+
+	parent.UnregisterSignal(tracked_loc, connections)
+
+	tracked_loc = null
+
+
+/datum/component/connect_loc_behalf/proc/on_moved()
+	SIGNAL_HANDLER
+
+	update_signals()
+

--- a/code/datums/components/swarming.dm
+++ b/code/datums/components/swarming.dm
@@ -3,15 +3,19 @@
 	var/offset_y = 0
 	var/is_swarming = FALSE
 	var/list/swarm_members = list()
+	var/static/list/swarming_loc_connections = list(
+		COMSIG_ATOM_EXITED = PROC_REF(leave_swarm),
+		COMSIG_ATOM_ENTERED = PROC_REF(join_swarm)
+	)
+
 
 /datum/component/swarming/Initialize(max_x = 24, max_y = 24)
 	if(!ismovable(parent))
 		return COMPONENT_INCOMPATIBLE
 	offset_x = rand(-max_x, max_x)
 	offset_y = rand(-max_y, max_y)
+	AddComponent(/datum/component/connect_loc_behalf, parent, swarming_loc_connections)
 
-	RegisterSignal(parent, COMSIG_MOVABLE_CROSSED, PROC_REF(join_swarm))
-	RegisterSignal(parent, COMSIG_MOVABLE_UNCROSSED, PROC_REF(leave_swarm))
 
 /datum/component/swarming/Destroy()
 	for(var/other in swarm_members)
@@ -22,8 +26,11 @@
 	swarm_members = null
 	return ..()
 
-/datum/component/swarming/proc/join_swarm(datum/source, atom/movable/AM)
-	var/datum/component/swarming/other_swarm = AM.GetComponent(/datum/component/swarming)
+
+/datum/component/swarming/proc/join_swarm(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
+	SIGNAL_HANDLER
+
+	var/datum/component/swarming/other_swarm = arrived.GetComponent(/datum/component/swarming)
 	if(!other_swarm)
 		return
 	swarm()
@@ -31,8 +38,11 @@
 	other_swarm.swarm()
 	other_swarm.swarm_members |= src
 
-/datum/component/swarming/proc/leave_swarm(datum/source, atom/movable/AM)
-	var/datum/component/swarming/other_swarm = AM.GetComponent(/datum/component/swarming)
+
+/datum/component/swarming/proc/leave_swarm(datum/source, atom/movable/departed, atom/newLoc)
+	SIGNAL_HANDLER
+
+	var/datum/component/swarming/other_swarm = departed.GetComponent(/datum/component/swarming)
 	if(!other_swarm || !(other_swarm in swarm_members))
 		return
 	swarm_members -= other_swarm
@@ -42,14 +52,17 @@
 	if(!other_swarm.swarm_members.len)
 		other_swarm.unswarm()
 
+
 /datum/component/swarming/proc/swarm()
 	var/atom/movable/owner = parent
 	if(!is_swarming)
 		is_swarming = TRUE
 		animate(owner, pixel_x = owner.pixel_x + offset_x, pixel_y = owner.pixel_y + offset_y, time = 2)
 
+
 /datum/component/swarming/proc/unswarm()
 	var/atom/movable/owner = parent
 	if(is_swarming)
 		animate(owner, pixel_x = owner.pixel_x - offset_x, pixel_y = owner.pixel_y - offset_y, time = 2)
 		is_swarming = FALSE
+

--- a/paradise.dme
+++ b/paradise.dme
@@ -394,6 +394,7 @@
 #include "code\datums\components\boss_music.dm"
 #include "code\datums\components\caltrop.dm"
 #include "code\datums\components\combo_attacks.dm"
+#include "code\datums\components\connect_loc_behalf.dm"
 #include "code\datums\components\connect_mob_behalf.dm"
 #include "code\datums\components\contsruction_regenerate.dm"
 #include "code\datums\components\cross_shock.dm"


### PR DESCRIPTION
## Описание
Компонент стаи переписан для взаимодействия с новым компонентом connect_loc_behalf.

Это часть более масштабного рефактора, дабы отказаться от проков Crossed/Uncrossed. Данные проки оверрайднуты не более чем у двух десятков объектов, но в то же время мы постоянно вызываем их в коде передвижения. Отказ в пользу сигналов поможет снизить нагрузку.