### PR TITLE
tweak: add crew transfer vote after blob death

### DIFF
--- a/code/__DEFINES/blob.dm
+++ b/code/__DEFINES/blob.dm
@@ -35,6 +35,10 @@
 #define BLOB_BASE_TARGET_POINT 350
 #define BLOB_TARGET_POINT_PER_CORE 350
 #define BLOB_PLAYERS_PER_CORE 30
+#define BLOB_DEATH_REPORT_FIRST 0
+#define BLOB_DEATH_REPORT_SECOND 1
+#define BLOB_DEATH_REPORT_THIRD 2
+#define BLOB_DEATH_REPORT_FOURTH 3
 #define AWAY_STATION_WARN span_userdanger("Вы готовы лопнуть, но это не подходящее место! Вы должны вернуться на станцию!")
 #define FIRST_STAGE_WARN span_userdanger("Вы чувствуете усталость и раздутость.")
 #define SECOND_STAGE_WARN span_userdanger("Вы чувствуете, что вот-вот лопнете.")

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -25,15 +25,19 @@ SUBSYSTEM_DEF(vote)
 	active_vote.start()
 
 /datum/controller/subsystem/vote/proc/on_vote_end()
-	if(votes_queue.len)
-		var/datum/vote/vote = votes_queue[1]
+	for(var/datum/vote/vote in votes_queue)
 		votes_queue -= vote
+		if(QDELETED(vote))
+			continue
 		start_vote(vote)
+		break;
 
 /datum/controller/subsystem/vote/proc/clear_transfer_votes()
-	for(var/vote in votes_queue)
+	for(var/datum/vote/vote in votes_queue)
 		if(istype(vote, /datum/vote/crew_transfer))
 			votes_queue -= vote
+			if(!QDELETED(vote))
+				qdel(vote)
 
 /datum/controller/subsystem/vote/Topic(href, list/href_list)
 	if(href_list["vote"] == "open")

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -9,6 +9,8 @@ SUBSYSTEM_DEF(vote)
 
 	/// Active vote, if any
 	var/datum/vote/active_vote
+	//Queue of votes being processed
+	var/list/votes_queue = list()
 
 /datum/controller/subsystem/vote/fire()
 	if(active_vote)
@@ -16,8 +18,22 @@ SUBSYSTEM_DEF(vote)
 
 /datum/controller/subsystem/vote/proc/start_vote(datum/vote/V)
 	// This will be fun if DM ever gets concurrency
+	if(active_vote)
+		votes_queue += V
+		return
 	active_vote = V
 	active_vote.start()
+
+/datum/controller/subsystem/vote/proc/on_vote_end()
+	if(votes_queue.len)
+		var/datum/vote/vote = votes_queue[1]
+		votes_queue -= vote
+		start_vote(vote)
+
+/datum/controller/subsystem/vote/proc/clear_transfer_votes()
+	for(var/vote in votes_queue)
+		if(istype(vote, /datum/vote/crew_transfer))
+			votes_queue -= vote
 
 /datum/controller/subsystem/vote/Topic(href, list/href_list)
 	if(href_list["vote"] == "open")

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -129,9 +129,10 @@
 /datum/game_mode/proc/report_blob_death()
 	send_intercept(BLOB_THIRD_REPORT)
 	if(SSshuttle)
-		SSshuttle.stop_lockdown()
+		addtimer(CALLBACK(SSshuttle, TYPE_PROC_REF(/datum/controller/subsystem/shuttle, stop_lockdown)), TIME_TO_SWITCH_CODE)
 	if(blob_stage >= BLOB_STAGE_SECOND && GLOB.security_level == SEC_LEVEL_GAMMA)
-		addtimer(CALLBACK(GLOBAL_PROC, /proc/set_security_level, SEC_LEVEL_RED), TIME_TO_SWITCH_CODE)
+		addtimer(CALLBACK(GLOBAL_PROC, /proc/set_security_level, SEC_LEVEL_RED), TIME_TO_SWITCH_CODE * 2)
+	addtimer(CALLBACK(SSvote, TYPE_PROC_REF(/datum/controller/subsystem/vote, start_vote), new /datum/vote/crew_transfer), TIME_TO_SWITCH_CODE * 3)
 	blob_stage = BLOB_STAGE_ZERO
 
 

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -112,7 +112,7 @@
 
 /datum/game_mode/proc/blob_died()
 	if(!GLOB.blob_cores.len && blob_stage >= BLOB_STAGE_FIRST && blob_stage < BLOB_STAGE_STORM)
