### PR TITLE
Fix: replace holotabes at any not-holodeck place

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -70250,10 +70250,6 @@
 	icon_state = "dark"
 	},
 /area/chapel/main)
-"llL" = (
-/obj/structure/extinguisher_cabinet/empty,
-/turf/space,
-/area/space)
 "llN" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -158142,7 +158138,7 @@ cth
 tSH
 pwN
 dIx
-llL
+aaq
 coE
 coE
 bqc

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -50847,9 +50847,9 @@
 /area/security/processing)
 "gto" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/holotable,
 /obj/item/wrench,
 /obj/item/crowbar,
+/obj/structure/table,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -105497,11 +105497,11 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
 	},
-/obj/structure/table/holotable,
 /obj/item/reagent_containers/food/snacks/beans,
 /obj/item/kitchen/utensil/pspoon{
 	pixel_x = 10
 	},
+/obj/structure/table,
 /turf/simulated/floor/plating,
 /area/maintenance/consarea_virology)
 "twQ" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
@@ -76,7 +76,7 @@
 /turf/simulated/floor/shuttle,
 /area/ruin/powered)
 "aD" = (
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/item/clothing/accessory/holster,
 /turf/simulated/floor/wood,
 /area/ruin/powered/space_bar)
@@ -107,7 +107,7 @@
 /turf/simulated/floor/wood,
 /area/ruin/powered/space_bar)
 "aM" = (
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/item/clothing/glasses/sunglasses,
 /obj/item/clothing/head/beret/black,
 /turf/simulated/floor/wood,
@@ -270,9 +270,9 @@
 /turf/simulated/floor/carpet/arcade,
 /area/ruin/powered/space_bar)
 "fb" = (
-/obj/structure/table/holotable/wood,
 /obj/item/newspaper,
 /obj/item/card/id/prisoner,
+/obj/structure/table/wood,
 /turf/simulated/floor/wood,
 /area/ruin/powered/space_bar)
 "fi" = (
@@ -702,7 +702,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/powered/space_bar)
 "Nn" = (
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/item/clipboard,
 /obj/item/paper,
 /obj/item/reagent_containers/food/snacks/donut/sprinkles,
@@ -715,7 +715,7 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/powered/space_bar)
 "Pa" = (
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/machinery/chem_dispenser/soda,
 /turf/simulated/floor/wood,
 /area/ruin/powered/space_bar)
@@ -770,7 +770,7 @@
 /turf/simulated/floor/carpet/arcade,
 /area/ruin/powered/space_bar)
 "TB" = (
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/item/reagent_containers/food/drinks/cans/beer,
 /obj/item/book/manual/barman_recipes,
 /obj/item/reagent_containers/food/drinks/shaker,

--- a/_maps/map_files/RandomZLevels/evil_santa.dmm
+++ b/_maps/map_files/RandomZLevels/evil_santa.dmm
@@ -481,7 +481,7 @@
 	},
 /area/vision_change_area/awaymission/evil_santa/spawn_nw)
 "et" = (
-/obj/structure/table/holotable/wood,
+/obj/structure/table/wood,
 /obj/item/weldingtool,
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plating/asteroid,
@@ -1301,7 +1301,7 @@
 	},
 /area/vision_change_area/awaymission/evil_santa/mine)
 "ki" = (
-/obj/structure/table/holotable/wood,
+/obj/structure/table/wood,
 /obj/item/stack/cable_coil,
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plating/asteroid,
@@ -1778,7 +1778,7 @@
 /turf/simulated/floor/wood/oak,
 /area/vision_change_area/awaymission/evil_santa/end/hall)
 "oj" = (
-/obj/structure/table/holotable/wood,
+/obj/structure/table/wood,
 /obj/item/paintkit/ripley_red,
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plating/asteroid,
@@ -2119,7 +2119,7 @@
 	},
 /area/vision_change_area/awaymission/evil_santa/forest_labyrinth)
 "qY" = (
-/obj/structure/table/holotable/wood,
+/obj/structure/table/wood,
 /obj/item/screwdriver{
 	pixel_y = 10
 	},
@@ -2521,7 +2521,7 @@
 /turf/simulated/floor/wood,
 /area/vision_change_area/awaymission/evil_santa/hut_w)
 "uw" = (
-/obj/structure/table/holotable/wood,
+/obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/oilcan/full,
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plating/asteroid,
@@ -5441,7 +5441,7 @@
 	},
 /area/vision_change_area/awaymission/evil_santa/hut_w)
 "TQ" = (
-/obj/structure/table/holotable/wood,
+/obj/structure/table/wood,
 /obj/item/clothing/head/welding/flamedecal,
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plating/asteroid,

--- a/_maps/map_files/RandomZLevels/stationCollision.dmm
+++ b/_maps/map_files/RandomZLevels/stationCollision.dmm
@@ -392,10 +392,6 @@
 	dir = 1
 	},
 /area/awaymission/northblock)
