### PR TITLE
tweak/bugfix: destroyer robot(droidec) tweaks and fixes

### DIFF
--- a/code/game/gamemodes/clockwork/clockwork.dm
+++ b/code/game/gamemodes/clockwork/clockwork.dm
@@ -211,6 +211,7 @@ GLOBAL_LIST_EMPTY(all_clockers)
 
 		if(power_reveal)
 			powered(clock_mind.current)
+			powered_borgs(clock_mind.current)
 		if(crew_reveal)
 			clocked(clock_mind.current)
 		check_clock_reveal()
@@ -223,7 +224,10 @@ GLOBAL_LIST_EMPTY(all_clockers)
 	if((GLOB.clockwork_power >= power_reveal_number) && !power_reveal)
 		power_reveal = TRUE
 		for(var/datum/mind/M in clockwork_cult)
-			if(!M.current || !ishuman(M.current))
+			if(!M.current)
+				continue
+			if(!ishuman(M.current))
+				powered_borgs(M.current)
 				continue
 			SEND_SOUND(M.current, 'sound/hallucinations/i_see_you2.ogg')
 			to_chat(M.current, "<span class='clocklarge'>The veil begins to stutter in fear as the power of Ratvar grows, your hands begin to glow...</span>")
@@ -261,6 +265,11 @@ GLOBAL_LIST_EMPTY(all_clockers)
 		var/mob/living/carbon/human/H = clocker
 		H.update_inv_gloves()
 		ADD_TRAIT(H, CLOCK_HANDS, CLOCK_TRAIT)
+
+/datum/game_mode/proc/powered_borgs(clocker)
+	if(isrobot(clocker))
+		var/mob/living/silicon/robot/borg = clocker
+		borg.update_icons()
 
 /datum/game_mode/proc/clocked(clocker)
 	if(ishuman(clocker) && isclocker(clocker))

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -62,6 +62,7 @@
 /obj/item/melee/baton/security/proc/link_new_cell(unlink = FALSE)
 	if(unlink)
 		cell = null
+		update_appearance(UPDATE_ICON_STATE)
 		return
 	var/mob/living/silicon/robot/robot = get(loc, /mob/living/silicon/robot)
 	if(robot)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -68,6 +68,7 @@
 		cell = robot.cell
 	else if(ispath(cell))
 		cell = new cell(src)
+	update_appearance(UPDATE_ICON_STATE)
 
 
 /obj/item/melee/baton/security/update_icon_state()

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -53,7 +53,8 @@
 		inv3.icon_state = "inv3"
 	if(hud_used)
 		hud_used.update_robot_modules_display()
-	return 1
+	update_icons()
+	return TRUE
 
 /mob/living/silicon/robot/proc/activate_module(var/obj/item/O)
 	if(!(locate(O) in src.module.modules) && O != src.module.emag)
@@ -179,6 +180,7 @@
 	if(!module_active(module))
 		return
 
+	deselect_module(get_selected_module())
 	switch(module)
 		if(1)
 			if(module_active != module_state_1)
@@ -203,6 +205,7 @@
 
 	if(istype(module_active, /obj/item/borg/destroyer/mobility))
 		add_movespeed_modifier(/datum/movespeed_modifier/destroyer_mobility)
+	update_icons()
 
 
 //deselect_module(module) - Deselects the module slot specified by "module"
@@ -226,6 +229,8 @@
 			if(module_active == module_state_3)
 				inv3.icon_state = "inv3"
 				module_active = null
+
+	update_icons()
 
 
 //toggle_module(module) - Toggles the selection of the module slot specified by "module".

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -404,10 +404,6 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 		if("Janitor")
 			module = new /obj/item/robot_module/janitor(src)
 
-		if("Destroyer") // Rolling Borg
-			module = new /obj/item/robot_module/destroyer(src)
-			status_flags &= ~CANPUSH
-
 		if("Combat") // Gamma ERT
 			module = new /obj/item/robot_module/combat(src)
 			status_flags &= ~CANPUSH
