### PR TITLE
bugfix: danger tray not working as intended

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -565,10 +565,10 @@
 
 	playsound(target, pick('sound/items/trayhit1.ogg', 'sound/items/trayhit2.ogg'), 50, TRUE)
 	if(target == user)
+		user.apply_damage(25, BRUTE, active_hand_zone, 0, FALSE, src)
 		if(prob(15))
 			var/obj/item/organ/external/L = user.get_organ(active_hand_zone)
 			L.droplimb(FALSE, DROPLIMB_SHARP)
-		user.apply_damage(25, BRUTE, active_hand_zone, 0, FALSE, /obj/item/storage/bag/dangertray)
 
 	if(ishuman(target) && prob(10))
 		target.Knockdown(4 SECONDS)
@@ -592,13 +592,13 @@
 		playsound(H, pick('sound/items/trayhit1.ogg', 'sound/items/trayhit2.ogg'), 50, TRUE)
 		if(prob(80)) // pick limbs, except for the head, also have a chance to cut them off
 			var/zone = pick(BODY_ZONE_L_ARM, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_R_ARM, BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_R_LEG, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_L_LEG, BODY_ZONE_PRECISE_L_FOOT)
-			H.apply_damage(25, BRUTE, zone, 0, FALSE, /obj/item/storage/bag/dangertray)
+			H.apply_damage(25, BRUTE, zone, 0, FALSE, src)
 			if(prob(15))
 				var/obj/item/organ/external/L = H.get_organ(zone)
 				L.droplimb(FALSE, DROPLIMB_SHARP)
 		else // head, chest, groin
 			var/zone = pick(BODY_ZONE_CHEST, BODY_ZONE_HEAD, BODY_ZONE_PRECISE_GROIN)
-			H.apply_damage(25, BRUTE, zone, 0, FALSE, /obj/item/storage/bag/dangertray)
+			H.apply_damage(25, BRUTE, zone, 0, FALSE, src)
 	if(isobj(hit_atom))
 		var/obj/H = hit_atom
 		playsound(H, pick('sound/items/trayhit1.ogg', 'sound/items/trayhit2.ogg'), 50, TRUE)

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -602,7 +602,7 @@
 	if(isobj(hit_atom))
 		var/obj/H = hit_atom
 		playsound(H, pick('sound/items/trayhit1.ogg', 'sound/items/trayhit2.ogg'), 50, TRUE)
-		H.take_damage(25, BRUTE, "melee")
+		H.take_damage(25, BRUTE, MELEE)
 
 
 /obj/item/storage/bag/dangertray/update_overlays()

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -541,7 +541,7 @@
 	icon = 'icons/obj/food/containers.dmi'
 	icon_state = "dangertray"
 	desc = "A metal tray to lay food on. The edges are razor sharp"
-	force = 25
+	force = 5
 	throwforce = 25.0
 	throw_speed = 3
 	throw_range = 7

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -542,7 +542,7 @@
 	icon_state = "dangertray"
 	desc = "A metal tray to lay food on. The edges are razor sharp"
 	force = 5
-	throwforce = 25.0
+	throwforce = 0 // throwimpact rewrite
 	throw_speed = 3
 	throw_range = 7
 	armour_penetration = 15
@@ -551,13 +551,24 @@
 	flags = CONDUCT
 	materials = list(MAT_METAL=3000)
 
+	var/active_hand_zone
 
 /obj/item/storage/bag/dangertray/attack(mob/living/target, mob/living/user, params, def_zone, skip_attack_anim = FALSE)
 	. = ..()
 	if(!ATTACK_CHAIN_SUCCESS_CHECK(.))
 		return .
 
+	if(user.hand == ACTIVE_HAND_RIGHT)
+		active_hand_zone = BODY_ZONE_PRECISE_R_HAND
+	else
+		active_hand_zone = BODY_ZONE_PRECISE_L_HAND
+
 	playsound(target, pick('sound/items/trayhit1.ogg', 'sound/items/trayhit2.ogg'), 50, TRUE)
+	if(target == user)
+		if(prob(15))
+			user.get_organ(active_hand_zone).droplimb(FALSE, DROPLIMB_SHARP)
+		user.apply_damage(25, BRUTE, active_hand_zone, 0, FALSE, /obj/item/storage/bag/dangertray)
+
 	if(ishuman(target) && prob(10))
 		target.Knockdown(4 SECONDS)
 
@@ -572,6 +583,24 @@
 				if(I)
 					step(I, pick(NORTH,SOUTH,EAST,WEST))
 					sleep(rand(2,4))