-"bE" = (
-/turf/space,
-/turf/simulated/wall/shuttle,
-/area/awaymission/syndishuttle)
 "bF" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -507,10 +503,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/shuttle/plating,
-/area/awaymission/syndishuttle)
-"bW" = (
-/turf/simulated/floor/shuttle/plating,
-/turf/simulated/wall/shuttle,
 /area/awaymission/syndishuttle)
 "bX" = (
 /turf/simulated/floor/plasteel/airless{
@@ -740,10 +732,6 @@
 	icon_state = "dark"
 	},
 /area/awaymission/research)
-"cD" = (
-/turf/simulated/floor/plating/airless,
-/turf/simulated/wall/shuttle,
-/area/awaymission/syndishuttle)
 "cE" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -2767,10 +2755,6 @@
 "hu" = (
 /turf/simulated/floor/plasteel,
 /area/awaymission/arrivalblock)
-"hv" = (
-/turf/space,
-/turf/simulated/wall/shuttle,
-/area/awaymission/arrivalblock)
 "hw" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel,
@@ -4526,7 +4510,7 @@ aa
 aa
 aa
 aa
-hv
+lq
 lq
 gw
 gQ
@@ -4571,15 +4555,15 @@ aa
 aa
 aa
 aa
-bE
-bW
+aC
+aC
 bf
 bq
 bq
 bq
 bf
-bW
-bE
+aC
+aC
 aa
 aa
 aa
@@ -4638,13 +4622,13 @@ aa
 aa
 aa
 aa
-bE
-bW
+aC
+aC
 br
 bf
 by
-bW
-bE
+aC
+aC
 aa
 aa
 aa
@@ -4705,11 +4689,11 @@ aa
 aa
 aa
 aa
-bE
+aC
 aC
 bt
 aC
-bE
+aC
 aa
 aa
 aa
@@ -4900,7 +4884,7 @@ aa
 aa
 aa
 aa
-bE
+aC
 aC
 aC
 aC
@@ -4910,7 +4894,7 @@ aC
 aC
 aC
 aC
-bE
+aC
 aa
 af
 af
@@ -4922,7 +4906,7 @@ aj
 aj
 aa
 aa
-hv
+lq
 lq
 gy
 gR
@@ -4967,7 +4951,7 @@ aa
 aa
 aa
 aa
-bE
+aC
 aC
 eh
 eK
@@ -4975,7 +4959,7 @@ eK
 eK
 fi
 aC
-bE
+aC
 aa
 aa
 af
@@ -5069,11 +5053,11 @@ iD
 hu
 jV
 km
-hv
 lq
 lq
 lq
-hv
+lq
+lq
 aa
 aa
 aa
@@ -5229,7 +5213,7 @@ ad
 aa
 aa
 aa
-bE
+aC
 aJ
 aP
 aC
@@ -5297,7 +5281,7 @@ ag
 af
 af
 aK
-cD
+aC
 aC
 ex
 eK
@@ -5305,7 +5289,7 @@ eK
 fh
 eK
 aC
-cD
+aC
 af
 af
 aj
@@ -5333,11 +5317,11 @@ gz
 jA
 hu
 kn
-hv
 lq
 lq
 lq
