### PR TITLE
add: Added waitfor = 0 for some background tasks

### DIFF
--- a/code/controllers/subsystem/http.dm
+++ b/code/controllers/subsystem/http.dm
@@ -1,4 +1,5 @@
 SUBSYSTEM_DEF(http)
+
 	name = "HTTP"
 	flags = SS_TICKER | SS_BACKGROUND | SS_NO_INIT // Measure in ticks, but also only run if we have the spare CPU. We also dont init.
 	wait = 1
@@ -26,6 +27,7 @@ SUBSYSTEM_DEF(http)
 
 
 /datum/controller/subsystem/http/fire(resumed)
+	set waitfor = 0
 	for(var/r in active_async_requests)
 		var/datum/http_request/req = r
 		// Check if we are complete

--- a/code/datums/radio.dm
+++ b/code/datums/radio.dm
@@ -112,4 +112,5 @@
 
 //callback used by objects to react to incoming radio signals
 /obj/proc/receive_signal(datum/signal/signal, receive_method, receive_param)
+	set waitfor = FALSE
 	return null

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -522,7 +522,7 @@
 
 
 /area/Entered(atom/movable/arrived, area/old_area)
-
+	set waitfor = FALSE
 	SEND_SIGNAL(src, COMSIG_AREA_ENTERED, arrived, old_area)
 	SEND_SIGNAL(arrived, COMSIG_ATOM_ENTERED_AREA, src, old_area)
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -164,6 +164,7 @@
 
 //called if Initialize returns INITIALIZE_HINT_LATELOAD
 /atom/proc/LateInitialize()
+	set waitfor = FALSE
 	return
 
 // Put your AddComponent() calls here
@@ -626,6 +627,7 @@
 	return
 
 /atom/proc/ex_act()
+	set waitfor = FALSE
 	return
 
 /atom/proc/blob_act(obj/structure/blob/B)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -1,6 +1,5 @@
 /mob/living/proc/Life(seconds, times_fired)
 	set waitfor = FALSE
-	set invisibility = 0
 
 	SEND_SIGNAL(src, COMSIG_LIVING_LIFE, seconds, times_fired)
 

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -617,6 +617,7 @@
 
 
 /obj/machinery/light/flicker(amount = rand(20, 30))
+	set waitfor = FALSE
 	if(flickering)
 		return FALSE
 

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -617,7 +617,6 @@
 
 
 /obj/machinery/light/flicker(amount = rand(20, 30))
-	set waitfor = FALSE
 	if(flickering)
 		return FALSE
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
[Testmerge] needed as always
Ставит waitfor = 0 для подсистем, которые не нуждаются в синхронности и их можно пустить в свободное плавание
