### PR TITLE
add: Adding an additional condition for selecting a station target.

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -663,8 +663,8 @@
 	return objective_parts.Join("<br>")
 
 /datum/game_mode/proc/generate_station_goals()
-    var/list/possible = list()
-    var/playerC = num_players()
+	var/list/possible = list()
+	var/playerC = num_players()
 	for(var/T in subtypesof(/datum/station_goal))
 		var/datum/station_goal/goal = new T
 		if(!goal.can_start(playerC))

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -662,15 +662,13 @@
 
 	return objective_parts.Join("<br>")
 
-
 /datum/game_mode/proc/generate_station_goals()
-	var/list/possible = list()
-
+    var/list/possible = list()
+    var/playerC = num_players()
 	for(var/T in subtypesof(/datum/station_goal))
 		var/datum/station_goal/goal = new T
-		if(config_tag in goal.gamemode_blacklist)
+		if(!goal.can_start(playerC))
 			continue
-
 		possible += goal
 
 	var/goal_weights = 0
@@ -681,7 +679,6 @@
 
 	if(length(station_goals))
 		send_station_goals_message()
-
 
 /datum/game_mode/proc/send_station_goals_message()
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -667,7 +667,7 @@
 	var/playerC = num_players()
 	for(var/T in subtypesof(/datum/station_goal))
 		var/datum/station_goal/goal = new T
-		if(!goal.can_start(playerC))
+		if(!goal.can_start(playerC, config_tag))
 			continue
 		possible += goal
 

--- a/code/modules/station_goals/bfl.dm
+++ b/code/modules/station_goals/bfl.dm
@@ -3,6 +3,8 @@
 /datum/station_goal/bfl
 	name = "BFL Mining laser"
 	gamemode_blacklist = list("extended")
