### PR TITLE
bugfix: AI PDA Messages Fix

### DIFF
--- a/code/modules/pda/PDA.dm
+++ b/code/modules/pda/PDA.dm
@@ -118,7 +118,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	if(loc != user)
 		return FALSE
 
-	if(user.incapacitated() || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
+	if(user.incapacitated() || (!(isAI(user) || ispAI(user))) && HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 		return FALSE
 
 	return TRUE

--- a/code/modules/pda/PDA.dm
+++ b/code/modules/pda/PDA.dm
@@ -118,7 +118,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	if(loc != user)
 		return FALSE
 
-	if(user.incapacitated() || (!(isAI(user) || ispAI(user))) && HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
+	if(user.incapacitated() || !isAI(user) && HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 		return FALSE
 
 	return TRUE


### PR DESCRIPTION
## Описание
ИИ и по всей видимости пИИ не могли пользоваться сообщениями ПДА из-за того, что у них нет рук. Руки мы им не даём, но своими ПДА пользоваться разрешаем.
Отдельное спасибо Den10901 за подсказку как красивее расписать условие в одну строку.

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1260661470262202389/1260661470262202389