-hv
+lq
+lq
 aa
 aa
 aa
@@ -5363,7 +5347,7 @@ ak
 ak
 af
 aa
-bE
+aC
 aC
 eJ
 eK
@@ -5634,7 +5618,7 @@ aC
 eK
 aC
 aC
-bE
+aC
 af
 ae
 aq
@@ -5699,7 +5683,7 @@ aa
 aK
 eK
 aC
-bE
+aC
 af
 aq
 af
@@ -5962,7 +5946,7 @@ aj
 bc
 bs
 eL
-bE
+aC
 aq
 aq
 cR

--- a/_maps/map_files/RandomZLevels/stationCollision.dmm
+++ b/_maps/map_files/RandomZLevels/stationCollision.dmm
@@ -142,16 +142,7 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/northblock)
 "aC" = (
-/turf/simulated/wall/shuttle{
-	icon_state = "wall3"
-	},
-/area/awaymission/syndishuttle)
-"aD" = (
-/turf/space,
-/turf/simulated/wall/shuttle{
-	dir = 1;
-	icon_state = "diagonalWall3"
-	},
+/turf/simulated/wall/shuttle,
 /area/awaymission/syndishuttle)
 "aE" = (
 /obj/machinery/door/airlock/engineering,
@@ -205,12 +196,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/syndishuttle)
-"aQ" = (
-/turf/simulated/floor/plating/airless,
-/turf/simulated/wall/shuttle{
-	icon_state = "diagonalWall3"
-	},
-/area/awaymission/syndishuttle)
 "aR" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/landmark/tiles/damageturf,
@@ -246,16 +231,8 @@
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/awaymission/syndishuttle)
-"aY" = (
-/turf/simulated/floor/shuttle/plating,
-/turf/simulated/wall/shuttle{
-	icon_state = "diagonalWall3"
-	},
-/area/awaymission/syndishuttle)
 "aZ" = (
-/turf/simulated/wall/shuttle{
-	icon_state = "wall3"
-	},
+/turf/simulated/wall/shuttle,
 /area/space/nearstation)
 "ba" = (
 /turf/simulated/wall,
@@ -417,10 +394,7 @@
 /area/awaymission/northblock)
 "bE" = (
 /turf/space,
-/turf/simulated/wall/shuttle{
-	dir = 4;
-	icon_state = "diagonalWall3"
-	},
+/turf/simulated/wall/shuttle,
 /area/awaymission/syndishuttle)
 "bF" = (
 /obj/effect/decal/warning_stripes/north,
@@ -536,10 +510,7 @@
 /area/awaymission/syndishuttle)
 "bW" = (
 /turf/simulated/floor/shuttle/plating,
-/turf/simulated/wall/shuttle{
-	dir = 8;
-	icon_state = "diagonalWall3"
-	},
+/turf/simulated/wall/shuttle,
 /area/awaymission/syndishuttle)
 "bX" = (
 /turf/simulated/floor/plasteel/airless{
@@ -571,7 +542,7 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/research)
 "cc" = (
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/item/gun/energy/floragun{
 	pixel_x = 2;
 	pixel_y = 3
@@ -771,10 +742,7 @@
 /area/awaymission/research)
 "cD" = (
 /turf/simulated/floor/plating/airless,
-/turf/simulated/wall/shuttle{
-	dir = 8;
-	icon_state = "diagonalWall3"
-	},
+/turf/simulated/wall/shuttle,
 /area/awaymission/syndishuttle)
 "cE" = (
 /obj/structure/window/reinforced{
@@ -888,11 +856,6 @@
 	icon_state = "dark"
 	},
 /area/awaymission/research)
-"cQ" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple,
-/turf/space,
-/area/awaymission/northblock)
 "cR" = (
 /obj/machinery/portable_atmospherics/canister/toxins{
 	stat = 1
@@ -1087,11 +1050,6 @@
 	icon_state = "dark"
 	},
 /area/awaymission/research)
-"do" = (
-/obj/machinery/atmospherics/pipe/simple,
-/obj/effect/landmark/tiles/damageturf,
-/turf/simulated/floor/plating/airless,
-/area/awaymission/northblock)
 "dp" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel,
@@ -2196,21 +2154,6 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/awaymission/midblock)
-"fL" = (
-/turf/space,
-/turf/simulated/wall/shuttle{
-	tag = "icon-swall_f6";
-	icon_state = "swall_f6";
-	dir = 2
-	},
-/area/awaymission/arrivalblock)
-"fM" = (
-/turf/simulated/wall/shuttle{
-	tag = "icon-swall14";
-	icon_state = "swall14";
-	dir = 2
-	},
-/area/awaymission/arrivalblock)
 "fN" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -2240,15 +2183,6 @@
 	},
 /obj/structure/grille,
 /turf/simulated/floor/shuttle/plating,
