### PR TITLE
qol: del powered zone from ABOTC, give power to computers and blast doors

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/oldstation.dmm
@@ -1859,10 +1859,11 @@
 	name = "Engineering"
 	},
 /obj/machinery/door/poddoor{
-	id_tag = "ancient"
+	id_tag = "ancient";
+	use_power = 0
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/ancientstation/powered)
+/area/ruin/space/ancientstation/engi)
 "oX" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -3662,14 +3663,17 @@
 /turf/simulated/floor/plasteel/airless,
 /area/ruin/space/ancientstation/atmos)
 "Gd" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer{
 	desc = "A computer long since rendered non-functional due to lack of maintenance. Spitting out error messages.";
 	dir = 8;
-	name = "Broken Computer"
+	name = "Broken Computer";
+	use_power = 0;
+	idle_power_usage = 0;
+	active_power_usage = 0
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/ancientstation/powered)
+/area/ruin/space/ancientstation)
 "Gi" = (
 /obj/structure/sign/redcross{
 	icon_state = "greencross"
@@ -3805,10 +3809,11 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/door/poddoor{
-	id_tag = "ancient"
+	id_tag = "ancient";
+	use_power = 0
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/ancientstation/powered)
+/area/ruin/space/ancientstation/engi)
 "HF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/airless,


### PR DESCRIPTION
## Описание

На аботч вместо тайлов с вечной энергией теперь будет обычные зоны, но бластдвери инженерного и компьютеры крио не будут требовать энергии