### PR TITLE
bugfix: Fix welding sec-glasses giving you permanent HUD

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -70,7 +70,7 @@
 	if(user && !can_use(user))
 		return FALSE
 
-	if(visor_toggling())
+	if(visor_toggling(user))
 		update_equipped_item(update_speedmods = FALSE)
 		if(user)
 			to_chat(user, span_notice("You adjust [src] [up ? "up" : "down"]."))
@@ -79,7 +79,7 @@
 	return FALSE
 
 
-/obj/item/clothing/proc/visor_toggling() //handles all the actual toggling of flags
+/obj/item/clothing/proc/visor_toggling(mob/user) //handles all the actual toggling of flags
 	if(!can_toggle)
 		return FALSE
 

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -69,7 +69,7 @@
 	return TRUE
 
 
-/obj/item/clothing/glasses/visor_toggling()
+/obj/item/clothing/glasses/visor_toggling(mob/user)
 	. = ..()
 	if(!.)
 		return .


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет проку `visor_toggling()` переменную моба.
Передаём моба в `weldingvisortoggle()`, чтобы очки работали.

## Ссылка на предложение/Причина создания ПР
[Ссылка](https://discord.com/channels/617003227182792704/1263199600987082822/1263199600987082822).
Из-за того что прок не принимал переменные - не обновлялся ХУД у очков.
