### PR TITLE
bugfix: racial loadout 

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -201,22 +201,8 @@
 			var/datum/gear/G = H.client.prefs.choosen_gears[gear]
 			if(!istype(G))
 				continue
-			var/permitted = FALSE
 
-			if(G.allowed_roles)
-				if(name in G.allowed_roles)
-					permitted = TRUE
-			else
-				permitted = TRUE
-
-			if(!G.can_select(H.dna.species.name))
-				permitted = FALSE
-
-			if(H.client.donator_level < G?.donator_tier)
-				permitted = FALSE
-
-			if(!permitted)
-				to_chat(H, "<span class='warning'>Your current job, donator tier or whitelist status does not permit you to spawn with [G.display_name]!</span>")
+			if(!G.can_select(cl = H.client, job_name = name, species_name = H.dna.species.name)) // some checks
 				continue
 
 			if(G.implantable) //only works for organ-implants

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -209,7 +209,7 @@
 			else
 				permitted = TRUE
 
-			if(G.whitelisted && G.whitelisted != H.dna.species.name)
+			if(!G.can_select(H.dna.species.name))
 				permitted = FALSE
 
 			if(H.client.donator_level < G?.donator_tier)

--- a/code/modules/client/preference/loadout/loadout.dm
+++ b/code/modules/client/preference/loadout/loadout.dm
@@ -19,7 +19,6 @@ GLOBAL_LIST_EMPTY(gear_datums)
 	var/cost = 1           //Number of points used. Items in general cost 1 point, storage/armor/gloves/special use costs 2 points.
 	var/slot               //Slot to equip to.
 	var/list/allowed_roles //Roles that can spawn with this item.
-	var/whitelisted        //Term to check the whitelist for..
 	var/sort_category = "General"
 	var/list/gear_tweaks = list() //List of datums which will alter the item after it has been spawned.
 	var/subtype_path = /datum/gear //for skipping organizational subtypes (optional)
@@ -64,3 +63,6 @@ GLOBAL_LIST_EMPTY(gear_datums)
 	for(var/datum/gear_tweak/gt in gear_tweaks)
 		gt.tweak_item(item, metadata["[gt]"])
 	return item
+
+/datum/gear/proc/can_select()
+	return TRUE

--- a/code/modules/client/preference/loadout/loadout.dm
+++ b/code/modules/client/preference/loadout/loadout.dm
@@ -63,12 +63,14 @@ GLOBAL_LIST_EMPTY(gear_datums)
 		gt.tweak_item(item, metadata["[gt]"])
 	return item
 
-/datum/gear/proc/can_select(client/cl = FALSE, job_name = FALSE, species_name = FALSE, silent = FALSE)
-	. = TRUE
+/datum/gear/proc/can_select(client/cl, job_name, species_name, silent = FALSE)
+	if(!job_name || !LAZYLEN(allowed_roles))
+		return TRUE
 
-	if((job_name && allowed_roles) && !(job_name in allowed_roles)) // incorrect job
-		. = FALSE
-		if(cl && !silent)
-			to_chat(cl, span_warning("\"[capitalize(display_name)]\" недоступно для вашей профессии!"))
+	if(job_name in allowed_roles)
+		return TRUE
 
+	if(cl && !silent)
+		to_chat(cl, span_warning("\"[capitalize(display_name)]\" недоступно для вашей профессии!"))
 
+	return FALSE

--- a/code/modules/client/preference/loadout/loadout.dm
+++ b/code/modules/client/preference/loadout/loadout.dm
@@ -74,3 +74,7 @@ GLOBAL_LIST_EMPTY(gear_datums)
 		to_chat(cl, span_warning("\"[capitalize(display_name)]\" недоступно для вашей профессии!"))
 
 	return FALSE
+
+
+/datum/gear/proc/get_header_tips()
+	return

--- a/code/modules/client/preference/loadout/loadout.dm
+++ b/code/modules/client/preference/loadout/loadout.dm
@@ -23,7 +23,6 @@ GLOBAL_LIST_EMPTY(gear_datums)
 	var/list/gear_tweaks = list() //List of datums which will alter the item after it has been spawned.
 	var/subtype_path = /datum/gear //for skipping organizational subtypes (optional)
 	var/subtype_cost_overlap = TRUE //if subtypes can take points at the same time
-	var/donator_tier = 0
 	var/implantable = FALSE    //For organ-like implants (huds, pumps, etc)
 
 /datum/gear/New()
