### PR TITLE
tweak: Удаление турелей тайпана + сапёр

### DIFF
--- a/_maps/map_files/generic/syndicatebase.dmm
+++ b/_maps/map_files/generic/syndicatebase.dmm
@@ -6169,8 +6169,8 @@
 	req_access = list(150)
 	},
 /obj/machinery/conveyor{
-	id = "bruh";
-	dir = 4
+	dir = 4;
+	id = "bruh"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -10952,8 +10952,8 @@
 "jZL" = (
 /obj/structure/closet/crate,
 /obj/machinery/conveyor{
-	id = "SQMLoad";
-	dir = 4
+	dir = 4;
+	id = "SQMLoad"
 	},
 /turf/simulated/floor/plating,
 /area/syndicate/unpowered/syndicate_space_base/cargo)
@@ -11212,9 +11212,8 @@
 	},
 /area/syndicate/unpowered/syndicate_space_base/medbay/virology)
 "ksR" = (
-/obj/effect/spawner/random_spawners/syndicate/turret/grenade,
-/turf/simulated/wall/mineral/plastitanium/nodiagonal,
-/area/syndicate/unpowered/syndicate_space_base/turrets)
+/turf/space,
+/area/ruin/unpowered)
 "kva" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
@@ -12039,7 +12038,7 @@
 	dir = 4;
 	layer = 2.9
 	},
-/obj/machinery/vending/crittercare/free,
+/obj/structure/chair/stool,
 /turf/simulated/floor/carpet/arcade,
 /area/syndicate/unpowered/syndicate_space_base/main/central_s)
 "led" = (
@@ -14297,8 +14296,8 @@
 "mSw" = (
 /obj/machinery/syndiepad/loadpad,
 /obj/machinery/conveyor{
-	id = "SQMLoad";
-	dir = 1
+	dir = 1;
+	id = "SQMLoad"
 	},
 /turf/simulated/floor/plating,
 /area/syndicate/unpowered/syndicate_space_base/cargo)
@@ -18645,8 +18644,8 @@
 /area/syndicate/unpowered/syndicate_space_base/maintenance/central)
 "qeh" = (
 /obj/machinery/conveyor{
-	id = "SQMLoad";
-	dir = 4
+	dir = 4;
+	id = "SQMLoad"
 	},
 /turf/simulated/floor/plating,
 /area/syndicate/unpowered/syndicate_space_base/cargo)
@@ -20890,8 +20889,8 @@
 	idle_power_usage = 200;
 	use_power = 1
 	},
-/turf/simulated/wall/mineral/plastitanium/nodiagonal,
-/area/syndicate/unpowered/syndicate_space_base/turrets)
+/turf/simulated/mineral/silver,
+/area/ruin/unpowered)
 "rSi" = (
 /obj/structure/rack{
 	dir = 8;
@@ -25980,6 +25979,7 @@
 	dir = 4;
 	layer = 2.9
 	},
+/obj/machinery/vending/crittercare/free,
 /turf/simulated/floor/carpet/arcade,
 /area/syndicate/unpowered/syndicate_space_base/main/central_s)
 "vvA" = (
@@ -26325,12 +26325,12 @@
 /area/syndicate/unpowered/syndicate_space_base/cargo/storage)
 "vIh" = (
 /obj/machinery/conveyor{
-	id = "SQMLoad2";
-	dir = 1
+	dir = 1;
+	id = "SQMLoad2"
 	},
 /obj/machinery/conveyor{
-	id = "SQMLoad2";
 	dir = 8;
+	id = "SQMLoad2";
 	layer = 2.494
 	},
 /turf/simulated/floor/plating,
@@ -27349,8 +27349,8 @@
 "wwr" = (
 /obj/machinery/syndiepad/loadpad,
 /obj/machinery/conveyor/inverted{
-	id = "SQMLoad";
-	dir = 10
+	dir = 10;
+	id = "SQMLoad"
 	},
 /turf/simulated/floor/plating,
 /area/syndicate/unpowered/syndicate_space_base/cargo)
@@ -28089,15 +28089,14 @@
 "wQh" = (
 /obj/structure/window/reinforced{
 	color = "red";
+	dir = 4;
 	layer = 2.9
 	},
 /obj/structure/window/reinforced{
 	color = "red";
-	dir = 4;
 	layer = 2.9
 	},
-/obj/structure/table,
-/obj/item/toy/plushie/tabby_cat,
+/obj/machinery/arcade/minesweeper,
 /turf/simulated/floor/carpet/arcade,
 /area/syndicate/unpowered/syndicate_space_base/main/central_s)
 "wRV" = (
@@ -28762,8 +28761,8 @@
 "xpu" = (
 /obj/structure/plasticflaps/mining,
 /obj/machinery/conveyor{
-	id = "SQMLoad2";
-	dir = 1
+	dir = 1;
+	id = "SQMLoad2"
 	},
 /turf/simulated/floor/plating,
 /area/syndicate/unpowered/syndicate_space_base/cargo/storage)
@@ -29043,30 +29042,30 @@
 /area/syndicate/unpowered/syndicate_space_base/cargo)
 "xyq" = (
 /obj/machinery/conveyor{
-	id = "SQMLoad2";
-	dir = 5
+	dir = 5;
+	id = "SQMLoad2"
 	},
 /turf/simulated/floor/plating,
 /area/syndicate/unpowered/syndicate_space_base/cargo)
 "xyw" = (
 /obj/machinery/conveyor{
-	id = "SQMLoad2";
-	dir = 4
+	dir = 4;
+	id = "SQMLoad2"
 	},
 /turf/simulated/floor/plating,
 /area/syndicate/unpowered/syndicate_space_base/cargo)
 "xyz" = (
 /obj/machinery/light/small,
 /obj/machinery/conveyor{
-	id = "SQMLoad2";
-	dir = 4
+	dir = 4;
+	id = "SQMLoad2"
 	},
 /turf/simulated/floor/plating,
 /area/syndicate/unpowered/syndicate_space_base/cargo)
 "xyZ" = (
 /obj/machinery/conveyor/inverted{
-	id = "SQMLoad2";
-	dir = 10
+	dir = 10;
+	id = "SQMLoad2"
 	},
 /turf/simulated/floor/plating,
 /area/syndicate/unpowered/syndicate_space_base/cargo)
@@ -29370,17 +29369,14 @@
 "xHf" = (
 /obj/structure/plasticflaps/mining,
 /obj/machinery/conveyor{
-	id = "SQMLoad2";
-	dir = 1
+	dir = 1;
+	id = "SQMLoad2"
 	},
 /turf/simulated/floor/plating,
 /area/syndicate/unpowered/syndicate_space_base/cargo)
 "xHx" = (
-/obj/effect/spawner/random_spawners/syndicate/turret/external{
-	use_power = 1
-	},
-/turf/simulated/wall/mineral/plastitanium/nodiagonal,
-/area/syndicate/unpowered/syndicate_space_base/turrets)
+/turf/simulated/mineral,
+/area/space)
 "xHM" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -29465,8 +29461,8 @@
 	pixel_y = -25
 	},
 /obj/machinery/conveyor{
-	id = "SQMLoad";
-	dir = 4
+	dir = 4;
+	id = "SQMLoad"
 	},
 /turf/simulated/floor/plating,
 /area/syndicate/unpowered/syndicate_space_base/cargo)