+
+/obj/item/storage/bag/dangertray/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
+	..()
+	if(ishuman(hit_atom))
+		var/mob/living/carbon/human/H = hit_atom
+		playsound(H, pick('sound/items/trayhit1.ogg', 'sound/items/trayhit2.ogg'), 50, TRUE)
+		if(prob(80)) // pick limbs, except for the head, also have a chance to cut them off
+			var/zone = pick(BODY_ZONE_L_ARM, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_R_ARM, BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_R_LEG, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_L_LEG, BODY_ZONE_PRECISE_L_FOOT)
+			H.apply_damage(25, BRUTE, zone, 0, FALSE, /obj/item/storage/bag/dangertray)
+			if(prob(15))
+				H.get_organ(zone).droplimb(FALSE, DROPLIMB_SHARP)
+		else // head, chest, groin
+			var/zone = pick(BODY_ZONE_CHEST, BODY_ZONE_HEAD, BODY_ZONE_PRECISE_GROIN)
+			H.apply_damage(25, BRUTE, zone, 0, FALSE, /obj/item/storage/bag/dangertray)
+	if(isobj(hit_atom))
+		var/obj/H = hit_atom
+		playsound(H, pick('sound/items/trayhit1.ogg', 'sound/items/trayhit2.ogg'), 50, TRUE)
+		H.take_damage(25, BRUTE, "melee")
 
 
 /obj/item/storage/bag/dangertray/update_overlays()

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -566,7 +566,8 @@
 	playsound(target, pick('sound/items/trayhit1.ogg', 'sound/items/trayhit2.ogg'), 50, TRUE)
 	if(target == user)
 		if(prob(15))
-			user.get_organ(active_hand_zone).droplimb(FALSE, DROPLIMB_SHARP)
+			var/L = user.get_organ(active_hand_zone)
+			L.droplimb(FALSE, DROPLIMB_SHARP)
 		user.apply_damage(25, BRUTE, active_hand_zone, 0, FALSE, /obj/item/storage/bag/dangertray)
 
 	if(ishuman(target) && prob(10))
@@ -593,7 +594,8 @@
 			var/zone = pick(BODY_ZONE_L_ARM, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_R_ARM, BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_R_LEG, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_L_LEG, BODY_ZONE_PRECISE_L_FOOT)
 			H.apply_damage(25, BRUTE, zone, 0, FALSE, /obj/item/storage/bag/dangertray)
 			if(prob(15))
-				H.get_organ(zone).droplimb(FALSE, DROPLIMB_SHARP)
+				var/L = H.get_organ(zone)
+				L.droplimb(FALSE, DROPLIMB_SHARP)
 		else // head, chest, groin
 			var/zone = pick(BODY_ZONE_CHEST, BODY_ZONE_HEAD, BODY_ZONE_PRECISE_GROIN)
 			H.apply_damage(25, BRUTE, zone, 0, FALSE, /obj/item/storage/bag/dangertray)

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -566,7 +566,7 @@
 	playsound(target, pick('sound/items/trayhit1.ogg', 'sound/items/trayhit2.ogg'), 50, TRUE)
 	if(target == user)
 		if(prob(15))
-			var/L = user.get_organ(active_hand_zone)
+			var/obj/item/organ/external/L = user.get_organ(active_hand_zone)
 			L.droplimb(FALSE, DROPLIMB_SHARP)
 		user.apply_damage(25, BRUTE, active_hand_zone, 0, FALSE, /obj/item/storage/bag/dangertray)
 
@@ -594,7 +594,7 @@
 			var/zone = pick(BODY_ZONE_L_ARM, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_R_ARM, BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_R_LEG, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_L_LEG, BODY_ZONE_PRECISE_L_FOOT)
 			H.apply_damage(25, BRUTE, zone, 0, FALSE, /obj/item/storage/bag/dangertray)
 			if(prob(15))
-				var/L = H.get_organ(zone)
+				var/obj/item/organ/external/L = H.get_organ(zone)
 				L.droplimb(FALSE, DROPLIMB_SHARP)
 		else // head, chest, groin
 			var/zone = pick(BODY_ZONE_CHEST, BODY_ZONE_HEAD, BODY_ZONE_PRECISE_GROIN)


### PR DESCRIPTION
## Описание

Исправляет работу острых блюдцев на ту, что должна была быть изначально (кроме бронепробития). Урон в ближку теперь 5, при ударе самого себя есть шанс отсечь конечность, при броске в кого-то есть шанс отсечь конечность, выше шанс попасть по конечностям, нежели по торсу или голове.

## Причина создания ПР

https://discord.com/channels/617003227182792704/755125334097133628/1133438238460215306
