### PR TITLE
bugfix: Change flash's null center to get_turf

### DIFF
--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -158,14 +158,14 @@
 	if(!try_use_flash(user))
 		return FALSE
 	user.visible_message("<span class='disarm'>[user]'s [src.name] emits a blinding light!</span>", "<span class='danger'>Your [src.name] emits a blinding light!</span>")
-	for(var/mob/living/carbon/M in oviewers(3, null))
+	for(var/mob/living/carbon/M in oviewers(3, get_turf(src)))
 		flash_carbon(M, user, 6 SECONDS, FALSE)
 
 
 /obj/item/flash/emp_act(severity)
 	if(!try_use_flash())
 		return FALSE
-	for(var/mob/living/carbon/M in viewers(3, null))
+	for(var/mob/living/carbon/M in viewers(3, get_turf(src)))
 		flash_carbon(M, null, 20 SECONDS, FALSE)
 	burn_out()
 	..()

--- a/code/game/objects/items/devices/memorizer.dm
+++ b/code/game/objects/items/devices/memorizer.dm
@@ -136,14 +136,14 @@
 	if(!try_use_flash(user))
 		return FALSE
 	user.visible_message("<span class='disarm'>[user]'s [src.name] emits a blinding light!</span>", "<span class='danger'>Your [src.name] emits a blinding light!</span>")
-	for(var/mob/living/carbon/fucking_target in oviewers(3, null))
+	for(var/mob/living/carbon/fucking_target in oviewers(3, get_turf(src)))
 		memorize_carbon(fucking_target, user, 3, FALSE)
 
 
 /obj/item/memorizer/emp_act(severity)
 	if(!try_use_flash())
 		return FALSE
-	for(var/mob/living/carbon/fucking_target in viewers(3, null))
+	for(var/mob/living/carbon/fucking_target in viewers(3, get_turf(src)))
 		memorize_carbon(fucking_target, null, 10, TRUE)
 	burn_out()
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Меняет центр флешки с `null` на турф, где флешка была использована.

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
[Ссылка на баг-репорт](https://discord.com/channels/617003227182792704/1256551825436577862/1256551825436577862)

https://github.com/ss220-space/Paradise/assets/87372121/3aa7c7e2-a1c4-46b6-a672-85e424f86e73

![image](https://github.com/ss220-space/Paradise/assets/87372121/a2a878bf-94fd-4df3-930e-bb899f349ef1)