### PR TITLE
bugfix: donor loadout

### DIFF
--- a/code/modules/client/preference/loadout/loadout_donor.dm
+++ b/code/modules/client/preference/loadout/loadout_donor.dm
@@ -11,6 +11,9 @@
 		stack_trace("Item with no donator tier in loadout donor items: [display_name].")
 		return TRUE
 
+	if(!cl.prefs) // DB loading, skip this check now
+		return TRUE
+
 	if(cl?.donator_level >= donator_tier)
 		return TRUE
 


### PR DESCRIPTION

## Описание
Убирает ошибку, вследствие которой при загрузке сервера стирались донатные айтемы из выбора в лодауте


## Тесты
Локалка. Работает, шмот не убирается
