### PR TITLE
bugfix: Syndie teleport no longer gibs you in openspace

### DIFF
--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -324,7 +324,7 @@ effective or pretty fucking useless.
 
 
 /obj/item/teleporter/proc/tile_check(turf/check_turf)
-	return isfloorturf(check_turf) || isspaceturf(check_turf)
+	return isfloorturf(check_turf) || isspaceturf(check_turf) || isopenspaceturf(check_turf)
 
 
 /obj/item/teleporter/proc/dir_correction(mob/user) //Direction movement, screws with teleport distance and saving throw, and thus must be removed first


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
PR исправляет ошибку, при которой попытка прыгнуть на телепортере в openspace гибает пользователя
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