@@ -64,5 +63,12 @@ GLOBAL_LIST_EMPTY(gear_datums)
 		gt.tweak_item(item, metadata["[gt]"])
 	return item
 
-/datum/gear/proc/can_select()
-	return TRUE
+/datum/gear/proc/can_select(client/cl = FALSE, job_name = FALSE, species_name = FALSE, silent = FALSE)
+	. = TRUE
+
+	if((job_name && allowed_roles) && !(job_name in allowed_roles)) // incorrect job
+		. = FALSE
+		if(cl && !silent)
+			to_chat(cl, span_warning("\"[capitalize(display_name)]\" недоступно для вашей профессии!"))
+
+

--- a/code/modules/client/preference/loadout/loadout_donor.dm
+++ b/code/modules/client/preference/loadout/loadout_donor.dm
@@ -3,19 +3,21 @@
 	sort_category = "Donor"
 	subtype_path = /datum/gear/donor
 
-/datum/gear/donor/can_select(client/cl = FALSE, job_name = FALSE, species_name = FALSE, silent = FALSE)
-	. = ..()
-
-	if(!.) // there's no point in being here
+/datum/gear/donor/can_select(client/cl, job_name, species_name, silent = FALSE)
+	if(!..()) // there's no point in being here
 		return FALSE
 
-	if(!donator_tier) // why are you here?.. allowed
+	if(!donator_tier) // why are you here?.. allowed, but
+		stack_trace("Item with no donator tier in loadout donor items: [display_name].")
 		return TRUE
 
-	if(cl && (cl.donator_level < donator_tier))
-		if(!silent)
-			to_chat(cl, span_warning("Для получения \"[display_name]\" необходим [donator_tier] или более высокий уровень пожертвований."))
-		return FALSE
+	if(cl?.donator_level >= donator_tier)
+		return TRUE
+
+	if(cl && !silent)
+		to_chat(cl, span_warning("Для получения \"[display_name]\" необходим [donator_tier] или более высокий уровень пожертвований."))
+
+	return FALSE
 
 
 /datum/gear/donor/ussptracksuit_black

--- a/code/modules/client/preference/loadout/loadout_donor.dm
+++ b/code/modules/client/preference/loadout/loadout_donor.dm
@@ -20,6 +20,10 @@
 	return FALSE
 
 
+/datum/gear/donor/get_header_tips()
+	return "\[Tier [donator_tier]\] "
+
+
 /datum/gear/donor/ussptracksuit_black
 	donator_tier = 1
 	cost = 1

--- a/code/modules/client/preference/loadout/loadout_donor.dm
+++ b/code/modules/client/preference/loadout/loadout_donor.dm
@@ -1,7 +1,22 @@
 /datum/gear/donor
-	donator_tier = 2
+	var/donator_tier = 2
 	sort_category = "Donor"
 	subtype_path = /datum/gear/donor
+
+/datum/gear/donor/can_select(client/cl = FALSE, job_name = FALSE, species_name = FALSE, silent = FALSE)
+	. = ..()
+
+	if(!.) // there's no point in being here
+		return FALSE
+
+	if(!donator_tier) // why are you here?.. allowed
+		return TRUE
+
+	if(cl && (cl.donator_level < donator_tier))
+		if(!silent)
+			to_chat(cl, span_warning("Для получения \"[display_name]\" необходим [donator_tier] или более высокий уровень пожертвований."))
+		return FALSE
+
 
 /datum/gear/donor/ussptracksuit_black
 	donator_tier = 1

--- a/code/modules/client/preference/loadout/loadout_racial.dm
+++ b/code/modules/client/preference/loadout/loadout_racial.dm
@@ -24,6 +24,10 @@
 	return FALSE
 
 
+/datum/gear/racial/get_header_tips()
+	return "\[Species: [english_list(whitelisted_species)]\] "
+
+
 /datum/gear/racial/taj
 	display_name = "embroidered veil"
 	description = "A common traditional nano-fiber veil worn by many Tajaran, It is rare and offensive to see it on other races."

--- a/code/modules/client/preference/loadout/loadout_racial.dm
+++ b/code/modules/client/preference/loadout/loadout_racial.dm
@@ -5,10 +5,10 @@
 	var/list/whitelisted_species = list()
 
 /datum/gear/racial/can_select(datum/species/S)
-	if(!LAZYLEN(whitelisted_species)) //empty list, allowed for all
+	if(!LAZYLEN(whitelisted_species)) // empty list, allowed for all
 		return TRUE
 
