### PR TITLE
refactor: CanExit Removal

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -241,10 +241,6 @@
 
 /////////////////
 
-///from base of area/Entered(): (/area)
-#define COMSIG_ENTER_AREA "enter_area"
-///from base of area/Exited(): (/area)
-#define COMSIG_EXIT_AREA "exit_area"
 ///from base of atom/Click(): (location, control, params, mob/user)
 #define COMSIG_CLICK "atom_click"
 ///from base of atom/ShiftClick(): (/mob)
@@ -266,13 +262,13 @@
 
 ///from base of area/proc/power_change(): ()
 #define COMSIG_AREA_POWER_CHANGE "area_power_change"
-///from base of area/Entered(): (atom/movable/M)
+///from base of area/Entered(): (atom/movable/arrived, area/old_area)
 #define COMSIG_AREA_ENTERED "area_entered"
-///from base of area/Exited(): (atom/movable/M)
+///from base of area/Exited(): (atom/movable/departed, area/new_area)
 #define COMSIG_AREA_EXITED "area_exited"
-///from base of area/Entered(): (atom/movable/M)
+///from base of area/Entered(): (area/current_area, area/old_area)
 #define COMSIG_ATOM_ENTERED_AREA "atom_entered_area"
-///from base of area/Exited(): (atom/movable/M)
+///from base of area/Exited(): (area/current_area, area/new_area)
 #define COMSIG_ATOM_EXITED_AREA "atom_exited_area"
 
 // /turf signals

--- a/code/datums/elements/connect_loc.dm
+++ b/code/datums/elements/connect_loc.dm
@@ -7,9 +7,10 @@
 	/// An assoc list of signal -> procpath to register to the loc this object is on.
 	var/list/connections
 
+
 /datum/element/connect_loc/Attach(atom/movable/listener, list/connections)
 	. = ..()
-	if (!istype(listener))
+	if(!istype(listener))
 		return ELEMENT_INCOMPATIBLE
 
 	src.connections = connections
@@ -17,19 +18,22 @@
 	RegisterSignal(listener, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved), override = TRUE)
 	update_signals(listener)
 
+
 /datum/element/connect_loc/Detach(atom/movable/listener)
 	. = ..()
 	unregister_signals(listener, listener.loc)
 	UnregisterSignal(listener, COMSIG_MOVABLE_MOVED)
 
+
 /datum/element/connect_loc/proc/update_signals(atom/movable/listener)
-	var/atom/listener_loc = listener.loc
-	if(isnull(listener_loc))
+	var/atom/listener_loc = listener?.loc
+	if(QDELETED(listener) || QDELETED(listener_loc))
 		return
 
-	for (var/signal in connections)
+	for(var/signal in connections)
 		//override=TRUE because more than one connect_loc element instance tracked object can be on the same loc
 		listener.RegisterSignal(listener_loc, signal, connections[signal], override=TRUE)
+
 
 /datum/element/connect_loc/proc/unregister_signals(datum/listener, atom/old_loc)
 	if(isnull(old_loc))
@@ -37,7 +41,9 @@
 
 	listener.UnregisterSignal(old_loc, connections)
 
+
 /datum/element/connect_loc/proc/on_moved(atom/movable/listener, atom/old_loc)
 	SIGNAL_HANDLER
 	unregister_signals(listener, old_loc)
 	update_signals(listener)
+

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -521,23 +521,14 @@
 			used_environ += amount
 
 
-/area/Entered(atom/movable/arrived)
+/area/Entered(atom/movable/arrived, area/old_area)
 
-	SEND_SIGNAL(src, COMSIG_AREA_ENTERED, arrived)
-	SEND_SIGNAL(arrived, COMSIG_ATOM_ENTERED_AREA, src)
-
-	var/area/newarea
-	var/area/oldarea
+	SEND_SIGNAL(src, COMSIG_AREA_ENTERED, arrived, old_area)
+	SEND_SIGNAL(arrived, COMSIG_ATOM_ENTERED_AREA, src, old_area)
 
 	if(ismob(arrived))
 		var/mob/arrived_mob = arrived
-
-		if(!arrived_mob.lastarea)
-			arrived_mob.lastarea = get_area(arrived_mob)
-		newarea = get_area(arrived_mob)
-		oldarea = arrived_mob.lastarea
-
-		if(newarea != oldarea)
+		if(!arrived_mob.lastarea || old_area != src)
 			arrived_mob.lastarea = src
 
 	if(!isliving(arrived))
