### PR TITLE
Tweak: pods placement

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -629,7 +629,9 @@
 	},
 /area/maintenance/asmaint4)
 "agN" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Airlock"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "agT" = (
@@ -776,10 +778,6 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry/additional)
-"aii" = (
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plating,
-/area/hallway/secondary/entry/westarrival)
 "aim" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random_spawners/rodent,
@@ -822,10 +820,6 @@
 	icon_state = "whitepurple"
 	},
 /area/toxins/lab)
-"aiL" = (
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plating,
-/area/hallway/secondary/entry/eastarrival)
 "aiT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -883,12 +877,16 @@
 	},
 /area/toxins/explab)
 "ajz" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/belt/utility,
+/obj/item/multitool,
+/obj/item/clothing/glasses/meson,
+/obj/machinery/light{
+	dir = 8
+	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -26
-	},
-/obj/machinery/light{
-	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/mechanic_workshop/expedition)
@@ -979,6 +977,9 @@
 "akl" = (
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_x = 32
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/mechanic_workshop/expedition)
@@ -1243,7 +1244,6 @@
 	network = list("SS13","Security");
 	pixel_x = -9
 	},
-/obj/machinery/light,
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/adv,
 /obj/item/storage/firstaid/o2{
@@ -1922,16 +1922,11 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/bar)
 "arT" = (
-/obj/machinery/light{
-	dir = 1
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "neutral"
 	},
-/obj/structure/table/reinforced,
-/obj/machinery/cell_charger{
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/obj/item/stock_parts/cell/high,
-/turf/simulated/floor/plasteel,
 /area/engine/mechanic_workshop/expedition)
 "arX" = (
 /obj/effect/decal/warning_stripes/southwest,
@@ -2034,9 +2029,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/garden)
 "atq" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plasteel,
 /area/engine/mechanic_workshop/expedition)
@@ -2059,13 +2051,15 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "atR" = (
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/stock_parts/cell/high,
 /obj/machinery/light_switch{
 	pixel_x = -24
 	},
-/obj/structure/table/reinforced,
-/obj/item/storage/belt/utility,
-/obj/item/multitool,
-/obj/item/clothing/glasses/meson,
 /turf/simulated/floor/plasteel,
 /area/engine/mechanic_workshop/expedition)
 "atV" = (
@@ -7523,9 +7517,6 @@
 	icon_state = "darkyellow"
 	},
 /area/engine/mechanic_workshop/hangar)
-"bdu" = (
-/turf/simulated/floor/plating,
-/area/construction/hallway)
 "bdz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/soda{
@@ -40800,7 +40791,9 @@
 	},
 /area/library)
 "dZo" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Airlock"
+	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
@@ -54055,7 +54048,9 @@
 	},
 /area/tcommsat/chamber)
 "heT" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Airlock"