-	if(S in whitelisted_species) //species in whitelist
+	if(S in whitelisted_species) // species in whitelist
 		return TRUE
 
 	return FALSE

--- a/code/modules/client/preference/loadout/loadout_racial.dm
+++ b/code/modules/client/preference/loadout/loadout_racial.dm
@@ -2,12 +2,23 @@
 	sort_category = "Racial"
 	subtype_path = /datum/gear/racial
 	cost = 1
+	var/list/whitelisted_species = list()
+
+/datum/gear/racial/can_select(datum/species/S)
+	if(!LAZYLEN(whitelisted_species)) //empty list, allowed for all
+		return TRUE
+
+	if(S in whitelisted_species) //species in whitelist
+		return TRUE
+
+	return FALSE
 
 /datum/gear/racial/taj
 	display_name = "embroidered veil"
 	description = "A common traditional nano-fiber veil worn by many Tajaran, It is rare and offensive to see it on other races."
 	path = /obj/item/clothing/glasses/tajblind
 	slot = ITEM_SLOT_EYES
+	whitelisted_species = list(SPECIES_TAJARAN)
 
 /datum/gear/racial/taj/job
 	subtype_path = /datum/gear/racial/taj/job
@@ -72,6 +83,7 @@
 	display_name = "cloth footwraps, select"
 	path = /obj/item/clothing/shoes/footwraps
 	slot = ITEM_SLOT_FEET
+	whitelisted_species = list() // it's just some bandages, especially since you can make footwraps via craft
 
 /datum/gear/racial/footwraps/New()
 	..()

--- a/code/modules/client/preference/loadout/loadout_racial.dm
+++ b/code/modules/client/preference/loadout/loadout_racial.dm
@@ -2,16 +2,22 @@
 	sort_category = "Racial"
 	subtype_path = /datum/gear/racial
 	cost = 1
-	var/list/whitelisted_species = list()
+	var/list/whitelisted_species
 
-/datum/gear/racial/can_select(datum/species/S)
+/datum/gear/racial/can_select(client/cl = FALSE, job_name = FALSE, species_name = FALSE, silent = FALSE)
+	. = ..()
+
+	if(!.) // there's no point in being here.
+		return FALSE
+
 	if(!LAZYLEN(whitelisted_species)) // empty list, allowed for all
 		return TRUE
 
-	if(S in whitelisted_species) // species in whitelist
-		return TRUE
+	if(species_name && !(species_name in whitelisted_species)) // check species whitelist
+		if(cl && !silent)
+			to_chat(cl, span_warning("Ваш вид не подходит для того, чтобы использовать \"[display_name]\"!"))
+		return FALSE
 
-	return FALSE
 
 /datum/gear/racial/taj
 	display_name = "embroidered veil"

--- a/code/modules/client/preference/loadout/loadout_racial.dm
+++ b/code/modules/client/preference/loadout/loadout_racial.dm
@@ -4,19 +4,24 @@
 	cost = 1
 	var/list/whitelisted_species
 
-/datum/gear/racial/can_select(client/cl = FALSE, job_name = FALSE, species_name = FALSE, silent = FALSE)
-	. = ..()
-
-	if(!.) // there's no point in being here.
+/datum/gear/racial/can_select(client/cl, job_name, species_name, silent = FALSE)
+	if(!..()) // there's no point in being here.
 		return FALSE
 
-	if(!LAZYLEN(whitelisted_species)) // empty list, allowed for all
+	if(!LAZYLEN(whitelisted_species)) // why are we here? allowed, but
+		stack_trace("Item with no racial list in loadout racial items: [display_name].")
 		return TRUE
 
-	if(species_name && !(species_name in whitelisted_species)) // check species whitelist
-		if(cl && !silent)
-			to_chat(cl, span_warning("Ваш вид не подходит для того, чтобы использовать \"[display_name]\"!"))
-		return FALSE
+	if(!species_name) // skip
+		return TRUE
+
+	if(species_name in whitelisted_species) // check species whitelist
+		return TRUE
+
+	if(cl && !silent)
+		to_chat(cl, span_warning("Ваш вид не подходит для того, чтобы использовать \"[display_name]\"!"))
+
+	return FALSE
 
 
 /datum/gear/racial/taj
@@ -85,20 +90,4 @@
 	path = /obj/item/clothing/glasses/hud/skills/tajblind
 	allowed_roles = list(JOB_TITLE_HOP, JOB_TITLE_CAPTAIN)
 
