### PR TITLE
qol: admin force trigger events

### DIFF
--- a/code/game/gamemodes/miniantags/changeling_slug/changeling_slug_event.dm
+++ b/code/game/gamemodes/miniantags/changeling_slug/changeling_slug_event.dm
@@ -43,13 +43,38 @@
 			log_game("[new_slug.key] has become Changeling Headslug.")
 
 /datum/event/headslug_infestation/can_start()
-	if(..())
+	var/list/adm_message
+	var/min_player_passed = (num_station_players() > HI_MINPLAYERS_TRIGGER)
+	var/gamemode_passed = !(GAMEMODE_IS_CULTS || GAMEMODE_IS_NUCLEAR || GAMEMODE_IS_SHADOWLING)
+
+	. = ..() // true == forced by admins
+
+	if(min_player_passed && gamemode_passed) // all checks passed
 		return TRUE
 
-	if((num_station_players() <= HI_MINPLAYERS_TRIGGER) || GAMEMODE_IS_CULTS || GAMEMODE_IS_NUCLEAR || GAMEMODE_IS_SHADOWLING)
-		return FALSE
+	if(. && !min_player_passed) // forced, bypassing player limits
+		LAZYADD(adm_message, "Minimum players")
 
-	return TRUE
+	if(. && !gamemode_passed) // forced, bypassing gamemode limits
+		LAZYADD(adm_message, "Gamemode(not Nuclear, Shadowling or Cults)")
+
+	if(LAZYLEN(adm_message))
+		adm_message = english_list(adm_message)
+		log_and_message_admins("Event \"[type]\" launched bypassing the limits: [adm_message]!")
+		return TRUE
+
+	// not forced, not passed
+	var/list/fail_messsage
+	if(!min_player_passed) // not enough players to start
+		LAZYADD(fail_messsage, "Minimum players")
+
+	if(!gamemode_passed) // not allowed in this gamemode
+		LAZYADD(fail_messsage, "Gamemode(not Nuclear, Shadowling or Cults)")
+
+	fail_messsage = english_list(fail_messsage)
+	log_and_message_admins("Random event attempted to spawn a headslug, but failed this checks: [fail_messsage]!")
+
+	return FALSE
 
 
 #undef GAMEMODE_IS_CULTS

--- a/code/game/gamemodes/miniantags/changeling_slug/changeling_slug_event.dm
+++ b/code/game/gamemodes/miniantags/changeling_slug/changeling_slug_event.dm
@@ -23,7 +23,7 @@
 
 /datum/event/headslug_infestation/proc/wrappedstart()
 	var/list/vents = get_valid_vent_spawns(exclude_mobs_nearby = TRUE, exclude_visible_by_mobs = TRUE) //check for amount of people
-	if(eventcheck())
+	if(!can_start())
 		var/datum/event_container/EC = SSevents.event_containers[EVENT_LEVEL_MODERATE]
 		EC.next_event_time = world.time + (60 * 10)
 		return
@@ -42,9 +42,14 @@
 			successSpawn = TRUE
 			log_game("[new_slug.key] has become Changeling Headslug.")
 
-/datum/event/headslug_infestation/proc/eventcheck()
-	if((num_station_players() <= HI_MINPLAYERS_TRIGGER) ||GAMEMODE_IS_CULTS || GAMEMODE_IS_NUCLEAR || GAMEMODE_IS_SHADOWLING)
+/datum/event/headslug_infestation/can_start()
+	if(..())
 		return TRUE
+
+	if((num_station_players() <= HI_MINPLAYERS_TRIGGER) || GAMEMODE_IS_CULTS || GAMEMODE_IS_NUCLEAR || GAMEMODE_IS_SHADOWLING)
+		return FALSE
+
+	return TRUE
 
 
 #undef GAMEMODE_IS_CULTS

--- a/code/game/gamemodes/miniantags/demons/pulse_demon/pulse_demon_event.dm
+++ b/code/game/gamemodes/miniantags/demons/pulse_demon/pulse_demon_event.dm
@@ -55,13 +55,17 @@
 
 
 /datum/event/spawn_pulsedemon/can_start()
-	if(..()) // override checks
+	var/player_count = num_station_players()
+	if(player_count > minplayers) // all passed
 		return TRUE
 
-	if(num_station_players() <= minplayers) // not enough
-		return FALSE
+	if(..()) //not passed, but forced
+		log_and_message_admins("Event \"[type]\" launched bypassing the minimum players limit!")
+		return TRUE
 
-	return TRUE
+	log_and_message_admins("Random event attempted to spawn a pulse demon, but there were only [player_count]/[minplayers] players.")
+
+	return FALSE
 
 
 #undef PULSEDEMON_MINPLAYERS

