### PR TITLE
bugfix: improper adjacent turfs check at area creation/expanding

### DIFF
--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -67,6 +67,8 @@
 			continue
 		if(!isnull(place.apc))
 			apc_map[place.name] = place.apc
+		if(!LAZYLEN(the_turf.atmos_adjacent_turfs)) // No expanding areas on blocked turfs
+			continue
 		if(length(apc_map) > 1) // When merging 2 or more areas make sure we arent merging their apc into 1 area
 			to_chat(creator, span_warning("Multiple APC's detected in the vicinity. only 1 is allowed."))
 			return


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Исправляет некорректную проверку соседних турфов при создании зоны.

Фиксит невозможность создать зону рядом с уже созданной, выдавая ошибку: "Multiple APC's detected in the vicinity. only 1 is allowed.". Из-за чего приходилось строить второй слой стен для создания новой зоны.
Так же убирает в некоторых случаях возможность объединения изолированных (стенами, окнами и пр.) зон.

Подробнее: https://github.com/tgstation/tgstation/pull/74620