### PR TITLE
Tweak: change "Point to" category

### DIFF
--- a/code/modules/point/point.dm
+++ b/code/modules/point/point.dm
@@ -120,7 +120,7 @@
  */
 /mob/verb/pointed(atom/target as mob|obj|turf in view(client.view, src))
 	set name = "Point To"
-	set category = "Object"
+	set category = "IC"
 
 	if(next_move >= world.time || !Master.current_runlevel) //No usage until subsystems initialized properly.
 		return


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Возникла проблема того, что в категории "Object" остался только верб ```point to``` из-за чего эта категория лишь занимает место в строках категорий, таким образом убирается второй ряд категорий и становится проще ориентироваться в них (для всех кроме боргов)