### PR TITLE
bugfix: Laser damage in solid smoke

### DIFF
--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -139,6 +139,12 @@
 		return .
 	INVOKE_ASYNC(victim, TYPE_PROC_REF(/mob, emote), "cough")
 
+/obj/effect/particle_effect/smoke/solid/CanAllowThrough(atom/movable/mover, border_dir)
+	. = ..()
+	if(istype(mover, /obj/item/projectile/beam))
+		var/obj/item/projectile/beam/beam = mover
+		beam.damage = (beam.damage / 2)
+
 /datum/effect_system/smoke_spread/solid
 	effect_type = /obj/effect/particle_effect/smoke/solid
 	custom_lifetime = 9

--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -15,6 +15,7 @@
 	var/steps = 0
 	var/lifetime = 5
 	var/direction
+	///Responsible for the damage of the laser passing through the smoke. If 0, damage is not calculated.
 	var/beam_resistance
 
 

--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -15,6 +15,7 @@
 	var/steps = 0
 	var/lifetime = 5
 	var/direction
+	var/beam_resistance
 
 
 /obj/effect/particle_effect/smoke/Initialize(mapload)
@@ -66,6 +67,7 @@
 	SIGNAL_HANDLER
 
 	smoke_mob(arrived)
+	smoke_beam(arrived)
 
 
 /obj/effect/particle_effect/smoke/proc/smoke_mob(mob/living/carbon/victim)
@@ -80,6 +82,14 @@
 	victim.smoke_delay++
 	addtimer(CALLBACK(src, PROC_REF(remove_smoke_delay), victim), 1 SECONDS)
 	return TRUE
+
+
+/obj/effect/particle_effect/smoke/proc/smoke_beam(obj/item/projectile/beam/mover)
+	if(!beam_resistance)
+		return FALSE
+	if(istype(mover))
+		var/obj/item/projectile/beam/beam = mover
+		beam.damage = (beam.damage / beam_resistance)
 
 
 /obj/effect/particle_effect/smoke/proc/remove_smoke_delay(mob/living/carbon/victim)
@@ -139,16 +149,16 @@
 		return .
 	INVOKE_ASYNC(victim, TYPE_PROC_REF(/mob, emote), "cough")
 
-/obj/effect/particle_effect/smoke/solid/CanAllowThrough(atom/movable/mover, border_dir)
-	. = ..()
-	if(istype(mover, /obj/item/projectile/beam))
-		var/obj/item/projectile/beam/beam = mover
-		beam.damage = (beam.damage / 2)
 
 /datum/effect_system/smoke_spread/solid
 	effect_type = /obj/effect/particle_effect/smoke/solid
 	custom_lifetime = 9
 	var/effect_range
+
+
+/obj/effect/particle_effect/smoke/solid
+	beam_resistance = 2
+
 
 /datum/effect_system/smoke_spread/solid/set_up(n = 5, c = 0, loca, direct, range = 0)
 	..()
@@ -184,6 +194,8 @@
 
 /obj/effect/particle_effect/smoke/bad
 	lifetime = 8
+	beam_resistance = 2
+
 
 /obj/effect/particle_effect/smoke/bad/process()
 	if(..())
@@ -198,13 +210,6 @@
 	victim.drop_from_active_hand()
 	victim.adjustOxyLoss(1)
 	INVOKE_ASYNC(victim, TYPE_PROC_REF(/mob, emote), "cough")
-
-
-/obj/effect/particle_effect/smoke/bad/CanAllowThrough(atom/movable/mover, border_dir)
-	. = ..()
-	if(istype(mover, /obj/item/projectile/beam))
-		var/obj/item/projectile/beam/beam = mover
-		beam.damage = (beam.damage / 2)
 
 
 /datum/effect_system/smoke_spread/bad


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Добавляет срез урона лазеров пролетающих через дым.

## Ссылка на предложение/Причина создания ПР
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Должно было идти отдельной предложкой, но настояли на том что формулировка первой (в которой был добавлен густой дым) включает в себя эту функцию.
https://discord.com/channels/617003227182792704/755125334097133628/1275100827031310347

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
Точно такая же реализация уже существует у другого дыма.