### PR TITLE
bugfix: Eatable component attack speed & cloth material fix

### DIFF
--- a/code/datums/components/eatable.dm
+++ b/code/datums/components/eatable.dm
@@ -94,7 +94,7 @@
 	if(is_only_grab_intent && user.a_intent != INTENT_GRAB)
 		return FALSE
 
-	target.changeNext_move(target.attack_speed)
+	target.changeNext_move(CLICK_CD_MELEE)
 	INVOKE_ASYNC(src, PROC_REF(try_eat_item), target, user)
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 

--- a/code/datums/components/eatable.dm
+++ b/code/datums/components/eatable.dm
@@ -94,6 +94,7 @@
 	if(is_only_grab_intent && user.a_intent != INTENT_GRAB)
 		return FALSE
 
+	target.changeNext_move(target.attack_speed)
 	INVOKE_ASYNC(src, PROC_REF(try_eat_item), target, user)
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -289,7 +289,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 		if(WEIGHT_CLASS_GIGANTIC)
 			size = "gigantic"
 
-	. = ..(user, "", "It is a [size] item. ")
+	. = ..(user, "", "It is a [size] item.")
 
 	if(user.research_scanner) //Mob has a research scanner active.
 		var/msg = "*--------* <BR>"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -289,7 +289,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 		if(WEIGHT_CLASS_GIGANTIC)
 			size = "gigantic"
 
-	. = ..(user, "", "It is a [size] item.")
+	. = ..(user, "", "It is a [size] item. ")
 
 	if(user.research_scanner) //Mob has a research scanner active.
 		var/msg = "*--------* <BR>"

--- a/code/modules/food_and_drinks/item_food/eat_item_list_cloth.dm
+++ b/code/modules/food_and_drinks/item_food/eat_item_list_cloth.dm
@@ -10,7 +10,7 @@
 /obj/item/clothing/add_eatable_component()
 	AddComponent( \
 	/datum/component/eatable, \
-	material_type = MATERIAL_CLASS_CLOTH, \
+	material_type = MATERIAL_CLASS_NONE, \
 	max_bites = 10, \
 	integrity_bite = 20, \
 	nutritional_value = 5, \

--- a/code/modules/food_and_drinks/item_food/eat_item_list_cloth.dm
+++ b/code/modules/food_and_drinks/item_food/eat_item_list_cloth.dm
@@ -27,19 +27,67 @@
 	)
 
 /obj/item/clothing/under/solgov/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 10, \
+	integrity_bite = 40, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/under/rank/centcom/blueshield/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 10, \
+	integrity_bite = 40, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/under/rank/centcom/officer/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 10, \
+	integrity_bite = 40, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/under/rank/centcom_commander/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 10, \
+	integrity_bite = 40, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/under/space/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 10, \
+	integrity_bite = 40, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/under/cursedclown/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 10, \
+	integrity_bite = 40, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/under/acj/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 10, \
+	integrity_bite = 40, \
+	nutritional_value = 10, \
+	)
 
 //NECK
 /obj/item/clothing/neck/add_eatable_component()
@@ -64,15 +112,54 @@
 	)
 
 /obj/item/clothing/accessory/holobadge/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 10, \
+	integrity_bite = 20, \
+	nutritional_value = 5, \
+	is_only_grab_intent = TRUE, \
+	)
+
 /obj/item/clothing/accessory/head_strip/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 10, \
+	integrity_bite = 20, \
+	nutritional_value = 5, \
+	is_only_grab_intent = TRUE, \
+	)
+
 /obj/item/clothing/accessory/necklace/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 10, \
+	integrity_bite = 20, \
+	nutritional_value = 5, \
+	is_only_grab_intent = TRUE, \
+	)
+
 /obj/item/clothing/accessory/medal/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 10, \
+	integrity_bite = 20, \
+	nutritional_value = 5, \
+	is_only_grab_intent = TRUE, \
+	)
+
 /obj/item/clothing/accessory/stethoscope/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 10, \
+	integrity_bite = 20, \
+	nutritional_value = 5, \
+	is_only_grab_intent = TRUE, \
+	)
 
 
 //GLOVES
@@ -86,17 +173,58 @@
 	)
 
 /obj/item/clothing/gloves/color/yellow/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 2, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/gloves/color/red/insulated/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 2, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/gloves/color/red/insulated/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 2, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/gloves/color/latex/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 2, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/gloves/color/captain/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 2, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/gloves/color/black/krav_maga/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 2, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
 
 
 //MASK
@@ -121,33 +249,130 @@
 	)
 
 /obj/item/clothing/head/helmet/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 6, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/head/helmet/space/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 6, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/head/collectable/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 6, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/head/caphat/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 6, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/head/det_hat/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 6, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/head/beret/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 6, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/head/HoS/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 6, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/head/warden/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 6, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/head/officer/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 6, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/head/surgery/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 6, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/head/welding/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 6, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/head/cakehat/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 6, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/head/kitty/add_eatable_component()	//Нет. Нельзя.
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 6, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/head/headmirror/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 6, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
 
 
 //SUIT
@@ -208,56 +433,194 @@
 	)
 
 /obj/item/clothing/suit/chameleon/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 16, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/suit/space/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 16, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/suit/armor/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 16, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/suit/storage/add_eatable_component()		//jacket e.t.c.
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 16, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/suit/fire/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 16, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
 
 
 
 //Full Costume
 /obj/item/clothing/head/cardborg/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 6, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+	
 /obj/item/clothing/suit/cardborg/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 16, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
 
 /obj/item/clothing/head/bio_hood/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 6, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/suit/bio_suit/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 16, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
 
 /obj/item/clothing/head/bomb_hood/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 6, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/suit/bomb_suit/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 16, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
 
 /obj/item/clothing/head/radiation/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 6, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/suit/radiation/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 16, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
 
 /obj/item/clothing/head/wizard/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 6, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/suit/wizrobe/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 16, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
 
 /obj/item/clothing/head/beekeeper_head/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 6, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/suit/beekeeper_suit/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 16, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
 
 /obj/item/clothing/suit/hooded/explorer/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 16, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/head/hooded/explorer/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 6, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
 
 /obj/item/clothing/head/beanie/durathread/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 6, \
+	integrity_bite = 20, \
+	nutritional_value = 10, \
+	)
+
 /obj/item/clothing/under/misc/durathread/add_eatable_component()
-	return
+	AddComponent( \
+	/datum/component/eatable, \
+	material_type = MATERIAL_CLASS_NONE, \
+	max_bites = 10, \
+	integrity_bite = 40, \
+	nutritional_value = 10, \
+	)
 


### PR DESCRIPTION
## Описание
Коррекция типа для clothing айтемов (она изначально должна была быть на MATERIAL_CLASS_NONE, что бы не было ситуаций со тканевыми кольцами) и добавление КД на атаку при триггере компонента.

И так как мы выдаем компонент всем предметам - предметам несъедобным он также присвоен, но со значением материала на MATERIAL_CLASS_NONE

## Ссылка на предложение/Причина создания ПР
Немного сломано

## Тесты
Обязательно тестировалось
