### PR TITLE
Fix: July Lavalend ruins general cleanup

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -26,28 +26,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/ruin/powered/clownplanet)
-"af" = (
-/obj/structure/disposalpipe/segment{
-	invisibility = 101
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/simulated/floor/lubed,
-/area/ruin/powered/clownplanet)
 "ag" = (
 /obj/effect/mob_spawn/human/corpse/damaged,
 /obj/effect/decal/cleanable/blood/old,
-/obj/structure/disposalpipe/segment{
-	invisibility = 101
-	},
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -84,9 +66,7 @@
 /area/ruin/powered/clownplanet)
 "aj" = (
 /obj/effect/decal/cleanable/pie_smudge,
-/obj/structure/disposalpipe/segment{
-	invisibility = 101
-	},
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -100,9 +80,7 @@
 /turf/simulated/floor/lubed,
 /area/ruin/powered/clownplanet)
 "ak" = (
-/obj/structure/disposalpipe/segment{
-	invisibility = 101
-	},
+/obj/structure/disposalpipe/segment,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -137,8 +115,7 @@
 /area/ruin/powered/clownplanet)
 "am" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	invisibility = 101
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow,
@@ -155,8 +132,7 @@
 /area/ruin/powered/clownplanet)
 "an" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	invisibility = 101
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -229,8 +205,7 @@
 /area/ruin/powered/clownplanet)
 "at" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	invisibility = 101
+	dir = 4
 	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/turf_decal/tile/yellow,
@@ -246,9 +221,7 @@
 /turf/simulated/floor/lubed,
 /area/ruin/powered/clownplanet)
 "au" = (
-/obj/structure/disposalpipe/segment{
-	invisibility = 101
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/ruin/powered/clownplanet)
 "av" = (
@@ -325,8 +298,7 @@
 /area/ruin/powered/clownplanet)
 "aB" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	invisibility = 101
+	dir = 4
 	},
 /obj/effect/decal/cleanable/pie_smudge,
 /obj/effect/turf_decal/tile/yellow,
@@ -360,8 +332,7 @@
 "aD" = (
 /obj/item/bikehorn,
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	invisibility = 101
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -383,9 +354,7 @@
 /area/ruin/powered/clownplanet)
 "aF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	invisibility = 101
-	},
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -440,9 +409,7 @@
 "aI" = (
 /obj/item/bikehorn,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	invisibility = 101
-	},
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -457,9 +424,7 @@
 /area/ruin/powered/clownplanet)
 "aJ" = (
 /obj/item/bikehorn,
-/obj/structure/disposalpipe/segment{
-	invisibility = 101
-	},
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -474,8 +439,7 @@
 /area/ruin/powered/clownplanet)
 "aK" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	invisibility = 101
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -491,8 +455,7 @@
 /area/ruin/powered/clownplanet)
 "aL" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	invisibility = 101
+	dir = 4
 	},
 /turf/simulated/wall/r_wall,
 /area/ruin/powered/clownplanet)
@@ -512,11 +475,9 @@
 /area/ruin/powered/clownplanet)
 "aN" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	invisibility = 101
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "white"
 	},
 /area/ruin/powered/clownplanet)
@@ -539,33 +500,28 @@
 /area/ruin/powered/clownplanet)
 "aP" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	invisibility = 101
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/ruin/powered/clownplanet)
 "aQ" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	invisibility = 101
+	dir = 4
 	},
 /obj/structure/table,
 /obj/item/paper/crumpled/bloody/ruins/lavaland/clown_planet/escape,
 /obj/item/pen/multi,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "white"
 	},
 /area/ruin/powered/clownplanet)
 "aR" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	invisibility = 101
+	dir = 4
 	},
 /obj/structure/table,
 /obj/item/flashlight/lamp/bananalamp,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "white"
 	},
 /area/ruin/powered/clownplanet)
@@ -588,12 +544,10 @@
 /area/ruin/powered/clownplanet)
 "aT" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	invisibility = 101
+	dir = 4
 	},
 /obj/item/pickaxe,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "white"
 	},
 /area/ruin/powered/clownplanet)
@@ -606,7 +560,6 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "white"
 	},
 /area/ruin/powered/clownplanet)
@@ -615,7 +568,6 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "white"
 	},
 /area/ruin/powered/clownplanet)
@@ -630,46 +582,38 @@
 /area/ruin/powered/clownplanet)
 "aY" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	invisibility = 101
+	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "white"
 	},
 /area/ruin/powered/clownplanet)
 "aZ" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	invisibility = 101
+	dir = 4
 	},
 /turf/simulated/floor/light,
 /area/ruin/powered/clownplanet)
 "ba" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	invisibility = 101
+	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "white"
 	},
 /area/ruin/powered/clownplanet)
 "bb" = (
-/obj/structure/disposalpipe/segment{
-	invisibility = 101
-	},
+/obj/structure/disposalpipe/segment,
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "white"
 	},
 /area/ruin/powered/clownplanet)
@@ -681,7 +625,6 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "white"
 	},
 /area/ruin/powered/clownplanet)
@@ -693,7 +636,6 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "white"
 	},
 /area/ruin/powered/clownplanet)
@@ -703,13 +645,11 @@
 "bg" = (
 /obj/item/pickaxe,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "white"
 	},
 /area/ruin/powered/clownplanet)
 "bh" = (
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "white"
 	},
 /area/ruin/powered/clownplanet)
@@ -774,7 +714,6 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "white"
 	},
 /area/ruin/powered/clownplanet)
@@ -826,7 +765,6 @@
 	},
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "white"
 	},
 /area/ruin/powered/clownplanet)
