### PR TITLE
bugfix: Mutate Virus Checks For Reagents Holder

### DIFF
--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -232,7 +232,7 @@ GLOBAL_LIST_INIT(diseases, subtypesof(/datum/disease))
  */
 /datum/disease/proc/mutate()
 	var/datum/reagents/reagents = affected_mob.reagents
-	if(!reagents.reagent_list.len)
+	if(!reagents || !length(reagents.reagent_list))
 		return FALSE
 	for(var/R in mutation_reagents)
 		if(!reagents.has_reagent(R))


### PR DESCRIPTION
## Описание
Проверка на наличие холдера реагентов, в связи с тем, что сейчас носителями вируса могут быть не только гуманоиды.
