### PR TITLE
bugfix: Fixed mind transfer potion on cortial borer

### DIFF
--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -147,6 +147,10 @@
 		return
 	transfer_personality(user.client)
 
+/mob/living/simple_animal/borer/sentience_act()
+	GrantBorerSpells()
+	hide_borer()
+
 /mob/living/simple_animal/borer/Stat()
 	..()
 	statpanel("Status")

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -391,10 +391,6 @@
 		if(!GLOB.med_hud_users.Find(SM))
 			var/datum/atom_hud/medsensor = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
 			medsensor.add_hud_to(SM)
-	if(istype(SM, /mob/living/simple_animal/borer))
-		var/mob/living/simple_animal/borer/B = SM
-		B.GrantBorerSpells()
-		B.hide_borer()
 	qdel(src)
 
 /obj/item/slimepotion/slime/steroid

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -391,6 +391,10 @@
 		if(!GLOB.med_hud_users.Find(SM))
 			var/datum/atom_hud/medsensor = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
 			medsensor.add_hud_to(SM)
+	if(istype(SM, /mob/living/simple_animal/borer))
+		var/mob/living/simple_animal/borer/B = SM
+		B.GrantBorerSpells()
+		B.hide_borer()
 	qdel(src)
 
 /obj/item/slimepotion/slime/steroid


### PR DESCRIPTION
## Описание
теперь борер получает свои способности при использовании на нем зелья переноса разума.. 

## Ссылка на предложение/Причина создания ПР
борер не получает способности при переносе сознания в него зельем разума.
