### PR TITLE
bugfix: some random spawn init fixes

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -2,29 +2,24 @@
 	icon = 'icons/effects/mapping_helpers.dmi'
 	icon_state = "standart"
 	var/lootcount = 1		//how many items will be spawned
-	var/lootdoubles = 1		//if the same item can be spawned twice
+	var/lootdoubles = TRUE		//if the same item can be spawned twice
 	var/list/loot			//a list of possible items to spawn e.g. list(/obj/item, /obj/structure, /obj/effect)
-
-/obj/effect/spawner/lootdrop/New()
-	..()
-	if(loot && loot.len)
-		for(var/i = lootcount, i > 0, i--)
-			if(!loot.len) break
-			var/lootspawn = pickweight(loot)
-			if(!lootdoubles)
-				loot.Remove(lootspawn)
-
-			if(lootspawn)
-				new lootspawn(loc)
 
 /obj/effect/spawner/lootdrop/Initialize(mapload)
 	. = ..()
+	while(lootcount)
+		var/lootspawn = pickweight(loot)
+		if(lootspawn)
+			new lootspawn(get_turf(src))
+			if(!lootdoubles)
+				loot.Remove(lootspawn)
+		lootcount--
 	return INITIALIZE_HINT_QDEL
 
 /obj/effect/spawner/lootdrop/armory_contraband
 	name = "armory contraband gun spawner"
 	icon_state ="stechkin"
