### PR TITLE
Fix/tweak: Mentors, Moders and A-Tickets

### DIFF
--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -500,7 +500,7 @@ SUBSYSTEM_DEF(dbcore)
 		return
 
 	if(SSdbcore.IsConnected())
-		if(!check_rights(R_ADMIN & R_DEBUG, FALSE)) //we dont want coders to deal with db
+		if(!check_rights(R_ADMIN, FALSE) || !check_rights(R_DEBUG, FALSE)) //we dont want coders to deal with db
 			to_chat(usr, "<span class='warning'>The database is already connected! (Only those with +DEBUG can force a reconnection)</span>")
 			return
 

--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -500,7 +500,7 @@ SUBSYSTEM_DEF(dbcore)
 		return
 
 	if(SSdbcore.IsConnected())
-		if(!check_rights(R_DEBUG, FALSE))
+		if(!check_rights(R_ADMIN & R_DEBUG, FALSE)) //we dont want coders to deal with db
 			to_chat(usr, "<span class='warning'>The database is already connected! (Only those with +DEBUG can force a reconnection)</span>")
 			return
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -25,7 +25,7 @@ GLOBAL_VAR_INIT(nologevent, 0)
  */
 /proc/message_adminTicket(msg, important = FALSE)
 	for(var/client/C in GLOB.admins)
-		if(R_MOD & C.holder.rights)
+		if((R_ADMIN|R_MOD) & C.holder.rights)
 			if(important || (C.prefs && !(C.prefs.toggles & PREFTOGGLE_CHAT_NO_TICKETLOGS)))
 				to_chat(C, msg, MESSAGE_TYPE_ADMINPM, confidential = TRUE)
 			if(important)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -25,7 +25,7 @@ GLOBAL_VAR_INIT(nologevent, 0)
  */
 /proc/message_adminTicket(msg, important = FALSE)
 	for(var/client/C in GLOB.admins)
-		if(R_ADMIN | R_MOD & C.holder.rights)
+		if(R_MOD & C.holder.rights)
 			if(important || (C.prefs && !(C.prefs.toggles & PREFTOGGLE_CHAT_NO_TICKETLOGS)))
 				to_chat(C, msg, MESSAGE_TYPE_ADMINPM, confidential = TRUE)
 			if(important)

--- a/code/modules/admin/tickets/adminticketsverbs.dm
+++ b/code/modules/admin/tickets/adminticketsverbs.dm
@@ -5,7 +5,7 @@
 	set name = "Open Admin Ticket Interface"
 	set category = "Admin"
 
-	if(!check_rights(R_ADMIN))
+	if(!check_rights(R_MOD))
 		return
 
 	SStickets.showUI(usr)

--- a/code/modules/admin/tickets/adminticketsverbs.dm
+++ b/code/modules/admin/tickets/adminticketsverbs.dm
@@ -5,7 +5,7 @@
 	set name = "Open Admin Ticket Interface"
 	set category = "Admin"
 
-	if(!check_rights(R_MOD))
+	if(!check_rights(R_ADMIN|R_MOD))
 		return
 
 	SStickets.showUI(usr)

--- a/code/modules/admin/tickets/mentorticketsverbs.dm
+++ b/code/modules/admin/tickets/mentorticketsverbs.dm
@@ -5,7 +5,7 @@
 	set name = "Open Mentor Ticket Interface"
 	set category = "Admin"
 
-	if(!check_rights(R_MENTOR|R_ADMIN))
+	if(!check_rights(R_MENTOR))
 		return
 
 	SSmentor_tickets.showUI(usr)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
По непонятной мне причине логика работы оператора или с оператором и сломана 
```if(R_ADMIN | R_MOD & C.holder.rights)``` игнорирует необходимость наличие флага мод/админ и позволяет любому кто обладает правами видеть атикеты.
Поэтому, и поскольку мы имеем накопительную систему прав администрирования, права на атикеты были полностью переданы R_MOD. 

Так же ограничивает флаг R_DEBAG необходимостью обладать R_ADMIN что бы взаимодействовать с бд.