### PR TITLE
tweak: all goals in extended mode

### DIFF
--- a/code/modules/station_goals/bfl.dm
+++ b/code/modules/station_goals/bfl.dm
@@ -2,7 +2,6 @@
 
 /datum/station_goal/bfl
 	name = "BFL Mining laser"
-	gamemode_blacklist = list("extended")
 
 /datum/station_goal/bfl/get_report()
 	return {"<b>Mining laser construcion</b><br>

--- a/code/modules/station_goals/bluespace_tap.dm
+++ b/code/modules/station_goals/bluespace_tap.dm
@@ -1,7 +1,6 @@
 //Station goal stuff goes here
 /datum/station_goal/bluespace_tap
 	name = "Bluespace Harvester"
-	gamemode_blacklist = list("extended")
 	var/goal = 25000
 
 /datum/station_goal/bluespace_tap/get_report()

--- a/code/modules/station_goals/brs.dm
+++ b/code/modules/station_goals/brs.dm
@@ -7,7 +7,6 @@ GLOBAL_LIST_EMPTY(bluespace_rifts_scanner_list)
 // The goal is to research the anomalous bluespace rift.
 /datum/station_goal/bluespace_rift
 	name = "Сканирование блюспейс разлома"
-	gamemode_blacklist = list("extended")
 	var/target_research_points = 25000
 	var/reward_given = FALSE
 	var/datum/bluespace_rift/rift

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -13,7 +13,6 @@
 
 /datum/station_goal/dna_vault
 	name = "DNA Vault"
-	gamemode_blacklist = list("extended")
 	var/animal_count
 	var/human_count
 	var/plant_count


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Убирает у целей БФЛ, БРС, ДНК и БСХ из блеклиста режим extended.

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/755125334097133628/1279305391943057480
