### PR TITLE
bugfix: wryn invisible windows + smoothing

### DIFF
--- a/code/game/objects/structures/wryn.dm
+++ b/code/game/objects/structures/wryn.dm
@@ -16,6 +16,7 @@
 	name = "wax"
 	desc = "Looks like some kind of thick wax."
 	icon = 'icons/obj/smooth_structures/wryn/wall.dmi'
+	icon_state = "wall"
 	base_icon_state = "wall"
 	density = TRUE
 	opacity = TRUE
@@ -56,6 +57,7 @@
 	desc = "Wax just thin enough to let light pass through."
 	icon = 'icons/obj/smooth_structures/wryn/window.dmi'
 	base_icon_state = "window"
+	icon_state = "window-0"
 	smoothing_groups = SMOOTH_GROUP_WRYN_WAX_WALL + SMOOTH_GROUP_WRYN_WAX_WINDOW
 	opacity = FALSE
 	max_integrity = 20

--- a/code/game/objects/structures/wryn.dm
+++ b/code/game/objects/structures/wryn.dm
@@ -16,7 +16,6 @@
 	name = "wax"
 	desc = "Looks like some kind of thick wax."
 	icon = 'icons/obj/smooth_structures/wryn/wall.dmi'
-	icon_state = "wall"
 	base_icon_state = "wall"
 	density = TRUE
 	opacity = TRUE
@@ -49,17 +48,17 @@
 /obj/structure/wryn/wax/wall
 	name = "wax wall"
 	desc = "Thick wax solidified into a wall."
-	canSmoothWith = SMOOTH_GROUP_WRYN_WAX_WALL + SMOOTH_GROUP_WRYN_WAX_WINDOW
+	smoothing_groups = SMOOTH_GROUP_WRYN_WAX_WALL + SMOOTH_GROUP_WRYN_WAX_WINDOW
 	obj_flags = BLOCK_Z_IN_DOWN | BLOCK_Z_IN_UP
 
 /obj/structure/wryn/wax/window
 	name = "wax window"
 	desc = "Wax just thin enough to let light pass through."
 	icon = 'icons/obj/smooth_structures/wryn/window.dmi'
-	icon_state = "window"
+	base_icon_state = "window"
+	smoothing_groups = SMOOTH_GROUP_WRYN_WAX_WALL + SMOOTH_GROUP_WRYN_WAX_WINDOW
 	opacity = FALSE
 	max_integrity = 20
-	canSmoothWith = SMOOTH_GROUP_WRYN_WAX_WALL + SMOOTH_GROUP_WRYN_WAX_WINDOW
 
 /obj/structure/wryn/floor
 	icon = 'icons/obj/smooth_structures/wryn/floor.dmi'


### PR DESCRIPTION
# Описание
Окна у вринов более не прозрачные. Так же вернул "слипание" стенок между собой (icon_smoothing), которое отвалилось после рефактора 4-х недельной давности

## Демонстрация изменений
До/После
![image](https://github.com/user-attachments/assets/45a8c877-0590-4dc8-94ca-acbf62a4b449)
![image](https://github.com/user-attachments/assets/cbbdd0a9-f2a8-4559-b52b-111490906d24)