@@ -558,9 +549,9 @@
 	else if(!(our_client.prefs.sound & SOUND_BUZZ))
 		our_client.ambience_playing = FALSE
 
-/area/Exited(atom/movable/departed)
-	SEND_SIGNAL(src, COMSIG_AREA_EXITED, departed)
-	SEND_SIGNAL(departed, COMSIG_ATOM_EXITED_AREA, src)
+/area/Exited(atom/movable/departed, area/new_area)
+	SEND_SIGNAL(src, COMSIG_AREA_EXITED, departed, new_area)
+	SEND_SIGNAL(departed, COMSIG_ATOM_EXITED_AREA, src, new_area)
 
 /area/proc/gravitychange()
 	for(var/mob/living/carbon/human/user in src)

--- a/code/game/area/vision_reset_areas.dm
+++ b/code/game/area/vision_reset_areas.dm
@@ -6,7 +6,7 @@
 
 /area/vision_change_area
 
-/area/vision_change_area/Entered(atom/movable/arrived)
+/area/vision_change_area/Entered(atom/movable/arrived, area/old_area)
 	. = ..()
 	if(iscarbon(arrived))
 		var/mob/living/carbon/C = arrived
@@ -17,7 +17,7 @@
 		C.sync_lighting_plane_alpha()
 		C.AddComponent(/datum/component/vision_reset)
 
