### PR TITLE
bugfix: correct removal of gloves

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -324,6 +324,8 @@ BLIND     // can't see anything
 
 /obj/item/clothing/gloves/dropped(mob/living/carbon/human/user, slot, silent = FALSE)
 	. = ..()
+	if(!ishuman(user) || slot != ITEM_SLOT_GLOVES)
+		return .
 	if(surgeryspeedmod)
 		user.remove_actionspeed_modifier(/datum/actionspeed_modifier/surgical_gloves)
 	if(toolspeedmod)


### PR DESCRIPTION
## Описание
Добавляет проверку при снятии, которая была убрана ранее.

## Ссылка на предложение/Причина создания ПР
Модификатор удаляется, даже если просто выкинуть вторые перчатки