--- a/code/game/gamemodes/miniantags/demons/pulse_demon/pulse_demon_event.dm
+++ b/code/game/gamemodes/miniantags/demons/pulse_demon/pulse_demon_event.dm
@@ -46,11 +46,22 @@
 	return pick(spawn_centers)
 
 /datum/event/spawn_pulsedemon/start()
-	if(num_station_players() <= minplayers)
+	if(!can_start())
 		var/datum/event_container/EC = SSevents.event_containers[EVENT_LEVEL_MODERATE]
 		EC.next_event_time = world.time + (60 * 10)
 		return	//we don't spawn demons on lowpop. Instead, we reroll!
 
 	INVOKE_ASYNC(src, PROC_REF(get_pulsedemon))
+
+
+/datum/event/spawn_pulsedemon/can_start()
+	if(..()) // override checks
+		return TRUE
+
+	if(num_station_players() <= minplayers) // not enough
+		return FALSE
+
+	return TRUE
+
 
 #undef PULSEDEMON_MINPLAYERS

--- a/code/game/gamemodes/miniantags/revenant/revenant_spawn_event.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_spawn_event.dm
@@ -5,11 +5,7 @@
 
 
 /datum/event/revenant/proc/get_revenant(var/end_if_fail = 0)
-	var/deadMobs = 0
-	for(var/mob/M in GLOB.dead_mob_list)
-		deadMobs++
-	if(deadMobs < REVENANT_SPAWN_THRESHOLD)
-		message_admins("Random event attempted to spawn a revenant, but there were only [deadMobs]/[REVENANT_SPAWN_THRESHOLD] dead mobs.")
+	if(!can_start())
 		return
 
 	spawn()
@@ -50,3 +46,18 @@
 
 /datum/event/revenant/start()
 	get_revenant()
+
+/datum/event/revenant/can_start()
+	if(..())
+		return TRUE
+
+	var/deadMobs = 0
+	for(var/mob/M in GLOB.dead_mob_list)
+		deadMobs++
+
+	//it's never FALSE, because roundstart amount of deadmobs ~40 i guess..
+	if(deadMobs < REVENANT_SPAWN_THRESHOLD)
+		message_admins("Random event attempted to spawn a revenant, but there were only [deadMobs]/[REVENANT_SPAWN_THRESHOLD] dead mobs.")
+		return FALSE
+
+	return TRUE

--- a/code/game/gamemodes/miniantags/revenant/revenant_spawn_event.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_spawn_event.dm
@@ -48,16 +48,18 @@
 	get_revenant()
 
 /datum/event/revenant/can_start()
-	if(..())
-		return TRUE
-
 	var/deadMobs = 0
 	for(var/mob/M in GLOB.dead_mob_list)
 		deadMobs++
 
 	//it's never FALSE, because roundstart amount of deadmobs ~40 i guess..
-	if(deadMobs < REVENANT_SPAWN_THRESHOLD)
-		message_admins("Random event attempted to spawn a revenant, but there were only [deadMobs]/[REVENANT_SPAWN_THRESHOLD] dead mobs.")
-		return FALSE
+	if(deadMobs >= REVENANT_SPAWN_THRESHOLD)
+		return TRUE
 
-	return TRUE
+	if(..()) // forced
+		log_and_message_admins("Event \"[type]\" launched bypassing the minimum deadmobs limits!")
+		return TRUE
+
+	log_and_message_admins("Random event attempted to spawn a revenant, but there were only [deadMobs]/[REVENANT_SPAWN_THRESHOLD] dead mobs.")
+
+	return FALSE

--- a/code/game/gamemodes/miniantags/space_dragon/space_dragon.dm
+++ b/code/game/gamemodes/miniantags/space_dragon/space_dragon.dm
@@ -14,9 +14,7 @@
 
 
 /datum/event/space_dragon/start()
-	var/player_count = num_station_players()
-	if(player_count < SPACE_DRAGON_SPAWN_THRESHOLD)
-		log_and_message_admins("Random event attempted to spawn a space dragon, but there were only [player_count]/[SPACE_DRAGON_SPAWN_THRESHOLD] players.")
+	if(!can_start())
 		var/datum/event_container/EC = SSevents.event_containers[EVENT_LEVEL_MAJOR]
 		EC.next_event_time = world.time + (60 * 10)
 		return
@@ -38,6 +36,18 @@
 	log_and_message_admins("[ADMIN_LOOKUPFLW(space_dragon)] has been made into a Space Dragon by an event.")
 	log_game("[space_dragon.key] was spawned as a Space Dragon by an event.")
 	successSpawn = TRUE
