### PR TITLE
bugfix: Fixed negative atmospherics, made lavaland plasma burning nice

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -86,23 +86,28 @@
 			turf_count++//Considered a valid turf for air calcs
 			continue
 		else if(isfloorturf(T))
-			var/turf/simulated/S = T
-			if(S.air)//Add the air's contents to the holders
-				aoxy += S.air.oxygen
-				anitro += S.air.nitrogen
-				aco += S.air.carbon_dioxide
-				atox += S.air.toxins
-				asleep += S.air.sleeping_agent
-				ab += S.air.agent_b
-				atemp += S.air.temperature
+			var/datum/gas_mixture/turf_air = T.return_air()
+			aoxy += turf_air.oxygen
+			anitro += turf_air.nitrogen
+			aco += turf_air.carbon_dioxide
+			atox += turf_air.toxins
+			asleep += turf_air.sleeping_agent
+			ab += turf_air.agent_b
+			atemp += turf_air.temperature
 			turf_count++
-	air.oxygen = (aoxy / max(turf_count, 1)) //Averages contents of the turfs, ignoring walls and the like
-	air.nitrogen = (anitro / max(turf_count, 1))
-	air.carbon_dioxide = (aco / max(turf_count, 1))
-	air.toxins = (atox / max(turf_count, 1))
-	air.sleeping_agent = (asleep / max(turf_count, 1))
-	air.agent_b = (ab / max(turf_count, 1))
-	air.temperature = (atemp / max(turf_count, 1))
+
+	var/datum/gas_mixture/new_air = new
+
+	new_air.oxygen = (aoxy / max(turf_count, 1)) //Averages contents of the turfs, ignoring walls and the like
+	new_air.nitrogen = (anitro / max(turf_count, 1))
+	new_air.carbon_dioxide = (aco / max(turf_count, 1))
+	new_air.toxins = (atox / max(turf_count, 1))
+	new_air.sleeping_agent = (asleep / max(turf_count, 1))
+	new_air.agent_b = (ab / max(turf_count, 1))
+	new_air.temperature = (atemp / max(turf_count, 1))
+
+	air = new_air
+
 	if(SSair)
 		SSair.add_to_active(src)
 

--- a/code/modules/atmospherics/enviromental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/enviromental/LINDA_turf_tile.dm
@@ -258,8 +258,10 @@
 				var/datum/excited_group/EG = new
 				EG.add_turf(src)
 				our_excited_group = excited_group
-			air.share(G, 0)
+			air.share(G, adjacent_turfs_length)
 			LAST_SHARE_CHECK
+		else
+			air = G //Gas difference is so small, so there is no need to process it further.
 
 	air.react()
 

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -86,10 +86,10 @@ What are the archived variables for?
 		if(toxins > MINIMUM_HEAT_CAPACITY && carbon_dioxide > MINIMUM_HEAT_CAPACITY)
 			var/reaction_rate = min(carbon_dioxide * 0.75, toxins * 0.25, agent_b * 0.05)
 
-			carbon_dioxide -= reaction_rate
+			carbon_dioxide = max(carbon_dioxide - reaction_rate, 0)
 			oxygen += reaction_rate
 
-			agent_b -= reaction_rate * 0.05
+			agent_b = max(agent_b - reaction_rate * 0.05, 0)
 
 			temperature += (reaction_rate * 20000) / heat_capacity()
 
@@ -229,12 +229,12 @@ What are the archived variables for?
 	removed.sleeping_agent = QUANTIZE((sleeping_agent / sum) * amount)
 	removed.agent_b = QUANTIZE((agent_b / sum) * amount)
 
-	oxygen -= removed.oxygen
-	nitrogen -= removed.nitrogen
-	carbon_dioxide -= removed.carbon_dioxide
-	toxins -= removed.toxins
-	sleeping_agent -= removed.sleeping_agent
-	agent_b -= removed.agent_b
+	oxygen = max(oxygen - removed.oxygen, 0)
+	nitrogen = max(nitrogen - removed.nitrogen, 0)
+	carbon_dioxide = max(carbon_dioxide - removed.carbon_dioxide, 0)
+	toxins = max(toxins - removed.toxins, 0)
+	sleeping_agent = max(sleeping_agent - removed.sleeping_agent, 0)
+	agent_b = max(agent_b - removed.agent_b, 0)
 
 	removed.temperature = temperature
 
@@ -256,12 +256,12 @@ What are the archived variables for?
 	removed.sleeping_agent = QUANTIZE(sleeping_agent * ratio)
 	removed.agent_b = QUANTIZE(agent_b * ratio)
 
-	oxygen -= removed.oxygen
-	nitrogen -= removed.nitrogen
-	carbon_dioxide -= removed.carbon_dioxide
-	toxins -= removed.toxins
-	sleeping_agent -= removed.sleeping_agent
-	agent_b -= removed.agent_b
+	oxygen = max(oxygen - removed.oxygen, 0)
+	nitrogen = max(nitrogen - removed.nitrogen, 0)
+	carbon_dioxide = max(carbon_dioxide - removed.carbon_dioxide, 0)
+	toxins = max(toxins - removed.toxins, 0)
+	sleeping_agent = max(sleeping_agent - removed.sleeping_agent, 0)
+	agent_b = max(agent_b - removed.agent_b, 0)
 
 	removed.temperature = temperature
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправляет ошибку, при которой в случае сгорании чего либо мог образовываться отрицательный атмос.
Исправляет целостность данных при работе прока assimilate_air.
Теперь лаваленд горит хорошо
Воздух планетарных планет теперь ставится строго таким, какой он есть изначально, если разница незначительна.

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
NaN атмос let's gooooooooooooooooooooooooooooooooooooooooooooooooooo

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
https://github.com/user-attachments/assets/e7d1f1a1-e8b6-45bb-b2f1-f3cb5e322017