@@ -29738,8 +29734,8 @@
 "xUq" = (
 /obj/machinery/syndiepad/receivepad,
 /obj/machinery/conveyor{
-	id = "SQMLoad2";
-	dir = 1
+	dir = 1;
+	id = "SQMLoad2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -29890,8 +29886,8 @@
 /area/syndicate/unpowered/syndicate_space_base/medbay/virology)
 "xZn" = (
 /obj/machinery/crema_switch{
-	pixel_x = 26;
 	id = "taipan";
+	pixel_x = 26;
 	req_access = list(150)
 	},
 /obj/effect/decal/warning_stripes/southeast,
@@ -30136,8 +30132,8 @@
 "yhV" = (
 /obj/machinery/syndiepad/receivepad,
 /obj/machinery/conveyor{
-	id = "SQMLoad2";
-	dir = 1
+	dir = 1;
+	id = "SQMLoad2"
 	},
 /turf/simulated/floor/plating,
 /area/syndicate/unpowered/syndicate_space_base/cargo)
@@ -37535,7 +37531,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 mEC
 mEC
 mEC
@@ -38335,7 +38331,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 pdd
 pdd
 pdd
@@ -38865,7 +38861,7 @@ mEC
 mEC
 mEC
 aTW
-rRZ
+mEC
 mEC
 mEC
 mEC
@@ -39050,7 +39046,7 @@ mEC
 mEC
 mEC
 aTW
-rRZ
+mEC
 mEC
 mEC
 mEC
@@ -39394,7 +39390,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 aTW
 aTW
 aTW
@@ -39670,7 +39666,7 @@ pdd
 pdd
 pdd
 aTW
-rRZ
+mEC
 mEC
 mEC
 mEC
@@ -39689,7 +39685,7 @@ pdd
 pdd
 pdd
 aTW
-rRZ
+mEC
 mEC
 mEC
 mEC
@@ -40104,7 +40100,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 mEC
 mEC
 mEC
@@ -40134,7 +40130,7 @@ mEC
 pdd
 pdd
 pdd
-rRZ
+mEC
 mEC
 mEC
 mEC
@@ -40220,7 +40216,7 @@ mEC
 jbN
 aTW
 aTW
-rRZ
+jbN
 jbN
 mEC
 mEC
@@ -40588,7 +40584,7 @@ mEC
 mEC
 mEC
 jbN
-rRZ
+jbN
 aTW
 jbN
 jbN
@@ -40900,7 +40896,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 pdd
 pdd
 pdd
@@ -41432,7 +41428,7 @@ pdd
 pdd
 pdd
 pdd
-rRZ
+mEC
 mEC
 mEC
 mEC
@@ -41902,7 +41898,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 aTW
 aTW
 aTW
@@ -41918,7 +41914,7 @@ pdd
 pdd
 pdd
 aTW
-rRZ
+mEC
 mEC
 mEC
 mEC
@@ -42196,7 +42192,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 pdd
 pdd
 aTW
@@ -42634,7 +42630,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 mEC
 mEC
 mEC
@@ -42645,7 +42641,7 @@ mEC
 mEC
 pdd
 aTW
-rRZ
+jbN
 jbN
 jbN
 aTW
@@ -42986,7 +42982,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 xiM
 xiM
 xiM
@@ -43018,7 +43014,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 mEC
 mEC
 mEC
@@ -43047,7 +43043,7 @@ mEC
 mEC
 jbN
 jbN
-rRZ
+jbN
 jbN
 jbN
 jbN
@@ -43194,8 +43190,8 @@ pdd
 pdd
 jbN
 tJo
-rRZ
-pdd
+jbN
+jbN
 pdd
 pdd
 pdd
@@ -43712,8 +43708,8 @@ pdd
 jbN
 jbN
 jbN
-pdd
-rRZ
+jbN
+jbN
 abT
 jbN
 jbN
@@ -43764,7 +43760,7 @@ pdd
 pdd
 xiM
 xiM
-rRZ
+jbN
 mEC
 mEC
 mEC
@@ -44089,7 +44085,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 aTW
 aTW
 mEC
@@ -44198,7 +44194,7 @@ jbN
 aTW
 pdd
 aTW
-rRZ
+mEC
 mEC
 mEC
 mEC
@@ -44984,7 +44980,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 aTW
 pdd
 pdd
@@ -45019,7 +45015,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 pdd
 pdd
 aTW
@@ -45333,7 +45329,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 aTW
 pdd
 pdd
@@ -45444,7 +45440,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 aTW
 aTW
 aTW
@@ -45717,7 +45713,7 @@ mEC
 jbN
 jbN
 jbN
-rRZ
+mEC
 mEC
 mEC
 mEC
@@ -45798,7 +45794,7 @@ aTW
 pdd
 pdd
 pdd
-rRZ
+mEC
 mEC
 mEC
 mEC
@@ -46027,7 +46023,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+mEC
 pdd
 pdd
 pdd
@@ -46277,7 +46273,6 @@ pdd
 pdd
 aTW
 aTW
-xHx
 mEC
 mEC
 mEC
@@ -46325,7 +46320,8 @@ mEC
 mEC
 mEC
 mEC
-xHx
+mEC
+xiM
 pdd
 pdd
 pdd
@@ -46581,60 +46577,60 @@ mEC
 mEC
 mEC
 mEC
-xiM
-pdd
-pdd
-pdd
-pdd
-pdd
-pdd
-xHx
-jbN
-jbN
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-jbN
-jbN
-jbN
-jbN
-jbN
-aTW
-pdd
-pdd
-pdd
-pdd
-pdd
-pdd
-pdd
-pdd
-aTW
 rRZ
+pdd
+pdd
+pdd
+pdd
+pdd
+pdd
+xiM
+jbN
+jbN
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+jbN
+jbN
+jbN
+jbN
+jbN
+aTW
+pdd
+pdd
+pdd
+pdd
+pdd
+pdd
+pdd
+pdd
+aTW
+mEC
 mEC
 mEC
 mEC
@@ -47018,7 +47014,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 aTW
 jbN
 jbN
@@ -47071,7 +47067,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+mEC
 aTW
 aTW
 mEC
@@ -47248,7 +47244,7 @@ jbN
 jbN
 jbN
 aTW
-rRZ
+mEC
 mEC
 mEC
 mEC
@@ -48090,7 +48086,7 @@ mEC
 jbN
 jbN
 aTW
-rRZ
+jbN
 jbN
 mEC
 mEC
@@ -48203,7 +48199,7 @@ jbN
 jbN
 aTW
 aTW
-rRZ
+pdd
 jbN
 jbN
 mEC
@@ -48587,7 +48583,7 @@ mEC
 mEC
 jbN
 jbN
-rRZ
+jbN
 pdd
 pdd
 mEC
@@ -48601,8 +48597,8 @@ mEC
 mEC
 mEC
 aTW
-xHx
-aTW
+jbN
+jbN
 pdd
 pdd
 aTW
@@ -48651,7 +48647,7 @@ cOj
 pdd
 pdd
 pdd
-rRZ
+jbN
 jbN
 jbN
 mEC
@@ -48875,7 +48871,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+mEC
 aTW
 pdd
 aTW
@@ -49084,7 +49080,7 @@ mEC
 mEC
 jbN
 jbN
-rRZ
+jbN
 aTW
 aTW
 jbN
@@ -49143,7 +49139,7 @@ pdd
 pdd
 aTW
 aTW
-ksR
+mEC
 mEC
 mEC
 mEC
@@ -49408,7 +49404,7 @@ mEC
 mEC
 mEC
 jbN
-xHx
+jbN
 jbN
 jbN
 jbN
@@ -49734,7 +49730,7 @@ aTW
 aTW
 aTW
 aTW
-rRZ
+pdd
 jbN
 mEC
 mEC
@@ -49933,7 +49929,7 @@ jbN
 jbN
 jbN
 pdd
-xHx
+jbN
 jbN
 jbN
 mEC
@@ -49956,7 +49952,7 @@ jbN
 jbN
 aTW
 pdd
-rRZ
+pdd
 mEC
 mEC
 mEC
@@ -50124,7 +50120,6 @@ mEC
 mEC
 mEC
 mEC
-xHx
 mEC
 mEC
 mEC
@@ -50160,7 +50155,8 @@ mEC
 mEC
 mEC
 mEC
-xHx
+mEC
+mEC
 pdd
 pdd
 pdd
@@ -50603,7 +50599,7 @@ pdd
 pdd
 aTW
 aTW
-rRZ
+jbN
 jbN
 mEC
 mEC
@@ -50623,7 +50619,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+mEC
 jbN
 jbN
 jbN
@@ -50886,7 +50882,7 @@ jbN
 jbN
 jbN
 aTW
-xHx
+jbN
 jbN
 mEC
 mEC
@@ -50959,7 +50955,7 @@ mEC
 jbN
 jbN
 pdd
-pdd
+jbN
 xiM
 jbN
 jbN
@@ -51188,7 +51184,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+mEC
 aTW
 aTW
 aTW
@@ -51197,7 +51193,7 @@ pdd
 pdd
 pdd
 pdd
-xHx
+mEC
 mEC
 mEC
 mEC
@@ -51215,7 +51211,7 @@ mEC
 mEC
 mEC
 jbN
-xHx
+jbN
 pdd
 pdd
 xiM
@@ -51268,7 +51264,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+pdd
 pdd
 pdd
 pdd
@@ -51450,7 +51446,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+mEC
 pdd
 pdd
 xKl
@@ -51537,7 +51533,7 @@ jbN
 jbN
 jbN
 aTW
-rRZ
+pdd
 mEC
 mEC
 mEC
@@ -51611,7 +51607,7 @@ jbN
 aTW
 aTW
 aTW
-rRZ
+jbN
 aTW
 aTW
 aTW
@@ -51868,7 +51864,7 @@ jbN
 jbN
 aTW
 aTW
-pdd
+jbN
 aTW
 pdd
 pdd
@@ -52675,7 +52671,7 @@ aTW
 pdd
 pdd
 pdd
-xHx
+mEC
 mEC
 mEC
 mEC
@@ -53428,7 +53424,7 @@ mEC
 mEC
 mEC
 jbN
-rRZ
+jbN
 aTW
 pdd
 pdd
@@ -53534,7 +53530,7 @@ mEC
 mEC
 mEC
 aTW
-xHx
+aTW
 jbN
 jbN
 mEC
@@ -53558,7 +53554,7 @@ mEC
 aTW
 pdd
 pdd
-rRZ
+pdd
 mEC
 mEC
 mEC
@@ -53797,7 +53793,7 @@ jbN
 jbN
 jbN
 mEC
-xHx
+aTW
 pdd
 mEC
 mEC
@@ -53921,7 +53917,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 pdd
 pdd
 pdd
@@ -54212,7 +54208,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+mEC
 pdd
 pdd
 jbN
@@ -54730,7 +54726,7 @@ mEC
 aTW
 pdd
 aTW
-xHx
+jbN
 jbN
 jbN
 mEC
@@ -54813,7 +54809,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+aTW
 ygQ
 ygQ
 aTW
@@ -54952,28 +54948,28 @@ mEC
 mEC
 mEC
 mEC
+jbN
+pdd
+pdd
+pdd
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+aTW
 aTW
 pdd
 pdd
 pdd
-rRZ
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
 aTW
-aTW
-pdd
-pdd
-pdd
-aTW
-rRZ
+mEC
 mEC
 mEC
 mEC
@@ -54997,7 +54993,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+mEC
 aTW
 aTW
 aTW
@@ -55351,7 +55347,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+pdd
 aTW
 pdd
 aTW
@@ -55376,13 +55372,13 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 aTW
 pdd
 aTW
 pdd
 aTW
-rRZ
+mEC
 mEC
 mEC
 mEC
@@ -55851,7 +55847,7 @@ jbN
 jbN
 jbN
 jbN
-xHx
+aTW
 mEC
 mEC
 mEC
@@ -56277,7 +56273,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+mEC
 aTW
 aTW
 jbN
@@ -56357,7 +56353,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+aTW
 pdd
 aTW
 jbN
@@ -56616,7 +56612,7 @@ mEC
 mEC
 mEC
 aTW
-xHx
+aTW
 jbN
 mEC
 mEC
@@ -57193,7 +57189,7 @@ mEC
 jbN
 aTW
 pdd
-rRZ
+pdd
 jbN
 mEC
 mEC
@@ -57562,7 +57558,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+mEC
 aTW
 pdd
 pdd
@@ -58086,7 +58082,7 @@ jbN
 aTW
 pdd
 pdd
-xHx
+mEC
 mEC
 mEC
 mEC
@@ -58557,7 +58553,7 @@ jbN
 jbN
 aTW
 aTW
-rRZ
+mEC
 mEC
 mEC
 mEC
@@ -59109,7 +59105,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+mEC
 aTW
 pdd
 aTW
@@ -59577,7 +59573,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+pdd
 aTW
 mEC
 jbN
@@ -59712,7 +59708,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+aTW
 aTW
 jbN
 uyx
@@ -59721,7 +59717,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+aTW
 mEC
 mEC
 mEC
@@ -59749,7 +59745,7 @@ jbN
 pdd
 aTW
 jbN
-rRZ
+mEC
 mEC
 mEC
 mEC
@@ -60479,7 +60475,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+aTW
 aTW
 pdd
 pdd
@@ -60798,7 +60794,7 @@ mEC
 mEC
 mEC
 aTW
-rRZ
+pdd
 jbN
 mEC
 mEC
@@ -60893,7 +60889,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+pdd
 mEC
 mEC
 mEC
@@ -61667,7 +61663,7 @@ pdd
 aTW
 jbN
 jbN
-xHx
+pdd
 mEC
 mEC
 mEC
@@ -61779,7 +61775,7 @@ pdd
 pdd
 pdd
 aTW
-xHx
+aTW
 mEC
 mEC
 mEC
@@ -61917,7 +61913,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+pdd
 pdd
 pdd
 aTW
@@ -62154,7 +62150,7 @@ mEC
 aTW
 aTW
 aTW
-rRZ
+pdd
 jbN
 mEC
 mEC
@@ -62794,7 +62790,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+aTW
 aTW
 aTW
 pdd
@@ -62834,7 +62830,7 @@ pdd
 pdd
 aTW
 aTW
-rRZ
+pdd
 jbN
 jbN
 jbN
@@ -63717,7 +63713,7 @@ mEC
 mEC
 mEC
 aTW
-xHx
+pdd
 jbN
 jbN
 jbN
@@ -63832,7 +63828,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+aTW
 mEC
 mEC
 mEC
@@ -64133,7 +64129,7 @@ pdd
 pdd
 pdd
 aTW
-rRZ
+pdd
 jbN
 mEC
 mEC
@@ -64236,7 +64232,7 @@ aTW
 pdd
 pdd
 pdd
-xHx
+pdd
 mEC
 mEC
 mEC
@@ -64368,7 +64364,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+pdd
 jbN
 aTW
 jbN
@@ -64736,7 +64732,7 @@ aTW
 aTW
 jbN
 abT
-jbN
+ksR
 jbN
 mEC
 mEC
@@ -65250,7 +65246,7 @@ jbN
 abT
 jbN
 aTW
-xHx
+pdd
 jbN
 mEC
 mEC
@@ -65755,7 +65751,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 aTW
 jbN
 jbN
@@ -66303,7 +66299,7 @@ mEC
 mEC
 mEC
 aTW
-mEC
+pdd
 pdd
 aTW
 mEC
@@ -66564,7 +66560,7 @@ pdd
 pdd
 pdd
 aTW
-xHx
+mEC
 mEC
 mEC
 mEC
@@ -66662,12 +66658,12 @@ mEC
 mEC
 jbN
 jbN
-xHx
+aTW
 pdd
 pdd
 pdd
 pdd
-xHx
+aTW
 jbN
 jbN
 mEC
@@ -66696,7 +66692,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 mEC
 mEC
 mEC
@@ -67303,37 +67299,37 @@ mEC
 mEC
 mEC
 mEC
-xHx
-jbN
-jbN
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
-mEC
 mEC
 jbN
-xHx
+jbN
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+mEC
+jbN
+pdd
 pdd
 pdd
 mEC
@@ -67690,7 +67686,7 @@ mEC
 mEC
 jbN
 jbN
-xHx
+aTW
 pdd
 pdd
 jbN
@@ -68333,7 +68329,7 @@ pdd
 pdd
 pdd
 pdd
-xHx
+mEC
 mEC
 mEC
 mEC
@@ -68979,7 +68975,7 @@ jbN
 jbN
 pdd
 aTW
-xHx
+aTW
 mEC
 mEC
 mEC
@@ -69389,10 +69385,10 @@ mEC
 mEC
 jbN
 jbN
-xHx
 pdd
 pdd
-xHx
+pdd
+mEC
 mEC
 mEC
 mEC
@@ -69535,7 +69531,7 @@ pdd
 pdd
 pdd
 aTW
-rRZ
+mEC
 mEC
 mEC
 mEC
@@ -69615,7 +69611,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 pdd
 pdd
 jbN
@@ -69747,7 +69743,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+aTW
 pdd
 jbN
 jbN
@@ -70272,7 +70268,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+aTW
 aTW
 pdd
 pdd
@@ -70418,7 +70414,7 @@ mEC
 mEC
 pdd
 pdd
-xHx
+mEC
 mEC
 mEC
 mEC
@@ -71141,7 +71137,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 aTW
 aTW
 pdd
@@ -71281,7 +71277,7 @@ aTW
 aTW
 aTW
 aTW
-xHx
+aTW
 mEC
 mEC
 mEC
@@ -71564,7 +71560,7 @@ ybu
 jbN
 jbN
 ybu
-rRZ
+pdd
 pdd
 pdd
 pdd
@@ -72047,10 +72043,10 @@ mEC
 mEC
 mEC
 mEC
-xHx
 aTW
 aTW
 aTW
+aTW
 jbN
 mEC
 mEC
@@ -72083,7 +72079,7 @@ pdd
 pdd
 pdd
 pdd
-rRZ
+mEC
 mEC
 mEC
 mEC
@@ -72612,7 +72608,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+pdd
 pdd
 pdd
 pdd
@@ -72782,14 +72778,14 @@ mEC
 mEC
 mEC
 mEC
-xHx
+aTW
 pdd
 pdd
 pdd
 jbN
 pdd
 pdd
-xHx
+aTW
 mEC
 mEC
 mEC
@@ -72802,7 +72798,7 @@ mEC
 mEC
 mEC
 jbN
-xHx
+aTW
 pdd
 aTW
 jbN
@@ -72970,7 +72966,7 @@ aTW
 aTW
 pdd
 pdd
-rRZ
+aTW
 jbN
 mEC
 mEC
@@ -73320,7 +73316,7 @@ jbN
 pdd
 pdd
 pdd
-xHx
+aTW
 jbN
 jbN
 jbN
@@ -73553,7 +73549,7 @@ mEC
 aTW
 pdd
 pdd
-xHx
+aTW
 jbN
 jbN
 jbN
@@ -74131,7 +74127,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+mEC
 aTW
 aTW
 pdd
@@ -74365,13 +74361,13 @@ mEC
 mEC
 mEC
 mEC
-xHx
+aTW
 pdd
 pdd
 pdd
 pdd
 aTW
-xHx
+aTW
 mEC
 mEC
 mEC
@@ -74520,7 +74516,7 @@ mEC
 mEC
 aTW
 aTW
-xHx
+aTW
 jbN
 mEC
 mEC
@@ -74561,9 +74557,9 @@ mEC
 mEC
 mEC
 jbN
-xHx
 aTW
 aTW
+aTW
 mEC
 mEC
 mEC
@@ -74608,7 +74604,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+aTW
 mEC
 mEC
 mEC
@@ -75045,11 +75041,11 @@ mEC
 mEC
 mEC
 mEC
-xHx
+mEC
 aTW
 aTW
 aTW
-xHx
+mEC
 mEC
 mEC
 mEC
@@ -75291,7 +75287,7 @@ mEC
 mEC
 mEC
 jbN
-xHx
+aTW
 aTW
 mEC
 mEC
@@ -75645,7 +75641,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+aTW
 jbN
 jbN
 pdd
@@ -75848,7 +75844,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+aTW
 mEC
 mEC
 mEC
@@ -76283,7 +76279,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 aTW
 jbN
 aTW
@@ -76332,7 +76328,7 @@ mEC
 mEC
 jbN
 jbN
-xHx
+pdd
 aTW
 aTW
 jbN
@@ -76348,7 +76344,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+aTW
 jbN
 jbN
 jbN
@@ -76560,7 +76556,7 @@ aTW
 pdd
 pdd
 aTW
-rRZ
+mEC
 mEC
 mEC
 mEC
@@ -77160,7 +77156,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+aTW
 pdd
 aTW
 aTW
@@ -77230,7 +77226,7 @@ pdd
 pdd
 pdd
 aTW
-rRZ
+pdd
 mEC
 mEC
 mEC
@@ -77457,8 +77453,8 @@ jbN
 aTW
 aTW
 aTW
-xHx
-mEC
+aTW
+aTW
 aTW
 mEC
 mEC
@@ -77575,7 +77571,7 @@ pdd
 pdd
 jbN
 afl
-rRZ
+pdd
 aTW
 pdd
 pdd
@@ -77631,12 +77627,12 @@ mEC
 mEC
 mEC
 mEC
-xHx
+aTW
 aTW
 pdd
 pdd
 aTW
-xHx
+aTW
 jbN
 jbN
 mEC
@@ -77680,7 +77676,7 @@ jbN
 aTW
 pdd
 pdd
-xHx
+aTW
 mEC
 mEC
 mEC
@@ -78168,7 +78164,7 @@ jbN
 pdd
 pdd
 pdd
-xHx
+mEC
 mEC
 mEC
 mEC
@@ -78269,7 +78265,7 @@ mEC
 mEC
 aTW
 aTW
-rRZ
+mEC
 mEC
 mEC
 mEC
@@ -78419,7 +78415,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+mEC
 aTW
 jbN
 tSA
@@ -79105,7 +79101,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 aTW
 aTW
 aTW
@@ -79213,7 +79209,7 @@ mEC
 mEC
 mEC
 mEC
-xHx
+aTW
 aTW
 pdd
 pdd
@@ -79224,7 +79220,7 @@ jbN
 jbN
 aTW
 pdd
-xHx
+aTW
 mEC
 mEC
 mEC
@@ -79284,7 +79280,7 @@ jbN
 aTW
 aTW
 aTW
-rRZ
+pdd
 mEC
 mEC
 mEC
@@ -79716,7 +79712,7 @@ mEC
 mEC
 aTW
 aTW
-xHx
+pdd
 jbN
 jbN
 mEC
@@ -80291,7 +80287,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+pdd
 aTW
 aTW
 pdd
@@ -80532,7 +80528,7 @@ pdd
 aTW
 aTW
 aTW
-rRZ
+mEC
 mEC
 mEC
 mEC
@@ -80664,7 +80660,7 @@ agd
 ajs
 agd
 agd
-rRZ
+pdd
 jbN
 afl
 jbN
@@ -80953,7 +80949,7 @@ mEC
 mEC
 mEC
 jbN
-rRZ
+pdd
 pdd
 pdd
 pdd
@@ -81015,7 +81011,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+aTW
 aTW
 aTW
 pdd
@@ -81705,7 +81701,7 @@ jbN
 jbN
 aTW
 aTW
-rRZ
+mEC
 mEC
 mEC
 mEC
@@ -83132,7 +83128,7 @@ aak
 aak
 pdd
 pdd
-rRZ
+pdd
 mEC
 mEC
 mEC
@@ -83218,7 +83214,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 aTW
 aTW
 jbN
@@ -83491,7 +83487,7 @@ jbN
 jbN
 jbN
 abT
-jbN
+pdd
 jbN
 aTW
 aTW
@@ -83867,7 +83863,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 aTW
 aTW
 mEC
@@ -84259,7 +84255,7 @@ aTW
 pdd
 aTW
 aTW
-rRZ
+pdd
 jbN
 jbN
 jbN
@@ -84319,7 +84315,7 @@ aTW
 jbN
 jbN
 jbN
-rRZ
+pdd
 aTW
 pdd
 pdd
@@ -84350,7 +84346,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 aTW
 aTW
 mEC
@@ -84915,7 +84911,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+pdd
 pdd
 pdd
 aTW
@@ -85140,7 +85136,7 @@ mEC
 jbN
 jbN
 jbN
-rRZ
+pdd
 jbN
 jbN
 mEC
@@ -85590,7 +85586,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 pdd
 pdd
 pdd
@@ -85946,7 +85942,7 @@ pdd
 pdd
 pdd
 jbN
-jbN
+pdd
 aak
 aak
 pdd
@@ -86207,7 +86203,7 @@ jbN
 jbN
 pdd
 pdd
-rRZ
+pdd
 mEC
 mEC
 mEC
@@ -86642,7 +86638,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 pdd
 jbN
 jbN
@@ -87164,7 +87160,6 @@ pdd
 pdd
 jbN
 pdd
-rRZ
 mEC
 mEC
 mEC
@@ -87190,7 +87185,8 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
+mEC
 aTW
 aTW
 pdd
@@ -87400,7 +87396,7 @@ mEC
 mEC
 mEC
 mEC
-rRZ
+mEC
 aTW
 aTW
 mEC
@@ -88484,7 +88480,7 @@ jbN
 jbN
 aTW
 aTW
-rRZ
+mEC
 mEC
 mEC
 mEC

--- a/_maps/map_files/generic/syndicatebase.dmm
+++ b/_maps/map_files/generic/syndicatebase.dmm
@@ -25227,6 +25227,18 @@
 	dir = 1;
 	layer = 2.9
 	},
+/obj/structure/sign/directions/medical{
+	dir = 8;
+	pixel_x = -32;
+	pixel_y = 6
+	},
+/obj/structure/sign/directions/science{
+	pixel_x = -32
+	},
+/obj/structure/sign/directions/cargo{
+	pixel_x = -32;
+	pixel_y = -6
+	},
 /turf/simulated/floor/carpet/arcade,
 /area/syndicate/unpowered/syndicate_space_base/main/central_s)
 "uUH" = (

--- a/_maps/map_files/generic/syndicatebase.dmm
+++ b/_maps/map_files/generic/syndicatebase.dmm
@@ -11211,9 +11211,6 @@
 	icon_state = "dark"
 	},
 /area/syndicate/unpowered/syndicate_space_base/medbay/virology)