-/area/awaymission/arrivalblock)
-"fQ" = (
-/turf/space,
-/turf/simulated/wall/shuttle{
-	dir = 3;
-	icon_state = "swall_f10";
-	layer = 2;
-	tag = "icon-swall_f10"
-	},
 /area/awaymission/arrivalblock)
 "fR" = (
 /obj/item/paper{
@@ -2309,20 +2243,6 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/awaymission/midblock)
-"fZ" = (
-/turf/simulated/wall/shuttle{
-	tag = "icon-swall3";
-	icon_state = "swall3";
-	dir = 2
-	},
-/area/awaymission/arrivalblock)
-"ga" = (
-/turf/simulated/wall/shuttle{
-	tag = "icon-swall1";
-	icon_state = "swall1";
-	dir = 2
-	},
-/area/awaymission/arrivalblock)
 "gb" = (
 /turf/simulated/floor/shuttle{
 	icon_state = "floor3"
@@ -2849,11 +2769,7 @@
 /area/awaymission/arrivalblock)
 "hv" = (
 /turf/space,
-/turf/simulated/wall/shuttle{
-	tag = "icon-swall_f5";
-	icon_state = "swall_f5";
-	dir = 2
-	},
+/turf/simulated/wall/shuttle,
 /area/awaymission/arrivalblock)
 "hw" = (
 /obj/structure/window/reinforced,
@@ -2998,14 +2914,6 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/simulated/floor/plasteel,
 /area/awaymission/midblock)
-"hR" = (
-/turf/space,
-/turf/simulated/wall/shuttle{
-	tag = "icon-swall_f9";
-	icon_state = "swall_f9";
-	dir = 2
-	},
-/area/awaymission/arrivalblock)
 "hS" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
@@ -4237,11 +4145,7 @@
 /turf/simulated/floor/plating,
 /area/awaymission/southblock)
 "lq" = (
-/turf/simulated/wall/shuttle{
-	tag = "icon-swall12";
-	icon_state = "swall12";
-	dir = 2
-	},
+/turf/simulated/wall/shuttle,
 /area/awaymission/arrivalblock)
 "lr" = (
 /obj/structure/grille,
@@ -4622,22 +4526,22 @@ aa
 aa
 aa
 aa
-fL
-fZ
+hv
+lq
 gw
 gQ
 hn
-fZ
-fZ
-fZ
+lq
+lq
+lq
 gw
 gQ
 hn
-fZ
-fZ
-fZ
-fZ
-ga
+lq
+lq
+lq
+lq
+lq
 aa
 aa
 aa
@@ -4667,8 +4571,8 @@ aa
 aa
 aa
 aa
-aD
-aY
+bE
+bW
 bf
 bq
 bq
@@ -4688,8 +4592,8 @@ aa
 aa
 aa
 aa
-fM
-ga
+lq
+lq
 gx
 gb
 gc
@@ -4734,8 +4638,8 @@ aa
 aa
 aa
 aa
-aD
-aY
+bE
+bW
 br
 bf
 by
@@ -4801,7 +4705,7 @@ aa
 aa
 aa
 aa
-aD
+bE
 aC
 bt
 aC
@@ -4952,8 +4856,8 @@ aj
 af
 aa
 aa
-fM
-ga
+lq
+lq
 gx
 gb
 gc
@@ -4996,7 +4900,7 @@ aa
 aa
 aa
 aa
-aD
+bE
 aC
 aC
 aC
@@ -5018,22 +4922,22 @@ aj
 aj
 aa
 aa
-fQ
-fZ
+hv
+lq
 gy
 gR
 ho
-fZ
-fZ
-fZ
+lq
+lq
+lq
 gw
 iK
 hn
-fZ
-fZ
-fZ
-fZ
-ga
+lq
+lq
+lq
+lq
+lq
 aa
 aa
 aa
@@ -5063,7 +4967,7 @@ aa
 aa
 aa
 aa
-aD
+bE
 aC
 eh
 eK
@@ -5165,10 +5069,10 @@ iD
 hu
 jV
 km
-fL
-fZ
-fZ
-fZ
+hv
+lq
+lq
+lq
 hv
 aa
 aa
@@ -5325,7 +5229,7 @@ ad
 aa
 aa
 aa
-aD
+bE
 aJ
 aP
 aC
@@ -5393,7 +5297,7 @@ ag
 af
 af
 aK
-aQ
+cD
 aC
 ex
 eK
@@ -5429,11 +5333,11 @@ gz
 jA
 hu
 kn
-fQ
-fZ
-fZ
-fZ
-hR
+hv
+lq
+lq
+lq
+hv
 aa
 aa
 aa
@@ -5459,7 +5363,7 @@ ak
 ak
 af
 aa
-aD
+bE
 aC
 eJ
 eK
@@ -5602,7 +5506,7 @@ aC
 af
 af
 af
-do
+aq
 aj
 af
 bB
@@ -5732,7 +5636,7 @@ aC
 aC
 bE
 af
-cQ
+ae
 aq
 an
 aj

--- a/_maps/map_files/RandomZLevels/terrorspiders.dmm
+++ b/_maps/map_files/RandomZLevels/terrorspiders.dmm
@@ -4550,10 +4550,7 @@
 	pixel_x = -2;
 	pixel_y = -1
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "warndark"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/UO71/gateway)
 "ly" = (
 /obj/structure/cable{
@@ -4947,10 +4944,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "warndark"
-	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/UO71/gateway)
 "ml" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11299,7 +11293,7 @@
 /turf/simulated/floor/wood,
 /area/awaymission/UO71/queen)
 "zU" = (
-/obj/structure/table/holotable/wood,
+/obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/cans/beer,
 /obj/machinery/light{
 	dir = 1
@@ -11324,7 +11318,7 @@
 /turf/simulated/floor/wood,
 /area/awaymission/UO71/queen)
 "zY" = (
-/obj/structure/table/holotable/wood,
+/obj/structure/table/wood,
 /turf/simulated/floor/wood,
 /area/awaymission/UO71/queen)
 "zZ" = (
@@ -11364,7 +11358,7 @@
 /turf/simulated/floor/wood,
 /area/awaymission/UO71/queen)
 "Af" = (
-/obj/structure/table/holotable/wood,
+/obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/cans/beer,
 /turf/simulated/floor/wood,
 /area/awaymission/UO71/queen)

--- a/_maps/map_files/celestation/celestation.dmm
+++ b/_maps/map_files/celestation/celestation.dmm
@@ -29240,12 +29240,12 @@
 	},
 /area/medical/research)
 "eit" = (
-/obj/structure/table/holotable,
 /obj/item/razor,
 /obj/structure/mirror{
 	pixel_y = 32
 	},
 /obj/item/razor,
+/obj/structure/table,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker/locker_toilet)
 "eiB" = (
@@ -36469,12 +36469,12 @@
 	},
 /area/crew_quarters/serviceyard)
 "fFb" = (
-/obj/structure/table/holotable,
 /obj/item/razor,
 /obj/item/razor,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/table,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/toilet)
 "fFe" = (
@@ -113895,7 +113895,6 @@
 	},
 /area/hallway/primary/fore/east)
 "uzE" = (
-/obj/structure/table/holotable,
 /obj/item/paperplane,
 /obj/item/paper,
 /obj/item/paper,
@@ -113911,6 +113910,7 @@
 /obj/item/paper,
 /obj/item/paper,
 /obj/item/paper,
+/obj/structure/table,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker/locker_toilet)
 "uzW" = (

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -42054,7 +42054,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal/north)
 "imm" = (
-/obj/structure/table/holotable/wood,
+/obj/structure/table/wood,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -82534,7 +82534,7 @@
 /turf/simulated/floor/plasteel,
 /area/engine/mechanic_workshop/expedition)
 "tIP" = (
-/obj/structure/table/holotable/wood,
+/obj/structure/table/wood,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "blue"

--- a/_maps/map_files/generic/CentComm.dmm
+++ b/_maps/map_files/generic/CentComm.dmm
@@ -804,7 +804,7 @@
 	},
 /area/centcom/specops)
 "aqo" = (
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/item/clothing/gloves/boxing/hologlove{
 	icon_state = "boxinggreen";
 	item_state = "boxinggreen"
@@ -5281,7 +5281,7 @@
 	},
 /area/centcom/evac)
 "ctz" = (
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/item/beach_ball,
 /obj/item/beach_ball/holoball,
 /turf/simulated/floor/plasteel{
@@ -7142,7 +7142,6 @@
 	icon_screen = "seclaptop";
 	icon_state = "laptop"
 	},
-/obj/structure/table/wood,
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = 26;
 	pixel_y = 26
@@ -7154,6 +7153,7 @@
 	pixel_x = -2;
 	pixel_y = 11
 	},
