### PR TITLE
bugfix: fix Re-incarnate and ninja name after cloning

### DIFF
--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -30,6 +30,7 @@
 	icon_state = "borgcharger1(old)"
 	anchored = TRUE
 	density = TRUE
+	var/use_old_mind = FALSE
 
 /obj/structure/respawner/attack_ghost(mob/dead/observer/user)
 	var/response = alert(user, "Are you sure you want to spawn here?\n(If you do this, you won't be able to be cloned!)", "Respawn?", "Yes", "No")
@@ -37,8 +38,11 @@
 		user.forceMove(get_turf(src))
 		log_admin("[key_name_log(user)] was incarnated by a respawner machine.")
 		message_admins("[key_name_admin(user)] was incarnated by a respawner machine.")
-		var/mob/living/carbon/human/new_human = user.incarnate_ghost()
+		var/mob/living/carbon/human/new_human = user.incarnate_ghost(use_old_mind)
 		new_human.mind.offstation_role = TRUE // To prevent them being an antag objective
+
+/obj/structure/respawner/old_mind
+	use_old_mind = TRUE
 
 /obj/structure/ghost_beacon
 	name = "ethereal beacon"

--- a/code/modules/antagonists/space_ninja/machinery/ninja_cloning.dm
+++ b/code/modules/antagonists/space_ninja/machinery/ninja_cloning.dm
@@ -66,7 +66,9 @@
 	attempting = TRUE //One at a time!!
 	icon_state = "ninja_cloning_on"
 	ninja_ghost.forceMove(src.loc)
-	ninja = ninja_ghost.incarnate_ghost()
+	ninja = ninja_ghost.incarnate_ghost(TRUE)
+	ninja.real_name = ninja.mind.name
+	ninja.name = ninja.mind.name
 	var/datum/antagonist/ninja/ninja_datum = ninja.mind.has_antag_datum(/datum/antagonist/ninja)
 	ninja_datum.equip_ninja()
 	ninja.forceMove(src)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -686,13 +686,13 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	return TRUE
 
 
-/mob/dead/observer/proc/incarnate_ghost()
+/mob/dead/observer/proc/incarnate_ghost(use_old_mind=FALSE)
 	if(!client)
 		return
 
 	var/mob/living/carbon/human/new_char = new(get_turf(src))
 	client.prefs.copy_to(new_char)
-	if(mind)
+	if(mind && use_old_mind)
 		mind.active = TRUE
 		mind.transfer_to(new_char)
 	else


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Исправление багогенератора под названием админская кнопка Re-incarnate, которая при создании новой куклы использовала майнд от старой, перенося на новую куклу всякий ненужный мусор(датумы антагов, би и прочее). У клонерки ниндзя остается старый вариант инкарнейта. Щитспавновая клонилка-респавнилка теперь так же создает новый майнд, однако для спавна был добавлен так же вариант, который использует старый майнд.
Так же поправлен баг, из-за которого после воскрешения в клонерке ниндзя у того было имя из префов, заместо того, которое он выбрал при появлении.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Исправление 2 багов. Первый очень много проблем при использовании кнопки админами. Второй просто немного ломает логику.
Репорт на второй баг https://discord.com/channels/617003227182792704/1230624467693076491/1230624467693076491
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