+	},
 /turf/simulated/floor/plating,
 /area/construction/hallway)
 "heZ" = (
@@ -69214,10 +69209,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/medical/research/nhallway)
-"kXR" = (
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
 "kXY" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/curved{
@@ -91827,7 +91818,9 @@
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
 "qjy" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Airlock"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "qjE" = (
@@ -130039,9 +130032,9 @@ aaq
 aaq
 aaq
 aaq
-yhg
-yhg
-yhg
+aaq
+aaq
+aaq
 aaq
 aaq
 aaq
@@ -130295,11 +130288,11 @@ aaq
 aaq
 aaq
 aaq
+aaq
 yhg
 yhg
 yhg
-yhg
-yhg
+aaq
 aaq
 aaq
 aaq
@@ -131323,11 +131316,11 @@ aaq
 aaq
 aaq
 aaq
-aaq
 yhg
-vAm
 yhg
-aaq
+yhg
+yhg
+yhg
 aaq
 aaq
 aaq
@@ -131580,11 +131573,11 @@ aaq
 aaq
 aaq
 aaq
-aaq
-tOj
-bdu
-tOj
-aaq
+coE
+yhg
+vAm
+yhg
+coE
 aaq
 aaq
 aaq
@@ -161044,12 +161037,12 @@ aaq
 aaq
 aaq
 aaq
-yhg
-yhg
-yhg
-yhg
 aaq
-aaq
+yhg
+yhg
+yhg
+yhg
+agp
 agp
 agp
 ahS
@@ -161300,13 +161293,13 @@ aaq
 aaq
 aaq
 aaq
+aaq
 yhg
 yhg
 yhg
 yhg
 yhg
 yhg
-ahS
 ahS
 alv
 axa
@@ -161557,13 +161550,13 @@ aaq
 aaq
 aaq
 aaq
+aaq
 yhg
 yhg
 yhg
 yhg
 yhg
 ahe
-aii
 dZo
 ayB
 amj
@@ -161814,13 +161807,13 @@ aaq
 aaq
 aaq
 aaq
+aaq
 yhg
 yhg
 yhg
 yhg
 yhg
 yhg
-ahS
 ahS
 ahr
 aah
@@ -162072,12 +162065,12 @@ aaq
 aaq
 aaq
 aaq
-yhg
-yhg
-yhg
-yhg
 aaq
-aaq
+yhg
+yhg
+yhg
+yhg
+agp
 agp
 agp
 ahS
@@ -165670,12 +165663,12 @@ aaq
 aaq
 aaq
 aaq
-yhg
-yhg
-yhg
-yhg
 aaq
-aaq
+yhg
+yhg
+yhg
+yhg
+aiE
 aiE
 ajN
 ala
@@ -165926,13 +165919,13 @@ aaq
 aaq
 aaq
 aaq
+aaq
 yhg
 yhg
 yhg
 yhg
 yhg
 yhg
-ala
 ala
 alw
 awV
@@ -166183,13 +166176,13 @@ aaq
 aaq
 aaq
 aaq
+aaq
 yhg
 yhg
 yhg
 yhg
 yhg
 ahf
-aiL
 agN
 ahs
 aml
@@ -166440,13 +166433,13 @@ aaq
 aaq
 aaq
 aaq
+aaq
 yhg
 yhg
 yhg
 yhg
 yhg
 yhg
-ala
 ala
 ahv
 aNA
@@ -166698,11 +166691,11 @@ aaq
 aaq
 aaq
 aaq
-yhg
-yhg
-yhg
-yhg
 aaq
+yhg
+yhg
+yhg
+yhg
 irJ
 irJ
 irJ
@@ -179682,7 +179675,7 @@ qEC
 oum
 yfp
 yfp
-xZu
+yfp
 vzF
 rsJ
 rsJ
@@ -179940,8 +179933,8 @@ xZu
 xZu
 qjy
 xZu
-hvU
-hvU
+vzF
+vzF
 vkX
 tff
 jpm
@@ -180193,12 +180186,12 @@ tOb
 xyi
 pVa
 qEC
-aaq
-xZu
-kXR
-xZu
+coE
+yhg
+mrO
+yhg
+coE
 vzF
-hvU
 hvU
 vYH
 eUo
@@ -180450,11 +180443,11 @@ pVa
 pVa
 rHr
 qEC
-aaq
 yhg
-mrO
 yhg
-vzF
+yhg
+yhg
+yhg
 vzF
 vkX
 lTr
@@ -181478,11 +181471,11 @@ coE
 coE
 coE
 coE
+aaq
 yhg
 yhg
 yhg
-yhg
-yhg
+aaq
 vzF
 vkX
 vEp
@@ -181736,9 +181729,9 @@ aaq
 aaq
 aaq
 aaq
-yhg
-yhg
-yhg
+aaq
+aaq
+aaq
 aaq
 usN
 vJb

--- a/_maps/map_files/celestation/celestation.dmm
+++ b/_maps/map_files/celestation/celestation.dmm
@@ -37633,6 +37633,12 @@
 	icon_state = "whitepurple"
 	},
 /area/medical/research/shallway)