+/obj/structure/table/holotable/wood,
 /turf/simulated/floor/carpet/black,
 /area/centcom/specops)
 "dnJ" = (
@@ -7682,7 +7682,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/item/reagent_containers/glass/beaker/waterbottle,
 /turf/simulated/floor/carpet/black,
 /area/centcom/zone2)
@@ -7877,7 +7877,7 @@
 /turf/simulated/floor/glass/reinforced,
 /area/centcom/zone1)
 "dDF" = (
-/obj/structure/table/holotable,
+/obj/structure/table,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -9928,7 +9928,7 @@
 /obj/structure/window/reinforced{
 	layer = 2.9
 	},
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/item/paper_bin/nanotrasen{
 	pixel_x = 3;
 	pixel_y = 12
@@ -10862,10 +10862,10 @@
 /obj/item/pen/fancy{
 	pixel_x = 8
 	},
-/obj/structure/table/wood,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/table/holotable/wood,
 /turf/simulated/floor/carpet/black,
 /area/centcom/specops)
 "fdP" = (
@@ -10963,8 +10963,8 @@
 /turf/simulated/floor/carpet,
 /area/centcom/evac)
 "fgt" = (
-/obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/officetoys,
+/obj/structure/table/holotable/wood,
 /turf/simulated/floor/carpet/black,
 /area/centcom/specops)
 "fgu" = (
@@ -14109,7 +14109,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/machinery/computer/library/public{
 	pixel_y = 4;
 	pixel_x = 1
@@ -15690,7 +15690,7 @@
 	department = "Central Command";
 	icon_state = "bigscanner"
 	},
-/obj/structure/table/wood,
+/obj/structure/table/holotable/wood,
 /turf/simulated/floor/carpet/black,
 /area/centcom/specops)
 "hsk" = (
@@ -18520,7 +18520,7 @@
 	},
 /area/ninja/outpost)
 "iMk" = (
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/item/paper,
 /obj/machinery/door/window/brigdoor{
 	dir = 8
@@ -20963,7 +20963,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/item/paper_bin/nanotrasen{
 	pixel_x = 3;
 	pixel_y = 12
@@ -21535,7 +21535,7 @@
 	dir = 1;
 	layer = 2.9
 	},
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/item/pen/multi/fountain,
 /obj/item/paper_bin/nanotrasen{
 	pixel_x = 3;
@@ -22397,8 +22397,8 @@
 	},
 /area/syndicate_mothership/elite_squad)
 "kDd" = (
-/obj/structure/table/holotable/wood,
 /obj/item/paper_bin/nanotrasen,
+/obj/structure/table/wood,
 /turf/simulated/floor/plating,
 /area/centcom/zone2)
 "kDg" = (
@@ -22885,7 +22885,7 @@
 	},
 /area/centcom/zone2)
 "kNq" = (
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/machinery/computer/library/public,
 /turf/simulated/floor/carpet/black,
 /area/centcom/zone2)
