### PR TITLE
Tweak: T-Admin/Mods gets more in-game rights

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -505,7 +505,7 @@
 /client/proc/view_var_Topic(href, href_list, hsrc)
 	//This should all be moved over to datum/admins/Topic() or something ~Carn
 	if(!check_rights(R_VAREDIT, FALSE) && !((href_list["datumrefresh"] || href_list["Vars"] || href_list["VarsList"])))
-		return // clients with R_VIEWRUNTIMES can still refresh the window/view references/view lists. they cannot edit anything else however.
+		return
 
 	if(view_var_Topic_list(href, href_list, hsrc))  // done because you can't use UIDs with lists and I don't want to snowflake into the below check to supress warnings
 		return
@@ -617,7 +617,7 @@
 		href_list["datumrefresh"] = href_list["give_spell"]
 
 	else if(href_list["givemartialart"])
-		if(!check_rights(R_SERVER|R_EVENT))	return
+		if(!check_rights(R_ADMIN|R_EVENT))	return
 
 		var/mob/living/carbon/C = locateUID(href_list["givemartialart"])
 		if(!istype(C))
@@ -645,7 +645,7 @@
 		href_list["datumrefresh"] = href_list["givemartialart"]
 
 	else if(href_list["give_disease"])
-		if(!check_rights(R_SERVER|R_EVENT))	return
+		if(!check_rights(R_ADMIN|R_EVENT))	return
 
 		var/mob/M = locateUID(href_list["give_disease"])
 		if(!istype(M))

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -504,7 +504,7 @@
 
 /client/proc/view_var_Topic(href, href_list, hsrc)
 	//This should all be moved over to datum/admins/Topic() or something ~Carn
-	if(!check_rights(R_ADMIN|R_MOD, FALSE) && !((href_list["datumrefresh"] || href_list["Vars"] || href_list["VarsList"]) && check_rights(R_VIEWRUNTIMES, FALSE)))
+	if(!check_rights(R_VAREDIT, FALSE) && !((href_list["datumrefresh"] || href_list["Vars"] || href_list["VarsList"])))
 		return // clients with R_VIEWRUNTIMES can still refresh the window/view references/view lists. they cannot edit anything else however.
 
 	if(view_var_Topic_list(href, href_list, hsrc))  // done because you can't use UIDs with lists and I don't want to snowflake into the below check to supress warnings
@@ -531,7 +531,8 @@
 
 	//~CARN: for renaming mobs (updates their name, real_name, mind.name, their ID/PDA and datacore records).
 	else if(href_list["rename"])
-		if(!check_rights(R_ADMIN))	return
+		if(!check_rights(R_ADMIN))	
+			return
 
 		var/mob/M = locateUID(href_list["rename"])
 		if(!istype(M))
@@ -539,14 +540,16 @@
 			return
 
 		var/new_name = reject_bad_name(sanitize(copytext_char(input(usr, "What would you like to name this mob?", "Input a name", M.real_name) as text|null, 1, MAX_NAME_LEN)), allow_numbers = TRUE)
-		if( !new_name || !M )	return
+		if( !new_name || !M )	
+			return
 
 		message_admins("Admin [key_name_admin(usr)] renamed [key_name_admin(M)] to [new_name].")
 		M.rename_character(M.real_name, new_name)
 		href_list["datumrefresh"] = href_list["rename"]
 
 	else if(href_list["varnameedit"] && href_list["datumedit"])
-		if(!check_rights(R_VAREDIT))	return
+		if(!check_rights(R_VAREDIT))	
+			return
 
 		var/D = locateUID(href_list["datumedit"])
 		if(!isdatum(D) && !isclient(D))

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -25,7 +25,7 @@ GLOBAL_VAR_INIT(nologevent, 0)
  */
 /proc/message_adminTicket(msg, important = FALSE)
 	for(var/client/C in GLOB.admins)
