### PR TITLE
bugfix: turret protection map and initialize fix.

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -15481,7 +15481,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/aisat/maintenance)
+/area/turret_protected/aisat)
 "bRt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -102731,7 +102731,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/aisat)
+/area/turret_protected/aisat)
 "sOS" = (
 /obj/machinery/disposal,
 /obj/effect/decal/warning_stripes/red/hollow,
@@ -135109,13 +135109,13 @@ qni
 qni
 bJW
 bJW
-cvf
-cvf
-cvf
+bJW
+bJW
+bJW
 bRr
-cvf
-cvf
-cvf
+bJW
+bJW
+bJW
 qrT
 qrT
 qrT
@@ -136144,7 +136144,7 @@ bPM
 bRy
 bTA
 bTA
-wRH
+bTA
 dxt
 wRH
 iox
@@ -137165,13 +137165,13 @@ qni
 qni
 bJW
 bJW
-cvg
-cvg
-cvg
+bJW
+bJW
+bJW
 sOI
-cvg
-cvg
-cvg
+bJW
+bJW
+bJW
 qrT
 qrT
 qrT

--- a/_maps/map_files/celestation/celestation.dmm
+++ b/_maps/map_files/celestation/celestation.dmm
@@ -13210,6 +13210,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/turretid/stun{
+	control_area = "AI Satellite Secondary Antechamber";
+	name = "AI Satellite Secondary Antechamber Turret Control";
+	req_access = list(75);
+	pixel_x = -30;
+	pixel_y = -24
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -15893,6 +15900,10 @@
 "cdq" = (
 /obj/machinery/cryopod/robot,
 /obj/effect/landmark/join_late_cyborg,
+/obj/item/radio/intercom{
+	pixel_y = 22;
+	pixel_x = 0
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "navyblue"
@@ -18890,6 +18901,13 @@
 	},
 /obj/machinery/camera/autoname{
 	dir = 8
+	},
+/obj/machinery/turretid/lethal{
+	check_synth = 1;
+	name = "AI Chamber Turret Control";
+	req_access = list(75);
+	pixel_x = 32;
+	pixel_y = 0
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/turret_protected/ai)
@@ -27539,13 +27557,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/cele/servise)
 "dOS" = (
-/obj/machinery/turretid/lethal{
-	check_synth = 1;
-	name = "AI Chamber Turret Control";
-	req_access = list(75)
+/obj/machinery/turretid/stun{
+	name = "AI Satellite Turret Control";
+	req_access = list(75);
+	pixel_x = 0;
+	pixel_y = -26
 	},
-/turf/simulated/wall/r_wall,
-/area/turret_protected/ai)
+/turf/simulated/floor/plating,
+/area/turret_protected/aisat)
 "dOW" = (
 /obj/effect/spawner/random_spawners/rock_50,
 /turf/simulated/floor/plating{
@@ -33943,14 +33962,6 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
-"fgB" = (
-/obj/machinery/turretid/stun{
-	control_area = "AI Satellite Antechamber";
-	name = "AI Satellite Antechamber Turret Control";
-	req_access = list(75)
-	},
-/turf/simulated/wall/r_wall,
-/area/turret_protected/aisat_interior)
 "fgL" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -60528,12 +60539,13 @@
 /area/toxins/lab)
 "kiQ" = (
 /obj/machinery/turretid/stun{
-	control_area = "AI Satellite Secondary Antechamber";
-	name = "AI Satellite Secondary Antechamber Turret Control";
-	req_access = list(75)
+	name = "AI Satellite Turret Control";
+	req_access = list(75);
+	pixel_x = 0;
+	pixel_y = 28
 	},
-/turf/simulated/wall/r_wall,
-/area/turret_protected/aisat_interior/secondary)
+/turf/simulated/floor/plating,
+/area/turret_protected/aisat)
 "kiY" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -90255,14 +90267,6 @@
 /obj/item/storage/box/mousetraps,
 /turf/simulated/floor/plasteel,
 /area/janitor)
-"pWZ" = (
-/obj/machinery/turretid/stun{
-	control_area = "AI Satellite";
-	name = "AI Satellite Turret Control";
-	req_access = list(75)
-	},
-/turf/simulated/wall/r_wall,
-/area/turret_protected/aisat)
 "pXa" = (
 /turf/simulated/wall/r_wall,
 /area/engine/engineering)
@@ -118304,6 +118308,13 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/turretid/stun{
+	control_area = "AI Satellite Antechamber";
+	name = "AI Satellite Antechamber Turret Control";
+	req_access = list(75);
+	pixel_x = -28;
+	pixel_y = 0
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "navyblue"
@@ -131605,8 +131616,12 @@
 	dir = 1;
 	network = list("SS13","MiniSat")
 	},
-/obj/item/radio/intercom{
-	pixel_y = -28
+/obj/machinery/turretid/stun{
+	control_area = "AI Satellite Antechamber";
+	name = "AI Satellite Antechamber Turret Control";
+	req_access = list(75);
+	pixel_x = 0;
+	pixel_y = -26
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "navyblue"
@@ -225726,7 +225741,7 @@ vZy
 vZy
 vZy
 qZf
-kiQ
+vZy
 vZy
 vZy
 rjo
@@ -227781,7 +227796,7 @@ kCa
 kCa
 mMX
 wJb
-fgB
+mMX
 aXe
 mMX
 eph
@@ -228032,7 +228047,7 @@ ntZ
 clk
 gKY
 oAd
-oAd
+dOS
 gKY
 vWt
 roh
@@ -228043,8 +228058,8 @@ jHo
 ktZ
 roh
 dMW
-pWZ
-oAd
+gKY
+kiQ
 oAd
 gKY
 umH
@@ -287663,7 +287678,7 @@ oVi
 oVi
 oVi
 pip
-dOS
+cnV
 gmZ
 oVi
 oVi

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -71663,7 +71663,6 @@
 "nMn" = (
 /obj/machinery/light/small,
 /obj/machinery/turretid/stun{
-	control_area = "AI Satellite Antechamber";
 	name = "AI Antechamber Turret Control";
 	pixel_y = -24;
 	req_access = list(75)

--- a/_maps/map_files/event/Station/delta_old.dmm
+++ b/_maps/map_files/event/Station/delta_old.dmm
@@ -13354,7 +13354,7 @@
 "bLO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/turretid/stun{
-	control_area = "\improper AI Satellite Antechamber";
+	control_area = "AI Satellite Antechamber";
 	name = "AI Antechamber Turret Control";
 	pixel_y = 28;
 	req_access = list(75)
@@ -14557,7 +14557,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/aisat/maintenance)
+/area/turret_protected/aisat)
 "bRt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -14608,15 +14608,6 @@
 	icon_state = "darkbluecorners"
 	},
 /area/turret_protected/aisat)
-"bRC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/aisat)
 "bRD" = (
 /obj/structure/showcase{
 	density = 0;
@@ -14631,7 +14622,7 @@
 	dir = 4
 	},
 /obj/machinery/turretid/stun{
-	control_area = "\improper AI Satellite";
+	control_area = "AI Satellite";
 	name = "AI Antechamber Turret Control";
 	pixel_x = -32;
 	req_access = list(75)
@@ -14770,7 +14761,7 @@
 	dir = 4
 	},
 /obj/machinery/turretid/stun{
-	control_area = "\improper AI Satellite";
+	control_area = "AI Satellite";
 	name = "AI Antechamber Turret Control";
 	pixel_x = 32;
 	req_access = list(75)
@@ -14955,7 +14946,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/r_wall,
-/area/aisat/maintenance)
+/area/turret_protected/aisat)
 "bTy" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -95711,7 +95702,7 @@
 "sNY" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/turretid/stun{
-	control_area = "\improper Telecoms Central Compartment";
+	control_area = "Telecoms Central Compartment";
 	name = "AI Antechamber Turret Control";
 	pixel_y = -26;
 	req_access = list(75)
@@ -95743,19 +95734,6 @@
 	icon_state = "whitepurple"
 	},
 /area/medical/research)