@@ -25777,7 +25777,7 @@
 /area/ninja/outside)
 "mfd" = (
 /obj/machinery/photocopier,
-/obj/structure/table/holotable/wood,
+/obj/structure/table/wood,
 /turf/simulated/floor/plating,
 /area/centcom/zone2)
 "mfn" = (
@@ -25929,11 +25929,11 @@
 	},
 /area/centcom/zone1)
 "mjU" = (
-/obj/structure/table/holotable/wood,
 /obj/machinery/light_construct/small{
 	dir = 4
 	},
 /obj/machinery/computer/library/public,
+/obj/structure/table/wood,
 /turf/simulated/floor/plating,
 /area/centcom/zone2)
 "mkb" = (
@@ -27293,7 +27293,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/item/reagent_containers/food/drinks/coffee,
 /turf/simulated/floor/carpet/black,
 /area/centcom/zone2)
@@ -28119,7 +28119,7 @@
 	},
 /area/shuttle/gamma)
 "neo" = (
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -29451,7 +29451,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/table/holotable,
+/obj/structure/table,
 /turf/simulated/floor/carpet/black,
 /area/centcom/zone2)
 "nFC" = (
@@ -30344,7 +30344,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/machinery/computer/library/public,
 /turf/simulated/floor/carpet/black,
 /area/centcom/zone2)
