### PR TITLE
bugfix: balloon_alert on vehicle

### DIFF
--- a/code/modules/vehicle/ambulance.dm
+++ b/code/modules/vehicle/ambulance.dm
@@ -132,7 +132,7 @@
 	var/obj/vehicle/ambulance/amb = over_object
 	if(amb.bed)
 		amb.bed = null
-		balloon_alert(usr, "прицеплено к машине")
+		balloon_alert(usr, "отцеплено от машины")
 	else
 		amb.bed = src
-		balloon_alert(usr, "отцеплено от машины")
+		balloon_alert(usr, "прицеплено к машине")


### PR DESCRIPTION
## Описание
Минорный фикс. Меняет местами всплывающее сообщение при перетягивании коляски на машину.

## Ссылка на предложение/Причина создания ПР
[discord:#Перепутаны местами сообщения об изменении статуса каталки парамедика](https://discord.com/channels/617003227182792704/1270481683715723264/1270481683715723264)