### PR TITLE
bugfix: Xenomorphs can't devour

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1379,6 +1379,7 @@
 
 	var/target = isturf(loc) ? src : gourmet
 
+	gourmet.dir = get_dir(gourmet, src)
 	gourmet.visible_message(span_danger("[gourmet.name] пыта[pluralize_ru(gourmet.gender,"ет","ют")]ся поглотить [name]!"))
 
 	if(!do_after(gourmet, get_devour_time(gourmet), target, NONE, extra_checks = CALLBACK(src, PROC_REF(can_devour), gourmet), max_interact_count = 1, cancel_on_max = TRUE, cancel_message = span_notice("Вы прекращаете поглощать [name]!")))

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1379,7 +1379,7 @@
 
 	var/target = isturf(loc) ? src : gourmet
 
-	gourmet.dir = get_dir(gourmet, src)
+	gourmet.setDir(get_dir(gourmet, src))
 	gourmet.visible_message(span_danger("[gourmet.name] пыта[pluralize_ru(gourmet.gender,"ет","ют")]ся поглотить [name]!"))
 
 	if(!do_after(gourmet, get_devour_time(gourmet), target, NONE, extra_checks = CALLBACK(src, PROC_REF(can_devour), gourmet), max_interact_count = 1, cancel_on_max = TRUE, cancel_message = span_notice("Вы прекращаете поглощать [name]!")))

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -147,7 +147,5 @@ GLOBAL_LIST_INIT(strippable_alien_humanoid_items, create_strippable_list(list(
 		return FALSE
 	if(incapacitated() || grab_state < GRAB_AGGRESSIVE || stat != CONSCIOUS)
 		return FALSE
-	if(get_dir(src, target) != dir) // Gotta face em 4head
-		return FALSE
 	return TRUE
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Ксеноморфы снова нормально жрут людей. Требование смотреть на цель заменено на насильный поворот на цель. Раньше было можно жрать спиной. Игроки не понимают, тем более что игра им не объясняет, что не так.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

