### PR TITLE
tweak: Change sucumb's and suicides' logs to attack logs

### DIFF
--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -40,13 +40,13 @@
 			if(confirm == "Yes")
 				suiciding = TRUE
 				do_suicide()
-				create_log(ATTACK_LOG, "Attempted suicide as special role")
+				add_attack_logs(src, src, "Attempted suicide as special role")
 				message_admins("[src] with a special role attempted suicide at [ADMIN_JMP(src)]")
 				return
 			return
 		suiciding = TRUE
 		do_suicide()
-		create_log(ATTACK_LOG, "Attempted suicide")
+		add_attack_logs(src, src, "Attempted suicide")
 
 
 /mob/living/proc/do_suicide()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -549,7 +549,7 @@
 /mob/living/verb/succumb()
 	set hidden = 1
 	if(InCritical())
-		add_misc_logs(src, "has succumbed to death with [round(health, 0.1)] points of health")
+		add_attack_logs(src, src, "has succumbed to death with [round(health, 0.1)] points of health")
 		adjustOxyLoss(health - HEALTH_THRESHOLD_DEAD)
 		// super check for weird mobs, including ones that adjust hp
 		// we don't want to go overboard and gib them, though


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Меняет логирование проков (вербов) `succumb` и `suicide` на аттак логи.

## Ссылка на предложение/Причина создания ПР
Просьба администрации.