-"ksR" = (
-/turf/space,
-/area/ruin/unpowered)
 "kva" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
@@ -23065,7 +23062,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/junction{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -23872,13 +23869,6 @@
 	icon_state = "dark"
 	},
 /area/syndicate/unpowered/syndicate_space_base/main/central_s)
-"uhB" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "dark"
-	},
-/area/syndicate/unpowered/syndicate_space_base/main/central_s)
 "uhH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -24420,28 +24410,6 @@
 	icon_state = "dark"
 	},
 /area/syndicate/unpowered/syndicate_space_base/rnd/restroom)
-"uyQ" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/structure/sign/directions/medical{
-	dir = 8;
-	pixel_x = -32;
-	pixel_y = 6
-	},
-/obj/structure/sign/directions/science{
-	pixel_x = -32
-	},
-/obj/structure/sign/directions/cargo{
-	pixel_x = -32;
-	pixel_y = -6
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "dark"
-	},
-/area/syndicate/unpowered/syndicate_space_base/main/central_s)
 "uyR" = (
 /obj/machinery/light,
 /obj/structure/reagent_dispensers/fueltank/chem{
@@ -25405,7 +25373,7 @@
 /turf/simulated/floor/plating,
 /area/syndicate/unpowered/syndicate_space_base/prison)
 "uZl" = (
-/obj/structure/chair/stool,
+/obj/machinery/vending/crittercare/free,
 /turf/simulated/floor/carpet/arcade,
 /area/syndicate/unpowered/syndicate_space_base/main/central_s)
 "vab" = (
@@ -25974,13 +25942,18 @@
 /turf/simulated/floor/carpet/arcade,
 /area/syndicate/unpowered/syndicate_space_base/main/central_s)
 "vvk" = (
-/obj/structure/window/reinforced{
-	color = "red";
-	dir = 4;
-	layer = 2.9
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/vending/crittercare/free,
-/turf/simulated/floor/carpet/arcade,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "dark"
+	},
 /area/syndicate/unpowered/syndicate_space_base/main/central_s)
 "vvA" = (
 /obj/structure/table,
@@ -26558,14 +26531,12 @@
 	},
 /area/syndicate/unpowered/syndicate_space_base/main/central_s)
 "vXh" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "dark"
