### PR TITLE
bugfix: Change robo's cryo area

### DIFF
--- a/_maps/map_files/celestation/celestation.dmm
+++ b/_maps/map_files/celestation/celestation.dmm
@@ -90267,7 +90267,7 @@
 	dir = 9;
 	icon_state = "darkpurple"
 	},
-/area/assembly/robotics)
+/area/assembly/chargebay)
 "qer" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Меняет зону в робототехнике, чтобы крио захватывало консоль робо-крио.

## Известные проблемы
Цела - Две консоли робо крио на спутнике.
Дельта - Две консоли крио в дормах.

## Ссылка на предложение/Причина создания ПР
Баг фикс по [этому репорту](https://discord.com/channels/617003227182792704/1264590839208874024/1264590839208874024).
Из-за того что консоль находилась в другой зоне - крио не могло подключиться к ней.

## Демонстрация изменений
![image](https://github.com/user-attachments/assets/64764658-71f8-4839-8e00-b7d0e0860195)
