### PR TITLE
bugfix: Resonator and fleshmaul attackchain cooldowns.

### DIFF
--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -266,8 +266,9 @@
 
 	else if(iswallturf(target))
 		var/turf/simulated/wall/wall = target
-		wall.take_damage(30)
 		user.do_attack_animation(wall)
+		user.changeNext_move(attack_speed)
+		wall.take_damage(30)
 		playsound(src, 'sound/weapons/smash.ogg', 50, TRUE)
 
 	else if(isliving(target))

--- a/code/modules/mining/equipment/resonator.dm
+++ b/code/modules/mining/equipment/resonator.dm
@@ -48,6 +48,7 @@
 	if(ATTACK_CHAIN_CANCEL_CHECK(.) || !check_allowed_items(target, TRUE))
 		return .
 	. |= ATTACK_CHAIN_BLOCKED
+	user.changeNext_move(attack_speed)
 	create_resonance(target, user)
 
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет кулдаун клика резонатору и булаве генокрада в удар по стене.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР
Видимо, раньше до-атака и после-атака давали при успешном завершении кулдауны в цепочку атаки. Сейчас впринципе клики по тюрфам кулдауна не дают, так что особым механам атаки у резонатора и булавы генокрада вписаны кулдауны на клик. В идеале пусть бы посмотрел Цвей и выдал экспертное мнение по тому, как это правильно чинить, но для **временного решения** должно пойти.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Потыкал стены булавой генокрада + резонатором поигрался. Кулдауны были.
<!-- Как вы тестировали свой код. Ревьеюру будет проще, если он будет знать какие действия вы совершали, проверяя свой ПР. -->