@@ -460,6 +456,12 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 		if("Deathsquad")
 			var/mob/living/silicon/robot/deathsquad/death = new(get_turf(src))
 			mind.transfer_to(death)
+			qdel(src)
+			return
+
+		if("Destroyer") // Rolling Borg
+			var/mob/living/silicon/robot/destroyer/destroy = new(get_turf(src))
+			mind.transfer_to(destroy)
 			qdel(src)
 			return
 
@@ -1145,22 +1147,8 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 
 /mob/living/silicon/robot/update_icons()
 	cut_overlays()
-
-	if(stat != DEAD && !HAS_TRAIT(src, TRAIT_INCAPACITATED) && !low_power_mode) //Not dead, not stunned.
-		var/eyes_olay
-		if(custom_panel in custom_eye_names)
-			if(isclocker(src) && SSticker.mode.power_reveal)
-				eyes_olay = "eyes-[custom_panel]-clocked"
-			else
-				eyes_olay = "eyes-[custom_panel]"
-		else
-			if(isclocker(src) && SSticker.mode.power_reveal)
-				eyes_olay = "eyes-[icon_state]-clocked"
-			else
-				eyes_olay = "eyes-[icon_state]"
-		if(eyes_olay)
-			add_overlay(eyes_olay)
-
+	borg_icons()
+	eyes_overlays()
 	if(opened)
 		var/panelprefix = "ov"
 		if(custom_sprite) //Custom borgs also have custom panels, heh
@@ -1189,7 +1177,6 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 		if(head_icon)
 			add_overlay(head_icon)
 
-	borg_icons()
 	update_fire()
 
 	if(blocks_emissive)
@@ -1197,6 +1184,23 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 
 
 /mob/living/silicon/robot/proc/borg_icons() // Exists so that robot/destroyer can override it
+	return
+
+/mob/living/silicon/robot/proc/eyes_overlays() // Exists so that robot/destroyer can override it
+	if(stat != DEAD && !HAS_TRAIT(src, TRAIT_INCAPACITATED) && !low_power_mode) //Not dead, not stunned.
+		var/eyes_olay
+		if(custom_panel in custom_eye_names)
+			if(isclocker(src) && SSticker.mode.power_reveal)
+				eyes_olay = "eyes-[custom_panel]-clocked"
+			else
+				eyes_olay = "eyes-[custom_panel]"
+		else
+			if(isclocker(src) && SSticker.mode.power_reveal)
+				eyes_olay = "eyes-[icon_state]-clocked"
+			else
+				eyes_olay = "eyes-[icon_state]"
+		if(eyes_olay)
+			add_overlay(eyes_olay)
 	return
 
 /mob/living/silicon/robot/proc/installed_modules()
@@ -1616,12 +1620,12 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	base_icon = "nano_bloodhound"
 	icon_state = "nano_bloodhound"
 	designation = "SpecOps"
-	lawupdate = 0
-	scrambledcodes = 1
+	lawupdate = FALSE
+	scrambledcodes = TRUE
 	has_camera = FALSE
 	req_access = list(ACCESS_CENT_SPECOPS)
-	ionpulse = 1
-	pdahide = 1
+	ionpulse = TRUE
+	pdahide = TRUE
 	eye_protection = FLASH_PROTECTION_WELDER // Immunity to flashes and the visual part of flashbangs
 	ear_protection = HEARING_PROTECTION_MINOR // Immunity to the audio part of flashbangs
 	damage_protection = 10 // Reduce all incoming damage by this number
@@ -1651,7 +1655,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	radio.recalculateChannels()
 	playsound(loc, 'sound/mecha/nominalsyndi.ogg', 75, 0)
 