-"sOI" = (
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Chamber Hallway";
-	req_access = list(75)
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/aisat)
 "sOS" = (
 /obj/machinery/disposal,
 /obj/effect/decal/warning_stripes/red/hollow,
@@ -124454,13 +124432,13 @@ qni
 qni
 bJW
 bJW
-cvf
-cvf
-cvf
+bJW
+bJW
+bJW
 bRr
 bTx
-cvf
-cvf
+bJW
+bJW
 qrT
 qrT
 qrT
@@ -125489,7 +125467,7 @@ bPM
 bRy
 bTA
 bTA
-wRH
+bTA
 dxt
 wRH
 iox
@@ -126510,13 +126488,13 @@ qni
 qni
 bJW
 bJW
-cvg
-cvg
-cvg
-sOI
-bRC
-cvg
-cvg
+bJW
+bJW
+bJW
+bRr
+bTx
+bJW
+bJW
 qrT
 qrT
 qrT

--- a/_maps/map_files/event/Station/towerstation.dmm
+++ b/_maps/map_files/event/Station/towerstation.dmm
@@ -22902,7 +22902,7 @@
 /area/medical/psych)
 "oNd" = (
 /obj/machinery/turretid{
-	control_area = "/area/turret_protected/ai_upload";
+	control_area = "AI Upload Chamber";
 	icon_state = "control_stun";
 	name = "AI Upload turret control";
 	pixel_y = 28

--- a/_maps/map_files/generic/CentComm.dmm
+++ b/_maps/map_files/generic/CentComm.dmm
@@ -12758,7 +12758,7 @@
 /area/shuttle/administration)
 "fVC" = (
 /obj/machinery/turretid{
-	control_area = "\improper Centcom Special Operations";
+	control_area = "Centcom Special Operations Forces";
 	name = "Quarantine Turret";
 	pixel_x = 3;
 	pixel_y = -26

--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -71,7 +71,7 @@
 			A.turret_controls -= src
 	return ..()
 
-/obj/machinery/turretid/Initialize()
+/obj/machinery/turretid/Initialize(mapload)
 	. = ..()
 	if(!control_area)
 		control_area = get_area(src)
@@ -88,9 +88,13 @@
 		else
 			control_area = null
 
-	updateTurrets()
 	update_icon(UPDATE_ICON_STATE)
 	update_turret_light()
+	return INITIALIZE_HINT_LATELOAD
+
+
+/obj/machinery/turretid/LateInitialize()
+	updateTurrets()
 
 
 /obj/machinery/turretid/proc/isLocked(mob/user)

--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -4,7 +4,7 @@
 
 /area
 	// Turrets use this list to see if individual power/lethal settings are allowed
-	var/list/turret_controls = list()
+	var/list/obj/machinery/turretid/turret_controls = list()
 
 /obj/machinery/turretid
 	name = "turret control panel"
@@ -181,35 +181,61 @@
 	)
 	return data
 
+
 /obj/machinery/turretid/ui_act(action, params)
-	if (..())
+	if(..())
 		return
+
 	if(isLocked(usr))
 		return
+
 	. = TRUE
-	switch(action)
-		if("power")
-			enabled = !enabled
-		if("lethal")
-			if(lethal_is_configurable)
-				lethal = !lethal
-	if(targetting_is_configurable)
-		switch(action)
-			if("authweapon")
-				check_weapons = !check_weapons
-			if("authaccess")
-				check_access = !check_access
-			if("authnorecord")
-				check_records = !check_records
-			if("autharrest")
-				check_arrest = !check_arrest
-			if("authxeno")
-				check_anomalies = !check_anomalies
-			if("authsynth")
-				check_synth = !check_synth
-			if("authborgs")
-				check_borgs = !check_borgs
+	if(!updateTurretId(action))
+		return
+
+	for(var/obj/machinery/turretid/panel as anything in (control_area.turret_controls - src))
+		panel.updateTurretId(action, force = TRUE)
+		panel.update_icon(UPDATE_ICON_STATE)
+		panel.update_turret_light()
+
+	update_icon(UPDATE_ICON_STATE)
+	update_turret_light()
 	updateTurrets()
+
+
+/obj/machinery/turretid/proc/updateTurretId(action, force = FALSE)
+	if(action == "power")
+		enabled = !enabled
+		return TRUE
+
+	if(action == "lethal")
+		if(!lethal_is_configurable && !force)
+			return FALSE
+
+		lethal = !lethal
+		return TRUE
+
+	if(!targetting_is_configurable && !force)
+		return FALSE
+
+	switch(action)
+		if("authweapon")
+			check_weapons = !check_weapons
+		if("authaccess")
+			check_access = !check_access
+		if("authnorecord")
+			check_records = !check_records
+		if("autharrest")
+			check_arrest = !check_arrest
+		if("authxeno")
+			check_anomalies = !check_anomalies
+		if("authsynth")
+			check_synth = !check_synth
+		if("authborgs")
+			check_borgs = !check_borgs
+
+	return TRUE
+
 
 /obj/machinery/turretid/proc/updateTurrets()
 	var/datum/turret_checks/TC = new
@@ -228,9 +254,6 @@
 		for(var/obj/machinery/porta_turret/aTurret in control_area.machinery_cache)
 			if(faction == aTurret.faction)
 				aTurret.setState(TC)
-
-	update_icon(UPDATE_ICON_STATE)
-	update_turret_light()
 
 
 /obj/machinery/turretid/power_change(forced = FALSE)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
- Переносит настройку турелей при спавне "панельки управления турелями" из обычной инициализации в позднюю.
- Заставляет все, принадлежащие одной зоне, панельки турелей переключаться через кнопочки в ТГУИ синхронно.
- Правит чуть зону на дельте и старой дельте, где была "сейвзона" от турелей.
- На старой дельте, кибериаде и ЦК корректирует названия зон, которыми управляют "панельки турелей".
- На Селестии добавляет одну "панельку турелей" ко входу от телепортера и правит остальные.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на баг-репорт
https://discord.com/channels/617003227182792704/1291411866530353152
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Заходил за ИИ на локалке и спавнил мартышек по спутнику.
<!-- Как вы тестировали свой код. Ревьеюру будет проще, если он будет знать какие действия вы совершали, проверяя свой ПР. -->
