### PR TITLE
bugfix: GasSensorDel

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -5809,11 +5809,6 @@
 /obj/machinery/atmospherics/air_sensor{
 	id_tag = "air_sensor"
 	},
-/obj/machinery/atmospherics/air_sensor{
-	frequency = 1443;
-	id_tag = "air_sensor";
-	output = 7
-	},
 /turf/simulated/floor/engine/air,
 /area/atmos)
 "aSO" = (


### PR DESCRIPTION
## Описание
Удаляет лишний ( второй ) сенсор газа из камеры
## Ссылка на предложение/Причина создания ПР
![image](https://github.com/user-attachments/assets/26b983f3-1874-44d3-b33d-d79e9a85ab48)
![image](https://github.com/user-attachments/assets/e76f49b4-0b57-4d06-a686-f741adda1597)
