### PR TITLE
bugfix: Extra syndie port del

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -153585,7 +153585,7 @@ yhg
 yhg
 yhg
 yhg
-plO
+yhg
 yhg
 yhg
 yhg


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание

Удаляет лишний порт синдишаттла на дельте.
![image](https://github.com/user-attachments/assets/4840bcdd-0e87-431c-a832-3682c003a938)