-/datum/gear/racial/footwraps
-	display_name = "cloth footwraps, select"
-	path = /obj/item/clothing/shoes/footwraps
-	slot = ITEM_SLOT_FEET
-	whitelisted_species = list() // it's just some bandages, especially since you can make footwraps via craft
 
-/datum/gear/racial/footwraps/New()
-	..()
-	var/list/feet = list("classic" = /obj/item/clothing/shoes/footwraps,
-						 "yellow" = /obj/item/clothing/shoes/footwraps/yellow,
-						 "silver" = /obj/item/clothing/shoes/footwraps/silver,
-						 "red" = /obj/item/clothing/shoes/footwraps/red,
-						 "blue" = /obj/item/clothing/shoes/footwraps/blue,
-						 "black" = /obj/item/clothing/shoes/footwraps/black,
-						 "brown" = /obj/item/clothing/shoes/footwraps/brown,
-						 )
-	gear_tweaks += new /datum/gear_tweak/path(feet, src)

--- a/code/modules/client/preference/loadout/loadout_shoes.dm
+++ b/code/modules/client/preference/loadout/loadout_shoes.dm
@@ -69,3 +69,19 @@
 /datum/gear/shoes/leather_boots
 	display_name = "high leather boots"
 	path = /obj/item/clothing/shoes/leather_boots
+
+/datum/gear/shoes/footwraps
+	display_name = "cloth footwraps, select"
+	path = /obj/item/clothing/shoes/footwraps
+
+/datum/gear/shoes/footwraps/New()
+	..()
+	var/list/feet = list("classic" = /obj/item/clothing/shoes/footwraps,
+						 "yellow" = /obj/item/clothing/shoes/footwraps/yellow,
+						 "silver" = /obj/item/clothing/shoes/footwraps/silver,
+						 "red" = /obj/item/clothing/shoes/footwraps/red,
+						 "blue" = /obj/item/clothing/shoes/footwraps/blue,
+						 "black" = /obj/item/clothing/shoes/footwraps/black,
+						 "brown" = /obj/item/clothing/shoes/footwraps/brown,
+						 )
+	gear_tweaks += new /datum/gear_tweak/path(feet, src)

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -1501,7 +1501,7 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 				loadout_gear -= TG.display_name
 				choosen_gears -= TG.display_name
 			else
-				if(!(TG.can_select(cl = user.client, job_name = FALSE, species_name = S.name))) // all gear checks there, no jobs while prefs
+				if(!(TG.can_select(cl = user.client, species_name = S.name))) // all gear checks there, no jobs while prefs
 					return
 				var/total_cost = 0
 				var/list/type_blacklist = list()

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -693,11 +693,7 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 					for(var/role in G.allowed_roles)
 						dat += role + " "
 					dat += "</font>"
-				var/datum/gear/donor/donate_gear = G
-				var/donor_info = ""
-				if(istype(donate_gear) && donate_gear.donator_tier)
-					donor_info = "\[Tier [donate_gear.donator_tier]\] "
-				dat += "</td><td style='vertical-align:middle'><font size=2>[donor_info]<i>[ticked ? ticked.description : donate_gear.description] <br/></i></font></td></tr>"
+				dat += "</td><td style='vertical-align:middle'><font size=2>[G.get_header_tips()]<i>[ticked ? ticked.description : G.description] <br/></i></font></td></tr>"
 			dat += "</table>"
 		if(TAB_KEYS)
 			dat += "<div align='center'><b>All Key Bindings:&nbsp;</b>"
@@ -1501,7 +1497,7 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 				loadout_gear -= TG.display_name
 				choosen_gears -= TG.display_name
 			else
-				if(!(TG.can_select(cl = user.client, species_name = S.name))) // all gear checks there, no jobs while prefs
+				if(!TG.can_select(cl = user.client, species_name = S.name)) // all gear checks there, no jobs while prefs
 					return
 				var/total_cost = 0
 				var/list/type_blacklist = list()

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -693,8 +693,11 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 					for(var/role in G.allowed_roles)
 						dat += role + " "
 					dat += "</font>"
-				var/donor_info = G.donator_tier > 0 ? "\[Tier [G.donator_tier]\] " : ""
-				dat += "</td><td style='vertical-align:middle'><font size=2>[donor_info]<i>[ticked ? ticked.description : G.description] <br/></i></font></td></tr>"
+				var/datum/gear/donor/donate_gear = G
+				var/donor_info = ""
+				if(istype(donate_gear) && donate_gear.donator_tier)
+					donor_info = "\[Tier [donate_gear.donator_tier]\] "
+				dat += "</td><td style='vertical-align:middle'><font size=2>[donor_info]<i>[ticked ? ticked.description : donate_gear.description] <br/></i></font></td></tr>"
 			dat += "</table>"
 		if(TAB_KEYS)
 			dat += "<div align='center'><b>All Key Bindings:&nbsp;</b>"