+"fPl" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "fPo" = (
 /obj/structure/railing{
 	dir = 4
@@ -77861,7 +77867,7 @@
 /area/turret_protected/aisat_interior/secondary)
 "nDk" = (
 /obj/machinery/door/airlock/external{
-	name = "Emergency Shuttle Airlock"
+	name = "Escape Pod Airlock"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -99848,7 +99854,7 @@
 /area/security/lobby)
 "rSu" = (
 /obj/machinery/door/airlock/external{
-	name = "Emergency Shuttle Airlock"
+	name = "Escape Pod Airlock"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
@@ -216359,7 +216365,7 @@ gqp
 pEz
 vWY
 esT
-rSu
+fPl
 gau
 gau
 gau
@@ -216616,7 +216622,7 @@ lit
 pEz
 mLQ
 esT
-rSu
+fPl
 gau
 dXC
 gau

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -110364,7 +110364,7 @@ rNK
 biI
 bnQ
 bnQ
-cdb
+eVf
 djt
 cni
 vsg
@@ -110621,7 +110621,7 @@ cdb
 biK
 bnQ
 eVf
-eVf
+dcG
 djt
 mQb
 pop

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -21661,7 +21661,7 @@
 /area/mimeoffice)
 "cOo" = (
 /obj/machinery/door/airlock/external{
-	name = "Emergency Shuttle Airlock"
+	name = "Escape Pod Airlock"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -31442,10 +31442,6 @@
 /obj/effect/landmark/join_late,
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
-"fdm" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/hallway/primary/aft/west)
 "fdB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -89171,6 +89167,12 @@
 	},
 /turf/simulated/floor/plasteel/freezer,
 /area/crew_quarters/locker/locker_toilet)
+"vMq" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Airlock"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/disposal/north)
 "vMA" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -110359,9 +110361,9 @@ ccW
 rWw
 rWw
 rNK
-rNK
-rNK
-rNK
+biI
+bnQ
+bnQ
 cdb
 djt
 cni
@@ -110616,9 +110618,9 @@ ccW
 ccW
 rWw
 cdb
-biI
+biK
 bnQ
-bnQ
+eVf
 eVf
 djt
 mQb
@@ -110873,9 +110875,9 @@ vtY
 ccW
 rWw
 cdb
-biK
+biI
 bnQ
-eVf
+cJu
 dcG
 djt
 sxb
@@ -111130,9 +111132,9 @@ vtY
 ccW
 rWw
 cdb
-biI
+biK
 bnQ
-cJu
+eVf
 dcG
 djt
 hXm
@@ -111387,9 +111389,9 @@ vtY
 ccW
 rWw
 cdb
-biK
+biI
 bnQ
-eVf
+cJu
 dcG
 djt
 sxb
@@ -111644,9 +111646,9 @@ vtY
 ccW
 rWw
 cdb
-biI
+biK
 bnQ
-cJu
+eVf
 dcG
 uCu
 owN
@@ -111900,10 +111902,10 @@ uCK
 vtY
 vtY
 rWw
-rWw
-biK
+cdb
+biI
 bnQ
-eVf
+cJu
 biK
 rlT
 bSE
@@ -112156,11 +112158,11 @@ uCK
 gur
 lOG
 vtY
-ccW
-jqn
-jqn
-jqn
+rWw
+rNK
 biK
+bnQ
+bnQ
 bnQ
 cjL
 jgl
@@ -112413,11 +112415,11 @@ vtY
 jUn
 ylJ
 vtY
+rWw
 jqn
 jqn
 jqn
-jqn
-jqn
+rNK
 cxg
 cxg
 cxg
@@ -113441,11 +113443,11 @@ chQ
 chQ
 tuK
 qWp
-vkl
 jqn
-lsT
 jqn
-qWp
+jqn
+jqn
+jqn
 cxg
 rQf
 rQf
@@ -113699,9 +113701,9 @@ nNd
 mKt
 pGq
 wsm
-vkl
-fdm
-vkl
+jqn
+lsT
+jqn
 qWp
 cxg
 eHc
@@ -125380,7 +125382,7 @@ jqn
 jqn
 jqn
 ajP
-akA
+vMq
 cAD
 akA
 akA

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -72095,6 +72095,12 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass,
 /area/hallway/secondary/exit)
+"nXN" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Airlock"
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry)
 "nYy" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
@@ -81974,6 +81980,12 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
+"uzE" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Airlock"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/atmospherics)
 "uBA" = (
 /obj/effect/decal/cleanable/dust,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -85404,6 +85416,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
+"wHa" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Airlock"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint)
 "wHj" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -95791,7 +95809,7 @@ ylx
 ylx
 ylx
 bQl
-bWz
+nXN
 bWz
 bZc
 jGQ
@@ -97333,7 +97351,7 @@ ylx
 ylx
 ylx
 bQn
-bWz
+nXN
 bWz
 bZc
 cdW
@@ -119286,7 +119304,7 @@ dcq
 dcq
 dcq
 dcq
-dhv
+uzE
 dcq
 dcq
 uTI
@@ -126358,7 +126376,7 @@ aWw
 atG
 atG
 atG
-avq
+wHa
 atG
 atG
 atG
@@ -126617,7 +126635,7 @@ uTI
 ylx
 avb
 ylx
-atG
+uTI
 uTI
 uTI
 uTI

--- a/_maps/map_files/event/Station/delta_old.dmm
+++ b/_maps/map_files/event/Station/delta_old.dmm
@@ -420,10 +420,6 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry/additional)
-"aii" = (
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plating,
-/area/hallway/secondary/entry/westarrival)
 "aip" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -457,10 +453,6 @@
 	icon_state = "white"
 	},
 /area/toxins/lab)
