### PR TITLE
tweak: remove fullscreen button, hide karma verbs

### DIFF
--- a/code/modules/karma/karma.dm
+++ b/code/modules/karma/karma.dm
@@ -1,3 +1,5 @@
+//#define KARMA_ENABLE
+
 /*	KARMA
 	Everything karma related is here.
 	Part of karma purchase is handled in client_procs.dm	*/
@@ -112,6 +114,7 @@ GLOBAL_LIST_EMPTY(karma_spenders)
 		return FALSE
 	return TRUE
 
+#ifdef KARMA_ENABLE
 
 /mob/verb/spend_karma_list()
 	set name = "Award Karma"
@@ -210,3 +213,5 @@ GLOBAL_LIST_EMPTY(karma_spenders)
 	currentkarma = (text2num(totalkarma) - text2num(karmaspent))
 
 	return currentkarma
+
+#endif

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -292,15 +292,9 @@ window "rpane"
 		left = "infowindow"
 		right = "outputwindow"
 		is-vert = false
-	elem "fullscreenb"
-		type = BUTTON
-		pos = 3,7
-		size = 65x16
-		text = "Fullscreen"
-		command = "fullscreen"
 	elem "textb"
 		type = BUTTON
-		pos = 70,7
+		pos = 3,7
 		size = 40x16
 		saved-params = "is-checked"
 		text = "Text"
@@ -309,7 +303,7 @@ window "rpane"
 		button-type = pushbox
 	elem "infob"
 		type = BUTTON
-		pos = 111,7
+		pos = 44,7
 		size = 40x16
 		is-checked = true
 		saved-params = "is-checked"
@@ -319,31 +313,31 @@ window "rpane"
 		button-type = pushbox
 	elem "wikib"
 		type = BUTTON
-		pos = 160,7
+		pos = 90,7
 		size = 50x16
 		text = "Wiki"
 		command = "wiki"
 	elem "rulesb"
 		type = BUTTON
-		pos = 211,7
+		pos = 141,7
 		size = 50x16
 		text = "Rules"
 		command = "rules"
 	elem "githubb"
 		type = BUTTON
-		pos = 262,7
+		pos = 192,7
 		size = 50x16
 		text = "GitHub"
 		command = "github"
 	elem "webmap"
 		type = BUTTON
-		pos = 313,7
+		pos = 243,7
 		size = 50x16
 		text = "Map"
 		command = "webmap"
 	elem "changelog"
 		type = BUTTON
-		pos = 370,7
+		pos = 310,7
 		size = 65x16
 		font-style = "bold"
 		text-color = #000000
@@ -352,7 +346,7 @@ window "rpane"
 		command = "Changelog"
 	elem "discordb"
 		type = BUTTON
-		pos = 436,7
+		pos = 376,7
 		size = 60x16
 		font-style = "bold"
 		text-color = #ffffff
@@ -361,7 +355,7 @@ window "rpane"
 		command = "discord"
 	elem "donate"
 		type = BUTTON
-		pos = 497,7
+		pos = 437,7
 		size = 60x16
 		font-style = "bold"
 		text-color = #ffffff


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Убирает кнопку fullscreen, имеющую аналог в ooc->toggle fullscreen, а также прячет вербы кармы за дефайна KARMA_ENABLE(я знаю про CONFIG_GET(кармаблаблабла) но я не придумал как на него подвязать выпил вербов)
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
![image](https://github.com/user-attachments/assets/25856438-7f89-43e2-bdec-e23eda34a936)

<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
