### PR TITLE
tweak: BIG error message for TGUI chat

### DIFF
--- a/code/modules/tgui/tgui_panel/tgui_panel.dm
+++ b/code/modules/tgui/tgui_panel/tgui_panel.dm
@@ -68,7 +68,7 @@
  */
 /datum/tgui_panel/proc/on_initialize_timed_out()
 	// Currently does nothing but sending a message to old chat.
-	SEND_TEXT(client, "<span class=\"userdanger\">Failed to load fancy chat, click <a href='byond://?src=[UID()];reload_tguipanel=1'>HERE</a> to attempt to reload it.</span>")
+	SEND_TEXT(client, span_userdanger("<h1>Failed to load fancy chat, click <a href='byond://?src=[UID()];reload_tguipanel=1'>HERE</a> to attempt to reload it.</h1>"))// users often miss this text, thinking it is wiki-page, so this text should be BIG
 
 /**
  * private


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Увеличивает текст "Мы не смогли загрузить чат!".

## Ссылка на предложение/Причина создания ПР
Игроки ЧАСТО пропускают эту строчку, перезаходя в игру, вместо нажатия на кнопку.
Думаю это из-за того, что текст слишком сливается с другими строчками, как с ссылками на вики и логами, от чего её легко пропустить.
![image](https://github.com/user-attachments/assets/e83721e7-feb1-4b05-b119-518a8adf316f)


## Демонстрация изменений
![image](https://github.com/user-attachments/assets/7432ab46-fc2a-4325-b634-65dc2823192c)
