### PR TITLE
bugfix: Returned old bubblegum speed after movement refactor

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -234,7 +234,7 @@ Difficulty: Hard
 	SetRecoveryTime(20)
 
 
-#define BUBLEGUM_CHARGE_SPEED 0.2
+#define BUBLEGUM_CHARGE_SPEED 0.4
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/charge(atom/chargeat = target, delay = 5, chargepast = 2)
 	if(!chargeat)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -234,7 +234,7 @@ Difficulty: Hard
 	SetRecoveryTime(20)
 
 
-#define BUBLEGUM_CHARGE_SPEED 0.7
+#define BUBLEGUM_CHARGE_SPEED 0.2
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/charge(atom/chargeat = target, delay = 5, chargepast = 2)
 	if(!chargeat)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление замедленности бубли после рефактора передвижения. Возвращена примерно та же скорость, что и до рефактора.
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

https://github.com/user-attachments/assets/128e2d96-cbec-4812-92ea-5aac2ac0dcb7


## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->



https://github.com/user-attachments/assets/d5b70cfa-8c7e-47c3-8359-bbbbc70a98d2


