### PR TITLE
bugfix: Delete pilot's laser from station orbit

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -112822,10 +112822,6 @@
 	icon_state = "grimy"
 	},
 /area/crew_quarters/chief)
-"vgo" = (
-/obj/structure/closet/secure_closet/pilot_sniper,
-/turf/space,
-/area/space)
 "vgq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -129637,7 +129633,7 @@ aaq
 aaq
 aaq
 aaq
-vgo
+aaq
 aaq
 aaq
 aaq


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Убирает лазерку в космосе.

## Ссылка на предложение/Причина создания ПР
Думал что убрали в #5752 из-за пометки `MAP`.
[Ссылка на картинку](https://discord.com/channels/617003227182792704/734823601110515882/1275874262552543275).
[Ссылка на проблему.](https://discord.com/channels/617003227182792704/1275878685043331268/1275878685043331268)

## Демонстрация изменений
![image](https://github.com/user-attachments/assets/4f3ee59a-3cd1-4432-9f35-7d32604b0f05)