### PR TITLE
tweak: Grab Tweaks N1

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -14,20 +14,21 @@
 #define SIBYL_LETHAL 2
 #define SIBYL_DESTRUCTIVE 3
 
-//Click cooldowns, in tenths of a second
-#define CLICK_CD_MELEE 8
-#define CLICK_CD_RANGE 4
-#define CLICK_CD_HANDCUFFED 10
-#define CLICK_CD_TKSTRANGLE 10
-#define CLICK_CD_POINT 10
-#define CLICK_CD_RESIST 20
-#define CLICK_CD_GRABBING 10
-#define CLICK_CD_CLICK_ABILITY 6
-#define CLICK_CD_RAPID 2
-#define CLICK_CD_LOOK_UP_DOWN 5
+//Click cooldowns
+#define CLICK_CD_MELEE (0.8 SECONDS)
+#define CLICK_CD_RANGE (0.4 SECONDS)
+#define CLICK_CD_HANDCUFFED (1 SECONDS)
+#define CLICK_CD_TKSTRANGLE (1 SECONDS)
+#define CLICK_CD_POINT (1 SECONDS)
+#define CLICK_CD_RESIST (2 SECONDS)
+#define CLICK_CD_PULLING (0.2 SECONDS)
+#define CLICK_CD_GRABBING (1 SECONDS)
+#define CLICK_CD_CLICK_ABILITY (0.6 SECONDS)
+#define CLICK_CD_RAPID (0.2 SECONDS)
+#define CLICK_CD_LOOK_UP_DOWN (0.5 SECONDS)
 
-///
-#define ROUNDSTART_LOGOUT_REPORT_TIME 6000 //Amount of time (in deciseconds) after the rounds starts, that the player disconnect report is issued.
+/// Amount of time after the rounds starts, that the player disconnect report is issued.
+#define ROUNDSTART_LOGOUT_REPORT_TIME (10 MINUTES)
 
 // DOOR CRUSHING DAMAGE!
 #define DOOR_CRUSH_DAMAGE 10

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -10,7 +10,7 @@
 
 	if(proximity_flag && pulling && (!isnull(pull_hand) && (pull_hand == PULL_WITHOUT_HANDS || pull_hand == hand)))
 		if(A.grab_attack(src, pulling))
-			changeNext_move(CLICK_CD_GRABBING)
+			changeNext_move(grab_state > GRAB_PASSIVE ? CLICK_CD_GRABBING : CLICK_CD_PULLING)
 			return
 
 	// Special glove functions:
@@ -104,7 +104,7 @@
 		return
 	if(proximity_flag && pulling && !isnull(pull_hand) && pull_hand != PULL_WITHOUT_HANDS && pull_hand == hand)
 		if(A.grab_attack(src, pulling))
-			changeNext_move(CLICK_CD_GRABBING)
+			changeNext_move(grab_state > GRAB_PASSIVE ? CLICK_CD_GRABBING : CLICK_CD_PULLING)
 			return
 	A.attack_animal(src)
 
@@ -113,7 +113,7 @@
 		return
 	if(proximity_flag && pulling && !isnull(pull_hand) && pull_hand != PULL_WITHOUT_HANDS && pull_hand == hand)
 		if(A.grab_attack(src, pulling))
-			changeNext_move(CLICK_CD_GRABBING)
+			changeNext_move(grab_state > GRAB_PASSIVE ? CLICK_CD_GRABBING : CLICK_CD_PULLING)
 			return
 	GiveTarget(A)
 	AttackingTarget()
@@ -133,7 +133,7 @@
 		return
 	if(proximity_flag && pulling && (!isnull(pull_hand) && (pull_hand == PULL_WITHOUT_HANDS || pull_hand == hand)))
 		if(A.grab_attack(src, pulling))
