### PR TITLE
bugfix: Fix polarized fulltile windows' IDs

### DIFF
--- a/code/game/objects/effects/spawners/windowspawner.dm
+++ b/code/game/objects/effects/spawners/windowspawner.dm
@@ -27,6 +27,7 @@
 			WI.dir = cdir
 	else
 		var/obj/structure/window/W = new window_to_spawn_full(get_turf(src))
+		sync_id(W)
 		W.dir = FULLTILE_WINDOW_DIR // THIS IS DUMB
 
 	if(useGrille)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет синхронизацию ID фуллтайл окон.

## Ссылка на предложение/Причина создания ПР
Заметили при создании #5461
Окна спавнятся без ID, от чего любая кнопка активирует эти окна.
