### PR TITLE
bugfix: haloperidol being harmless

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -1099,6 +1099,7 @@
 	reagent_state = LIQUID
 	color = "#FFDCFF"
 	taste_description = "stability"
+	harmless = FALSE
 	var/list/drug_list = list("crank","methamphetamine","space_drugs","psilocybin","ephedrine","epinephrine","stimulants","bath_salts","lsd","thc")
 
 /datum/reagent/medicine/haloperidol/on_mob_life(mob/living/M)


### PR DESCRIPTION
## Описание

Изменяет значение переменной harmless у галоперидола на FALSE

## Причина создания ПР

Галоперидол даёт сонливость и может нанести урон мозгу, но ещё всё является "безопасным". Его не выводит реджув вампира из-за этого.
