### PR TITLE
bugfix: fixed the interaction of the holotool with the mechs

### DIFF
--- a/code/game/mecha/mecha_construction_paths.dm
+++ b/code/game/mecha/mecha_construction_paths.dm
@@ -105,7 +105,7 @@
 					 list("key"=/obj/item/stack/sheet/metal,
 					 		"backkey"=TOOL_SCREWDRIVER,
 					 		"desc"="Peripherals control module is secured."),
-					 //7
+					//7
 					 list("key"=TOOL_SCREWDRIVER,
 					 		"backkey"=TOOL_CROWBAR,
 					 		"desc"="Peripherals control module is installed."),
@@ -122,7 +122,7 @@
 					 		"backkey"=TOOL_SCREWDRIVER,
 					 		"desc"="The wiring is adjusted."),
 					 //11
-					 list("key"=/obj/item/wirecutters,
+					 list("key"=TOOL_WIRECUTTER,
 					 		"backkey"=TOOL_SCREWDRIVER,
 					 		"desc"="The wiring is added."),
 					 //12
@@ -346,7 +346,7 @@
 					 		"backkey"=TOOL_SCREWDRIVER,
 					 		"desc"="The wiring is adjusted."),
 					 //17
-					 list("key"=/obj/item/wirecutters,
+					 list("key"=TOOL_WIRECUTTER,
 					 		"backkey"=TOOL_SCREWDRIVER,
 					 		"desc"="The wiring is added."),
 					 //18
@@ -601,7 +601,7 @@
 					 		"backkey"=TOOL_SCREWDRIVER,
 					 		"desc"="The wiring is adjusted."),
 					 //12
-					 list("key"=/obj/item/wirecutters,
+					 list("key"=TOOL_WIRECUTTER,
 					 		"backkey"=TOOL_SCREWDRIVER,
 					 		"desc"="The wiring is added."),
 					 //13
@@ -979,7 +979,7 @@
 					 		"backkey"=TOOL_SCREWDRIVER,
 					 		"desc"="The wiring is adjusted."),
 					 //17
-					 list("key"=/obj/item/wirecutters,
+					 list("key"=TOOL_WIRECUTTER,
 					 		"backkey"=TOOL_SCREWDRIVER,
 					 		"desc"="The wiring is added."),
 					 //18
@@ -1271,7 +1271,7 @@
 					 		"backkey"=TOOL_SCREWDRIVER,
 					 		"desc"="The wiring is adjusted."),
 					 //21
-					 list("key" = /obj/item/wirecutters,
+					 list("key" = TOOL_WIRECUTTER,
 					 		"backkey"=TOOL_SCREWDRIVER,
 					 		"desc"="The wiring is added."),
 					 //22
@@ -1549,7 +1549,7 @@
 					 		"backkey"=TOOL_SCREWDRIVER,
 					 		"desc"="The wiring is adjusted."),
 					 //11
-					 list("key"=/obj/item/wirecutters,
+					 list("key"=TOOL_WIRECUTTER,
 					 		"backkey"=TOOL_SCREWDRIVER,
 					 		"desc"="The wiring is added."),
 					 //12
@@ -1754,7 +1754,7 @@
 					 		"backkey"=TOOL_SCREWDRIVER,
 					 		"desc"="The wiring is adjusted."),
 					 //11
-					 list("key"=/obj/item/wirecutters,
+					 list("key"=TOOL_WIRECUTTER,
 					 		"backkey"=TOOL_SCREWDRIVER,
 					 		"desc"="The wiring is added."),
 					 //12
@@ -1980,7 +1980,7 @@
 					 		"backkey"=TOOL_SCREWDRIVER,
 					 		"desc"="The wiring is adjusted."),
 					 //17
-					 list("key"=/obj/item/wirecutters,
+					 list("key"=TOOL_WIRECUTTER,
 					 		"backkey"=TOOL_SCREWDRIVER,
 					 		"desc"="The wiring is added."),
 					 //18
@@ -2255,7 +2255,7 @@
 					 		"backkey"=TOOL_SCREWDRIVER,
 					 		"desc"="The wiring is adjusted."),
 					 //17
-					 list("key"=/obj/item/wirecutters,
+					 list("key"=TOOL_WIRECUTTER,
 					 		"backkey"=TOOL_SCREWDRIVER,
 					 		"desc"="The wiring is added."),
 					 //18

--- a/code/game/mecha/mecha_construction_paths.dm
+++ b/code/game/mecha/mecha_construction_paths.dm
@@ -1220,7 +1220,7 @@
 					 		"desc"="The bluespace crystal is engaged."),
 					 //8
 					 list("key" = TOOL_SCREWDRIVER,
-					 		"backkey"=/TOOL_WIRECUTTER,
+					 		"backkey"=TOOL_WIRECUTTER,
 					 		"desc"="The bluespace crystal is connected."),
 					 //9
 					 list("key" = /obj/item/stack/cable_coil,

--- a/code/game/mecha/mecha_construction_paths.dm
+++ b/code/game/mecha/mecha_construction_paths.dm
@@ -1220,7 +1220,7 @@
 					 		"desc"="The bluespace crystal is engaged."),
 					 //8
 					 list("key" = TOOL_SCREWDRIVER,
-					 		"backkey"=/obj/item/wirecutters,
+					 		"backkey"=/TOOL_WIRECUTTER,
 					 		"desc"="The bluespace crystal is connected."),
 					 //9
 					 list("key" = /obj/item/stack/cable_coil,


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Исправлена ошибка, из-за которой нельзя использовать режим кусачек голотула вместо самих кусачек.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Багфикс, ссылка на багрепорт:
https://discord.com/channels/617003227182792704/1282757417976860704/1282757417976860704
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
теперь при сборке меха, на этапе с кусачками можно использовать голотул
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->

## Тесты
Начать сборку меха, дойти до этапа с использованием кусачек<!-- Как вы тестировали свой код. Ревьеюру будет проще, если он будет знать какие действия вы совершали, проверяя свой ПР. -->