-/mob/living/silicon/robot/deathsquad/bullet_act(var/obj/item/projectile/P)
+/mob/living/silicon/robot/deathsquad/bullet_act(obj/item/projectile/P)
 	if(istype(P) && P.is_reflectable(REFLECTABILITY_ENERGY) && P.starting)
 		visible_message("<span class='danger'>The [P.name] gets reflected by [src]!</span>", "<span class='userdanger'>The [P.name] gets reflected by [src]!</span>")
 		P.reflect_back(src)
@@ -1720,16 +1724,20 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	icon_state = "droidcombat"
 	modtype = "Destroyer"
 	designation = "Destroyer"
-	lawupdate = 0
-	scrambledcodes = 1
+	lawupdate = FALSE
+	scrambledcodes = TRUE
 	has_camera = FALSE
 	req_access = list(ACCESS_CENT_SPECOPS)
-	ionpulse = 1
-	pdahide = 1
+	ionpulse = TRUE
+	pdahide = TRUE
 	eye_protection = FLASH_PROTECTION_WELDER // Immunity to flashes and the visual part of flashbangs
 	ear_protection = HEARING_PROTECTION_MINOR // Immunity to the audio part of flashbangs
 	emp_protection = TRUE // Immunity to EMP, due to heavy shielding
+	brute_mod = 0.5 // Пулевые орудия наносят на 50%+5ед меньше урона. Теперь полная обойма ружейных пуль не убьет киборга(но заставит потерять 2 модуля и броню)
+	burn_mod = 0.5 // Забавно, у киборга отряда смерти отражение лазерных снарядов, впрочем все еще снижает урон от взрывов, и позволяет пережить более чем одну ракету из SRM8.
 	damage_protection = 20 // Reduce all incoming damage by this number. Very high in the case of /destroyer borgs, since it is an admin-only borg.
+	faction = list("nanotrasen")
+	is_emaggable = FALSE
 	can_lock_cover = TRUE
 	default_cell_type = /obj/item/stock_parts/cell/infinite/abductor
 	see_reagents = TRUE
@@ -1749,11 +1757,19 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	module.add_languages(src)
 	module.add_subsystems_and_actions(src)
 	status_flags &= ~CANPUSH
+	addtimer(CALLBACK(module, TYPE_PROC_REF(/obj/item/robot_module, update_cells)), 1 SECONDS)
 	if(radio)
 		qdel(radio)
 	radio = new /obj/item/radio/borg/ert/specops(src)
 	radio.recalculateChannels()
 	playsound(loc, 'sound/mecha/nominalsyndi.ogg', 75, 0)
+
+/mob/living/silicon/robot/destroyer/bullet_act(obj/item/projectile/P)
+	if(istype(P) && P.is_reflectable(REFLECTABILITY_ENERGY) && P.starting && !(istype(module_active, /obj/item/borg/destroyer/mobility)))
+		visible_message("<span class='danger'>The [P.name] gets reflected by [src]!</span>", "<span class='userdanger'>The [P.name] gets reflected by [src]!</span>")
+		P.reflect_back(src)
+		return -1
+	return ..(P)
 
 /mob/living/silicon/robot/destroyer/borg_icons()
 	if(base_icon == "")
@@ -1763,6 +1779,17 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	else
 		icon_state = base_icon
 		add_overlay("[base_icon]-shield")
+
+/mob/living/silicon/robot/destroyer/eyes_overlays()
+	if(stat != DEAD && !HAS_TRAIT(src, TRAIT_INCAPACITATED) && !low_power_mode) //Not dead, not stunned.
+		var/eyes_olay
+		if(isclocker(src) && SSticker.mode.power_reveal)
+			eyes_olay = "eyes-[base_icon]-clocked"
+		else
+			eyes_olay = "eyes-[base_icon]"
+		if(eyes_olay)
+			add_overlay(eyes_olay)
+	return
 
 
 /mob/living/silicon/robot/extinguish_light(force = FALSE)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -376,9 +376,6 @@
 
 	fix_modules()
 
