### PR TITLE
bugfix: Fakedeath Removes Sleeping Overlay

### DIFF
--- a/code/__DEFINES/logs.dm
+++ b/code/__DEFINES/logs.dm
@@ -30,7 +30,6 @@
 #define INVESTIGATE_RESEARCH "research"
 #define INVESTIGATE_SYNDIE_CARGO "syndicate_cargo"
 #define INVESTIGATE_WIRES "wires"
-#define INVESTIGATE_DEATHS "deaths"
 
 //This is an external call, "true" and "false" are how rust parses out booleans
 #define WRITE_LOG(log, text) rustg_log_write(log, text, "true")

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1331,7 +1331,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 
 
 /mob/living/carbon/human/update_unconscious_overlay()
-	if(stat == UNCONSCIOUS)
+	if(stat == UNCONSCIOUS && !HAS_TRAIT(src, TRAIT_FAKEDEATH))
 		var/mutable_appearance/sleep_effect = mutable_appearance('icons/effects/effects.dmi', "sleep", -SLEEP_LAYER, appearance_flags = KEEP_APART|RESET_TRANSFORM|RESET_COLOR)
 		sleep_effect.pixel_z = 8
 		overlays_standing[SLEEP_LAYER] = sleep_effect


### PR DESCRIPTION
## Описание
Скрытие оверлея сна, при наличии трейта фальшивой смерти.

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1260300394949775583