### PR TITLE
bugfix: devil revive contract, spell targeting fix & gravemarker rename fix

### DIFF
--- a/code/datums/spells/devil.dm
+++ b/code/datums/spells/devil.dm
@@ -43,6 +43,7 @@
 
 /obj/effect/proc_holder/spell/summon_contract/create_new_targeting()
 	var/datum/spell_targeting/click/T = new()
+	T.try_auto_target = FALSE
 	T.range = 5
 	T.click_radius = -1
 	T.allowed_type = /mob/living/carbon

--- a/code/datums/spells/devil.dm
+++ b/code/datums/spells/devil.dm
@@ -50,7 +50,7 @@
 
 
 /obj/effect/proc_holder/spell/summon_contract/valid_target(mob/living/carbon/target, mob/user)
-	return target.mind && target.ckey && !target.stat
+	return target.mind
 
 
 /obj/effect/proc_holder/spell/summon_contract/cast(list/targets, mob/user = usr)

--- a/code/game/objects/structures/pit.dm
+++ b/code/game/objects/structures/pit.dm
@@ -212,7 +212,6 @@
 	pixel_x = 5
 	pixel_y = 8
 	anchored = TRUE
-	var/message = "Unknown."
 
 /obj/structure/gravemarker/cross
 	icon_state = "cross"
@@ -220,7 +219,6 @@
 /obj/structure/gravemarker/random/Initialize(mapload)
 	. = ..()
 	generate()
-	desc = "[message]"
 
 /obj/structure/gravemarker/random/proc/generate()
 	var/nam
@@ -236,7 +234,7 @@
 	var/born = cur_year - rand(5,150)
 	var/died = max(cur_year - rand(0,70),born)
 
-	message = "Здесь упокоен [nam], [born] - [died]."
+	desc = "Здесь упокоен [nam], [born] - [died]."
 
 
 /obj/structure/gravemarker/attackby(obj/item/I, mob/user, params)

--- a/code/game/objects/structures/pit.dm
+++ b/code/game/objects/structures/pit.dm
@@ -244,9 +244,9 @@
 		return ..()
 
 	if(is_pen(I))
-		var/msg = tgui_input_text(user, "What should it say?", "Grave marker", "Rest In Peace")
+		var/msg = tgui_input_text(user, "What should it say?", "Grave marker", desc)
 		if(msg)
-			message = msg
+			desc = msg
 		return ATTACK_CHAIN_PROCEED_SUCCESS
 
 	if(istype(I, /obj/item/hatchet))

--- a/code/game/objects/structures/pit.dm
+++ b/code/game/objects/structures/pit.dm
@@ -225,7 +225,7 @@
 	icon_state = pick("wood","cross")
 	var/female = (prob(1) ?  TRUE : FALSE)
 	if(female)
-		name = pick(GLOB.first_names_female)
+		nam = pick(GLOB.first_names_female)
 		nam += " " + pick(GLOB.last_names_female)
 	else
 		nam = pick(GLOB.first_names_male)

--- a/code/game/objects/structures/pit.dm
+++ b/code/game/objects/structures/pit.dm
@@ -212,6 +212,11 @@
 	pixel_x = 5
 	pixel_y = 8
 	anchored = TRUE
+	var/message = "Unknown."
+
+/obj/structure/gravemarker/update_desc(updates = ALL)
+	. = ..()
+	desc = "[message]"
 
 /obj/structure/gravemarker/cross
 	icon_state = "cross"
@@ -234,7 +239,8 @@
 	var/born = cur_year - rand(5,150)
 	var/died = max(cur_year - rand(0,70),born)
 
-	desc = "Здесь упокоен [nam], [born] - [died]."
+	message = "Здесь упокоен [nam], [born] - [died]."
+	update_appearance(UPDATE_DESC)
 
 
 /obj/structure/gravemarker/attackby(obj/item/I, mob/user, params)
@@ -244,7 +250,8 @@
 	if(is_pen(I))
 		var/msg = tgui_input_text(user, "What should it say?", "Grave marker", desc)
 		if(msg)
-			desc = msg
+			message = msg
+			update_appearance(UPDATE_DESC)
 		return ATTACK_CHAIN_PROCEED_SUCCESS
 
 	if(istype(I, /obj/item/hatchet))


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание

1. Фиксит невозможность за дьявола выдать контракт ревайва мертвому телу (new spell system rework moment):
    - Убрана проверка target.stat - нам нужны и живые и мертвые таргеты, где они обрабатываются в cast;
    - Убрана проверка target.ckey - игрок вылетает из мертвого тела = сикея нет, контракт ревайва вылетевшему из тела госту не предлагался.
2. Убирает автотаргет на спелл выдачи контракта, теперь нужно как изначально и задуман спелл - активировать спелл и выбрать цель (new spell system rework moment);
3. Крест на могиле нельзя было переименовать, ~~записывалось в неверную переменную~~ не обновлялось описание;
4. Чуть чуть подправлен код gravemarker:
    - Ошибка name->nam;
    - Странная работа с переменными в функции generate() и ините gravermarker/random - ~~сделана запись напрямую в desc, убрана лишняя переменная message~~ сделано обновление описания через update_desc.

Из возможных небольших проблем:
1. Контракт ревайва автоматически подписывается и поднимает куклу с майндом, но с уже ливнувшим куда либо гостом.
2. Контракты выдаются и ССД и кататоникам, которые в принципе не могут подписать контракт (в текущем состоянии).

По моему мнению данные проблемы скорее должны быть исправлены возможным реворком/рефактором дьявола, а не багфиксом (изначальный код дьявола таков). По запросу могу добавить фиксы в PR.

## Тесты

1. Протыканы контракты на локалке на тушках с майндом, и без - все корректно, за исключением вышеупомянутых моментов;
2. Функционал спавна рандомных крестов на могилах в космо-руинке и при спавне через гейм панель корректен - имена генерируются, ручкой изменяются.
