### PR TITLE
tweak: Projectiles Ignore Lying Mobs

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -446,14 +446,20 @@
 
 
 /// Special projectiles handling for living mobs
-/mob/living/proc/projectile_allow_through(obj/item/projectile, border_dir)
-	if(!(mobility_flags & (MOBILITY_REST|MOBILITY_LIEDOWN)))	// default behavior for generic mobs
+/mob/living/proc/projectile_allow_through(obj/item/projectile/projectile, border_dir)
+	// default behavior for generic mobs
+	if(!(mobility_flags & (MOBILITY_REST|MOBILITY_LIEDOWN)))
 		return !density
-	if(stat == DEAD)	// DEAD mobs are fine to skip if they are not dense or lying
+	// DEAD mobs are fine to skip if they are not dense or lying
+	if(stat == DEAD)
 		return !density || body_position == LYING_DOWN
-	if(density || body_position == STANDING_UP)	// always hitting dense/standing mobs
+	// always hitting dense/standing mobs
+	if(density || body_position == STANDING_UP)
 		return FALSE
-	return prob(67)	// 33% to hit lying mobs
+	// otherwise chance to hit is defined by the projectile var/hit_crawling_mobs_chance
+	if(projectile.hit_crawling_mobs_chance > 0 && projectile.hit_crawling_mobs_chance <= 100)
+		return !prob(projectile.hit_crawling_mobs_chance)
+	return FALSE
 
 
 /mob/living/tompost_bump_override(atom/movable/mover, border_dir)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -9,6 +9,7 @@
 	pass_flags = PASSTABLE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	movement_type = FLYING
+	animate_movement = NO_STEPS
 	hitsound = 'sound/weapons/pierce.ogg'
 	var/hitsound_wall = ""
 	/// Body part at which the projectile was aimed.
@@ -42,7 +43,6 @@
 	var/spread = 0
 	/// If set to `TRUE` [/obj/item/hardsuit_taser_proof] upgrage will block this projectile.
 	var/shockbull = FALSE
-	animate_movement = NO_STEPS
 
 	var/ignore_source_check = FALSE
 
@@ -111,6 +111,8 @@
 	var/dismember_limbs = FALSE
 	/// If `TRUE`, projectile with dismemberment will forcefully cut head instead of gibbing them
 	var/dismember_head = FALSE
+	/// Probability to hit lying non-dead mobs
+	var/hit_crawling_mobs_chance = 0
 
 
 /obj/item/projectile/proc/Range()

--- a/code/modules/spacepods/equipment.dm
+++ b/code/modules/spacepods/equipment.dm
@@ -38,10 +38,12 @@
 		projone.firer = usr
 		projone.firer_source_atom = src
 		projone.def_zone = BODY_ZONE_CHEST
+		projone.hit_crawling_mobs_chance = 33	// temporal soulution (or permanent), until weapons targeting rework
 		projtwo.starting = get_turf(my_atom)
 		projtwo.firer = usr
 		projtwo.firer_source_atom = src
 		projtwo.def_zone = BODY_ZONE_CHEST
+		projtwo.hit_crawling_mobs_chance = 33
 		spawn()
 			playsound(src, fire_sound, 50, 1)
 			projone.dumbfire(my_atom.dir)


### PR DESCRIPTION
## Описание
Все снаряды, за исключением стрельбы из орудий спейсподов, теперь игнорируют лежачих мобов.

Добавлена новая переменная, для снарядов, которая позволяет регулировать данный шанс.

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1257605509352263854