-/obj/item/robot_module/security/update_cells(unlink_cell = FALSE)
-	var/obj/item/melee/baton/security/baton = locate() in modules
-	baton?.link_new_cell(unlink_cell)
 
 /obj/item/robot_module/janitor
 	name = "Janitor"
@@ -591,7 +588,7 @@
 	modules += new /obj/item/crowbar(src)
 	modules += new /obj/item/gripper/nuclear(src)
 	modules += new /obj/item/pinpointer(src)
-	emag = null
+	emag = new /obj/item/gun/energy/pulse/destroyer/annihilator(src)
 
 	fix_modules()
 
@@ -706,6 +703,7 @@
 	channels = list("Security" = 1)
 	default_skin = "droidcombat"
 	borg_skins = list("Destroyer" = "droidcombat")
+	has_transform_animation = TRUE
 
 /obj/item/robot_module/destroyer/New()
 	..()
@@ -718,7 +716,7 @@
 	modules += new /obj/item/crowbar/cyborg(src)
 	modules += new /obj/item/gripper/nuclear(src)
 	modules += new /obj/item/pinpointer(src)
-	emag = null
+	emag = new /obj/item/gun/energy/pulse/destroyer/annihilator(src)
 	fix_modules()
 
 
@@ -1038,5 +1036,9 @@
  * * unlink_cell - If TRUE, set the item's power cell variable to `null` rather than linking it to a new one.
  */
 /obj/item/robot_module/proc/update_cells(unlink_cell = FALSE)
+	for(var/obj/item/melee/baton/security/baton in modules)
+		if(istype(baton))
+			baton?.link_new_cell(unlink_cell)
+			baton?.update_appearance(UPDATE_OVERLAYS | UPDATE_ICON | UPDATE_DESC)
 	return
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -1037,8 +1037,5 @@
  */
 /obj/item/robot_module/proc/update_cells(unlink_cell = FALSE)
 	for(var/obj/item/melee/baton/security/baton in modules)
-		if(istype(baton))
-			baton?.link_new_cell(unlink_cell)
-			baton?.update_appearance(UPDATE_OVERLAYS | UPDATE_ICON | UPDATE_DESC)
-	return
+		baton.link_new_cell(unlink_cell)
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Данный ПР исправляет несколько багов, а так же добавляет несколько твиков щитспавновым боргам(дройдеку и дедоборгу).
Исправления:
1) Исправлено отсутствие отображения перехода в мобильный режим у дройдека
2) Исправлено отсутствие смены цвета глаз у боргов в культе ратвара. У них после набора культом силы(при свечении ладошек) должен меняться цвет глаз на желтый у тех модулей, у которых это возможно, однако сейчас это проявляется только при вызове изменения визуала из-за других причин(например открытие/закрытие люка).
3) Исправлено отсутствие привязки батареи дройдека к его станбатону, из-за чего у него в инвентаре появляется разряженный станбатон.
4) Исправлено отсутствие оверлея энергощита у дройдека, если он был получен сменой модуля через админскую борг панель.
Твики:
1) Дройдеку, если тот находится не в мобильном режиме добавлен щит, отражающий энергоснаряды. Причина: у дройдека визуально есть этот щит. Он есть у референса(дройдеки из звездных войн). Он есть у дедоборга. Логично что он должен быть у борга, которым предлагается усиливать дедов.
2) Дройдеку добавлены некоторые параметры дедоборга. Причина: если дройдеки -- усиление для дедов, логично, что они сильнее обычных дедоборгов или хотя бы равны им по силе(что сейчас не так).
3) Добавлено появление у дедоборга и дройдека анигилятора при емаге или переписывании кодов безопасности. Учитывая что емагнуть их практически невозможно(для открытия люка нужен доступ соо, емагом его не открыть), то это просто быстрый способ для админа(одно нажатие в борг панели) выдать боргам анигиляторы по желанию, что по сути qol.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багфиксы. Причины твиков уже расписаны в описании изменений. Все твики касаются щитспавновых боргов и на игроков практически не влияют.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

