### PR TITLE
del: Comment debug code for saylogs

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -44,7 +44,7 @@
 			if(!tmp_msg)
 				continue
 			msg = tmp_msg
-			log_debug(msg)
+			//log_debug(msg)
 
 	return trim(msg)
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Чистит чат у всех дебаггеров.
В #5404 в проке `/combine_message(` добавили логирование каждого услышаного сообщения, если есть `/datum/component/codeword_hearing`. Поскольку у нас несколько трейторов в раунде - этот лог засирает чаты у всех, кто смотрит рантаймы.

## Ссылка на предложение/Причина создания ПР
Сообщили об [ошибке тут](https://discord.com/channels/617003227182792704/734823601110515882/1264760474998673498).
Выглядит не очень полезно для дебага, когда в чат выводится `DEBUG: "Предложение через IC-Say"`