### PR TITLE
bugfix: Borg jobs are now showing correctly in announcements

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -423,7 +423,8 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 
 	// --- Cyborg ---
 	else if(isrobot(M))
-		jobname = JOB_TITLE_CYBORG
+		var/mob/living/silicon/robot/R = M
+		jobname = R.mind.role_alt_title ? R.mind.role_alt_title : JOB_TITLE_CYBORG
 		rank = JOB_TITLE_CYBORG
 
 	// --- Personal AI (pAI) ---

--- a/code/modules/mob/living/silicon/ai/ai_say.dm
+++ b/code/modules/mob/living/silicon/ai/ai_say.dm
@@ -33,7 +33,8 @@
 	else if(iscogscarab(speaker))
 		jobname = "Unknown"
 	else if(isrobot(speaker))
-		jobname = JOB_TITLE_CYBORG
+		var/mob/living/silicon/robot/R = speaker
+		jobname = R.mind.role_alt_title ? R.mind.role_alt_title : JOB_TITLE_CYBORG
 	else if(ispAI(speaker))
 		jobname = "Personal AI"
 	else if(isAutoAnnouncer(speaker))

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -465,7 +465,8 @@
 	SSticker.mode.latespawn(character)
 
 	if(character.mind.assigned_role == JOB_TITLE_CYBORG)
-		AnnounceCyborg(character, rank, join_message)
+		var/mob/living/silicon/robot/R = character
+		AnnounceCyborg(character, R.mind.role_alt_title ? R.mind.role_alt_title : JOB_TITLE_CYBORG, join_message)
 	else
 		SSticker.minds += character.mind//Cyborgs and AIs handle this in the transform proc.	//TODO!!!!! ~Carn
 		if(!IsAdminJob(rank))


### PR DESCRIPTION
## Описание
Теперь подпрофессии боргов будут отображаться в рации, при слежке ИИ, анонсах.

## Ссылка на предложение/Причина создания ПР
https://github.com/ss220-space/Paradise/issues/5169
