### PR TITLE
bugfix: Registered Turf Signals Stay Registered

### DIFF
--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -67,6 +67,15 @@
 				qdel(single_comp, FALSE)
 		components.Cut()
 
+	_clear_signal_refs()
+	//END: ECS SHIT
+
+	return QDEL_HINT_QUEUE
+
+
+///Only override this if you know what you're doing. You do not know what you're doing
+///This is a threat
+/datum/proc/_clear_signal_refs()
 	var/list/lookup = comp_lookup
 	if(lookup)
 		for(var/sig in lookup)
@@ -81,9 +90,6 @@
 
 	for(var/target in signal_procs)
 		UnregisterSignal(target, signal_procs[target])
-	//END: ECS SHIT
-
-	return QDEL_HINT_QUEUE
 
 
 /datum/nothing

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -200,7 +200,7 @@
 	if(istype(T.loc, /area/shuttle/syndicate_elite) || istype(T.loc, /area/syndicate_mothership))
 		return TRUE
 
-/atom/Destroy()
+/atom/Destroy(force)
 	if(alternate_appearances)
 		for(var/aakey in alternate_appearances)
 			var/datum/alternate_appearance/AA = alternate_appearances[aakey]
@@ -208,10 +208,16 @@
 		alternate_appearances = null
 
 	QDEL_NULL(reagents)
-	invisibility = INVISIBILITY_ABSTRACT
-	LAZYCLEARLIST(overlays)
+
+	// Checking length(overlays) before cutting has significant speed benefits
+	if(length(overlays))
+		overlays.Cut()
+
+	LAZYNULL(managed_overlays)
 
 	QDEL_NULL(light)
+	if(length(light_sources))
+		light_sources.Cut()
 
 	return ..()
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -160,6 +160,8 @@
 	if(opacity)
 		RemoveElement(/datum/element/light_blocking)
 
+	invisibility = INVISIBILITY_ABSTRACT
+
 	if(pulledby)
 		pulledby.stop_pulling()
 	if(pulling)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -151,6 +151,18 @@
 	initialized = FALSE
 	..()
 
+	if(length(vis_contents))
+		vis_contents.Cut()
+
+
+/// WARNING WARNING
+/// Turfs DO NOT lose their signals when they get replaced, REMEMBER THIS
+/// It's possible because turfs are fucked, and if you have one in a list and it's replaced with another one, the list ref points to the new turf
+/// We do it because moving signals over was needlessly expensive, and bloated a very commonly used bit of code
+/turf/_clear_signal_refs()
+	return
+
+
 /turf/attack_hand(mob/user)
 	SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_HAND, user)
 	user.Move_Pulled(src)


### PR DESCRIPTION
## Описание
Сигналы более не анрегаются с удаляемых турфов.

Требуется длительный тестмерж.