### PR TITLE
bugfix: Closets use correct sprite

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -111,7 +111,7 @@
 /obj/structure/closet/secure_closet/security
 	name = "security officer's locker"
 	req_access = list(ACCESS_SECURITY)
-	icon_state = "secward"
+	icon_state = "sec"
 
 /obj/structure/closet/secure_closet/security/populate_contents()
 	if(prob(50))

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -39,7 +39,7 @@
 
 /obj/structure/closet/secure_closet/miner
 	name = "miner's equipment"
-	icon_state = "mine_pers"
+	icon_state = "mining"
 	req_access = list(ACCESS_MINING)
 
 /obj/structure/closet/secure_closet/miner/populate_contents()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание

Меняет названия спрайтов, используемые шкафами шахтёров и СБ.

## Ссылка на предложение/Причина создания ПР

[Ссылка](https://discord.com/channels/617003227182792704/1282611570177740822/1282611570177740822).

## Демонстрация изменений

![image](https://github.com/user-attachments/assets/d3500157-a476-4239-b8d4-ab162d7041cd)
![image](https://github.com/user-attachments/assets/e6a83d13-67bd-4db8-b5f4-155c0fa63b19)

## Тесты

Зашёл на локальный сервер - полетал у шкафов