### PR TITLE
bugfix: tables now do not become invisible

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -73,9 +73,6 @@
 
 
 /obj/structure/table/update_icon_state()
-	if(smooth && !flipped)
-		icon_state = ""
-
 	if(flipped)
 		var/type = 0
 		var/subtype = null
@@ -86,7 +83,7 @@
 				if(type == 1)
 					subtype = direction == turn(dir, 90) ? "-" : "+"
 
-		icon_state = "[initial(icon_state)][type][type == 1 ? subtype : ""]"
+		icon_state = "[initial(icon_state)]["flip"][type][type == 1 ? subtype : ""]"
 
 
 /obj/structure/table/proc/update_smoothing()
@@ -447,6 +444,7 @@
 		var/obj/structure/table/other_table = locate(/obj/structure/table, get_step(src, check_dir))
 		if(other_table)
 			other_table.unflip()
+
 	dir = initial(dir)
 	update_icon(UPDATE_ICON_STATE)
 	queue_smooth(src)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление ошибки, при которой столы становились невидимые после переворота
Всё ещё не чинит сглаживание столов


https://github.com/user-attachments/assets/4ccb4efb-fe43-4f30-b9f6-62d4955f43dc