@@ -27066,15 +27037,6 @@
 /area/syndicate/unpowered/syndicate_space_base/vault)
 "wnD" = (
 /obj/structure/chair/comfy/black,
-/turf/simulated/floor/carpet/arcade,
-/area/syndicate/unpowered/syndicate_space_base/main/central_s)
-"wnJ" = (
-/obj/machinery/computer/arcade/battle,
-/obj/structure/window/reinforced{
-	color = "red";
-	dir = 4;
-	layer = 2.9
-	},
 /turf/simulated/floor/carpet/arcade,
 /area/syndicate/unpowered/syndicate_space_base/main/central_s)
 "wnM" = (
@@ -28087,6 +28049,7 @@
 	},
 /area/syndicate/unpowered/syndicate_space_base/prison)
 "wQh" = (
+/obj/machinery/arcade/minesweeper,
 /obj/structure/window/reinforced{
 	color = "red";
 	dir = 4;
@@ -28096,7 +28059,6 @@
 	color = "red";
 	layer = 2.9
 	},
-/obj/machinery/arcade/minesweeper,
 /turf/simulated/floor/carpet/arcade,
 /area/syndicate/unpowered/syndicate_space_base/main/central_s)
 "wRV" = (
@@ -29375,8 +29337,14 @@
 /turf/simulated/floor/plating,
 /area/syndicate/unpowered/syndicate_space_base/cargo)
 "xHx" = (
-/turf/simulated/mineral,
-/area/space)
+/obj/structure/window/reinforced{
+	color = "red";
+	dir = 4;
+	layer = 2.9
+	},
+/obj/machinery/computer/arcade/battle,
+/turf/simulated/floor/carpet/arcade,
+/area/syndicate/unpowered/syndicate_space_base/main/central_s)
 "xHM" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -43191,7 +43159,7 @@ pdd
 jbN
 tJo
 jbN