+    min_players = 40
+    max_players = INFINITY
 
 /datum/station_goal/bfl/get_report()
 	return {"<b>Mining laser construcion</b><br>

--- a/code/modules/station_goals/bfl.dm
+++ b/code/modules/station_goals/bfl.dm
@@ -3,8 +3,8 @@
 /datum/station_goal/bfl
 	name = "BFL Mining laser"
 	gamemode_blacklist = list("extended")
-    min_players = 40
-    max_players = INFINITY
+	min_players = 40
+	max_players = INFINITY
 
 /datum/station_goal/bfl/get_report()
 	return {"<b>Mining laser construcion</b><br>

--- a/code/modules/station_goals/bluespace_tap.dm
+++ b/code/modules/station_goals/bluespace_tap.dm
@@ -3,8 +3,8 @@
 	name = "Bluespace Harvester"
 	gamemode_blacklist = list("extended")
 	var/goal = 25000
-    min_players = 20
-    max_players = 40
+	min_players = 20
+	max_players = 40
 
 /datum/station_goal/bluespace_tap/get_report()
 	return {"<b>Bluespace Harvester Experiment</b><br>

--- a/code/modules/station_goals/bluespace_tap.dm
+++ b/code/modules/station_goals/bluespace_tap.dm
@@ -3,6 +3,8 @@
 	name = "Bluespace Harvester"
 	gamemode_blacklist = list("extended")
 	var/goal = 25000
+    min_players = 20
+    max_players = 40
 
 /datum/station_goal/bluespace_tap/get_report()
 	return {"<b>Bluespace Harvester Experiment</b><br>

--- a/code/modules/station_goals/brs.dm
+++ b/code/modules/station_goals/brs.dm
@@ -11,8 +11,8 @@ GLOBAL_LIST_EMPTY(bluespace_rifts_scanner_list)
 	var/target_research_points = 25000
 	var/reward_given = FALSE
 	var/datum/bluespace_rift/rift
-    min_players = 30
-    max_players = INFINITY
+	min_players = 30
+	max_players = INFINITY
 
 /datum/station_goal/bluespace_rift/Destroy()
 

--- a/code/modules/station_goals/brs.dm
+++ b/code/modules/station_goals/brs.dm
@@ -11,6 +11,8 @@ GLOBAL_LIST_EMPTY(bluespace_rifts_scanner_list)
 	var/target_research_points = 25000
 	var/reward_given = FALSE
 	var/datum/bluespace_rift/rift
+    min_players = 30
+    max_players = INFINITY
 
 /datum/station_goal/bluespace_rift/Destroy()
 

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -5,6 +5,8 @@
 
 /datum/station_goal/bluespace_cannon
 	name = "Bluespace Artillery"
+    min_players = 30
+    max_players = INFINITY
 
 /datum/station_goal/bluespace_cannon/get_report()
 	return {"<b>Bluespace Artillery position construction</b><br>

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -5,8 +5,8 @@
 
 /datum/station_goal/bluespace_cannon
 	name = "Bluespace Artillery"
-    min_players = 30
-    max_players = INFINITY
+	min_players = 30
+	max_players = INFINITY
 
 /datum/station_goal/bluespace_cannon/get_report()
 	return {"<b>Bluespace Artillery position construction</b><br>

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -17,8 +17,8 @@
 	var/animal_count
 	var/human_count
 	var/plant_count
-    min_players = 30
-    max_players = INFINITY
+	min_players = 30
+	max_players = INFINITY
 
 /datum/station_goal/dna_vault/New()
 	..()

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -17,6 +17,8 @@
 	var/animal_count
 	var/human_count
 	var/plant_count
+    min_players = 30
+    max_players = INFINITY
 
 /datum/station_goal/dna_vault/New()
 	..()

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -7,6 +7,8 @@ GLOBAL_LIST_INIT(meteor_shields, list())
 	name = "Station Shield"
 	VAR_PRIVATE/cached_coverage_length
 	var/coverage_goal = 10000
+    min_players = 1
+    max_players = 40
 
 /datum/station_goal/station_shield/get_report()
 	return {"<b>Сооружение щитов станции</b><br>

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -7,8 +7,8 @@ GLOBAL_LIST_INIT(meteor_shields, list())
 	name = "Station Shield"
 	VAR_PRIVATE/cached_coverage_length
 	var/coverage_goal = 10000
-    min_players = 1
-    max_players = 40
+	min_players = 1
+	max_players = 40
 
 /datum/station_goal/station_shield/get_report()
 	return {"<b>Сооружение щитов станции</b><br>

--- a/code/modules/station_goals/station_goal.dm
+++ b/code/modules/station_goals/station_goal.dm
@@ -12,13 +12,13 @@
 	var/report_message = "Complete this goal."
 	var/list/obj/item/paper/papers_list = list()
 	var/list/datum/supply_packs/supply_list = list()
-    var/min_players = 0
-    var/max_players = INFINITY
+	var/min_players = 0
+	var/max_players = INFINITY
 
-/datum/station_goal/proc/can_start(var/players = 0, var/game_mode = "secret")
-    if(game_mode  in gamemode_blacklist)
+/datum/station_goal/proc/can_start(players = 0, game_mode = "secret")
+    if(game_mode in gamemode_blacklist)
         return FALSE
-    return (players <= max_players && players >= min_players)
+    return ((players <= max_players) && (players >= min_players))
 
 /datum/station_goal/proc/send_report()
 	on_report()

--- a/code/modules/station_goals/station_goal.dm
+++ b/code/modules/station_goals/station_goal.dm
@@ -12,6 +12,13 @@
 	var/report_message = "Complete this goal."
 	var/list/obj/item/paper/papers_list = list()
 	var/list/datum/supply_packs/supply_list = list()
+    var/min_players = 0
+    var/max_players = INFINITY
+
+/datum/station_goal/proc/can_start(var/players = 0, var/game_mode = "secret")
+    if(game_mode  in gamemode_blacklist)
+        return FALSE
+    return (players <= max_players && players >= min_players)
 
 /datum/station_goal/proc/send_report()
 	on_report()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет дополнительное условие выбора цели для станции в виде проверки на количество игроков. Создана отдельная функция для этого в station_goal (can_start).
Запихнул в can_start и проверку на возможность цели при выбранном режиме удалив данную проверку из code/game/game_mode
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР

https://discord.com/channels/617003227182792704/618952559607939072/1270074147292315692
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений

Блинб на лоупопе будут вечно щиты
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