-		if(R_ADMIN & C.holder.rights)
+		if(R_ADMIN | R_MOD & C.holder.rights)
 			if(important || (C.prefs && !(C.prefs.toggles & PREFTOGGLE_CHAT_NO_TICKETLOGS)))
 				to_chat(C, msg, MESSAGE_TYPE_ADMINPM, confidential = TRUE)
 			if(important)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -333,7 +333,7 @@ GLOBAL_LIST_INIT(view_runtimes_verbs, list(
 	set category = "Admin"
 	set name = "Aghost"
 
-	if(!check_rights(R_ADMIN|R_MOD))
+	if(!check_rights(R_ADMIN|R_MOD|R_POSSESS))
 		return
 
 	if(istype(mob,/mob/dead/observer))

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -8,6 +8,7 @@ GLOBAL_LIST_INIT(admin_verbs_default, list(
 GLOBAL_LIST_INIT(admin_verbs_admin, list(
 	/client/proc/check_antagonists,		/*shows all antags*/
 	/datum/admins/proc/show_player_panel,
+	/client/proc/fax_panel,
 	/client/proc/player_panel_new,		/*shows an interface for all players, with links to various panels*/
 	/client/proc/invisimin,				/*allows our mob to go invisible/visible*/
 	/datum/admins/proc/announce,		/*priority announce something to all clients.*/
@@ -54,7 +55,6 @@ GLOBAL_LIST_INIT(admin_verbs_admin, list(
 	/client/proc/empty_ai_core_toggle_latejoin,
 	/client/proc/aooc,
 	/client/proc/freeze,
-	/client/proc/secrets,
 	/client/proc/debug_variables,
 	/client/proc/reset_all_tcs,			/*resets all telecomms scripts*/
 	/client/proc/toggle_mentor_chat,
@@ -80,6 +80,7 @@ GLOBAL_LIST_INIT(admin_verbs_sounds, list(
 	/client/proc/stop_global_admin_sounds
 	))
 GLOBAL_LIST_INIT(admin_verbs_event, list(
+	/client/proc/secrets,
 	/client/proc/object_talk,
 	/client/proc/cmd_admin_dress,
 	/client/proc/cmd_admin_gib_self,
@@ -98,7 +99,6 @@ GLOBAL_LIST_INIT(admin_verbs_event, list(
 	/client/proc/cmd_admin_world_narrate,	/*sends text to all players with no padding*/
 	/client/proc/response_team, // Response Teams admin verb
 	/client/proc/cmd_admin_create_centcom_report,
-	/client/proc/fax_panel,
 	/client/proc/event_manager_panel,
 	/client/proc/modify_goals,
 	/client/proc/outfit_manager,
@@ -384,7 +384,7 @@ GLOBAL_LIST_INIT(view_runtimes_verbs, list(
 	set name = "Player Panel"
 	set category = "Admin"
 
-	if(!check_rights(R_ADMIN|R_MOD))
+	if(!check_rights(R_ADMIN | R_MOD))
 		return
 
 	holder.player_panel_new()
@@ -419,9 +419,9 @@ GLOBAL_LIST_INIT(view_runtimes_verbs, list(
 
 /client/proc/game_panel()
 	set name = "Game Panel"
-	set category = "Admin"
+	set category = "Event"
 
-	if(!check_rights(R_ADMIN))
+	if(!check_rights(R_ADMIN | R_EVENT))
 		return
 
 	holder.Game()
@@ -430,9 +430,9 @@ GLOBAL_LIST_INIT(view_runtimes_verbs, list(
 
 /client/proc/secrets()
 	set name = "Secrets"
-	set category = "Admin"
+	set category = "Event"
 
-	if(!check_rights(R_ADMIN))
+	if(!check_rights(R_ADMIN | R_EVENT))
 		return
 
 	holder.Secrets()
@@ -461,7 +461,7 @@ GLOBAL_LIST_INIT(view_runtimes_verbs, list(
 		return
 
 	if(holder)
-		holder.big_brother = 0
+		holder.big_brother = FALSE
 		if(holder.fakekey)
 			holder.fakekey = null
 		else
@@ -484,7 +484,7 @@ GLOBAL_LIST_INIT(view_runtimes_verbs, list(
 	if(holder)
 		if(holder.fakekey)
 			holder.fakekey = null
-			holder.big_brother = 0
+			holder.big_brother = FALSE
 		else
 			var/new_key = ckeyEx(clean_input("Enter your desired display name. Unlike normal stealth mode, this will not appear in Who at all, except for other heads.", "Fake Key", key))
 			if(!new_key)
@@ -492,7 +492,7 @@ GLOBAL_LIST_INIT(view_runtimes_verbs, list(
 			if(length(new_key) >= 26)
 				new_key = copytext(new_key, 1, 26)
 			holder.fakekey = new_key
-			holder.big_brother = 1
+			holder.big_brother = TRUE
 			createStealthKey()
 		log_admin("[key_name(usr)] has turned BB mode [holder.fakekey ? "ON" : "OFF"]")
 		SSblackbox.record_feedback("tally", "admin_verb", 1, "Big Brother Mode")
@@ -880,7 +880,7 @@ GLOBAL_LIST_INIT(view_runtimes_verbs, list(
 	set name = "\[Admin\] Make Sound"
 	set desc = "Display a message to everyone who can hear the target"
 
-	if(!check_rights(R_EVENT))
+	if(!check_rights(R_SOUNDS))
 		return
 
 	if(O)
@@ -1051,7 +1051,7 @@ GLOBAL_LIST_INIT(view_runtimes_verbs, list(
 	set name = "Select next map"
 	set category = "Server"
 
-	if(!check_rights(R_SERVER))
+	if(!check_rights(R_SERVER | R_EVENT))
 		return
 
 	var/list/all_maps = subtypesof(/datum/map)

--- a/code/modules/admin/verbs/map_template_loadverb.dm
+++ b/code/modules/admin/verbs/map_template_loadverb.dm
@@ -1,8 +1,8 @@
 /client/proc/map_template_load()
-	set category = "Debug"
+	set category = "Event"
 	set name = "Map template - Place"
 
-	if(!check_rights(R_DEBUG))
+	if(!check_rights(R_DEBUG | R_EVENT))
 		return
 
 	var/datum/map_template/template
@@ -36,10 +36,10 @@
 	usr.client.images -= preview
 
 /client/proc/map_template_upload()
-	set category = "Debug"
+	set category = "Event"
 	set name = "Map Template - Upload"
 
-	if(!check_rights(R_DEBUG))
+	if(!check_rights(R_DEBUG | R_EVENT))
 		return
 
 	var/map = input(usr, "Choose a Map Template to upload to template storage","Upload Map Template") as null|file

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -23,7 +23,9 @@ GLOBAL_LIST_EMPTY(adminfaxes)
 // Fax panel - lets admins check all faxes sent during the round
 /client/proc/fax_panel()
 	set name = "Fax Panel"
-	set category = "Event"
+	set category = "Admin"
+	if(!check_rights(R_ADMIN))
+		return
 	if(holder)
 		holder.fax_panel(usr)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Fax Panel") //If you are copy-pasting this, ensure the 4th parameter is unique to the new proc!


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет триалам возможность пользоваться факс панелью, модерам обрабатывать атикеты.

Были изменены категории кнопок Game Panel, Secrets, Map Templates на Event, флаг SOUND для make_sound (:-), флаги ивент в 3 местах для потенциального ввода ивентмастеров.

Исправляет невозможность редактировать переменные контрибуторам потому что это было завязано на флагах админ и мод, но по какой-то странной причине не флаге varedit

TODO:
[] - тесты/ревью поскольку я впервые работаю с подобным