### PR TITLE
bugfix: diona "Evacuation" evacuate right into nullspace

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -756,6 +756,8 @@
 #define COMSIG_ITEM_DISABLE_EMBED "item_disable_embed"
 ///from [/obj/effect/mine/proc/triggermine]:
 #define COMSIG_MINE_TRIGGERED "minegoboom"
+///from [/obj/item/organ/internal/remove]:
+#define COMSIG_ORGAN_REMOVED "organ_removed"
 
 /// Defib-specific signals
 

--- a/code/modules/mob/living/simple_animal/friendly/diona.dm
+++ b/code/modules/mob/living/simple_animal/friendly/diona.dm
@@ -66,7 +66,7 @@
 /datum/action/innate/diona/evolve
 	name = "Evolve"
 	icon_icon = 'icons/obj/machines/cloning.dmi'
-	button_icon_state = "pod_1"
+	button_icon_state = "pod_cloning"
 
 /datum/action/innate/diona/evolve/Activate()
 	var/mob/living/simple_animal/diona/user = owner

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -331,7 +331,7 @@
 		return
 
 	SEND_SIGNAL(owner, COMSIG_CARBON_LOSE_ORGAN, src)
-	SEND_SIGNAL(src, COMSIG_ORGAN_REMOVED)
+	SEND_SIGNAL(src, COMSIG_ORGAN_REMOVED, owner)
 	owner.internal_organs -= src
 
 	var/obj/item/organ/external/affected = owner.get_organ(parent_organ_zone)

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -331,6 +331,7 @@
 		return
 
 	SEND_SIGNAL(owner, COMSIG_CARBON_LOSE_ORGAN, src)
+	SEND_SIGNAL(src, COMSIG_ORGAN_REMOVED)
 	owner.internal_organs -= src
 
 	var/obj/item/organ/external/affected = owner.get_organ(parent_organ_zone)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -96,7 +96,7 @@
 
 	if(send_signal)
 		SEND_SIGNAL(target, COMSIG_CARBON_LOSE_ORGAN, src)
-		SEND_SIGNAL(src, COMSIG_CARBON_LOSE_ORGAN)
+		SEND_SIGNAL(src, COMSIG_ORGAN_REMOVED)
 
 	owner = null
 	START_PROCESSING(SSobj, src)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -96,6 +96,7 @@
 
 	if(send_signal)
 		SEND_SIGNAL(target, COMSIG_CARBON_LOSE_ORGAN, src)
+		SEND_SIGNAL(src, COMSIG_CARBON_LOSE_ORGAN)
 
 	owner = null
 	START_PROCESSING(SSobj, src)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -95,8 +95,8 @@
 		action.Remove(organ_owner)
 
 	if(send_signal)
-		SEND_SIGNAL(target, COMSIG_CARBON_LOSE_ORGAN, src)
-		SEND_SIGNAL(src, COMSIG_ORGAN_REMOVED)
+		SEND_SIGNAL(organ_owner, COMSIG_CARBON_LOSE_ORGAN, src)
+		SEND_SIGNAL(src, COMSIG_ORGAN_REMOVED, organ_owner)
 
 	owner = null
 	START_PROCESSING(SSobj, src)

--- a/code/modules/surgery/organs/subtypes/diona.dm
+++ b/code/modules/surgery/organs/subtypes/diona.dm
@@ -181,11 +181,11 @@
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
 	if(istype(parent, /obj/item/organ/internal))
-		RegisterSignal(parent, COMSIG_CARBON_LOSE_ORGAN, PROC_REF(transform_organ))
+		RegisterSignal(parent, COMSIG_ORGAN_REMOVED, PROC_REF(transform_organ))
 
 
 /datum/component/diona_internals/proc/transform_organ()
-	SIGNAL_HANDLER
+	SIGNAL_HANDLER // COMSIG_ORGAN_REMOVED
 
 	if(is_int_organ(parent))
 		var/obj/item/organ/internal/organ = parent


### PR DESCRIPTION

## Описание
Добавил ранее убранный SEND_SIGNAL в прок органов, чтобы /datum/component/diona_internals вновь вызывался и не телепортировал игрока в нуллспейс. Так же поменял иконку у "Evolve" нимфы с пустой на существующую

