### PR TITLE
bugfix: fixes table smoothing after unflipping

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -452,6 +452,8 @@
 			other_table.unflip()
 	dir = initial(dir)
 	update_icon(UPDATE_ICON_STATE)
+	queue_smooth(src)
+	queue_smooth_neighbors(src)
 
 	creates_cover = TRUE
 	if(isturf(loc))


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление ошибки, при которой обратный переворот стола не смузил столы между собой. Увы