-jbN
+pdd
 pdd
 pdd
 pdd
@@ -43709,7 +43677,7 @@ jbN
 jbN
 jbN
 jbN
-jbN
+pdd
 abT
 jbN
 jbN
@@ -50955,7 +50923,7 @@ mEC
 jbN
 jbN
 pdd
-jbN
+pdd
 xiM
 jbN
 jbN
@@ -51864,7 +51832,7 @@ jbN
 jbN
 aTW
 aTW
-jbN
+pdd
 aTW
 pdd
 pdd
@@ -54438,7 +54406,7 @@ pdd
 pdd
 pdd
 pdd
-jbN
+pdd
 jbN
 mEC
 mEC
@@ -54948,7 +54916,7 @@ mEC
 mEC
 mEC
 mEC
-jbN
+pdd
 pdd
 pdd
 pdd
@@ -56541,7 +56509,7 @@ jbN
 jbN
 aTW
 pdd
-xHx
+aTW
 mEC
 mEC
 mEC
@@ -61663,7 +61631,7 @@ pdd
 aTW
 jbN
 jbN
-pdd
+jbN
 mEC
 mEC
 mEC
@@ -64732,7 +64700,7 @@ aTW
 aTW
 jbN
 abT
-ksR
+jbN
 jbN
 mEC
 mEC