-			changeNext_move(CLICK_CD_GRABBING)
+			changeNext_move(grab_state > GRAB_PASSIVE ? CLICK_CD_GRABBING : CLICK_CD_PULLING)
 			return
 	A.attack_alien(src)
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -344,7 +344,7 @@
 		return FALSE
 	if(ismob(src))
 		var/mob/mob = src
-		mob.changeNext_move(CLICK_CD_GRABBING)
+		mob.changeNext_move(CLICK_CD_PULLING)
 	return pulling.Move(pull_turf, move_dir, glide_size)
 
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -45,7 +45,7 @@
 			var/mob/living/grabber = src
 			if(!isnull(grabber.pull_hand) && grabber.pull_hand != PULL_WITHOUT_HANDS)
 				if(next_move <= world.time && grabber.hand == grabber.pull_hand && grabber.on_grab_quick_equip(pulling, grabber.pull_hand))
-					grabber.changeNext_move(CLICK_CD_GRABBING)
+					grabber.changeNext_move(grabber.grab_state > GRAB_PASSIVE ? CLICK_CD_GRABBING : CLICK_CD_PULLING)
 				return
 		to_chat(src, span_warning("Вы ничего не держите в руке!"))
 		return

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -1,6 +1,8 @@
 /mob/living/carbon/alien/larva/Life(seconds, times_fired)
-	set invisibility = 0
+	var/old_evo_points = evolution_points
 	. = ..()
+	if(. && old_evo_points != evolution_points)
+		update_icons()
 
 
 /mob/living/carbon/alien/larva/update_stat(reason = "none given", should_log = FALSE)

--- a/code/modules/mob/living/carbon/alien/larva/update_icons.dm
+++ b/code/modules/mob/living/carbon/alien/larva/update_icons.dm
@@ -6,10 +6,13 @@
 
 /mob/living/carbon/alien/larva/update_icons()
 	var/state = 0
-	if(evolution_points > 150)
-		state = 2
-	else if(evolution_points > 50)
-		state = 1
+	switch(evolution_points)
+		if(-INFINITY to 50)
+			state = 0
+		if(51 to 150)
+			state = 1
+		if(151 to INFINITY)
+			state = 2
 
 	var/incapacitated = HAS_TRAIT(src, TRAIT_INCAPACITATED)
 	if(stat == DEAD)

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -1,12 +1,13 @@
 /mob/living/carbon/alien/Life(seconds, times_fired)
-	if(..() && can_evolve && evolution_points < max_evolution_points)
+	. = ..()
+	if(. && can_evolve && evolution_points < max_evolution_points)
 		var/points_to_add = 1
 		if(locate(/obj/structure/alien/weeds) in loc)
 			points_to_add *= 2
 		if(body_position == LYING_DOWN)
 			points_to_add *= 2
 		evolution_points = min(evolution_points + points_to_add, max_evolution_points)
-		update_icons()
+
 
 /mob/living/carbon/alien/check_breath(datum/gas_mixture/breath)
 	if(status_flags & GODMODE)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -516,6 +516,10 @@
 		throw_icon.icon_state = "act_throw_on"
 	if(client?.mouse_pointer_icon == initial(client.mouse_pointer_icon))
 		client.mouse_pointer_icon = THROW_MODE_ICON
+	// we nullify click cd when someone tries to throw a grabbed mob
+	// improves combat robustness a lot
+	if(pulling && grab_state > GRAB_PASSIVE)
+		changeNext_move(0)
 
 #undef THROW_MODE_ICON
 


### PR DESCRIPTION
## Описание
- добавлена новая задержка на клики с пуллом - 0.2с.; ранее задержка была такой же как и у грабов - 1с.
- добавлено обнуление КД на клик, при попытке бросить грабнутую цель; то есть теперь взяв моба в агрессивный захват его можно моментально бросить, а не ждать 1с., безумно кликая
- убрал постоянное обновление иконок у ксеноморфов в лайфе, что корёжило пиксель оффсеты грабов (перенесено в код грудолома, где это действительно необходимо)