-"aiL" = (
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plating,
-/area/hallway/secondary/entry/eastarrival)
 "aiT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6900,9 +6892,6 @@
 	icon_state = "darkyellow"
 	},
 /area/engine/mechanic_workshop/hangar)
-"bdu" = (
-/turf/simulated/floor/plating,
-/area/construction/hallway)
 "bdz" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/radio/intercom{
@@ -119412,9 +119401,9 @@ aaa
 aaa
 aaa
 aaa
-gXq
-gXq
-gXq
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -119668,11 +119657,11 @@ aaa
 aaa
 aaa
 aaa
+aaa
 gXq
 gXq
 gXq
-gXq
-gXq
+aaa
 aaa
 aaa
 aaa
@@ -120696,11 +120685,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
 gXq
-vAm
 gXq
-aaa
+gXq
+gXq
+gXq
 aaa
 aaa
 aaa
@@ -120954,9 +120943,9 @@ aaa
 aaa
 aaa
 aaa
-tOj
-bdu
-tOj
+gXq
+vAm
+gXq
 aaa
 aaa
 aaa
@@ -151445,11 +151434,11 @@ aaa
 aaa
 aaa
 aaa
-gXq
-gXq
-gXq
-gXq
 aaa
+gXq
+gXq
+gXq
+gXq
 aaa
 agp
 agp
@@ -151701,13 +151690,13 @@ aaa
 aaa
 aaa
 aaa
+aaa
 gXq
 gXq
 gXq
 gXq
 gXq
 gXq
-ahS
 ahS
 alv
 axa
@@ -151958,13 +151947,13 @@ aaa
 aaa
 aaa
 aaa
+aaa
 gXq
 gXq
 gXq
 gXq
 gXq
 ahe
-aii
 dZo
 ayB
 amj
@@ -152215,13 +152204,13 @@ aaa
 aaa
 aaa
 aaa
+aaa
 gXq
 gXq
 gXq
 gXq
 gXq
 gXq
-ahS
 ahS
 ahr
 aud
@@ -152473,11 +152462,11 @@ aaa
 aaa
 aaa
 aaa
-gXq
-gXq
-gXq
-gXq
 aaa
+gXq
+gXq
+gXq
+gXq
 iGw
 agp
 agp
@@ -156071,12 +156060,12 @@ aaa
 aaa
 aaa
 aaa
+aaa
 gXq
 gXq
 gXq
 gXq
 aaa
-iGw
 aiE
 ajN
 ala
@@ -156327,13 +156316,13 @@ aaa
 aaa
 aaa
 aaa
+aaa
 gXq
 gXq
 gXq
 gXq
 gXq
 gXq
-ala
 ala
 alw
 awV
@@ -156584,13 +156573,13 @@ aaa
 aaa
 aaa
 aaa
+aaa
 gXq
 gXq
 gXq
 gXq
 gXq
 ahf
-aiL
 agN
 ahs
 aml
@@ -156841,13 +156830,13 @@ aaa
 aaa
 aaa
 aaa
+aaa
 gXq
 gXq
 gXq
 gXq
 gXq
 gXq
-ala
 ala
 ahv
 aNA
@@ -157099,11 +157088,11 @@ aaa
 aaa
 aaa
 aaa
-gXq
-gXq
-gXq
-gXq
 aaa
+gXq
+gXq
+gXq
+gXq
 arA
 arA
 arA
@@ -168541,9 +168530,9 @@ qEC
 iGw
 aaa
 aaa
-hLL
-lsh
-hLL
+gXq
+qGq
+gXq
 aaa
 aaa
 iGw
@@ -168797,11 +168786,11 @@ kud
 qEC
 iGw
 iGw
-iGw
 gXq
-qGq
 gXq
-iGw
+gXq
+gXq
+gXq
 iGw
 iGw
 hLL
@@ -169825,11 +169814,11 @@ nop
 csj
 iGw
 aaa
+aaa
 gXq
 gXq
 gXq
-gXq
-gXq
+aaa
 aaa
 bCI
 aaa
@@ -170083,9 +170072,9 @@ csj
 iGw
 aaa
 aaa
-gXq
-gXq
-gXq
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Чисто декоративное изменение карт.
Убирает визуальный уродск ненужных двойных окон на дельте в местах стыковок подов, добавляет аирлоки где их не было, что бы дополнительно не нагружать атмос разгермами после отлёта шаттла эвакуации
## Причины для ввода
Работа по фидбеку https://discord.com/channels/617003227182792704/740800433739661383/1267496921057198091