+
+
+/datum/event/space_dragon/can_start()
+	if(..())
+		return TRUE
+
+	var/player_count = num_station_players()
+	if(player_count < SPACE_DRAGON_SPAWN_THRESHOLD)
+		log_and_message_admins("Random event attempted to spawn a space dragon, but there were only [player_count]/[SPACE_DRAGON_SPAWN_THRESHOLD] players.")
+		return FALSE
+
+	return TRUE
 
 
 #undef SPACE_DRAGON_SPAWN_THRESHOLD

--- a/code/game/gamemodes/miniantags/space_dragon/space_dragon.dm
+++ b/code/game/gamemodes/miniantags/space_dragon/space_dragon.dm
@@ -39,15 +39,17 @@
 
 
 /datum/event/space_dragon/can_start()
-	if(..())
+	var/player_count = num_station_players()
+	if(player_count >= SPACE_DRAGON_SPAWN_THRESHOLD) // all passed
 		return TRUE
 
-	var/player_count = num_station_players()
-	if(player_count < SPACE_DRAGON_SPAWN_THRESHOLD)
-		log_and_message_admins("Random event attempted to spawn a space dragon, but there were only [player_count]/[SPACE_DRAGON_SPAWN_THRESHOLD] players.")
-		return FALSE
+	if(..()) // forced
+		log_and_message_admins("Event \"[type]\" launched bypassing the minimum players limit!")
+		return TRUE
 
-	return TRUE
+	log_and_message_admins("Random event attempted to spawn a space dragon, but there were only [player_count]/[SPACE_DRAGON_SPAWN_THRESHOLD] players.")
+
+	return FALSE
 
 
 #undef SPACE_DRAGON_SPAWN_THRESHOLD

--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -178,10 +178,12 @@
 	SSevents.active_events -= src
 	SSevents.event_complete(src)
 
-/datum/event/New(datum/event_meta/EM, skeleton = FALSE)
+/datum/event/New(datum/event_meta/EM, skeleton = FALSE, forced_event = FALSE)
 	// event needs to be responsible for this, as stuff like APLUs currently make their own events for curious reasons
 	if(!skeleton)
 		SSevents.active_events += src
+
+	src.forced_event = forced_event
 
 	if(!EM)
 		EM = new /datum/event_meta(EVENT_LEVEL_MAJOR, "Unknown, Most likely admin called", src.type)

--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -72,6 +72,8 @@
 	var/endedAt			= 0
 	/// Does the event end automatically after endWhen passes?
 	var/noAutoEnd       = FALSE
+	/// If the event was triggered by admins and should bypass start checks?
+	var/forced_event 	= FALSE
 	/// The area the event will hit
 	var/area/impact_area
 	var/datum/event_meta/event_meta = null
@@ -214,4 +216,12 @@
   * If this proc returns TRUE, the regular Announce() won't be called.
   */
 /datum/event/proc/fake_announce()
+	return FALSE
+
+//Optional proc that can be owerwritten with ..() check and used in start() to check if the event can start
+//May contain checks for number of players, round gamemodes, phases of the moon, etc
+/datum/event/proc/can_start()
+	if(forced_event) // admin spawned
+		return TRUE
+
 	return FALSE

--- a/code/modules/events/event_procs.dm
+++ b/code/modules/events/event_procs.dm
@@ -7,9 +7,8 @@
 		return
 	var/type = tgui_input_list(src, "Выберите событие для запуска", "Выбор события", SSevents.allEvents)
 	if(ispath(type))
-		var/datum/event/E = new type(new /datum/event_meta(EVENT_LEVEL_MAJOR))
-		E.forced_event = TRUE
-		message_admins("[key_name_admin(usr)] has triggered an event. ([type])")
+		new type(new /datum/event_meta(EVENT_LEVEL_MAJOR), forced_event = TRUE)
+		log_and_message_admins("[key_name_admin(usr)] has triggered an event. ([type])")
 
 /client/proc/event_manager_panel()
 	set name = "Event Manager Panel"

--- a/code/modules/events/event_procs.dm
+++ b/code/modules/events/event_procs.dm
@@ -7,7 +7,8 @@
 		return
 	var/type = tgui_input_list(src, "Выберите событие для запуска", "Выбор события", SSevents.allEvents)
 	if(ispath(type))
-		new type(new /datum/event_meta(EVENT_LEVEL_MAJOR))
+		var/datum/event/E = new type(new /datum/event_meta(EVENT_LEVEL_MAJOR))
+		E.forced_event = TRUE
 		message_admins("[key_name_admin(usr)] has triggered an event. ([type])")
 
 /client/proc/event_manager_panel()