@@ -940,8 +878,7 @@
 "bD" = (
 /obj/structure/mecha_wreckage/honker,
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	invisibility = 101
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/ruin/powered/clownplanet)
@@ -1023,9 +960,7 @@
 /turf/simulated/wall/r_wall,
 /area/ruin/powered/clownplanet)
 "ch" = (
-/obj/structure/disposalpipe/segment{
-	invisibility = 101
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/wall/r_wall,
 /area/ruin/powered/clownplanet)
 "cu" = (
@@ -1332,9 +1267,9 @@ ye
 cc
 at
 ah
-af
+bo
 aI
-af
+bo
 av
 aL
 ye
@@ -1367,7 +1302,7 @@ aj
 ap
 am
 ah
-af
+bo
 aA
 aL
 aL
@@ -1397,7 +1332,7 @@ cc
 ye
 ye
 ae
-af
+bo
 av
 am
 aL
@@ -1430,8 +1365,8 @@ aa
 cc
 ye
 ab
-af
-af
+bo
+bo
 ay
 an
 an
@@ -1465,7 +1400,7 @@ cc
 ye
 ac
 ag
-af
+bo
 av
 aL
 am
@@ -1532,8 +1467,8 @@ Mv
 cc
 ye
 ae
-af
-af
+bo
+bo
 az
 am
 ac
@@ -1567,11 +1502,11 @@ cc
 ye
 cc
 ah
-af
+bo
 ap
 aC
 aj
-af
+bo
 ap
 aL
 aL
@@ -1601,12 +1536,12 @@ cc
 cc
 ye
 ac
-af
-af
-af
-af
+bo
+bo
+bo
+bo
 aJ
-af
+bo
 ay
 an
 bj
@@ -1635,13 +1570,13 @@ LH
 ch
 ch
 au
-af
+bo
 ch
-af
+bo
 aF
 ch
 aj
-af
+bo
 ay
 as
 an
@@ -1674,8 +1609,8 @@ aA
 ah
 av
 ah
-af
-af
+bo
+bo
 au
 bk
 aC
@@ -1709,7 +1644,7 @@ an
 aL
 an
 aO
-af
+bo
 av
 bl
 bo
@@ -2013,8 +1948,8 @@ cc
 aC
 ap
 aG
-af
-af
+bo
+bo
 aE
 cc
 ye

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_green.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_green.dmm
@@ -42,6 +42,11 @@
 /obj/item/kitchen/utensil/fork,
 /turf/simulated/floor/carpet,
 /area/ruin/powered/green_bio)
+"dR" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/gas,
+/turf/simulated/floor/pod/light,
+/area/ruin/powered/green_bio)
 "en" = (
 /obj/effect/turf_decal/siding/green{
 	dir = 8
@@ -60,6 +65,11 @@
 /area/ruin/powered/green_bio)
 "gm" = (
 /turf/simulated/wall/mineral/wood/nonmetal,
+/area/ruin/powered/green_bio)
+"gD" = (
+/obj/structure/table,
+/obj/item/clothing/shoes/sandal/fancy,
+/turf/simulated/floor/pod,
 /area/ruin/powered/green_bio)
 "gP" = (
 /obj/structure/window/plasmareinforced{
@@ -110,8 +120,7 @@
 	pixel_x = 11
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/ruin/powered/green_bio)
 "jG" = (
@@ -171,6 +180,7 @@
 /area/ruin/powered/green_bio)
 "mP" = (
 /obj/structure/table,
+/obj/item/camera,
 /turf/simulated/floor/pod,
 /area/ruin/powered/green_bio)
 "nK" = (
@@ -224,6 +234,11 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/indestructible/grass,
 /area/ruin/powered/green_bio)
+"ra" = (
+/obj/structure/rack,
+/obj/item/pickaxe,
+/turf/simulated/floor/pod/light,
+/area/ruin/powered/green_bio)
 "rj" = (
 /obj/machinery/hydroponics/soil,
 /turf/simulated/floor/indestructible/grass,
@@ -234,6 +249,11 @@
 	tag = "icon-plant-34"
 	},
 /turf/simulated/floor/wood,
+/area/ruin/powered/green_bio)
+"rv" = (
+/obj/structure/table,
+/obj/item/clothing/shoes/footwraps,
+/turf/simulated/floor/pod,
 /area/ruin/powered/green_bio)
 "rN" = (
 /obj/structure/railing/wooden{
@@ -256,8 +276,7 @@
 	pixel_y = 7
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/ruin/powered/green_bio)
 "tg" = (
@@ -399,6 +418,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/tank/internals/oxygen,
 /turf/simulated/floor/pod/light,
 /area/ruin/powered/green_bio)
 "De" = (
@@ -411,8 +431,7 @@
 /obj/structure/window/reinforced,
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/ruin/powered/green_bio)
 "Du" = (
@@ -451,8 +470,7 @@
 /obj/structure/table/reinforced,
 /obj/item/kitchen/knife,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/ruin/powered/green_bio)
 "FN" = (
@@ -568,6 +586,11 @@
 /obj/structure/chair/sofa/right,
 /turf/simulated/floor/carpet,
 /area/ruin/powered/green_bio)
+"Lq" = (
+/obj/structure/rack,
+/obj/item/soap,
+/turf/simulated/floor/pod/light,
+/area/ruin/powered/green_bio)
 "Mc" = (
 /obj/structure/railing/wooden{
 	dir = 4
@@ -579,6 +602,11 @@
 /area/ruin/powered/green_bio)
 "MD" = (
 /turf/simulated/wall/indestructible/rock,
+/area/ruin/powered/green_bio)
+"MQ" = (
+/obj/structure/table,
+/obj/item/paper,
+/turf/simulated/floor/pod,
 /area/ruin/powered/green_bio)
 "Ne" = (
 /obj/structure/window/reinforced{
@@ -632,8 +660,7 @@
 /area/ruin/powered/green_bio)
 "SL" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/ruin/powered/green_bio)
 "SY" = (
@@ -1297,7 +1324,7 @@ ol
 zf
 CL
 qj
-mP
+MQ
 mg
 hW
 "}
@@ -1332,7 +1359,7 @@ MD
 MD
 ol
 mg
-fG
+ra
 CL
 mP
 mg
@@ -1369,7 +1396,7 @@ MD
 MD
 MD
 mg
-fG
+Lq
 CL
 CL
 zf
@@ -1480,9 +1507,9 @@ ol
 ol
 MD
 mg
-fG
+dR
 CL
-mP
+rv
 mg
 hW
 "}
@@ -1519,7 +1546,7 @@ ol
 zf
 CL
 zh
-mP
+gD
 mg
 hW
 "}

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_althland_facility.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_althland_facility.dmm
@@ -15,7 +15,7 @@
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -31,7 +31,7 @@
 	dir = 8;
 	id = "mining_internal"
 	},
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -42,7 +42,7 @@
 	desc = "A computer long since rendered non-functional due to lack of maintenance. Spitting out error messages.";
 	name = "Broken Computer"
 	},
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -51,7 +51,7 @@
 "ba" = (
 /obj/effect/landmark/tiles/burnturf,
 /obj/effect/decal/cleanable/glass,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -74,7 +74,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -120,7 +120,7 @@
 "cg" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -146,7 +146,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -164,7 +164,7 @@
 /obj/structure/closet/crate/secure/loot,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -173,7 +173,7 @@
 "eX" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -199,7 +199,7 @@
 	dir = 8;
 	id = "mining_internal"
 	},
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -209,7 +209,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
 /obj/item/clothing/under/rank/miner,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -218,7 +218,7 @@
 "fG" = (
 /obj/effect/landmark/tiles/damageturf,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -227,7 +227,7 @@
 "fI" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -236,7 +236,7 @@
 "fU" = (
 /obj/machinery/atmospherics/unary/tank/oxygen_agent_b,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -259,7 +259,7 @@
 /obj/structure/ore_box,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -268,7 +268,7 @@
 "iv" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -280,7 +280,7 @@
 /obj/item/bedsheet,
 /obj/structure/bed,
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -293,7 +293,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/tiles/damageturf,
 /obj/item/stack/sheet/metal/fifty,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -316,7 +316,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -326,7 +326,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -351,7 +351,6 @@
 /obj/structure/sign/poster/contraband/red_rum{
 	pixel_y = 31
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	nitrogen = 23;
 	oxygen = 14;
@@ -370,7 +369,6 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "kq" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_construct/small{
 	dir = 1
@@ -391,7 +389,7 @@
 /obj/effect/landmark/tiles/damageturf,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -402,7 +400,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -414,23 +412,12 @@
 /area/lavaland/surface/outdoors)
 "kK" = (
 /obj/effect/landmark/tiles/burnturf,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors)
-"kQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/tiles/damageturf,
-/turf/simulated/floor{
-	nitrogen = 23;
-	oxygen = 14;
-	temperature = 300
-	},
-/area/ruin/unpowered)
 "li" = (
 /obj/effect/mapping_helpers/no_lava,
 /obj/structure/disposalpipe/segment,
@@ -438,7 +425,7 @@
 /area/lavaland/surface/outdoors)
 "mP" = (
 /obj/structure/girder,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -479,7 +466,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/storage/box/donkpockets,
 /turf/simulated/floor/plasteel{
 	nitrogen = 23;
@@ -492,7 +478,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -514,7 +500,7 @@
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -522,12 +508,9 @@
 /area/ruin/unpowered)
 "oZ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/mounted/frame/apc_frame{
-	pixel_y = 31
-	},
 /obj/item/clothing/under/rank/miner,
 /obj/effect/decal/remains/human,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -538,7 +521,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -549,7 +532,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
 /obj/item/clothing/under/rank/miner,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -559,7 +542,7 @@
 /obj/structure/door_assembly/door_assembly_ext,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -569,7 +552,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille,
 /obj/item/shard,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -608,7 +591,7 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -618,7 +601,7 @@
 /obj/structure/door_assembly/door_assembly_mhatch,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -628,7 +611,7 @@
 /obj/effect/turf_decal/caution/stand_clear/white,
 /obj/effect/turf_decal/box/white,
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -636,14 +619,14 @@
 /area/ruin/unpowered)
 "sp" = (
 /obj/effect/decal/cleanable/glass,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
 	},
 /area/lavaland/surface/outdoors)
 "sD" = (
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -674,7 +657,7 @@
 	id = "mining_internal"
 	},
 /obj/item/stack/sheet/mineral/silver,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -685,7 +668,7 @@
 	dir = 8;
 	id = "mining_internal"
 	},
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -699,7 +682,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -720,7 +703,7 @@
 /area/ruin/unpowered)
 "uq" = (
 /obj/effect/decal/warning_stripes/white,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -737,7 +720,7 @@
 /obj/item/clothing/shoes/workboots/mining,
 /obj/item/clothing/shoes/workboots/mining,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -746,7 +729,7 @@
 "uL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -761,7 +744,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -773,7 +756,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -805,7 +788,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -839,7 +822,7 @@
 "xl" = (
 /obj/effect/landmark/tiles/burnturf,
 /obj/item/stack/sheet/metal/fifty,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -853,7 +836,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -870,7 +853,7 @@
 /obj/structure/disposalpipe/broken,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -888,7 +871,7 @@
 /area/lavaland/surface/outdoors)
 "yL" = (
 /obj/structure/door_assembly/door_assembly_ext,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -916,8 +899,7 @@
 /obj/effect/landmark/tiles/damageturf,
 /obj/effect/landmark/tiles/burnturf,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -929,7 +911,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -951,7 +933,7 @@
 "zy" = (
 /obj/effect/landmark/tiles/damageturf,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -961,7 +943,7 @@
 /obj/effect/landmark/tiles/damageturf,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -989,7 +971,6 @@
 "AV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -1010,7 +991,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1020,7 +1001,7 @@
 /obj/effect/landmark/tiles/damageturf,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/marker_beacon,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1038,7 +1019,7 @@
 "Cf" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1050,7 +1031,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1060,7 +1041,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/door_assembly/door_assembly_mhatch,
 /obj/effect/landmark/tiles/damageturf,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1068,7 +1049,7 @@
 /area/ruin/unpowered)
 "CF" = (
 /obj/effect/landmark/tiles/damageturf,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1092,7 +1073,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/chinese,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1128,15 +1109,13 @@
 /area/ruin/unpowered)
 "EP" = (
 /obj/structure/door_assembly/door_assembly_ext,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
 	},
 /area/ruin/unpowered)
 "Hc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -1169,13 +1148,10 @@
 /area/ruin/unpowered)
 "HW" = (
 /obj/effect/landmark/tiles/damageturf,
-/obj/item/mounted/frame/apc_frame{
-	pixel_y = 31
-	},
 /obj/structure/closet/crate/secure/loot,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1185,7 +1161,7 @@
 /obj/item/stack/ore/plasma,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1194,7 +1170,7 @@
 "It" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/marker_beacon,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1207,7 +1183,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1218,7 +1194,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1228,7 +1204,7 @@
 /obj/machinery/constructable_frame/machine_frame,
 /obj/item/stack/cable_coil,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1240,7 +1216,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1260,7 +1236,7 @@
 /area/ruin/unpowered)
 "JF" = (
 /obj/machinery/vending/cigarette,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1270,7 +1246,7 @@
 /obj/item/pickaxe,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1282,7 +1258,7 @@
 	id = "mining_internal";
 	dir = 5
 	},
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1301,7 +1277,7 @@
 "Lq" = (
 /obj/item/chair,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1311,7 +1287,7 @@
 /obj/machinery/mech_bay_recharge_port,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1322,7 +1298,7 @@
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1346,7 +1322,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1356,7 +1332,7 @@
 /obj/machinery/light_construct/small,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1366,7 +1342,7 @@
 /obj/effect/landmark/tiles/burnturf,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/tiles/damageturf,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1375,7 +1351,7 @@
 "NJ" = (
 /obj/machinery/power/smes,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1406,7 +1382,7 @@
 /obj/structure/table,
 /obj/machinery/light_construct/small,
 /obj/item/storage/belt/mining/alt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1415,7 +1391,7 @@
 "OU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1426,7 +1402,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
 /obj/item/clothing/under/rank/miner,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1439,7 +1415,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1447,7 +1423,7 @@
 /area/ruin/unpowered)
 "Po" = (
 /obj/structure/grille,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1478,24 +1454,14 @@
 	},
 /area/ruin/unpowered)
 "PS" = (
-/obj/item/mounted/frame/apc_frame{
-	pixel_y = 31
-	},
-/obj/structure/ore_box,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	nitrogen = 23;
-	oxygen = 14;
-	temperature = 300
-	},
-/area/ruin/unpowered)
+/turf/template_noop,
+/area/template_noop)
 "Qm" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
 /obj/item/shard,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1521,7 +1487,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1553,7 +1519,7 @@
 /obj/effect/landmark/tiles/burnturf,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1563,7 +1529,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1582,7 +1548,7 @@
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1590,7 +1556,7 @@
 /area/ruin/unpowered)
 "TT" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1600,7 +1566,7 @@
 /obj/structure/girder,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1619,7 +1585,7 @@
 "Uu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1627,7 +1593,7 @@
 /area/lavaland/surface/outdoors)
 "Uy" = (
 /obj/machinery/mech_bay_recharge_port,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1638,7 +1604,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1656,7 +1622,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/glass,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	nitrogen = 23;
 	oxygen = 14;
@@ -1669,7 +1634,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1681,7 +1646,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1700,7 +1665,7 @@
 /obj/structure/mecha_wreckage/ripley,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1712,7 +1677,7 @@
 	name = "Broken Computer"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1722,7 +1687,7 @@
 /obj/effect/landmark/tiles/damageturf,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1732,7 +1697,7 @@
 /obj/effect/landmark/tiles/damageturf,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1755,7 +1720,7 @@
 "ZJ" = (
 /obj/structure/grille,
 /obj/item/shard,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1765,7 +1730,7 @@
 /obj/structure/door_assembly/door_assembly_ext,
 /obj/effect/landmark/tiles/damageturf,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1782,7 +1747,7 @@
 	dir = 8;
 	id = "mining_internal"
 	},
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	nitrogen = 23;
 	oxygen = 14;
 	temperature = 300
@@ -1799,56 +1764,56 @@
 /area/ruin/unpowered)
 
 (1,1,1) = {"
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
 "}
 (2,1,1) = {"
-xS
-xS
-xS
-xS
-xS
-xS
-xS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
 ap
 ap
-xS
-xS
-xS
-xS
-xS
+PS
+PS
+PS
+PS
+PS
 ap
 xS
 xS
@@ -1862,28 +1827,28 @@ Bb
 ap
 ap
 ap
-xS
-xS
-xS
-xS
-xS
-xS
-xS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
 "}
 (3,1,1) = {"
-xS
-xS
-xS
-xS
+PS
+PS
+PS
+PS
 xS
 xS
 xS
 nW
 ap
-xS
-xS
-xS
-xS
+PS
+PS
+PS
+PS
 ap
 ap
 ap
@@ -1899,17 +1864,17 @@ ZJ
 sp
 uM
 nW
-xS
-xS
-xS
-xS
-xS
-xS
+PS
+PS
+PS
+PS
+PS
+PS
 "}
 (4,1,1) = {"
-xS
-xS
-xS
+PS
+PS
+PS
 ap
 ap
 nW
@@ -1938,14 +1903,14 @@ nW
 nW
 nW
 ap
-xS
-xS
-xS
+PS
+PS
+PS
 "}
 (5,1,1) = {"
-xS
-xS
-xS
+PS
+PS
+PS
 ap
 ap
 nW
@@ -1975,14 +1940,14 @@ xH
 xH
 ap
 ap
-xS
-xS
+PS
+PS
 "}
 (6,1,1) = {"
-xS
-xS
-xS
-xS
+PS
+PS
+PS
+PS
 ap
 nW
 ap
@@ -2012,13 +1977,13 @@ xH
 ap
 ap
 ap
-xS
+PS
 "}
 (7,1,1) = {"
-xS
-xS
-xS
-xS
+PS
+PS
+PS
+PS
 ap
 nW
 nW
@@ -2048,12 +2013,12 @@ xH
 ap
 ap
 xS
-xS
+PS
 "}
 (8,1,1) = {"
-xS
-xS
-xS
+PS
+PS
+PS
 ap
 ap
 nW
@@ -2084,12 +2049,12 @@ xH
 ap
 ap
 xS
-xS
+PS
 "}
 (9,1,1) = {"
-xS
-xS
-xS
+PS
+PS
+PS
 ap
 nW
 nW
@@ -2120,11 +2085,11 @@ mP
 ap
 ap
 ap
-xS
+PS
 "}
 (10,1,1) = {"
-xS
-xS
+PS
+PS
 ap
 nW
 nW
@@ -2156,11 +2121,11 @@ mP
 ap
 ap
 xS
-xS
+PS
 "}
 (11,1,1) = {"
-xS
-xS
+PS
+PS
 ap
 uM
 xH
@@ -2192,11 +2157,11 @@ xH
 nW
 ap
 xS
-xS
+PS
 "}
 (12,1,1) = {"
-xS
-xS
+PS
+PS
 ap
 nW
 uM
@@ -2228,11 +2193,11 @@ xH
 nW
 nW
 xS
-xS
+PS
 "}
 (13,1,1) = {"
-xS
-xS
+PS
+PS
 ap
 ap
 nW
@@ -2264,11 +2229,11 @@ xH
 nW
 nW
 ap
-xS
+PS
 "}
 (14,1,1) = {"
-xS
-xS
+PS
+PS
 ap
 ap
 nW
@@ -2300,10 +2265,10 @@ xH
 nW
 nW
 ap
-xS
+PS
 "}
 (15,1,1) = {"
-xS
+PS
 ap
 ap
 ap
@@ -2336,11 +2301,11 @@ xH
 nW
 ap
 ap
-xS
+PS
 "}
 (16,1,1) = {"
-xS
-xS
+PS
+PS
 ap
 ap
 nW
@@ -2372,12 +2337,12 @@ xH
 nW
 nW
 ap
-xS
+PS
 "}
 (17,1,1) = {"
-xS
-xS
-xS
+PS
+PS
+PS
 ap
 nW
 nW
@@ -2408,12 +2373,12 @@ xH
 nW
 nW
 ap
-xS
+PS
 "}
 (18,1,1) = {"
-xS
-xS
-xS
+PS
+PS
+PS
 ap
 nW
 nW
@@ -2444,12 +2409,12 @@ uM
 nW
 ap
 ap
-xS
+PS
 "}
 (19,1,1) = {"
-xS
-xS
-xS
+PS
+PS
+PS
 ap
 nW
 nW
@@ -2458,7 +2423,7 @@ ap
 ap
 ap
 oz
-PS
+RR
 yZ
 uh
 xH
@@ -2480,11 +2445,11 @@ nW
 nW
 kz
 ap
-xS
+PS
 "}
 (20,1,1) = {"
-xS
-xS
+PS
+PS
 ap
 ap
 nW
@@ -2516,11 +2481,11 @@ nW
 nW
 ap
 ap
-xS
+PS
 "}
 (21,1,1) = {"
-xS
-xS
+PS
+PS
 ap
 ap
 uM
@@ -2552,11 +2517,11 @@ xH
 uM
 nW
 ap
-xS
+PS
 "}
 (22,1,1) = {"
-xS
-xS
+PS
+PS
 ap
 ap
 xH
@@ -2588,10 +2553,10 @@ nW
 nW
 ap
 ap
-xS
+PS
 "}
 (23,1,1) = {"
-xS
+PS
 ap
 ap
 ap
@@ -2624,10 +2589,10 @@ nW
 ap
 ap
 ap
-xS
+PS
 "}
 (24,1,1) = {"
-xS
+PS
 ap
 ap
 ap
@@ -2660,12 +2625,12 @@ nW
 ap
 Hq
 ap
-xS
+PS
 "}
 (25,1,1) = {"
-xS
-xS
-xS
+PS
+PS
+PS
 ap
 ap
 nW
@@ -2696,12 +2661,12 @@ nW
 nW
 nW
 ap
-xS
+PS
 "}
 (26,1,1) = {"
-xS
-xS
-xS
+PS
+PS
+PS
 ap
 ap
 nW
@@ -2718,7 +2683,7 @@ xH
 xH
 jO
 oq
-kQ
+OU
 xH
 nW
 Pj
@@ -2732,12 +2697,12 @@ nW
 nW
 nW
 ap
-xS
+PS
 "}
 (27,1,1) = {"
-xS
-xS
-xS
+PS
+PS
+PS
 ap
 nW
 CF
@@ -2754,7 +2719,7 @@ PA
 xH
 kq
 tE
-kQ
+OU
 ZS
 zK
 Wp
@@ -2768,11 +2733,11 @@ nW
 nW
 nW
 ap
-xS
+PS
 "}
 (28,1,1) = {"
-xS
-xS
+PS
+PS
 ap
 ap
 nW
@@ -2804,11 +2769,11 @@ nW
 nW
 ap
 ap
-xS
+PS
 "}
 (29,1,1) = {"
-xS
-xS
+PS
+PS
 ap
 ap
 kK
@@ -2825,7 +2790,7 @@ xH
 At
 xH
 HS
-EJ
+dJ
 iW
 xH
 uM
@@ -2840,11 +2805,11 @@ nW
 nW
 nW
 ap
-xS
+PS
 "}
 (30,1,1) = {"
-xS
-xS
+PS
+PS
 ap
 ap
 CF
@@ -2862,7 +2827,7 @@ EJ
 CD
 Nt
 dJ
-EJ
+dJ
 xH
 nW
 wn
@@ -2876,11 +2841,11 @@ nW
 nW
 ap
 ap
-xS
+PS
 "}
 (31,1,1) = {"
-xS
-xS
+PS
+PS
 ap
 ap
 ap
@@ -2912,12 +2877,12 @@ nW
 ap
 ap
 ap
-xS
+PS
 "}
 (32,1,1) = {"
-xS
-xS
-xS
+PS
+PS
+PS
 ap
 ap
 nW
@@ -2948,13 +2913,13 @@ nW
 ap
 ap
 ap
-xS
+PS
 "}
 (33,1,1) = {"
-xS
-xS
-xS
-xS
+PS
+PS
+PS
+PS
 ap
 ap
 ap
@@ -2984,13 +2949,13 @@ ap
 ap
 ap
 ap
-xS
+PS
 "}
 (34,1,1) = {"
-xS
-xS
-xS
-xS
+PS
+PS
+PS
+PS
 ap
 ap
 ap
@@ -3017,19 +2982,19 @@ ap
 ap
 ap
 ap
-xS
-xS
-xS
-xS
+PS
+PS
+PS
+PS
 "}
 (35,1,1) = {"
-xS
-xS
-xS
-xS
-xS
-xS
-xS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
 ap
 ap
 ap
@@ -3051,25 +3016,25 @@ xS
 ap
 ap
 ap
-xS
-xS
-xS
-xS
-xS
-xS
+PS
+PS
+PS
+PS
+PS
+PS
 "}
 (36,1,1) = {"
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
 ap
 ap
 ap
@@ -3082,51 +3047,51 @@ ap
 ap
 ap
 ap
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
 "}
 (37,1,1) = {"
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-ap
-ap
-ap
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
-xS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
+PS
 "}

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
@@ -266,8 +266,16 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/powered/animal_hospital)
 "aG" = (
-/obj/structure/extinguisher_cabinet,
-/turf/simulated/wall/mineral/titanium,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel,
 /area/ruin/powered/animal_hospital)
 "aJ" = (
 /turf/simulated/floor/plasteel/grimy{
@@ -313,6 +321,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue,
 /turf/simulated/floor/plasteel,
 /area/ruin/powered/animal_hospital)
 "aP" = (
@@ -1228,15 +1237,15 @@ ae
 ae
 ae
 ae
+ae
 aG
-aL
 cw
 ae
 aV
 ba
 cI
+ae
 aG
-aL
 br
 bA
 aP
@@ -1408,8 +1417,8 @@ ae
 ae
 ae
 ae
+ae
 aG
-aL
 aP
 ae
 cf

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_cube.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_cube.dmm
@@ -21,41 +21,44 @@
 /obj/item/gun/energy/gun/nuclear,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"G" = (
+/turf/template_noop,
+/area/template_noop)
 
 (1,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-b
-a
-b
-b
-b
-b
-b
-b
-a
-a
-a
-a
-a
-a
-a
-b
-a
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
 "}
 (2,1,1) = {"
-a
+G
 a
 a
 a
@@ -84,10 +87,10 @@ a
 a
 a
 a
-a
+G
 "}
 (3,1,1) = {"
-a
+G
 b
 a
 a
@@ -116,10 +119,10 @@ b
 b
 a
 a
-a
+G
 "}
 (4,1,1) = {"
-a
+G
 a
 a
 a
@@ -148,31 +151,11 @@ c
 b
 a
 b
-b
+G
 "}
 (5,1,1) = {"
+G
 a
-a
-b
-b
-b
-b
-b
-a
-a
-a
-a
-a
-a
-a
-a
-a
-b
-b
-b
-b
-b
-b
 b
 b
 b
@@ -180,10 +163,30 @@ b
 b
 a
 a
+a
+a
+a
+a
+a
+a
+a
 b
+b
+b
+b
+b
+b
+b
+b
+b
+b
+b
+a
+a
+G
 "}
 (6,1,1) = {"
-b
+G
 a
 a
 a
@@ -212,10 +215,10 @@ b
 b
 b
 a
-b
+G
 "}
 (7,1,1) = {"
-b
+G
 a
 a
 a
@@ -244,10 +247,10 @@ b
 b
 b
 b
-a
+G
 "}
 (8,1,1) = {"
-a
+G
 a
 a
 a
@@ -276,10 +279,10 @@ b
 b
 c
 b
-a
+G
 "}
 (9,1,1) = {"
-a
+G
 a
 b
 a
@@ -308,10 +311,10 @@ b
 b
 b
 b
-b
+G
 "}
 (10,1,1) = {"
-a
+G
 a
 a
 a
@@ -340,10 +343,10 @@ b
 c
 b
 b
-b
+G
 "}
 (11,1,1) = {"
-a
+G
 a
 a
 b
@@ -372,10 +375,10 @@ b
 b
 b
 b
-b
+G
 "}
 (12,1,1) = {"
-a
+G
 a
 b
 a
@@ -404,10 +407,10 @@ b
 b
 b
 b
-b
+G
 "}
 (13,1,1) = {"
-a
+G
 a
 b
 b
@@ -436,11 +439,11 @@ b
 b
 b
 c
-b
+G
 "}
 (14,1,1) = {"
+G
 a
-a
 b
 c
 b
@@ -468,42 +471,42 @@ b
 b
 b
 b
-b
+G
 "}
 (15,1,1) = {"
-a
-a
-b
-b
-b
-b
-c
-b
-b
-b
-d
-d
-d
-d
-d
-d
-d
-c
-b
-b
-c
-b
+G
 a
 b
 b
 b
+b
 c
 b
 b
 b
+d
+d
+d
+d
+d
+d
+d
+c
+b
+b
+c
+b
+a
+b
+b
+b
+c
+b
+b
+G
 "}
 (16,1,1) = {"
-a
+G
 a
 b
 b
@@ -532,10 +535,10 @@ b
 b
 b
 b
-b
+G
 "}
 (17,1,1) = {"
-a
+G
 a
 b
 c
@@ -564,10 +567,10 @@ b
 b
 a
 b
-b
+G
 "}
 (18,1,1) = {"
-a
+G
 a
 b
 a
@@ -596,10 +599,10 @@ b
 b
 c
 a
-a
+G
 "}
 (19,1,1) = {"
-a
+G
 a
 b
 a
@@ -628,10 +631,10 @@ a
 b
 b
 a
-a
+G
 "}
 (20,1,1) = {"
-a
+G
 a
 b
 b
@@ -660,10 +663,10 @@ a
 a
 a
 a
-a
+G
 "}
 (21,1,1) = {"
-a
+G
 a
 b
 b
@@ -692,16 +695,12 @@ a
 a
 a
 a
-a
+G
 "}
 (22,1,1) = {"
+G
 a
-a
 b
-b
-b
-b
-a
 b
 b
 b
@@ -709,12 +708,16 @@ a
 b
 b
 b
+a
 b
 b
 b
 b
 b
 b
+b
+b
+b
 a
 a
 a
@@ -724,10 +727,10 @@ a
 a
 a
 a
-a
+G
 "}
 (23,1,1) = {"
-a
+G
 a
 a
 a
@@ -756,10 +759,10 @@ a
 a
 a
 a
-a
+G
 "}
 (24,1,1) = {"
-a
+G
 a
 a
 a
@@ -788,10 +791,10 @@ a
 a
 a
 a
-a
+G
 "}
 (25,1,1) = {"
-a
+G
 a
 b
 b
@@ -820,10 +823,10 @@ a
 a
 a
 a
-a
+G
 "}
 (26,1,1) = {"
-b
+G
 b
 b
 b
@@ -852,10 +855,10 @@ a
 a
 a
 a
-a
+G
 "}
 (27,1,1) = {"
-b
+G
 b
 b
 a
@@ -884,10 +887,10 @@ a
 a
 a
 a
-a
+G
 "}
 (28,1,1) = {"
-b
+G
 b
 b
 a
@@ -916,10 +919,10 @@ b
 b
 b
 b
-b
+G
 "}
 (29,1,1) = {"
-b
+G
 a
 a
 a
@@ -948,37 +951,37 @@ a
 b
 b
 b
-b
+G
 "}
 (30,1,1) = {"
-b
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
 "}

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_cultaltar.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_cultaltar.dmm
@@ -4,7 +4,7 @@
 /area/template_noop)
 "b" = (
 /turf/simulated/floor/engine/cult{
-	oxygen = 24;
+	oxygen = 14;
 	nitrogen = 23;
 	temperature = 300
 	},
@@ -26,7 +26,7 @@
 "g" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/engine/cult{
-	oxygen = 24;
+	oxygen = 14;
 	nitrogen = 23;
 	temperature = 300
 	},
@@ -39,7 +39,7 @@
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/engine/cult{
-	oxygen = 24;
+	oxygen = 14;
 	nitrogen = 23;
 	temperature = 300
 	},
@@ -48,7 +48,7 @@
 /obj/effect/decal/remains/human,
 /obj/item/melee/cultblade,
 /turf/simulated/floor/engine/cult{
-	oxygen = 24;
+	oxygen = 14;
 	nitrogen = 23;
 	temperature = 300
 	},
@@ -58,7 +58,7 @@
 /obj/item/clothing/shoes/cult,
 /obj/item/clothing/suit/hooded/cultrobes,
 /turf/simulated/floor/engine/cult{
-	oxygen = 24;
+	oxygen = 14;
 	nitrogen = 23;
 	temperature = 300
 	},
@@ -66,7 +66,7 @@
 "m" = (
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/engine/cult{
-	oxygen = 24;
+	oxygen = 14;
 	nitrogen = 23;
 	temperature = 300
 	},
@@ -90,7 +90,7 @@
 	name = "ohfuck"
 	},
 /turf/simulated/floor/engine/cult{
-	oxygen = 24;
+	oxygen = 14;
 	nitrogen = 23;
 	temperature = 300
 	},
@@ -101,7 +101,7 @@
 /obj/item/clothing/suit/hooded/cultrobes,
 /obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/engine/cult{
-	oxygen = 24;
+	oxygen = 14;
 	nitrogen = 23;
 	temperature = 300
 	},

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_dragon.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_dragon.dmm
@@ -74,10 +74,6 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/drake)
-"hx" = (
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "hQ" = (
 /obj/structure/stone_tile/cracked{
 	dir = 1
@@ -261,9 +257,6 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/drake)
-"LB" = (
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/drake)
 "NI" = (
@@ -766,7 +759,7 @@ xU
 gY
 gY
 gY
-hx
+bB
 bB
 bB
 bB
@@ -874,7 +867,7 @@ gY
 gY
 gY
 gY
-LB
+gY
 gY
 bB
 bB

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_dragon.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_dragon.dmm
@@ -77,7 +77,7 @@
 "hx" = (
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/ruin/unpowered/drake)
+/area/lavaland/surface/outdoors)
 "hQ" = (
 /obj/structure/stone_tile/cracked{
 	dir = 1
@@ -280,9 +280,6 @@
 /mob/living/simple_animal/hostile/asteroid/goliath/beast/ancient,
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/drake)
-"Os" = (
-/turf/simulated/floor/plating/lava/smooth/lava_land_surface,
 /area/ruin/unpowered/drake)
 "PI" = (
 /obj/structure/stone_tile{
@@ -498,7 +495,7 @@ gY
 RQ
 QD
 gY
-Os
+qj
 gY
 bB
 bB
@@ -714,7 +711,7 @@ ZL
 gY
 aS
 Vs
-Os
+qj
 gY
 bB
 bB

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
@@ -162,6 +162,7 @@
 /obj/machinery/door/airlock/titanium{
 	name = "Escape Pod Airlock"
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/ruin/powered)
 "I" = (

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_pirateship.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_pirateship.dmm
@@ -556,7 +556,11 @@
 /obj/structure/railing,
 /obj/machinery/constructable_frame/machine_frame,
 /obj/effect/decal/cleanable/dust,
-/turf/simulated/floor/pod/dark,
+/turf/simulated/floor/pod/dark{
+	nitrogen = 23;
+	oxygen = 14;
+	temperature = 300
+	},
 /area/ruin/powered/pirateship)
 "jP" = (
 /obj/item/storage/backpack/duffel/syndie,
@@ -631,7 +635,11 @@
 	pixel_x = 3;
 	pixel_y = 7
 	},
-/turf/simulated/floor/plasteel/dark,
+/turf/simulated/floor/plasteel/dark{
+	nitrogen = 23;
+	oxygen = 14;
+	temperature = 300
+	},
 /area/ruin/powered/pirateship)
 "kV" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -716,7 +724,11 @@
 	pixel_x = 4
 	},
 /obj/effect/decal/warning_stripes/northwestcorner,
-/turf/simulated/floor/pod/dark,
+/turf/simulated/floor/pod/dark{
+	nitrogen = 23;
+	oxygen = 14;
+	temperature = 300
+	},
 /area/ruin/powered/pirateship)
 "md" = (
 /obj/structure/bonfire,
@@ -1205,7 +1217,11 @@
 /area/ruin/unpowered/safe_cave)
 "ur" = (
 /obj/machinery/door/airlock/external/glass,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	nitrogen = 23;
+	oxygen = 14;
+	temperature = 300
+	},
 /area/ruin/powered/pirateship)
 "uS" = (
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
@@ -1216,7 +1232,11 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	nitrogen = 23;
+	oxygen = 14;
+	temperature = 300
+	},
 /area/lavaland/surface/outdoors)
 "vH" = (
 /obj/structure/window/plasmareinforced{
@@ -1228,7 +1248,11 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	nitrogen = 23;
+	oxygen = 14;
+	temperature = 300
+	},
 /area/lavaland/surface/outdoors)
 "vW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -1435,7 +1459,11 @@
 "yA" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/effect/landmark/tiles/burnturf,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	nitrogen = 23;
+	oxygen = 14;
+	temperature = 300
+	},
 /area/lavaland/surface/outdoors)
 "yP" = (
 /obj/effect/decal/cleanable/dust,
@@ -1639,7 +1667,11 @@
 	},
 /obj/machinery/door/airlock/highsecurity,
 /obj/effect/decal/cleanable/dust,
-/turf/simulated/floor/plasteel/dark,
+/turf/simulated/floor/plasteel/dark{
+	nitrogen = 23;
+	oxygen = 14;
+	temperature = 300
+	},
 /area/ruin/powered/pirateship)
 "Cs" = (
 /obj/structure/cable/yellow{
@@ -1806,7 +1838,11 @@
 /obj/machinery/door/window/northright{
 	name = "Engine Access"
 	},
-/turf/simulated/floor/pod/dark,
+/turf/simulated/floor/pod/dark{
+	nitrogen = 23;
+	oxygen = 14;
+	temperature = 300
+	},
 /area/ruin/powered/pirateship)
 "EE" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -1959,7 +1995,11 @@
 	icon_state = "heater3x3";
 	tag = "icon-heater (NORTH)"
 	},
-/turf/simulated/floor/pod/dark,
+/turf/simulated/floor/pod/dark{
+	nitrogen = 23;
+	oxygen = 14;
+	temperature = 300
+	},
 /area/ruin/powered/pirateship)
 "Gz" = (
 /turf/simulated/wall/mineral/plastitanium/nodiagonal,
@@ -2151,7 +2191,11 @@
 /obj/effect/decal/warning_stripes/east,
 /obj/effect/decal/cleanable/glass,
 /obj/effect/landmark/tiles/burnturf,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	nitrogen = 23;
+	oxygen = 14;
+	temperature = 300
+	},
 /area/lavaland/surface/outdoors)
 "KA" = (
 /obj/effect/decal/cleanable/dust,
@@ -2213,7 +2257,11 @@
 /area/ruin/powered/pirateship)
 "LM" = (
 /obj/structure/grille,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	nitrogen = 23;
+	oxygen = 14;
+	temperature = 300
+	},
 /area/lavaland/surface/outdoors)
 "LQ" = (
 /obj/structure/flora/ash/cacti,
@@ -2434,7 +2482,11 @@
 /obj/effect/decal/warning_stripes/east,
 /obj/effect/landmark/tiles/burnturf,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	nitrogen = 23;
+	oxygen = 14;
+	temperature = 300
+	},
 /area/lavaland/surface/outdoors)
 "OA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2495,7 +2547,11 @@
 	dir = 8;
 	id_tag = "pcarrier_windows"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	nitrogen = 23;
+	oxygen = 14;
+	temperature = 300
+	},
 /area/ruin/powered/pirateship)
 "Py" = (
 /obj/machinery/power/terminal,
@@ -2571,7 +2627,11 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	nitrogen = 23;
+	oxygen = 14;
+	temperature = 300
+	},
 /area/lavaland/surface/outdoors)
 "Qa" = (
 /obj/item/clothing/suit/pirate_brown,
@@ -2760,14 +2820,6 @@
 	},
 /obj/machinery/door/window/northright{
 	name = "Engine Access"
-	},
-/obj/machinery/atmospherics/pipe/cap/visible/supply{
-	dir = 1;
-	pixel_x = 3
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
-	dir = 9;
-	pixel_x = 1
 	},
 /turf/simulated/floor/pod/dark{
 	nitrogen = 23;
@@ -3033,7 +3085,11 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/turf/simulated/floor/pod/dark,
+/turf/simulated/floor/pod/dark{
+	nitrogen = 23;
+	oxygen = 14;
+	temperature = 300
+	},
 /area/ruin/powered/pirateship)
 "WX" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
@@ -3058,7 +3114,11 @@
 "WZ" = (
 /obj/effect/spawner/window/shuttle/gray,
 /obj/machinery/door/poddoor/shutters,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	nitrogen = 23;
+	oxygen = 14;
+	temperature = 300
+	},
 /area/ruin/powered/pirateship)
 "Xk" = (
 /obj/item/reagent_containers/food/condiment/rice,
@@ -3076,7 +3136,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
 /obj/machinery/door/airlock/glass,
-/turf/simulated/floor/pod/dark,
+/turf/simulated/floor/pod/dark{
+	nitrogen = 23;
+	oxygen = 14;
+	temperature = 300
+	},
 /area/ruin/powered/pirateship)
 "XA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
@@ -3110,7 +3174,11 @@
 "XJ" = (
 /obj/effect/landmark/tiles/burnturf,
 /obj/effect/decal/cleanable/dust,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	nitrogen = 23;
+	oxygen = 14;
+	temperature = 300
+	},
 /area/lavaland/surface/outdoors)
 "XL" = (
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
@@ -3160,7 +3228,11 @@
 /obj/machinery/door/poddoor/shutters{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	nitrogen = 23;
+	oxygen = 14;
+	temperature = 300
+	},
 /area/ruin/powered/pirateship)
 "Yw" = (
 /obj/machinery/atmospherics/binary/pump,
@@ -3240,7 +3312,11 @@
 	dir = 2;
 	id_tag = "pcarrier_bridge"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	nitrogen = 23;
+	oxygen = 14;
+	temperature = 300
+	},
 /area/ruin/powered/pirateship)
 "ZV" = (
 /obj/effect/landmark/tiles/damageturf,

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
@@ -78,9 +78,7 @@
 "Y" = (
 /obj/machinery/door/airlock/diamond,
 /obj/structure/fans/tiny/invisible,
-/turf/simulated/floor/mineral/silver{
-	blocks_air = 1
-	},
+/turf/simulated/floor/mineral/silver,
 /area/ruin/powered/pride)
 "Z" = (
 /obj/effect/mapping_helpers/no_lava,

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
@@ -5,10 +5,23 @@
 "b" = (
 /obj/structure/bed,
 /obj/item/bedsheet/centcom,
-/turf/simulated/floor/wood/cold,
+/turf/simulated/floor/wood,
+/area/ruin/unpowered/misc_lavaruin)
+"d" = (
+/obj/machinery/door/airlock/wood/glass,
+/obj/structure/fans/tiny,
+/turf/simulated/floor/wood{
+	oxygen = 14;
+	nitrogen = 23;
+	temperature = 300
+	},
 /area/ruin/unpowered/misc_lavaruin)
 "g" = (
-/turf/simulated/floor/wood/cold,
+/turf/simulated/floor/wood{
+	oxygen = 14;
+	nitrogen = 23;
+	temperature = 300
+	},
 /area/ruin/unpowered/misc_lavaruin)
 "k" = (
 /turf/simulated/wall/indestructible,
@@ -17,15 +30,23 @@
 /obj/structure/table/wood,
 /obj/item/paper/fluff/stations/lavaland/sloth/note,
 /obj/item/flashlight/lamp,
-/turf/simulated/floor/wood/cold,
+/turf/simulated/floor/wood{
+	oxygen = 14;
+	nitrogen = 23;
+	temperature = 300
+	},
 /area/ruin/unpowered/misc_lavaruin)
 "v" = (
 /obj/structure/chair/wood,
-/turf/simulated/floor/wood/cold,
+/turf/simulated/floor/wood{
+	oxygen = 14;
+	nitrogen = 23;
+	temperature = 300
+	},
 /area/ruin/unpowered/misc_lavaruin)
 "w" = (
 /obj/effect/spawner/random_spawners/dirt_50,
-/turf/simulated/floor/wood/cold,
+/turf/simulated/floor/wood,
 /area/ruin/unpowered/misc_lavaruin)
 "z" = (
 /turf/simulated/floor/sepia{
@@ -34,16 +55,20 @@
 /area/ruin/unpowered/misc_lavaruin)
 "A" = (
 /obj/machinery/door/airlock/wood/glass,
-/turf/simulated/floor/wood/cold,
+/turf/simulated/floor/wood{
+	oxygen = 14;
+	nitrogen = 23;
+	temperature = 300
+	},
 /area/ruin/unpowered/misc_lavaruin)
 "C" = (
 /obj/machinery/computer/security/wooden_tv{
 	network = list("SS13","Research Outpost","Mining Outpost")
 	},
-/turf/simulated/floor/wood/cold,
+/turf/simulated/floor/wood,
 /area/ruin/unpowered/misc_lavaruin)
 "D" = (
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/wood,
 /area/ruin/unpowered/misc_lavaruin)
 "F" = (
 /obj/structure/table/wood,
@@ -55,13 +80,17 @@
 	pixel_x = 10;
 	pixel_y = -1
 	},
-/turf/simulated/floor/wood/cold,
+/turf/simulated/floor/wood{
+	oxygen = 14;
+	nitrogen = 23;
+	temperature = 300
+	},
 /area/ruin/unpowered/misc_lavaruin)
 "G" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
 /obj/item/reagent_containers/food/snacks/grown/citrus/orange,
-/turf/simulated/floor/wood/cold,
+/turf/simulated/floor/wood,
 /area/ruin/unpowered/misc_lavaruin)
 "J" = (
 /obj/effect/baseturf_helper/lava_land/surface,
@@ -69,13 +98,17 @@
 /area/ruin/unpowered/misc_lavaruin)
 "M" = (
 /obj/machinery/vending/cola/free,
-/turf/simulated/floor/wood/cold,
+/turf/simulated/floor/wood{
+	oxygen = 14;
+	nitrogen = 23;
+	temperature = 300
+	},
 /area/ruin/unpowered/misc_lavaruin)
 "O" = (
 /obj/structure/chair/comfy/beige{
 	dir = 1
 	},
-/turf/simulated/floor/wood/cold,
+/turf/simulated/floor/wood,
 /area/ruin/unpowered/misc_lavaruin)
 "P" = (
 /obj/effect/mapping_helpers/no_lava,
@@ -86,13 +119,21 @@
 /area/ruin/unpowered/misc_lavaruin)
 "W" = (
 /obj/machinery/vending/snack/free,
-/turf/simulated/floor/wood/cold,
+/turf/simulated/floor/wood,
 /area/ruin/unpowered/misc_lavaruin)
 "X" = (
 /obj/structure/chair/wood{
 	dir = 1
 	},
-/turf/simulated/floor/wood/cold,
+/turf/simulated/floor/wood{
+	oxygen = 14;
+	nitrogen = 23;
+	temperature = 300
+	},
+/area/ruin/unpowered/misc_lavaruin)
+"Z" = (
+/obj/machinery/door/airlock/wood/glass,
+/turf/simulated/floor/wood,
 /area/ruin/unpowered/misc_lavaruin)
 
 (1,1,1) = {"
@@ -242,7 +283,7 @@ k
 k
 k
 z
-A
+d
 g
 g
 J
@@ -449,7 +490,7 @@ k
 z
 k
 C
-g
+D
 O
 k
 z
@@ -478,7 +519,7 @@ k
 z
 k
 z
-A
+Z
 D
 w
 G
@@ -511,7 +552,7 @@ k
 k
 k
 W
-g
+D
 b
 k
 z

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_ufo_crash.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_ufo_crash.dmm
@@ -9,66 +9,122 @@
 /obj/machinery/abductor/experiment{
 	stat = 1
 	},
-/turf/simulated/floor/mineral/abductor,
+/turf/simulated/floor/mineral/abductor{
+	oxygen = 14;
+	temperature = 300;
+	nitrogen = 23
+	},
 /area/ruin/unpowered/misc_lavaruin)
 "d" = (
 /turf/simulated/wall/mineral/abductor,
 /area/ruin/unpowered/misc_lavaruin)
 "e" = (
-/turf/simulated/floor/mineral/abductor,
+/turf/simulated/floor/mineral/abductor{
+	oxygen = 14;
+	temperature = 300;
+	nitrogen = 23
+	},
 /area/ruin/unpowered/misc_lavaruin)
 "g" = (
 /obj/machinery/abductor/pad,
-/turf/simulated/floor/mineral/abductor,
+/turf/simulated/floor/mineral/abductor{
+	oxygen = 14;
+	temperature = 300;
+	nitrogen = 23
+	},
 /area/ruin/unpowered/misc_lavaruin)
 "h" = (
 /obj/item/hemostat/alien,
-/turf/simulated/floor/mineral/abductor,
+/turf/simulated/floor/mineral/abductor{
+	oxygen = 14;
+	temperature = 300;
+	nitrogen = 23
+	},
 /area/ruin/unpowered/misc_lavaruin)
 "i" = (
 /obj/effect/mob_spawn/human/abductor,
-/turf/simulated/floor/mineral/abductor,
+/turf/simulated/floor/mineral/abductor{
+	oxygen = 14;
+	temperature = 300;
+	nitrogen = 23
+	},
 /area/ruin/unpowered/misc_lavaruin)
 "j" = (
 /obj/structure/closet/abductor,
-/turf/simulated/floor/mineral/abductor,
+/turf/simulated/floor/mineral/abductor{
+	oxygen = 14;
+	temperature = 300;
+	nitrogen = 23
+	},
 /area/ruin/unpowered/misc_lavaruin)
 "k" = (
 /obj/effect/baseturf_helper/lava_land/surface,
-/turf/simulated/floor/mineral/abductor,
+/turf/simulated/floor/mineral/abductor{
+	oxygen = 14;
+	temperature = 300;
+	nitrogen = 23
+	},
 /area/ruin/unpowered/misc_lavaruin)
 "l" = (
 /obj/machinery/optable/abductor,
 /obj/item/cautery/alien,
-/turf/simulated/floor/mineral/abductor,
+/turf/simulated/floor/mineral/abductor{
+	oxygen = 14;
+	temperature = 300;
+	nitrogen = 23
+	},
 /area/ruin/unpowered/misc_lavaruin)
 "m" = (
 /obj/structure/table/abductor,
 /obj/item/storage/box/alienhandcuffs,
-/turf/simulated/floor/mineral/abductor,
+/turf/simulated/floor/mineral/abductor{
+	oxygen = 14;
+	temperature = 300;
+	nitrogen = 23
+	},
 /area/ruin/unpowered/misc_lavaruin)
 "n" = (
 /obj/item/scalpel/alien,
 /obj/item/surgical_drapes,
-/turf/simulated/floor/mineral/abductor,
+/turf/simulated/floor/mineral/abductor{
+	oxygen = 14;
+	temperature = 300;
+	nitrogen = 23
+	},
 /area/ruin/unpowered/misc_lavaruin)
 "o" = (
 /obj/item/retractor/alien,
-/turf/simulated/floor/mineral/abductor,
+/turf/simulated/floor/mineral/abductor{
+	oxygen = 14;
+	temperature = 300;
+	nitrogen = 23
+	},
 /area/ruin/unpowered/misc_lavaruin)
 "p" = (
 /obj/machinery/abductor/gland_dispenser,
-/turf/simulated/floor/mineral/abductor,
+/turf/simulated/floor/mineral/abductor{
+	oxygen = 14;
+	temperature = 300;
+	nitrogen = 23
+	},
 /area/ruin/unpowered/misc_lavaruin)
 "q" = (
 /obj/structure/table/abductor,
 /obj/item/surgicaldrill/alien,
 /obj/item/circular_saw/alien,
-/turf/simulated/floor/mineral/abductor,
+/turf/simulated/floor/mineral/abductor{
+	oxygen = 14;
+	temperature = 300;
+	nitrogen = 23
+	},
 /area/ruin/unpowered/misc_lavaruin)
 "r" = (
 /obj/structure/bed/abductor,
-/turf/simulated/floor/mineral/abductor,
+/turf/simulated/floor/mineral/abductor{
+	oxygen = 14;
+	temperature = 300;
+	nitrogen = 23
+	},
 /area/ruin/unpowered/misc_lavaruin)
 "s" = (
 /obj/effect/mapping_helpers/no_lava,


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Пак фиксов руин лаваленда (был проверен каждый файл в папке), а именно:

У труб убран ненужный ```invisibility = 101``` биодома клоунов
У пола убран ненужный ```tag``` зеленого биодома 
Восстановлен lavaland_surface_althland_facility
Исправлена разница атмоса руины культа
Исправлен один кривоватый тайл с зоной и хелпером руины дракона
У пода отшельника появился атмос блок, два тайла, но тем не менее.
На корабле пиратов исправлена куча тайлов с нелаваленд атмосом
На входе в награждение у тайла убран ```blocks_air = 1``` (там и так стоит атмос блок)
У медленного лабиринта исправлены тайлы с неправильным атмосом
Точно так же исправлен пол корабля абдукторов

## Демонстрация изменений
Дифбот некорректно показывает изменения руины куба
(ранее не было пасстру тайлов по периметру)
![image](https://github.com/user-attachments/assets/2ad74ac6-3e64-4a49-a2ad-4452d42a0572)
