### PR TITLE
bugfix: Returns white noise, ambience now works

### DIFF
--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -27,14 +27,18 @@ SUBSYSTEM_DEF(ambience)
 		var/client/client_iterator = cached_clients[cached_clients.len]
 		cached_clients.len--
 
-		//Check to see if the client exists and isn't held by a new player
-		var/mob/client_mob = client_iterator?.mob
-		if(isnull(client_iterator) || !client_mob || isnewplayer(client_mob))
+		if(isnull(client_iterator))
 			ambience_listening_clients -= client_iterator
 			client_old_areas -= client_iterator
+
+		//Check to see if the client isn't held by a new player
+		var/mob/client_mob = client_iterator?.mob
+		if(!client_mob || isnewplayer(client_mob))
 			continue
 
 		if(!client_mob.can_hear()) //WHAT? I CAN'T HEAR YOU
+			client_iterator.white_noise_playing = FALSE
+			client_mob.stop_sound_channel(CHANNEL_BUZZ)
 			continue
 
 		var/area/current_area = get_area(client_mob)
@@ -48,11 +52,16 @@ SUBSYSTEM_DEF(ambience)
 			ambience_listening_clients -= client_iterator
 			continue
 
+		if(client_iterator.white_noise_playing == FALSE && client_iterator.prefs.sound & SOUND_BUZZ)
+			client_iterator.white_noise_playing = TRUE
+			SEND_SOUND(client_iterator.mob, sound('sound/ambience/shipambience.ogg', repeat = TRUE, wait = FALSE, volume = 35 * client_iterator.prefs.get_channel_volume(CHANNEL_BUZZ), channel = CHANNEL_BUZZ))
+
 		var/ambience = safepick(current_area.ambientsounds)
 		if(!ambience)
 			continue
 
 		SEND_SOUND(client_iterator.mob, sound(ambience, repeat = 0, wait = 0, volume = 25 * client_iterator.prefs.get_channel_volume(CHANNEL_AMBIENCE), channel = CHANNEL_AMBIENCE))
+
 
 		ambience_listening_clients[client_iterator] = world.time + rand(current_area.min_ambience_cooldown, current_area.max_ambience_cooldown)
 

--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -15,7 +15,7 @@ SUBSYSTEM_DEF(ambience)
 
 /datum/controller/subsystem/ambience/proc/remove_ambience_client(client/to_remove)
 	ambience_listening_clients -= to_remove
-	currentrun -= to_remove
+	client_old_areas -= to_remove
 	currentrun -= to_remove
 
 /datum/controller/subsystem/ambience/fire(resumed)

--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -30,6 +30,7 @@ SUBSYSTEM_DEF(ambience)
 		if(isnull(client_iterator))
 			ambience_listening_clients -= client_iterator
 			client_old_areas -= client_iterator
+			continue
 
 		//Check to see if the client isn't held by a new player
 		var/mob/client_mob = client_iterator?.mob

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -30,6 +30,12 @@
 
 	var/adminhelped = 0
 
+		///////////////
+		//SOUND STUFF//
+		///////////////
+
+	var/white_noise_playing = FALSE
+
 		////////////
 		//SECURITY//
 		////////////


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Оказывается эмбиенты не работали по причине того, что в лобби они исключались из итерации по эмбиентам. Штош.
Также возвращает белый шум, незаконно удаленный в https://github.com/ss220-space/Paradise/pull/5537
