### PR TITLE
tweak: add waistcoat to loadout and law's clothesmate

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -2849,6 +2849,7 @@
 		/obj/item/clothing/accessory/blue 		= 10,
 		/obj/item/clothing/accessory/red 		= 10,
 		/obj/item/clothing/accessory/black 		= 10,
+		/obj/item/clothing/accessory/waistcoat	= 5,
 
 		/obj/item/storage/backpack/satchel 	= 10,
 		/obj/item/storage/briefcase			= 5,

--- a/code/modules/client/preference/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference/loadout/loadout_accessories.dm
@@ -70,6 +70,10 @@
 	path = /obj/item/clothing/accessory/ntrjacket
 	allowed_roles = list(JOB_TITLE_REPRESENTATIVE)
 
+/datum/gear/accessory/waistcoat
+	display_name = "waistcoat"
+	path = /obj/item/clothing/accessory/waistcoat
+
 /datum/gear/accessory/cowboyshirt
 	display_name = "cowboy shirt, select"
 	path = /obj/item/clothing/accessory/cowboyshirt


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавить в меню Loadout, в раздел Аксессуаров, жилетку обычную, или же waistcoat. А также добавить в Вендормат Юристов 5 таких жилеток.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1273631705089183859/1275061156397973525
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
Визуальной демонстрации не будет, т. к. локалка решила заруинить мне свет. Так что вот вам то, как она сидит на моем любимом персе.
![СТИЛЬ!](https://github.com/user-attachments/assets/b2770e54-f205-43df-8815-2c18b1594ac4)
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
