### PR TITLE
bugfix: fix incorrect shadowlings announcement threshold

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -2338,8 +2338,8 @@
 					to_chat(usr, "<span class='warning'>This only works on humans!</span>")
 					return
 				SSticker.mode.shadows += src
-				SSticker.mode.recount_required_thralls()
 				special_role = SPECIAL_ROLE_SHADOWLING
+				SSticker.mode.recount_required_thralls()
 				to_chat(current, "<span class='shadowling'><b>Something stirs deep in your mind. A red light floods your vision, and slowly you remember. Though your human disguise has served you well, the \
 				time is nigh to cast it off and enter your true form. You have disguised yourself amongst the humans, but you are not one of them. You are a shadowling, and you are to ascend at all costs.\
 				</b></span>")

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -2338,6 +2338,7 @@
 					to_chat(usr, "<span class='warning'>This only works on humans!</span>")
 					return
 				SSticker.mode.shadows += src
+				SSticker.mode.recount_required_thralls()
 				special_role = SPECIAL_ROLE_SHADOWLING
 				to_chat(current, "<span class='shadowling'><b>Something stirs deep in your mind. A red light floods your vision, and slowly you remember. Though your human disguise has served you well, the \
 				time is nigh to cast it off and enter your true form. You have disguised yourself amongst the humans, but you are not one of them. You are a shadowling, and you are to ascend at all costs.\

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -99,11 +99,7 @@ Made by Xhuis
 		shadow.restricted_roles = restricted_jobs
 		shadowlings--
 
-	var/thrall_scaling = round(num_players() / 3)
-	required_thralls = clamp(thrall_scaling, 15, 25)
-	thrall_ratio = required_thralls / 15
-
-	warning_threshold = round(0.66 * required_thralls)
+	recount_required_thralls()
 
 	..()
 	return 1
@@ -339,3 +335,10 @@ Made by Xhuis
 	var/datum/atom_hud/antag/shadow_hud = GLOB.huds[ANTAG_HUD_SHADOW]
 	shadow_hud.leave_hud(shadow_mind.current)
 	set_antag_hud(shadow_mind.current, null)
+
+
+/datum/game_mode/proc/recount_required_thralls()
+	var/thrall_scaling = round(num_players() / 3)
+	required_thralls = clamp(thrall_scaling, 15, 25)
+	thrall_ratio = required_thralls / 15
+	warning_threshold = round(0.66 * required_thralls)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Исправляет преждевременное возникновение анонса о неминуемом возвышении тенелингов, происходящее при конверте рабов тенями, роль которым была выдана через трейтор панель вне режима тенелингов.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Исправление бага, который не дает полноценно играть теням, которым роль выдал админ вне режима тенелингов.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
