### PR TITLE
bugfix: no more bursts in l6_saw

### DIFF
--- a/code/modules/projectiles/guns/projectile/saw.dm
+++ b/code/modules/projectiles/guns/projectile/saw.dm
@@ -14,6 +14,8 @@
 	var/cover_open = 0
 	can_suppress = 0
 	fire_delay = 1
+	burst_size = 1
+	actions_types = null
 
 /obj/item/gun/projectile/automatic/l6_saw/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Чинит баг, когда можно было нажимать на кнопку смены очереди на пулемете и усиливать мощность автоматического огня (и количество лагов от нее)
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багфикс
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
