### PR TITLE
add: objectives for changelings

### DIFF
--- a/code/modules/antagonists/changeling/changeling_datum.dm
+++ b/code/modules/antagonists/changeling/changeling_datum.dm
@@ -205,6 +205,10 @@ GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","E
 	absorb.owner = owner
 	objectives += absorb
 
+	if(prob(50))
+		add_objective(/datum/objective/protect)
+		add_objective(/datum/objective/pain_hunter)
+
 	if(prob(60))
 		add_objective(/datum/objective/steal)
 	else


### PR DESCRIPTION
## Описание

Добавляет Генокрадам 2 дополнительные цели сгенерированные как у триторов.

## Ссылка на предложение/Причина создания ПР

https://discord.com/channels/617003227182792704/755125334097133628/1270345199402483763
