### PR TITLE
bugfix: Now mine checks for both legs, not just left ones

### DIFF
--- a/code/game/objects/items/weapons/caution.dm
+++ b/code/game/objects/items/weapons/caution.dm
@@ -58,7 +58,7 @@
 
 /obj/item/caution/proximity_sign/proc/dead_legs(mob/living/carbon/human/H as mob)
 	var/obj/item/organ/external/l = H.get_organ(BODY_ZONE_L_LEG)
-	var/obj/item/organ/external/r = H.get_organ(BODY_ZONE_L_LEG)
+	var/obj/item/organ/external/r = H.get_organ(BODY_ZONE_R_LEG)
 	if(l)
 		l.droplimb(0, DROPLIMB_SHARP)
 	if(r)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
(Не от той ветки ребейз сделал)
Меняет ногу, что проверяет мина. Чтобы отрывало обе ноги.

## Ссылка на предложение/Причина создания ПР
Выглядело как опечатка

## Тесты
Закомпилил - пробежался у мины.
