### PR TITLE
bugfix: Anchoring conveyors' switches

### DIFF
--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -396,6 +396,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	icon_state = "switch-off"
 	base_icon_state = "switch"
 	processing_flags = START_PROCESSING_MANUALLY
+	anchored = TRUE
 	/// The current state of the switch.
 	var/position = CONVEYOR_OFF
 	/// If the switch only operates the conveyor belts in a single direction.


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Прикручивает к земле рычаги для конвееров.

## Ссылка на предложение/Причина создания ПР
[Ссылка на баг репорт](https://discord.com/channels/617003227182792704/1273590567699480709/1273590567699480709).
Когда реворкали конвеера (#5395), то убрали им прикрученность. Учитывая что об этом не сказано в ПРе - посчитано багом.