### PR TITLE
tweak/bugfix: robotic organ removal

### DIFF
--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -527,7 +527,7 @@
 			organs -= O
 			organs[O.name] = O
 
-			I = tgui_input_list(user, "Remove which organ?", "Surgery", organs)
+		I = tgui_input_list(user, "Remove which organ?", "Surgery", organs)
 		if(I && user && target && user.Adjacent(target) && user.get_active_hand() == tool)
 			I = organs[I]
 			if(!I)


### PR DESCRIPTION
## Описание
При извлечении органов или имплантов из роботизированных частей тела ГУИ выбора "органа" всплывала столько раз, сколько в части тела органов.
Фиским этот случайный пробел.

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1261385313893355612/1261385313893355612

## Демонстрация изменений
ГУИ при извлечении органа из роботизированной части всплывает только один раз.