@@ -1498,11 +1501,7 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 				loadout_gear -= TG.display_name
 				choosen_gears -= TG.display_name
 			else
-				if(TG.donator_tier && user.client.donator_level < TG.donator_tier)
-					to_chat(user, span_warning("Это снаряжение доступно лишь на [TG.donator_tier] или более высоких уровнях пожертвований."))
-					return
-				if(!TG.can_select(S))
-					to_chat(user, span_warning("Ваш вид не подходит для того, чтобы использовать это снаряжение."))
+				if(!(TG.can_select(cl = user.client, job_name = FALSE, species_name = S.name))) // all gear checks there, no jobs while prefs
 					return
 				var/total_cost = 0
 				var/list/type_blacklist = list()

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -1499,7 +1499,10 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 				choosen_gears -= TG.display_name
 			else
 				if(TG.donator_tier && user.client.donator_level < TG.donator_tier)
-					to_chat(user, span_warning("That gear is only available at [TG.donator_tier] and higher donation tier."))
+					to_chat(user, span_warning("Это снаряжение доступно лишь на [TG.donator_tier] или более высоких уровнях пожертвований."))
+					return
+				if(!TG.can_select(S))
+					to_chat(user, span_warning("Ваш вид не подходит для того, чтобы использовать это снаряжение."))
 					return
 				var/total_cost = 0
 				var/list/type_blacklist = list()

--- a/code/modules/client/preference/preferences_mysql.dm
+++ b/code/modules/client/preference/preferences_mysql.dm
@@ -416,6 +416,9 @@
 		if(geartype.donator_tier > parent.donator_level && parent.prefs)
 			loadout_gear -= gear // Gagaga, donate again
 			continue
+		if(!geartype.can_select(species))
+			loadout_gear -= gear // Just to be safe, let's check
+			continue
 		var/datum/gear/new_gear = new geartype.type
 		for(var/tweak in loadout_gear[gear])
 			for(var/datum/gear_tweak/gear_tweak in new_gear.gear_tweaks)

--- a/code/modules/client/preference/preferences_mysql.dm
+++ b/code/modules/client/preference/preferences_mysql.dm
@@ -413,11 +413,8 @@
 		if(!istype(geartype))
 			loadout_gear -= gear // Delete wrong/outdated data
 			continue
-		if(geartype.donator_tier > parent.donator_level && parent.prefs)
-			loadout_gear -= gear // Gagaga, donate again
-			continue
-		if(!geartype.can_select(species))
-			loadout_gear -= gear // Just to be safe, let's check
+		if(!geartype.can_select(cl = parent, job_name = FALSE, species_name = species, silent = TRUE)) // all other checks, no jobs in prefs, be quiet
+			loadout_gear -= gear
 			continue
 		var/datum/gear/new_gear = new geartype.type
 		for(var/tweak in loadout_gear[gear])

--- a/code/modules/client/preference/preferences_mysql.dm
+++ b/code/modules/client/preference/preferences_mysql.dm
@@ -413,7 +413,7 @@
 		if(!istype(geartype))
 			loadout_gear -= gear // Delete wrong/outdated data
 			continue
-		if(!geartype.can_select(cl = parent, job_name = FALSE, species_name = species, silent = TRUE)) // all other checks, no jobs in prefs, be quiet
+		if(!geartype.can_select(cl = parent, species_name = species, silent = TRUE)) // all other checks, no jobs in prefs, be quiet
 			loadout_gear -= gear
 			continue
 		var/datum/gear/new_gear = new geartype.type


### PR DESCRIPTION
## Описание
Пока делал другой ПР, увидел, что во вкладке "Racial" лодаута в целом нет нормального вайтлиста на виды, и условные таярские вуали может взять любой хуман. Исправил, теперь можно легко добавлять видовые вещи. 
Обмотки оставил для всех, потому что это.. просто тряпки на ногах, которые к тому же можно скрафтить

## Тесты
Запустил локалку. Больше нельзя взять уникальные для видов вещи любому встречному, так же чистит уже сохранённые лодауты при загрузке персонажа, не позволяя абузить старые сохранения
