### PR TITLE
add: Supermatter explosion now gives random mutation (with 10% chance!) without monkeyfication

### DIFF
--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -39,12 +39,16 @@
 		return "biotech=6"
 	return I.origin_tech
 
-///Gives random mutation excluding monkeyfication
-/proc/randmut(mob/living/M)
+///Gives random mutation
+/proc/randmut(mob/living/M, include_monkey = TRUE)
 	if(!M || !M.dna)
 		return
 	M.dna.check_integrity()
-	var/block = pick(GLOB.bad_blocks + GLOB.good_blocks)
+	var/possible_mutations = GLOB.bad_blocks + GLOB.good_blocks
+	if(include_monkey)
+		possible_mutations += GLOB.monkeyblock
+
+	var/block = pick(possible_mutations)
 	M.dna.SetSEState(block, 1)
 
 // Give Random Bad Mutation to M

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -39,6 +39,14 @@
 		return "biotech=6"
 	return I.origin_tech
 
+///Gives random mutation excluding monkeyfication
+/proc/randmut(mob/living/M)
+	if(!M || !M.dna)
+		return
+	M.dna.check_integrity()
+	var/block = pick(GLOB.bad_blocks + GLOB.good_blocks)
+	M.dna.SetSEState(block, 1)
+
 // Give Random Bad Mutation to M
 /proc/randmutb(mob/living/M)
 	if(!M || !M.dna)

--- a/code/modules/power/supermatter/supermatter_special_effects.dm
+++ b/code/modules/power/supermatter/supermatter_special_effects.dm
@@ -149,10 +149,17 @@
 		var/turf/T = get_turf(creature)
 		if(!T || T.z != src.z)
 			continue
+
+		if(!creature.dna)
+			continue
+
 		if(NO_DNA in creature.dna?.species.species_traits)
 			continue
-		if(prob(dna_mutation_chance))
-			randmut(creature)
+
+		var/resist = creature.getarmor(attack_flag = RAD)
+		var/chance = clamp(dna_mutation_chance * (1 - (resist / 100)), 0, 100)
+		if(!(RADIMMUNE in creature.dna?.species.species_traits) && prob(chance))
+			randmut(creature, FALSE)
 			creature.check_genes(MUTCHK_FORCED)
 
 /datum/supermatter_explosive_effects/proc/give_mind_lesser(mob/living/carbon/human/lesser/monke)

--- a/code/modules/power/supermatter/supermatter_special_effects.dm
+++ b/code/modules/power/supermatter/supermatter_special_effects.dm
@@ -153,12 +153,12 @@
 		if(!creature.dna)
 			continue
 
-		if(NO_DNA in creature.dna?.species.species_traits)
+		if(NO_DNA in creature.dna.species.species_traits)
 			continue
 
 		var/resist = creature.getarmor(attack_flag = RAD)
 		var/chance = clamp(dna_mutation_chance * (1 - (resist / 100)), 0, 100)
-		if(!(RADIMMUNE in creature.dna?.species.species_traits) && prob(chance))
+		if(!(RADIMMUNE in creature.dna.species.species_traits) && prob(chance))
 			randmut(creature, FALSE)
 			creature.check_genes(MUTCHK_FORCED)
 

--- a/code/modules/power/supermatter/supermatter_special_effects.dm
+++ b/code/modules/power/supermatter/supermatter_special_effects.dm
@@ -198,3 +198,10 @@
 			else
 				seed.product = /obj/item/reagent_containers/food/snacks/grown/random
 				seed.transform_into_random()
+
+#undef DETONATION_MACHINE_BREAKDOWN_CHANCE
+#undef DETONATION_MACHINE_EFFECT_CHANCE
+#undef DETONATION_APC_BREAKDOWN_CHANCE
+#undef SPECIAL_EFFECTS_TIMER_DELAY
+#undef SIMPLE_ANIMAL_MINDGIVING_CHANCE
+#undef DNA_MUTATION_CHANCE


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
ПР добавляет возможность получить случайную мутацию при взрыве СМа
## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
https://discord.com/channels/617003227182792704/755125334097133628/1273683688831455386
По результатом доработок решили взять 10% шанс заместо 4% (Редкое событие, все же)
## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
![изображение](https://github.com/user-attachments/assets/ddf631f7-7801-4982-8f0c-fb9197832bfc)
