### PR TITLE
bugfix: BlueShield's gun now stores in cryo

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -253,8 +253,7 @@
 	)
 	// These items will NOT be preserved
 	var/list/do_not_preserve_items = list (
-		/obj/item/mmi/robotic_brain,
-		/obj/item/gun/energy/gun/blueshield
+		/obj/item/mmi/robotic_brain
 	)
 
 //////


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Revert "bugfix: Blueshield gun duplicates (#5282)"
This reverts commit ff8c5cc77c47b512b19f206f3cf55b33e5532294.

## Ссылка на предложение/Причина создания ПР
[Ссылка](https://discord.com/channels/617003227182792704/1257361752719364114/1257361752719364114)
Не ясно почему пушка в крио = баг.

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