-	lootdoubles = 0
+	lootdoubles = FALSE
 
 	loot = list(
 				/obj/item/gun/projectile/automatic/pistol = 8,
@@ -174,8 +169,7 @@
 /obj/effect/spawner/lootdrop/crate_spawner // for ruins
 	name = "lootcrate spawner"
 	icon_state = "lootcrate"
-	lootdoubles = 0
-
+	lootdoubles = FALSE
 	loot = list(
 				/obj/structure/closet/crate/secure/loot = 20,
 				"" = 80,
@@ -192,7 +186,7 @@
 /obj/effect/spawner/lootdrop/trade_sol/
 	name = "trader item spawner"
 	lootcount = 6
-	lootdoubles = 1
+	lootdoubles = TRUE
 	color = "#00FFFF"
 
 //У нас не используется
@@ -219,7 +213,6 @@
 
 /obj/effect/spawner/lootdrop/trade_sol/serv
 	name = "1. Service gear"
-	lootdoubles = 2
 	lootcount = 8
 	loot = list(
 		/obj/item/storage/box/beakers/bluespace = 50,
@@ -246,7 +239,6 @@
 
 /obj/effect/spawner/lootdrop/trade_sol/minerals
 	name = "2. Minerals"
-	lootdoubles = 1
 	loot = list(
 				// Common stuff you get from mining which isn't already present on the station
 				// Note that plasma and derived hybrid materials are NOT included in this list because plasma is the trader's objective!
@@ -268,23 +260,16 @@
 				/obj/item/stack/sheet/mineral/sandstone = 50
 				)
 
-/obj/effect/spawner/lootdrop/trade_sol/minerals/New()
+/obj/effect/spawner/lootdrop/trade_sol/minerals/Initialize(mapload)
+	while(lootcount)
+		var/lootspawn = pickweight(loot)
+		var/obj/item/stack/sheet/S = new lootspawn(get_turf(src))
+		S.amount = 25
+		lootcount--
 	. = ..()
-	if(loot && loot.len)
-		for(var/i = lootcount, i > 0, i--)
-			if(!loot.len)
-				break
-			var/lootspawn = pickweight(loot)
-			if(!lootdoubles)
-				loot.Remove(lootspawn)
-			if(lootspawn)
-				new lootspawn(get_turf(src), 25)
-	qdel(src)
-
 
 /obj/effect/spawner/lootdrop/trade_sol/donksoft
 	name = "3. Donksoft gear"
-	lootdoubles = 2
 	lootcount = 8
 	loot = list(
 		/obj/item/gun/projectile/automatic/c20r/toy = 150,
@@ -305,7 +290,6 @@
 
 /obj/effect/spawner/lootdrop/trade_sol/sci
 	name = "4. Science gear"
-	lootdoubles = 2
 	lootcount = 8
 	loot = list(
 		/obj/item/mmi/robotic_brain = 50,
@@ -336,7 +320,6 @@
 
 /obj/effect/spawner/lootdrop/trade_sol/med
 	name = "5. Medical gear"
-	lootdoubles = 2
 	lootcount = 8
 	loot = list(
 		/obj/item/storage/fancy/cigarettes/cigpack_med = 50,
@@ -364,7 +347,6 @@
 
 /obj/effect/spawner/lootdrop/trade_sol/sec
 	name = "6. Security gear"
-	lootdoubles = 2
 	lootcount = 10
 	loot = list(
 		/obj/item/clothing/gloves/combat = 50,
@@ -390,7 +372,6 @@
 
 /obj/effect/spawner/lootdrop/trade_sol/eng
 	name = "7. Eng gear"
-	lootdoubles = 2
 	lootcount = 8
 	loot = list(
 	/obj/item/pickaxe/drill/jackhammer = 50,
@@ -427,16 +408,14 @@
 		/obj/vehicle/space/speedbike/red = 50,
 		/obj/vehicle/space/speedbike = 50)
 
-/obj/effect/spawner/lootdrop/trade_sol/vehicle/New()
+/obj/effect/spawner/lootdrop/trade_sol/vehicle/Initialize(mapload)
+	while(lootcount)
+		var/lootspawn = pickweight(loot)
+		var/obj/vehicle/V = new lootspawn(get_turf(src))
+		if(V.key_type)
+			V.inserted_key = new V.key_type(V)
+		lootcount--
 	. = ..()
-	if(!loot.len)
-		return
-	var/lootspawn = pickweight(loot)
-	var/obj/vehicle/V = new lootspawn(get_turf(src))
-	if(V.key_type)
-		new V.key_type(get_turf(src))
-	qdel(src)
-
 
 /obj/effect/spawner/lootdrop/three_course_meal
 	name = "three course meal spawner"
@@ -458,7 +437,7 @@
 			/obj/item/reagent_containers/food/snacks/bigbiteburger,
 			/obj/item/reagent_containers/food/snacks/superbiteburger)
 
-/obj/effect/spawner/lootdrop/three_course_meal/New()
+/obj/effect/spawner/lootdrop/three_course_meal/Initialize(mapload)
 	loot = list(pick(soups) = 1,pick(salads) = 1,pick(mains) = 1)
 	. = ..()
 
@@ -477,7 +456,7 @@
 	name = "40% marrow weaver spawner"
 	icon = 'icons/mob/lavaland/lavaland_monsters.dmi'
 	icon_state = "weaver"
-	lootdoubles = 0
+	lootdoubles = FALSE
 	lootcount = 1
 	loot = list(/mob/living/simple_animal/hostile/asteroid/marrowweaver = 40,
 	/mob/living/simple_animal/hostile/asteroid/marrowweaver/frost = 20,
@@ -486,8 +465,7 @@
 /obj/effect/spawner/lootdrop/bouquet_spawner
 	name = "50% bouquet spawner"
 	icon_state = "bouquet"
-	lootdoubles = 0
-
+	lootdoubles = FALSE
 	loot = list(
 				/obj/item/decorations/bouquets/random = 50,
 				"" = 50,

--- a/code/game/objects/effects/spawners/random_spawners.dm
+++ b/code/game/objects/effects/spawners/random_spawners.dm
@@ -13,23 +13,19 @@
 	var/active_power_usage = null // Сколько энергии оно тратит если активно
 	var/idle_power_usage = null // Сколько энергии оно тратит в пассивном режиме
 
-// This needs to use New() instead of Initialize() because the thing it creates might need to be initialized too
-/obj/effect/spawner/random_spawners/New()
-	. = ..()
+/obj/effect/spawner/random_spawners/Initialize(mapload)
+	. = ..()	
 	var/turf/T = get_turf(src)
 	if(!T)
 		log_runtime(EXCEPTION("Spawner placed in nullspace!"), src)
 		return
 	randspawn(T)
-
-/obj/effect/spawner/random_spawners/Initialize(mapload)
-	. = ..()
 	return INITIALIZE_HINT_QDEL
 
 /obj/effect/spawner/random_spawners/proc/randspawn(turf/T)
 	var/thing_to_place = pickweight(result)
 	if(ispath(thing_to_place, /datum/nothing))
-		// Nothing.
+		return
 	else if(ispath(thing_to_place, /turf))
 		T.ChangeTurf(thing_to_place)
 	else

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -8,14 +8,12 @@
 
 
 // creates a new object and deletes itself
-/obj/random/New()
-	..()
-	if(!prob(spawn_nothing_percentage))
-		spawn_item()
-
 /obj/random/Initialize(mapload)
 	. = ..()
+	if(!prob(spawn_nothing_percentage))
+		spawn_item()
 	return INITIALIZE_HINT_QDEL
+
 
 // this function should return a specific item to spawn
 /obj/random/proc/item_to_spawn()

--- a/code/modules/awaymissions/mission_code/evil_santa.dm
+++ b/code/modules/awaymissions/mission_code/evil_santa.dm
@@ -272,7 +272,7 @@
 /obj/effect/spawner/lootdrop/evil_santa_gift
 	name = "evil santa reward gift spawner 1 to 3"
 	icon_state = "evil_santa_gift"
-	lootdoubles = 0
+	lootdoubles = FALSE
 
 	loot = list(
 				/obj/item/a_gift/evil_santa_reward = 33,

--- a/code/modules/awaymissions/mission_code/ruins/USSP_gorky17.dm
+++ b/code/modules/awaymissions/mission_code/ruins/USSP_gorky17.dm
@@ -233,7 +233,7 @@
 /obj/effect/spawner/lootdrop/randomsafe
 	name = "Secret or data documents safe spawner"
 	icon_state = "floorsafe-open"
-	lootdoubles = 0
+	lootdoubles = FALSE
 	loot = list(
 				/obj/structure/safe/floor/random_documents,
 				/obj/structure/safe/floor/random_researchnotes_MatBioProg


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Небольшие исправления https://github.com/ss220-space/Paradise/pull/5726.
В ходе раунда не спавнились /obj/random/... и .../spawner/lootdrop/... (например, игрушки с капсулы из игровых автоматов)
Небольшой рефактор того, что подрезало глаза.
Всё проверено на локалке - теперь работает как надо.

По хорошему переписать в один хороший spawner... потом.