-/area/vision_change_area/Exited(atom/movable/departed)
+/area/vision_change_area/Exited(atom/movable/departed, area/new_area)
 	. = ..()
 	if(iscarbon(departed))
 		var/mob/living/carbon/carbon = departed

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1545,13 +1545,6 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 	return !density
 
 
-/// Returns true or false to allow the mover to exit turf with src
-/atom/proc/CanExit(atom/movable/mover, moving_direction)
-	SHOULD_CALL_PARENT(TRUE)
-	SHOULD_BE_PURE(TRUE)
-	return TRUE
-
-
 /**
  * Returns `TRUE` if this atom has gravity for the passed in turf
  *

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -959,9 +959,9 @@
 			if(z_move_flags & ZMOVE_FEEDBACK)
 				to_chat(rider || src, span_warning("There's nowhere to go in that direction!"))
 			return FALSE
-	if(z_move_flags & ZMOVE_FALL_CHECKS && (throwing || (movement_type & MOVETYPES_NOT_TOUCHING_GROUND) || !has_gravity(start)))
+	if(z_move_flags & ZMOVE_FALL_CHECKS && (throwing || (movement_type & (FLYING|FLOATING)) || !has_gravity(start)))
 		return FALSE
-	if(z_move_flags & ZMOVE_CAN_FLY_CHECKS && (movement_type & MOVETYPES_NOT_TOUCHING_GROUND) && has_gravity(start))
+	if(z_move_flags & ZMOVE_CAN_FLY_CHECKS && (movement_type & (FLYING|FLOATING)) && has_gravity(start))
 		if(z_move_flags & ZMOVE_FEEDBACK)
 			if(rider)
 				to_chat(rider, span_notice("[src] is not capable of flight."))

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -3,6 +3,7 @@
 	desc = "Basic railing meant to protect idiots like you from falling."
 	icon = 'icons/obj/fence.dmi'
 	icon_state = "railing"
+	flags = ON_BORDER
 	density = TRUE
 	anchored = TRUE
 	pass_flags_self = LETPASSTHROW|PASSFENCE
@@ -12,6 +13,18 @@
 	var/currently_climbed = FALSE
 	var/buildstacktype = /obj/item/stack/rods
 	var/buildstackamount = 3
+
+
+/obj/structure/railing/Initialize(mapload)
+	. = ..()
+	handle_layer()
+
+	if(density) // blocks normal movement from and to the direction it's facing.
+		var/static/list/loc_connections = list(
+			COMSIG_ATOM_EXIT = PROC_REF(on_exit),
+		)
+		AddElement(/datum/element/connect_loc, loc_connections)
+
 
 /obj/structure/railing/corner //aesthetic corner sharp edges hurt oof ouch
 	icon_state = "railing_corner"
@@ -77,24 +90,27 @@
 	return ..()
 
 
-/obj/structure/railing/CanExit(atom/movable/mover, moving_direction)
-	. = ..()
+/obj/structure/railing/proc/on_exit(datum/source, atom/movable/leaving, atom/newLoc)
+	SIGNAL_HANDLER
+
 	if(!density)
-		return TRUE
-	if(checkpass(mover, PASSFENCE))
-		return TRUE
-	if(mover.throwing)
-		return TRUE
-	if(isprojectile(mover))
-		return TRUE
-	if(mover.movement_type & (PHASING|MOVETYPES_NOT_TOUCHING_GROUND))
-		return TRUE
-	if(mover.move_force >= MOVE_FORCE_EXTREMELY_STRONG)
-		return TRUE
+		return
+	if(leaving == src)
+		return // Let's not block ourselves.
+	if(leaving.throwing)
+		return
+	if(checkpass(leaving, PASSFENCE))
+		return
+	if(leaving.movement_type & (PHASING|MOVETYPES_NOT_TOUCHING_GROUND))
+		return
+	if(leaving.move_force >= MOVE_FORCE_EXTREMELY_STRONG)
+		return
 	if(currently_climbed)
-		return TRUE
-	if(dir & moving_direction)
-		return FALSE
+		return
+	if(!(get_dir(leaving, newLoc) & dir))
+		return
+	leaving.Bump(src)
+	return COMPONENT_ATOM_BLOCK_EXIT
 
 
 /obj/structure/railing/do_climb(mob/living/user)
@@ -134,9 +150,6 @@
 	if(can_be_rotated(user))
 		setDir(turn(dir, 45))
 
-/obj/structure/railing/Initialize(mapload) //Only for mappers
-	..()
-	handle_layer()
 
 /obj/structure/railing/setDir(newdir)
 	. = ..()
@@ -160,7 +173,6 @@
 	resistance_flags = FLAMMABLE
 	climbable = TRUE
 	can_be_unanchored = TRUE
-	flags = ON_BORDER
 	buildstacktype = /obj/item/stack/sheet/wood
 	buildstackamount = 5
 

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -41,6 +41,12 @@
 	ini_dir = dir
 	air_update_turf(1)
 
+	var/static/list/loc_connections = list(
+		COMSIG_ATOM_EXIT = PROC_REF(on_exit),
+	)
+	AddElement(/datum/element/connect_loc, loc_connections)
+
+
 /obj/structure/windoor_assembly/Destroy()
 	set_density(FALSE)
 	QDEL_NULL(electronics)
@@ -76,14 +82,24 @@
 /obj/structure/windoor_assembly/CanAtmosPass(turf/T, vertical)
 	if(get_dir(loc, T) == dir)
 		return !density
-	else
-		return 1
+	return TRUE
 
 
-/obj/structure/windoor_assembly/CanExit(atom/movable/mover, moving_direction)
-	. = ..()
-	if(dir == moving_direction)
-		return !density || checkpass(mover, PASSGLASS)
+/obj/structure/windoor_assembly/proc/on_exit(datum/source, atom/movable/leaving, atom/newLoc)
+	SIGNAL_HANDLER
+
+	if(leaving.movement_type & PHASING)
+		return
+
+	if(leaving == src)
+		return // Let's not block ourselves.
+
+	if(leaving.pass_flags == PASSEVERYTHING || (pass_flags_self & leaving.pass_flags) || ((pass_flags_self & LETPASSTHROW) && leaving.throwing))
+		return
+
+	if(density && dir == get_dir(leaving, newLoc))
+		leaving.Bump(src)
+		return COMPONENT_ATOM_BLOCK_EXIT
 
 
 /obj/structure/windoor_assembly/attack_hand(mob/user)
@@ -183,28 +199,21 @@
 		for(var/obj/machinery/door/window/WD in loc)
 			if(WD.dir == dir)
 				return
-		set_density(TRUE) //Shouldn't matter but just incase
 		to_chat(user, "<span class='notice'>You finish the [(src.secure) ? "secure" : ""] windoor.</span>")
 		var/obj/machinery/door/window/windoor
 		if(secure)
-			windoor = new /obj/machinery/door/window/brigdoor(src.loc)
+			windoor = new /obj/machinery/door/window/brigdoor(loc, dir)
 			if(facing == "l")
-				windoor.icon_state = "leftsecureopen"
 				windoor.base_state = "leftsecure"
 			else
-				windoor.icon_state = "rightsecureopen"
 				windoor.base_state = "rightsecure"
 		else
-			windoor = new /obj/machinery/door/window(loc)
+			windoor = new /obj/machinery/door/window(loc, dir)
 			if(facing == "l")
-				windoor.icon_state = "leftopen"
 				windoor.base_state = "left"
 			else
-				windoor.icon_state = "rightopen"
 				windoor.base_state = "right"
-		windoor.setDir(dir)
-		windoor.set_density(FALSE)
-
+		windoor.update_icon(UPDATE_ICON_STATE)
 		windoor.unres_sides = electronics.unres_access_from
 		windoor.req_access = electronics.selected_accesses
 		windoor.check_one_access = electronics.one_access

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -53,24 +53,6 @@ GLOBAL_LIST_INIT(wcCommon, pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e",
 	var/breaksound = "shatter"
 	var/hitsound = 'sound/effects/glasshit.ogg'
 
-/obj/structure/window/examine(mob/user)
-	. = ..()
-	if(reinf)
-		if(anchored && state == WINDOW_SCREWED_TO_FRAME)
-			. += "<span class='notice'>The window is <b>screwed</b> to the frame.</span>"
-		else if(anchored && state == WINDOW_IN_FRAME)
-			. += "<span class='notice'>The window is <i>unscrewed</i> but <b>pried</b> into the frame.</span>"
-		else if(anchored && state == WINDOW_OUT_OF_FRAME)
-			. += "<span class='notice'>The window is out of the frame, but could be <i>pried</i> in. It is <b>screwed</b> to the floor.</span>"
-		else if(!anchored)
-			. += "<span class='notice'>The window is <i>unscrewed</i> from the floor, and could be deconstructed by <b>wrenching</b>.</span>"
-	else
-		if(anchored)
-			. += "<span class='notice'>The window is <b>screwed</b> to the floor.</span>"
-		else
-			. += "<span class='notice'>The window is <i>unscrewed</i> from the floor, and could be deconstructed by <b>wrenching</b>.</span>"
-	if(!anchored && !fulltile)
-		. += "<span class='notice'>Alt-click to rotate it.</span>"
 
 /obj/structure/window/Initialize(mapload, direct)
 	. = ..()
@@ -112,6 +94,39 @@ GLOBAL_LIST_INIT(wcCommon, pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e",
 	explosion_block = EXPLOSION_BLOCK_PROC
 
 	air_update_turf(TRUE)
+
+	var/static/list/loc_connections = list(
+		COMSIG_ATOM_EXIT = PROC_REF(on_exit),
+	)
+	AddElement(/datum/element/connect_loc, loc_connections)
+
+
+/obj/structure/window/Destroy()
+	set_density(FALSE)
+	air_update_turf(1)
+	update_nearby_icons()
+	return ..()
+
+
+/obj/structure/window/examine(mob/user)
+	. = ..()
+	if(reinf)
+		if(anchored && state == WINDOW_SCREWED_TO_FRAME)
+			. += "<span class='notice'>The window is <b>screwed</b> to the frame.</span>"
+		else if(anchored && state == WINDOW_IN_FRAME)
+			. += "<span class='notice'>The window is <i>unscrewed</i> but <b>pried</b> into the frame.</span>"
+		else if(anchored && state == WINDOW_OUT_OF_FRAME)
+			. += "<span class='notice'>The window is out of the frame, but could be <i>pried</i> in. It is <b>screwed</b> to the floor.</span>"
+		else if(!anchored)
+			. += "<span class='notice'>The window is <i>unscrewed</i> from the floor, and could be deconstructed by <b>wrenching</b>.</span>"
+	else
+		if(anchored)
+			. += "<span class='notice'>The window is <b>screwed</b> to the floor.</span>"
+		else
+			. += "<span class='notice'>The window is <i>unscrewed</i> from the floor, and could be deconstructed by <b>wrenching</b>.</span>"
+	if(!anchored && !fulltile)
+		. += "<span class='notice'>Alt-click to rotate it.</span>"
+
 
 /obj/structure/window/narsie_act()
 	color = NARSIE_WINDOW_COLOUR
@@ -157,10 +172,24 @@ GLOBAL_LIST_INIT(wcCommon, pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e",
 	return TRUE
 
 
-/obj/structure/window/CanExit(atom/movable/mover, moving_direction)
-	. = ..()
-	if(dir == moving_direction)
-		return !density || checkpass(mover, PASSGLASS)
+/obj/structure/window/proc/on_exit(datum/source, atom/movable/leaving, atom/newLoc)
+	SIGNAL_HANDLER
+
+	if(leaving.movement_type & PHASING)
+		return
+
+	if(leaving == src)
+		return // Let's not block ourselves.
+
+	if(pass_flags_self & leaving.pass_flags)
+		return
+
+	if(fulltile || dir == FULLTILE_WINDOW_DIR)
+		return
+
+	if(density && dir == get_dir(leaving, newLoc))
+		leaving.Bump(src)
+		return COMPONENT_ATOM_BLOCK_EXIT
 
 
 /obj/structure/window/CanPathfindPass(obj/item/card/id/ID, to_dir, atom/movable/caller, no_id = FALSE)
@@ -467,11 +496,6 @@ GLOBAL_LIST_INIT(wcCommon, pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e",
 	add_fingerprint(user)
 	return TRUE
 
-/obj/structure/window/Destroy()
-	set_density(FALSE)
-	air_update_turf(1)
-	update_nearby_icons()
-	return ..()
 
 /obj/structure/window/Move(atom/newloc, direct = NONE, glide_size_override = 0, update_dir = TRUE)
 	var/turf/T = loc

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -198,18 +198,6 @@
 	// but not runtime when something gets deleted by a Bump/CanPass/Cross call
 
 	var/atom/mover_loc = mover.loc
-
-	// First, make sure it can leave its square
-	if(isturf(mover_loc))
-		// Nothing but border objects stop you from leaving a tile, only one loop is needed
-		var/movement_dir = get_dir(mover, src)
-		for(var/obj/obstacle in mover_loc)
-			if(obstacle == mover)
-				continue
-			if(!obstacle.CanExit(mover, movement_dir))
-				mover.Bump(obstacle)
-				return FALSE
-
 	var/border_dir = get_dir(src, mover)
 	var/can_pass_self = CanPass(mover, border_dir)
 	var/atom/movable/tompost_bump
@@ -794,15 +782,6 @@
 	// Prevents jaunting onto the AI core cheese, AI should always block a turf due to being a dense mob even when unanchored
 	if(locate(/mob/living/silicon/ai) in contents)
 		return TRUE
-
-	// in case of source_atom we are also checking if it can exit its turf contents
-	if(source_atom && isturf(source_atom.loc) && source_atom.loc != src)
-		var/movement_dir = get_dir(source_atom, src)
-		for(var/obj/obstacle in source_atom.loc)
-			if(obstacle == source_atom)
-				continue
-			if(!obstacle.CanExit(source_atom, movement_dir))
-				return TRUE
 
 	for(var/atom/movable/movable_content as anything in contents)
 		// We don't want to block ourselves

--- a/code/modules/awaymissions/mission_code/evil_santa.dm
+++ b/code/modules/awaymissions/mission_code/evil_santa.dm
@@ -158,7 +158,7 @@
 	else
 		UnlockBlastDoors()
 
-/area/vision_change_area/awaymission/evil_santa/end/santa/Entered(mob/living/carbon/naughty)
+/area/vision_change_area/awaymission/evil_santa/end/santa/Entered(mob/living/carbon/naughty, area/old_area)
 	. = ..()
 	if(ismecha(naughty))
 		var/obj/mecha/robot = naughty

--- a/code/modules/awaymissions/mission_code/ruins/USSP_gorky17.dm
+++ b/code/modules/awaymissions/mission_code/ruins/USSP_gorky17.dm
@@ -590,7 +590,7 @@
 	playsound(src, 'sound/effects/empulse.ogg', 80)
 	qdel(C)
 
-/area/ruin/space/USSP_gorky17/collapsed/vault/Entered(mob/living/bourgeois)
+/area/ruin/space/USSP_gorky17/collapsed/vault/Entered(mob/living/bourgeois, area/old_area)
 	. = ..()
 	if(!communism_has_fallen && istype(bourgeois) && !faction_check(bourgeois.faction, safe_faction))
 		var/obj/machinery/syndicatebomb/gorky17/bomb = locate(/obj/machinery/syndicatebomb/gorky17) in src


### PR DESCRIPTION
## Описание
Убираем проверку CanExit() у каждого атома в игре, поскольку её используют меньше десятка объектов. Переведено на элемент connect loc.

Заливать после: https://github.com/ss220-space/Paradise/pull/5245