### PR TITLE
tweak: Makes lattice two-way path block

### DIFF
--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -19,7 +19,7 @@
 	var/compromised_integrity = FALSE
 	var/mob/camera/blob/overmind
 	creates_cover = TRUE
-	obj_flags = BLOCK_Z_OUT_DOWN // stops blob mobs from falling on multiz.
+	obj_flags = BLOCK_Z_OUT_DOWN | BLOCK_Z_IN_UP // stops blob mobs from falling on multiz.
 
 /obj/structure/blob/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -16,7 +16,7 @@
 						/obj/structure/falsewall,
 						/obj/structure/lattice/fireproof)
 	smooth = SMOOTH_MORE
-	obj_flags = BLOCK_Z_OUT_DOWN
+	obj_flags = BLOCK_Z_OUT_DOWN | BLOCK_Z_IN_UP
 
 /obj/structure/lattice/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/structures/wryn.dm
+++ b/code/game/objects/structures/wryn.dm
@@ -71,7 +71,7 @@
 	max_integrity = 10
 	var/current_dir
 	var/static/list/floorImageCache
-	obj_flags = BLOCK_Z_OUT_DOWN
+	obj_flags = BLOCK_Z_OUT_DOWN | BLOCK_Z_IN_UP
 
 
 /obj/structure/wryn/floor/update_overlays()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Даёт флаг `нельзя наверх залезть` у `/obj/structure/lattice` и `/obj/structure/wryn/floor`, что раньше только блочили падание/слезание вниз.

## Ссылка на предложение/Причина создания ПР
[Ссылка](https://discord.com/channels/617003227182792704/943940908162875473/1257052406995353671) на сообщение Биба.

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