-		addtimer(CALLBACK(src, PROC_REF(report_blob_death), SEC_LEVEL_RED), TIME_TO_ANNOUNCE_BLOBS_DIE)
+		addtimer(CALLBACK(src, PROC_REF(report_blob_death), BLOB_DEATH_REPORT_FIRST), TIME_TO_ANNOUNCE_BLOBS_DIE)
 
 
 /datum/game_mode/proc/get_blobs_minds()
@@ -126,14 +126,22 @@
 	return blob_list
 
 
-/datum/game_mode/proc/report_blob_death()
-	send_intercept(BLOB_THIRD_REPORT)
-	if(SSshuttle)
-		addtimer(CALLBACK(SSshuttle, TYPE_PROC_REF(/datum/controller/subsystem/shuttle, stop_lockdown)), TIME_TO_SWITCH_CODE)
-	if(blob_stage >= BLOB_STAGE_SECOND && GLOB.security_level == SEC_LEVEL_GAMMA)
-		addtimer(CALLBACK(GLOBAL_PROC, /proc/set_security_level, SEC_LEVEL_RED), TIME_TO_SWITCH_CODE * 2)
-	addtimer(CALLBACK(SSvote, TYPE_PROC_REF(/datum/controller/subsystem/vote, start_vote), new /datum/vote/crew_transfer), TIME_TO_SWITCH_CODE * 3)
-	blob_stage = BLOB_STAGE_ZERO
+/datum/game_mode/proc/report_blob_death(report_number)
+	switch(report_number)
+		if (BLOB_DEATH_REPORT_FIRST)
+			send_intercept(BLOB_THIRD_REPORT)
+		if (BLOB_DEATH_REPORT_SECOND)
+			SSshuttle?.stop_lockdown()
+		if (BLOB_DEATH_REPORT_THIRD)
+			if(blob_stage >= BLOB_STAGE_SECOND && GLOB.security_level == SEC_LEVEL_GAMMA)
+				set_security_level(SEC_LEVEL_RED)
+		if (BLOB_DEATH_REPORT_FOURTH)
+			blob_stage = BLOB_STAGE_ZERO
+			SSvote.start_vote(new /datum/vote/crew_transfer)
+			return
+		else
+			return
+	addtimer(CALLBACK(src, PROC_REF(report_blob_death), report_number + 1), TIME_TO_SWITCH_CODE)
 
 
 /datum/game_mode/proc/make_blobs(count, need_new_blob = FALSE)

--- a/code/modules/vote/vote_datum.dm
+++ b/code/modules/vote/vote_datum.dm
@@ -26,8 +26,6 @@
 
 
 /datum/vote/New(_initiator, _question, list/_choices, _is_custom = FALSE)
-	if(SSvote.active_vote)
-		CRASH("Attempted to start another vote with one already in progress!")
 
 	if(_initiator)
 		initiator = _initiator
@@ -141,6 +139,7 @@
 		SSvote.active_vote = null
 		if(ooc_auto_muted && !CONFIG_GET(flag/ooc_allowed))
 			toggle_ooc()
+		addtimer(CALLBACK(SSvote, TYPE_PROC_REF(/datum/controller/subsystem/vote, on_vote_end)), 3 SECONDS)
 	return ..()
 
 

--- a/code/modules/vote/vote_presets.dm
+++ b/code/modules/vote/vote_presets.dm
@@ -11,6 +11,7 @@
 
 /datum/vote/crew_transfer/handle_result(result)
 	if(result == "Initiate Crew Transfer")
+		SSvote.clear_transfer_votes()
 		init_shift_change(null, TRUE)
 
 // Map vote

--- a/code/modules/vote/vote_verb.dm
+++ b/code/modules/vote/vote_verb.dm
@@ -21,9 +21,6 @@
 	if(!check_rights(R_ADMIN))
 		return
 
-	if(SSvote.active_vote)
-		to_chat(usr, "A vote is already in progress")
-		return
 
 	// Ask admins which type of vote they want to start
 	var/vote_types = subtypesof(/datum/vote)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет вот на вызов шаттла после смерти всех блобов.
Исправляется поломка воутов из-за того, что один стартует раньше, чем закончится другой. Теперь, если есть активный воут, то новопоявившийся добавляется в очередь воутов. Когда текущий воут пройдет или отменится, воут достанется из очереди и начнется. Так же в случае, если в воуте на трансфер победит вызов шаттла, то из очереди удаляются все воуты на трансфер, дабы избежать бесполезного спама воутами. Учитывая появление очереди воутов, убраны ненужные ограничения на их количество в админкнопке и при их создании.
Так же добавляются небольшие задержки между событиями, имеющими анонс и происходящими после убийства блоба, дабы избежать спама.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1265266014640148533 ссылка на предложку на трансфер воут после убийства блобов. Причины остальных изменений в описании изменений.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

