### PR TITLE
QOL: Перевод + балун алерты для часто применимых статус эффектов.

### DIFF
--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -76,9 +76,9 @@
 
 	if(!get_location_accessible(target, BODY_ZONE_PRECISE_MOUTH))
 		if(target == user)
-			balloon_alert(user, span_warning("лицо скрыто."))
+			balloon_alert(user, span_warning("лицо скрыто"))
 		else
-			balloon_alert(user, span_warning("у [target] скрыто лицо."))
+			balloon_alert(user, span_warning("у [target] скрыто лицо"))
 		return .
 
 	if(target.eat(toEat, user))

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -78,7 +78,7 @@
 		if(target == user)
 			balloon_alert(user, span_warning("лицо скрыто"))
 		else
-			balloon_alert(user, span_warning("у [target] скрыто лицо"))
+			balloon_alert(user, span_warning("мешает скрытое лицо"))
 		return .
 
 	if(target.eat(toEat, user))

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -76,9 +76,9 @@
 
 	if(!get_location_accessible(target, BODY_ZONE_PRECISE_MOUTH))
 		if(target == user)
-			to_chat(user, span_warning("Your face is obscured."))
+			balloon_alert(user, span_warning("лицо скрыто."))
 		else
-			to_chat(user, span_warning("[target]'s face is obscured."))
+			balloon_alert(user, span_warning("у [target] скрыто лицо."))
 		return .
 
 	if(target.eat(toEat, user))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1608,7 +1608,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	. = ..()
 
 	if(check_gun.trigger_guard == TRIGGER_GUARD_NORMAL && HAS_TRAIT(src, TRAIT_NO_GUNS))
-		to_chat(src, span_warning("Your fingers don't fit in the trigger guard!"))
+		balloon_alert(src, span_warning("слишком широкие пальцы"))
 		return FALSE
 
 	if(mind && mind.martial_art && mind.martial_art.no_guns) //great dishonor to famiry

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1608,7 +1608,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	. = ..()
 
 	if(check_gun.trigger_guard == TRIGGER_GUARD_NORMAL && HAS_TRAIT(src, TRAIT_NO_GUNS))
-		balloon_alert(src, span_warning("слишком широкие пальцы"))
+		balloon_alert(src, span_warning("слишком толстые пальцы"))
 		return FALSE
 
 	if(mind && mind.martial_art && mind.martial_art.no_guns) //great dishonor to famiry


### PR DESCRIPTION


## Описание

Добавляет балун алерты для попытки покушать с маской и выстреле при толстых пальцах .

## Ссылка на предложение/Причина создания ПР
Огромное количество ментор тикетов с не пониманием почему в бюджетных изолях нельзя стрелять
![image](https://github.com/user-attachments/assets/af274107-65c5-475f-913e-c6db68570890)

## Тесты

Посмотрел
