### PR TITLE
bugfix: Magic charge broking KA.

### DIFF
--- a/code/datums/spells/charge.dm
+++ b/code/datums/spells/charge.dm
@@ -77,12 +77,9 @@
 
 			else if(istype(item, /obj/item/stock_parts/cell/))
 				var/obj/item/stock_parts/cell/C = item
-				if(!C.self_recharge)
-					if(prob(80))
-						C.maxcharge -= 200
-					if(C.maxcharge <= 1) //Div by 0 protection
-						C.maxcharge = 1
-						burnt_out = TRUE
+				if(prob(80) && !C.adjust_maxcharge(-200))
+					burnt_out = TRUE
+
 				C.charge = C.maxcharge
 				charged_item = C
 				break
@@ -92,12 +89,9 @@
 				for(I in item.contents)
 					if(istype(I, /obj/item/stock_parts/cell/))
 						var/obj/item/stock_parts/cell/C = I
-						if(!C.self_recharge)
-							if(prob(80))
-								C.maxcharge -= 200
-							if(C.maxcharge <= 1) //Div by 0 protection
-								C.maxcharge = 1
-								burnt_out = TRUE
+						if(prob(80) && !C.adjust_maxcharge(-200))
+							burnt_out = TRUE
+
 						C.charge = C.maxcharge
 						item.update_icon()
 						charged_item = item

--- a/code/datums/spells/charge.dm
+++ b/code/datums/spells/charge.dm
@@ -85,17 +85,15 @@
 				break
 
 			else if(item.contents)
-				var/obj/I = null
-				for(I in item.contents)
-					if(istype(I, /obj/item/stock_parts/cell/))
-						var/obj/item/stock_parts/cell/C = I
-						if(prob(80) && !C.adjust_maxcharge(-200))
-							burnt_out = TRUE
+				for(var/obj/item/stock_parts/cell/C in item.contents)
+					if(prob(80) && !C.adjust_maxcharge(-200))
+						burnt_out = TRUE
 
-						C.charge = C.maxcharge
-						item.update_icon()
-						charged_item = item
-						break
+					C.charge = C.maxcharge
+					item.update_icon()
+					charged_item = item
+					break
+
 		if(!charged_item)
 			to_chat(L, "<span class='notice'>You feel magical power surging to your hands, but the feeling rapidly fades...</span>")
 		else if(burnt_out)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -77,7 +77,7 @@
 		return FALSE	// SelfCharging uses static charge values ​​per tick, so we don't want it to mess up the recharge balance.
 
 	var/oldcharge = maxcharge
-	maxcharge = min(maxcharge + amount, 1)
+	maxcharge = max(maxcharge + amount, 1)
 
 	if(charge > maxcharge)
 		charge = maxcharge

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -71,6 +71,20 @@
 /obj/item/stock_parts/cell/proc/percent()		// return % charge of cell
 	return 100 * charge / maxcharge
 
+
+/obj/item/stock_parts/cell/proc/adjust_maxcharge(amount)
+	if(self_recharge)
+		return FALSE	// SelfCharging uses static charge values ​​per tick, so we don't want it to mess up the recharge balance.
+
+	var/oldcharge = maxcharge
+	maxcharge = min(maxcharge + amount, 1)
+
+	if(charge > maxcharge)
+		charge = maxcharge
+
+	return maxcharge != oldcharge
+
+
 // use power from a cell
 /obj/item/stock_parts/cell/use(amount)
 	if(rigged && amount > 0)
@@ -368,6 +382,11 @@
 
 /obj/item/stock_parts/cell/emproof/corrupt()
 	return
+
+
+/obj/item/stock_parts/cell/emproof/adjust_maxcharge(amount)
+	return FALSE
+
 
 /obj/item/stock_parts/cell/ninja
 	name = "spider-clan power cell"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Спелл мага на зарядку еганов теперь не отнимает у батарейки КА максимальный заряд.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР
Репорт через М-тикет. Батарейка КА имеет заряд ровно на 1 выстрел, так что заклинание зарядки просто делало невозможным стрельбу из КА.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Заспавнил КА - проюзал спелл - пострелял.
<!-- Как вы тестировали свой код. Ревьеюру будет проще, если он будет знать какие действия вы совершали, проверяя свой ПР. -->
