### PR TITLE
bugfix: crematorium content check fix

### DIFF
--- a/code/__HELPERS/atoms.dm
+++ b/code/__HELPERS/atoms.dm
@@ -1,10 +1,10 @@
 /// Returns the src and all recursive contents as a list.
-/atom/proc/get_all_contents()
+/atom/proc/get_all_contents(ignore_flags)
 	. = list(src)
 	var/idx = 0
 	while(idx < length(.))
 		var/atom/checked_atom = .[++idx]
-		if(checked_atom.flags)
+		if(checked_atom.flags & ignore_flags)
 			continue
 		. += checked_atom.contents
 

--- a/code/__HELPERS/atoms.dm
+++ b/code/__HELPERS/atoms.dm
@@ -39,7 +39,7 @@
 	for(var/atom/movable/I in contents)
 		if(!is_type_in_list(I, GLOB.ungibbable_items_types))
 			if(length(I.contents))
-				I.drop_ungibbable_items(new_loc)
+				. += I.drop_ungibbable_items(new_loc)
 			continue
 
 		. += I


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
2 фикса:
- Крематорий ничего не сжигал. Неизвестно какие флаги у нас раньше проверял get_all_contents и как оно работало, но сейчас оно скипает все, у чего есть флаги. Добавил параметр для фильтрации флагов на возможное будущее с запилом отдельных флагов. В теории, можно ~~закомментить~~ удалить эту проверку флагов, ибо эта функция используется только в крематории, которому ничего не нужно фильтровать (drop_ungibbable_items накостылена отдельно);
- ungibbable_items_types (хайриски и прочие цельки) сгорали в крематории если были в контейнерах. drop_ungibbable_items во время рекурсивного выполнения не пополнял возвращаемый список ungibbable_items_types предметами, только выкидывал из контейнеров. В результате предметы из контейнеров не шли в список saved_contents для крематория и просто сгорали (зато выкидывались... в крематорий).

Теперь пламя крематория работает как положено.

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1275092570351079484