@@ -32774,7 +32774,7 @@
 /turf/simulated/floor/carpet,
 /area/centcom/evac)
 "pfP" = (
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -34694,7 +34694,7 @@
 /obj/structure/window/reinforced{
 	layer = 2.9
 	},
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/item/reagent_containers/glass/beaker/waterbottle,
 /turf/simulated/floor/carpet/black,
 /area/centcom/zone2)
@@ -37734,7 +37734,7 @@
 	},
 /area/syndicate_mothership)
 "rtr" = (
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/item/gift,
 /turf/simulated/floor/carpet/black,
 /area/centcom/zone2)
@@ -38446,7 +38446,7 @@
 	},
 /area/syndicate_mothership/infteam)
 "rIS" = (
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -41504,7 +41504,7 @@
 	},
 /area/syndicate_mothership/jail)
 "teo" = (
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/item/pen/multi/fountain,
 /obj/item/paper_bin/nanotrasen{
 	pixel_x = 3;
@@ -41892,7 +41892,7 @@
 /area/centcom/specops)
 "tpf" = (
 /obj/structure/window/reinforced,
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -43666,7 +43666,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/item/paper_bin/nanotrasen{
 	pixel_x = 3;
 	pixel_y = 12
@@ -43720,7 +43720,7 @@
 /obj/structure/window/reinforced{
 	layer = 2.9
 	},
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/item/paper_bin/nanotrasen{
 	pixel_x = 3;
 	pixel_y = 12
@@ -44461,7 +44461,7 @@
 /turf/simulated/floor/indestructible/grass,
 /area/syndicate_mothership/outside)
 "uuD" = (
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/item/paper_bin/nanotrasen{
 	pixel_x = 3;
 	pixel_y = 12
@@ -46993,7 +46993,7 @@
 	dir = 1;
 	layer = 2.9
 	},
-/obj/structure/table/holotable,
+/obj/structure/table,
 /obj/machinery/computer/library/public,
 /turf/simulated/floor/carpet/black,
 /area/centcom/zone2)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Голостолы не разбираются и должны располагаться только на голодеке.
Заменяет голостолы со всех карт на обычные, кроме ЦК(в комнате где намеренно допущены ошибки)
Так же удаляет случайный огнетушитель в космосе дельты

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1267526479277985914