--- a/code/modules/events/slaughterevent.dm
+++ b/code/modules/events/slaughterevent.dm
@@ -78,13 +78,17 @@
 	kill()
 
 /datum/event/spawn_slaughter/can_start()
-	if(..())
+	var/player_count = num_station_players()
+	if(player_count > minplayers) // all passed
 		return TRUE
 
-	if(num_station_players() <= minplayers)
-		return FALSE
+	if(..()) // forced
+		log_and_message_admins("Event \"[type]\" launched bypassing the minimum players limit!")
+		return TRUE
 
-	return TRUE
+	log_and_message_admins("Random event attempted to spawn a slaughter demon, but there were only [player_count]/[minplayers] players.")
+
+	return FALSE
 
 
 #undef SLAUGHTER_MINPLAYERS

--- a/code/modules/events/slaughterevent.dm
+++ b/code/modules/events/slaughterevent.dm
@@ -52,7 +52,7 @@
 
 
 /datum/event/spawn_slaughter/start()
-	if(num_station_players() <= minplayers)
+	if(!can_start())
 		var/datum/event_container/EC = SSevents.event_containers[EVENT_LEVEL_MAJOR]
 		EC.next_event_time = world.time + (60 * 10)
 		return	//we don't spawn demons on lowpop. Instead, we reroll!
@@ -76,6 +76,16 @@
 			continue
 		return check // return the first turf that is dark nearby.
 	kill()
+
+/datum/event/spawn_slaughter/can_start()
+	if(..())
+		return TRUE
+
+	if(num_station_players() <= minplayers)
+		return FALSE
+
+	return TRUE
+
 
 #undef SLAUGHTER_MINPLAYERS
 #undef LAUGHTER_MINPLAYERS

--- a/code/modules/events/spider_terror.dm
+++ b/code/modules/events/spider_terror.dm
@@ -27,11 +27,11 @@
 	var/spider_type
 	var/infestation_type
 	var/player_count = num_station_players()
-	if(player_count <= TS_MINPLAYERS_TRIGGER)
+	if(!can_start(player_count))
 		var/datum/event_container/EC = SSevents.event_containers[EVENT_LEVEL_MAJOR]
 		EC.next_event_time = world.time + (60 * 10)
 		return	//we don't spawn spiders on lowpop. Instead, we reroll!
-	else if(player_count >= TS_HIGHPOP_TRIGGER)
+	if(player_count >= TS_HIGHPOP_TRIGGER)
 		infestation_type = pick(5, 6)
 	else if(player_count >= TS_MIDPOP_TRIGGER)
 		infestation_type = pick(3, 4)
@@ -67,6 +67,17 @@
 		spawncount--
 		successSpawn = TRUE
 		log_game("[S.key] has become [S].")
+
+
+/datum/event/spider_terror/can_start(player_count)
+	if(..())
+		return TRUE
+
+	if(player_count <= TS_MINPLAYERS_TRIGGER)
+		return FALSE
+
+	return TRUE
+
 
 #undef TS_MINPLAYERS_TRIGGER
 #undef TS_HIGHPOP_TRIGGER

--- a/code/modules/events/spider_terror.dm
+++ b/code/modules/events/spider_terror.dm
@@ -70,13 +70,16 @@
 
 
 /datum/event/spider_terror/can_start(player_count)
-	if(..())
+	if(player_count > TS_MINPLAYERS_TRIGGER) // passed
 		return TRUE
 
-	if(player_count <= TS_MINPLAYERS_TRIGGER)
-		return FALSE
+	if(..()) // forced
+		log_and_message_admins("Event \"[type]\" launched bypassing the minimum players limit!")
+		return TRUE
 
-	return TRUE
+	log_and_message_admins("Random event attempted to spawn a terror spiders, but there were only [player_count]/[TS_MINPLAYERS_TRIGGER] players.")
+
+	return FALSE
 
 
 #undef TS_MINPLAYERS_TRIGGER


### PR DESCRIPTION

## Описание

 Убирает требования к игрокам/режимам при спавне ивента через админ меню Trigger Event, позволяя срать вечно даже на лоупопе
 Никак не влияет на стандартный спавн ивентов

## Ссылка на предложение/Причина создания ПР

 Админ пожаловался, что не может срать на лоупопе. Теперь может.. 
 
## Тесты

Каждый ивент был проверен на локалке: сначала админкнопками через Trigger Event, затем естественным рандомным спавном ивентов, никаких аномалий не обнаружено