@@ -65055,10 +65023,10 @@ sfw
 sLQ
 okS
 tHo
-uhB
-uyQ
+oLs
 uUA
 vtz
+uZl
 vQV
 wnD
 wCh
@@ -65313,11 +65281,11 @@ sMs
 okS
 tHJ
 oLs
-oLs
 uUH
 vvf
-uZl
-uZl
+vvf
+vvf
+vvf
 vvf
 wPz
 ybK
@@ -65570,11 +65538,11 @@ sNt
 okS
 tIT
 oLs
-oLs
 uVo
-vvk
+ldT
 vRL
-wnJ
+xHx
+ldT
 ldT
 wQh
 ybK
@@ -65828,9 +65796,9 @@ okS
 tIX
 oLs
 oLs
-oLs
 vvR
 vTr
+oLs
 wnM
 wCB
 wRV
@@ -66086,8 +66054,8 @@ tJw
 oLs
 oLs
 oLs
-oLs
 vUI
+oLs
 wnU
 oLs
 wSo
@@ -66343,7 +66311,7 @@ tJZ
 uhH
 uza
 uVq
-uVq
+vvk
 vXh
 wnX
 aOE
@@ -83487,7 +83455,7 @@ jbN
 jbN
 jbN
 abT
-pdd
+jbN
 jbN
 aTW
 aTW
@@ -85942,7 +85910,7 @@ pdd
 pdd
 pdd
 jbN
-pdd
+jbN
 aak
 aak
 pdd


### PR DESCRIPTION
## Описание
Удаляет все турели тайпана на астероидах.
Турели остаются только на самой станции
Так же на тайпан в дормиторий добавил QOL сапёр

## Ссылка на предложение/Причина создания ПР

Было 4 предложки на это. Все прошли .На все трупанулся мапер.
Вот последняя.
https://discord.com/channels/617003227182792704/755125334097133628/1135953981995233424

Хочу отметить что турелей слишком дохуя, учитывая что сектор заблокирован и в него нельзя влететь пока нету 3 человек онлайн, такая защита просто не нужна.

## Демонстрация изменений
![image](https://github.com/user-attachments/assets/3589c863-5f58-47be-bdbd-11bda2b107e5)

## Тесты
Было
![image](https://github.com/user-attachments/assets/45583c3f-1798-4310-992d-aec7c2ed1841)
Стало
![image](https://github.com/user-attachments/assets/5b2a5549-a980-4a01-8db7-115c8f114d4e)

