### PR TITLE
tweak: Engi areas type shuffling. Supermatter and sub-engine areas overload-protected APCs.

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -484,7 +484,7 @@
 	network = list("SS13","Engineering")
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aeY" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -495,7 +495,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "afb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
@@ -518,7 +518,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "afD" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -571,7 +571,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "afY" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -741,7 +741,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "ahQ" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -795,7 +795,7 @@
 "aiC" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "aiE" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/secondary/entry/eastarrival)
@@ -833,7 +833,7 @@
 	dir = 6;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "aiY" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -884,7 +884,7 @@
 	pixel_x = -26
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "ajD" = (
 /obj/machinery/door/poddoor/shutters{
 	id_tag = "CargoBay Shutters South";
@@ -916,7 +916,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ajN" = (
 /turf/simulated/wall,
 /area/hallway/secondary/entry/eastarrival)
@@ -944,7 +944,7 @@
 	dir = 9;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "ajY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -977,7 +977,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "akv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
@@ -1016,7 +1016,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "ald" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/structure/sign/vacuum{
@@ -1058,7 +1058,7 @@
 "alQ" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "alT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1072,7 +1072,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "alW" = (
 /obj/structure/chair/comfy/brown,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1161,7 +1161,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "amu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1175,7 +1175,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "amA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1203,7 +1203,7 @@
 	},
 /obj/machinery/disposal,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "amL" = (
 /obj/structure/computerframe,
 /obj/structure/sign/poster/contraband/random{
@@ -1220,7 +1220,7 @@
 /obj/item/radio,
 /obj/item/radio,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "amQ" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-dead";
@@ -1246,7 +1246,7 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "amS" = (
 /obj/structure/table,
 /obj/item/storage/box/prisoner,
@@ -1372,7 +1372,7 @@
 	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "aoe" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -1565,7 +1565,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "apE" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -1617,7 +1617,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "apO" = (
 /obj/machinery/status_display{
 	pixel_x = -32
@@ -1665,7 +1665,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "aqf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1684,7 +1684,7 @@
 	dir = 10;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "aqj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool,
@@ -1709,7 +1709,7 @@
 	pixel_y = -3
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "aqu" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -1787,7 +1787,7 @@
 	},
 /obj/item/gun/energy/kinetic_accelerator,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "arh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
@@ -1809,7 +1809,7 @@
 	name = "Expedition Lockdown"
 	},
 /turf/simulated/floor/plating,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "ars" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1922,7 +1922,7 @@
 	dir = 9;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "arX" = (
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
@@ -1935,7 +1935,7 @@
 	req_access = list(18,48,70,71)
 	},
 /turf/simulated/wall,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "asg" = (
 /obj/machinery/light,
 /obj/structure/table/reinforced,
@@ -1947,7 +1947,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "asi" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -1959,7 +1959,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "asq" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -1979,30 +1979,30 @@
 	name = "Expedition Lockdown"
 	},
 /turf/simulated/floor/plating,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "asF" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "asH" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "asR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "asX" = (
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "asY" = (
 /obj/structure/closet/wardrobe/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2026,7 +2026,7 @@
 "atq" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "atv" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -2056,7 +2056,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "atV" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -2066,7 +2066,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "atW" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -2083,7 +2083,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "auc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -2100,7 +2100,7 @@
 	dir = 1;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "aul" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -2135,14 +2135,14 @@
 	dir = 5;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "auq" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "aux" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -2169,7 +2169,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "auH" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -2185,7 +2185,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "auJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2214,7 +2214,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "avb" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
@@ -2237,7 +2237,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "avf" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -2265,7 +2265,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "avj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -2278,7 +2278,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "avk" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plating,
@@ -2288,7 +2288,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "avq" = (
 /obj/effect/decal/warning_stripes/arrow{
 	pixel_y = 15
@@ -2319,7 +2319,7 @@
 	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "avA" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -2354,7 +2354,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "avC" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -2362,7 +2362,7 @@
 	},
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "avD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2373,20 +2373,20 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "avE" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "avH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "avL" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -2485,17 +2485,17 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "awI" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "awJ" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "awP" = (
 /obj/structure/chair{
 	dir = 8
@@ -2550,7 +2550,7 @@
 	name = "Expedition Lockdown"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "axg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -2570,7 +2570,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "axj" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -2629,19 +2629,19 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "axG" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "axM" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "axP" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -2651,7 +2651,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "axT" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/firealarm{
@@ -2674,7 +2674,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ayi" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/shuttle,
@@ -2766,13 +2766,13 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "ayI" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "ayQ" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 8;
@@ -2782,7 +2782,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ayU" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atm{
@@ -2802,7 +2802,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "azi" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/machinery/light_switch{
@@ -2831,13 +2831,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "azr" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "azs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2981,7 +2981,7 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aAK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3059,7 +3059,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aBb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3091,13 +3091,13 @@
 	dir = 10;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aBe" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aBh" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
@@ -3105,7 +3105,7 @@
 	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "aBj" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -3125,7 +3125,7 @@
 	pixel_x = 26
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "aBl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -3152,7 +3152,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aBr" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -3251,7 +3251,7 @@
 	name = "Supermatter Blast Doors"
 	},
 /turf/simulated/floor/plating,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "aBZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3261,7 +3261,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aCe" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 1;
@@ -3296,7 +3296,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "aCv" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -3354,7 +3354,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aCV" = (
 /obj/machinery/door/airlock/highsecurity{
 	heat_proof = 1;
@@ -3366,7 +3366,7 @@
 	name = "Supermatter Blast Doors"
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "aCY" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "construction access"
@@ -3386,12 +3386,12 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "aDe" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/binary/volume_pump/on,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aDf" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -3403,7 +3403,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aDh" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/structure/cable/yellow{
@@ -3414,7 +3414,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aDj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -3465,7 +3465,7 @@
 	anchored = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "aDD" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -3518,7 +3518,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aEc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -3539,7 +3539,7 @@
 	name = "Supermatter Blast Doors"
 	},
 /turf/simulated/floor/plating,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "aEe" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/emergency,
@@ -3548,7 +3548,7 @@
 "aEg" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aEh" = (
 /obj/machinery/vending/coffee,
 /obj/effect/decal/warning_stripes/north,
@@ -3603,7 +3603,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aEo" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3657,7 +3657,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aEx" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -3711,7 +3711,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aEY" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -3735,7 +3735,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aFf" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/small{
@@ -3743,12 +3743,12 @@
 	},
 /obj/item/clothing/glasses/welding,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aFg" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aFj" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
@@ -3776,7 +3776,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aFs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4012,7 +4012,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aHe" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -4023,14 +4023,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aHf" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/warning_stripes/blue,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aHo" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4042,7 +4042,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aHs" = (
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -4100,13 +4100,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aHS" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aHZ" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -4125,7 +4125,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aIl" = (
 /obj/structure/sign/directions/engineering{
 	pixel_y = 8
@@ -4155,7 +4155,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "aIr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4197,7 +4197,7 @@
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aIC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4217,7 +4217,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aII" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4234,7 +4234,7 @@
 	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aIO" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -4325,7 +4325,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aJz" = (
 /obj/machinery/light{
 	dir = 1
@@ -4398,7 +4398,7 @@
 	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aJO" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -4408,7 +4408,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aJQ" = (
 /obj/machinery/light/small,
 /obj/effect/decal/warning_stripes/southwest,
@@ -4416,7 +4416,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aJV" = (
 /obj/machinery/door/airlock/external{
 	name = "Arrival Airlock"
@@ -4459,7 +4459,7 @@
 	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/wall,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aKj" = (
 /obj/machinery/light{
 	dir = 1
@@ -4524,7 +4524,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aKy" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -4559,7 +4559,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aKL" = (
 /turf/simulated/floor/wood{
 	broken = 1;
@@ -4584,7 +4584,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aKS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4596,7 +4596,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aKT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4656,7 +4656,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aLf" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -4664,7 +4664,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aLi" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable{
@@ -4694,7 +4694,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aLr" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -4720,7 +4720,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aLv" = (
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -4752,7 +4752,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aLI" = (
 /obj/machinery/light{
 	dir = 4
@@ -4761,7 +4761,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aLM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -4769,7 +4769,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "aLQ" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
@@ -4849,13 +4849,13 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aMC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aMD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -4879,7 +4879,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aMI" = (
 /obj/machinery/status_display{
 	pixel_y = 32
@@ -4968,7 +4968,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aNe" = (
 /obj/machinery/light{
 	dir = 4
@@ -4990,7 +4990,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aNj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -5058,7 +5058,7 @@
 	dir = 10;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aNG" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -5133,7 +5133,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aOn" = (
 /obj/structure/sink{
 	pixel_y = 29
@@ -5178,7 +5178,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aOB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5308,7 +5308,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aOY" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -5488,7 +5488,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aQi" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -5558,14 +5558,14 @@
 "aQJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/greengrid,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aQK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/warning_stripes/eastsouthwest,
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aQM" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -5795,7 +5795,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aSH" = (
 /obj/machinery/atmospherics/air_sensor{
 	id_tag = "air_sensor";
@@ -5814,7 +5814,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aSP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5849,7 +5849,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aSV" = (
 /obj/structure/chair/stool/bar,
 /turf/simulated/floor/carpet,
@@ -5921,7 +5921,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aTx" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -5939,7 +5939,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aTy" = (
 /obj/machinery/light{
 	dir = 8
@@ -5948,7 +5948,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aTA" = (
 /obj/structure/closet,
 /obj/item/crowbar/red{
@@ -5978,7 +5978,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aTD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5998,7 +5998,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aTU" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -6036,7 +6036,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "aUh" = (
 /turf/simulated/floor/wood/fancy/light,
 /area/ntrep)
@@ -6294,13 +6294,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aVh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aVi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6309,7 +6309,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aVj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6319,7 +6319,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aVo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
@@ -6443,7 +6443,7 @@
 "aWB" = (
 /obj/effect/landmark/start/mechanic,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aWC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -6451,7 +6451,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aWI" = (
 /obj/structure/sign/directions/engineering{
 	pixel_y = 8
@@ -6552,7 +6552,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "aXl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6727,14 +6727,14 @@
 /obj/machinery/light,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aYt" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aYx" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/suit_storage_unit/atmos,
@@ -6749,7 +6749,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "aYE" = (
 /obj/structure/sign/nosmoking_1{
 	pixel_x = 28;
@@ -6759,14 +6759,14 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "aYF" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aYH" = (
 /obj/structure/table/reinforced,
 /obj/item/folder,
@@ -6784,7 +6784,7 @@
 	anchored = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aYP" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -6837,7 +6837,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aYY" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel{
@@ -6960,7 +6960,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aZx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7130,7 +7130,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "baM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -7187,7 +7187,7 @@
 /area/quartermaster/miningdock)
 "bbf" = (
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bbh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -7218,7 +7218,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bbl" = (
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
@@ -7364,7 +7364,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bcn" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -7455,7 +7455,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bda" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -7489,7 +7489,7 @@
 	dir = 10;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bdq" = (
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken5"
@@ -7507,7 +7507,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bdz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/soda{
@@ -7541,7 +7541,7 @@
 	},
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bdO" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -7636,7 +7636,7 @@
 /area/maintenance/library)
 "beC" = (
 /turf/simulated/wall,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "beO" = (
 /obj/machinery/atmospherics/air_sensor{
 	id_tag = "n2_sensor"
@@ -7651,7 +7651,7 @@
 /area/janitor)
 "beV" = (
 /turf/simulated/wall,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "beW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7761,7 +7761,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bgb" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/wood,
@@ -7914,7 +7914,7 @@
 "bgw" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "bgy" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -7989,7 +7989,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bgN" = (
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
@@ -8043,7 +8043,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bhl" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 2;
@@ -8180,7 +8180,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bhE" = (
 /obj/structure/toilet{
 	dir = 8
@@ -8261,7 +8261,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bie" = (
 /obj/machinery/mineral/equipment_vendor,
 /obj/structure/sign/poster/official/dig{
@@ -8336,7 +8336,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "biL" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -8365,7 +8365,7 @@
 	on = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "biU" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/wood,
@@ -8490,7 +8490,7 @@
 "bjx" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bjz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8512,7 +8512,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bjB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8530,7 +8530,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bjD" = (
 /obj/structure/table/wood,
 /obj/item/paper/deltainfo,
@@ -8674,7 +8674,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bjV" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/light/small{
@@ -8768,11 +8768,11 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bkQ" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "bkS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8847,7 +8847,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "blf" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -8970,7 +8970,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "blK" = (
 /obj/structure/chair,
 /obj/structure/sign/vacuum{
@@ -9158,7 +9158,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bmX" = (
 /obj/effect/decal/cleanable/dust,
 /obj/item/bikehorn/rubberducky,
@@ -9246,7 +9246,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "bnL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9364,7 +9364,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "boK" = (
 /obj/machinery/power/solar{
 	name = "South-East Solar Panel"
@@ -9382,11 +9382,11 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "boP" = (
 /obj/structure/sign/fire,
 /turf/simulated/wall/r_wall,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "boU" = (
 /obj/structure/table/wood/fancy/royalblack,
 /obj/item/stack/spacechips/c5000,
@@ -9619,7 +9619,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bqG" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -9627,7 +9627,7 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bqH" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/door_control{
@@ -9648,7 +9648,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bqK" = (
 /obj/machinery/camera{
 	c_tag = "Supermatter South";
@@ -9666,7 +9666,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bqN" = (
 /turf/simulated/floor/carpet/black,
 /area/maintenance/casino)
@@ -9687,13 +9687,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "brj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "brk" = (
 /obj/structure/reagent_dispensers/fueltank/chem{
 	pixel_x = 32;
@@ -9708,7 +9708,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "brl" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -9782,7 +9782,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "brI" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -9819,7 +9819,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "brO" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/cardboard,
@@ -9838,7 +9838,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "brV" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
@@ -9877,7 +9877,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bsi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9909,7 +9909,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bsu" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -9919,7 +9919,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bsw" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -9929,7 +9929,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bsx" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/hologram/holopad,
@@ -9941,7 +9941,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bsy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9954,7 +9954,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bsB" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -10168,7 +10168,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "btC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10185,7 +10185,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "btD" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -10206,7 +10206,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "btF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10219,7 +10219,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "btG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10234,7 +10234,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "btH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10250,7 +10250,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "btL" = (
 /turf/simulated/wall/r_wall,
 /area/security/nuke_storage)
@@ -10332,7 +10332,7 @@
 "btX" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall/r_wall,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "btY" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -10372,11 +10372,11 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "buk" = (
 /obj/structure/sign/biohazard,
 /turf/simulated/wall/r_wall,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bul" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10390,7 +10390,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bum" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
@@ -10398,7 +10398,7 @@
 	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "buo" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -10637,7 +10637,7 @@
 	network = list("SS13","Engineering")
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bvv" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -10654,7 +10654,7 @@
 /obj/structure/closet/radiation,
 /obj/item/clothing/glasses/meson,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bvD" = (
 /obj/machinery/vending/cola,
 /obj/machinery/newscaster{
@@ -10663,7 +10663,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bvF" = (
 /obj/machinery/camera{
 	c_tag = "Medbay South-East Hallway";
@@ -10869,7 +10869,7 @@
 "bwl" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bws" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -10924,7 +10924,7 @@
 /area/turret_protected/ai)
 "bwN" = (
 /turf/simulated/wall/r_wall,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bwO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -10954,11 +10954,11 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bwS" = (
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "bwT" = (
 /obj/effect/decal/warning_stripes/blue,
 /obj/structure/closet/emcloset,
@@ -11026,7 +11026,7 @@
 /obj/structure/closet/radiation,
 /obj/item/clothing/glasses/meson,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bxh" = (
 /turf/simulated/wall/r_wall,
 /area/storage/tech)
@@ -11274,7 +11274,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "byn" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -11292,7 +11292,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "byp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11306,7 +11306,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "bys" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -11316,7 +11316,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "byt" = (
 /obj/machinery/light,
 /obj/machinery/newscaster{
@@ -11621,22 +11621,22 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bzz" = (
 /obj/structure/sign/electricshock,
 /turf/simulated/wall/r_wall,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bzA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/greengrid,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bzB" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bzC" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "High Sec Zone";
@@ -11662,7 +11662,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bzF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11704,7 +11704,7 @@
 	},
 /obj/effect/decal/warning_stripes/northwestsouth,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "bzL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11716,7 +11716,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "bzP" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/donkpockets{
@@ -11741,7 +11741,7 @@
 "bzV" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bzW" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -11996,7 +11996,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "bAN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12100,11 +12100,11 @@
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bBj" = (
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bBl" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/firealarm{
@@ -12116,13 +12116,13 @@
 	dir = 10;
 	icon_state = "caution"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bBn" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bBo" = (
 /turf/simulated/wall,
 /area/maintenance/garden)
@@ -12144,7 +12144,7 @@
 	dir = 6;
 	icon_state = "caution"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bBt" = (
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
@@ -12178,7 +12178,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bBB" = (
 /obj/effect/spawner/random_spawners/blood_5,
 /turf/simulated/floor/glass/reinforced,
@@ -12281,7 +12281,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "bBS" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -12352,7 +12352,7 @@
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bCk" = (
 /obj/structure/closet/wardrobe/coroner,
 /obj/item/reagent_containers/glass/bottle/reagent/formaldehyde,
@@ -12571,7 +12571,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bDf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -12603,7 +12603,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/break_room)
+/area/engineering/break_room)
 "bDk" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -12627,7 +12627,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bDn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12639,7 +12639,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bDt" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12657,7 +12657,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bDv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12939,7 +12939,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bEK" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -12975,7 +12975,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bES" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12985,15 +12985,15 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bEV" = (
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "bEX" = (
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "bFb" = (
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
@@ -13030,7 +13030,7 @@
 	dir = 6;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "bFk" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/fyellow,
@@ -13131,7 +13131,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bFB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -13189,7 +13189,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bFJ" = (
 /obj/machinery/photocopier,
 /obj/structure/cable{
@@ -13332,18 +13332,18 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "bGD" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bGE" = (
 /obj/structure/sign/electricshock,
 /turf/simulated/wall/r_wall,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bGJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13468,7 +13468,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bHp" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -13476,7 +13476,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bHq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13484,7 +13484,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bHr" = (
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -13648,13 +13648,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bIr" = (
 /obj/machinery/autolathe,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bIz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13664,7 +13664,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bIA" = (
 /obj/machinery/light{
 	dir = 4
@@ -13682,7 +13682,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bIE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13719,7 +13719,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bIK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -13767,7 +13767,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bJf" = (
 /obj/machinery/power/solar{
 	id = "portsolar";
@@ -13789,7 +13789,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bJk" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -13896,7 +13896,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bKl" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Monitoring";
@@ -13915,7 +13915,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bKq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack{
@@ -14270,7 +14270,7 @@
 	pixel_x = 26
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "bMn" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/effect/decal/warning_stripes/south,
@@ -14278,7 +14278,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bMo" = (
 /obj/machinery/light_switch{
 	pixel_x = -24
@@ -14295,7 +14295,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bMq" = (
 /obj/item/radio/intercom{
 	pixel_x = 28
@@ -14306,7 +14306,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bMw" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -14329,7 +14329,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bMB" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "Perma1";
@@ -14369,7 +14369,7 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bMG" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/sop_command,
@@ -14680,7 +14680,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "bOh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -14809,7 +14809,7 @@
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bOF" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -14859,7 +14859,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bOP" = (
 /obj/structure/table/wood/fancy/royalblack,
 /obj/item/deck/cards/syndicate,
@@ -14925,7 +14925,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "bPo" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -15055,7 +15055,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bPM" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -15096,7 +15096,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bPT" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -15120,13 +15120,13 @@
 "bPV" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bPW" = (
 /obj/machinery/atmospherics/binary/valve/digital,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bPZ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -15135,12 +15135,12 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bQa" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/trinary/tvalve/digital/flipped/bypass,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bQc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15192,7 +15192,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "bQk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -15203,7 +15203,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bQl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -15214,21 +15214,21 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bQm" = (
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bQp" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bQq" = (
 /obj/machinery/light{
 	dir = 8
@@ -15261,7 +15261,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "bQu" = (
 /obj/structure/closet/firecloset,
 /obj/effect/decal/warning_stripes/red,
@@ -15274,7 +15274,7 @@
 /obj/effect/decal/warning_stripes/west,
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bQx" = (
 /obj/structure/mopbucket/full,
 /obj/item/mop,
@@ -15283,7 +15283,7 @@
 "bQB" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bQD" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -15308,10 +15308,10 @@
 "bQF" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bQH" = (
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bQL" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/suit_storage_unit/atmos,
@@ -15425,7 +15425,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bRk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15491,7 +15491,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bRv" = (
 /obj/structure/table,
 /obj/item/paper/deltainfo,
@@ -15560,7 +15560,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bRK" = (
 /mob/living/simple_animal/bot/cleanbot{
 	name = "D.E.N";
@@ -15629,7 +15629,7 @@
 /obj/machinery/light/small,
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "bRY" = (
 /obj/machinery/newscaster{
 	pixel_x = -30
@@ -15645,7 +15645,7 @@
 /obj/structure/closet/radiation,
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "bSc" = (
 /obj/machinery/ai_status_display{
 	pixel_y = -32
@@ -15655,7 +15655,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bSf" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -15970,7 +15970,7 @@
 	dir = 6;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bTY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -16029,7 +16029,7 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "bUf" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Supply North"
@@ -16047,13 +16047,13 @@
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "bUh" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "bUk" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -16071,7 +16071,7 @@
 	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "bUm" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -16095,7 +16095,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bUq" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -16211,7 +16211,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bUR" = (
 /obj/effect/decal/cleanable/vomit,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -16248,7 +16248,7 @@
 /area/aisat)
 "bVk" = (
 /turf/simulated/wall/r_wall,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bVn" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -16300,7 +16300,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bVt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -16355,7 +16355,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bVI" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/structure/cable{
@@ -16365,7 +16365,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bVJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -16517,12 +16517,12 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "bWn" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bWp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -16534,7 +16534,7 @@
 	charge = 2e+006
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/engineering)
+/area/engineering/engine)
 "bWs" = (
 /obj/machinery/atmospherics/trinary/filter{
 	desc = "Отфильтровывает кислород из трубы и отправляет его в камеру хранения";
@@ -16861,7 +16861,7 @@
 /area/hallway/secondary/entry/commercial)
 "bXU" = (
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "bXY" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -16869,7 +16869,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bYa" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -16894,7 +16894,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "bYd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17065,7 +17065,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "bZn" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -17074,7 +17074,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "bZt" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow{
@@ -17092,7 +17092,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "bZv" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -17114,7 +17114,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "bZz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17304,7 +17304,7 @@
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cag" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -17381,7 +17381,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cas" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder{
@@ -17430,7 +17430,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "caB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -17490,11 +17490,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "caN" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "caQ" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/tripple,
@@ -17509,11 +17509,11 @@
 /area/maintenance/asmaint4)
 "cbb" = (
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "cbc" = (
 /obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cbj" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -17522,7 +17522,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cbk" = (
 /obj/machinery/vending/engivend,
 /obj/effect/decal/warning_stripes/yellow,
@@ -17530,12 +17530,12 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "cbl" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "cbm" = (
 /obj/machinery/status_display{
 	pixel_y = -32
@@ -17550,7 +17550,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "cbn" = (
 /obj/machinery/shieldgen,
 /turf/simulated/floor/plating,
@@ -17697,7 +17697,7 @@
 	},
 /obj/item/analyzer,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cbR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/airlock/external{
@@ -17717,7 +17717,7 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cbY" = (
 /obj/structure/table/wood,
 /obj/item/storage/secure/briefcase,
@@ -17738,7 +17738,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "cca" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/structure/cable{
@@ -17751,7 +17751,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ccb" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -17761,7 +17761,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ccc" = (
 /obj/machinery/light{
 	dir = 8
@@ -17784,7 +17784,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ccf" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -17797,7 +17797,7 @@
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ccg" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -17807,7 +17807,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cch" = (
 /obj/structure/table/reinforced,
 /obj/item/tank/internals/emergency_oxygen/engi,
@@ -17817,7 +17817,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ccj" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
@@ -18012,7 +18012,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cdj" = (
 /obj/structure/table/reinforced,
 /obj/item/pen,
@@ -18188,7 +18188,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cdV" = (
 /obj/structure/plasticflaps,
 /obj/effect/decal/warning_stripes/yellow,
@@ -18215,7 +18215,7 @@
 	req_access = list(10,24)
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "ced" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -18425,7 +18425,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cfi" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
@@ -18437,7 +18437,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cfm" = (
 /obj/machinery/atmospherics/trinary/filter/flipped{
 	dir = 1;
@@ -18455,7 +18455,7 @@
 /area/hallway/secondary/entry)
 "cfr" = (
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "cfs" = (
 /obj/machinery/camera{
 	c_tag = "Interrogation Room";
@@ -18477,7 +18477,7 @@
 	},
 /obj/machinery/atmospherics/binary/valve/digital,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "cfu" = (
 /obj/structure/table/wood,
 /obj/item/dice/d2,
@@ -18560,7 +18560,7 @@
 	network = list("SS13","Singularity","Engineering")
 	},
 /turf/space,
-/area/engine/engineering)
+/area/engineering/engine)
 "cfM" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -18595,7 +18595,7 @@
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cge" = (
 /turf/simulated/floor/engine/n2,
 /area/atmos)
@@ -18678,7 +18678,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cgE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18711,7 +18711,7 @@
 	},
 /obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cgJ" = (
 /obj/machinery/vending/clothing/departament/science,
 /obj/structure/sign/poster/random{
@@ -18753,7 +18753,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cgR" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -18810,7 +18810,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "chd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
@@ -19343,7 +19343,7 @@
 	dir = 8
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ckj" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/carpet,
@@ -19376,7 +19376,7 @@
 	},
 /obj/structure/dispenser,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cko" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19470,7 +19470,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ckN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/black,
@@ -19564,7 +19564,7 @@
 	shock_proof = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "clv" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/fore)
@@ -19702,7 +19702,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cmd" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -19732,7 +19732,7 @@
 "cmi" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/wall/r_wall,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "cmj" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
@@ -19745,7 +19745,7 @@
 	},
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cmk" = (
 /obj/effect/decal/cleanable/dust,
 /obj/effect/decal/remains/mouse,
@@ -19898,7 +19898,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cmV" = (
 /obj/machinery/light{
 	dir = 4
@@ -19964,7 +19964,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cnm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -20144,7 +20144,7 @@
 "cod" = (
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cof" = (
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
@@ -20255,7 +20255,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "coL" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -20361,11 +20361,11 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "cpi" = (
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cpk" = (
 /obj/machinery/power/tesla_coil,
 /obj/effect/decal/cleanable/dirt,
@@ -20391,7 +20391,7 @@
 	pixel_y = -1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cpm" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall/r_wall,
@@ -20612,7 +20612,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "cqT" = (
 /obj/effect/landmark/start/janitor,
 /turf/simulated/floor/plasteel{
@@ -20682,7 +20682,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "crk" = (
 /obj/machinery/atmospherics/trinary/filter{
 	dir = 8;
@@ -20695,7 +20695,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "crn" = (
 /obj/machinery/door/morgue{
 	name = "Private Study";
@@ -20722,7 +20722,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "crp" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
@@ -21108,12 +21108,12 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ctK" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ctL" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -21161,7 +21161,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cua" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -21210,7 +21210,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cum" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -21219,7 +21219,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cuo" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -21260,7 +21260,7 @@
 	pixel_y = -4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cuv" = (
 /obj/machinery/requests_console{
 	department = "Locker Room";
@@ -21366,7 +21366,7 @@
 	},
 /obj/structure/reflector/box,
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cvf" = (
 /turf/simulated/wall/r_wall,
 /area/aisat/maintenance)
@@ -21388,14 +21388,14 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cvk" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cvo" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -21511,7 +21511,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cvJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hydroponics/soil,
@@ -21585,7 +21585,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "cvX" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/structure/cable/yellow{
@@ -21596,7 +21596,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cvZ" = (
 /obj/structure/dresser,
 /obj/machinery/power/apc{
@@ -21691,7 +21691,7 @@
 "cwu" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "cwv" = (
 /turf/simulated/floor/plating/airless,
 /area/space)
@@ -21708,7 +21708,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "cwz" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/rack,
@@ -21738,7 +21738,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "cwA" = (
 /obj/effect/landmark/start/mime,
 /obj/machinery/hologram/holopad,
@@ -21963,7 +21963,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cxF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -21980,14 +21980,14 @@
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cxK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "cxM" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light{
@@ -22061,7 +22061,7 @@
 /obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cxV" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -22071,7 +22071,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cxW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22399,7 +22399,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "czo" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -22767,7 +22767,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "cAK" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
@@ -23038,7 +23038,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "cCg" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer{
 	dir = 4
@@ -23052,7 +23052,7 @@
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cCh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23084,7 +23084,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "cCl" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23097,7 +23097,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cCn" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/barricade/wooden,
@@ -23110,7 +23110,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "cCt" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/disposalpipe/segment,
@@ -23365,7 +23365,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cDg" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/sign/nosmoking_2{
@@ -23381,7 +23381,7 @@
 "cDh" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cDk" = (
 /obj/effect/decal/cleanable/dust,
 /obj/item/trash/can,
@@ -23434,7 +23434,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "cDx" = (
 /obj/machinery/door/poddoor{
 	id_tag = "trash";
@@ -23490,12 +23490,12 @@
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cDG" = (
 /obj/machinery/vending/tool,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cDH" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -23510,7 +23510,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cDK" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -23557,7 +23557,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cDR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -23588,7 +23588,7 @@
 /area/maintenance/engineering)
 "cDV" = (
 /turf/simulated/wall/r_wall/rust,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cDZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -23671,7 +23671,7 @@
 	dir = 5
 	},
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "cEj" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
@@ -23734,7 +23734,7 @@
 	},
 /obj/machinery/atmospherics/meter,
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "cEA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/greengrid,
@@ -23773,7 +23773,7 @@
 	},
 /obj/machinery/atmospherics/meter,
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "cEJ" = (
 /turf/simulated/wall,
 /area/mimeoffice)
@@ -23857,7 +23857,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cFe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -24016,7 +24016,7 @@
 	dir = 9
 	},
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "cFK" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light/small{
@@ -24088,7 +24088,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cGa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -24124,7 +24124,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cGf" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -24183,7 +24183,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cGx" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -24217,7 +24217,7 @@
 	name = "Труба подачи азота в реактор"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cGE" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -24229,7 +24229,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cGF" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 9
@@ -24270,7 +24270,7 @@
 /obj/structure/closet/radiation,
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cGW" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/metal{
@@ -24283,7 +24283,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cGX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -24538,7 +24538,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cIr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -24551,7 +24551,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cIt" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -24564,7 +24564,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cIu" = (
 /obj/machinery/camera{
 	c_tag = "Theatre North"
@@ -24618,7 +24618,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cIA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -24632,13 +24632,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cIB" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cID" = (
 /obj/structure/table,
 /obj/item/reagent_containers/syringe/antiviral,
@@ -24705,7 +24705,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cII" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/machinery/status_display,
@@ -24742,7 +24742,7 @@
 /obj/structure/closet/radiation,
 /obj/item/clothing/glasses/meson,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cIO" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -24752,7 +24752,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cIQ" = (
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 32
@@ -24761,7 +24761,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cIR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -24962,15 +24962,15 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cJI" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cJJ" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cJK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -24986,7 +24986,7 @@
 /obj/machinery/power/port_gen/pacman,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cJM" = (
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -25036,7 +25036,7 @@
 /obj/structure/closet/radiation,
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cKb" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -25076,7 +25076,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cKh" = (
 /obj/machinery/newscaster{
 	pixel_x = 30
@@ -25305,7 +25305,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cLA" = (
 /obj/machinery/status_display{
 	pixel_y = -32
@@ -25316,7 +25316,7 @@
 /obj/item/crowbar,
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cLB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -25327,7 +25327,7 @@
 "cLC" = (
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cLF" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
@@ -25348,7 +25348,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/paper/gravity_gen,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cLJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -25357,7 +25357,7 @@
 /obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cLL" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -25433,7 +25433,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cMi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25591,7 +25591,7 @@
 	},
 /obj/machinery/atmospherics/binary/valve/digital,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "cNb" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -25621,7 +25621,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cNl" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/experimentor,
@@ -25751,7 +25751,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cOa" = (
 /obj/item/radio/intercom{
 	pixel_x = -28
@@ -25910,7 +25910,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/aienter)
+/area/engineering/aienter)
 "cOv" = (
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -26090,7 +26090,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cPd" = (
 /obj/structure/chair/comfy/purp{
 	dir = 4
@@ -26167,7 +26167,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cPm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26182,7 +26182,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cPt" = (
 /obj/machinery/door/airlock/glass{
 	autoclose = 0;
@@ -26249,7 +26249,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cPE" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/structure/disposalpipe/segment,
@@ -26361,7 +26361,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cQb" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 10
@@ -26623,7 +26623,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cRg" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -26775,7 +26775,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cRz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -26806,7 +26806,7 @@
 /obj/effect/decal/warning_stripes/yellow,
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cRK" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -26814,7 +26814,7 @@
 	},
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cRT" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -26826,7 +26826,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cRU" = (
 /obj/effect/decal/warning_stripes/northeast,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -26881,7 +26881,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cSb" = (
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -26964,7 +26964,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cSy" = (
 /obj/machinery/light,
 /obj/structure/cable{
@@ -26990,7 +26990,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cSB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -27026,7 +27026,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cSI" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/biogenerator,
@@ -27082,7 +27082,7 @@
 /area/crew_quarters/fitness)
 "cTf" = (
 /turf/simulated/wall/r_wall,
-/area/engine/aienter)
+/area/engineering/aienter)
 "cTg" = (
 /turf/simulated/wall,
 /area/maintenance/electrical)
@@ -27223,7 +27223,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cTO" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -27232,7 +27232,7 @@
 	dir = 10;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cTP" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
@@ -27267,7 +27267,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "cTU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27283,7 +27283,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cTZ" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -28232,7 +28232,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "cXQ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/syndie,
@@ -28315,7 +28315,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cYd" = (
 /obj/structure/morgue,
 /obj/machinery/alarm{
@@ -28329,7 +28329,7 @@
 "cYf" = (
 /obj/structure/sign/nosmoking_2,
 /turf/simulated/wall,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cYg" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -28553,7 +28553,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "cZf" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -28894,7 +28894,7 @@
 /obj/item/tank/internals/plasma,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "daC" = (
 /obj/machinery/r_n_d/protolathe{
 	pixel_x = 1
@@ -28981,7 +28981,7 @@
 	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "dbj" = (
 /obj/machinery/light,
 /obj/structure/table,
@@ -29311,7 +29311,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "dcO" = (
 /obj/machinery/door/airlock/freezer{
 	req_access = list(28)
@@ -29687,7 +29687,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "dew" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -29975,7 +29975,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "dfv" = (
 /turf/simulated/wall,
 /area/medical/paramedic)
@@ -30161,7 +30161,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dgk" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -30217,7 +30217,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "dgH" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
@@ -30385,7 +30385,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "dho" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30404,7 +30404,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "dhp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -30430,7 +30430,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "dhs" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -30447,7 +30447,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "dht" = (
 /obj/structure/chair{
 	dir = 4
@@ -30731,7 +30731,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "diD" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -31391,7 +31391,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dlJ" = (
 /obj/machinery/light{
 	dir = 1
@@ -31437,7 +31437,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "dlO" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 8;
@@ -31917,7 +31917,7 @@
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "dnB" = (
 /obj/structure/chair/sofa/pew/right{
 	dir = 4
@@ -31981,7 +31981,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "dnO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
@@ -32993,7 +32993,7 @@
 	req_access = list(18,48,70)
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "dsO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/atmos/glass{
@@ -33078,7 +33078,7 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "dsY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -33318,7 +33318,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "dtZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -33331,7 +33331,7 @@
 "duf" = (
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "duh" = (
 /obj/structure/window/reinforced,
 /obj/machinery/photocopier,
@@ -33360,7 +33360,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "dup" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -33411,7 +33411,7 @@
 	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "duI" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
@@ -33455,7 +33455,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "duT" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -33626,7 +33626,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "dvB" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -34319,7 +34319,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dzc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -34356,7 +34356,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dzj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -34369,7 +34369,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "dzm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -34380,7 +34380,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dzr" = (
 /obj/structure/cable,
 /obj/structure/cable{
@@ -34395,7 +34395,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "dzs" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -34466,7 +34466,7 @@
 /obj/machinery/light/small,
 /obj/machinery/power/smes,
 /turf/simulated/floor/greengrid,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "dzy" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = -32
@@ -34867,7 +34867,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dBr" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -34889,7 +34889,7 @@
 /obj/effect/landmark/start/engineer,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dBu" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -34904,7 +34904,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dBv" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/barman_recipes,
@@ -34960,7 +34960,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "dBG" = (
 /obj/structure/filingcabinet,
 /turf/simulated/floor/plasteel{
@@ -35048,7 +35048,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "dCq" = (
 /obj/machinery/light{
 	dir = 4
@@ -35093,7 +35093,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dCw" = (
 /obj/structure/table,
 /obj/machinery/computer/library/public,
@@ -35115,7 +35115,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dCz" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/engineering_hacking{
@@ -35131,7 +35131,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dCA" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -35179,7 +35179,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "dCK" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/condiment/peppermill{
@@ -35477,7 +35477,7 @@
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dDQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -35581,7 +35581,7 @@
 /area/atmos)
 "dEs" = (
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dEt" = (
 /turf/simulated/wall,
 /area/maintenance/banya)
@@ -36863,7 +36863,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dJE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -37476,7 +37476,7 @@
 "dMr" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "dMs" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
@@ -37996,7 +37996,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dON" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -38368,14 +38368,14 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "dQA" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "dQB" = (
 /obj/machinery/light{
 	dir = 4
@@ -38389,7 +38389,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dQF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -38400,7 +38400,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "dQK" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -38451,7 +38451,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dQR" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/bottle/vodka{
@@ -38473,7 +38473,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dQT" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/hologram/holopad,
@@ -38495,7 +38495,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dQV" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -38881,7 +38881,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "dSz" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -38894,7 +38894,7 @@
 	name = "Singularity Blast Doors"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dSA" = (
 /obj/item/radio/intercom{
 	pixel_x = -28
@@ -38920,7 +38920,7 @@
 	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dSD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -38944,7 +38944,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dSH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -38957,7 +38957,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dSI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -39394,7 +39394,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "dUC" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -39404,7 +39404,7 @@
 /obj/effect/decal/warning_stripes/southeast,
 /obj/item/wrench,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "dUD" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -39462,7 +39462,7 @@
 "dUI" = (
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dUJ" = (
 /obj/structure/window/full/reinforced,
 /obj/structure/marker_beacon{
@@ -39504,7 +39504,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dUP" = (
 /obj/machinery/door/poddoor{
 	id_tag = "auxincineratorvent";
@@ -39767,7 +39767,7 @@
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "dVX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -39800,7 +39800,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dWb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -39865,7 +39865,7 @@
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
 /turf/simulated/floor/plating,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "dWj" = (
 /obj/effect/landmark/event/lightsout,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -40207,7 +40207,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "dXo" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -40219,7 +40219,7 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "dXp" = (
 /obj/machinery/power/solar{
 	id = "portsolar";
@@ -40234,7 +40234,7 @@
 /obj/structure/closet/secure_closet/engineering_electrical,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dXt" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -40311,7 +40311,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dXG" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/cleaner/brig,
@@ -40694,7 +40694,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dZe" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -40945,7 +40945,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "dZM" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
@@ -41221,7 +41221,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ecf" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt,
@@ -41235,7 +41235,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "ecz" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -41258,7 +41258,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "ecK" = (
 /mob/living/simple_animal/hostile/carp/koi{
 	desc = "Прелестный карп.";
@@ -41455,7 +41455,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "eeI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -41606,7 +41606,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "egO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
@@ -41691,7 +41691,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "ehL" = (
 /obj/structure/closet/boxinggloves,
 /turf/simulated/floor/plasteel{
@@ -41720,7 +41720,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "ehY" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -41805,7 +41805,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "ejj" = (
 /obj/structure/rack{
 	dir = 8;
@@ -41856,7 +41856,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "ejB" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -42086,7 +42086,7 @@
 	network = list("SS13","Singularity","Engineering")
 	},
 /turf/space,
-/area/engine/engineering)
+/area/engineering/engine)
 "elW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -42489,7 +42489,7 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "erT" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/detectives_office)
@@ -42706,7 +42706,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "eue" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/botanic_leather,
@@ -43015,7 +43015,7 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "eyR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -43106,7 +43106,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "eAg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -43714,7 +43714,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "eIv" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -43845,7 +43845,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "eJm" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/simulated/floor/plating,
@@ -43910,7 +43910,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "eJI" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -44088,7 +44088,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "eMg" = (
 /obj/machinery/door/airlock/glass{
 	name = "Cabin"
@@ -44144,7 +44144,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "eMz" = (
 /obj/structure/table/glass,
 /obj/item/storage/fancy/vials{
@@ -44447,7 +44447,7 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ePi" = (
 /obj/structure/reagent_dispensers/virusfood{
 	pixel_x = 32
@@ -44512,7 +44512,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "ePU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -44592,7 +44592,7 @@
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "eRa" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/structure/cable{
@@ -45178,7 +45178,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "eYe" = (
 /obj/machinery/camera{
 	c_tag = "Central Ring Hallway West 2";
@@ -45784,7 +45784,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "ffi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45843,7 +45843,7 @@
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "fgj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -46242,7 +46242,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "flo" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -46324,7 +46324,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "fmK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46675,7 +46675,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "fsk" = (
 /obj/machinery/door_control{
 	desiredstate = 1;
@@ -46788,7 +46788,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "fsZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -46881,7 +46881,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "fuj" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -47369,7 +47369,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "fBw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -47779,7 +47779,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "fFT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -48475,13 +48475,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "fPD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "fPF" = (
 /obj/structure/closet/secure_closet/security,
 /obj/effect/decal/warning_stripes/red/hollow,
@@ -48545,7 +48545,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "fQD" = (
 /obj/structure/chair/comfy/red{
 	dir = 4
@@ -49638,7 +49638,7 @@
 	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "gcs" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -49737,7 +49737,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "geg" = (
 /obj/machinery/newscaster{
 	pixel_y = 30
@@ -49903,7 +49903,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "ggC" = (
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -50158,7 +50158,7 @@
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "glv" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -50219,7 +50219,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "glJ" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -50316,7 +50316,7 @@
 /mob/living/simple_animal/possum/Poppy,
 /obj/structure/bed/dogbed/pet,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "gmO" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "redfull"
@@ -50619,7 +50619,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "gqd" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -50638,7 +50638,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "gqf" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -50672,7 +50672,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "gqS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -51322,7 +51322,7 @@
 	name = "Singularity Blast Doors"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "gAB" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -51399,7 +51399,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "gBH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -51591,7 +51591,7 @@
 	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "gDV" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -51720,7 +51720,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "gFd" = (
 /obj/machinery/computer/supplycomp{
 	dir = 4
@@ -51776,7 +51776,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "gFN" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/cargo_technician,
@@ -51925,7 +51925,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "gHm" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -51968,7 +51968,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "gHB" = (
 /obj/structure/curtain/open,
 /turf/simulated/floor/plasteel{
@@ -53048,7 +53048,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "gRQ" = (
 /obj/machinery/door/airlock/glass{
 	name = "Cabin"
@@ -53363,7 +53363,7 @@
 	location = "Engineering"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "gVO" = (
 /obj/machinery/light_switch{
 	pixel_x = 24;
@@ -53944,7 +53944,7 @@
 	anchored = 1
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "hec" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
@@ -54050,7 +54050,7 @@
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/structure/cable,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "hfq" = (
 /obj/machinery/vending/artvend,
 /obj/effect/decal/cleanable/dirt,
@@ -54566,7 +54566,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "hmM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -55008,7 +55008,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "hrX" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
@@ -55289,7 +55289,7 @@
 "hvP" = (
 /obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "hvU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -55495,7 +55495,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "hyI" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -55809,7 +55809,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "hCD" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -57057,7 +57057,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "hSO" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/effect/decal/cleanable/dirt,
@@ -57193,7 +57193,7 @@
 "hUm" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "hUH" = (
 /obj/structure/sign/biohazard,
 /turf/simulated/wall,
@@ -57305,7 +57305,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "hWb" = (
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/rack{
@@ -57390,7 +57390,7 @@
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "hWX" = (
 /obj/structure/closet/secure_closet/brig/evidence,
 /obj/machinery/light{
@@ -57717,7 +57717,7 @@
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "ibW" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -59024,7 +59024,7 @@
 /area/maintenance/trading)
 "irJ" = (
 /turf/simulated/wall/r_wall,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "irV" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -59323,7 +59323,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "ivL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -60060,7 +60060,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "iFO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -60287,7 +60287,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "iIc" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer{
 	dir = 4
@@ -60310,7 +60310,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "iIq" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 1;
@@ -60415,7 +60415,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "iJW" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Experimentor";
@@ -60641,7 +60641,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "iMk" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -60662,7 +60662,7 @@
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "iNh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -60924,7 +60924,7 @@
 	},
 /obj/effect/decal/warning_stripes/northeastsouth,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "iPH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -61042,7 +61042,7 @@
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "iST" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/firealarm{
@@ -61123,7 +61123,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "iTQ" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -61206,7 +61206,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "iVn" = (
 /obj/structure/chair/sofa/pew,
 /turf/simulated/floor/plasteel{
@@ -61911,7 +61911,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "jdU" = (
 /obj/machinery/button/windowtint{
 	id = "visiting room";
@@ -62698,7 +62698,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "joA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -63081,7 +63081,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "jst" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
@@ -63130,7 +63130,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "jtd" = (
 /obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/atmospherics/binary/valve/digital/open{
@@ -63432,7 +63432,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "jwR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/west,
@@ -63508,7 +63508,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "jxB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -63818,7 +63818,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "jAB" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/ids,
@@ -64249,7 +64249,7 @@
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/light,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "jGz" = (
 /obj/machinery/door/airlock/external{
 	hackProof = 1;
@@ -64501,7 +64501,7 @@
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/reagent_containers/food/drinks/mug/eng,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "jJj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -65730,7 +65730,7 @@
 "jZI" = (
 /obj/structure/lattice,
 /turf/space,
-/area/engine/engineering)
+/area/engineering/engine)
 "jZL" = (
 /obj/machinery/light{
 	dir = 8
@@ -65798,7 +65798,7 @@
 "kaE" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall/r_wall,
-/area/engine/break_room)
+/area/engineering/break_room)
 "kaJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -66023,7 +66023,7 @@
 	},
 /obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "keY" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/recharge_station,
@@ -66111,7 +66111,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "kfS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -66471,7 +66471,7 @@
 /obj/structure/grille,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "klj" = (
 /turf/simulated/wall,
 /area/hallway/primary/central/ne)
@@ -66529,7 +66529,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "klB" = (
 /obj/structure/curtain/open,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -67194,7 +67194,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "kud" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/decal/warning_stripes/yellow,
@@ -67311,7 +67311,7 @@
 /area/maintenance/starboardsolar)
 "kwk" = (
 /turf/simulated/wall,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "kwl" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -67448,7 +67448,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "kyv" = (
 /obj/machinery/light{
 	dir = 8
@@ -67540,7 +67540,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "kzh" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/ids,
@@ -67621,7 +67621,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "kAm" = (
 /obj/structure/chair{
 	dir = 4
@@ -67646,7 +67646,7 @@
 /area/maintenance/electrical)
 "kAF" = (
 /turf/simulated/wall/r_wall,
-/area/engine/break_room)
+/area/engineering/break_room)
 "kAV" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/camera/emp_proof{
@@ -67655,7 +67655,7 @@
 	network = list("SS13","Singularity","Engineering")
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "kAW" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -68028,7 +68028,7 @@
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "kFQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -68169,7 +68169,7 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/light,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "kHz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -69055,7 +69055,7 @@
 /area/maintenance/tourist)
 "kVo" = (
 /turf/simulated/wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "kVs" = (
 /turf/simulated/wall,
 /area/medical/medbay2)
@@ -69332,7 +69332,7 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/light,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "kZL" = (
 /obj/structure/table/wood,
 /obj/machinery/status_display{
@@ -69575,7 +69575,7 @@
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/glasses/welding,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "ldC" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -69588,7 +69588,7 @@
 /obj/effect/decal/warning_stripes/east,
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "ldR" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -70039,7 +70039,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "ljn" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -70143,7 +70143,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "lkL" = (
 /obj/effect/landmark/start/atmospheric,
 /turf/simulated/floor/plasteel{
@@ -70452,7 +70452,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "loO" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -70507,7 +70507,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "lpd" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
@@ -70551,7 +70551,7 @@
 	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "lpx" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -70605,7 +70605,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "lqa" = (
 /obj/machinery/biogenerator,
 /obj/effect/decal/cleanable/dirt,
@@ -70849,7 +70849,7 @@
 /area/bridge/meeting_room)
 "lsT" = (
 /turf/simulated/wall,
-/area/engine/break_room)
+/area/engineering/break_room)
 "lsV" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -71160,7 +71160,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "lxY" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -71362,7 +71362,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "lzZ" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall/r_wall,
@@ -71383,7 +71383,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "lAr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -71646,7 +71646,7 @@
 "lEd" = (
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "lEe" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -71707,7 +71707,7 @@
 "lFf" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "lFj" = (
 /obj/structure/table,
 /obj/machinery/firealarm{
@@ -73415,7 +73415,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "maB" = (
 /obj/effect/decal/warning_stripes/southwestcorner,
 /obj/machinery/light/small{
@@ -73871,7 +73871,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "mgP" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/camera{
@@ -73989,7 +73989,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "mhX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -74080,7 +74080,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "mjs" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
@@ -74124,7 +74124,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "mka" = (
 /obj/machinery/door/airlock/external{
 	name = "Toxins Test Chamber"
@@ -74353,14 +74353,14 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "mmv" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
 	dir = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "mmA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -74570,7 +74570,7 @@
 	dir = 8;
 	icon_state = "brown"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "mop" = (
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/closet/secure_closet/pilot_sniper,
@@ -74680,7 +74680,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "mpI" = (
 /turf/simulated/wall/r_wall,
 /area/security/prison/cell_block/A)
@@ -74821,7 +74821,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "mrf" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/hologram/holopad,
@@ -74877,7 +74877,7 @@
 	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "mrN" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -74968,7 +74968,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "mtz" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder{
@@ -75492,7 +75492,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "mAn" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -75611,7 +75611,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "mBa" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/structure/chair/stool,
@@ -75825,7 +75825,7 @@
 /area/teleporter)
 "mDe" = (
 /turf/simulated/wall/r_wall,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "mDi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -76181,7 +76181,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "mGt" = (
 /obj/structure/table/glass,
 /obj/item/storage/toolbox/surgery{
@@ -76907,7 +76907,7 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/effect/landmark/start/trainee_engineer,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "mPs" = (
 /obj/machinery/power/rad_collector{
 	anchored = 1
@@ -76921,7 +76921,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "mPz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -76951,7 +76951,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "mPJ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -76997,7 +76997,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "mQr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -77489,7 +77489,7 @@
 	name = "Singularity Blast Doors"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "mWY" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -77539,7 +77539,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "mYa" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -78576,7 +78576,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "nkg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -78798,7 +78798,7 @@
 	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "nmp" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -78874,7 +78874,7 @@
 /obj/machinery/particle_accelerator/control_box,
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "nof" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/writing,
@@ -79157,7 +79157,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "nqL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -79472,7 +79472,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "ntj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille,
@@ -79936,7 +79936,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "nAA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light{
@@ -79992,7 +79992,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "nBc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -80271,7 +80271,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "nEb" = (
 /obj/machinery/chem_heater,
 /obj/effect/decal/warning_stripes/southwest,
@@ -80370,7 +80370,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "nFB" = (
 /obj/structure/table/wood,
 /obj/item/folder/yellow,
@@ -80494,7 +80494,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "nGC" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -80543,7 +80543,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "nHp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -80635,7 +80635,7 @@
 	dir = 8;
 	icon_state = "brown"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "nIp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
@@ -81147,7 +81147,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "nOs" = (
 /obj/structure/safe/floor,
 /obj/item/paper{
@@ -81272,7 +81272,7 @@
 	dir = 6;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "nQv" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -81588,7 +81588,7 @@
 	dir = 6;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "nTo" = (
 /obj/structure/table/reinforced,
 /obj/item/t_scanner,
@@ -81618,7 +81618,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "nTD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -81725,7 +81725,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "nUR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -82022,7 +82022,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "oah" = (
 /obj/effect/landmark/observer_start,
 /turf/simulated/floor/plasteel{
@@ -82038,7 +82038,7 @@
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "oan" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -82185,7 +82185,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "obR" = (
 /obj/machinery/light,
 /obj/item/radio/intercom{
@@ -82302,7 +82302,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "ocJ" = (
 /obj/machinery/door/airlock/command{
 	id_tag = "captainofficedoor";
@@ -82486,7 +82486,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "ofZ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright{
@@ -82652,7 +82652,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "ohb" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood/fancy/light,
@@ -82674,7 +82674,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "ohs" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -82736,7 +82736,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "ohN" = (
 /obj/structure/table,
 /obj/machinery/light,
@@ -82892,7 +82892,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "oke" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -82920,7 +82920,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "okh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -82977,7 +82977,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "okX" = (
 /obj/machinery/power/apc{
 	pixel_y = -26
@@ -83234,7 +83234,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "ooV" = (
 /obj/machinery/atm{
 	pixel_x = -32
@@ -83331,7 +83331,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "oqp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -84264,7 +84264,7 @@
 	},
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "oBd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
@@ -84449,7 +84449,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "oDx" = (
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
@@ -84594,7 +84594,7 @@
 /area/teleporter/abandoned)
 "oFs" = (
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "oFJ" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
@@ -84700,7 +84700,7 @@
 "oGZ" = (
 /obj/structure/sign/vacuum,
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "oHb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -85197,7 +85197,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "oMt" = (
 /obj/item/radio/intercom{
 	pixel_x = -28
@@ -85362,7 +85362,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "oOX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -85467,7 +85467,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "oQk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -85510,7 +85510,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "oQJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -85526,7 +85526,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "oRe" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -85592,7 +85592,7 @@
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
 /turf/simulated/floor/plating,
-/area/engine/break_room)
+/area/engineering/break_room)
 "oRQ" = (
 /mob/living/simple_animal/moth,
 /turf/simulated/floor/wood{
@@ -86598,7 +86598,7 @@
 	dir = 6;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "pej" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/carpet/royalblack,
@@ -87307,7 +87307,7 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "pnb" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -87509,7 +87509,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "poE" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -87615,7 +87615,7 @@
 	dir = 8;
 	icon_state = "brown"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "pqz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -87666,7 +87666,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "prh" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger{
@@ -87759,7 +87759,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "prR" = (
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -87782,7 +87782,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "pse" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -87837,7 +87837,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "pso" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastleft{
@@ -87941,7 +87941,7 @@
 	},
 /obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "pua" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -88115,7 +88115,7 @@
 	name = "Singularity Blast Doors"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "pvu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -88304,7 +88304,7 @@
 	},
 /obj/effect/decal/warning_stripes/eastnorthwest,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "pyO" = (
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
@@ -88312,7 +88312,7 @@
 /obj/effect/decal/warning_stripes/yellow,
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "pzh" = (
 /obj/machinery/vending/medical{
 	req_access = list(3,5,19)
@@ -88470,7 +88470,7 @@
 	pixel_x = 26
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/engineering)
+/area/engineering/engine)
 "pAn" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -88568,7 +88568,7 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/light,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "pBj" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
@@ -88951,7 +88951,7 @@
 "pEz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "pEC" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -88992,7 +88992,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "pFk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -89177,7 +89177,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "pGI" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -89865,7 +89865,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "pNE" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/bot/right,
@@ -90295,7 +90295,7 @@
 	req_access = list(10,13)
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "pTv" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -90304,7 +90304,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "pTx" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -90406,7 +90406,7 @@
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "pVa" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -90552,7 +90552,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "pWy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -90571,7 +90571,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "pWD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -90604,7 +90604,7 @@
 	pixel_y = -26
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "pWN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -90614,7 +90614,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "pWQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -90669,7 +90669,7 @@
 	},
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "pXq" = (
 /obj/structure/table,
 /obj/item/paper/deltainfo,
@@ -90895,7 +90895,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "pZR" = (
 /obj/effect/decal/warning_stripes/northwest,
 /obj/item/radio/intercom{
@@ -91741,7 +91741,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qjq" = (
 /obj/machinery/newscaster{
 	pixel_x = 30
@@ -91772,7 +91772,7 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qjy" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Airlock"
@@ -91860,7 +91860,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qkz" = (
 /turf/simulated/floor/plating,
 /area/crew_quarters/theatre)
@@ -91921,7 +91921,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "qlu" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -91934,7 +91934,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "qlw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -92015,7 +92015,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "qmr" = (
 /turf/simulated/wall/r_wall,
 /area/security/holding_cell)
@@ -92025,7 +92025,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "qmz" = (
 /obj/structure/window/reinforced/polarized{
 	id = "vir_work_zone1"
@@ -92853,7 +92853,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "quv" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -92961,7 +92961,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "qvN" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -92975,7 +92975,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "qwa" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -93336,7 +93336,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "qAT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -93574,7 +93574,7 @@
 /obj/structure/cable/yellow,
 /obj/effect/decal/warning_stripes/eastsouthwest,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "qDc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -93835,7 +93835,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "qGj" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -93883,7 +93883,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "qGy" = (
 /obj/structure/sign/poster/contraband/lusty_xenomorph,
 /turf/simulated/wall,
@@ -93999,7 +93999,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "qIz" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -94215,7 +94215,7 @@
 	},
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "qLa" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -94884,7 +94884,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qTP" = (
 /obj/machinery/door/airlock/command{
 	id_tag = "blueshieldofficedoor";
@@ -94930,7 +94930,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qUz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -94972,7 +94972,7 @@
 /obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/computer/station_alert,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qUO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -95110,7 +95110,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "qWw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -95253,7 +95253,7 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qYR" = (
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -95276,7 +95276,7 @@
 	network = list("SS13","Engineering")
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qZm" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -95290,7 +95290,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qZn" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -95311,7 +95311,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qZt" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -95336,7 +95336,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "qZO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -95396,7 +95396,7 @@
 /area/hallway/primary/central/se)
 "raC" = (
 /turf/simulated/wall,
-/area/engine/aienter)
+/area/engineering/aienter)
 "raO" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -95406,7 +95406,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "raR" = (
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plating,
@@ -95422,7 +95422,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "rbh" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -95488,7 +95488,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "rbH" = (
 /obj/machinery/light{
 	dir = 8
@@ -95665,7 +95665,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "rcP" = (
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall,
@@ -95673,7 +95673,7 @@
 "rcV" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall,
-/area/engine/break_room)
+/area/engineering/break_room)
 "rcX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -95879,7 +95879,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "rfA" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -95936,7 +95936,7 @@
 "rfZ" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "rgj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -96027,7 +96027,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "rhD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -96383,7 +96383,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "rmB" = (
 /obj/structure/bed,
 /obj/item/bedsheet/hos,
@@ -96432,7 +96432,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "rna" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer,
 /turf/simulated/floor/plasteel{
@@ -96765,7 +96765,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "rqI" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/light/small,
@@ -97381,7 +97381,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "ryP" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel{
@@ -97417,7 +97417,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "rzh" = (
 /turf/simulated/wall,
 /area/security/processing)
@@ -97790,7 +97790,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "rDJ" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
@@ -97908,7 +97908,7 @@
 /obj/item/wrench,
 /obj/item/tank/internals/emergency_oxygen/engi,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "rES" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -98382,7 +98382,7 @@
 	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "rLh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/sandbags,
@@ -98631,7 +98631,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "rNX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -98770,7 +98770,7 @@
 	name = "Transit Tube Blast Doors"
 	},
 /turf/simulated/floor/plating,
-/area/engine/aienter)
+/area/engineering/aienter)
 "rQm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/dresser,
@@ -98853,7 +98853,7 @@
 	name = "Singularity Blast Doors"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "rRf" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	id_tag = "engineering_east_airlock";
@@ -98874,7 +98874,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "rRl" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
@@ -99011,7 +99011,7 @@
 	dir = 1;
 	icon_state = "yellowcorner"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "rSJ" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -99074,7 +99074,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "rUr" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plating,
@@ -99096,7 +99096,7 @@
 "rUC" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "rUE" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -99160,7 +99160,7 @@
 /obj/effect/decal/warning_stripes/west,
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "rVf" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -99168,7 +99168,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "rVi" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -99305,7 +99305,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "rXo" = (
 /obj/structure/rack,
 /obj/item/storage/firstaid/regular{
@@ -99328,7 +99328,7 @@
 	dir = 9;
 	icon_state = "caution"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "rXz" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -99393,7 +99393,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "rZo" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/alarm{
@@ -99403,7 +99403,7 @@
 	dir = 5;
 	icon_state = "caution"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "rZz" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/structure/extinguisher_cabinet{
@@ -99417,7 +99417,7 @@
 	dir = 8;
 	icon_state = "brown"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "rZF" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -99441,7 +99441,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "rZY" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -99517,7 +99517,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "saS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -100438,7 +100438,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "smu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -100735,7 +100735,7 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "spR" = (
 /obj/machinery/crematorium,
 /turf/simulated/floor/plasteel{
@@ -101164,7 +101164,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "sum" = (
 /obj/structure/table/wood,
 /obj/item/pen/multi{
@@ -101910,7 +101910,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "sCH" = (
 /obj/machinery/camera{
 	c_tag = "Locker Room North"
@@ -102313,7 +102313,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "sIL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -102372,10 +102372,10 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "sJK" = (
 /turf/simulated/floor/greengrid,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "sKg" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -102440,7 +102440,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "sLl" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -102497,7 +102497,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "sMv" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -102552,7 +102552,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "sMM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -103311,7 +103311,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "sVU" = (
 /turf/simulated/wall,
 /area/security/range)
@@ -103373,7 +103373,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "sXk" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -103397,7 +103397,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "sXQ" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bottle/morphine{
@@ -103880,7 +103880,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "tdA" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -103974,7 +103974,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "teD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -104134,7 +104134,7 @@
 	network = list("SS13","Singularity","Engineering")
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "tgg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/girder,
@@ -104236,7 +104236,7 @@
 /obj/effect/decal/warning_stripes/east,
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "thA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -104758,7 +104758,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "tnD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -104875,7 +104875,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "toO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -104937,7 +104937,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "tpI" = (
 /obj/machinery/light_switch{
 	pixel_x = 24;
@@ -105553,7 +105553,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "tyn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -105599,7 +105599,7 @@
 	dir = 4;
 	icon_state = "cautioncorner"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "tzg" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/warning_stripes/northwest,
@@ -105610,7 +105610,7 @@
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "tzh" = (
 /turf/simulated/wall/r_wall,
 /area/security/warden)
@@ -105618,7 +105618,7 @@
 /obj/structure/grille,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "tzk" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -105652,7 +105652,7 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "tzt" = (
 /obj/machinery/computer/arcade/orion_trail,
 /turf/simulated/floor/carpet/arcade,
@@ -105700,7 +105700,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "tzR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -105787,7 +105787,7 @@
 "tAB" = (
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "tAC" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -106086,7 +106086,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "tEE" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -106218,7 +106218,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "tFR" = (
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/aisat_interior)
@@ -106302,7 +106302,7 @@
 /area/medical/cmo)
 "tGE" = (
 /turf/simulated/wall/r_wall,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "tGG" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-dead";
@@ -106665,7 +106665,7 @@
 "tKz" = (
 /obj/item/screwdriver,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "tKI" = (
 /obj/machinery/vending/cigarette/free,
 /turf/simulated/floor/wood,
@@ -107258,7 +107258,7 @@
 "tPh" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "tPj" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -107272,7 +107272,7 @@
 "tPv" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "tPD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random_spawners/rodent,
@@ -107325,7 +107325,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "tQq" = (
 /obj/effect/landmark/start/detective,
 /obj/structure/cable{
@@ -107392,7 +107392,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "tQX" = (
 /obj/machinery/computer/message_monitor,
 /turf/simulated/floor/bluegrid,
@@ -107447,7 +107447,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "tRG" = (
 /obj/machinery/optable,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -107476,7 +107476,7 @@
 /area/space)
 "tSc" = (
 /turf/simulated/wall/r_wall,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "tSn" = (
 /obj/structure/mirror{
 	pixel_y = 32
@@ -107561,14 +107561,14 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "tTI" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/sign/electricshock{
 	pixel_y = -32
 	},
 /turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "tTR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -107674,7 +107674,7 @@
 /obj/effect/decal/warning_stripes/south,
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "tUW" = (
 /obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/vending/wallmed{
@@ -107685,7 +107685,7 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "tUX" = (
 /obj/effect/decal/remains/mouse{
 	name = "Джерри"
@@ -107695,7 +107695,7 @@
 "tVr" = (
 /obj/machinery/status_display,
 /turf/simulated/wall,
-/area/engine/break_room)
+/area/engineering/break_room)
 "tVu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -107715,7 +107715,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "tVz" = (
 /obj/item/book/manual/security_space_law,
 /turf/simulated/floor/plasteel{
@@ -107770,7 +107770,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "tVV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -107789,7 +107789,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "tWb" = (
 /obj/structure/delta_statue/ne,
 /turf/simulated/floor/plasteel{
@@ -107856,7 +107856,7 @@
 "tXp" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "tXq" = (
 /obj/machinery/light{
 	dir = 4
@@ -108509,7 +108509,7 @@
 	},
 /obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "ufn" = (
 /obj/structure/window/reinforced,
 /obj/structure/transit_tube/horizontal,
@@ -110056,7 +110056,7 @@
 "uyI" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "uyQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -110316,7 +110316,7 @@
 	dir = 5;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "uBD" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Security";
@@ -110399,7 +110399,7 @@
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "uCv" = (
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/suit_storage_unit/security,
@@ -110497,7 +110497,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "uEq" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
@@ -110677,7 +110677,7 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "uGH" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -110926,7 +110926,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "uJj" = (
 /obj/machinery/access_button{
 	command = "cycle_exterior";
@@ -110943,7 +110943,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "uJo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -111134,7 +111134,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "uLp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -111267,7 +111267,7 @@
 	dir = 8;
 	icon_state = "brown"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "uNA" = (
 /obj/item/mop,
 /turf/simulated/floor/wood{
@@ -111378,7 +111378,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "uOG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -111433,7 +111433,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "uPb" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -111510,7 +111510,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "uQo" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -111518,7 +111518,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "uQp" = (
 /obj/machinery/vending/tool,
 /obj/item/radio/intercom{
@@ -111746,7 +111746,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "uST" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -111797,7 +111797,7 @@
 	dir = 10;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "uTr" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -112108,7 +112108,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "uXU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -112141,7 +112141,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "uYe" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -112482,7 +112482,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "vcw" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/carpet/royalblue,
@@ -112919,7 +112919,7 @@
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "vhW" = (
 /obj/structure/cable,
 /obj/effect/spawner/window/reinforced,
@@ -113129,7 +113129,7 @@
 	dir = 6;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "vku" = (
 /turf/simulated/wall,
 /area/security/permahallway)
@@ -113208,7 +113208,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "vlD" = (
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -113859,7 +113859,7 @@
 /area/medical/chemistry)
 "vsN" = (
 /turf/simulated/wall/r_wall,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "vsT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -113895,7 +113895,7 @@
 "vtm" = (
 /obj/machinery/status_display,
 /turf/simulated/wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "vtu" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
@@ -114309,7 +114309,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "vxU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -114481,7 +114481,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "vzE" = (
 /obj/machinery/camera{
 	c_tag = "Locker Room West";
@@ -114554,7 +114554,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "vAg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -114615,7 +114615,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "vAJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/kitchen_machine/candy_maker,
@@ -114771,7 +114771,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "vCh" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -114785,7 +114785,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "vCj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -114793,7 +114793,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "vCl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -114889,7 +114889,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "vDb" = (
 /obj/structure/chair/sofa/pew/right,
 /turf/simulated/floor/plasteel{
@@ -114906,7 +114906,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "vDe" = (
 /obj/machinery/computer/card/minor/cmo{
 	dir = 8
@@ -115431,7 +115431,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "vLG" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -115955,7 +115955,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "vSH" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/tripple,
@@ -115974,7 +115974,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "vSU" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Library Maintenance";
@@ -116136,7 +116136,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "vTW" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -116221,7 +116221,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "vUL" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
@@ -116724,7 +116724,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "waL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -116891,7 +116891,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "wcz" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -116905,7 +116905,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "wcB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -117057,7 +117057,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "wek" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -117081,7 +117081,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "weY" = (
 /obj/item/radio/intercom{
 	pixel_x = 28
@@ -117155,7 +117155,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "wgt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -117216,7 +117216,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "whs" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -117256,7 +117256,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "wiT" = (
 /obj/structure/grille,
 /obj/structure/window/plasmareinforced{
@@ -117301,7 +117301,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "wjc" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -117373,7 +117373,7 @@
 	},
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "wka" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -117440,7 +117440,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "wkE" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -117559,7 +117559,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "wmA" = (
 /obj/machinery/light{
 	dir = 8
@@ -117623,7 +117623,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "wnc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -117818,7 +117818,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "wps" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -117865,7 +117865,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "wpP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -118000,7 +118000,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "wrc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood/fancy/light,
@@ -118803,7 +118803,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "wBr" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/insulated{
@@ -119046,7 +119046,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "wEJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -119286,7 +119286,7 @@
 /obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "wGW" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -119763,7 +119763,7 @@
 	name = "Singularity Blast Doors"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "wNN" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 2;
@@ -119848,7 +119848,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "wOp" = (
 /turf/simulated/wall,
 /area/hallway/secondary/exit/maint)
@@ -120284,7 +120284,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "wUC" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/suit_storage_unit/engine,
@@ -120484,7 +120484,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "wXh" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -120508,7 +120508,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "wXn" = (
 /obj/item/storage/box/donkpockets,
 /turf/simulated/floor/plasteel{
@@ -121211,7 +121211,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "xgb" = (
 /obj/machinery/ai_status_display{
 	pixel_y = 32
@@ -121418,7 +121418,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "xiA" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -121679,7 +121679,7 @@
 /area/toxins/misc_lab)
 "xnf" = (
 /turf/simulated/wall,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "xnm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -122044,7 +122044,7 @@
 	},
 /obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "xqE" = (
 /obj/vehicle/secway,
 /turf/simulated/floor/plasteel{
@@ -122162,7 +122162,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xsl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -122481,7 +122481,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "xva" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
@@ -122540,7 +122540,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "xvv" = (
 /obj/machinery/status_display{
 	pixel_y = 32
@@ -123186,7 +123186,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "xCj" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -123592,7 +123592,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xGk" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Transit Tube";
@@ -123610,7 +123610,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "xGB" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -123766,7 +123766,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "xIm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed,
@@ -123893,7 +123893,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "xJH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -124097,7 +124097,7 @@
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "xLB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -124154,7 +124154,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "xLY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -124179,7 +124179,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "xMf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -124234,7 +124234,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "xMC" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/machinery/door/poddoor/preopen{
@@ -124271,7 +124271,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "xNa" = (
 /obj/machinery/status_display,
 /turf/simulated/wall,
@@ -124294,7 +124294,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xNu" = (
 /obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -124376,7 +124376,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "xOs" = (
 /obj/machinery/status_display{
 	pixel_y = 32
@@ -124449,7 +124449,7 @@
 "xOM" = (
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "xOX" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Staff Room";
@@ -124665,7 +124665,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "xQz" = (
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/flora/ausbushes/brflowers,
@@ -124854,7 +124854,7 @@
 	pixel_y = 26
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "xSx" = (
 /obj/structure/closet/wardrobe/virology_white,
 /turf/simulated/floor/plasteel{
@@ -125746,13 +125746,13 @@
 	},
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "ybU" = (
 /obj/structure/grille,
 /obj/effect/decal/warning_stripes/west,
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "ybW" = (
 /obj/machinery/computer/secure_data,
 /turf/simulated/floor/wood,
@@ -126181,7 +126181,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "yga" = (
 /obj/structure/grille/broken,
 /turf/space,
@@ -126477,7 +126477,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "yjC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/bluegrid{

--- a/_maps/map_files/celestation/celestation.dmm
+++ b/_maps/map_files/celestation/celestation.dmm
@@ -88,7 +88,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "abn" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
@@ -368,7 +368,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "adt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -377,7 +377,7 @@
 	dir = 6;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "adE" = (
 /obj/structure/window/plasmareinforced{
 	dir = 4
@@ -392,7 +392,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "adF" = (
 /obj/structure/window/plasmareinforced{
 	dir = 8
@@ -412,7 +412,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "adH" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -421,7 +421,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "adJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -430,13 +430,13 @@
 	dir = 10
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "adK" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "adL" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -540,7 +540,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "afr" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "barber"
@@ -1745,7 +1745,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "aoL" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plasteel{
@@ -1856,7 +1856,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "apT" = (
 /obj/machinery/status_display{
 	pixel_y = 32
@@ -1928,7 +1928,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "aqx" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=ArrivalCentral2";
@@ -2028,7 +2028,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "arT" = (
 /obj/machinery/door/window/westleft{
 	name = "Monkey Pen";
@@ -2065,7 +2065,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "asm" = (
 /obj/structure/cable/orange,
 /obj/effect/decal/cleanable/dirt,
@@ -2230,7 +2230,7 @@
 /area/maintenance/cele/cargo)
 "atD" = (
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "atK" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -2648,7 +2648,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "awy" = (
 /obj/machinery/light{
 	dir = 1
@@ -3031,7 +3031,7 @@
 	req_access = list(70)
 	},
 /turf/simulated/openspace,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "ayU" = (
 /obj/structure/closet/crate{
 	name = "solar pack crate"
@@ -3165,7 +3165,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "aAl" = (
 /obj/machinery/blackbox_recorder,
 /turf/simulated/floor/plasteel{
@@ -3244,7 +3244,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "aBa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/corner{
@@ -3412,7 +3412,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "aCg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -3431,7 +3431,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "aCi" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -3529,7 +3529,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "aDu" = (
 /obj/item/folder/blue,
 /obj/item/megaphone,
@@ -3644,7 +3644,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "aEg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -3863,7 +3863,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "aGu" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -3953,7 +3953,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "aGY" = (
 /obj/effect/decal/warning_stripes/red/partial{
 	dir = 4
@@ -4022,7 +4022,7 @@
 	output_level = 90000
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "aHC" = (
 /obj/machinery/firealarm{
 	pixel_y = 26
@@ -4322,13 +4322,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aKf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/item/twohanded/rcl/pre_loaded,
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "aKg" = (
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
@@ -4442,7 +4442,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aLe" = (
 /obj/machinery/computer/prisoner{
 	req_access = list(2)
@@ -4540,7 +4540,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "aLN" = (
 /obj/structure/sign/fire{
 	pixel_x = 32
@@ -4928,7 +4928,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "aPA" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -5700,7 +5700,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "aVy" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -6121,7 +6121,7 @@
 "aXY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "aXZ" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteyellowcorner"
@@ -6219,7 +6219,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "aYw" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/double,
@@ -6227,7 +6227,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aYC" = (
 /turf/space/openspace,
 /area/solar/fore)
@@ -6299,7 +6299,7 @@
 	dir = 5;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aZa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/orange{
@@ -7009,7 +7009,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bdh" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -7029,7 +7029,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "bdx" = (
 /obj/effect/spawner/lootdrop/maintenance/double,
 /turf/simulated/floor/plating,
@@ -7064,7 +7064,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bdG" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -7139,7 +7139,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "bev" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7321,7 +7321,7 @@
 	dir = 1;
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bfm" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -7409,7 +7409,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bfw" = (
 /obj/machinery/conveyor{
 	id = "garbage"
@@ -7669,7 +7669,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/glass,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bhA" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
@@ -7706,7 +7706,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "bhR" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
@@ -7732,7 +7732,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bhY" = (
 /obj/item/pipe_painter,
 /obj/item/pipe_painter,
@@ -7757,7 +7757,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bib" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -7813,7 +7813,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "biI" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/metal/fifty,
@@ -7865,7 +7865,7 @@
 	dir = 5;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "biU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -8265,7 +8265,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bls" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8680,7 +8680,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bnX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
@@ -9098,7 +9098,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bqx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -9109,7 +9109,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bqz" = (
 /obj/machinery/atmospherics/trinary/filter{
 	dir = 4
@@ -9117,7 +9117,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bqA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -9148,7 +9148,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bqD" = (
 /obj/machinery/atmospherics/unary/outlet_injector/on{
 	dir = 8;
@@ -9156,7 +9156,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/space/openspace,
-/area/engine/engineering)
+/area/engineering/engine)
 "bqE" = (
 /obj/item/storage/secure/safe{
 	pixel_y = 32
@@ -9363,7 +9363,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "brZ" = (
 /obj/machinery/atmospherics/binary/valve/digital/open{
 	dir = 4
@@ -9371,7 +9371,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bsa" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
@@ -9383,7 +9383,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bsb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -9391,7 +9391,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bsc" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -9403,7 +9403,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bsg" = (
 /obj/machinery/atmospherics/binary/pump{
 	name = "O2 tank pump"
@@ -9431,7 +9431,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bsy" = (
 /obj/item/radio/intercom{
 	pixel_x = 28
@@ -9578,7 +9578,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "btt" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -9601,7 +9601,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "btA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -9637,7 +9637,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "btD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
@@ -9823,7 +9823,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "buW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -9873,7 +9873,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "buZ" = (
 /obj/machinery/door/airlock/atmos/glass{
 	autoclose = 0;
@@ -9894,7 +9894,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bvc" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 1
@@ -9902,7 +9902,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bvd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -10065,7 +10065,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bwr" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/railing{
@@ -10083,7 +10083,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bwu" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -10288,7 +10288,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bxC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -10300,7 +10300,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bxD" = (
 /obj/machinery/atmospherics/binary/valve/digital{
 	dir = 4
@@ -10314,7 +10314,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bxE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10446,33 +10446,33 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "byA" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
 	},
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "byB" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
 	},
 /obj/machinery/atmospherics/meter,
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "byD" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
 	},
 /obj/machinery/atmospherics/meter,
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "byE" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
 	},
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "byF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -10484,7 +10484,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "byH" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/orange{
@@ -10703,7 +10703,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bzA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/binary/valve/digital,
@@ -10711,12 +10711,12 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bzB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event/lightsout,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bzD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10936,7 +10936,7 @@
 "bAO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bAP" = (
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "engsm";
@@ -10948,11 +10948,11 @@
 	req_access = list(10,24)
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bAQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bAR" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -11089,7 +11089,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bBO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
@@ -11133,7 +11133,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bBR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -11172,7 +11172,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bBW" = (
 /obj/structure/spacepoddoor{
 	luminosity = 3
@@ -11196,7 +11196,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bCf" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -11267,7 +11267,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bCT" = (
 /obj/structure/table,
 /obj/machinery/kitchen_machine/microwave,
@@ -11299,7 +11299,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bDd" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -11431,7 +11431,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bDP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -11609,7 +11609,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bFd" = (
 /obj/machinery/camera/autoname,
 /turf/space,
@@ -11620,7 +11620,7 @@
 	dir = 5;
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "bFm" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -11795,7 +11795,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bGl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11936,7 +11936,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "bGP" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
@@ -11960,7 +11960,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bGS" = (
 /obj/effect/landmark/event/lightsout,
 /obj/machinery/hologram/holopad,
@@ -11971,7 +11971,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bGU" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
@@ -11999,7 +11999,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "bHh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12060,7 +12060,7 @@
 	dir = 10;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bHp" = (
 /obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/delivery,
@@ -12431,7 +12431,7 @@
 /area/atmos)
 "bJE" = (
 /turf/simulated/wall,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "bJF" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
@@ -12465,7 +12465,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/glass,
-/area/engine/break_room)
+/area/engineering/break_room)
 "bJY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12526,7 +12526,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "bKr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12604,7 +12604,7 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "bKZ" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Staff Room";
@@ -12631,7 +12631,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bLd" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
@@ -12720,7 +12720,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bLz" = (
 /obj/structure/table/reinforced,
 /obj/item/shard{
@@ -12839,7 +12839,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bLV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 5
@@ -12864,7 +12864,7 @@
 	dir = 6;
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "bMf" = (
 /obj/machinery/computer/area_atmos/area,
 /obj/machinery/light{
@@ -13096,7 +13096,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bNz" = (
 /obj/structure/railing,
 /turf/simulated/floor/carpet,
@@ -13276,14 +13276,14 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "bOy" = (
 /obj/machinery/suit_storage_unit/engine,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "bOz" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -13430,7 +13430,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bPo" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
@@ -13557,7 +13557,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bPL" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -13571,7 +13571,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bPS" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
@@ -13632,7 +13632,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bQq" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
@@ -13671,7 +13671,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bQx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -13829,7 +13829,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bRI" = (
 /obj/structure/table,
 /obj/item/twohanded/rcl,
@@ -13840,7 +13840,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bRJ" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -14170,7 +14170,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bTp" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
@@ -14288,7 +14288,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "bTN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -14408,7 +14408,7 @@
 	},
 /obj/structure/plasticflaps,
 /turf/simulated/floor/plating,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bUp" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
@@ -14439,7 +14439,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bUC" = (
 /obj/structure/table,
 /obj/machinery/fishtank/bowl{
@@ -14459,7 +14459,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "bUR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14812,7 +14812,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "bWl" = (
 /obj/machinery/chem_master/condimaster,
 /obj/machinery/camera/autoname{
@@ -15044,7 +15044,7 @@
 	dir = 10;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "bXa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -15340,7 +15340,7 @@
 	dir = 6;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bYN" = (
 /obj/machinery/newscaster{
 	pixel_x = -32
@@ -15428,7 +15428,7 @@
 /area/maintenance/fsmaint2)
 "bZv" = (
 /turf/simulated/openspace,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bZD" = (
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/locker/locker_toilet)
@@ -15681,7 +15681,7 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "cbu" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -16511,7 +16511,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "cgZ" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -17197,7 +17197,7 @@
 /area/security/main)
 "clz" = (
 /turf/simulated/floor/glass,
-/area/engine/break_room)
+/area/engineering/break_room)
 "clC" = (
 /obj/structure/chair{
 	dir = 4
@@ -17282,7 +17282,7 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "cmw" = (
 /obj/machinery/door/airlock/glass{
 	name = "Disposals";
@@ -17561,7 +17561,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "cnN" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -17653,7 +17653,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "cox" = (
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -17776,7 +17776,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "cpm" = (
 /obj/structure/railing{
 	dir = 4
@@ -18236,7 +18236,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "crS" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
@@ -18309,7 +18309,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "cso" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -18362,7 +18362,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/glass,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "csE" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin/nanotrasen,
@@ -18621,7 +18621,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "cuy" = (
 /obj/item/assembly/mousetrap/armed,
 /obj/item/stack/sheet/metal,
@@ -19134,7 +19134,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "cyo" = (
 /obj/effect/spawner/random_spawners/rock_50,
 /turf/simulated/floor/plating,
@@ -19210,7 +19210,7 @@
 "cyO" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/glass/reinforced,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cyZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -19264,7 +19264,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "czw" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -20129,7 +20129,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cGc" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/drinkingglass{
@@ -20209,7 +20209,7 @@
 	},
 /obj/item/stock_parts/cell/high,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "cHa" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -20399,7 +20399,7 @@
 	dir = 8;
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "cIk" = (
 /obj/machinery/light,
 /obj/item/radio/intercom{
@@ -20553,7 +20553,7 @@
 	dir = 9;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cJy" = (
 /obj/structure/sign/directions/floor/alt{
 	dir = 8;
@@ -21173,7 +21173,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cOd" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -21280,7 +21280,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "cOP" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -21622,7 +21622,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cQS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random_spawners/rock_50,
@@ -21739,7 +21739,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "cRH" = (
 /obj/machinery/light{
 	dir = 4
@@ -21792,7 +21792,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cSf" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil{
@@ -22099,7 +22099,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cUt" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -22563,7 +22563,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "cWL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -22618,7 +22618,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "cXa" = (
 /turf/simulated/floor/light,
 /area/teleporter/quantum/engi)
@@ -22773,7 +22773,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "cYh" = (
 /obj/machinery/photocopier/faxmachine/longrange{
 	department = "Internal Affairs Office"
@@ -22837,7 +22837,7 @@
 	name = "Engineering Emergency Lockdown"
 	},
 /turf/simulated/floor/plating,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cYC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
@@ -22954,7 +22954,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "cZV" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "Труба служит для подачу горючей смеси в турбину для её работы";
@@ -23099,7 +23099,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dbU" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -23239,7 +23239,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "ddy" = (
 /obj/item/radio/intercom{
 	pixel_x = -28
@@ -23280,7 +23280,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "ddJ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -23346,7 +23346,7 @@
 "ddP" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "ddQ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -23569,7 +23569,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "dez" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
@@ -24143,7 +24143,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dkr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -24315,7 +24315,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "dlm" = (
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -24364,7 +24364,7 @@
 	dir = 1;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "dmf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -24670,7 +24670,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "doO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -24960,14 +24960,14 @@
 	dir = 8;
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "drC" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "drE" = (
 /obj/structure/closet/wardrobe/red,
 /turf/simulated/floor/plasteel{
@@ -25043,7 +25043,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/engine,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "dtd" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -25087,7 +25087,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "dtX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -25252,7 +25252,7 @@
 "dvk" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "dvt" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -25414,7 +25414,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "dxf" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
@@ -25444,7 +25444,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "dxo" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -25491,7 +25491,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "dxH" = (
 /obj/machinery/computer/med_data/laptop,
 /obj/structure/table/glass,
@@ -25766,7 +25766,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dzf" = (
 /obj/machinery/atmospherics/binary/valve/digital,
 /obj/machinery/light/small{
@@ -25777,7 +25777,7 @@
 	network = list("SS13","Engineering")
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "dzo" = (
 /obj/machinery/light{
 	dir = 1
@@ -25861,7 +25861,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "dAg" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -26478,7 +26478,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/engine,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "dFn" = (
 /obj/structure/cable/orange{
 	icon_state = "1-8"
@@ -26620,7 +26620,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "dGp" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -26760,7 +26760,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "dIr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -26849,7 +26849,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dJq" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
@@ -26983,7 +26983,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dKj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -27292,7 +27292,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dMN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -27301,7 +27301,7 @@
 "dMO" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "dMP" = (
 /obj/structure/railing{
 	dir = 4
@@ -27365,7 +27365,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "dNs" = (
 /obj/docking_port/stationary{
 	dwidth = 8;
@@ -27410,7 +27410,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "dNS" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
@@ -27673,7 +27673,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/openspace,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "dQo" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -27784,7 +27784,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dRc" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -28206,7 +28206,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dWs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -28386,7 +28386,7 @@
 /area/assembly/chargebay)
 "dYs" = (
 /turf/simulated/wall/r_wall,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "dYy" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing/corner,
@@ -28516,7 +28516,7 @@
 /obj/structure/table,
 /obj/item/clothing/glasses/welding,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "eaf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -28613,7 +28613,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "ebx" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light/small{
@@ -28687,7 +28687,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "ecE" = (
 /obj/structure/ladder,
 /turf/simulated/floor/glass,
@@ -28835,7 +28835,7 @@
 /area/hallway/primary/central)
 "eeB" = (
 /turf/simulated/wall/r_wall,
-/area/engine/break_room)
+/area/engineering/break_room)
 "eeH" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -28853,7 +28853,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "eeI" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable/orange{
@@ -29013,10 +29013,10 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "egJ" = (
 /turf/simulated/openspace,
-/area/engine/break_room)
+/area/engineering/break_room)
 "egL" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -29029,7 +29029,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "egW" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -29094,7 +29094,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ehD" = (
 /turf/simulated/wall,
 /area/maintenance/gambling_den)
@@ -29504,7 +29504,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "eld" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating{
@@ -29615,7 +29615,7 @@
 	dir = 5;
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "ena" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -29675,7 +29675,7 @@
 "enF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/glass,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "enG" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
@@ -29961,7 +29961,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "era" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
@@ -30176,7 +30176,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "esk" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -30254,7 +30254,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "esS" = (
 /obj/effect/turf_decal/box,
 /turf/simulated/floor/plasteel{
@@ -31014,7 +31014,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "eAY" = (
 /obj/structure/lattice/catwalk,
 /turf/space/openspace,
@@ -31051,7 +31051,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "eBu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31256,7 +31256,7 @@
 	dir = 9;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "eDY" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -31523,7 +31523,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/openspace,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "eGJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor/preopen{
@@ -31616,7 +31616,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "eHS" = (
 /obj/structure/railing{
 	dir = 8
@@ -31867,7 +31867,7 @@
 /obj/structure/table,
 /obj/item/flashlight/lamp,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "eKI" = (
 /obj/structure/cable/orange{
 	icon_state = "0-4"
@@ -32116,7 +32116,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/glass,
-/area/engine/break_room)
+/area/engineering/break_room)
 "eNh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -32187,7 +32187,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "eNN" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -32198,7 +32198,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "eNS" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -32406,7 +32406,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "ePF" = (
 /obj/structure/closet/emcloset,
 /obj/item/pickaxe,
@@ -32470,7 +32470,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "eQi" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -32526,7 +32526,7 @@
 	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "eQS" = (
 /obj/machinery/light{
 	dir = 1
@@ -32588,7 +32588,7 @@
 	dir = 5;
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "eRm" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -32799,7 +32799,7 @@
 /obj/machinery/power/terminal,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/glass,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "eTo" = (
 /obj/structure/chair/sofa/corp,
 /turf/simulated/floor/carpet,
@@ -32910,7 +32910,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "eUE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -33048,7 +33048,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "eVT" = (
 /obj/machinery/computer/cryopod{
 	pixel_y = 32
@@ -33314,7 +33314,7 @@
 "eZE" = (
 /obj/structure/ladder,
 /turf/simulated/floor/glass/reinforced,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "eZH" = (
 /turf/simulated/wall/r_wall,
 /area/teleporter/quantum/docking)
@@ -33324,7 +33324,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "eZR" = (
 /mob/living/simple_animal/pet/cat/Runtime,
 /obj/structure/bed/dogbed/runtime,
@@ -33384,7 +33384,7 @@
 	dir = 9;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "faF" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -33524,7 +33524,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "fcd" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -33586,7 +33586,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "fcL" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
@@ -33961,7 +33961,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "fgL" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -34218,7 +34218,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "fjj" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -34697,7 +34697,7 @@
 	dir = 5;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "fnp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -34871,7 +34871,7 @@
 	name = "Engineering Emergency Lockdown"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "fpf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -34965,7 +34965,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "fqn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/internals,
@@ -35112,7 +35112,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "fso" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -35124,7 +35124,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "fsF" = (
 /obj/effect/landmark/start/janitor,
 /turf/simulated/floor/plasteel{
@@ -35193,7 +35193,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "fsW" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -35313,7 +35313,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "ftR" = (
 /obj/structure/stairs{
 	dir = 1
@@ -35520,7 +35520,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "fwd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -35551,7 +35551,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "fwz" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating{
@@ -35682,7 +35682,7 @@
 	dir = 6;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "fxK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -35936,7 +35936,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "fAs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36121,7 +36121,7 @@
 	},
 /obj/effect/turf_decal/box,
 /turf/simulated/floor/glass,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "fCj" = (
 /obj/item/radio/intercom{
 	pixel_y = 28
@@ -36819,7 +36819,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "fHY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -36945,7 +36945,7 @@
 /area/security/brig)
 "fIJ" = (
 /turf/simulated/wall/r_wall,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "fIO" = (
 /obj/structure/railing,
 /turf/simulated/floor/glass,
@@ -37108,7 +37108,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "fKC" = (
 /turf/simulated/mineral/ancient,
 /area/maintenance/cele/cargo)
@@ -37142,7 +37142,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "fKS" = (
 /obj/structure/holosign/barrier/atmos,
 /turf/simulated/floor/plating,
@@ -37176,7 +37176,7 @@
 "fLq" = (
 /obj/structure/sign/radiation,
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "fLv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -37304,7 +37304,7 @@
 "fMI" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "fMJ" = (
 /obj/machinery/computer/communications{
 	dir = 1
@@ -37328,7 +37328,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "fMR" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -37687,7 +37687,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "fPD" = (
 /obj/machinery/light,
 /obj/machinery/camera/autoname{
@@ -37825,7 +37825,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "fQu" = (
 /obj/structure/closet/firecloset/full,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -37836,7 +37836,7 @@
 /area/toxins/mixing)
 "fQF" = (
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/engineering)
+/area/engineering/engine)
 "fQI" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Holodeck Door"
@@ -37932,7 +37932,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/glass,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "fRw" = (
 /obj/item/reagent_containers/glass/bottle/nutrient/ez,
 /obj/item/reagent_containers/spray/pestspray,
@@ -38028,7 +38028,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "fSi" = (
 /obj/effect/decal/warning_stripes/west{
 	icon = 'icons/turf/floors.dmi';
@@ -38169,7 +38169,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "fTO" = (
 /obj/structure/toilet{
 	dir = 4
@@ -38199,7 +38199,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "fTT" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
@@ -38387,7 +38387,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "fVz" = (
 /obj/structure/railing,
 /turf/simulated/floor/glass,
@@ -38473,7 +38473,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "fWu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -38866,7 +38866,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "fZG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -39026,7 +39026,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "gbT" = (
 /obj/machinery/light,
 /obj/machinery/camera/autoname{
@@ -39253,7 +39253,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "ged" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -39277,7 +39277,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "geB" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/machinery/door/poddoor/preopen{
@@ -39298,7 +39298,7 @@
 	id_tag = "ceoffice"
 	},
 /turf/simulated/floor/plating,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "geH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -39523,7 +39523,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "ggt" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
@@ -39689,7 +39689,7 @@
 	output_level = 90000
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "gic" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -39933,7 +39933,7 @@
 "gka" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "gkb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40002,7 +40002,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "gkB" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -40149,7 +40149,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "glG" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -40240,7 +40240,7 @@
 	output_level = 190000
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "gmP" = (
 /obj/item/radio/intercom{
 	pixel_y = 28
@@ -40298,7 +40298,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "gnz" = (
 /obj/item/flashlight/pen{
 	pixel_x = 2;
@@ -40577,7 +40577,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "gqD" = (
 /obj/effect/spawner/random_spawners/rock_50,
 /turf/simulated/floor/plating{
@@ -40626,7 +40626,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "grm" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -41472,7 +41472,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "gyz" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -41797,7 +41797,7 @@
 	},
 /obj/effect/turf_decal/box,
 /turf/simulated/floor/glass,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "gBF" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -42054,7 +42054,7 @@
 	dir = 6;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "gEW" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -42176,7 +42176,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "gGf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -42214,7 +42214,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "gGM" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -42269,7 +42269,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "gHh" = (
 /obj/structure/bedsheetbin,
 /obj/structure/table/wood,
@@ -42318,7 +42318,7 @@
 	dir = 5;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "gHL" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -42359,7 +42359,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "gHY" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -42495,7 +42495,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "gJj" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -42540,7 +42540,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "gJD" = (
 /turf/simulated/openspace,
 /area/maintenance/ai)
@@ -42601,7 +42601,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "gKl" = (
 /obj/item/radio/intercom{
 	pixel_x = -28
@@ -42697,7 +42697,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "gKY" = (
 /turf/simulated/wall/r_wall,
 /area/turret_protected/aisat)
@@ -42873,7 +42873,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "gMC" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -43285,7 +43285,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "gQj" = (
 /obj/structure/cable/orange{
 	icon_state = "2-8"
@@ -43304,7 +43304,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "gQp" = (
 /obj/structure/table/reinforced,
 /obj/item/mmi,
@@ -43498,7 +43498,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "gSb" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -43546,7 +43546,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "gTi" = (
 /obj/structure/sign/directions/floor/alt{
 	dir = 6;
@@ -43595,7 +43595,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "gUv" = (
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint3)
@@ -43670,7 +43670,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "gVk" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -44281,7 +44281,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "hbg" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/primary/starboard/south)
@@ -44527,7 +44527,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "hdP" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -44700,7 +44700,7 @@
 /area/toxins/explab_chamber)
 "hfI" = (
 /turf/simulated/floor/glass/reinforced,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "hfP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -44951,7 +44951,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/glass,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "hit" = (
 /obj/item/honey_frame,
 /obj/item/honey_frame,
@@ -44986,7 +44986,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "hiD" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
@@ -45471,7 +45471,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "hmB" = (
 /obj/machinery/alarm{
 	pixel_y = 26
@@ -45531,7 +45531,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "hnj" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -45556,7 +45556,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "hns" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
@@ -45572,7 +45572,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "hnu" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -45864,7 +45864,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "hqA" = (
 /obj/item/radio/intercom{
 	pixel_y = 28
@@ -46052,7 +46052,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "hsg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
@@ -46431,7 +46431,7 @@
 	dir = 9;
 	icon_state = "whiteyellow"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "hwm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -46795,7 +46795,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "hzs" = (
 /obj/machinery/gateway{
 	density = 0
@@ -46835,7 +46835,7 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "hzJ" = (
 /obj/effect/spawner/random_spawners/rock_50,
 /turf/simulated/floor/plating,
@@ -47127,7 +47127,7 @@
 	name = "Supermatter Blast Doors"
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "hCG" = (
 /obj/machinery/atmospherics/air_sensor{
 	id_tag = "n2_sensor"
@@ -47693,7 +47693,7 @@
 	dir = 10;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "hJa" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -47767,7 +47767,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "hKa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -47863,7 +47863,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "hKW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -48168,7 +48168,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "hNU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -48392,7 +48392,7 @@
 	dir = 6;
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "hQy" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
@@ -48921,7 +48921,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "hVl" = (
 /obj/structure/stairs{
 	dir = 1
@@ -49420,7 +49420,7 @@
 /area/construction/hallway)
 "ibK" = (
 /turf/simulated/wall/r_wall,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "ibV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
@@ -49596,7 +49596,7 @@
 /area/clownoffice/secret)
 "iex" = (
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "iey" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -49649,7 +49649,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "ieT" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -49760,7 +49760,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "igu" = (
 /obj/machinery/reagentgrinder,
 /obj/item/wrench,
@@ -49842,7 +49842,7 @@
 	pixel_y = -3
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "ihZ" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable,
@@ -50000,7 +50000,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/noslip,
-/area/engine/engineering)
+/area/engineering/engine)
 "ijD" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -50061,7 +50061,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "ikk" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -50217,7 +50217,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "ilD" = (
 /obj/structure/cable/orange,
 /obj/structure/cable/multiz{
@@ -50312,7 +50312,7 @@
 	dir = 9;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "imt" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -50484,7 +50484,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "ino" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -50494,7 +50494,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "inq" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/simulated/floor/plating,
@@ -50668,7 +50668,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ioT" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
@@ -50762,7 +50762,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "iqc" = (
 /obj/machinery/door/airlock/mining{
 	name = "Cargo Warehouse";
@@ -50793,7 +50793,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/glass,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "iqh" = (
 /obj/structure/table,
 /obj/machinery/alarm{
@@ -50805,7 +50805,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "iqk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -51140,7 +51140,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "isL" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
@@ -51318,7 +51318,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "itT" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -51389,7 +51389,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "iuy" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
@@ -51669,7 +51669,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ixu" = (
 /obj/machinery/firealarm{
 	pixel_y = 26
@@ -51776,7 +51776,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "iyR" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -51912,7 +51912,7 @@
 	dir = 10;
 	icon_state = "whiteyellow"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "iAx" = (
 /obj/machinery/door_control{
 	id = "secmaintdorm2";
@@ -52159,7 +52159,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/glass,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "iCT" = (
 /obj/structure/sign/fire{
 	pixel_y = -32
@@ -52178,7 +52178,7 @@
 	dir = 9;
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "iDh" = (
 /obj/machinery/access_button{
 	command = "cycle_exterior";
@@ -52191,7 +52191,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "iDl" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass,
@@ -52437,7 +52437,7 @@
 	req_access = list(10,11)
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "iEW" = (
 /obj/machinery/smartfridge,
 /turf/simulated/floor/plasteel{
@@ -52539,7 +52539,7 @@
 "iGA" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "iGF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
@@ -52850,7 +52850,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/glass,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "iJB" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -53038,7 +53038,7 @@
 "iLV" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall,
-/area/engine/break_room)
+/area/engineering/break_room)
 "iLY" = (
 /obj/structure/chair/sofa/left{
 	dir = 1
@@ -53276,7 +53276,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "iOd" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -53321,7 +53321,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "iOy" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -53406,7 +53406,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "iPq" = (
 /obj/structure/sign/directions/floor/alt{
 	dir = 6;
@@ -53466,7 +53466,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "iPH" = (
 /turf/simulated/mineral/ancient,
 /area/maintenance/fore)
@@ -53574,7 +53574,7 @@
 /obj/structure/cable/orange,
 /obj/effect/turf_decal/box,
 /turf/simulated/floor/glass,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "iQn" = (
 /obj/machinery/vending/security,
 /obj/machinery/camera/autoname{
@@ -53604,7 +53604,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "iQQ" = (
 /obj/structure/table/glass,
 /obj/item/folder/white,
@@ -53692,7 +53692,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "iRO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -53929,7 +53929,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "iTR" = (
 /obj/structure/chair/sofa/corp{
 	dir = 1
@@ -54458,7 +54458,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "iYA" = (
 /turf/simulated/floor/light{
 	icon_state = "light_on-w"
@@ -54478,7 +54478,7 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "iYX" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/machinery/light{
@@ -54719,13 +54719,13 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "jbi" = (
 /obj/structure/railing{
 	dir = 4
 	},
 /turf/simulated/floor/glass,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "jbk" = (
 /turf/simulated/floor/grass,
 /area/hydroponics)
@@ -55052,7 +55052,7 @@
 	dir = 5;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "jef" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
@@ -55067,7 +55067,7 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/orange,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "jeq" = (
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel{
@@ -55171,7 +55171,7 @@
 	dir = 10;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "jfo" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -55244,7 +55244,7 @@
 /obj/machinery/hologram/holopad,
 /obj/effect/landmark/event/lightsout,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "jfT" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -55653,7 +55653,7 @@
 	dir = 4;
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "jjZ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -55661,7 +55661,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "jke" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/toxins,
@@ -55784,7 +55784,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "jkW" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -55930,7 +55930,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "jnc" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -56055,7 +56055,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "jok" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -56130,7 +56130,7 @@
 /area/security/prisonlockers)
 "jpb" = (
 /turf/simulated/floor/plasteel,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "jpc" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -56188,7 +56188,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "jpE" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
@@ -56211,7 +56211,7 @@
 "jpU" = (
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/engine,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "jqh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
@@ -56296,7 +56296,7 @@
 /area/hallway/secondary/entry/south)
 "jra" = (
 /turf/simulated/wall/r_wall,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "jrf" = (
 /obj/structure/railing{
 	dir = 8
@@ -56309,7 +56309,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/glass,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "jrw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -56317,7 +56317,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "jrC" = (
 /obj/structure/bed/dogbed,
 /mob/living/simple_animal/pet/dog/security/warden,
@@ -56514,7 +56514,7 @@
 	dir = 6;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "jsK" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -56558,7 +56558,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "jtn" = (
 /obj/item/flag/sec,
 /turf/simulated/floor/plasteel{
@@ -56797,7 +56797,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "jvI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
@@ -56957,7 +56957,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "jwN" = (
 /obj/structure/table/wood,
 /obj/item/newspaper,
@@ -57008,7 +57008,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "jxF" = (
 /obj/effect/spawner/random_spawners/rock_50,
 /turf/simulated/floor/plating,
@@ -57042,7 +57042,7 @@
 	dir = 4;
 	icon_state = "whiteyellow"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "jyf" = (
 /obj/machinery/computer/sm_monitor,
 /obj/machinery/status_display{
@@ -57052,7 +57052,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "jyg" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
@@ -57110,7 +57110,7 @@
 	dir = 9;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "jyO" = (
 /obj/structure/railing{
 	dir = 1
@@ -57420,7 +57420,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "jCc" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
@@ -57835,7 +57835,7 @@
 	dir = 6;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "jHl" = (
 /obj/structure/chair/comfy/green{
 	dir = 4
@@ -57896,7 +57896,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "jHB" = (
 /obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor/plasteel,
@@ -58546,7 +58546,7 @@
 "jOa" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "jOi" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
@@ -58626,7 +58626,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "jPa" = (
 /obj/structure/grille,
 /obj/structure/cable/orange{
@@ -58827,7 +58827,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "jRu" = (
 /obj/effect/decal/warning_stripes/blue,
 /turf/simulated/floor/plasteel{
@@ -59150,7 +59150,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "jUZ" = (
 /turf/simulated/wall,
 /area/hallway/primary/starboard/south)
@@ -59220,7 +59220,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "jVQ" = (
 /obj/structure/table/glass,
 /obj/item/soap/nanotrasen,
@@ -59417,7 +59417,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "jXV" = (
 /obj/machinery/status_display{
 	pixel_x = -32
@@ -59527,7 +59527,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "jZs" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -59601,7 +59601,7 @@
 "kam" = (
 /obj/machinery/atmospherics/binary/valve/digital/open,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "kao" = (
 /obj/item/radio/intercom{
 	pixel_x = -28
@@ -59633,7 +59633,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "kaL" = (
 /obj/structure/closet/wardrobe/virology_white,
 /obj/item/soap,
@@ -59781,7 +59781,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "kcy" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -59808,7 +59808,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "kcJ" = (
 /obj/effect/decal/warning_stripes/blue,
 /obj/effect/turf_decal/stripes/end{
@@ -60035,7 +60035,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "kfe" = (
 /obj/machinery/gateway{
 	dir = 1
@@ -60476,7 +60476,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "kio" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -60868,7 +60868,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "klS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -60901,7 +60901,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "kmm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -60945,7 +60945,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "kmB" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
@@ -60960,7 +60960,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "kmC" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "Труба служит для подачу горючей смеси в турбину для её работы";
@@ -61035,7 +61035,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "knk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -61459,7 +61459,7 @@
 	id_tag = "ceoffice"
 	},
 /turf/simulated/floor/plating,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "ksj" = (
 /obj/machinery/light{
 	dir = 1
@@ -61575,7 +61575,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ktf" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -61955,7 +61955,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "kwB" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -62161,7 +62161,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "kyz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -62233,7 +62233,7 @@
 	},
 /obj/item/stock_parts/cell/high,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "kzB" = (
 /turf/simulated/wall,
 /area/maintenance/brig)
@@ -62776,7 +62776,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "kDV" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -62934,7 +62934,7 @@
 "kFk" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "kFL" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -62947,7 +62947,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "kFX" = (
 /obj/structure/railing,
 /obj/structure/morgue,
@@ -63346,10 +63346,10 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "kJX" = (
 /turf/simulated/wall/r_wall/rust,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "kKe" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -63397,7 +63397,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "kLc" = (
 /obj/structure/chair/sofa/pew/left{
 	dir = 8
@@ -63586,7 +63586,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "kMN" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -63724,7 +63724,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "kOF" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -63736,7 +63736,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "kOI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
@@ -63827,7 +63827,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "kPI" = (
 /obj/structure/cable/orange{
 	icon_state = "0-2"
@@ -63843,7 +63843,7 @@
 	output_level = 90000
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "kQa" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -63980,7 +63980,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "kQU" = (
 /obj/machinery/status_display{
 	pixel_y = -32
@@ -64049,7 +64049,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "kRx" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Science Asteroid Maintenance";
@@ -64564,7 +64564,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "kXq" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -64725,7 +64725,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "kYw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -64852,7 +64852,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "kZz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -65033,7 +65033,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/glass,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "laV" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -65369,7 +65369,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "leO" = (
 /turf/simulated/floor/plasteel,
 /area/security/prison/cell_block/A)
@@ -65578,7 +65578,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "lgT" = (
 /obj/item/radio/intercom{
 	pixel_x = -28
@@ -65712,7 +65712,7 @@
 "lip" = (
 /obj/structure/reflector/double,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "lir" = (
 /obj/structure/window/reinforced{
 	color = "red";
@@ -65948,7 +65948,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "lkr" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/spray/cleaner/medical,
@@ -66011,7 +66011,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "lls" = (
 /obj/structure/cable/orange,
 /obj/machinery/power/apc{
@@ -66085,7 +66085,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "lmc" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/quantumpad/cere/comand_servise,
@@ -66194,7 +66194,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "lnp" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass,
@@ -66553,7 +66553,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "lse" = (
 /obj/machinery/r_n_d/experimentor,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -66680,7 +66680,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "ltg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -66786,7 +66786,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "lus" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -66808,7 +66808,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "luV" = (
 /obj/machinery/door/window{
 	dir = 2;
@@ -66956,7 +66956,7 @@
 	},
 /obj/structure/cable/orange,
 /turf/simulated/floor/glass/reinforced,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "lwr" = (
 /obj/machinery/vending/assist,
 /turf/simulated/floor/plasteel{
@@ -67031,7 +67031,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "lwP" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -67226,7 +67226,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "lyT" = (
 /obj/structure/table/glass,
 /obj/item/book/manual/medical_cloning,
@@ -67338,7 +67338,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "lAl" = (
 /obj/machinery/light_switch{
 	pixel_x = 26
@@ -67428,7 +67428,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "lBi" = (
 /obj/structure/sink{
 	dir = 4;
@@ -67479,7 +67479,7 @@
 /area/hallway/primary/central)
 "lBC" = (
 /turf/simulated/openspace,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "lBD" = (
 /obj/machinery/button/windowtint{
 	id = "CargoCR";
@@ -67656,7 +67656,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "lDu" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -67676,7 +67676,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "lDA" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -67988,7 +67988,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "lGZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -68029,7 +68029,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "lHm" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -68037,7 +68037,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "lHo" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/cheesiehonkers,
@@ -68154,7 +68154,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "lIz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -68187,7 +68187,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "lIN" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -68523,7 +68523,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "lMG" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -68536,7 +68536,7 @@
 	dir = 6;
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "lMN" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -68679,7 +68679,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "lOg" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -69061,7 +69061,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "lSA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -69364,7 +69364,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "lVC" = (
 /obj/structure/table,
 /obj/machinery/vending/wallmed{
@@ -69674,7 +69674,7 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "lYF" = (
 /obj/machinery/atmospherics/pipe/multiz{
 	dir = 1
@@ -69822,7 +69822,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "mac" = (
 /obj/structure/stairs{
 	dir = 8
@@ -69944,7 +69944,7 @@
 	dir = 5;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "maX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -70095,11 +70095,11 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "mcC" = (
 /obj/machinery/power/supermatter_shard/crystal,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "mcI" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
@@ -70329,7 +70329,7 @@
 "meC" = (
 /obj/item/tank/internals/plasma,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "meD" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
@@ -70691,7 +70691,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "miy" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -70810,7 +70810,7 @@
 	req_access = list(19,23)
 	},
 /turf/simulated/floor/glass,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "mjS" = (
 /obj/machinery/light{
 	dir = 8
@@ -71094,7 +71094,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/carpet/orange,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "mms" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -71261,7 +71261,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "moz" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -71394,7 +71394,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "mpZ" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/simulated/floor/plating,
@@ -71634,7 +71634,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "mtc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -71654,7 +71654,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "mtu" = (
 /turf/simulated/wall/r_wall,
 /area/security/processing)
@@ -72123,7 +72123,7 @@
 	},
 /obj/structure/table,
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "mxX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -72281,7 +72281,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "mzs" = (
 /obj/machinery/light{
 	dir = 4
@@ -72487,7 +72487,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "mBy" = (
 /obj/structure/railing,
 /obj/structure/table,
@@ -72498,7 +72498,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "mBA" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -72567,7 +72567,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "mBW" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -72601,10 +72601,10 @@
 "mCq" = (
 /obj/machinery/power/emitter,
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/engineering)
+/area/engineering/engine)
 "mCv" = (
 /turf/simulated/wall/r_wall,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "mCx" = (
 /obj/machinery/camera{
 	c_tag = "Brig Cell 8";
@@ -72747,7 +72747,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "mDI" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/orange{
@@ -72794,7 +72794,7 @@
 	dir = 8;
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "mEd" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -72812,7 +72812,7 @@
 /obj/effect/turf_decal/bot/left,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "mEo" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/multiz{
@@ -73045,7 +73045,7 @@
 "mFA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "mFL" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
@@ -73243,7 +73243,7 @@
 	},
 /obj/machinery/camera/autoname,
 /turf/simulated/floor/glass,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "mHm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10
@@ -73258,7 +73258,7 @@
 	dir = 10;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "mHt" = (
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating/asteroid,
@@ -73313,7 +73313,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "mHP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating{
@@ -73653,7 +73653,7 @@
 /area/maintenance/asmaint2)
 "mLS" = (
 /turf/simulated/openspace,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "mLU" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -73758,7 +73758,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "mMs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -73830,7 +73830,7 @@
 	dir = 9;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "mNn" = (
 /turf/simulated/wall/r_wall,
 /area/lawoffice)
@@ -73845,7 +73845,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "mNv" = (
 /obj/machinery/requests_console{
 	department = "Arrival Shuttle";
@@ -73954,7 +73954,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "mOf" = (
 /obj/machinery/camera{
 	c_tag = "Hangar South";
@@ -73967,7 +73967,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "mOm" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -74384,7 +74384,7 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "mTj" = (
 /obj/structure/railing,
 /obj/machinery/door/firedoor/border_only,
@@ -74392,7 +74392,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "mTw" = (
 /obj/structure/bookcase{
 	name = "Forbidden Knowledge"
@@ -74421,7 +74421,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "mTJ" = (
 /obj/effect/spawner/random_spawners/rock_50,
 /turf/simulated/floor/plating,
@@ -74528,7 +74528,7 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/multitool,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "mVL" = (
 /turf/simulated/wall,
 /area/medical/virology/lab)
@@ -74648,7 +74648,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "mWR" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -74672,7 +74672,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "mXi" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -74713,13 +74713,13 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "mXC" = (
 /obj/structure/railing/corner,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "mXL" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "Труба служит для подачу горючей смеси в турбину для её работы";
@@ -74750,7 +74750,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "mYo" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "navybluealt"
@@ -74882,7 +74882,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "mZH" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "laborcamp_home";
@@ -74923,7 +74923,7 @@
 "mZZ" = (
 /obj/machinery/computer/station_alert,
 /turf/simulated/floor/glass/reinforced,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "nab" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -74959,11 +74959,11 @@
 	dir = 9;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "naB" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/glass,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "naC" = (
 /obj/structure/morgue,
 /obj/machinery/light/small{
@@ -75198,7 +75198,7 @@
 	network = list("Engineering","SS13")
 	},
 /turf/simulated/openspace,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "ndo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -75355,7 +75355,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "neP" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -75402,7 +75402,7 @@
 	dir = 8;
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "nfb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -75440,7 +75440,7 @@
 	department = "Chief Engineer's Office"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "nfC" = (
 /obj/structure/table/wood,
 /obj/machinery/camera{
@@ -75523,7 +75523,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "ngn" = (
 /obj/structure/grille/broken,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -75740,7 +75740,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "nhF" = (
 /obj/structure/sign/electricshock{
 	pixel_x = 32
@@ -75749,7 +75749,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "nhG" = (
 /obj/structure/railing,
 /turf/simulated/floor/plasteel{
@@ -75857,7 +75857,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "niG" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/plating,
@@ -76486,7 +76486,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "nqj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -76658,7 +76658,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "nrt" = (
 /obj/effect/turf_decal/number/number_6{
 	dir = 8
@@ -76666,7 +76666,7 @@
 /obj/effect/turf_decal/number/number_7,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "nrx" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -76715,7 +76715,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "nsf" = (
 /obj/structure/chair,
 /obj/structure/disposalpipe/segment{
@@ -76874,11 +76874,11 @@
 /area/security/prison/cell_block/A)
 "ntF" = (
 /turf/simulated/openspace,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "ntG" = (
 /obj/structure/cable/orange,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "ntJ" = (
 /obj/machinery/camera/autoname,
 /obj/machinery/light{
@@ -76965,7 +76965,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "nuc" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -76986,7 +76986,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "nuh" = (
 /turf/simulated/floor/engine,
 /area/toxins/explab_chamber)
@@ -77728,7 +77728,7 @@
 	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/wall,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "nBA" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -77902,7 +77902,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "nDC" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -78093,7 +78093,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "nGh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -78381,7 +78381,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/glass,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "nJh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating{
@@ -78437,7 +78437,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "nJP" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -78511,7 +78511,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "nKt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/window/reinforced{
@@ -78945,7 +78945,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "nOY" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -78969,7 +78969,7 @@
 "nPw" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "nPC" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -79073,7 +79073,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "nQU" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -79093,7 +79093,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "nRd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -79268,7 +79268,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "nTZ" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -79865,7 +79865,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteyellow"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "nZx" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4;
@@ -80031,7 +80031,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/orange,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "obg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -80184,7 +80184,7 @@
 	amount = 5
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "ocr" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -80197,7 +80197,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "ocA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -80375,7 +80375,7 @@
 /area/mimeoffice)
 "oeu" = (
 /turf/simulated/floor/glass,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "oev" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "navyblue"
@@ -80401,7 +80401,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "oeM" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Library"
@@ -80443,7 +80443,7 @@
 	name = "Engineering Emergency Lockdown"
 	},
 /turf/simulated/floor/plating,
-/area/engine/break_room)
+/area/engineering/break_room)
 "ofx" = (
 /turf/simulated/floor/glass,
 /area/hallway/primary/starboard/south)
@@ -80653,7 +80653,7 @@
 	dir = 1;
 	icon_state = "whiteyellow"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "oic" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
@@ -80768,7 +80768,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "ojn" = (
 /obj/structure/sink{
 	dir = 4;
@@ -81062,7 +81062,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "oni" = (
 /obj/machinery/suit_storage_unit/cmo{
 	name = "chief medical officer's suit storage unit"
@@ -81463,7 +81463,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "orZ" = (
 /turf/simulated/openspace,
 /area/quartermaster/storage)
@@ -81575,7 +81575,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "otY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -82003,7 +82003,7 @@
 	dir = 6;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "oxN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -82727,7 +82727,7 @@
 	req_access = list(10)
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/engineering)
+/area/engineering/engine)
 "oEr" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
@@ -83023,7 +83023,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "oGU" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -83182,7 +83182,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/openspace,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "oIs" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -83533,7 +83533,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "oLG" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -83651,7 +83651,7 @@
 	id_tag = "mechanicgate"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "oMD" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -83771,7 +83771,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "oNQ" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -83977,7 +83977,7 @@
 "oPJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "oPK" = (
 /obj/structure/closet/masks,
 /obj/structure/window/basic{
@@ -84091,7 +84091,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "oRf" = (
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard_medi";
@@ -84285,7 +84285,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "oSw" = (
 /obj/structure/flora/grass/jungle,
 /turf/simulated/floor/grass,
@@ -84391,7 +84391,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "oTP" = (
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "XenoPod5";
@@ -84407,7 +84407,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "oTW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -84501,7 +84501,7 @@
 /obj/effect/turf_decal/bot/right,
 /obj/machinery/portable_atmospherics/canister,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "oUO" = (
 /obj/machinery/light{
 	dir = 8
@@ -84742,7 +84742,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "oXc" = (
 /turf/simulated/wall,
 /area/crew_quarters/cabin1)
@@ -84808,7 +84808,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "oXn" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -84820,7 +84820,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "oXr" = (
 /obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor/plasteel{
@@ -84921,7 +84921,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/glass,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "oYe" = (
 /obj/machinery/camera{
 	c_tag = "Medbay South";
@@ -85393,7 +85393,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "pbt" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -85670,7 +85670,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "pee" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/gloves{
@@ -85788,7 +85788,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "pfm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -85852,7 +85852,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/engineering)
+/area/engineering/engine)
 "pfR" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/simulated/floor/grass,
@@ -86311,7 +86311,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/engineering)
+/area/engineering/engine)
 "pkV" = (
 /obj/structure/cable/orange{
 	icon_state = "2-8"
@@ -86917,7 +86917,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "pqg" = (
 /obj/structure/table/glass,
 /obj/item/grenade/chem_grenade,
@@ -87076,7 +87076,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "prq" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
@@ -87100,7 +87100,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "prx" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -87229,7 +87229,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "psl" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -87247,7 +87247,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "psu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -87391,7 +87391,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "ptn" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -87421,7 +87421,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ptz" = (
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard";
@@ -87581,7 +87581,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "pvS" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Laser Room";
@@ -87594,7 +87594,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "pvV" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
@@ -87978,7 +87978,7 @@
 	dir = 6;
 	icon_state = "whiteyellow"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "pzi" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -88152,7 +88152,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "pBp" = (
 /turf/simulated/floor/plasteel,
 /area/security/lobby)
@@ -88238,7 +88238,7 @@
 "pCi" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/carpet/orange,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "pCr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -88390,7 +88390,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "pEj" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -88999,7 +88999,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "pJE" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
@@ -89241,7 +89241,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "pLG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -89283,7 +89283,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "pMa" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -89703,7 +89703,7 @@
 	dir = 1;
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "pQu" = (
 /obj/structure/closet/secure_closet/security,
 /obj/item/spacepod_equipment/key{
@@ -89750,10 +89750,10 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "pQE" = (
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "pQQ" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -89907,7 +89907,7 @@
 	id_tag = "hangar_enterior"
 	},
 /turf/simulated/openspace,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "pSN" = (
 /obj/structure/closet/secure_closet/reagents,
 /turf/simulated/floor/plating,
@@ -89973,7 +89973,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "pTS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -89984,7 +89984,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "pTV" = (
 /obj/structure/sign/directions/floor/alt{
 	dir = 6;
@@ -90030,7 +90030,7 @@
 /obj/structure/railing/corner,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/glass,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "pUE" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/grass,
@@ -90269,7 +90269,7 @@
 /area/janitor)
 "pXa" = (
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "pXe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -90531,7 +90531,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "pZc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -90853,7 +90853,7 @@
 	dir = 8;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "qdi" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -90864,7 +90864,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "qdk" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Oxygen Tank";
@@ -90898,7 +90898,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "qdE" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowcorner"
@@ -91219,7 +91219,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "qgH" = (
 /turf/simulated/wall,
 /area/atmos)
@@ -91432,7 +91432,7 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/carpet/orange,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "qjd" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -91537,7 +91537,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "qjz" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -91616,7 +91616,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "qks" = (
 /obj/item/storage/belt/champion/wrestling/true,
 /obj/item/stack/sheet/mineral/gold{
@@ -91673,7 +91673,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "qlb" = (
 /obj/structure/sign/directions/floor/alt{
 	dir = 8;
@@ -91921,7 +91921,7 @@
 /area/hallway/secondary/entry/north)
 "qnz" = (
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "qnM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -91946,7 +91946,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "qop" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -92283,7 +92283,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "qrx" = (
 /obj/structure/showcase{
 	desc = "Something very old and dusty."
@@ -92436,11 +92436,11 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "qth" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/glass/reinforced,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qti" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -92817,7 +92817,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "qwZ" = (
 /obj/structure/table/wood,
 /obj/item/folder/yellow{
@@ -92947,7 +92947,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "qxO" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
@@ -93156,7 +93156,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/glass,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "qAf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -93188,7 +93188,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qAG" = (
 /turf/simulated/wall/r_wall,
 /area/storage/secure)
@@ -93423,7 +93423,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "qDO" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -93712,7 +93712,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "qGl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -93791,7 +93791,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "qHd" = (
 /turf/simulated/floor/carpet,
 /area/lawoffice)
@@ -94502,7 +94502,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "qPK" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -94617,7 +94617,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "qQx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -94829,7 +94829,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "qSs" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Cryo Room";
@@ -94873,7 +94873,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "qSO" = (
 /obj/structure/table_frame/wood,
 /turf/simulated/floor/wood/fancy/oak{
@@ -95002,7 +95002,7 @@
 	dir = 4;
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "qUu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -95093,7 +95093,7 @@
 	dir = 8;
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "qVR" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -95123,7 +95123,7 @@
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "qWI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/stairs{
@@ -95143,7 +95143,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "qWR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -95247,7 +95247,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "qXZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -95433,7 +95433,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "rad" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment{
@@ -95474,7 +95474,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "rao" = (
 /obj/item/assembly/mousetrap/armed,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -95503,7 +95503,7 @@
 	dir = 4;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "rat" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -95630,7 +95630,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "rbR" = (
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Secure Gate";
@@ -95698,7 +95698,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "rcM" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -95748,7 +95748,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "rdp" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -95898,7 +95898,7 @@
 	dir = 6;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "ren" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -95948,7 +95948,7 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "ret" = (
 /obj/machinery/vending/boozeomat,
 /turf/simulated/floor/plating,
@@ -95974,7 +95974,7 @@
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "reY" = (
 /obj/machinery/atmospherics/trinary/filter{
 	dir = 8;
@@ -95989,7 +95989,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "reZ" = (
 /obj/machinery/washing_machine,
 /turf/simulated/floor/wood/fancy/oak,
@@ -96017,7 +96017,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "rfi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -96141,7 +96141,7 @@
 /area/maintenance/starboard2)
 "rgJ" = (
 /turf/simulated/floor/carpet/orange,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "rgK" = (
 /obj/machinery/light{
 	dir = 8
@@ -96615,7 +96615,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "rlU" = (
 /obj/structure/sign/restroom{
 	pixel_x = 32
@@ -96633,7 +96633,7 @@
 	dir = 10;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "rmc" = (
 /turf/simulated/wall/r_wall,
 /area/medical/morgue)
@@ -96669,7 +96669,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "rmn" = (
 /obj/machinery/light_switch{
 	pixel_y = 26
@@ -96730,7 +96730,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "rmR" = (
 /obj/structure/table/glass,
 /obj/item/clothing/gloves/color/latex,
@@ -96768,7 +96768,7 @@
 /area/crew_quarters/fitness)
 "rng" = (
 /turf/simulated/openspace,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "rnr" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -96852,7 +96852,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "rod" = (
 /obj/structure/chair{
 	dir = 1
@@ -96947,7 +96947,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "roJ" = (
 /turf/simulated/floor/carpet/green,
 /area/library/game_zone)
@@ -97127,7 +97127,7 @@
 	shock_proof = 1
 	},
 /turf/simulated/floor/glass,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "rqm" = (
 /turf/simulated/floor/plasteel/white,
 /area/assembly/chargebay)
@@ -97244,7 +97244,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "rrz" = (
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard_medi";
@@ -97510,7 +97510,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "rtP" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -97648,7 +97648,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ruW" = (
 /obj/machinery/alarm{
 	pixel_y = 26
@@ -97848,7 +97848,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "rwO" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -98101,7 +98101,7 @@
 	dir = 10;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "rzZ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/rd,
@@ -98133,7 +98133,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "rAu" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -98210,7 +98210,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "rAL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -98292,7 +98292,7 @@
 /area/turret_protected/aisat)
 "rBw" = (
 /turf/simulated/wall/r_wall,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "rBz" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/tripple,
@@ -98641,7 +98641,7 @@
 "rEP" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "rEQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -98719,7 +98719,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "rFU" = (
 /obj/machinery/camera/autoname,
 /obj/machinery/firealarm{
@@ -98800,7 +98800,7 @@
 /obj/machinery/power/terminal,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/glass,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "rGZ" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -99060,7 +99060,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "rJZ" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -99084,7 +99084,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "rKr" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -99208,7 +99208,7 @@
 	pixel_x = 26
 	},
 /turf/simulated/floor/carpet/orange,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "rMg" = (
 /obj/effect/spawner/random_spawners/rock_50,
 /turf/simulated/floor/plating/asteroid,
@@ -99673,7 +99673,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "rQo" = (
 /obj/effect/spawner/random_spawners/rock_50,
 /turf/simulated/floor/plating,
@@ -99877,7 +99877,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "rSJ" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -99903,7 +99903,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "rSN" = (
 /obj/structure/table/wood,
 /obj/machinery/bottler{
@@ -99943,7 +99943,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "rSY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -100055,7 +100055,7 @@
 	output_level = 90000
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "rTS" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -100079,7 +100079,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "rTY" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -100202,7 +100202,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "rVj" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -100211,7 +100211,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "rVk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -100232,7 +100232,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "rVu" = (
 /obj/machinery/alarm{
 	pixel_y = 26
@@ -101379,7 +101379,7 @@
 "shp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "shv" = (
 /obj/structure/cable/orange{
 	icon_state = "0-8"
@@ -101487,7 +101487,7 @@
 /obj/effect/turf_decal/number/number_9,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "sjj" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass,
@@ -101828,7 +101828,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "smz" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -102171,7 +102171,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "sqB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -102270,7 +102270,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "srP" = (
 /obj/machinery/atmospherics/trinary/filter{
 	desc = "Отфильтровывает кислород из трубы и отправляет его в камеру хранения";
@@ -102387,7 +102387,7 @@
 "ssW" = (
 /obj/structure/reflector/double,
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/engineering)
+/area/engineering/engine)
 "ssZ" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating{
@@ -102475,7 +102475,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "stD" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -102905,7 +102905,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "syk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -103201,7 +103201,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "sAt" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -103293,7 +103293,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "sBL" = (
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
@@ -103358,7 +103358,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "sCp" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -103713,7 +103713,7 @@
 "sFj" = (
 /obj/machinery/computer/sm_monitor,
 /turf/simulated/floor/glass,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "sFm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -103916,7 +103916,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "sHj" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/firealarm{
@@ -104408,7 +104408,7 @@
 	dir = 5;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "sMe" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/item/reagent_containers/glass/bucket/wooden,
@@ -104579,7 +104579,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "sNx" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -104704,7 +104704,7 @@
 /area/medical/research)
 "sOC" = (
 /turf/simulated/wall,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "sOH" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
@@ -104941,7 +104941,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "sQV" = (
 /obj/machinery/vending/security,
 /turf/simulated/floor/plasteel{
@@ -105060,7 +105060,7 @@
 	req_access = list(10,24)
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "sSA" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -105176,7 +105176,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "sTy" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -105297,7 +105297,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "sUE" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light_switch{
@@ -105307,7 +105307,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "sUG" = (
 /obj/structure/railing{
 	dir = 8
@@ -106023,7 +106023,7 @@
 	dir = 9;
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "tcs" = (
 /obj/item/chair,
 /obj/machinery/light/small{
@@ -106286,7 +106286,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "tea" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -106357,7 +106357,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "teD" = (
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -106551,7 +106551,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "tgT" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -106635,7 +106635,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "thT" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -106671,7 +106671,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "tii" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -106804,7 +106804,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "tjp" = (
 /obj/machinery/door/window/northleft{
 	req_access = list(55)
@@ -106823,7 +106823,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/glass,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "tjt" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -107280,7 +107280,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "tnI" = (
 /turf/simulated/wall,
 /area/maintenance/west_solars)
@@ -107326,7 +107326,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "too" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
@@ -107401,7 +107401,7 @@
 	dir = 10;
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "tpl" = (
 /obj/effect/turf_decal/loading_area/white{
 	dir = 8
@@ -107759,7 +107759,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "tsi" = (
 /obj/structure/sign/cargo{
 	pixel_x = 32
@@ -108175,7 +108175,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "tvP" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -108198,7 +108198,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "tvV" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -108453,7 +108453,7 @@
 "typ" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "tyt" = (
 /obj/structure/dresser,
 /turf/simulated/floor/carpet/royalblack,
@@ -108461,7 +108461,7 @@
 "tyv" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "tyH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -108695,7 +108695,7 @@
 "tBg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "tBi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -108779,7 +108779,7 @@
 /obj/structure/table/glass,
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/glass/reinforced,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "tCd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -108952,7 +108952,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "tDF" = (
 /obj/machinery/atmospherics/pipe/multiz{
 	dir = 4
@@ -109218,7 +109218,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "tGq" = (
 /obj/structure/chair/comfy/teal{
 	dir = 4
@@ -109369,7 +109369,7 @@
 	},
 /obj/effect/spawner/lootdrop/officetoys,
 /turf/simulated/floor/plasteel,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "tIe" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -109488,7 +109488,7 @@
 	dir = 10;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "tIQ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -109578,7 +109578,7 @@
 	dir = 9;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "tJy" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -110092,7 +110092,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "tOp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -110193,7 +110193,7 @@
 	},
 /obj/structure/reflector/single,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "tPb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -110485,7 +110485,7 @@
 	pixel_x = 26
 	},
 /turf/simulated/floor/carpet/orange,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "tSq" = (
 /obj/structure/punching_bag,
 /obj/item/radio/intercom{
@@ -110565,7 +110565,7 @@
 	name = "Engineering Emergency Lockdown"
 	},
 /turf/simulated/floor/plating,
-/area/engine/break_room)
+/area/engineering/break_room)
 "tSO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -110594,7 +110594,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "tTe" = (
 /obj/machinery/light_switch{
 	pixel_x = -26
@@ -110807,7 +110807,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "tVm" = (
 /obj/machinery/door/airlock/hatch{
 	name = "AI Satellite Antechamber";
@@ -110848,13 +110848,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "tVF" = (
 /obj/machinery/atmospherics/binary/valve/digital{
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "tVI" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -111264,7 +111264,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "tZP" = (
 /obj/structure/cable/orange{
 	icon_state = "1-8"
@@ -111290,7 +111290,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "uab" = (
 /obj/structure/table,
 /obj/item/book/manual/experimentor,
@@ -111480,7 +111480,7 @@
 	},
 /obj/effect/turf_decal/box,
 /turf/simulated/floor/glass,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "ubO" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -111488,7 +111488,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "ubP" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -111641,7 +111641,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "udG" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -111949,7 +111949,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "ugl" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -112004,7 +112004,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "ugQ" = (
 /obj/machinery/suit_storage_unit/atmos,
 /obj/effect/turf_decal/stripes/line{
@@ -112128,7 +112128,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "uii" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -112358,7 +112358,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "uki" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
@@ -112497,7 +112497,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "ulz" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/simulated/floor/plating,
@@ -113541,7 +113541,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "uwe" = (
 /obj/machinery/camera{
 	c_tag = "Xenobio South";
@@ -114216,7 +114216,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "uCI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -114250,7 +114250,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "uCQ" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -114616,7 +114616,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "uFK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -114766,7 +114766,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "uHh" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/tripple,
@@ -114953,7 +114953,7 @@
 /obj/item/storage/belt/utility,
 /obj/item/radio,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "uJH" = (
 /obj/machinery/atmospherics/unary/outlet_injector/on,
 /turf/simulated/floor/plating{
@@ -115189,7 +115189,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "uLZ" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -115216,7 +115216,7 @@
 "uMg" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "uMl" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -115229,7 +115229,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/carpet/orange,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "uMq" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/orange{
@@ -115312,7 +115312,7 @@
 	dir = 8;
 	icon_state = "whiteyellow"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "uNm" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -115399,7 +115399,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/glass,
-/area/engine/break_room)
+/area/engineering/break_room)
 "uOj" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/intern,
@@ -115473,7 +115473,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "uOM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -115496,7 +115496,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "uOW" = (
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -115522,7 +115522,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "uPv" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
@@ -115532,7 +115532,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "uPF" = (
 /obj/machinery/computer/med_data/laptop,
 /obj/structure/table/glass,
@@ -115652,7 +115652,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "uRn" = (
 /obj/machinery/computer/rdconsole/robotics,
 /turf/simulated/floor/plasteel{
@@ -115750,7 +115750,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "uSr" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -116500,7 +116500,7 @@
 /obj/effect/turf_decal/number/number_8,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "vak" = (
 /turf/simulated/wall,
 /area/teleporter/quantum/security)
@@ -116729,7 +116729,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "vcp" = (
 /obj/structure/cable/orange{
 	icon_state = "2-4"
@@ -116915,7 +116915,7 @@
 /area/medical/sleeper)
 "vdI" = (
 /turf/simulated/wall/r_wall,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "vdK" = (
 /obj/structure/morgue,
 /obj/effect/landmark/event/revenantspawn,
@@ -117204,7 +117204,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "vgA" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/landmark/event/lightsout,
@@ -117587,7 +117587,7 @@
 	},
 /obj/machinery/power/port_gen/pacman,
 /turf/simulated/floor/glass/reinforced,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "vli" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -117650,7 +117650,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "vmg" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -117691,7 +117691,7 @@
 /obj/item/wrench,
 /obj/item/paper/gravity_gen,
 /turf/simulated/floor/glass/reinforced,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "vmJ" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/multiz{
@@ -117923,7 +117923,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "vpf" = (
 /obj/machinery/newscaster{
 	pixel_x = 32
@@ -118082,7 +118082,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "vrw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -118142,7 +118142,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "vsg" = (
 /obj/machinery/light{
 	dir = 4
@@ -118342,7 +118342,7 @@
 "vuu" = (
 /obj/effect/turf_decal/stripes/red/full,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "vuw" = (
 /obj/structure/disposalpipe/junction/reversed{
 	dir = 1
@@ -118562,7 +118562,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "vwc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -118628,7 +118628,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "vxd" = (
 /obj/structure/chair{
 	dir = 1
@@ -118685,7 +118685,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "vxN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -118713,7 +118713,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "vxR" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
@@ -118745,7 +118745,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "vya" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/item/extinguisher,
@@ -119140,7 +119140,7 @@
 	dir = 10;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "vCa" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -119178,7 +119178,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "vCp" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/lights/mixed,
@@ -119204,7 +119204,7 @@
 	dir = 5;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "vCR" = (
 /obj/effect/turf_decal/loading_area/white{
 	dir = 4
@@ -119575,7 +119575,7 @@
 "vFX" = (
 /obj/machinery/camera/autoname,
 /turf/simulated/openspace,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "vGb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -119955,7 +119955,7 @@
 /area/crew_quarters/locker/locker_toilet)
 "vJq" = (
 /turf/simulated/openspace,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "vJx" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -120159,7 +120159,7 @@
 	dir = 6;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "vLZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -120202,7 +120202,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "vMm" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
@@ -120474,7 +120474,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "vPd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -120767,7 +120767,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "vRT" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -120893,13 +120893,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "vSY" = (
 /obj/machinery/door/poddoor/multi_tile/two_tile_ver{
 	id_tag = "mechanicgate"
 	},
 /turf/simulated/openspace,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "vTn" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -121040,7 +121040,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "vVo" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
@@ -121608,7 +121608,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "waI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
@@ -122055,7 +122055,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "wfr" = (
 /obj/structure/dispenser,
 /turf/simulated/floor/plasteel{
@@ -122299,7 +122299,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "wgN" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -122385,7 +122385,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "whn" = (
 /turf/simulated/openspace,
 /area/medical/surgery/south)
@@ -122712,7 +122712,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "wkU" = (
 /obj/item/radio/intercom{
 	pixel_y = 28
@@ -122896,7 +122896,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "wmK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -123409,7 +123409,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "wrv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -123519,7 +123519,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/carpet/orange,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "wse" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -123698,7 +123698,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "wtI" = (
 /obj/machinery/status_display{
 	pixel_x = 32
@@ -124337,7 +124337,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "wBc" = (
 /obj/machinery/porta_turret,
 /turf/simulated/floor/plasteel{
@@ -124393,7 +124393,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "wBA" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -124562,7 +124562,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "wDw" = (
 /turf/simulated/floor/wood/fancy/light,
 /area/security/detectives_office)
@@ -124766,7 +124766,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "wFB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -124794,7 +124794,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "wFN" = (
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard_medi";
@@ -124862,7 +124862,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "wGi" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -125037,7 +125037,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "wHG" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line,
@@ -125121,7 +125121,7 @@
 /area/quartermaster/storage)
 "wIB" = (
 /turf/simulated/wall/r_wall,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "wIF" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -125140,7 +125140,7 @@
 	req_access = list(19,23)
 	},
 /turf/simulated/floor/glass,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "wIQ" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -125283,7 +125283,7 @@
 	dir = 9;
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "wKj" = (
 /obj/effect/spawner/random_barrier/possibly_welded_airlock,
 /obj/structure/barricade/wooden,
@@ -125981,7 +125981,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "wSw" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/mug/eng,
@@ -126000,7 +126000,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "wSx" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -126128,7 +126128,7 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "wTH" = (
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -126542,7 +126542,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "wWW" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Science Asteroid Maintenance"
@@ -126606,7 +126606,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "wXt" = (
 /turf/simulated/openspace,
 /area/hallway/spacebridge/engmed)
@@ -126676,7 +126676,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "wXY" = (
 /obj/machinery/suit_storage_unit/atmos,
 /obj/effect/turf_decal/stripes/line{
@@ -126730,7 +126730,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "wYM" = (
 /obj/effect/landmark/start/paramedic,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -126916,7 +126916,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xaS" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -126963,7 +126963,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "xbn" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -127328,7 +127328,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "xeA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -127351,7 +127351,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "xeJ" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -127524,7 +127524,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "xgF" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
@@ -127759,7 +127759,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "xje" = (
 /obj/machinery/light{
 	dir = 1
@@ -127868,7 +127868,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xkf" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -128083,7 +128083,7 @@
 	dir = 1;
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "xmB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -128249,7 +128249,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "xon" = (
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -128309,7 +128309,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xoN" = (
 /turf/simulated/floor/plating,
 /area/clownoffice/secret)
@@ -128327,7 +128327,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "xoX" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -128560,7 +128560,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xrT" = (
 /obj/structure/sign/poster/random{
 	name = "random official poster";
@@ -128695,7 +128695,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xta" = (
 /obj/structure/cable/orange{
 	icon_state = "1-8"
@@ -129055,7 +129055,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xwM" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/reagent_containers/food/drinks/bottle/vodka{
@@ -129514,7 +129514,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "xzJ" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Garden";
@@ -129612,7 +129612,7 @@
 	dir = 9;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "xAW" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -129702,7 +129702,7 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/glass,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "xBr" = (
 /obj/machinery/light{
 	dir = 1
@@ -130030,7 +130030,7 @@
 	dir = 6;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "xEX" = (
 /turf/simulated/wall/r_wall,
 /area/medical/chemistry)
@@ -130190,7 +130190,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xGd" = (
 /obj/structure/stairs{
 	dir = 8
@@ -130464,7 +130464,7 @@
 	dir = 10;
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "xII" = (
 /obj/structure/railing{
 	dir = 4
@@ -131055,7 +131055,7 @@
 /area/medical/reception)
 "xOk" = (
 /turf/simulated/wall/r_wall,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "xOq" = (
 /obj/structure/table,
 /obj/item/clothing/shoes/orange,
@@ -131139,7 +131139,7 @@
 	color = "#dd1010"
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "xOY" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
@@ -131400,7 +131400,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "xRG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -131538,7 +131538,7 @@
 /area/hallway/secondary/entry/north)
 "xSR" = (
 /turf/simulated/wall,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "xSS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/structure/cable/yellow{
@@ -131555,7 +131555,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xSX" = (
 /obj/machinery/door/morgue{
 	name = "Confession Booth"
@@ -131646,7 +131646,7 @@
 	dir = 5;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "xTW" = (
 /obj/machinery/computer/station_alert,
 /obj/item/radio/intercom{
@@ -131656,7 +131656,7 @@
 	dir = 5;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "xTX" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -131682,12 +131682,12 @@
 	pixel_x = -26
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "xUg" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "xUh" = (
 /obj/structure/rack,
 /obj/item/clothing/under/plasmaman{
@@ -131925,7 +131925,7 @@
 	dir = 5;
 	icon_state = "whiteyellow"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "xWB" = (
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard_medi";
@@ -132147,7 +132147,7 @@
 	dir = 10;
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "xZs" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot,
@@ -132495,7 +132495,7 @@
 	dir = 9;
 	icon_state = "darkyellow"
 	},
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "yde" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -132752,7 +132752,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "yfs" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -132863,7 +132863,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "ygS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -133083,7 +133083,7 @@
 	req_access = list(24)
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/engineering)
+/area/engineering/engine)
 "yjf" = (
 /obj/structure/chair/sofa/right{
 	dir = 4
@@ -133189,7 +133189,7 @@
 "yjO" = (
 /obj/machinery/alarm,
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "yjR" = (
 /obj/structure/sign/holy{
 	pixel_x = -32
@@ -133211,7 +133211,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ykh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -133369,7 +133369,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "ylX" = (
 /obj/structure/sign/directions/floor/alt{
 	dir = 8;

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -384,7 +384,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "adF" = (
 /obj/structure/window/plasmareinforced{
 	dir = 8
@@ -398,7 +398,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "adH" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -407,7 +407,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "adI" = (
 /obj/structure/curtain/open/shower,
 /obj/machinery/shower{
@@ -426,7 +426,7 @@
 /obj/item/tank/internals/plasma,
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "adL" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -650,7 +650,7 @@
 /area/turret_protected/ai)
 "afX" = (
 /turf/simulated/wall,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aga" = (
 /obj/structure/table,
 /obj/item/storage/box/matches,
@@ -871,7 +871,7 @@
 	dir = 1;
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aiF" = (
 /obj/structure/chair/comfy{
 	dir = 1
@@ -998,7 +998,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "ajn" = (
 /obj/machinery/light{
 	dir = 1
@@ -2732,7 +2732,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "ayo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2882,7 +2882,7 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ayU" = (
 /obj/structure/cable/orange{
 	icon_state = "0-2"
@@ -3374,7 +3374,7 @@
 /area/hallway/primary/aft/west)
 "aCZ" = (
 /turf/simulated/wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "aDb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -3644,7 +3644,7 @@
 "aFE" = (
 /obj/effect/turf_decal/stripes/red/full,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "aFQ" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -4286,7 +4286,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aLe" = (
 /obj/machinery/computer/prisoner{
 	dir = 4;
@@ -4364,7 +4364,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aLJ" = (
 /obj/structure/dresser,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -5597,7 +5597,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "aVt" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
@@ -5745,7 +5745,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aWu" = (
 /obj/structure/sign/custodian,
 /turf/simulated/wall,
@@ -7007,7 +7007,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/spacepoddoor,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "bdZ" = (
 /obj/machinery/computer/HolodeckControl{
 	dir = 4
@@ -7287,7 +7287,7 @@
 	id_tag = "mechanicgate"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "bfK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -7582,7 +7582,7 @@
 /area/crew_quarters/fitness)
 "bhd" = (
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "bhg" = (
 /obj/effect/spawner/airlock/w_to_e,
 /turf/simulated/wall,
@@ -8373,7 +8373,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "blA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8388,7 +8388,7 @@
 	dir = 8;
 	icon_state = "yellowcorner"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "blF" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -8416,7 +8416,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "blM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8461,7 +8461,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/engineering)
+/area/engineering/engine)
 "blZ" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -8535,13 +8535,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bmB" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "bmG" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -8586,7 +8586,7 @@
 	dir = 9;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "bmX" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -8729,11 +8729,11 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bnS" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "bnW" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -8824,7 +8824,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "boG" = (
 /obj/machinery/light{
 	dir = 8
@@ -8870,7 +8870,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bpi" = (
 /obj/structure/bed,
 /obj/item/bedsheet/hop,
@@ -9018,7 +9018,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bqs" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -9031,7 +9031,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bqt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -9043,7 +9043,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bqu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -9052,7 +9052,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bqx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -9061,7 +9061,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bqz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -9070,7 +9070,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bqA" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -9080,7 +9080,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bqB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -9089,7 +9089,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bqD" = (
 /obj/machinery/atmospherics/unary/outlet_injector/on{
 	dir = 8;
@@ -9097,7 +9097,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
-/area/engine/engineering)
+/area/engineering/engine)
 "bqE" = (
 /obj/structure/closet/secure_closet/hop,
 /obj/item/storage/secure/safe{
@@ -9300,7 +9300,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "brx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -9373,7 +9373,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bsa" = (
 /obj/item/radio/intercom{
 	dir = 1;
@@ -9390,7 +9390,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bsc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 10
@@ -9402,13 +9402,13 @@
 	dir = 5
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bsd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bse" = (
 /obj/machinery/status_display{
 	layer = 4
@@ -9561,7 +9561,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "btt" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -9576,7 +9576,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "btv" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel's Private Quarters";
@@ -9596,11 +9596,11 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "btx" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "btz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -9638,13 +9638,13 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "btE" = (
 /obj/machinery/status_display{
 	layer = 4
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "btG" = (
 /obj/machinery/light{
 	dir = 1
@@ -9693,7 +9693,7 @@
 "bue" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "buf" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -9833,7 +9833,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "buU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9844,7 +9844,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "buV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -9861,7 +9861,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "buW" = (
 /obj/structure/window/plasmareinforced{
 	dir = 4
@@ -9877,7 +9877,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "buY" = (
 /obj/structure/window/plasmareinforced{
 	dir = 8
@@ -9898,7 +9898,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "buZ" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -9906,7 +9906,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bva" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -9918,13 +9918,13 @@
 	},
 /obj/machinery/atmospherics/trinary/tvalve/digital/flipped,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bvc" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bvd" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -10058,7 +10058,7 @@
 /area/hallway/primary/port/north)
 "bwi" = (
 /turf/simulated/wall/r_wall,
-/area/engine/break_room)
+/area/engineering/break_room)
 "bwk" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -10090,7 +10090,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bwp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -10107,11 +10107,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bwr" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bwu" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -10312,7 +10312,7 @@
 /area/crew_quarters/heads/hop)
 "bxz" = (
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bxB" = (
 /obj/structure/window/plasmareinforced{
 	dir = 4
@@ -10328,7 +10328,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bxC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -10347,7 +10347,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bxD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10355,7 +10355,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bxF" = (
 /obj/machinery/pdapainter,
 /turf/simulated/floor/wood/fancy/light,
@@ -10494,7 +10494,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "byz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -10506,19 +10506,19 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "byA" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
 	},
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "byE" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
 	},
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "byF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -10530,7 +10530,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "byM" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
@@ -10674,7 +10674,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bzA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/binary/valve/digital,
@@ -10682,11 +10682,11 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bzB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bzJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -10761,7 +10761,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bzU" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -10993,7 +10993,7 @@
 "bAO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bAP" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -11008,11 +11008,11 @@
 	req_access = list(10,24)
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bAQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bBj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11023,7 +11023,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bBk" = (
 /obj/effect/spawner/lootdrop/crate_spawner,
 /turf/simulated/floor/plating{
@@ -11084,7 +11084,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bBN" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -11101,7 +11101,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bBO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -11113,7 +11113,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bBP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -11126,7 +11126,7 @@
 	filter_type = -1
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bBQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -11138,7 +11138,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bBR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random_spawners/rodent,
@@ -11150,7 +11150,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bBT" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -11164,13 +11164,13 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bBW" = (
 /obj/machinery/status_display{
 	layer = 4
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/break_room)
+/area/engineering/break_room)
 "bBX" = (
 /obj/item/gun/projectile/shotgun/riot{
 	pixel_x = -3;
@@ -11207,7 +11207,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bCe" = (
 /obj/structure/chair{
 	dir = 1
@@ -11357,7 +11357,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bCP" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -11368,7 +11368,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bCT" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -11376,7 +11376,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bCV" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -11392,7 +11392,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bCX" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -11400,7 +11400,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bDh" = (
 /obj/structure/table/wood,
 /obj/structure/railing{
@@ -11533,13 +11533,13 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "bEc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "bEe" = (
 /obj/machinery/door/airlock/engineering/glass{
 	autoclose = 0;
@@ -11553,7 +11553,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bEg" = (
 /obj/machinery/door/airlock/engineering/glass{
 	autoclose = 0;
@@ -11569,13 +11569,13 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bEh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "bEj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -11816,7 +11816,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bFm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -11832,7 +11832,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bFn" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -11843,7 +11843,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bFo" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/effect/turf_decal/stripes/line{
@@ -11852,7 +11852,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bFp" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty,
@@ -11866,14 +11866,14 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bFq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "bFr" = (
 /obj/machinery/shower{
 	pixel_y = 20
@@ -11883,7 +11883,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/noslip,
-/area/engine/engineering)
+/area/engineering/engine)
 "bFs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -11896,7 +11896,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bFt" = (
 /obj/machinery/shower{
 	pixel_y = 20
@@ -11906,7 +11906,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/noslip,
-/area/engine/engineering)
+/area/engineering/engine)
 "bFu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11916,7 +11916,7 @@
 	dir = 4;
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bFv" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil,
@@ -11932,7 +11932,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bFC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12183,7 +12183,7 @@
 	dir = 8;
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bGU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12201,7 +12201,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bGY" = (
 /obj/machinery/access_button{
 	command = "cycle_exterior";
@@ -12215,7 +12215,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bHa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -12229,7 +12229,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bHe" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12243,7 +12243,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bHp" = (
 /obj/machinery/shower{
 	dir = 1
@@ -12284,7 +12284,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bHF" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Fitness Room"
@@ -12452,7 +12452,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bIx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -12471,7 +12471,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bIA" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -12481,13 +12481,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bIF" = (
 /turf/simulated/wall/r_wall/coated,
 /area/atmos/distribution)
 "bIG" = (
 /turf/simulated/mineral/ancient,
-/area/engine/break_room)
+/area/engineering/break_room)
 "bIK" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder,
@@ -12686,13 +12686,13 @@
 	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/wall,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bJG" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bJK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -12712,7 +12712,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bJN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12720,7 +12720,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bJP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12798,7 +12798,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bKz" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/purple,
 /turf/simulated/floor/plasteel{
@@ -13109,7 +13109,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bMe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -13121,14 +13121,14 @@
 	dir = 10;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bMf" = (
 /obj/machinery/light,
 /obj/structure/closet/radiation,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bMh" = (
 /obj/structure/rack,
 /obj/item/rpd,
@@ -13137,7 +13137,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bMi" = (
 /obj/structure/rack,
 /obj/item/storage/belt/utility,
@@ -13149,7 +13149,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bMj" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -13165,13 +13165,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bMk" = (
 /obj/machinery/vending/clothing/departament/engineering,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bMw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -13433,10 +13433,10 @@
 	dir = 8;
 	icon_state = "darkyellowfull"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bNx" = (
 /turf/simulated/wall,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bNz" = (
 /obj/structure/railing,
 /turf/simulated/floor/carpet,
@@ -13449,20 +13449,20 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bNB" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bNC" = (
 /obj/machinery/status_display{
 	layer = 4
 	},
 /turf/simulated/wall,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bND" = (
 /turf/simulated/wall/r_wall,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bNE" = (
 /turf/simulated/floor/plating,
 /area/hallway/primary/starboard/south)
@@ -13545,7 +13545,7 @@
 /area/atmos)
 "bOj" = (
 /turf/simulated/mineral/ancient,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bOk" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -13579,7 +13579,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bOA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13594,7 +13594,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bOB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13604,7 +13604,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bOI" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -13770,7 +13770,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bPH" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -13781,7 +13781,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bPK" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -13798,7 +13798,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bPL" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -13810,7 +13810,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bPM" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -13822,7 +13822,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bPN" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -13839,7 +13839,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bPR" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -13991,7 +13991,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bQG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -14002,7 +14002,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bQH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -14013,7 +14013,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bQI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -14021,13 +14021,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bQJ" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bQK" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -14044,7 +14044,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bQM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -14056,7 +14056,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bQN" = (
 /obj/machinery/vending/wallmed{
 	pixel_x = -28
@@ -14077,7 +14077,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bQZ" = (
 /obj/machinery/door/airlock/glass{
 	id_tag = "Cryogenics";
@@ -14173,7 +14173,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bRt" = (
 /obj/machinery/light{
 	dir = 1
@@ -14241,7 +14241,7 @@
 	dir = 10;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bRD" = (
 /obj/machinery/light,
 /obj/machinery/camera{
@@ -14253,7 +14253,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bRE" = (
 /obj/structure/table,
 /obj/item/book/manual/engineering_particle_accelerator,
@@ -14263,7 +14263,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bRF" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -14271,7 +14271,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bRG" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -14283,13 +14283,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bRI" = (
 /obj/structure/dispenser,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bRJ" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -14299,28 +14299,28 @@
 	dir = 6;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bRK" = (
 /obj/machinery/suit_storage_unit/engine,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bRL" = (
 /obj/machinery/suit_storage_unit/engine,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bRM" = (
 /obj/machinery/suit_storage_unit/engine,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bRN" = (
 /obj/machinery/computer/account_database{
 	dir = 4
@@ -14480,13 +14480,13 @@
 	name = "Engineering Secure Storage"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bSz" = (
 /obj/machinery/status_display{
 	layer = 4
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bSA" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -14652,11 +14652,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bTk" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bTl" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/metal{
@@ -14678,11 +14678,11 @@
 	amount = 50
 	},
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bTm" = (
 /obj/machinery/field/generator,
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bTp" = (
 /obj/machinery/door/poddoor/multi_tile/two_tile_ver,
 /obj/structure/spacepoddoor{
@@ -14835,7 +14835,7 @@
 	},
 /obj/machinery/power/port_gen/pacman,
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bTL" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -14988,16 +14988,16 @@
 "bUv" = (
 /obj/machinery/power/port_gen/pacman,
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bUw" = (
 /obj/machinery/light,
 /obj/structure/dispenser,
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bUx" = (
 /obj/machinery/shieldgen,
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bUy" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Medbay Atmospherics Checkpoint";
@@ -15011,11 +15011,11 @@
 "bUz" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bUA" = (
 /obj/machinery/power/emitter,
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bUB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -15046,7 +15046,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bUN" = (
 /turf/simulated/wall,
 /area/chapel/main)
@@ -15597,7 +15597,7 @@
 	dir = 6;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bWS" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
@@ -15669,7 +15669,7 @@
 	dir = 10;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "bWY" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
@@ -15758,7 +15758,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bXx" = (
 /turf/simulated/floor/engine/plasma,
 /area/atmos)
@@ -16137,7 +16137,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bZP" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -16632,7 +16632,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "cdv" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -17187,7 +17187,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "cgz" = (
 /obj/machinery/computer/prisoner,
 /obj/machinery/light_switch{
@@ -17394,7 +17394,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "chQ" = (
 /turf/simulated/floor/plating,
 /area/hallway/primary/aft/west)
@@ -17596,7 +17596,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cjv" = (
 /obj/item/assembly/mousetrap/armed,
 /obj/structure/cable/orange{
@@ -17685,13 +17685,13 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "ckt" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ckw" = (
 /obj/structure/chair/sofa/corp{
 	dir = 1
@@ -18169,7 +18169,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "coj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -18319,7 +18319,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "cpB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -18913,7 +18913,7 @@
 	icon_state = "cobweb2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "ctQ" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/delivery,
@@ -19270,7 +19270,7 @@
 	dir = 6;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cxg" = (
 /turf/simulated/wall/r_wall,
 /area/toxins/storage)
@@ -19293,7 +19293,7 @@
 	},
 /obj/item/stock_parts/cell/high,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "cxm" = (
 /obj/machinery/ai_status_display{
 	pixel_x = -32
@@ -19705,7 +19705,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "cAl" = (
 /obj/machinery/camera{
 	c_tag = "Research Eastern Wing";
@@ -19979,7 +19979,7 @@
 	},
 /obj/effect/turf_decal/stripes/end,
 /turf/simulated/floor/plating,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "cCe" = (
 /obj/structure/rack,
 /obj/item/circuitboard/cyborgrecharger{
@@ -20378,7 +20378,7 @@
 "cFw" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "cFA" = (
 /turf/simulated/mineral/ancient/outer,
 /area/medical/genetics)
@@ -20390,11 +20390,11 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "cFE" = (
 /obj/structure/plasticflaps,
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "cFF" = (
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -20532,7 +20532,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "cGD" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -20596,7 +20596,7 @@
 /area/hallway/primary/starboard/south)
 "cGY" = (
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "cHb" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -20875,7 +20875,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cJf" = (
 /obj/machinery/alarm{
 	pixel_y = 24
@@ -20889,7 +20889,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cJh" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -20966,7 +20966,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "cJD" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -20979,7 +20979,7 @@
 	state = 2
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "cJE" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -20989,7 +20989,7 @@
 	state = 2
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "cJF" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -21065,10 +21065,10 @@
 /area/crew_quarters/sleep/secondary)
 "cKr" = (
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "cKs" = (
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "cKv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -21735,7 +21735,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "cOR" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -21799,7 +21799,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "cOZ" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -21906,7 +21906,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "cPU" = (
 /obj/machinery/power/apc{
 	cell_type = 25000;
@@ -21924,7 +21924,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "cPV" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -21966,7 +21966,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "cQl" = (
 /turf/simulated/wall,
 /area/atmos/control)
@@ -22218,7 +22218,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "cRZ" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -22425,7 +22425,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "cTh" = (
 /turf/simulated/wall,
 /area/maintenance/disposal/south)
@@ -23252,13 +23252,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "cWK" = (
 /obj/structure/reflector/box,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "cWO" = (
 /obj/structure/reflector/single{
 	dir = 1
@@ -23266,7 +23266,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "cWP" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel{
@@ -23547,7 +23547,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dac" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -23638,7 +23638,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "daC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -23911,14 +23911,14 @@
 "ddB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "ddD" = (
 /turf/simulated/wall,
 /area/crew_quarters/cabin1)
 "ddE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "ddF" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -24641,7 +24641,7 @@
 /area/maintenance/fore)
 "djo" = (
 /turf/simulated/wall,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "djp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -24776,7 +24776,7 @@
 	dir = 5;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "djS" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall,
@@ -25055,10 +25055,10 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "dmf" = (
 /turf/simulated/mineral/ancient/outer,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "dmg" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -26280,7 +26280,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dzd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -26304,7 +26304,7 @@
 	network = list("SS13","Engineering")
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "dzg" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -26902,7 +26902,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dDu" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -27193,7 +27193,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "dID" = (
 /obj/machinery/atm{
 	pixel_x = -28
@@ -27297,7 +27297,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dJZ" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=ArrivalsWest2";
@@ -27348,7 +27348,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "dKU" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Walkway"
@@ -27533,7 +27533,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "dNp" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -27725,7 +27725,7 @@
 /area/atmos)
 "dPc" = (
 /turf/simulated/wall/r_wall,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "dPG" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -27946,7 +27946,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "dTd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -27974,7 +27974,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dTB" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
@@ -28010,7 +28010,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "dTM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -28354,7 +28354,7 @@
 	dir = 8;
 	icon_state = "darkyellowfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "dZT" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -28472,7 +28472,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "ebm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -28596,7 +28596,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "edu" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -28789,7 +28789,7 @@
 	},
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "egu" = (
 /obj/effect/landmark/join_late_cyborg,
 /turf/simulated/floor/shuttle,
@@ -29024,7 +29024,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "elC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -29097,7 +29097,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "ene" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -29229,7 +29229,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "eqF" = (
 /obj/structure/sign/electricshock{
 	pixel_y = -32
@@ -29237,7 +29237,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "eqG" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/warning_stripes/southwest,
@@ -29519,7 +29519,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "evG" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -29945,7 +29945,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "eDN" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = -32
@@ -29962,7 +29962,7 @@
 	dir = 9;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "eDV" = (
 /obj/machinery/camera{
 	c_tag = "Docking Asteroid Hall 11";
@@ -30124,7 +30124,7 @@
 /area/chapel/main)
 "eGr" = (
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "eGH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -30154,7 +30154,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "eGS" = (
 /obj/machinery/door_control{
 	desc = "A remote control-switch for the pod doors.";
@@ -30344,7 +30344,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "eKh" = (
 /obj/machinery/atm{
 	pixel_x = 32
@@ -30744,7 +30744,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "eRg" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
@@ -30954,7 +30954,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "eTT" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
@@ -31023,7 +31023,7 @@
 	dir = 10;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "eUM" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -31114,7 +31114,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "eWU" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
@@ -31158,7 +31158,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "eXH" = (
 /obj/machinery/door/window{
 	dir = 1
@@ -31260,7 +31260,7 @@
 "eZM" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "eZS" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -31299,7 +31299,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "fav" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
@@ -31387,7 +31387,7 @@
 /obj/machinery/power/emitter,
 /obj/machinery/light,
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "fcL" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/item/radio/intercom{
@@ -31507,7 +31507,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "fet" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -31652,7 +31652,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "fgT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31789,7 +31789,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "fjo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -31902,7 +31902,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "flH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -31939,7 +31939,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "fmk" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -32308,7 +32308,7 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "fsw" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -32740,7 +32740,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "fyS" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -32986,7 +32986,7 @@
 	dir = 6;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "fCY" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -33050,7 +33050,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "fEh" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/drinkingglass{
@@ -33242,7 +33242,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "fGv" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -33366,7 +33366,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "fIV" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -33481,7 +33481,7 @@
 "fLq" = (
 /obj/structure/sign/radiation,
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "fLz" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = -32
@@ -33656,7 +33656,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "fNR" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible,
@@ -33724,7 +33724,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "fPc" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -33836,7 +33836,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "fRc" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -34041,7 +34041,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "fUe" = (
 /obj/structure/cable/orange{
 	icon_state = "2-4"
@@ -34490,7 +34490,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "gak" = (
 /obj/structure/cable/orange{
 	icon_state = "2-4"
@@ -34758,7 +34758,7 @@
 	id_tag = "ceoffice"
 	},
 /turf/simulated/floor/plating,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "geI" = (
 /obj/effect/turf_decal/bot_red,
 /obj/machinery/shower{
@@ -34796,7 +34796,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/break_room)
+/area/engineering/break_room)
 "geX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -35112,7 +35112,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "glG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -35513,7 +35513,7 @@
 "gsj" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "gso" = (
 /obj/machinery/camera{
 	c_tag = "Library North"
@@ -35717,7 +35717,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "gww" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/landmark/start/botanist,
@@ -35917,7 +35917,7 @@
 /area/clownoffice/secret)
 "gzv" = (
 /turf/simulated/wall/r_wall,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "gAa" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -36479,7 +36479,7 @@
 	dir = 5;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "gHA" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -36622,7 +36622,7 @@
 /turf/simulated/floor/plasteel{
 	dir = 8
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "gJG" = (
 /obj/item/radio/intercom{
 	pixel_y = 28
@@ -37028,7 +37028,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "gPm" = (
 /turf/simulated/floor/plasteel{
 	dir = 0;
@@ -37183,7 +37183,7 @@
 /turf/simulated/floor/plasteel{
 	dir = 8
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "gQP" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
@@ -37960,7 +37960,7 @@
 	req_access = list(18,70,71,48)
 	},
 /turf/simulated/wall,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "hcv" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -38319,7 +38319,7 @@
 "hjD" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "hjL" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel{
@@ -38499,7 +38499,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "hlM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -38598,7 +38598,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "hnl" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -38699,7 +38699,7 @@
 "hol" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/engine,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "hoq" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/aquatic_kit/full,
@@ -38944,7 +38944,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "hrp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -39180,7 +39180,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "hud" = (
 /obj/structure/chair,
 /obj/machinery/light{
@@ -39226,7 +39226,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "huO" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -39246,7 +39246,7 @@
 	dir = 1;
 	icon_state = "yellowcorner"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "hvl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -39590,7 +39590,7 @@
 "hzX" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "hAh" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -39609,7 +39609,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/engineering)
+/area/engineering/engine)
 "hAn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light_switch{
@@ -39673,7 +39673,7 @@
 	},
 /obj/effect/landmark/start/mechanic,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "hBI" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -40050,14 +40050,14 @@
 	dir = 8
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/engineering)
+/area/engineering/engine)
 "hId" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "hIi" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -40116,7 +40116,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "hIY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -40229,7 +40229,7 @@
 	},
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "hKn" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
@@ -40256,7 +40256,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "hLg" = (
 /obj/machinery/status_display{
 	layer = 4
@@ -40434,7 +40434,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "hOf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -40698,7 +40698,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "hRR" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -40817,7 +40817,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "hTx" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -40965,7 +40965,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "hVz" = (
 /obj/machinery/newscaster{
 	dir = 1;
@@ -41462,7 +41462,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "icM" = (
 /obj/structure/chair/wood/wings,
 /turf/simulated/floor/wood/fancy/oak,
@@ -41591,7 +41591,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/engineering)
+/area/engineering/engine)
 "ieZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -41665,7 +41665,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "igu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -42031,7 +42031,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "imE" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -42153,7 +42153,7 @@
 "ioJ" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "ioO" = (
 /obj/structure/closet/firecloset/full,
 /obj/item/pickaxe,
@@ -42206,7 +42206,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "ipg" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
@@ -42218,7 +42218,7 @@
 	dir = 4;
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "ipy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -42585,7 +42585,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "ivg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -42812,7 +42812,7 @@
 "ixs" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/break_room)
+/area/engineering/break_room)
 "ixu" = (
 /obj/structure/girder,
 /obj/item/stack/sheet/metal,
@@ -43012,7 +43012,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "iBc" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/chair/sofa/corp/left,
@@ -43283,7 +43283,7 @@
 "iGA" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "iGD" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Walkway"
@@ -43415,7 +43415,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "iJk" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall,
@@ -44010,7 +44010,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "iQn" = (
 /obj/machinery/vending/clothing/departament/security,
 /turf/simulated/floor/plasteel{
@@ -44076,7 +44076,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "iRg" = (
 /obj/machinery/disposal,
 /obj/item/radio/intercom{
@@ -44216,7 +44216,7 @@
 	dir = 6;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "iTE" = (
 /obj/machinery/door/airlock/glass{
 	name = "Library"
@@ -44231,7 +44231,7 @@
 /area/library/game_zone)
 "iTF" = (
 /turf/simulated/wall,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "iTR" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 8
@@ -44310,7 +44310,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "iVn" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -44927,7 +44927,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/orange,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "jeq" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/simulated/floor/plasteel{
@@ -45237,7 +45237,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "jiS" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -45349,7 +45349,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "jjW" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/cobweb,
@@ -45414,7 +45414,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "jkW" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -45507,7 +45507,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "jlP" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'WARNING: FUN-SIZED JUSTICE'.";
@@ -46162,7 +46162,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "jvG" = (
 /obj/machinery/cryopod,
 /turf/simulated/floor/plasteel{
@@ -46222,7 +46222,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "jwd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -46524,7 +46524,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "jAF" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Garden";
@@ -46551,7 +46551,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "jAQ" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -46672,7 +46672,7 @@
 	dir = 9;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "jBV" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -46714,7 +46714,7 @@
 /turf/simulated/floor/plasteel{
 	dir = 8
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "jCK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -46894,7 +46894,7 @@
 "jEh" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "jEq" = (
 /obj/structure/rack,
 /obj/item/stack/rods,
@@ -47550,7 +47550,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "jPa" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating{
@@ -47639,7 +47639,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "jSc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -47729,7 +47729,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "jTr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -48566,7 +48566,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "kfs" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/seeds/wheat,
@@ -48848,7 +48848,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "kju" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -49064,7 +49064,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "kmC" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/tripple,
@@ -49072,7 +49072,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "kmJ" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -49374,7 +49374,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ksi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/orange{
@@ -49398,7 +49398,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "ksD" = (
 /obj/structure/safe,
 /obj/item/clothing/head/bearpelt,
@@ -49427,7 +49427,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ksP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -49763,7 +49763,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/carpet/orange,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "kxp" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
@@ -49778,7 +49778,7 @@
 	req_access = list(10)
 	},
 /turf/simulated/floor/plating,
-/area/engine/break_room)
+/area/engineering/break_room)
 "kxv" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/orange{
@@ -49938,7 +49938,7 @@
 	dir = 6;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "kzy" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -50550,7 +50550,7 @@
 	dir = 5;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "kIm" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -50635,7 +50635,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "kIM" = (
 /obj/item/radio/intercom{
 	pixel_x = -28
@@ -50787,7 +50787,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "kLd" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -50939,7 +50939,7 @@
 	},
 /obj/item/gun/energy/kinetic_accelerator,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "kNK" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -51025,7 +51025,7 @@
 	},
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "kOL" = (
 /obj/structure/cable/orange{
 	icon_state = "1-4"
@@ -51228,7 +51228,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "kRx" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -51474,7 +51474,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "kTc" = (
 /obj/structure/cable/orange{
 	icon_state = "1-8"
@@ -51526,7 +51526,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "kUO" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/bottle/nutrient/ez,
@@ -51574,7 +51574,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "kVA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
@@ -51840,13 +51840,13 @@
 	dir = 9;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "kZb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "kZj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable{
@@ -51860,7 +51860,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "kZz" = (
 /obj/machinery/light{
 	dir = 1
@@ -51934,7 +51934,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "laI" = (
 /obj/effect/spawner/airlock,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -52215,7 +52215,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "leF" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -52539,7 +52539,7 @@
 	},
 /mob/living/simple_animal/pet/cat/birman/Crusher,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "ljF" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -52627,7 +52627,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "lkE" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/bottle/epinephrine{
@@ -52724,7 +52724,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "llW" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/orange,
@@ -52889,7 +52889,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "lop" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -52924,7 +52924,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "lph" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -53085,7 +53085,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "lrY" = (
 /obj/item/flag/atmos{
 	name = "Atmosia Flag"
@@ -53099,7 +53099,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "lsg" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor,
@@ -53269,7 +53269,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "lva" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -53496,7 +53496,7 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "lyI" = (
 /turf/simulated/wall,
 /area/teleporter/quantum/science)
@@ -53562,7 +53562,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "lzT" = (
 /obj/effect/landmark/start/clown,
 /obj/structure/cable/orange{
@@ -54196,7 +54196,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "lJK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -54320,7 +54320,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "lMC" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -54773,7 +54773,7 @@
 /turf/simulated/floor/plasteel{
 	dir = 8
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "lSt" = (
 /obj/machinery/bodyscanner{
 	dir = 4
@@ -54951,7 +54951,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "lUQ" = (
 /obj/effect/turf_decal/siding/wood{
 	do_not_delete_me = 1
@@ -55092,7 +55092,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "lWo" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -55246,7 +55246,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "lYL" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -55453,7 +55453,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "maM" = (
 /obj/effect/spawner/airlock,
 /turf/simulated/wall/r_wall,
@@ -55531,7 +55531,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "mbR" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Walkway"
@@ -55601,7 +55601,7 @@
 "mcC" = (
 /obj/machinery/power/supermatter_shard/crystal,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "mcM" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -55691,7 +55691,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "mdZ" = (
 /turf/simulated/floor/glass/reinforced,
 /area/maintenance/fsmaint3)
@@ -56040,7 +56040,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "miy" = (
 /obj/structure/closet/secure_closet/chaplain,
 /turf/simulated/floor/carpet/black,
@@ -56165,7 +56165,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/carpet/orange,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "mmx" = (
 /obj/structure/spacepoddoor{
 	luminosity = 3
@@ -56182,7 +56182,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "mmF" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Walkway"
@@ -56229,7 +56229,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "mnl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -56357,7 +56357,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "mpQ" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -57079,7 +57079,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "mBM" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -57157,7 +57157,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "mCo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -57257,7 +57257,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "mDp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -57276,7 +57276,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "mDL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -57297,7 +57297,7 @@
 "mEc" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "mEf" = (
 /obj/structure/sink{
 	pixel_y = 24
@@ -57612,7 +57612,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "mHu" = (
 /obj/effect/spawner/random_spawners/blood_20,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -57642,7 +57642,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "mHL" = (
 /obj/effect/spawner/random_spawners/grille_13,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -57790,7 +57790,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "mKh" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -57943,7 +57943,7 @@
 "mLU" = (
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/engine,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "mMb" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -58255,7 +58255,7 @@
 	},
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "mPT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -58464,7 +58464,7 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "mTp" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -58702,7 +58702,7 @@
 	dir = 8;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "mWQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/power/apc{
@@ -58722,7 +58722,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "mXg" = (
 /obj/effect/spawner/random_spawners/wall_rusted_70,
 /turf/simulated/wall,
@@ -59239,7 +59239,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "nfQ" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -59968,11 +59968,11 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "nqj" = (
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/engine,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "nql" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall,
@@ -60038,7 +60038,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "nqM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -60077,7 +60077,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "nrN" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -60163,7 +60163,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "nsG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -60416,7 +60416,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "nvG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -60538,7 +60538,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "nwQ" = (
 /turf/simulated/wall,
 /area/hallway/spacebridge/dockmed)
@@ -60890,7 +60890,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "nBU" = (
 /obj/effect/landmark/start/chef,
 /obj/structure/disposalpipe/segment{
@@ -61112,7 +61112,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "nFk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -61434,7 +61434,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "nJy" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -61526,7 +61526,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "nKt" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -61869,12 +61869,12 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "nOF" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "nOL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -61899,7 +61899,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "nPs" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -61918,7 +61918,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "nQj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -62060,7 +62060,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "nSj" = (
 /obj/machinery/chem_dispenser/botanical,
 /turf/simulated/floor/plasteel{
@@ -63151,7 +63151,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "ohO" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -63428,7 +63428,7 @@
 	req_access = list(56)
 	},
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "okP" = (
 /turf/simulated/wall/r_wall,
 /area/turret_protected/aisat_interior/secondary)
@@ -63622,7 +63622,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "opP" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -63740,7 +63740,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "orm" = (
 /obj/effect/spawner/random_spawners/cobweb_right_frequent,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -64028,7 +64028,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "owE" = (
 /obj/structure/table/reinforced,
 /obj/item/gps{
@@ -64045,7 +64045,7 @@
 	pixel_y = -3
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "owN" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
@@ -64150,7 +64150,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "oyt" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -64476,7 +64476,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "oCx" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -64791,7 +64791,7 @@
 	dir = 1;
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "oGK" = (
 /obj/machinery/vending/chinese,
 /turf/simulated/floor/wood/fancy/light{
@@ -64897,7 +64897,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "oIN" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -65418,7 +65418,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "oRw" = (
 /obj/structure/sign/poster/random{
 	name = "random contraband poster";
@@ -65468,7 +65468,7 @@
 "oRG" = (
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/engine,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "oRS" = (
 /obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor/plating{
@@ -65532,7 +65532,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "oSs" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -65585,7 +65585,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "oSw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -65764,7 +65764,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "oUa" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Port Asteroid Maintenance";
@@ -65952,7 +65952,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "oXn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -66346,7 +66346,7 @@
 /area/medical/surgery/south)
 "pdc" = (
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "pdj" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -66385,7 +66385,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "peG" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -66557,7 +66557,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "pgO" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 5
@@ -66910,7 +66910,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "pmA" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -66927,7 +66927,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "pmS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -67481,7 +67481,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "ptJ" = (
 /obj/structure/cable/orange{
 	icon_state = "1-8"
@@ -67598,7 +67598,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "pvr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -67653,7 +67653,7 @@
 	req_access = list(10)
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "pvX" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -67744,7 +67744,7 @@
 "pxa" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "pxb" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -67792,7 +67792,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "pxr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -68056,7 +68056,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "pBh" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/double,
@@ -68064,7 +68064,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "pBi" = (
 /obj/structure/table/wood,
 /obj/item/storage/firstaid/brute,
@@ -68120,7 +68120,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/carpet/orange,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "pCm" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -68208,7 +68208,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "pDz" = (
 /obj/item/flag/clown,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -68672,7 +68672,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "pLi" = (
 /obj/structure/morgue,
 /obj/machinery/light/small{
@@ -68710,7 +68710,7 @@
 	dir = 8;
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "pLM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -68825,7 +68825,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "pOB" = (
 /obj/effect/landmark/event/lightsout,
 /turf/simulated/floor/plasteel{
@@ -69164,7 +69164,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/orange,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "pTJ" = (
 /obj/structure/rack,
 /obj/item/weldingtool/largetank,
@@ -69182,7 +69182,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "pTV" = (
 /obj/machinery/newscaster{
 	dir = 8;
@@ -69192,7 +69192,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "pUW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -69502,7 +69502,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "pYn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -69821,7 +69821,7 @@
 	dir = 6
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "qcL" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced{
@@ -69955,7 +69955,7 @@
 	dir = 10
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "qea" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -70280,7 +70280,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "qhx" = (
 /obj/item/radio/intercom{
 	pixel_y = 23
@@ -70337,7 +70337,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "qiy" = (
 /obj/item/stack/packageWrap,
 /obj/item/pen/blue{
@@ -70374,7 +70374,7 @@
 	network = list("SS13","CE")
 	},
 /turf/simulated/floor/carpet/orange,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "qjn" = (
 /obj/machinery/computer/operating{
 	dir = 8
@@ -70401,7 +70401,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "qjG" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -70535,7 +70535,7 @@
 	dir = 10;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "qle" = (
 /obj/item/chair/stool,
 /obj/structure/sign/poster/random{
@@ -70724,7 +70724,7 @@
 	dir = 4;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "qnz" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -71383,7 +71383,7 @@
 	},
 /obj/machinery/atmospherics/meter,
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "qxI" = (
 /mob/living/simple_animal/bot/secbot/podsky,
 /obj/machinery/hologram/holopad,
@@ -71567,7 +71567,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "qAi" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/plating,
@@ -71593,7 +71593,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "qAY" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -71769,7 +71769,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "qCK" = (
 /obj/machinery/camera{
 	c_tag = "Mech bay";
@@ -71843,7 +71843,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "qEp" = (
 /obj/machinery/light{
 	dir = 1
@@ -71896,7 +71896,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "qFp" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -71979,7 +71979,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "qGz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 1;
@@ -72219,7 +72219,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qKe" = (
 /obj/structure/cable/orange{
 	icon_state = "1-4"
@@ -72273,7 +72273,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qKK" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
@@ -72336,7 +72336,7 @@
 /area/maintenance/fsmaint4)
 "qMy" = (
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/engineering)
+/area/engineering/engine)
 "qMS" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -72436,7 +72436,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qNK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -72548,7 +72548,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qPs" = (
 /obj/machinery/light,
 /obj/structure/cable{
@@ -72586,7 +72586,7 @@
 	icon_state = "freezer_0"
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "qQx" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Port Asteroid Maintenance"
@@ -72793,7 +72793,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "qTE" = (
 /obj/structure/chair/comfy{
 	dir = 1
@@ -72902,7 +72902,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "qUH" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 7";
@@ -72975,7 +72975,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "qVA" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -73358,7 +73358,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "rbx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -73462,7 +73462,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "rdq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -73669,7 +73669,7 @@
 "rgJ" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/orange,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "rgX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -73700,7 +73700,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "rhr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -73845,7 +73845,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "rki" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/storage/belt/medical,
@@ -74044,7 +74044,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "ron" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -74061,7 +74061,7 @@
 	},
 /obj/effect/turf_decal/stripes/end,
 /turf/simulated/floor/plating,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "rox" = (
 /obj/effect/landmark/start/intern,
 /turf/simulated/floor/plasteel{
@@ -74072,7 +74072,7 @@
 /obj/structure/table,
 /obj/item/book/manual/supermatter_engine,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "roH" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "graveyard_church";
@@ -74096,7 +74096,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "roY" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -74204,7 +74204,7 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "rpT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -74285,7 +74285,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "rrz" = (
 /obj/structure/sign/directions/security{
 	dir = 1;
@@ -74791,7 +74791,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "rxB" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -75463,7 +75463,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "rHv" = (
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -75633,7 +75633,7 @@
 	},
 /obj/structure/closet/radiation,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "rKo" = (
 /obj/item/radio/intercom{
 	pixel_y = -30
@@ -75676,7 +75676,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "rLi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -75762,7 +75762,7 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/carpet/orange,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "rMs" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -76089,7 +76089,7 @@
 /turf/simulated/floor/plasteel{
 	dir = 8
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "rRk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -76195,7 +76195,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "rSk" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
@@ -76341,13 +76341,13 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "rUs" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "rUz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -76377,7 +76377,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "rUV" = (
 /turf/simulated/floor/engine,
 /area/toxins/explab_chamber)
@@ -76421,7 +76421,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "rVu" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -76695,7 +76695,7 @@
 	anchored = 1
 	},
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "rZA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -77221,7 +77221,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "sfL" = (
 /obj/effect/decal/warning_stripes/southeastcorner,
 /obj/effect/turf_decal/loading_area{
@@ -77318,7 +77318,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "sgV" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Escape Shuttle Cell";
@@ -77586,7 +77586,7 @@
 	dir = 8;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "slW" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/orange{
@@ -77819,7 +77819,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "spf" = (
 /obj/effect/spawner/random_spawners/blood_5,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -77867,7 +77867,7 @@
 	},
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "sqf" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -78368,7 +78368,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "sxI" = (
 /obj/structure/closet/firecloset/full,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -78467,7 +78467,7 @@
 /obj/machinery/gravity_generator/main/station,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/engine,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "szv" = (
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -78743,7 +78743,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "sFm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -79003,7 +79003,7 @@
 	},
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "sJD" = (
 /obj/effect/turf_decal/loading_area/white{
 	dir = 1
@@ -79361,7 +79361,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "sOl" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -79467,7 +79467,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "sPV" = (
 /obj/machinery/flasher{
 	desc = "A floor-mounted flashbulb device.";
@@ -79550,7 +79550,7 @@
 	dir = 10;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "sQV" = (
 /obj/item/radio/intercom{
 	dir = 4;
@@ -79681,7 +79681,7 @@
 	req_access = list(10,24)
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "sSB" = (
 /obj/machinery/holosign/surgery{
 	id = "surgery1"
@@ -79756,7 +79756,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "sTy" = (
 /obj/structure/spacepoddoor{
 	dir = 4;
@@ -79816,7 +79816,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "sUW" = (
 /turf/simulated/wall,
 /area/storage/eva)
@@ -80320,7 +80320,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "teH" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -80373,7 +80373,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "tfi" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
@@ -80430,7 +80430,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "tfI" = (
 /obj/item/target,
 /turf/simulated/floor/plasteel/airless,
@@ -80476,7 +80476,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "tgq" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/wood/fancy/light{
@@ -80596,7 +80596,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "thZ" = (
 /obj/structure/chair/stool/bar{
 	dir = 4
@@ -80642,7 +80642,7 @@
 	pixel_y = -3
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "tiD" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -81198,7 +81198,7 @@
 "tpH" = (
 /obj/effect/decal/warning_stripes/green,
 /turf/simulated/floor/engine,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "tpL" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -81360,7 +81360,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "tsc" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -81442,7 +81442,7 @@
 	layer = 4
 	},
 /turf/simulated/wall,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ttm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -81572,7 +81572,7 @@
 "tvw" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "tvA" = (
 /obj/effect/spawner/random_spawners/rodent,
 /turf/simulated/floor/wood/fancy/oak,
@@ -82327,7 +82327,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "tGD" = (
 /obj/machinery/door/poddoor/shutters{
 	id_tag = "MiningWarehouse"
@@ -82483,7 +82483,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "tIP" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/plasteel{
@@ -82502,7 +82502,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "tIZ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -82990,7 +82990,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "tPa" = (
 /turf/simulated/wall/r_wall,
 /area/security/detectives_office)
@@ -83072,7 +83072,7 @@
 "tQv" = (
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/engine,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "tQA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -83196,7 +83196,7 @@
 	pixel_y = -4
 	},
 /turf/simulated/floor/carpet/orange,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "tSs" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -83402,7 +83402,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "tVq" = (
 /obj/structure/spacepoddoor{
 	dir = 4;
@@ -83792,7 +83792,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "ubJ" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -83934,7 +83934,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ueJ" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Kitchen";
@@ -83995,7 +83995,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "ugs" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall,
@@ -84963,7 +84963,7 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "uvG" = (
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating,
@@ -85372,7 +85372,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "uCl" = (
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes,
@@ -85469,7 +85469,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "uCX" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -85582,7 +85582,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "uEX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -85900,7 +85900,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "uKq" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -86026,7 +86026,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "uMr" = (
 /turf/simulated/wall/r_wall,
 /area/toxins/lab)
@@ -86356,7 +86356,7 @@
 	anchored = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "uRn" = (
 /obj/machinery/computer/rdconsole/robotics,
 /turf/simulated/floor/plasteel{
@@ -86422,7 +86422,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "uRW" = (
 /obj/machinery/door/airlock/maintenance/external{
 	name = "External Airlock Access"
@@ -86558,7 +86558,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "uUY" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -86625,7 +86625,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "uWc" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -86667,7 +86667,7 @@
 "uWX" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "uXl" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -86727,7 +86727,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "uYp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -87002,7 +87002,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/visible/cyan,
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "vdN" = (
 /obj/machinery/power/apc{
 	pixel_y = -24
@@ -88420,7 +88420,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "vCc" = (
 /obj/structure/chair{
 	dir = 4
@@ -88754,7 +88754,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "vHE" = (
 /obj/structure/railing{
 	dir = 9
@@ -89342,7 +89342,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "vPn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -89532,7 +89532,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "vRg" = (
 /obj/structure/table/wood,
 /obj/machinery/light,
@@ -89777,7 +89777,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "vTh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -90301,7 +90301,7 @@
 	anchored = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "waT" = (
 /obj/item/clothing/head/cone,
 /turf/simulated/floor/plating,
@@ -90500,7 +90500,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "weO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -90518,7 +90518,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "weY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -90567,7 +90567,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "wfN" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -90693,7 +90693,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "whp" = (
 /obj/structure/window/reinforced,
 /obj/structure/cable/orange{
@@ -90997,7 +90997,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "wmp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -91057,7 +91057,7 @@
 	specialfunctions = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "wmJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -91141,7 +91141,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "wnM" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -91395,7 +91395,7 @@
 	},
 /obj/item/rcd/combat,
 /turf/simulated/floor/carpet/orange,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "wsb" = (
 /obj/machinery/door/poddoor/shutters{
 	id_tag = "stationawaygate";
@@ -92204,7 +92204,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "wDD" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -92224,7 +92224,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "wDX" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -92400,7 +92400,7 @@
 	dir = 6;
 	icon_state = "darkyellow"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "wFX" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/warning_stripes/west,
@@ -92453,7 +92453,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "wGP" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
@@ -92536,7 +92536,7 @@
 	},
 /obj/machinery/atmospherics/meter,
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "wIb" = (
 /obj/structure/cable/orange{
 	icon_state = "0-8"
@@ -92640,7 +92640,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "wJl" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 8
@@ -92695,7 +92695,7 @@
 "wKe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "wKi" = (
 /obj/effect/spawner/airlock,
 /turf/simulated/wall,
@@ -92764,7 +92764,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "wLz" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -92831,7 +92831,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "wNA" = (
 /obj/structure/table,
 /obj/item/storage/box/syringes,
@@ -92982,7 +92982,7 @@
 	pixel_y = 20
 	},
 /turf/simulated/floor/noslip,
-/area/engine/engineering)
+/area/engineering/engine)
 "wPL" = (
 /obj/structure/window/reinforced{
 	color = "red";
@@ -93018,7 +93018,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "wQf" = (
 /turf/simulated/wall,
 /area/crew_quarters/locker/locker_toilet)
@@ -93144,7 +93144,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "wSx" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -93217,7 +93217,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "wTF" = (
 /obj/structure/closet/secure_closet/security,
 /obj/structure/window/reinforced{
@@ -93884,7 +93884,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "xdw" = (
 /obj/structure/chair{
 	dir = 4
@@ -94068,7 +94068,7 @@
 "xfU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "xgi" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -94249,7 +94249,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "xji" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -94404,7 +94404,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "xlM" = (
 /turf/simulated/wall/r_wall,
 /area/janitor)
@@ -94426,7 +94426,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xlV" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -94473,7 +94473,7 @@
 "xmT" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "xmU" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -94730,7 +94730,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xrM" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -94985,7 +94985,7 @@
 /area/hallway/spacebridge/serveng)
 "xvx" = (
 /turf/simulated/wall,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "xvy" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -95054,7 +95054,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xwl" = (
 /obj/machinery/door/poddoor/shutters{
 	id_tag = "paramedic";
@@ -95180,7 +95180,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "xyd" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -95217,7 +95217,7 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "xyw" = (
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -95354,7 +95354,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "xzJ" = (
 /obj/machinery/alarm{
 	pixel_y = 24
@@ -95415,7 +95415,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xAz" = (
 /obj/machinery/iv_drip,
 /turf/simulated/floor/plasteel{
@@ -95686,7 +95686,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xEJ" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/shieldwallgen,
@@ -95789,7 +95789,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xGa" = (
 /obj/machinery/flasher{
 	id = "Cell 7";
@@ -95902,7 +95902,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xGE" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -95984,7 +95984,7 @@
 "xIu" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "xIG" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastleft{
@@ -96049,7 +96049,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "xJl" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -96145,7 +96145,7 @@
 	dir = 8;
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xKL" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -96251,7 +96251,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xLH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -96276,7 +96276,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "xMf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -96522,7 +96522,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "xQS" = (
 /turf/simulated/wall/r_wall,
 /area/security/prisonlockers)
@@ -96569,7 +96569,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "xRJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -96796,7 +96796,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "xTX" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -97007,7 +97007,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "xYM" = (
 /turf/space,
 /area/security/armory)
@@ -97170,7 +97170,7 @@
 /turf/simulated/floor/plasteel{
 	dir = 8
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "ybP" = (
 /turf/simulated/floor/carpet/green,
 /area/library)
@@ -97648,7 +97648,7 @@
 	dir = 10;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ykn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -925,7 +925,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "aey" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5794,7 +5794,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "atC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6875,7 +6875,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "awA" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
@@ -15485,7 +15485,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "aYu" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -15915,7 +15915,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "aZD" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -25812,7 +25812,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bEd" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -26173,13 +26173,13 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bFD" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bFG" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -26603,7 +26603,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bGR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -26920,7 +26920,7 @@
 	},
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "bIa" = (
 /turf/simulated/wall,
 /area/assembly/robotics)
@@ -28002,7 +28002,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "bLw" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -28245,7 +28245,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "bMs" = (
 /obj/structure/closet/wardrobe/black,
 /obj/item/toy/figure/ian,
@@ -28354,7 +28354,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bMJ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -28848,7 +28848,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bOv" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -28945,7 +28945,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bOJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -29394,7 +29394,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bQr" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
@@ -30804,7 +30804,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bUu" = (
 /obj/structure/chair{
 	dir = 8
@@ -31098,7 +31098,7 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/t_scanner,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "bVo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -31227,7 +31227,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bVC" = (
 /obj/machinery/optable{
 	name = "Robotics Operating Table"
@@ -31741,7 +31741,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bXf" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/wood,
@@ -31829,7 +31829,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bXs" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -31853,7 +31853,7 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bXu" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -32488,7 +32488,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bZf" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -33098,7 +33098,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "caF" = (
 /obj/machinery/light,
 /obj/machinery/disposal,
@@ -33242,7 +33242,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "caQ" = (
 /obj/effect/spawner/random_spawners/grille_13,
 /turf/simulated/floor/plating,
@@ -33292,7 +33292,7 @@
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cbe" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
@@ -33307,7 +33307,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "vault"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cbf" = (
 /turf/simulated/wall/r_wall,
 /area/toxins/server)
@@ -34506,7 +34506,7 @@
 "ceG" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "ceH" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -34734,7 +34734,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "cfy" = (
 /obj/item/extinguisher,
 /obj/item/storage/belt/utility,
@@ -34756,7 +34756,7 @@
 	},
 /obj/structure/table,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "cfz" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -36224,7 +36224,7 @@
 	},
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "cju" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
@@ -37139,7 +37139,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cmj" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -37335,7 +37335,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cmR" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -37874,7 +37874,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "coX" = (
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/plating,
@@ -38680,7 +38680,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "crX" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
@@ -38801,7 +38801,7 @@
 /area/medical/research)
 "csD" = (
 /turf/simulated/wall,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "csE" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -38829,7 +38829,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "csK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
@@ -38853,7 +38853,7 @@
 	dir = 4;
 	icon_state = "caution"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "csO" = (
 /obj/effect/decal/cleanable/dust,
 /obj/item/clothing/shoes/galoshes,
@@ -39015,7 +39015,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ctk" = (
 /obj/structure/rack{
 	dir = 8;
@@ -39039,7 +39039,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ctm" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -39111,7 +39111,7 @@
 	},
 /obj/item/radio,
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "ctu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -39144,7 +39144,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ctO" = (
 /obj/machinery/light{
 	dir = 8
@@ -39179,7 +39179,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ctT" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -39218,7 +39218,7 @@
 	pixel_x = -1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cub" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -39245,7 +39245,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cui" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39279,7 +39279,7 @@
 	dir = 4;
 	icon_state = "caution"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cul" = (
 /obj/structure/table/glass,
 /obj/item/seeds/apple,
@@ -39369,7 +39369,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cuu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -39680,7 +39680,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cvz" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -39712,11 +39712,11 @@
 	},
 /obj/item/radio,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cvC" = (
 /obj/machinery/computer/station_alert,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cvD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -39777,7 +39777,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cvK" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -39787,7 +39787,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cvL" = (
 /obj/machinery/computer/general_air_control{
 	name = "Tank Monitor";
@@ -39797,7 +39797,7 @@
 	dir = 4;
 	icon_state = "caution"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cvN" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -40047,7 +40047,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cwx" = (
 /obj/machinery/atmospherics/unary/tank/toxins{
 	volume = 3200
@@ -40142,7 +40142,7 @@
 /obj/machinery/computer/guestpass,
 /obj/structure/table,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cwM" = (
 /obj/structure/table,
 /obj/item/t_scanner,
@@ -40150,7 +40150,7 @@
 	dir = 4;
 	icon_state = "caution"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cwN" = (
 /obj/structure/rack{
 	dir = 8;
@@ -40282,7 +40282,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cxh" = (
 /obj/structure/sign/biohazard{
 	pixel_y = 32
@@ -40331,7 +40331,7 @@
 	dir = 6;
 	icon_state = "caution"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cxs" = (
 /obj/machinery/light{
 	dir = 8
@@ -40735,7 +40735,7 @@
 	sensors = list("mair_in_meter"="Mixed Air In","air_sensor"="Mixed Air Supply Tank","mair_out_meter"="Mixed Air Out","dloop_atm_meter"="Distribution Loop","wloop_atm_meter"="Waste Loop")
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cyy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -40957,7 +40957,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "czA" = (
 /obj/structure/table,
 /obj/machinery/firealarm{
@@ -40974,7 +40974,7 @@
 "czB" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "czC" = (
 /obj/structure/table,
 /obj/machinery/alarm{
@@ -41008,7 +41008,7 @@
 	amount = 50
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "czH" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
@@ -41271,7 +41271,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cAl" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil{
@@ -41283,7 +41283,7 @@
 	pixel_y = -7
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cAm" = (
 /obj/machinery/nuclearbomb{
 	r_code = "LOLNO"
@@ -41450,7 +41450,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cAN" = (
 /obj/machinery/gateway{
 	dir = 10
@@ -41479,7 +41479,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cAP" = (
 /turf/simulated/wall/r_wall,
 /area/toxins/misc_lab)
@@ -41706,7 +41706,7 @@
 /obj/machinery/recharger,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cBx" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -42663,7 +42663,7 @@
 "cEi" = (
 /obj/machinery/drone_fabricator,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cEj" = (
 /obj/item/radio/intercom{
 	name = "south station intercom (General)";
@@ -42671,7 +42671,7 @@
 	},
 /obj/machinery/computer/drone_control,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cEk" = (
 /obj/item/radio/intercom{
 	name = "south station intercom (General)";
@@ -42744,7 +42744,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "cEw" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -42761,7 +42761,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "cEx" = (
 /obj/item/stack/rods{
 	amount = 10
@@ -42826,7 +42826,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "cEK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -42845,7 +42845,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "cEM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -42960,7 +42960,7 @@
 /area/hallway/primary/aft)
 "cEY" = (
 /turf/simulated/wall,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "cEZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -42994,7 +42994,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "cFe" = (
 /obj/machinery/light,
 /turf/simulated/floor/plating,
@@ -43085,7 +43085,7 @@
 "cFu" = (
 /obj/machinery/computer/arcade,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cFw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -43132,7 +43132,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "cFD" = (
 /mob/living/simple_animal/mouse/brown/Tom,
 /turf/simulated/floor/plasteel{
@@ -43151,21 +43151,21 @@
 "cFK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "cFL" = (
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "cFM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "cFN" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "cFO" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -43177,7 +43177,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "cFP" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -43186,7 +43186,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "cFQ" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -43250,10 +43250,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/engine,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "cFX" = (
 /turf/simulated/floor/engine,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "cFY" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
@@ -43339,7 +43339,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cGq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43348,7 +43348,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cGs" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -43504,7 +43504,7 @@
 /area/crew_quarters/mrchangs)
 "cGJ" = (
 /turf/simulated/wall,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cGK" = (
 /turf/simulated/wall/r_wall,
 /area/atmos/control)
@@ -43619,7 +43619,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "cGZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -43643,7 +43643,7 @@
 "cHa" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "cHb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -43705,7 +43705,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cHj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43720,7 +43720,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cHk" = (
 /obj/structure/chair{
 	dir = 1
@@ -43742,7 +43742,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "cHm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43757,7 +43757,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cHn" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -43830,7 +43830,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cHx" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -43865,14 +43865,14 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "cHD" = (
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cHE" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/engine,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "cHF" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -43894,20 +43894,20 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cHL" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cHM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cHN" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Foyer"
@@ -43923,7 +43923,7 @@
 	dir = 5;
 	icon_state = "caution"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cHO" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/cable{
@@ -43939,7 +43939,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cHQ" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Control Room"
@@ -43991,7 +43991,7 @@
 	},
 /obj/effect/landmark/start/trainee_engineer,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cHV" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -44004,7 +44004,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/trainee_engineer,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cHW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44057,7 +44057,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cIf" = (
 /obj/structure/extinguisher_cabinet{
 	name = "north extinguisher cabinet";
@@ -44179,7 +44179,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "cIx" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
@@ -44263,7 +44263,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "cIM" = (
 /obj/machinery/door_control{
 	id = "mechpod";
@@ -44288,7 +44288,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "cIN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -44356,14 +44356,14 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cIT" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
 /obj/effect/landmark/start/atmospheric,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cIU" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel{
@@ -44508,7 +44508,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cJn" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -44530,7 +44530,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cJp" = (
 /obj/structure/table,
 /obj/item/weldingtool,
@@ -44665,7 +44665,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cJC" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -44674,7 +44674,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cJD" = (
 /obj/machinery/door/airlock/vault{
 	locked = 1;
@@ -44787,7 +44787,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "cJY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -45433,7 +45433,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cLQ" = (
 /obj/structure/table,
 /obj/item/stack/sheet/mineral/plasma{
@@ -45463,14 +45463,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cLT" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
 /obj/effect/landmark/start/atmospheric,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cLV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -45637,7 +45637,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/engine,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "cMr" = (
 /obj/machinery/newscaster{
 	name = "south newscaster";
@@ -45814,7 +45814,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cMN" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/window/southleft{
@@ -45885,7 +45885,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cMX" = (
 /obj/machinery/light_switch{
 	name = "north light switch";
@@ -46008,7 +46008,7 @@
 /obj/machinery/particle_accelerator/control_box,
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "cNk" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -46018,7 +46018,7 @@
 /obj/effect/decal/warning_stripes/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cNl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -46234,7 +46234,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cNP" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4;
@@ -46289,11 +46289,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "cNW" = (
 /obj/structure/particle_accelerator/fuel_chamber,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "cNX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -46341,23 +46341,23 @@
 	},
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "cOd" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cOe" = (
 /obj/effect/landmark/start/engineer,
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cOf" = (
 /turf/simulated/wall/r_wall,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "cOi" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -46389,7 +46389,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cOn" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
@@ -46440,7 +46440,7 @@
 "cOt" = (
 /obj/machinery/vending/tool,
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "cOu" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -46474,7 +46474,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "cOz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -46561,7 +46561,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cOM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -46649,7 +46649,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cOZ" = (
 /obj/structure/extinguisher_cabinet{
 	name = "east extinguisher cabinet";
@@ -46657,7 +46657,7 @@
 	},
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cPb" = (
 /obj/machinery/newscaster{
 	name = "south newscaster";
@@ -46696,7 +46696,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "cPg" = (
 /obj/structure/closet/cardboard{
 	icon_closed = "cardboard_engineering";
@@ -46738,7 +46738,7 @@
 "cPl" = (
 /obj/structure/engineeringcart,
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "cPm" = (
 /obj/structure/table,
 /obj/item/storage/box/beakers{
@@ -46952,7 +46952,7 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "cPO" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -47265,13 +47265,13 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cQI" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "cQJ" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -47292,7 +47292,7 @@
 /obj/item/radio,
 /obj/item/storage/belt/utility,
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "cQP" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	input_tag = "n2_in";
@@ -47355,7 +47355,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cQW" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -47391,7 +47391,7 @@
 /obj/item/tank/internals/plasma,
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "cQZ" = (
 /obj/structure/grille,
 /turf/simulated/wall/r_wall,
@@ -47432,7 +47432,7 @@
 "cRf" = (
 /obj/structure/particle_accelerator/particle_emitter/center,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "cRh" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -47535,7 +47535,7 @@
 	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cRq" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -47544,7 +47544,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cRr" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -47565,7 +47565,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "cRs" = (
 /obj/machinery/alarm{
 	pixel_y = 24
@@ -47693,7 +47693,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cRJ" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -47719,7 +47719,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "cRK" = (
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 1
@@ -47732,14 +47732,14 @@
 	id = "ceoffice"
 	},
 /turf/simulated/floor/plating,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "cRM" = (
 /obj/machinery/computer/card/minor/ce,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "cRN" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -47765,7 +47765,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "cRR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
@@ -47781,7 +47781,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "cRS" = (
 /turf/simulated/wall/r_wall,
 /area/atmos)
@@ -47791,7 +47791,7 @@
 	amount = 15
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "cRV" = (
 /obj/machinery/computer/atmos_alert,
 /obj/effect/decal/warning_stripes/southeast,
@@ -47812,7 +47812,7 @@
 /area/crew_quarters/bar)
 "cRX" = (
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "cRY" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -47927,7 +47927,7 @@
 /obj/item/pen,
 /obj/structure/table,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cSm" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	input_tag = "waste_in";
@@ -47979,7 +47979,7 @@
 "cSx" = (
 /obj/structure/particle_accelerator/power_box,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "cSy" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -48023,7 +48023,7 @@
 	},
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "cSH" = (
 /obj/item/extinguisher,
 /obj/item/extinguisher{
@@ -48069,11 +48069,11 @@
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "cSN" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cSO" = (
 /obj/machinery/light{
 	dir = 8
@@ -48123,7 +48123,7 @@
 /area/maintenance/engineering)
 "cSU" = (
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "cSV" = (
 /obj/structure/table/wood,
 /obj/item/deck/cards,
@@ -48217,7 +48217,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "cTg" = (
 /obj/structure/table,
 /obj/item/airlock_electronics,
@@ -48227,7 +48227,7 @@
 /obj/item/stack/tape_roll,
 /obj/item/stack/tape_roll,
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "cTh" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -48336,7 +48336,7 @@
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "cTy" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -48403,14 +48403,14 @@
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "cTG" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cTI" = (
 /turf/simulated/wall/r_wall,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "cTJ" = (
 /obj/structure/chair/comfy/blue{
 	dir = 1
@@ -48439,7 +48439,7 @@
 /area/hallway/primary/port)
 "cTM" = (
 /turf/simulated/wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "cTN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -48449,14 +48449,14 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "cTO" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "cTP" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -48596,7 +48596,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cUi" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -48611,7 +48611,7 @@
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "cUm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -48696,7 +48696,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "cUu" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -48712,7 +48712,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "cUv" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -48736,7 +48736,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "cUx" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -48748,7 +48748,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "cUz" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
@@ -48857,7 +48857,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "cUQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -48920,7 +48920,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cUZ" = (
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel{
@@ -48955,7 +48955,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cVc" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -49013,7 +49013,7 @@
 "cVh" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cVi" = (
 /obj/machinery/door/airlock/public/glass{
 	id = "vipbar";
@@ -49035,7 +49035,7 @@
 /area/crew_quarters/bar)
 "cVj" = (
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cVk" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -49045,7 +49045,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cVm" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -49090,7 +49090,7 @@
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cVr" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -49159,7 +49159,7 @@
 "cVw" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cVx" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -49168,7 +49168,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cVz" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -49194,7 +49194,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cVC" = (
 /obj/machinery/door/morgue{
 	name = "Confession Booth (Chaplain)";
@@ -49210,7 +49210,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cVE" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -49310,7 +49310,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cVV" = (
 /obj/structure/chair{
 	dir = 4
@@ -49342,7 +49342,7 @@
 	anchored = 1
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "cVY" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes{
@@ -49392,7 +49392,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cWh" = (
 /obj/item/flag/nt,
 /obj/effect/decal/warning_stripes/southeast,
@@ -49490,7 +49490,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cWt" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -49504,7 +49504,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cWv" = (
 /obj/item/radio/intercom{
 	name = "south station intercom (General)";
@@ -49568,7 +49568,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cWD" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -49584,7 +49584,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "cWE" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 10
@@ -49604,7 +49604,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cWG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -49621,7 +49621,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cWI" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -49633,7 +49633,7 @@
 /obj/machinery/power/smes/engineering,
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cWJ" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -49659,7 +49659,7 @@
 "cWN" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cWO" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -49862,7 +49862,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cXx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -49879,7 +49879,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "cXz" = (
 /obj/structure/bookcase{
 	name = "bookcase (Reference)"
@@ -49904,7 +49904,7 @@
 	},
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "cXD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -49913,7 +49913,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cXE" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engine Room";
@@ -49922,7 +49922,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cXF" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
@@ -49930,7 +49930,7 @@
 	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "cXG" = (
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -49940,7 +49940,7 @@
 	id = "ceoffice"
 	},
 /turf/simulated/floor/plating,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "cXH" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -49964,7 +49964,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cXL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -49975,7 +49975,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "cXM" = (
 /obj/structure/extinguisher_cabinet{
 	name = "east extinguisher cabinet";
@@ -49990,7 +49990,7 @@
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cXN" = (
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -50001,7 +50001,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cXO" = (
 /obj/machinery/atmospherics/binary/volume_pump/on{
 	dir = 8;
@@ -50022,7 +50022,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cXQ" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -50049,7 +50049,7 @@
 "cXS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cYa" = (
 /obj/machinery/atmospherics/trinary/filter/flipped{
 	filter_type = 4;
@@ -50133,7 +50133,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cYn" = (
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plating,
@@ -50150,7 +50150,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cYq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -50165,7 +50165,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cYs" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -50173,7 +50173,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cYu" = (
 /obj/machinery/door/airlock/research,
 /obj/machinery/door/firedoor,
@@ -50208,7 +50208,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cYw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -50251,7 +50251,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cYD" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/structure/cable/yellow{
@@ -50265,7 +50265,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cYE" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -50278,11 +50278,11 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cYF" = (
 /obj/structure/particle_accelerator/end_cap,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "cYG" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -50291,7 +50291,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cYH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -50357,7 +50357,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cYR" = (
 /obj/effect/decal/warning_stripes/northwestcorner,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -50389,7 +50389,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "cYY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -50412,7 +50412,7 @@
 	req_access = list(10)
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cYZ" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -50426,7 +50426,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cZc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
@@ -50489,7 +50489,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cZm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -50604,7 +50604,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cZH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -50653,7 +50653,7 @@
 "cZL" = (
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cZM" = (
 /obj/machinery/light{
 	dir = 8
@@ -50671,7 +50671,7 @@
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cZP" = (
 /obj/machinery/computer/monitor{
 	name = "Grid Power Monitoring Computer"
@@ -50684,13 +50684,13 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cZQ" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cZR" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -50709,7 +50709,7 @@
 /obj/effect/decal/warning_stripes/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cZS" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
@@ -50866,7 +50866,7 @@
 "daw" = (
 /obj/item/radio,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "day" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -51128,7 +51128,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dbs" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -51143,7 +51143,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dbt" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -51196,7 +51196,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dbI" = (
 /turf/simulated/floor/engine/plasma,
 /area/atmos)
@@ -51272,7 +51272,7 @@
 /area/library)
 "dcj" = (
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "dcl" = (
 /obj/machinery/door/morgue{
 	name = "Confession Booth"
@@ -51374,7 +51374,7 @@
 	},
 /obj/effect/landmark/start/trainee_engineer,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "dcC" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -51469,7 +51469,7 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dcQ" = (
 /obj/structure/table,
 /obj/item/cartridge/medical,
@@ -51548,7 +51548,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "ddc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -51829,7 +51829,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "ddX" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -52079,7 +52079,7 @@
 	},
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "deD" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
@@ -52359,7 +52359,7 @@
 "dfo" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "dfp" = (
 /obj/structure/table/reinforced,
 /obj/item/flash,
@@ -52913,7 +52913,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dhk" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -56217,7 +56217,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dsI" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -56225,7 +56225,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dsK" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -56250,7 +56250,7 @@
 	id = "ceoffice"
 	},
 /turf/simulated/floor/plating,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "dsL" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -56262,7 +56262,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "dsO" = (
 /obj/structure/rack{
 	dir = 8;
@@ -56278,17 +56278,17 @@
 "dsP" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dsT" = (
 /obj/structure/closet/secure_closet/engineering_welding,
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "dsU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dsX" = (
 /obj/item/cartridge/engineering{
 	pixel_x = 3
@@ -56303,7 +56303,7 @@
 	},
 /obj/structure/table,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dsY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -56315,7 +56315,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "dta" = (
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -56325,7 +56325,7 @@
 	id = "ceoffice"
 	},
 /turf/simulated/floor/plating,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "dtb" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -56342,7 +56342,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "dtk" = (
 /obj/structure/chair/stool,
 /obj/effect/decal/warning_stripes/northwest,
@@ -56355,7 +56355,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dtn" = (
 /obj/machinery/atmospherics/binary/pump{
 	desc = "Позволяет подать смесь в вентиляции станции";
@@ -56378,7 +56378,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dtq" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable/yellow{
@@ -56396,7 +56396,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dts" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -56415,7 +56415,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dtt" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -56434,7 +56434,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dtv" = (
 /obj/machinery/atmospherics/binary/volume_pump,
 /turf/simulated/floor/plasteel,
@@ -56447,7 +56447,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "dtJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -56491,7 +56491,7 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "dwd" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -56827,7 +56827,7 @@
 	req_access = list(70)
 	},
 /turf/simulated/floor/engine,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "dHU" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -57169,7 +57169,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "dTh" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -57258,7 +57258,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dWZ" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
@@ -57540,7 +57540,7 @@
 /obj/machinery/light,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "eij" = (
 /obj/machinery/atmospherics/binary/valve/digital{
 	color = "";
@@ -57703,7 +57703,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "ene" = (
 /obj/structure/sign/barsign,
 /turf/simulated/wall,
@@ -57748,7 +57748,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "eou" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -57759,7 +57759,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "eoD" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plating,
@@ -57792,7 +57792,7 @@
 	anchored = 1
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "epx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_construct{
@@ -58036,7 +58036,7 @@
 "ezE" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall,
-/area/engine/break_room)
+/area/engineering/break_room)
 "ezX" = (
 /obj/item/radio/intercom{
 	name = "west station intercom (General)";
@@ -58052,7 +58052,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "eAt" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -58176,7 +58176,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "eEk" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -58288,7 +58288,7 @@
 	},
 /obj/item/storage/belt/utility,
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "eGG" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -58412,7 +58412,7 @@
 /obj/machinery/power/smes/engineering,
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "eKm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -58421,7 +58421,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/engine,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "eKr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -58434,7 +58434,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "eKD" = (
 /obj/effect/spawner/random_spawners/oil_20,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -58560,7 +58560,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "eNn" = (
 /obj/item/restraints/handcuffs/cable/zipties/used,
 /obj/structure/filingcabinet,
@@ -59169,7 +59169,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "fqf" = (
 /obj/structure/extinguisher_cabinet{
 	name = "north extinguisher cabinet";
@@ -59316,7 +59316,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "fuS" = (
 /obj/item/radio/intercom{
 	name = "north station intercom (General)";
@@ -59455,7 +59455,7 @@
 	req_access = list(56)
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "fys" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -59623,7 +59623,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "fEn" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -59748,7 +59748,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "fIu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59829,7 +59829,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "fLc" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -59906,7 +59906,7 @@
 	network = list("Singularity","SS13")
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "fNF" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -60640,7 +60640,7 @@
 "gkC" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "gkT" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -60753,7 +60753,7 @@
 	dir = 10
 	},
 /turf/simulated/wall,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "gnw" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -60777,7 +60777,7 @@
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "goP" = (
 /obj/machinery/atmospherics/binary/pump,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -60847,7 +60847,7 @@
 /area/security/securearmory)
 "gqS" = (
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "grc" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -61506,7 +61506,7 @@
 "gRH" = (
 /obj/machinery/suit_storage_unit/engine,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "gRL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -62130,7 +62130,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "hmT" = (
 /obj/machinery/suit_storage_unit/atmos,
 /obj/item/radio/intercom{
@@ -62198,7 +62198,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "hpW" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
@@ -62301,7 +62301,7 @@
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "htx" = (
 /obj/effect/decal/cleanable/dust,
 /obj/effect/decal/cleanable/blood/drip{
@@ -62447,7 +62447,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "hxK" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "blue"
@@ -62489,7 +62489,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "hyv" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -62524,7 +62524,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "hzw" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -62808,7 +62808,7 @@
 	req_access = list(70)
 	},
 /turf/simulated/floor/engine,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "hJq" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/red{
@@ -63069,7 +63069,7 @@
 "hTc" = (
 /obj/machinery/vending/engivend,
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "hTd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -63119,7 +63119,7 @@
 	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "hUJ" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -63402,7 +63402,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "idU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -63552,7 +63552,7 @@
 "iiL" = (
 /obj/item/multitool,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "iko" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
@@ -63602,7 +63602,7 @@
 "imf" = (
 /obj/structure/particle_accelerator/particle_emitter/left,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "imD" = (
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start/scientist,
@@ -63677,7 +63677,7 @@
 /obj/structure/cable,
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "iow" = (
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken7"
@@ -64013,7 +64013,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "iBi" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -64114,7 +64114,7 @@
 	id = "ceoffice"
 	},
 /turf/simulated/floor/plating,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "iDA" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
@@ -64832,7 +64832,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "jcp" = (
 /obj/machinery/light{
 	dir = 1
@@ -64840,7 +64840,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "jcJ" = (
 /obj/effect/landmark/start/shaft_miner,
 /obj/structure/sign/poster/official/space_a{
@@ -65022,7 +65022,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "jkT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -65531,7 +65531,7 @@
 	},
 /obj/effect/decal/warning_stripes/northwestsouth,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "jEi" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/binary/valve{
@@ -65751,7 +65751,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "jOA" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light{
@@ -65817,7 +65817,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "jSz" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -65839,7 +65839,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "jSX" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
@@ -66020,7 +66020,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "jYT" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_x = -24;
@@ -66091,7 +66091,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "kbl" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Launch Room";
@@ -66380,7 +66380,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "kjl" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Morgue"
@@ -66487,7 +66487,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/engine,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "kmd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall,
@@ -66634,7 +66634,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "ksA" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -66690,7 +66690,7 @@
 	dir = 5;
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "ktZ" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -66958,7 +66958,7 @@
 /area/medical/patients_rooms)
 "kCz" = (
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "kCL" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -66986,7 +66986,7 @@
 "kDj" = (
 /obj/structure/lattice,
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "kDx" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor{
@@ -67299,7 +67299,7 @@
 /obj/machinery/computer/podtracker,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "kNZ" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -67363,7 +67363,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "kRU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -67751,7 +67751,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "lki" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/spawner/lootdrop{
@@ -67840,13 +67840,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "lop" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "lpl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -67978,7 +67978,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "lsc" = (
 /obj/machinery/suit_storage_unit/captain,
 /turf/simulated/floor/wood,
@@ -67991,7 +67991,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "lsD" = (
 /obj/machinery/light{
 	dir = 1
@@ -68099,7 +68099,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "lww" = (
 /obj/effect/decal/cleanable/dust,
 /obj/structure/computerframe,
@@ -68275,7 +68275,7 @@
 	shock_proof = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "lBX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -68287,7 +68287,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "lCh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -68869,7 +68869,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "lUU" = (
 /obj/structure/rack{
 	dir = 1
@@ -69065,7 +69065,7 @@
 	network = list("Singularity","SS13")
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "lZI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -69469,7 +69469,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "mmq" = (
 /obj/structure/urinal{
 	pixel_y = 30
@@ -69668,7 +69668,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "mug" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
@@ -69682,7 +69682,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "muw" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/wood{
@@ -69982,7 +69982,7 @@
 	id = "ceoffice"
 	},
 /turf/simulated/floor/plating,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "mCD" = (
 /obj/machinery/door/window{
 	base_state = "right";
@@ -70293,7 +70293,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "mNR" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/warning_stripes/yellow,
@@ -70336,7 +70336,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "mQQ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -70395,7 +70395,7 @@
 	},
 /obj/machinery/computer/station_alert,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "mTD" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -70530,7 +70530,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "mZa" = (
 /obj/machinery/chem_master,
 /turf/simulated/floor/plating,
@@ -70657,7 +70657,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "nfh" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -70786,7 +70786,7 @@
 	},
 /obj/structure/table,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "niQ" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -70897,7 +70897,7 @@
 	req_access = list(32)
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "nmo" = (
 /obj/effect/decal/warning_stripes/west{
 	icon = 'icons/turf/floors.dmi';
@@ -70996,7 +70996,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "nqt" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -71171,7 +71171,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "nvB" = (
 /obj/structure/sign/electricshock,
 /turf/simulated/wall/r_wall,
@@ -71179,14 +71179,14 @@
 "nvG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "nwm" = (
 /obj/machinery/gravity_generator/main/station,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "nwH" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
@@ -71443,7 +71443,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "nFy" = (
 /obj/machinery/mech_bay_recharge_port,
 /obj/machinery/status_display{
@@ -71578,7 +71578,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "nKt" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -71659,7 +71659,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "nMn" = (
 /obj/machinery/light/small,
 /obj/machinery/turretid/stun{
@@ -72111,7 +72111,7 @@
 "ocw" = (
 /obj/machinery/computer/station_alert,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "ocx" = (
 /obj/structure/grille/broken,
 /obj/structure/disposalpipe/segment{
@@ -72405,7 +72405,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "orW" = (
 /obj/machinery/door_control{
 	id = "Warden";
@@ -72932,7 +72932,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "oMl" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -73071,7 +73071,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "oQe" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -73282,7 +73282,7 @@
 	c_tag = "Mechanic's Workshop West"
 	},
 /turf/simulated/floor/engine,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "oVG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -73386,7 +73386,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "oZx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
@@ -73481,7 +73481,7 @@
 	},
 /obj/effect/decal/warning_stripes/northeastsouth,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "pbS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -73489,7 +73489,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "pcR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -73500,7 +73500,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "pcV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -73513,7 +73513,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "pdw" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -73572,7 +73572,7 @@
 "pfl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "pgN" = (
 /obj/machinery/light{
 	dir = 1
@@ -73602,7 +73602,7 @@
 	c_tag = "Engineering North-West"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "phj" = (
 /obj/machinery/disposal,
 /obj/structure/window/reinforced,
@@ -73930,7 +73930,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "prU" = (
 /obj/machinery/door/poddoor{
 	id_tag = "ToxinsVenting";
@@ -73968,7 +73968,7 @@
 /obj/item/mounted/frame/apc_frame,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "pur" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/effect/decal/cleanable/dirt,
@@ -74180,7 +74180,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "pzT" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "bluecorner"
@@ -74216,7 +74216,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "pBT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -74610,7 +74610,7 @@
 "pPs" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "pPy" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -74646,7 +74646,7 @@
 /obj/machinery/power/smes/engineering,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "pSk" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -74746,7 +74746,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "pUQ" = (
 /obj/effect/landmark/event/blobstart,
 /turf/simulated/floor/plating,
@@ -74801,7 +74801,7 @@
 	amount = 50
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "pXp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -74860,7 +74860,7 @@
 	},
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "pYu" = (
 /obj/item/shard{
 	icon_state = "medium"
@@ -75104,7 +75104,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qfh" = (
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -75224,7 +75224,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "qis" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -75246,7 +75246,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "qiZ" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
@@ -75523,7 +75523,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qrd" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow{
@@ -75536,7 +75536,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qrt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -75584,7 +75584,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qrU" = (
 /obj/machinery/access_button{
 	command = "cycle_exterior";
@@ -75629,7 +75629,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qrZ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -75649,7 +75649,7 @@
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "qsv" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -75799,7 +75799,7 @@
 "qyc" = (
 /obj/machinery/light,
 /turf/simulated/floor/engine,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "qyM" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -76076,7 +76076,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "qGJ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -76547,7 +76547,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "qWv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -76556,7 +76556,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "qWW" = (
 /obj/effect/spawner/random_spawners/grille_13,
 /turf/simulated/floor/plating,
@@ -76721,7 +76721,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "rcC" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -76733,7 +76733,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "rcW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -76747,7 +76747,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "rdG" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -76827,7 +76827,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "rgJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -77043,7 +77043,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "rns" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
@@ -77128,7 +77128,7 @@
 /obj/structure/table,
 /obj/item/folder/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "rra" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -77178,7 +77178,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "rtf" = (
 /obj/machinery/computer/monitor{
 	name = "Grid Power Monitoring Computer"
@@ -77191,7 +77191,7 @@
 	dir = 5;
 	icon_state = "caution"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "rts" = (
 /obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
@@ -77239,7 +77239,7 @@
 	req_access = list(10)
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "rvB" = (
 /obj/item/radio/intercom{
 	name = "east station intercom (General)";
@@ -77322,7 +77322,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "rzs" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Launch Room";
@@ -77401,7 +77401,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "rBk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -77695,7 +77695,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "rKT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -77803,7 +77803,7 @@
 	},
 /obj/structure/closet/walllocker/emerglocker/north,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "rOf" = (
 /obj/structure/table,
 /obj/machinery/computer/library,
@@ -78158,7 +78158,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "rYX" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable{
@@ -78281,7 +78281,7 @@
 "seg" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "seB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -78461,7 +78461,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "slH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -78584,7 +78584,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "soD" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 6
@@ -78836,7 +78836,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "sxQ" = (
 /obj/machinery/seed_extractor,
 /turf/simulated/floor/plasteel{
@@ -78950,7 +78950,7 @@
 "sAN" = (
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "sAQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -78974,7 +78974,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "sBn" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -79001,7 +79001,7 @@
 "sCk" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "sCv" = (
 /obj/machinery/keycard_auth{
 	pixel_x = -24
@@ -79112,7 +79112,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "sGx" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -79125,7 +79125,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "sGy" = (
 /turf/simulated/floor/wood,
 /area/security/permabrig)
@@ -79258,7 +79258,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "sJK" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -79363,7 +79363,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "sNF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -79503,7 +79503,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "sSa" = (
 /obj/item/radio/intercom{
 	name = "east station intercom (General)";
@@ -79534,7 +79534,7 @@
 	req_access = list(70)
 	},
 /turf/simulated/floor/engine,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "sTD" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -79620,7 +79620,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "sVP" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -79806,7 +79806,7 @@
 "tai" = (
 /obj/structure/particle_accelerator/particle_emitter/right,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "tar" = (
 /obj/machinery/atm{
 	pixel_y = 32
@@ -79915,7 +79915,7 @@
 /area/security/main)
 "tel" = (
 /turf/simulated/wall/r_wall,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "teF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80281,7 +80281,7 @@
 	id_tag = "engineering_east_pump"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "tsS" = (
 /obj/machinery/door/poddoor{
 	id_tag = "QMLoaddoor2";
@@ -80302,7 +80302,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "tul" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -80400,7 +80400,7 @@
 "twI" = (
 /obj/item/screwdriver,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "txb" = (
 /obj/structure/chair{
 	dir = 8
@@ -80555,7 +80555,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "tDy" = (
 /obj/machinery/atmospherics/binary/pump,
 /obj/effect/decal/warning_stripes/east,
@@ -80573,7 +80573,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "tEe" = (
 /obj/machinery/disposal,
 /obj/structure/sign/poster/random{
@@ -80597,7 +80597,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "tFt" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/conveyor{
@@ -80659,7 +80659,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "tGS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -80671,7 +80671,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "tGW" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/transit_tube/horizontal,
@@ -80697,7 +80697,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "tHR" = (
 /obj/structure/extinguisher_cabinet{
 	name = "west extinguisher cabinet";
@@ -80762,7 +80762,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "tKP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -81020,7 +81020,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "tSN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -81153,7 +81153,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "tUW" = (
 /obj/structure/sink{
 	dir = 8;
@@ -81259,7 +81259,7 @@
 /obj/structure/table,
 /obj/item/book/manual/supermatter_engine,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "tZJ" = (
 /turf/simulated/wall/r_wall,
 /area/security/prison/cell_block/A)
@@ -81382,7 +81382,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "uee" = (
 /obj/machinery/atmospherics/unary/passive_vent{
 	dir = 8
@@ -81445,7 +81445,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "ugo" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -81597,7 +81597,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "ulP" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -81791,7 +81791,7 @@
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "urb" = (
 /obj/machinery/vending/coffee/free,
 /obj/effect/decal/cleanable/dust,
@@ -82010,7 +82010,7 @@
 "uFb" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine/vacuum,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "uGn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -82079,7 +82079,7 @@
 "uIN" = (
 /obj/structure/spacepoddoor,
 /turf/simulated/floor/engine,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "uKm" = (
 /obj/structure/closet/wardrobe/robotics_black,
 /turf/simulated/floor/plasteel{
@@ -82775,7 +82775,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "vhX" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -83090,7 +83090,7 @@
 	name = "HIGH VOLTAGE"
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "vqF" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
@@ -83105,7 +83105,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "vqU" = (
 /obj/effect/decal/cleanable/dust,
 /obj/structure/cable{
@@ -83213,7 +83213,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "vuP" = (
 /obj/structure/sink{
 	dir = 4;
@@ -83259,7 +83259,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "vwm" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/reinforced,
@@ -83538,7 +83538,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "vGs" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -83603,7 +83603,7 @@
 	},
 /obj/item/book/manual/sop_engineering,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "vHO" = (
 /obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plasteel,
@@ -83681,7 +83681,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "vKB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -83772,7 +83772,7 @@
 	},
 /obj/machinery/vending/clothing/departament/engineering,
 /turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
+/area/engineering/equipmentstorage)
 "vMW" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plating,
@@ -84034,7 +84034,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "vUO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -84044,7 +84044,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "vUY" = (
 /mob/living/carbon/human/lesser/monkey,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -84208,7 +84208,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "vYZ" = (
 /obj/effect/decal/warning_stripes/northwest,
 /obj/effect/decal/cleanable/cobweb,
@@ -84465,7 +84465,7 @@
 /area/maintenance/starboardsolar)
 "wgs" = (
 /turf/simulated/wall/r_wall,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "wgv" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -84570,7 +84570,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "whS" = (
 /obj/machinery/ai_status_display{
 	pixel_y = 32
@@ -84615,7 +84615,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "wjB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -84819,7 +84819,7 @@
 	id = "ceoffice"
 	},
 /turf/simulated/floor/plating,
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "won" = (
 /obj/structure/table,
 /obj/machinery/alarm{
@@ -85296,7 +85296,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "wES" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -85397,7 +85397,7 @@
 /obj/effect/decal/warning_stripes/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "wHt" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -85721,7 +85721,7 @@
 /obj/item/book/manual/engineering_construction,
 /obj/item/book/manual/supermatter_engine,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "wQN" = (
 /obj/structure/mirror{
 	pixel_x = 28
@@ -85973,7 +85973,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "wZh" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/item/radio/intercom{
@@ -86035,7 +86035,7 @@
 	req_access = list(70)
 	},
 /turf/simulated/floor/engine,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "xbH" = (
 /obj/effect/spawner/window/reinforced/polarized{
 	id = "qm"
@@ -86376,7 +86376,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "xku" = (
 /obj/effect/spawner/window/reinforced/polarized{
 	id = "qm"
@@ -86589,7 +86589,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "xpC" = (
 /obj/item/flag/nt,
 /turf/simulated/floor/wood,
@@ -86886,7 +86886,7 @@
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "xzR" = (
 /obj/structure/chair/stool,
 /obj/effect/decal/warning_stripes/red/hollow,
@@ -86983,7 +86983,7 @@
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "xCu" = (
 /obj/structure/table/glass,
 /obj/item/taperecorder{
@@ -87143,7 +87143,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "xId" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -87466,7 +87466,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "xTY" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/status_display/supply_display{
@@ -87490,7 +87490,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/chiefs_office)
+/area/engineering/chiefs_office)
 "xVn" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -87633,7 +87633,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "xZU" = (
 /obj/machinery/computer/crew,
 /turf/simulated/floor/plasteel{
@@ -87800,7 +87800,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/engine,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "ygO" = (
 /obj/machinery/light/small{
 	dir = 8

--- a/_maps/map_files/debug/multiz_test.dmm
+++ b/_maps/map_files/debug/multiz_test.dmm
@@ -57,7 +57,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bC" = (
 /turf/space/openspace,
 /area/space/nearstation)
@@ -66,7 +66,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -84,7 +84,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "cr" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
@@ -108,7 +108,7 @@
 /obj/item/screwdriver/power,
 /obj/item/wirecutters/power,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "cT" = (
 /turf/simulated/wall/r_wall,
 /area/atmos)
@@ -158,7 +158,7 @@
 	},
 /obj/structure/dispenser,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "eO" = (
 /obj/machinery/light{
 	dir = 1
@@ -178,7 +178,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "fa" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -217,7 +217,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "gw" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -299,7 +299,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "ih" = (
 /obj/item/wirecutters,
 /turf/simulated/floor/glass/plasma,
@@ -309,7 +309,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "is" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 8
@@ -324,7 +324,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "iA" = (
 /turf/simulated/floor/plasteel{
 	dir = 10
@@ -345,13 +345,13 @@
 	anchored = 1
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "iP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "ja" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
@@ -394,7 +394,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "kN" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -507,7 +507,7 @@
 /turf/simulated/floor/plasteel{
 	dir = 8
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "nR" = (
 /obj/machinery/light{
 	dir = 1
@@ -537,7 +537,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "pi" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -546,7 +546,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "pp" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -562,14 +562,14 @@
 "qe" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "qg" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 1
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "qq" = (
 /turf/space,
 /area/space)
@@ -605,7 +605,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "ri" = (
 /obj/machinery/light{
 	dir = 1
@@ -634,14 +634,14 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "rP" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
 	on = 1
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "rW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -675,7 +675,7 @@
 "ss" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "sv" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
@@ -743,7 +743,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "ud" = (
 /obj/machinery/alarm{
 	locked = 0;
@@ -758,12 +758,12 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "uh" = (
 /turf/simulated/floor/plasteel{
 	dir = 4
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "ur" = (
 /obj/machinery/light{
 	dir = 4
@@ -774,7 +774,7 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/unary/outlet_injector/on,
 /turf/space,
-/area/engine/engineering)
+/area/engineering/engine)
 "uO" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -790,14 +790,14 @@
 	},
 /obj/machinery/door/airlock,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "vq" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /obj/item/wrench/power,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "vr" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -837,7 +837,7 @@
 "wj" = (
 /obj/machinery/computer/sm_monitor,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "wl" = (
 /turf/simulated/floor/plasteel,
 /area/construction/hallway)
@@ -847,7 +847,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "wG" = (
 /obj/structure/cable/multiz{
 	color = "#dd1010"
@@ -888,7 +888,7 @@
 "xg" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "xs" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/item/pizzabox,
@@ -976,7 +976,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "zY" = (
 /obj/item/pizzabox,
 /turf/simulated/floor/plasteel{
@@ -1005,7 +1005,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "AI" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/openspace,
@@ -1066,13 +1066,13 @@
 /turf/simulated/floor/plasteel{
 	dir = 8
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "Cm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "CJ" = (
 /obj/machinery/light{
 	dir = 8
@@ -1104,7 +1104,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "Dr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall/r_wall,
@@ -1175,7 +1175,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "EL" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "L13"
@@ -1194,7 +1194,7 @@
 "FT" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "FX" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -1210,7 +1210,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "Gh" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera/autoname,
@@ -1232,7 +1232,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "Gy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1250,7 +1250,7 @@
 /area/construction)
 "GW" = (
 /turf/simulated/wall/r_wall,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "Hk" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/maintcentral)
@@ -1273,7 +1273,7 @@
 	},
 /obj/machinery/door/airlock,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "If" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
@@ -1366,7 +1366,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "Ko" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -1413,7 +1413,7 @@
 /area/construction/hallway)
 "Lr" = (
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "Ly" = (
 /turf/simulated/floor/plasteel{
 	dir = 1
@@ -1435,7 +1435,7 @@
 "LZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "Md" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1478,7 +1478,7 @@
 	},
 /obj/item/airlock_painter,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "MN" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "L9"
@@ -1516,12 +1516,12 @@
 /area/storage/primary)
 "Nu" = (
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "Nz" = (
 /obj/item/clothing/head/welding,
 /obj/item/weldingtool/experimental/mecha,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "ND" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 1
@@ -1603,7 +1603,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "PS" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/plating,
@@ -1629,7 +1629,7 @@
 /turf/simulated/floor/plasteel{
 	dir = 1
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "Qs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -1666,7 +1666,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "Sb" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -1706,7 +1706,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "SC" = (
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
@@ -1725,7 +1725,7 @@
 /obj/structure/table,
 /obj/item/weldingtool/experimental,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "SX" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "L11"
@@ -1778,7 +1778,7 @@
 /obj/item/storage/box/lights/mixed,
 /obj/item/lightreplacer,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "TR" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 8
@@ -1833,7 +1833,7 @@
 	name = "nitrogen filter"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "Vp" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -1917,11 +1917,11 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "WT" = (
 /obj/structure/closet/secure_closet/engineering_welding,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "Xl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -1932,14 +1932,14 @@
 /area/construction/hallway)
 "XH" = (
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "XI" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/primary/central)
 "XM" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "XO" = (
 /turf/simulated/floor/plasteel,
 /area/bridge)
@@ -1995,7 +1995,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "Yv" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4
@@ -2033,11 +2033,11 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "YY" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "Zg" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel,

--- a/_maps/map_files/event/Station/delta_old.dmm
+++ b/_maps/map_files/event/Station/delta_old.dmm
@@ -201,7 +201,7 @@
 	network = list("SS13","Engineering")
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aeY" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -212,7 +212,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "afb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
@@ -225,7 +225,7 @@
 	dir = 5;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "afD" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -257,7 +257,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "agp" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/secondary/entry/westarrival)
@@ -365,7 +365,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "ahQ" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -430,7 +430,7 @@
 "aiC" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "aiE" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/secondary/entry/eastarrival)
@@ -464,7 +464,7 @@
 	dir = 6;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "aiZ" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -503,7 +503,7 @@
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "ajG" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -525,7 +525,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ajN" = (
 /turf/simulated/wall,
 /area/hallway/secondary/entry/eastarrival)
@@ -553,7 +553,7 @@
 	dir = 9;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "ake" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -569,7 +569,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "aky" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -591,7 +591,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "ald" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/structure/sign/vacuum{
@@ -650,7 +650,7 @@
 "alQ" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "alT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -664,7 +664,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "alX" = (
 /obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor/plating,
@@ -739,7 +739,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "amu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -753,7 +753,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "amJ" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -762,7 +762,7 @@
 	pixel_x = -26
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "amL" = (
 /obj/structure/computerframe,
 /obj/structure/sign/poster/contraband/random{
@@ -779,7 +779,7 @@
 /obj/item/radio,
 /obj/item/radio,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "amQ" = (
 /obj/machinery/light{
 	dir = 8
@@ -805,7 +805,7 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "amS" = (
 /obj/structure/table,
 /obj/item/storage/box/prisoner,
@@ -934,7 +934,7 @@
 	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "aof" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -1104,7 +1104,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "apF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1148,7 +1148,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "apO" = (
 /obj/machinery/status_display{
 	pixel_x = -32
@@ -1209,7 +1209,7 @@
 	dir = 10;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "aqq" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots{
@@ -1222,7 +1222,7 @@
 	pixel_y = -3
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "aqu" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -1301,7 +1301,7 @@
 	},
 /obj/item/gun/energy/kinetic_accelerator,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "arn" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -1312,7 +1312,7 @@
 	name = "Expedition Lockdown"
 	},
 /turf/simulated/floor/plating,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "ars" = (
 /obj/machinery/light{
 	dir = 8
@@ -1351,7 +1351,7 @@
 /area/lawoffice)
 "arA" = (
 /turf/simulated/wall/r_wall,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "arD" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -1429,7 +1429,7 @@
 	},
 /obj/item/stock_parts/cell/high,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "arX" = (
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
@@ -1442,7 +1442,7 @@
 	req_access = list(18,48,70,71)
 	},
 /turf/simulated/wall,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "asg" = (
 /obj/machinery/light,
 /obj/structure/table/reinforced,
@@ -1454,7 +1454,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "asi" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -1466,7 +1466,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "asq" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -1487,26 +1487,26 @@
 	name = "Expedition Lockdown"
 	},
 /turf/simulated/floor/plating,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "asF" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "asH" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "asR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "asT" = (
 /turf/simulated/wall,
 /area/hallway/secondary/entry/additional)
@@ -1523,7 +1523,7 @@
 "asX" = (
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "asY" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -30;
@@ -1544,7 +1544,7 @@
 /area/security/checkpoint)
 "atd" = (
 /turf/simulated/wall/r_wall,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "atl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1556,7 +1556,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "atv" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -1586,7 +1586,7 @@
 /obj/item/multitool,
 /obj/item/clothing/glasses/meson,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "atV" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -1596,7 +1596,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "atW" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -1613,7 +1613,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "auc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -1634,7 +1634,7 @@
 	dir = 1;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "auk" = (
 /obj/machinery/vending/hydronutrients,
 /turf/simulated/floor/plating,
@@ -1680,14 +1680,14 @@
 	dir = 5;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "auq" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "aux" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -1714,7 +1714,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "auH" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -1730,7 +1730,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "auJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1760,7 +1760,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "avb" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
@@ -1783,7 +1783,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "avf" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -1800,7 +1800,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "avj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -1813,7 +1813,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "avk" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plating,
@@ -1823,7 +1823,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "avr" = (
 /obj/machinery/power/solar{
 	id = "portsolar";
@@ -1845,7 +1845,7 @@
 	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "avB" = (
 /obj/machinery/atmospherics/trinary/filter{
 	dir = 4;
@@ -1856,14 +1856,14 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "avC" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "avD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1874,20 +1874,20 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "avE" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "avH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "avL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -1968,17 +1968,17 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "awI" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "awJ" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "awP" = (
 /obj/structure/chair{
 	dir = 8
@@ -2038,7 +2038,7 @@
 	name = "Expedition Lockdown"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "axg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -2058,7 +2058,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "axj" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -2090,19 +2090,19 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "axG" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "axM" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "axP" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -2112,7 +2112,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "axT" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/firealarm{
@@ -2128,7 +2128,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ayi" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/shuttle,
@@ -2175,7 +2175,7 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ayA" = (
 /turf/simulated/wall,
 /area/quartermaster/sorting)
@@ -2204,13 +2204,13 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "ayI" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "ayQ" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 8;
@@ -2220,7 +2220,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ayU" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -2237,7 +2237,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "azi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2270,13 +2270,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "azr" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "azs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2432,7 +2432,7 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aAK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2511,7 +2511,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aBb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -2539,13 +2539,13 @@
 	dir = 10;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aBe" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aBh" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
@@ -2553,7 +2553,7 @@
 	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "aBj" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -2574,7 +2574,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "aBl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2612,7 +2612,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aBr" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "construction access"
@@ -2693,7 +2693,7 @@
 	name = "Supermatter Blast Doors"
 	},
 /turf/simulated/floor/plating,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "aBZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2703,7 +2703,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aCe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -2733,7 +2733,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "aCv" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -2791,7 +2791,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aCV" = (
 /obj/machinery/door/airlock/highsecurity{
 	heat_proof = 1;
@@ -2803,7 +2803,7 @@
 	name = "Supermatter Blast Doors"
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "aDc" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -2813,12 +2813,12 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "aDe" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/binary/volume_pump/on,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aDf" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -2827,7 +2827,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aDg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2847,7 +2847,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aDj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -2885,7 +2885,7 @@
 	anchored = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "aDD" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -2940,7 +2940,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aEc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -2961,7 +2961,7 @@
 	name = "Supermatter Blast Doors"
 	},
 /turf/simulated/floor/plating,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "aEe" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/emergency,
@@ -2970,7 +2970,7 @@
 "aEg" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aEh" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -3019,7 +3019,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aEo" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -3060,7 +3060,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aEx" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -3119,7 +3119,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aEZ" = (
 /obj/structure/closet/firecloset,
 /obj/effect/decal/warning_stripes/red,
@@ -3138,7 +3138,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aFf" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/small{
@@ -3146,12 +3146,12 @@
 	},
 /obj/item/clothing/glasses/welding,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aFg" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aFj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -3179,7 +3179,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aFo" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -3502,7 +3502,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aHe" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -3513,14 +3513,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aHf" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/warning_stripes/blue,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aHo" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3532,7 +3532,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aHs" = (
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -3603,19 +3603,19 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aHS" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aIh" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aIl" = (
 /obj/structure/sign/directions/engineering{
 	pixel_y = 8
@@ -3631,7 +3631,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "aIr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3675,7 +3675,7 @@
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aIC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3699,7 +3699,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aII" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3716,7 +3716,7 @@
 	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aIO" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -3842,7 +3842,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aJz" = (
 /obj/machinery/light{
 	dir = 1
@@ -3900,7 +3900,7 @@
 	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aJO" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -3910,7 +3910,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aJQ" = (
 /obj/machinery/light/small,
 /obj/effect/decal/warning_stripes/southwest,
@@ -3918,7 +3918,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aJV" = (
 /obj/machinery/door/airlock/external{
 	name = "Arrival Airlock"
@@ -3933,7 +3933,7 @@
 /obj/structure/closet/radiation,
 /obj/item/clothing/glasses/meson,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aJY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -3986,7 +3986,7 @@
 	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/wall,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aKj" = (
 /obj/machinery/light{
 	dir = 1
@@ -4043,7 +4043,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aKy" = (
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
@@ -4079,7 +4079,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aKL" = (
 /obj/machinery/light{
 	dir = 8
@@ -4107,7 +4107,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aKS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4119,7 +4119,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aKT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4166,7 +4166,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aLf" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -4174,7 +4174,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aLi" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable{
@@ -4204,7 +4204,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aLr" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -4219,7 +4219,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aLC" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -25
@@ -4259,7 +4259,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aLI" = (
 /obj/machinery/light{
 	dir = 4
@@ -4268,7 +4268,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aLM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -4277,7 +4277,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "aLQ" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
@@ -4354,13 +4354,13 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aMC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aMD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -4375,7 +4375,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aMI" = (
 /obj/machinery/status_display{
 	pixel_y = 32
@@ -4467,7 +4467,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aNe" = (
 /obj/machinery/light{
 	dir = 4
@@ -4489,7 +4489,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aNj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -4575,7 +4575,7 @@
 	dir = 10;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aNG" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -4649,7 +4649,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aOn" = (
 /obj/structure/sink{
 	pixel_y = 29
@@ -4691,7 +4691,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aOB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4797,7 +4797,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aOY" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -4998,7 +4998,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aQi" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -5061,14 +5061,14 @@
 "aQJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/greengrid,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aQK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/warning_stripes/eastsouthwest,
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aQM" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -5291,7 +5291,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aSO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5303,7 +5303,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aSP" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -5330,7 +5330,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aSV" = (
 /obj/structure/chair/stool/bar,
 /turf/simulated/floor/carpet,
@@ -5422,7 +5422,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aTv" = (
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/structure/sign/poster/official/random{
@@ -5452,7 +5452,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aTy" = (
 /obj/machinery/light{
 	dir = 8
@@ -5464,7 +5464,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aTA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5492,7 +5492,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aTD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5512,7 +5512,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aTU" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -5550,7 +5550,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "aUm" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -5771,13 +5771,13 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aVh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aVi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5787,7 +5787,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aVj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5798,7 +5798,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aVB" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -5882,7 +5882,7 @@
 "aWB" = (
 /obj/effect/landmark/start/mechanic,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aWC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -5890,7 +5890,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aWI" = (
 /obj/structure/sign/directions/engineering{
 	pixel_y = 8
@@ -5995,7 +5995,7 @@
 	dir = 7;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "aXl" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6137,7 +6137,7 @@
 /obj/machinery/light,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aYo" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6159,7 +6159,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aYx" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/suit_storage_unit/atmos,
@@ -6178,7 +6178,7 @@
 	icon_state = "dark";
 	tag = "icon-vault (NORTHEAST)"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "aYE" = (
 /obj/structure/sign/nosmoking_1{
 	pixel_x = 28;
@@ -6190,14 +6190,14 @@
 	icon_state = "dark";
 	tag = "icon-vault (NORTHEAST)"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "aYF" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aYH" = (
 /obj/structure/table/reinforced,
 /obj/item/folder,
@@ -6215,7 +6215,7 @@
 	anchored = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aYP" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -6244,7 +6244,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aYY" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel{
@@ -6388,7 +6388,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aZx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6545,7 +6545,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "baS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6583,7 +6583,7 @@
 /area/quartermaster/miningdock)
 "bbf" = (
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bbh" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/turf_decal/box,
@@ -6613,7 +6613,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bbl" = (
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
@@ -6769,7 +6769,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bcn" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -6835,7 +6835,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bda" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
@@ -6862,7 +6862,7 @@
 	dir = 10;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bdq" = (
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken5"
@@ -6880,7 +6880,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bdz" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/radio/intercom{
@@ -6920,7 +6920,7 @@
 	},
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bdO" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -7018,14 +7018,14 @@
 /area/maintenance/engrooms)
 "beC" = (
 /turf/simulated/wall,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "beU" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "beV" = (
 /turf/simulated/wall,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "beW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7119,7 +7119,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bgb" = (
 /obj/structure/table/wood,
 /obj/item/camera_film,
@@ -7273,7 +7273,7 @@
 "bgw" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "bgz" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -7359,7 +7359,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bgN" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -7413,7 +7413,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bhn" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=A4";
@@ -7520,7 +7520,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bhE" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -7675,7 +7675,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "biL" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -7704,7 +7704,7 @@
 	on = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "biU" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/wood,
@@ -7854,7 +7854,7 @@
 "bjx" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bjz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7876,7 +7876,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bjB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7895,7 +7895,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bjD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8048,7 +8048,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bjV" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/light/small{
@@ -8131,11 +8131,11 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bkQ" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "bkS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8210,7 +8210,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "blf" = (
 /obj/machinery/light{
 	dir = 1;
@@ -8482,7 +8482,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bmX" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plating,
@@ -8560,7 +8560,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "bnL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -8679,7 +8679,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "boK" = (
 /obj/machinery/power/solar{
 	name = "Aft Starboard Solar Panel"
@@ -8697,11 +8697,11 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "boP" = (
 /obj/structure/sign/fire,
 /turf/simulated/wall/r_wall,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "boU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/walllocker/emerglocker{
@@ -8945,14 +8945,14 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bqG" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bqH" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/door_control{
@@ -8973,7 +8973,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bqK" = (
 /obj/machinery/camera{
 	c_tag = "Supermatter South";
@@ -8992,7 +8992,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bqN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9011,13 +9011,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "brj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "brk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -9030,7 +9030,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "brl" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -9095,7 +9095,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "brI" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -9129,7 +9129,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "brO" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/cardboard,
@@ -9145,7 +9145,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "brV" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -9190,7 +9190,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bsi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9222,7 +9222,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bsu" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -9233,7 +9233,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bsw" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -9243,7 +9243,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bsx" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/hologram/holopad,
@@ -9256,7 +9256,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bsy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9269,7 +9269,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bsB" = (
 /obj/item/crowbar/red{
 	desc = "...";
@@ -9484,7 +9484,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "btC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -9501,7 +9501,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "btD" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -9522,7 +9522,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "btF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -9535,7 +9535,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "btG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -9550,7 +9550,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "btH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -9566,7 +9566,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "btL" = (
 /turf/simulated/wall/r_wall,
 /area/security/nuke_storage)
@@ -9647,7 +9647,7 @@
 "btX" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall/r_wall,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "btY" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -9667,11 +9667,11 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "buk" = (
 /obj/structure/sign/biohazard,
 /turf/simulated/wall/r_wall,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bul" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9685,7 +9685,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bum" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
@@ -9693,7 +9693,7 @@
 	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "buq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -9931,7 +9931,7 @@
 	network = list("SS13","Engineering")
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bvv" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -9948,7 +9948,7 @@
 /obj/structure/closet/radiation,
 /obj/item/clothing/glasses/meson,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bvD" = (
 /obj/machinery/vending/cola,
 /obj/machinery/newscaster{
@@ -9957,7 +9957,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bvF" = (
 /obj/machinery/camera{
 	c_tag = "Medbay South East Hallway";
@@ -10161,7 +10161,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bwp" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
@@ -10216,7 +10216,7 @@
 /area/turret_protected/ai)
 "bwN" = (
 /turf/simulated/wall/r_wall,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bwO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -10248,11 +10248,11 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bwS" = (
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "bwT" = (
 /obj/effect/decal/warning_stripes/blue,
 /obj/structure/closet/emcloset,
@@ -10322,7 +10322,7 @@
 /obj/structure/closet/radiation,
 /obj/item/clothing/glasses/meson,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bxh" = (
 /turf/simulated/wall/r_wall,
 /area/storage/tech)
@@ -10565,7 +10565,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "byn" = (
 /obj/machinery/iv_drip,
 /turf/simulated/floor/plating,
@@ -10578,7 +10578,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "byp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10591,7 +10591,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "bys" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -10601,7 +10601,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "byt" = (
 /obj/machinery/light,
 /obj/machinery/newscaster{
@@ -10870,22 +10870,22 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bzz" = (
 /obj/structure/sign/electricshock,
 /turf/simulated/wall/r_wall,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bzA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/greengrid,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bzB" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bzC" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "High Sec Zone";
@@ -10912,7 +10912,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bzG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10936,7 +10936,7 @@
 	},
 /obj/effect/decal/warning_stripes/northwestsouth,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "bzL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10948,7 +10948,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "bzP" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/donkpockets{
@@ -10976,7 +10976,7 @@
 "bzV" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bzW" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -11231,7 +11231,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "bAN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11320,11 +11320,11 @@
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bBj" = (
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bBl" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/firealarm{
@@ -11336,13 +11336,13 @@
 	dir = 10;
 	icon_state = "caution"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bBn" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bBo" = (
 /turf/simulated/wall,
 /area/storage/eva)
@@ -11368,7 +11368,7 @@
 	dir = 6;
 	icon_state = "caution"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bBt" = (
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel{
@@ -11391,7 +11391,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bBB" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel,
@@ -11500,7 +11500,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "bBS" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -11569,7 +11569,7 @@
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bCk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11771,7 +11771,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bDf" = (
 /obj/machinery/vending/hydroseeds,
 /turf/simulated/floor/plating,
@@ -11802,7 +11802,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/break_room)
+/area/engineering/break_room)
 "bDk" = (
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
@@ -11819,7 +11819,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bDn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11832,7 +11832,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bDt" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11851,7 +11851,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bDv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12137,7 +12137,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bEK" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/polarized{
@@ -12174,7 +12174,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bES" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12185,15 +12185,15 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bEV" = (
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "bEX" = (
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "bFb" = (
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
@@ -12220,7 +12220,7 @@
 	dir = 6;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "bFk" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/fyellow,
@@ -12286,7 +12286,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bFB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12343,7 +12343,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bFJ" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -12516,18 +12516,18 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "bGD" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bGE" = (
 /obj/structure/sign/electricshock,
 /turf/simulated/wall/r_wall,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bGJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12626,7 +12626,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bHp" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -12634,7 +12634,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bHq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12643,7 +12643,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bHr" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small,
@@ -12809,14 +12809,14 @@
 	dir = 7;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bIr" = (
 /obj/machinery/autolathe,
 /turf/simulated/floor/plasteel{
 	dir = 7;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bIz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12826,7 +12826,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bIA" = (
 /obj/machinery/light{
 	dir = 4
@@ -12844,7 +12844,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bIE" = (
 /obj/machinery/status_display{
 	pixel_x = 32
@@ -12871,7 +12871,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bIK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -12947,7 +12947,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bJf" = (
 /obj/machinery/power/solar{
 	id = "portsolar";
@@ -12969,7 +12969,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bJk" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -13088,7 +13088,7 @@
 	dir = 6;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bKe" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/wood,
@@ -13108,7 +13108,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bKl" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Monitoring";
@@ -13128,7 +13128,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bKr" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -13430,7 +13430,7 @@
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "bMn" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/effect/decal/warning_stripes/south,
@@ -13438,7 +13438,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bMo" = (
 /obj/machinery/light_switch{
 	pixel_x = -26
@@ -13455,7 +13455,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bMq" = (
 /obj/item/radio/intercom{
 	dir = 4;
@@ -13467,7 +13467,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bMz" = (
 /obj/machinery/computer/security/mining{
 	dir = 8
@@ -13485,7 +13485,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bMB" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "Perma1";
@@ -13525,7 +13525,7 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bMG" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -13802,7 +13802,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "bOh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -13945,7 +13945,7 @@
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bOG" = (
 /obj/item/aiModule/reset,
 /obj/structure/table/glass,
@@ -13984,7 +13984,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bOP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -14170,7 +14170,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bPM" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -14193,7 +14193,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bPT" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -14217,14 +14217,14 @@
 "bPV" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bPW" = (
 /obj/machinery/atmospherics/binary/valve/digital,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bPY" = (
 /obj/structure/chair/comfy/beige{
 	dir = 1
@@ -14236,12 +14236,12 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bQa" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/trinary/tvalve/digital/flipped/bypass,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bQc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14291,7 +14291,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "bQk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -14303,7 +14303,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bQl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -14319,21 +14319,21 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bQm" = (
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bQp" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bQq" = (
 /obj/machinery/light{
 	dir = 8
@@ -14366,7 +14366,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "bQu" = (
 /obj/structure/closet/firecloset,
 /obj/effect/decal/warning_stripes/red,
@@ -14379,7 +14379,7 @@
 /obj/effect/decal/warning_stripes/west,
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bQx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -14390,7 +14390,7 @@
 "bQB" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bQD" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -14420,10 +14420,10 @@
 "bQF" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bQH" = (
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bQL" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/suit_storage_unit/atmos,
@@ -14519,7 +14519,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bRk" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -14564,7 +14564,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bRv" = (
 /obj/structure/table,
 /obj/item/paper/deltainfo,
@@ -14650,7 +14650,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bRK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -14696,7 +14696,7 @@
 /obj/machinery/light/small,
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "bRY" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -14718,7 +14718,7 @@
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "bSc" = (
 /obj/machinery/ai_status_display{
 	pixel_y = -32
@@ -14729,7 +14729,7 @@
 	dir = 7;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bSf" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -15074,7 +15074,7 @@
 	dir = 6;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bTY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -15143,7 +15143,7 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "bUf" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Supply North"
@@ -15161,13 +15161,13 @@
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "bUh" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "bUl" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
@@ -15175,7 +15175,7 @@
 	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "bUm" = (
 /obj/effect/decal/warning_stripes/west{
 	icon = 'icons/turf/floors.dmi';
@@ -15206,7 +15206,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bUo" = (
 /obj/structure/table/wood,
 /obj/item/clothing/head/ushanka,
@@ -15337,7 +15337,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bUR" = (
 /obj/effect/decal/cleanable/vomit,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -15426,7 +15426,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bVt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -15460,7 +15460,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bVI" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/structure/cable{
@@ -15470,7 +15470,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bVJ" = (
 /obj/machinery/monkey_recycler,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -15623,12 +15623,12 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "bWn" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bWp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -15640,7 +15640,7 @@
 	charge = 2e+006
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/engineering)
+/area/engineering/engine)
 "bWs" = (
 /obj/machinery/atmospherics/trinary/filter{
 	desc = "Отфильтровывает кислород из трубы и отправляет его в камеру хранения";
@@ -15971,7 +15971,7 @@
 /area/hallway/secondary/entry/commercial)
 "bXU" = (
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "bXY" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -15979,7 +15979,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bYa" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -16004,7 +16004,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "bYd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16164,7 +16164,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "bZm" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -16180,7 +16180,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "bZs" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -16189,7 +16189,7 @@
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "bZt" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow{
@@ -16207,7 +16207,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "bZv" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -16229,7 +16229,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "bZz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16436,7 +16436,7 @@
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cag" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -16519,7 +16519,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "car" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -16589,7 +16589,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "caB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16657,11 +16657,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "caN" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "caQ" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -16672,11 +16672,11 @@
 /area/maintenance/fpmaint)
 "cbb" = (
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "cbc" = (
 /obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cbj" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -16685,7 +16685,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cbk" = (
 /obj/machinery/vending/engivend,
 /obj/effect/decal/warning_stripes/yellow,
@@ -16693,12 +16693,12 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "cbl" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "cbm" = (
 /obj/machinery/status_display{
 	pixel_y = -32
@@ -16720,7 +16720,7 @@
 	icon_state = "dark";
 	tag = "icon-vault (NORTHEAST)"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "cbn" = (
 /obj/machinery/shieldgen,
 /turf/simulated/floor/plating,
@@ -16858,7 +16858,7 @@
 	},
 /obj/item/analyzer,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cbN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -16879,7 +16879,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cbY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -16897,7 +16897,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "cca" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/structure/cable{
@@ -16910,7 +16910,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ccb" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -16920,7 +16920,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ccc" = (
 /obj/machinery/light{
 	dir = 8
@@ -16943,7 +16943,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ccf" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -16956,7 +16956,7 @@
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ccg" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -16966,7 +16966,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cch" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -16974,7 +16974,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ccj" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
@@ -17169,7 +17169,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cdf" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -17402,7 +17402,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cdV" = (
 /obj/structure/plasticflaps,
 /obj/effect/decal/warning_stripes/yellow,
@@ -17429,7 +17429,7 @@
 	req_access = list(10,24)
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "ced" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -17645,7 +17645,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cfi" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
@@ -17657,7 +17657,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cfj" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -17682,7 +17682,7 @@
 /area/hallway/secondary/entry)
 "cfr" = (
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "cfs" = (
 /obj/item/wirecutters,
 /turf/simulated/floor/plating,
@@ -17697,7 +17697,7 @@
 	},
 /obj/machinery/atmospherics/binary/valve/digital,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "cfu" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -17789,7 +17789,7 @@
 	network = list("SS13","Singularity","Engineering")
 	},
 /turf/space,
-/area/engine/engineering)
+/area/engineering/engine)
 "cfM" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -17818,7 +17818,7 @@
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cge" = (
 /turf/simulated/floor/engine/n2,
 /area/atmos)
@@ -17901,7 +17901,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cgE" = (
 /obj/structure/closet/secure_closet/ntrep,
 /turf/simulated/floor/wood,
@@ -17918,7 +17918,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cgK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -17950,7 +17950,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cgR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18024,7 +18024,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "chd" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "construction access"
@@ -18586,7 +18586,7 @@
 	dir = 8
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ckj" = (
 /turf/simulated/floor/wood,
 /area/library)
@@ -18606,7 +18606,7 @@
 	},
 /obj/structure/dispenser,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cko" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall,
@@ -18706,7 +18706,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ckN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -18804,7 +18804,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "clv" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/fore)
@@ -18962,7 +18962,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cmd" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light{
@@ -18995,7 +18995,7 @@
 "cmi" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/wall/r_wall,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "cmj" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
@@ -19008,7 +19008,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cmk" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -19160,7 +19160,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cmV" = (
 /obj/machinery/light{
 	dir = 4
@@ -19231,7 +19231,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cnm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19418,7 +19418,7 @@
 "cod" = (
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cof" = (
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
@@ -19537,7 +19537,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "coL" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "construction access"
@@ -19643,11 +19643,11 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "cpi" = (
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cpk" = (
 /obj/machinery/power/tesla_coil,
 /obj/effect/decal/cleanable/dirt,
@@ -19673,7 +19673,7 @@
 	pixel_y = -1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cpm" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall/r_wall,
@@ -19924,7 +19924,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "cqT" = (
 /obj/effect/landmark/start/janitor,
 /turf/simulated/floor/plasteel{
@@ -19999,7 +19999,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "crk" = (
 /obj/machinery/atmospherics/trinary/filter{
 	dir = 8;
@@ -20012,7 +20012,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "crn" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -20029,7 +20029,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "crp" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
@@ -20458,12 +20458,12 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ctK" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ctL" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -20527,7 +20527,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cua" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -20589,7 +20589,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cum" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -20599,7 +20599,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cuo" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -20626,7 +20626,7 @@
 	pixel_y = -4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cus" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
@@ -20774,7 +20774,7 @@
 	},
 /obj/structure/reflector/box,
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cvf" = (
 /turf/simulated/wall/r_wall,
 /area/aisat/maintenance)
@@ -20798,14 +20798,14 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cvk" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cvo" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -20951,7 +20951,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cvK" = (
 /obj/item/radio/intercom{
 	dir = 0;
@@ -21022,7 +21022,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "cvX" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/structure/cable/yellow{
@@ -21033,7 +21033,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cvZ" = (
 /obj/structure/dresser,
 /obj/machinery/power/apc{
@@ -21133,7 +21133,7 @@
 "cwu" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "cwv" = (
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
@@ -21150,7 +21150,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "cwz" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/rack,
@@ -21180,7 +21180,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "cwA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -21365,7 +21365,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cxF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -21382,14 +21382,14 @@
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cxK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "cxM" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light{
@@ -21465,7 +21465,7 @@
 /obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cxV" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -21475,7 +21475,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cxW" = (
 /obj/structure/rack,
 /obj/item/weldingtool,
@@ -21854,7 +21854,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "czo" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -22224,7 +22224,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "cAK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/cabinet,
@@ -22534,7 +22534,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "cCg" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer{
 	dir = 4
@@ -22548,7 +22548,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cCh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22580,7 +22580,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "cCl" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22593,7 +22593,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cCn" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -22609,7 +22609,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "cCt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -22869,7 +22869,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cDg" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/sign/nosmoking_2{
@@ -22885,7 +22885,7 @@
 "cDh" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cDi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
@@ -22964,7 +22964,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "cDx" = (
 /obj/machinery/door/poddoor{
 	id_tag = "trash";
@@ -23037,12 +23037,12 @@
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cDG" = (
 /obj/machinery/vending/tool,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cDH" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -23057,7 +23057,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cDK" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -23105,7 +23105,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cDR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -23135,7 +23135,7 @@
 /area/maintenance/engineering)
 "cDV" = (
 /turf/simulated/wall/r_wall/rust,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cDZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -23224,7 +23224,7 @@
 	dir = 5
 	},
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "cEj" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
@@ -23280,7 +23280,7 @@
 	dir = 10
 	},
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "cEA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/greengrid,
@@ -23315,7 +23315,7 @@
 	level = 1
 	},
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "cEJ" = (
 /turf/simulated/wall,
 /area/mimeoffice)
@@ -23398,7 +23398,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cFe" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -23580,7 +23580,7 @@
 	dir = 9
 	},
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "cFK" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light/small{
@@ -23681,7 +23681,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cGa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -23720,7 +23720,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cGf" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -23778,7 +23778,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cGx" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23813,7 +23813,7 @@
 	name = "Труба подачи азота в реактор"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cGE" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -23825,7 +23825,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cGF" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -23889,7 +23889,7 @@
 /obj/structure/closet/radiation,
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cGW" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/metal{
@@ -23902,7 +23902,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cGX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -24187,7 +24187,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cIr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -24200,7 +24200,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cIt" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -24213,7 +24213,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cIu" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -24270,7 +24270,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cIA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -24285,13 +24285,13 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cIB" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cID" = (
 /obj/structure/table,
 /obj/item/reagent_containers/syringe/antiviral,
@@ -24362,7 +24362,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cII" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
@@ -24400,7 +24400,7 @@
 /obj/structure/closet/radiation,
 /obj/item/clothing/glasses/meson,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cIO" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -24411,7 +24411,7 @@
 	pixel_y = -25
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cIQ" = (
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 32
@@ -24421,7 +24421,7 @@
 	dir = 1;
 	icon_state = "dark"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cIR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24639,15 +24639,15 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cJI" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cJJ" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cJK" = (
 /obj/effect/decal/remains/xeno,
 /turf/simulated/floor/plasteel{
@@ -24658,7 +24658,7 @@
 /obj/machinery/power/port_gen/pacman,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cJM" = (
 /obj/item/stack/cable_coil,
 /turf/simulated/floor/plating,
@@ -24691,7 +24691,7 @@
 /obj/structure/closet/radiation,
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cKb" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -24731,7 +24731,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cKh" = (
 /obj/machinery/vending/wallmed{
 	pixel_y = 30
@@ -25001,7 +25001,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cLz" = (
 /obj/machinery/smartfridge/secure/extract,
 /obj/machinery/light/small{
@@ -25022,11 +25022,11 @@
 /obj/item/crowbar,
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cLC" = (
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cLI" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/plasteel,
@@ -25041,7 +25041,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/paper/gravity_gen,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cLJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -25050,7 +25050,7 @@
 /obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cLL" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -25112,7 +25112,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cMi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25285,7 +25285,7 @@
 	},
 /obj/machinery/atmospherics/binary/valve/digital,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "cNb" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -25315,7 +25315,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cNl" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/structure/chair/office/light{
@@ -25432,7 +25432,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cOa" = (
 /obj/structure/bed,
 /obj/item/radio/intercom{
@@ -25588,7 +25588,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/aienter)
+/area/engineering/aienter)
 "cOv" = (
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -25786,7 +25786,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cPd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -25875,7 +25875,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cPm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25890,7 +25890,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cPt" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -25952,7 +25952,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cPE" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/structure/disposalpipe/segment,
@@ -26062,7 +26062,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cQb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -26338,7 +26338,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cRg" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -26481,7 +26481,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cRz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -26510,14 +26510,14 @@
 /obj/effect/decal/warning_stripes/yellow,
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cRK" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cRT" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -26529,7 +26529,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cRU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -26582,7 +26582,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cSb" = (
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -26655,7 +26655,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cSy" = (
 /obj/machinery/light,
 /obj/structure/cable{
@@ -26680,7 +26680,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cSB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -26710,7 +26710,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cSI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -26774,7 +26774,7 @@
 /area/crew_quarters/fitness)
 "cTf" = (
 /turf/simulated/wall/r_wall,
-/area/engine/aienter)
+/area/engineering/aienter)
 "cTg" = (
 /turf/simulated/wall,
 /area/maintenance/electrical)
@@ -26905,7 +26905,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cTO" = (
 /obj/item/radio/intercom{
 	dir = 1;
@@ -26916,7 +26916,7 @@
 	dir = 10;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cTP" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -26958,7 +26958,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "cTU" = (
 /obj/effect/decal/warning_stripes/southwest,
 /obj/structure/cable{
@@ -27895,7 +27895,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "cXQ" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -27985,7 +27985,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cYd" = (
 /obj/structure/morgue,
 /obj/machinery/alarm{
@@ -27999,7 +27999,7 @@
 "cYf" = (
 /obj/structure/sign/nosmoking_2,
 /turf/simulated/wall,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cYg" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -28256,7 +28256,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "cZg" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -28577,7 +28577,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "daC" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/warning_stripes/north,
@@ -28691,7 +28691,7 @@
 	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "dbj" = (
 /obj/structure/table,
 /obj/machinery/light,
@@ -29043,7 +29043,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "dcN" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -29450,7 +29450,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "dew" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -29763,7 +29763,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "dfv" = (
 /turf/simulated/wall,
 /area/medical/paramedic)
@@ -29962,7 +29962,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dgk" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -30036,7 +30036,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "dgH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30216,7 +30216,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "dhn" = (
 /obj/structure/table,
 /obj/item/clipboard,
@@ -30244,7 +30244,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "dhp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -30273,7 +30273,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "dhs" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -30290,7 +30290,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "dht" = (
 /obj/structure/chair{
 	dir = 4
@@ -30566,7 +30566,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "diD" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -31284,7 +31284,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dlJ" = (
 /obj/machinery/light{
 	dir = 1
@@ -31333,7 +31333,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "dlO" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 8;
@@ -31856,7 +31856,7 @@
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "dnB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -31933,7 +31933,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "dnO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
@@ -33122,7 +33122,7 @@
 	req_access = list(18,48,70)
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "dsO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/atmos/glass{
@@ -33421,7 +33421,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "dtZ" = (
 /obj/structure/table,
 /turf/simulated/floor/plating,
@@ -33429,7 +33429,7 @@
 "duf" = (
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "duh" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22";
@@ -33464,7 +33464,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "dup" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -33515,7 +33515,7 @@
 	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "duJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -33551,7 +33551,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "duT" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -33710,7 +33710,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "dvB" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -34440,7 +34440,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dzc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -34479,7 +34479,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dzj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -34492,7 +34492,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "dzm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -34504,7 +34504,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dzp" = (
 /obj/structure/table/wood,
 /obj/item/picket_sign,
@@ -34525,7 +34525,7 @@
 	dir = 1;
 	icon_state = "dark"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "dzs" = (
 /obj/machinery/photocopier,
 /obj/machinery/firealarm{
@@ -34583,7 +34583,7 @@
 /obj/machinery/light/small,
 /obj/machinery/power/smes,
 /turf/simulated/floor/greengrid,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "dzy" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/alarm{
@@ -34973,7 +34973,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dBr" = (
 /turf/simulated/floor/carpet,
 /area/maintenance/fsmaint)
@@ -34991,7 +34991,7 @@
 /obj/effect/landmark/start/engineer,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dBu" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -35010,7 +35010,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dBv" = (
 /obj/effect/decal/warning_stripes/west{
 	icon = 'icons/turf/floors.dmi';
@@ -35070,7 +35070,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "dBG" = (
 /obj/structure/sign/nosmoking_2,
 /turf/simulated/wall,
@@ -35210,7 +35210,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "dCr" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -35237,7 +35237,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dCw" = (
 /obj/structure/table,
 /obj/machinery/computer/library/public,
@@ -35259,7 +35259,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dCz" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/engineering_hacking{
@@ -35275,7 +35275,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dCA" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -35629,7 +35629,7 @@
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dDQ" = (
 /obj/effect/decal/warning_stripes/northwest,
 /obj/structure/chair/comfy/purp{
@@ -35734,7 +35734,7 @@
 /area/atmos)
 "dEs" = (
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dEt" = (
 /obj/structure/table/wood,
 /obj/item/clothing/glasses/sunglasses,
@@ -37031,7 +37031,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dJE" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1
@@ -37648,7 +37648,7 @@
 "dMr" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "dMs" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
@@ -38165,7 +38165,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dOS" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/candle_box/eternal,
@@ -38502,14 +38502,14 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "dQA" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "dQB" = (
 /obj/machinery/light{
 	dir = 4
@@ -38523,12 +38523,12 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/wardrobe/engineering_yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dQD" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dQF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -38539,7 +38539,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "dQK" = (
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/light/small,
@@ -38575,7 +38575,7 @@
 /obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dQR" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/bottle/vodka{
@@ -38597,7 +38597,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dQT" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/hologram/holopad,
@@ -38620,7 +38620,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dQV" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -39097,7 +39097,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "dSz" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -39110,7 +39110,7 @@
 	name = "Singularity Blast Doors"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dSA" = (
 /obj/item/radio/intercom{
 	dir = 1;
@@ -39131,7 +39131,7 @@
 	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dSD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -39155,7 +39155,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dSH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -39168,7 +39168,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dSI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -39681,7 +39681,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "dUC" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -39691,11 +39691,11 @@
 /obj/effect/decal/warning_stripes/southeast,
 /obj/item/wrench,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "dUD" = (
 /obj/machinery/computer/security/telescreen/singularity,
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "dUE" = (
 /obj/machinery/power/tesla_coil{
 	anchored = 1
@@ -39740,7 +39740,7 @@
 "dUI" = (
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dUK" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
@@ -39772,7 +39772,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dUP" = (
 /obj/machinery/door/poddoor{
 	id_tag = "auxincineratorvent";
@@ -40017,7 +40017,7 @@
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "dVX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -40043,7 +40043,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dWb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -40134,7 +40134,7 @@
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
 /turf/simulated/floor/plating,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "dWj" = (
 /obj/effect/landmark/event/lightsout,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -40464,7 +40464,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "dXo" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -40476,7 +40476,7 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "dXp" = (
 /obj/machinery/power/solar{
 	id = "portsolar";
@@ -40491,7 +40491,7 @@
 /obj/structure/closet/secure_closet/engineering_electrical,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dXt" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -40562,7 +40562,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dXG" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/cleaner,
@@ -41004,7 +41004,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dZe" = (
 /obj/effect/landmark/event/blobstart,
 /obj/structure/chair/office/dark{
@@ -41241,7 +41241,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "dZM" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -41498,7 +41498,7 @@
 	on = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "eci" = (
 /obj/effect/landmark/start/engineer,
 /obj/structure/cable/yellow{
@@ -41507,7 +41507,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "ecz" = (
 /obj/machinery/light,
 /obj/structure/closet/secure_closet/freezer/meat,
@@ -41527,7 +41527,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "ecO" = (
 /obj/item/radio/intercom{
 	pixel_y = 24
@@ -41669,7 +41669,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "eeI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -41799,7 +41799,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "egO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
@@ -41895,7 +41895,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "ehL" = (
 /obj/structure/closet/boxinggloves,
 /turf/simulated/floor/plasteel{
@@ -41911,7 +41911,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "ein" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41960,7 +41960,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "ejm" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -41990,7 +41990,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "ejB" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -42168,7 +42168,7 @@
 	network = list("SS13","Singularity","Engineering")
 	},
 /turf/space,
-/area/engine/engineering)
+/area/engineering/engine)
 "elW" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -42498,7 +42498,7 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "esa" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -42701,7 +42701,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "etU" = (
 /obj/effect/decal/warning_stripes/southwest,
 /obj/structure/closet/walllocker/emerglocker/north{
@@ -43002,7 +43002,7 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "eyR" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -43094,7 +43094,7 @@
 	dir = 7;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "eAg" = (
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/plasteel{
@@ -43648,7 +43648,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "eIv" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -43763,7 +43763,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "eJs" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/binary/volume_pump/on{
@@ -43818,7 +43818,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "eJI" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -43986,7 +43986,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "eMg" = (
 /obj/machinery/door/airlock/glass{
 	name = "Cabin"
@@ -44038,7 +44038,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "eMz" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -44239,7 +44239,7 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ePl" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
@@ -44286,7 +44286,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "ePU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -44330,7 +44330,7 @@
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "eQZ" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -44820,7 +44820,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "eYe" = (
 /obj/machinery/requests_console{
 	department = "EVA";
@@ -45327,7 +45327,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "ffi" = (
 /obj/structure/table,
 /obj/item/folder,
@@ -45373,7 +45373,7 @@
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "fgj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
@@ -45712,7 +45712,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "flo" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -45800,7 +45800,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "fmK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46146,7 +46146,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "fsk" = (
 /obj/machinery/light,
 /obj/structure/table/wood,
@@ -46235,7 +46235,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "fsZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -46315,7 +46315,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "fuj" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -46800,7 +46800,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "fBw" = (
 /obj/structure/table/glass,
 /obj/item/clipboard,
@@ -47136,7 +47136,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "fGa" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -47775,7 +47775,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "fPD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	name = "standard air scrubber";
@@ -47786,7 +47786,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "fPF" = (
 /obj/structure/closet/secure_closet/security,
 /obj/effect/decal/warning_stripes/red/hollow,
@@ -47848,7 +47848,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "fQy" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -48852,7 +48852,7 @@
 	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "gcs" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -48965,7 +48965,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "geg" = (
 /obj/machinery/door/airlock{
 	id_tag = "toilet3";
@@ -49094,7 +49094,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "ggC" = (
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -49380,7 +49380,7 @@
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "glv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -49445,7 +49445,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "glJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -49519,7 +49519,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "gnf" = (
 /turf/simulated/wall,
 /area/crew_quarters/cabin2)
@@ -49780,7 +49780,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "gqd" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -49799,7 +49799,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "gqf" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -49833,7 +49833,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "gqD" = (
 /obj/machinery/atmospherics/air_sensor{
 	id_tag = "tox_sensor"
@@ -50475,7 +50475,7 @@
 	name = "Singularity Blast Doors"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "gAB" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -50551,7 +50551,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "gBH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -50715,7 +50715,7 @@
 	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "gDV" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -50851,7 +50851,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "gFd" = (
 /obj/machinery/computer/supplycomp{
 	dir = 4
@@ -50878,7 +50878,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "gFN" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/cargo_technician,
@@ -51036,7 +51036,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "gHm" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -51081,7 +51081,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "gHB" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/syringe{
@@ -52095,7 +52095,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "gRQ" = (
 /obj/machinery/door/airlock/glass{
 	name = "Cabin"
@@ -52393,7 +52393,7 @@
 /obj/effect/decal/warning_stripes/yellow,
 /obj/structure/plasticflaps,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "gVO" = (
 /obj/structure/table,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -52948,7 +52948,7 @@
 	anchored = 1
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "hec" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
@@ -53042,7 +53042,7 @@
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/structure/cable,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "hfq" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/cleanable/dirt,
@@ -53467,7 +53467,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "hmS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -53905,7 +53905,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "hrX" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
@@ -54135,7 +54135,7 @@
 "hvP" = (
 /obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "hvW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
@@ -54304,7 +54304,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "hyI" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -54604,7 +54604,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "hCD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -55819,7 +55819,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "hSN" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall,
@@ -55891,7 +55891,7 @@
 "hUm" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "hUH" = (
 /obj/structure/sign/biohazard,
 /turf/simulated/wall,
@@ -56007,7 +56007,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "hVP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -56062,7 +56062,7 @@
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "hWX" = (
 /obj/machinery/sleeper{
 	dir = 4
@@ -57731,7 +57731,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "ivL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58374,7 +58374,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "iFO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -58652,7 +58652,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "iIc" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer{
 	dir = 4
@@ -58675,7 +58675,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "iIq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58745,7 +58745,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "iJW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -58926,7 +58926,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "iMk" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -58967,7 +58967,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "iNk" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
@@ -59164,7 +59164,7 @@
 	},
 /obj/effect/decal/warning_stripes/northeastsouth,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "iQf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -59235,7 +59235,7 @@
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "iST" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/firealarm{
@@ -59320,7 +59320,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "iTQ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -59426,7 +59426,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "iVn" = (
 /obj/structure/chair/wood,
 /turf/simulated/floor/plasteel{
@@ -60043,7 +60043,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "jdU" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -60760,7 +60760,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "joA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -61055,7 +61055,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "jst" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
@@ -61090,7 +61090,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "jtd" = (
 /obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/atmospherics/binary/valve/digital/open{
@@ -61396,7 +61396,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "jwR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/west,
@@ -61472,7 +61472,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "jxB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -61780,7 +61780,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "jAB" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/ids,
@@ -62092,7 +62092,7 @@
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/light,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "jGz" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -63170,7 +63170,7 @@
 "jVz" = (
 /obj/structure/sign/nosmoking_2,
 /turf/simulated/wall/r_wall,
-/area/engine/break_room)
+/area/engineering/break_room)
 "jVF" = (
 /obj/machinery/light_switch{
 	pixel_x = -8;
@@ -63411,7 +63411,7 @@
 "jZI" = (
 /obj/structure/lattice,
 /turf/space,
-/area/engine/engineering)
+/area/engineering/engine)
 "jZL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light{
@@ -63463,7 +63463,7 @@
 "kaE" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall/r_wall,
-/area/engine/break_room)
+/area/engineering/break_room)
 "kaJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -63674,7 +63674,7 @@
 	},
 /obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "keW" = (
 /obj/machinery/atmospherics/air_sensor{
 	id_tag = "co2_sensor"
@@ -63733,7 +63733,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "kfS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -64016,7 +64016,7 @@
 /obj/structure/grille,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "klj" = (
 /turf/simulated/wall,
 /area/hallway/primary/central/ne)
@@ -64079,7 +64079,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "klC" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics N2O Tank";
@@ -64756,7 +64756,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "kud" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/decal/warning_stripes/yellow,
@@ -64825,7 +64825,7 @@
 /area/toxins/explab)
 "kwk" = (
 /turf/simulated/wall,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "kwl" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/light{
@@ -64946,7 +64946,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "kyv" = (
 /obj/machinery/light{
 	dir = 8
@@ -64999,7 +64999,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "kzh" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/ids,
@@ -65085,7 +65085,7 @@
 	dir = 7;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "kAm" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Brig Medical Bay";
@@ -65116,7 +65116,7 @@
 /area/security/medbay)
 "kAF" = (
 /turf/simulated/wall/r_wall,
-/area/engine/break_room)
+/area/engineering/break_room)
 "kAV" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/camera/emp_proof{
@@ -65125,7 +65125,7 @@
 	network = list("SS13","Singularity","Engineering")
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "kAW" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -65435,7 +65435,7 @@
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "kFQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -65561,7 +65561,7 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/light,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "kHz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -66350,7 +66350,7 @@
 /area/maintenance/xenozoo)
 "kVo" = (
 /turf/simulated/wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "kVs" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -66549,7 +66549,7 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/light,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "kZL" = (
 /obj/structure/table/wood,
 /obj/machinery/status_display{
@@ -66742,7 +66742,7 @@
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/glasses/welding,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "ldC" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -66755,7 +66755,7 @@
 /obj/effect/decal/warning_stripes/east,
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "ldR" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -67145,7 +67145,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "ljn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/chair/office/dark{
@@ -67234,7 +67234,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "lkN" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -67476,7 +67476,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "loO" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -67527,7 +67527,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "lpd" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -67570,7 +67570,7 @@
 	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "lpx" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -67629,7 +67629,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "lqe" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -67810,7 +67810,7 @@
 /area/bridge/vip)
 "lsT" = (
 /turf/simulated/wall,
-/area/engine/break_room)
+/area/engineering/break_room)
 "lsV" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -68064,7 +68064,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "lxZ" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/candle_box,
@@ -68258,7 +68258,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "lAc" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -68277,7 +68277,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "lAr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -68508,7 +68508,7 @@
 "lEd" = (
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "lEe" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/chair{
@@ -68538,7 +68538,7 @@
 "lFf" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "lFj" = (
 /obj/structure/table,
 /obj/machinery/firealarm{
@@ -70054,7 +70054,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "maB" = (
 /obj/effect/decal/warning_stripes/southwestcorner,
 /obj/machinery/light/small{
@@ -70485,7 +70485,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "mgP" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/camera{
@@ -70606,7 +70606,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "mhX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -70707,7 +70707,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "mjs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -70754,7 +70754,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "mka" = (
 /obj/machinery/door/airlock/external{
 	name = "Toxins Test Chamber"
@@ -70980,14 +70980,14 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "mmv" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
 	dir = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "mmA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -71140,7 +71140,7 @@
 	dir = 8;
 	icon_state = "brown"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "mop" = (
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/closet/secure_closet/pilot_sniper,
@@ -71217,7 +71217,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "mpI" = (
 /turf/simulated/wall/r_wall,
 /area/security/medbay)
@@ -71376,7 +71376,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "mrf" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/hologram/holopad,
@@ -71427,7 +71427,7 @@
 	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "mrN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -71484,7 +71484,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "mtz" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder{
@@ -72024,7 +72024,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "mAn" = (
 /obj/machinery/computer/camera_advanced/xenobio,
 /obj/machinery/status_display{
@@ -72120,7 +72120,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "mBa" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/structure/chair/stool,
@@ -72332,7 +72332,7 @@
 /area/teleporter)
 "mDe" = (
 /turf/simulated/wall/r_wall,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "mDi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -72620,7 +72620,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "mGt" = (
 /obj/structure/table/glass,
 /obj/item/storage/toolbox/surgery{
@@ -73242,7 +73242,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "mPC" = (
 /obj/machinery/light{
 	dir = 4
@@ -73259,7 +73259,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "mPE" = (
 /obj/structure/grille{
 	density = 0;
@@ -73330,7 +73330,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "mQI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -73736,7 +73736,7 @@
 	name = "Singularity Blast Doors"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "mWY" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -74610,7 +74610,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "nkm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -74777,7 +74777,7 @@
 	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "nmp" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -74847,7 +74847,7 @@
 /obj/machinery/particle_accelerator/control_box,
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "noj" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -75082,7 +75082,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "nqL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -75332,7 +75332,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "ntj" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -75825,7 +75825,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "nAA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	name = "standard air scrubber";
@@ -75876,7 +75876,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "nBl" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -76057,7 +76057,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "nEb" = (
 /obj/machinery/chem_heater,
 /obj/effect/decal/warning_stripes/southwest,
@@ -76143,7 +76143,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "nFB" = (
 /obj/structure/chair/comfy/brown,
 /obj/effect/landmark/start/librarian,
@@ -76257,7 +76257,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "nGy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -76320,7 +76320,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "nHp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -76389,7 +76389,7 @@
 	dir = 8;
 	icon_state = "brown"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "nIr" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
@@ -76865,7 +76865,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "nOn" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/science{
@@ -76988,7 +76988,7 @@
 	dir = 6;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "nQv" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -77009,7 +77009,7 @@
 	dir = 7;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "nQC" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
@@ -77225,7 +77225,7 @@
 	dir = 6;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "nTo" = (
 /obj/structure/table/reinforced,
 /obj/item/t_scanner,
@@ -77256,7 +77256,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "nTD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -77365,7 +77365,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "nVA" = (
 /obj/machinery/computer/HolodeckControl,
 /turf/simulated/floor/plasteel,
@@ -77614,7 +77614,7 @@
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "oan" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -77739,7 +77739,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "obR" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -77843,7 +77843,7 @@
 	dir = 7;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "ocK" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -77994,7 +77994,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "ogb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -78167,7 +78167,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "ohb" = (
 /turf/simulated/floor/carpet,
 /area/ntrep)
@@ -78189,7 +78189,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "ohs" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -78238,7 +78238,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "ohN" = (
 /obj/structure/chair{
 	dir = 8
@@ -78391,7 +78391,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "oke" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -78420,7 +78420,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "okj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -78475,7 +78475,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "okX" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -78718,7 +78718,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "ooV" = (
 /obj/machinery/atm{
 	pixel_x = -32
@@ -78808,7 +78808,7 @@
 	on = 1
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "oql" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -79643,7 +79643,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "oBd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
@@ -79805,7 +79805,7 @@
 	on = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "oDx" = (
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
@@ -79907,7 +79907,7 @@
 /area/medical/research/restroom)
 "oFs" = (
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "oFJ" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
@@ -80020,7 +80020,7 @@
 "oGZ" = (
 /obj/structure/sign/vacuum,
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "oHg" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -80504,7 +80504,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "oMt" = (
 /obj/item/radio/intercom{
 	pixel_x = -28
@@ -80682,7 +80682,7 @@
 	on = 1
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "oOX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -80771,7 +80771,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "oQg" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -80828,7 +80828,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "oQQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -80842,7 +80842,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "oQU" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
@@ -80899,7 +80899,7 @@
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
 /turf/simulated/floor/plating,
-/area/engine/break_room)
+/area/engineering/break_room)
 "oRQ" = (
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken3";
@@ -81716,7 +81716,7 @@
 	dir = 6;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "pem" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/light/small{
@@ -82569,7 +82569,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "poE" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -82671,7 +82671,7 @@
 	dir = 8;
 	icon_state = "brown"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "pqz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -82734,7 +82734,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "prh" = (
 /obj/structure/closet/secure_closet/guncabinet{
 	anchored = 1;
@@ -82818,7 +82818,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "prU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -82836,7 +82836,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "pse" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -82897,7 +82897,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "psx" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -82958,7 +82958,7 @@
 	},
 /obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "ptH" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/meter,
@@ -83099,7 +83099,7 @@
 	name = "Singularity Blast Doors"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "pvu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -83222,7 +83222,7 @@
 	},
 /obj/effect/decal/warning_stripes/eastnorthwest,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "pyO" = (
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
@@ -83230,7 +83230,7 @@
 /obj/effect/decal/warning_stripes/yellow,
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "pzi" = (
 /obj/structure/chair/comfy/brown,
 /turf/simulated/floor/carpet,
@@ -83353,7 +83353,7 @@
 	charge = 2e+006
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/engineering)
+/area/engineering/engine)
 "pAn" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/brflowers,
@@ -83441,7 +83441,7 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/light,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "pBj" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
@@ -83749,7 +83749,7 @@
 "pEz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "pEC" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -83777,7 +83777,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "pFn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -83905,7 +83905,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "pGI" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -84528,7 +84528,7 @@
 	dir = 1;
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "pNE" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/bot/right,
@@ -84925,7 +84925,7 @@
 	req_access = list(10,13)
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "pTv" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -84934,7 +84934,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "pTx" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -85013,7 +85013,7 @@
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "pVa" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -85150,7 +85150,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "pWC" = (
 /obj/structure/table/reinforced,
 /obj/structure/extinguisher_cabinet{
@@ -85160,7 +85160,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "pWD" = (
 /obj/structure/closet/secure_closet/security,
 /obj/effect/decal/warning_stripes/red/hollow,
@@ -85185,7 +85185,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "pWN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -85194,7 +85194,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "pWR" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/wood,
@@ -85239,7 +85239,7 @@
 	},
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "pXr" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
@@ -85409,7 +85409,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "pZR" = (
 /obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/light/small{
@@ -86138,7 +86138,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qjr" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -86160,7 +86160,7 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qjy" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -86261,7 +86261,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qkH" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
@@ -86290,7 +86290,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "qlw" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -86367,14 +86367,14 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "qmu" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "qmv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -87009,7 +87009,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "quv" = (
 /obj/machinery/light{
 	dir = 1;
@@ -87086,7 +87086,7 @@
 	on = 1
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "qvN" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -87101,7 +87101,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "qvY" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -87432,7 +87432,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "qAT" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -87623,7 +87623,7 @@
 /obj/structure/cable/yellow,
 /obj/effect/decal/warning_stripes/eastsouthwest,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "qDm" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -87847,7 +87847,7 @@
 	dir = 7;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "qGj" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -87899,7 +87899,7 @@
 	dir = 7;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "qGy" = (
 /turf/simulated/wall/r_wall,
 /area/medical/virology/lab)
@@ -88028,7 +88028,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "qIz" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -88204,7 +88204,7 @@
 	},
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "qLc" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
@@ -88730,7 +88730,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qTP" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -88763,7 +88763,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qUz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -88797,7 +88797,7 @@
 /obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/computer/station_alert,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qUL" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
@@ -88911,7 +88911,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "qWw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -89079,7 +89079,7 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qYZ" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -89096,7 +89096,7 @@
 	network = list("SS13","Engineering")
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qZm" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -89110,7 +89110,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qZn" = (
 /obj/machinery/light_switch{
 	pixel_x = -26
@@ -89133,7 +89133,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qZt" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/status_display,
@@ -89155,7 +89155,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "qZG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -89218,7 +89218,7 @@
 /area/hallway/primary/central/se)
 "raC" = (
 /turf/simulated/wall,
-/area/engine/aienter)
+/area/engineering/aienter)
 "raO" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -89228,7 +89228,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "raR" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light,
@@ -89251,7 +89251,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "rbh" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -89307,7 +89307,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "rbH" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -89467,7 +89467,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "rcP" = (
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall,
@@ -89491,7 +89491,7 @@
 "rcV" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall,
-/area/engine/break_room)
+/area/engineering/break_room)
 "rcX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -89666,7 +89666,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "rfA" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -89744,7 +89744,7 @@
 "rfZ" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "rgj" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -89824,7 +89824,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "rhD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -90136,7 +90136,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "rmy" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -90177,7 +90177,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "rna" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer,
 /turf/simulated/floor/plasteel{
@@ -90456,7 +90456,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "rqO" = (
 /obj/machinery/light{
 	dir = 8
@@ -91001,7 +91001,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "ryP" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel{
@@ -91025,7 +91025,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "rzh" = (
 /turf/simulated/wall,
 /area/security/processing)
@@ -91335,7 +91335,7 @@
 	dir = 7;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "rDJ" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
@@ -91476,7 +91476,7 @@
 /obj/item/crowbar,
 /obj/item/wrench,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "rFb" = (
 /obj/machinery/light{
 	dir = 8
@@ -91966,7 +91966,7 @@
 	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "rLk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/navbeacon{
@@ -92100,7 +92100,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "rNX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -92260,7 +92260,7 @@
 	name = "Transit Tube Blast Doors"
 	},
 /turf/simulated/floor/plating,
-/area/engine/aienter)
+/area/engineering/aienter)
 "rQm" = (
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel{
@@ -92332,7 +92332,7 @@
 	name = "Singularity Blast Doors"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "rQT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -92370,7 +92370,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "rRs" = (
 /obj/structure/chair,
 /obj/item/poster/random_contraband{
@@ -92485,7 +92485,7 @@
 	dir = 1;
 	icon_state = "yellowcorner"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "rSJ" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -92549,7 +92549,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "rUr" = (
 /mob/living/simple_animal/hostile/carp/megacarp{
 	desc = "Странная космическая акула, летающая неподалёку от станции. Многие поговаривают, что данное существо - аватар могущественного блю-спейс божества";
@@ -92579,7 +92579,7 @@
 "rUC" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "rUE" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -92637,7 +92637,7 @@
 /obj/effect/decal/warning_stripes/west,
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "rVf" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
@@ -92649,7 +92649,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "rVi" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -92771,7 +92771,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "rXo" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -92788,7 +92788,7 @@
 	dir = 9;
 	icon_state = "caution"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "rYp" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -92828,14 +92828,14 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "rZo" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "caution"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "rZz" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/structure/extinguisher_cabinet{
@@ -92846,7 +92846,7 @@
 	dir = 8;
 	icon_state = "brown"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "rZF" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/disposal,
@@ -92888,7 +92888,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "sag" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -92931,7 +92931,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "saS" = (
 /obj/machinery/light{
 	dir = 1;
@@ -93690,7 +93690,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "smu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -93922,7 +93922,7 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "spS" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/sop_engineering,
@@ -94288,7 +94288,7 @@
 	on = 1
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "sum" = (
 /obj/structure/chair{
 	dir = 4
@@ -94929,7 +94929,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "sCH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -95343,7 +95343,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "sIS" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -95409,10 +95409,10 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "sJK" = (
 /turf/simulated/floor/greengrid,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "sJO" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -95468,7 +95468,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "sKT" = (
 /obj/structure/chair/comfy/brown,
 /turf/simulated/floor/carpet/black,
@@ -95537,7 +95537,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "sMv" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -95590,7 +95590,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "sMM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -96196,7 +96196,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "sVN" = (
 /turf/simulated/wall,
 /area/teleporter/abandoned)
@@ -96692,7 +96692,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "tdA" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -96794,7 +96794,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "teD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -96911,7 +96911,7 @@
 	network = list("SS13","Singularity","Engineering")
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "tgg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/girder,
@@ -97025,7 +97025,7 @@
 /obj/effect/decal/warning_stripes/east,
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "thA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -97544,7 +97544,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "toP" = (
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -97608,7 +97608,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "tpA" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -98071,7 +98071,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "tyn" = (
 /obj/machinery/photocopier,
 /obj/structure/extinguisher_cabinet{
@@ -98138,7 +98138,7 @@
 	dir = 4;
 	icon_state = "cautioncorner"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "tzg" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/warning_stripes/northwest,
@@ -98149,7 +98149,7 @@
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "tzh" = (
 /turf/simulated/wall/r_wall,
 /area/security/warden)
@@ -98157,7 +98157,7 @@
 /obj/structure/grille,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "tzk" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -98178,7 +98178,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "tzt" = (
 /obj/machinery/computer/arcade/orion_trail,
 /turf/simulated/floor/carpet/arcade,
@@ -98208,7 +98208,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "tzR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -98270,7 +98270,7 @@
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "tAC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/twohanded/required/kirbyplants,
@@ -98538,7 +98538,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "tEE" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -98636,7 +98636,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "tFR" = (
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/aisat_interior)
@@ -98716,7 +98716,7 @@
 /area/medical/cmo)
 "tGE" = (
 /turf/simulated/wall/r_wall,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "tGG" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -98981,7 +98981,7 @@
 "tKz" = (
 /obj/item/screwdriver,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "tKK" = (
 /obj/structure/table,
 /obj/item/book/manual/security_space_law,
@@ -99449,7 +99449,7 @@
 "tPh" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "tPj" = (
 /obj/structure/chair/sofa,
 /obj/effect/landmark/start/civilian,
@@ -99458,7 +99458,7 @@
 "tPv" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "tQe" = (
 /obj/structure/chair/comfy/brown,
 /obj/structure/cable{
@@ -99509,7 +99509,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "tQq" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -99568,7 +99568,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "tQX" = (
 /obj/machinery/computer/message_monitor,
 /turf/simulated/floor/bluegrid,
@@ -99607,10 +99607,10 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "tSc" = (
 /turf/simulated/wall/r_wall,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "tSj" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -99702,14 +99702,14 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "tTI" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/sign/electricshock{
 	pixel_y = -32
 	},
 /turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "tTR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -99790,7 +99790,7 @@
 /obj/effect/decal/warning_stripes/south,
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "tUW" = (
 /obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/vending/wallmed{
@@ -99798,14 +99798,14 @@
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "tUX" = (
 /turf/simulated/floor/engine/insulated/vacuum,
 /area/toxins/mixing)
 "tVr" = (
 /obj/machinery/status_display,
 /turf/simulated/wall,
-/area/engine/break_room)
+/area/engineering/break_room)
 "tVu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -99826,7 +99826,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "tVz" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
@@ -99874,7 +99874,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "tVV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -99894,7 +99894,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "tWn" = (
 /turf/simulated/wall,
 /area/security/execution)
@@ -99923,7 +99923,7 @@
 "tXp" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "tXq" = (
 /obj/machinery/light{
 	dir = 4
@@ -100507,7 +100507,7 @@
 	},
 /obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "ufn" = (
 /obj/structure/window/reinforced,
 /obj/item/twohanded/required/kirbyplants,
@@ -101888,7 +101888,7 @@
 "uyI" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "uyQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -102146,7 +102146,7 @@
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "uCv" = (
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/suit_storage_unit/security,
@@ -102227,7 +102227,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "uEq" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
@@ -102399,7 +102399,7 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "uGH" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/item/storage/toolbox/fakesyndi,
@@ -102621,7 +102621,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "uJj" = (
 /obj/machinery/access_button{
 	command = "cycle_exterior";
@@ -102638,7 +102638,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "uJo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -102809,7 +102809,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "uLp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -102941,7 +102941,7 @@
 	dir = 8;
 	icon_state = "brown"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "uNA" = (
 /obj/item/mop,
 /turf/simulated/floor/wood{
@@ -103038,7 +103038,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "uOJ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/window/reinforced{
@@ -103056,7 +103056,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "uPb" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -103124,7 +103124,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "uQo" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -103132,7 +103132,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "uQp" = (
 /obj/machinery/vending/tool,
 /obj/item/radio/intercom{
@@ -103367,7 +103367,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "uST" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -103405,7 +103405,7 @@
 	dir = 10;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "uTr" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -103749,7 +103749,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "uXU" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/cleanable/cobweb,
@@ -103778,7 +103778,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "uYe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -104120,7 +104120,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "vcw" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/vending/wallmed{
@@ -104481,7 +104481,7 @@
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "vhW" = (
 /obj/structure/chair/stool,
 /obj/structure/disposalpipe/segment{
@@ -104709,7 +104709,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "vlD" = (
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -105271,7 +105271,7 @@
 /area/medical/chemistry)
 "vsN" = (
 /turf/simulated/wall/r_wall,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "vsT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -105295,7 +105295,7 @@
 "vtm" = (
 /obj/machinery/status_display,
 /turf/simulated/wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "vtu" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
@@ -105666,7 +105666,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "vxU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -105822,7 +105822,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "vzE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -105908,7 +105908,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "vAj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -105956,7 +105956,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "vAN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -106108,7 +106108,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "vCh" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -106122,7 +106122,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "vCj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -106131,7 +106131,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "vCl" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -106195,7 +106195,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "vDb" = (
 /obj/item/twohanded/required/kirbyplants/dead,
 /turf/simulated/floor/plasteel{
@@ -106213,7 +106213,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "vDe" = (
 /obj/machinery/light_switch{
 	pixel_x = 26;
@@ -106737,7 +106737,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "vLQ" = (
 /obj/structure/table/wood,
 /obj/item/kitchen/utensil/fork,
@@ -107213,7 +107213,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "vSH" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -107235,7 +107235,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "vSU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -107376,7 +107376,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "vTW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -107475,7 +107475,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "vUL" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -107960,7 +107960,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "waL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -108121,7 +108121,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "wcz" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -108135,7 +108135,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "wcE" = (
 /obj/machinery/light,
 /obj/machinery/status_display{
@@ -108294,7 +108294,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "wek" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
@@ -108322,7 +108322,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "weY" = (
 /obj/machinery/light{
 	dir = 4
@@ -108398,7 +108398,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "wgt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -108451,7 +108451,7 @@
 	dir = 7;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "whO" = (
 /turf/simulated/wall/r_wall/coated,
 /area/crew_quarters/hor)
@@ -108474,7 +108474,7 @@
 	dir = 7;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "wiT" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
@@ -108520,7 +108520,7 @@
 	dir = 7;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "wjc" = (
 /obj/machinery/light{
 	dir = 4
@@ -108596,7 +108596,7 @@
 	},
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "wka" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -108670,7 +108670,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "wkE" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -108754,7 +108754,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "wmD" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -108811,7 +108811,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "wnc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -108965,7 +108965,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "wps" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -109003,7 +109003,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "wpP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -109142,7 +109142,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "wrc" = (
 /obj/structure/table/wood,
 /obj/item/gavelblock,
@@ -109948,7 +109948,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "wBr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -110216,7 +110216,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "wEJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -110395,7 +110395,7 @@
 /obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "wGW" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -110812,7 +110812,7 @@
 	name = "Singularity Blast Doors"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "wNN" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -110889,7 +110889,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "wOF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -111367,7 +111367,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "wUC" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/suit_storage_unit/engine,
@@ -111537,7 +111537,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "wXh" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -111552,7 +111552,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "wXp" = (
 /obj/effect/decal/warning_stripes/southwest,
 /obj/effect/decal/cleanable/dirt,
@@ -112222,7 +112222,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "xgb" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -112467,7 +112467,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "xiA" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -112724,7 +112724,7 @@
 /area/toxins/xenobiology)
 "xnf" = (
 /turf/simulated/wall,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "xnm" = (
 /obj/structure/chair/office/light{
 	dir = 4;
@@ -113085,7 +113085,7 @@
 	},
 /obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "xqJ" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/cleanable/blood,
@@ -113194,7 +113194,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xsl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -113472,7 +113472,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "xva" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
@@ -113520,7 +113520,7 @@
 "xvt" = (
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "xvv" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -114125,7 +114125,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "xBT" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/curved/flipped{
@@ -114424,7 +114424,7 @@
 	dir = 7;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xGk" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Transit Tube";
@@ -114442,7 +114442,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "xGB" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -114567,7 +114567,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "xIm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed,
@@ -114682,7 +114682,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "xJH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -114873,7 +114873,7 @@
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "xLB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -114936,7 +114936,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "xLY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -114962,7 +114962,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "xMf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -115008,7 +115008,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "xMC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
@@ -115038,7 +115038,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "xNa" = (
 /obj/machinery/status_display,
 /turf/simulated/wall,
@@ -115060,7 +115060,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xNu" = (
 /obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -115119,7 +115119,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "xOx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -115152,7 +115152,7 @@
 "xOM" = (
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "xOP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -115341,7 +115341,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "xQv" = (
 /obj/machinery/camera{
 	c_tag = "Command Meeting Room";
@@ -115531,7 +115531,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "xSG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating,
@@ -116233,13 +116233,13 @@
 	},
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "ybU" = (
 /obj/structure/grille,
 /obj/effect/decal/warning_stripes/west,
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "ybW" = (
 /obj/machinery/computer/secure_data,
 /turf/simulated/floor/wood,
@@ -116560,7 +116560,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "ygb" = (
 /turf/simulated/wall,
 /area/hallway/secondary/exit)
@@ -116837,7 +116837,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "yjC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/bluegrid{

--- a/_maps/map_files/event/Station/towerstation.dmm
+++ b/_maps/map_files/event/Station/towerstation.dmm
@@ -16,7 +16,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aaj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -34,7 +34,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "aar" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -70,12 +70,12 @@
 "abx" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "abL" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "acf" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -262,7 +262,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "agF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -337,7 +337,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "aii" = (
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
@@ -501,7 +501,7 @@
 /area/crew_quarters/dorms)
 "alT" = (
 /turf/simulated/wall/r_wall,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "alU" = (
 /obj/structure/table/reinforced,
 /obj/item/aicard,
@@ -717,7 +717,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "rampbottom"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "atG" = (
 /obj/machinery/light{
 	dir = 1
@@ -824,7 +824,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "awY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -930,7 +930,7 @@
 	},
 /obj/machinery/camera/autoname,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "azW" = (
 /obj/structure/sign/poster/random{
 	pixel_x = -32
@@ -1030,7 +1030,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "aES" = (
 /obj/structure/bookcase/random/religion,
 /turf/simulated/floor/plasteel/grimy,
@@ -1135,7 +1135,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "aJk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -1143,7 +1143,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aJF" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -1173,7 +1173,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "aKC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1240,7 +1240,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "aMz" = (
 /obj/machinery/power/solar{
 	name = "South-East Solar Panel"
@@ -1309,7 +1309,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "aOR" = (
 /obj/structure/closet/walllocker{
 	pixel_x = -32
@@ -1438,7 +1438,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "aTj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/wardrobe/miner,
@@ -1603,7 +1603,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "aWW" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -1677,7 +1677,7 @@
 "aZq" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "bap" = (
 /obj/structure/table/reinforced,
 /obj/item/pod_parts/core,
@@ -1693,7 +1693,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "bax" = (
 /obj/machinery/door/airlock/silver{
 	name = "Bathroom"
@@ -1814,7 +1814,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "bfh" = (
 /obj/machinery/door/window{
 	req_access = list(73)
@@ -1999,7 +1999,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "blU" = (
 /obj/structure/rack,
 /obj/item/grenade/chem_grenade/metalfoam,
@@ -2204,7 +2204,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowcorner"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bvm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -2306,7 +2306,7 @@
 "bzb" = (
 /obj/effect/turf_decal/bot_red,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "bzd" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -2337,7 +2337,7 @@
 /obj/machinery/field/generator,
 /obj/effect/turf_decal/bot_red,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "bzw" = (
 /obj/machinery/bluespace_beacon,
 /obj/structure/cable{
@@ -2425,7 +2425,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "bCx" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -32
@@ -2451,7 +2451,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "bDM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2715,7 +2715,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/engineering)
+/area/engineering/engine)
 "bMY" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -2788,7 +2788,7 @@
 	},
 /obj/effect/turf_decal/bot_red,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "bOJ" = (
 /obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt,
@@ -2826,7 +2826,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bPU" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/grass/jungle/b,
@@ -2898,7 +2898,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bSq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -3084,7 +3084,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "bYp" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/vending/cola,
@@ -3534,7 +3534,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "cne" = (
 /obj/effect/landmark/start/doctor,
 /turf/simulated/floor/plasteel{
@@ -4020,7 +4020,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "cHB" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -4086,7 +4086,7 @@
 	},
 /obj/machinery/atmospherics/trinary/filter,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "cKn" = (
 /obj/effect/landmark/start/nanotrasen_rep,
 /turf/simulated/floor/wood/fancy/light{
@@ -4115,7 +4115,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "cLj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4152,7 +4152,7 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/camera/autoname,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cNH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plasteel,
@@ -4226,7 +4226,7 @@
 "cPV" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cQn" = (
 /obj/machinery/vending/clothing,
 /turf/simulated/floor/plasteel{
@@ -4263,7 +4263,7 @@
 	req_access = list(10,24)
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "cRJ" = (
 /obj/machinery/light{
 	dir = 1
@@ -4282,7 +4282,7 @@
 "cRS" = (
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "cSb" = (
 /obj/machinery/processor,
 /obj/effect/turf_decal/delivery,
@@ -4315,7 +4315,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cSI" = (
 /obj/machinery/camera/autoname,
 /turf/simulated/floor/plasteel,
@@ -4421,7 +4421,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cVT" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
@@ -4591,7 +4591,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "daX" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/flask/gold,
@@ -4607,7 +4607,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "dbi" = (
 /obj/structure/railing{
 	dir = 4
@@ -4651,7 +4651,7 @@
 "dcn" = (
 /obj/effect/landmark/start/engineer,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dcw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4814,7 +4814,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "diN" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/grass/jungle,
@@ -4841,7 +4841,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "djx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -4904,7 +4904,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "dmb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4934,7 +4934,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dmI" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
@@ -5179,7 +5179,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "dwT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -5223,7 +5223,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "dxJ" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/door/firedoor,
@@ -5232,7 +5232,7 @@
 "dxX" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "dzj" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/glass/fifty,
@@ -5336,7 +5336,7 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "dDj" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -5465,7 +5465,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "dGN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -5492,7 +5492,7 @@
 /area/hallway/secondary/exit)
 "dHQ" = (
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "dIv" = (
 /obj/structure/table/wood/fancy/black,
 /turf/simulated/floor/carpet/black,
@@ -5642,7 +5642,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "dNH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5745,7 +5745,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "dRj" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
@@ -5814,7 +5814,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dWu" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -5874,14 +5874,14 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "dXQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "dYN" = (
 /obj/structure/flora/ausbushes/fernybush,
 /turf/simulated/floor/grass,
@@ -6024,7 +6024,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "edT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6076,7 +6076,7 @@
 /obj/effect/landmark/start/engineer,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "eeH" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -6140,7 +6140,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "egz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6181,7 +6181,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "ejZ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -6369,7 +6369,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "erq" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /turf/simulated/floor/plasteel,
@@ -6640,7 +6640,7 @@
 	req_access = list(24,10)
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "ezy" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -6728,7 +6728,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "eCr" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -6790,7 +6790,7 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "eDW" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -6969,7 +6969,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "eJz" = (
 /obj/machinery/door/airlock/external{
 	name = "Toxins Test Chamber"
@@ -7089,7 +7089,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "eMC" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/reagent_containers/iv_bag/bloodsynthetic/oxygenis,
@@ -7171,7 +7171,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "eQn" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/reagent_dispensers/fueltank,
@@ -7182,7 +7182,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "eQR" = (
 /obj/machinery/light{
 	dir = 1
@@ -7220,7 +7220,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "eRD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -7542,7 +7542,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "fcn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7652,7 +7652,7 @@
 /obj/effect/decal/warning_stripes/south,
 /obj/effect/landmark/start/trainee_engineer,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "fgW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7818,7 +7818,7 @@
 	dir = 8;
 	icon_state = "rampbottom"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "fmd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -8070,7 +8070,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "fsa" = (
 /obj/effect/landmark/event/lightsout,
 /obj/effect/landmark/event/lightsout,
@@ -8146,7 +8146,7 @@
 "fuv" = (
 /obj/structure/disposalpipe/trunk/multiz,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "fuy" = (
 /obj/machinery/atmospherics/binary/pump{
 	name = "N2O to Pure"
@@ -8227,7 +8227,7 @@
 	req_access = list(11)
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "fwm" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "permaouter";
@@ -8305,7 +8305,7 @@
 /obj/structure/closet/radiation,
 /obj/item/clothing/glasses/meson,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "fxT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -8328,7 +8328,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "fyy" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -8614,7 +8614,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "fFI" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -8651,7 +8651,7 @@
 	dir = 4;
 	icon_state = "rampbottom"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "fGv" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/structure/filingcabinet,
@@ -8776,7 +8776,7 @@
 	},
 /obj/item/tank/internals/plasma,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "fKf" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -9000,7 +9000,7 @@
 	pixel_y = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "fSH" = (
 /obj/machinery/vending/cart{
 	pixel_x = -1;
@@ -9019,7 +9019,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "fTH" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -9084,7 +9084,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "fVu" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -9107,7 +9107,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "fWW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -9181,7 +9181,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "fZW" = (
 /turf/simulated/wall/r_wall,
 /area/security/prison)
@@ -9239,7 +9239,7 @@
 	},
 /obj/item/newspaper,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "gbL" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -9419,7 +9419,7 @@
 /obj/machinery/power/emitter,
 /obj/effect/turf_decal/bot_red,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "gkg" = (
 /obj/machinery/computer/security{
 	dir = 4
@@ -9470,7 +9470,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "gmh" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -9542,7 +9542,7 @@
 	dir = 10;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "gnN" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 8
@@ -9556,7 +9556,7 @@
 "gnW" = (
 /obj/structure/disposalpipe/trunk/multiz/down,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "gok" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9583,7 +9583,7 @@
 "goM" = (
 /obj/structure/bookcase/random,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "gpw" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology - Cell 3";
@@ -9676,7 +9676,7 @@
 	dir = 9
 	},
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "grE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -9813,7 +9813,7 @@
 	dir = 8;
 	icon_state = "rampbottom"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "gur" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
@@ -9874,7 +9874,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowcorner"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "gwd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -9973,7 +9973,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "gAv" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -10058,7 +10058,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "gDU" = (
 /obj/structure/ladder,
 /obj/machinery/light,
@@ -10141,7 +10141,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "gGj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -10152,7 +10152,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "gGz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10209,7 +10209,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "gIT" = (
 /obj/structure/railing{
 	dir = 8
@@ -10328,7 +10328,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "gMS" = (
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -10431,7 +10431,7 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "gPV" = (
 /obj/machinery/firealarm{
 	pixel_y = -28
@@ -10454,7 +10454,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "gQH" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -10553,7 +10553,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "gSK" = (
 /obj/structure/table/reinforced,
 /obj/item/cartridge/engineering{
@@ -10718,10 +10718,10 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "gXu" = (
 /turf/simulated/floor/engine/vacuum,
-/area/engine/engineering)
+/area/engineering/engine)
 "gXD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -10821,7 +10821,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "gZH" = (
 /obj/structure/chair/stool/bar,
 /turf/simulated/floor/carpet/black,
@@ -10866,7 +10866,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "hbJ" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/genericbush,
@@ -11027,7 +11027,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "hgQ" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
@@ -11084,7 +11084,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine/vacuum,
-/area/engine/engineering)
+/area/engineering/engine)
 "hhK" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -11130,7 +11130,7 @@
 	pixel_x = 5
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "hiz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11214,7 +11214,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "hlH" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/requests_console{
@@ -11262,7 +11262,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "hns" = (
 /obj/machinery/door/airlock/external{
 	name = "External Airlock";
@@ -11305,7 +11305,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "hoa" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/dark,
@@ -11448,7 +11448,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "hsb" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/cans/ale,
@@ -11514,7 +11514,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "huh" = (
 /obj/structure/cable/multiz{
 	color = "#dd1010"
@@ -11552,7 +11552,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "hvD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11607,7 +11607,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "hwN" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "cargodisposals";
@@ -11698,13 +11698,13 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "hBV" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "hCq" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -11720,7 +11720,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "hCY" = (
 /obj/machinery/door/airlock/command{
 	name = "E.V.A. Storage";
@@ -11749,7 +11749,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "hDo" = (
 /obj/effect/landmark/start/paramedic,
 /turf/simulated/floor/plasteel/white,
@@ -11855,7 +11855,7 @@
 "hHo" = (
 /obj/item/radio/beacon,
 /turf/simulated/floor/glass/reinforced,
-/area/engine/break_room)
+/area/engineering/break_room)
 "hHC" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	input_tag = "o2_in";
@@ -11880,7 +11880,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "hIf" = (
 /turf/simulated/floor/engine,
 /area/toxins/test_chamber)
@@ -12015,7 +12015,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "hMm" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -12321,7 +12321,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowcorner"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "hVs" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/coffee{
@@ -12447,7 +12447,7 @@
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/bot_red,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "hZk" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -12466,7 +12466,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "iat" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -12534,7 +12534,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "icR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -12790,7 +12790,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "ikA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12802,10 +12802,10 @@
 /area/assembly/robotics)
 "ikC" = (
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "ikQ" = (
 /turf/simulated/openspace,
-/area/engine/break_room)
+/area/engineering/break_room)
 "ilN" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
@@ -12857,11 +12857,11 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "ipc" = (
 /obj/structure/stairs,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "ipu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -12994,7 +12994,7 @@
 "itP" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/wall/r_wall,
-/area/engine/break_room)
+/area/engineering/break_room)
 "itZ" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/pump,
@@ -13010,7 +13010,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "iux" = (
 /obj/machinery/computer/card/minor/cmo{
 	dir = 8
@@ -13086,7 +13086,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "iwe" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -13116,7 +13116,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "ixg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -13195,7 +13195,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "izj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -13272,7 +13272,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "iBm" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -13515,7 +13515,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "iJG" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/machinery/light,
@@ -13524,7 +13524,7 @@
 "iJX" = (
 /obj/structure/sign/radiation/rad_area,
 /turf/simulated/wall/r_wall,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "iKd" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 5
@@ -13557,7 +13557,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "iLa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -13706,7 +13706,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "iPB" = (
 /obj/structure/disposalpipe/trunk/multiz/down,
 /turf/simulated/floor/plasteel/dark,
@@ -13743,7 +13743,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "iQr" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge Access";
@@ -13775,7 +13775,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "iQR" = (
 /obj/structure/closet/crate/secure/loot,
 /obj/effect/decal/cleanable/dirt,
@@ -13901,7 +13901,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "iVk" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -14030,7 +14030,7 @@
 	dir = 1;
 	icon_state = "yellowcorner"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "iZc" = (
 /turf/simulated/openspace,
 /area/crew_quarters/dorms)
@@ -14095,12 +14095,12 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "jbZ" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "jcc" = (
 /obj/item/radio/intercom{
 	pixel_y = 32
@@ -14120,7 +14120,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "jdZ" = (
 /obj/machinery/atmospherics/air_sensor{
 	id_tag = "o2_sensor"
@@ -14215,7 +14215,7 @@
 	dir = 4;
 	icon_state = "yellowcorner"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "jgI" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -14277,7 +14277,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "jjl" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -14295,7 +14295,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "jjy" = (
 /obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt,
@@ -14318,7 +14318,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "jkc" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -14379,7 +14379,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "jnd" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 8
@@ -14487,7 +14487,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "jpU" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/condiment/flour,
@@ -14616,7 +14616,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "jtS" = (
 /obj/machinery/light{
 	dir = 1
@@ -14825,7 +14825,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "jzT" = (
 /obj/structure/sink{
 	dir = 8;
@@ -14842,7 +14842,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "jAj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -14927,7 +14927,7 @@
 "jDR" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/break_room)
+/area/engineering/break_room)
 "jDT" = (
 /obj/structure/table,
 /obj/item/folder/red,
@@ -15013,7 +15013,7 @@
 "jGc" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "jGd" = (
 /obj/structure/bed/psych,
 /obj/random/therapy,
@@ -15125,7 +15125,7 @@
 	dir = 1;
 	icon_state = "rampbottom"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "jKH" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
@@ -15166,7 +15166,7 @@
 /area/hallway/primary/aft)
 "jMj" = (
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "jMo" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -15289,7 +15289,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "jSf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -15334,7 +15334,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "jSL" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/door/firedoor,
@@ -15373,7 +15373,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "jTP" = (
 /obj/machinery/light{
 	dir = 1
@@ -15581,7 +15581,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/engineering)
+/area/engineering/engine)
 "kcD" = (
 /obj/machinery/light{
 	dir = 1
@@ -15620,7 +15620,7 @@
 "kej" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "ken" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -15894,7 +15894,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "kmP" = (
 /obj/effect/landmark/start/hop,
 /turf/simulated/floor/wood/fancy/light,
@@ -15939,7 +15939,7 @@
 "kon" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "kqD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -16512,7 +16512,7 @@
 "kIb" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "kIC" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -16592,7 +16592,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/engineering)
+/area/engineering/engine)
 "kKD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -16622,7 +16622,7 @@
 	dir = 4;
 	icon_state = "yellowcorner"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "kNE" = (
 /obj/structure/table/glass,
 /obj/item/clothing/gloves/color/latex,
@@ -16701,7 +16701,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "kPR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -16741,7 +16741,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "kQW" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -16799,7 +16799,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "kVs" = (
 /obj/effect/landmark/start/chief_engineer,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -16914,7 +16914,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "kYs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -17008,7 +17008,7 @@
 	},
 /obj/effect/landmark/start/civilian,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "lbm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -17120,7 +17120,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "lel" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplecorner"
@@ -17216,7 +17216,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "lhi" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
@@ -17244,7 +17244,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "rampbottom"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "liJ" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -17319,7 +17319,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "lli" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -17455,7 +17455,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "lpf" = (
 /obj/machinery/requests_console{
 	department = "Locker Room";
@@ -17688,7 +17688,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "lvN" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/scrubber/huge,
@@ -17710,7 +17710,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "lwx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -17776,7 +17776,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "lyU" = (
 /obj/structure/rack,
 /obj/item/storage/bag/tray,
@@ -18211,7 +18211,7 @@
 	dir = 5
 	},
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "lOc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -18246,7 +18246,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "lPj" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology - Secure Cell";
@@ -18471,7 +18471,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "lXl" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced,
@@ -18574,7 +18574,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "lYZ" = (
 /obj/structure/chair{
 	dir = 8
@@ -18610,7 +18610,7 @@
 	},
 /obj/effect/landmark/start/trainee_engineer,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "lZh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18716,7 +18716,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "mbJ" = (
 /obj/machinery/door/airlock/external{
 	name = "Arrival Airlock"
@@ -18782,7 +18782,7 @@
 "mdS" = (
 /obj/structure/sign/radiation,
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "mdZ" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -19085,7 +19085,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "mnD" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -19271,7 +19271,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "mvn" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
@@ -19416,7 +19416,7 @@
 "mzB" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "mAe" = (
 /obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plasteel/dark,
@@ -19610,7 +19610,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "mFW" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/effect/turf_decal/delivery/red,
@@ -19673,7 +19673,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "mHt" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -19739,7 +19739,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "mJs" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/delivery/red,
@@ -19816,7 +19816,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "mKV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -20125,7 +20125,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "mVx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -20154,7 +20154,7 @@
 /obj/item/clothing/gloves/color/black,
 /obj/item/clothing/gloves/color/black,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "mVX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20232,7 +20232,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "mYg" = (
 /obj/machinery/atmospherics/pipe/multiz,
 /turf/simulated/floor/plasteel,
@@ -20460,7 +20460,7 @@
 /obj/item/wrench,
 /obj/item/clothing/mask/gas,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "njc" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/security/wooden_tv{
@@ -20589,7 +20589,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "nnQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -20675,7 +20675,7 @@
 	},
 /obj/structure/cable/yellow,
 /turf/simulated/floor/greengrid,
-/area/engine/engineering)
+/area/engineering/engine)
 "nqu" = (
 /obj/machinery/light{
 	dir = 1
@@ -20708,7 +20708,7 @@
 "nru" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "nrx" = (
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai_upload)
@@ -20790,7 +20790,7 @@
 	pixel_x = 4
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "nuq" = (
 /obj/machinery/computer/med_data/laptop,
 /obj/structure/table/wood,
@@ -20861,7 +20861,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "nzh" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -20953,7 +20953,7 @@
 /obj/machinery/shieldgen,
 /obj/effect/turf_decal/bot_red,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "nBR" = (
 /obj/machinery/door/airlock/command{
 	name = "Chief Medical Officer's Office";
@@ -21047,7 +21047,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/break_room)
+/area/engineering/break_room)
 "nDG" = (
 /obj/machinery/light{
 	dir = 1
@@ -21159,7 +21159,7 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/effect/landmark/start/trainee_engineer,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "nGG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -21340,7 +21340,7 @@
 /area/bridge)
 "nKH" = (
 /turf/simulated/floor/glass/reinforced,
-/area/engine/break_room)
+/area/engineering/break_room)
 "nLc" = (
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
@@ -21357,7 +21357,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "nMi" = (
 /obj/structure/table,
 /obj/machinery/kitchen_machine/microwave{
@@ -21461,7 +21461,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "nPm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -21564,7 +21564,7 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "nWc" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -21800,7 +21800,7 @@
 	name = "Secure Storage Blast Doors"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "oeo" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Engineering Maintenance";
@@ -21872,7 +21872,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine/vacuum,
-/area/engine/engineering)
+/area/engineering/engine)
 "ofn" = (
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/heads/hos)
@@ -21919,7 +21919,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "ogE" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Access";
@@ -22023,7 +22023,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "oja" = (
 /obj/machinery/camera/autoname{
 	dir = 5
@@ -22079,7 +22079,7 @@
 	dir = 8;
 	icon_state = "yellowcorner"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "okH" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
@@ -22514,7 +22514,7 @@
 	},
 /obj/machinery/camera/autoname,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "ozR" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -22886,7 +22886,7 @@
 "oMJ" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "oMR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
@@ -23133,7 +23133,7 @@
 	dir = 1;
 	icon_state = "yellowcorner"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "oVS" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/table/wood,
@@ -23150,7 +23150,7 @@
 /area/quartermaster/storage)
 "oVX" = (
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "oWn" = (
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/heads/chief)
@@ -23173,7 +23173,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "oXj" = (
 /obj/machinery/atmospherics/unary/outlet_injector/on{
 	id = "n2o_in"
@@ -23198,7 +23198,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "oYJ" = (
 /obj/structure/filingcabinet,
 /obj/item/folder/documents,
@@ -23252,7 +23252,7 @@
 /obj/structure/closet/emcloset/anchored,
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "oZZ" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/grass/jungle,
@@ -23591,7 +23591,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "png" = (
 /obj/effect/decal/warning_stripes/southwest,
 /obj/spacepod/sec{
@@ -23639,7 +23639,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "ppK" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -23656,7 +23656,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "pqV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -23717,7 +23717,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowcorner"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "psc" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/fernybush,
@@ -23769,7 +23769,7 @@
 	dir = 10;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "pvN" = (
 /turf/simulated/wall/r_wall,
 /area/security/securearmory)
@@ -23905,7 +23905,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "pys" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -24055,7 +24055,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "pCz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -24110,7 +24110,7 @@
 "pDZ" = (
 /obj/machinery/power/supermatter_shard/crystal,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "pEu" = (
 /obj/structure/ladder,
 /obj/machinery/light{
@@ -24243,7 +24243,7 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "pGT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -24267,7 +24267,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "pHi" = (
 /obj/machinery/door/window{
 	name = "Fitness Ring"
@@ -24303,7 +24303,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "pIg" = (
 /obj/machinery/computer/robotics,
 /obj/machinery/firealarm{
@@ -24589,7 +24589,7 @@
 "pSi" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "pSt" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/vending/cigarette,
@@ -24686,7 +24686,7 @@
 	dir = 8;
 	icon_state = "rampbottom"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "pUG" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -24818,7 +24818,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "pYk" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment,
@@ -24965,7 +24965,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "qdp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25135,7 +25135,7 @@
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "qjM" = (
 /obj/machinery/keycard_auth{
 	pixel_y = -24
@@ -25197,7 +25197,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "qls" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -25358,7 +25358,7 @@
 /obj/effect/turf_decal/bot_red,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "qsd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -25369,7 +25369,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "qsj" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -25595,7 +25595,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "qyF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -25609,7 +25609,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "qzy" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Engineering Maintenance";
@@ -25694,13 +25694,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "qDa" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "qDp" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
@@ -25715,7 +25715,7 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "qDw" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /obj/effect/turf_decal/delivery,
@@ -25725,7 +25725,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "qDB" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/space_heater,
@@ -25808,7 +25808,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/engineering)
+/area/engineering/engine)
 "qGU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -25959,7 +25959,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine/vacuum,
-/area/engine/engineering)
+/area/engineering/engine)
 "qLv" = (
 /obj/effect/landmark/start/clown,
 /turf/simulated/floor/plasteel{
@@ -26186,7 +26186,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "qSD" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -26195,7 +26195,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "qSN" = (
 /obj/machinery/atmospherics/pipe/multiz,
 /turf/simulated/floor/plasteel,
@@ -26234,7 +26234,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/engineering)
+/area/engineering/engine)
 "qVO" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -26458,7 +26458,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "rcx" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -26489,7 +26489,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "rdP" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/plasteel{
@@ -26523,7 +26523,7 @@
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "rfA" = (
 /obj/machinery/light{
 	dir = 1
@@ -26654,7 +26654,7 @@
 /area/crew_quarters/dorms)
 "riC" = (
 /turf/simulated/wall/r_wall,
-/area/engine/break_room)
+/area/engineering/break_room)
 "riK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -26662,7 +26662,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "riP" = (
 /obj/structure/disposalpipe/trunk/multiz/down,
 /turf/simulated/floor/plasteel/dark,
@@ -26892,7 +26892,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "roO" = (
 /obj/effect/decal/warning_stripes/northeast,
 /obj/structure/cable{
@@ -26913,7 +26913,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "rqk" = (
 /obj/structure/closet{
 	name = "Evidence Closet 3"
@@ -26959,7 +26959,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "rsE" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
 /turf/simulated/floor/plasteel{
@@ -27027,7 +27027,7 @@
 "rvf" = (
 /obj/effect/landmark/event/blobstart,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "rvh" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/gloves{
@@ -27106,7 +27106,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "rxM" = (
 /obj/effect/landmark/ninja_teleport,
 /turf/simulated/floor/plasteel/dark,
@@ -27130,7 +27130,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "ryM" = (
 /obj/structure/chair/comfy/black,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -27255,7 +27255,7 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "rDc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/structure/cable/yellow{
@@ -27267,7 +27267,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "rDF" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -27276,7 +27276,7 @@
 	dir = 8;
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "rDM" = (
 /obj/structure/table,
 /obj/item/storage/box/syringes,
@@ -27329,7 +27329,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "rFi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -27410,7 +27410,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "rHU" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -27750,7 +27750,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "rSc" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27798,7 +27798,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/engineering)
+/area/engineering/engine)
 "rSR" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/window/reinforced,
@@ -27886,7 +27886,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "rWr" = (
 /obj/structure/bed/dogbed,
 /mob/living/simple_animal/pet/cat/Runtime,
@@ -27920,7 +27920,7 @@
 "rYE" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "rZq" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plasteel,
@@ -28286,7 +28286,7 @@
 	dir = 10
 	},
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "soa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -28373,7 +28373,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "sqE" = (
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
@@ -28538,7 +28538,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "sxC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28754,7 +28754,7 @@
 	dir = 6
 	},
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "sGe" = (
 /turf/simulated/floor/plasteel/white,
 /area/crew_quarters/kitchen)
@@ -28783,7 +28783,7 @@
 "sHT" = (
 /obj/machinery/atmospherics/pipe/multiz,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "sIc" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28807,7 +28807,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "sIp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
@@ -28847,13 +28847,13 @@
 /area/crew_quarters/dorms)
 "sJl" = (
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "sJy" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "yellowcorner"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "sJG" = (
 /obj/structure/chair/sofa/left{
 	dir = 8
@@ -29011,7 +29011,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "sOd" = (
 /obj/structure/window/reinforced,
 /obj/structure/flora/ausbushes/fernybush,
@@ -29086,7 +29086,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/engineering)
+/area/engineering/engine)
 "sPE" = (
 /obj/machinery/computer/podtracker,
 /turf/simulated/floor/plasteel{
@@ -29231,7 +29231,7 @@
 	dir = 4;
 	icon_state = "yellowcorner"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "sVm" = (
 /obj/machinery/light{
 	dir = 4
@@ -29269,7 +29269,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "sWo" = (
 /obj/machinery/door/airlock/command{
 	id_tag = "blueshieldofficedoor";
@@ -29358,7 +29358,7 @@
 /obj/effect/landmark/start/engineer,
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "sZR" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/recharge_station,
@@ -29381,7 +29381,7 @@
 /area/medical/surgery/north)
 "tbt" = (
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "tbD" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -29436,7 +29436,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "tee" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
@@ -29602,7 +29602,7 @@
 	},
 /obj/effect/landmark/event/lightsout,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "thy" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -29782,7 +29782,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/greengrid,
-/area/engine/engineering)
+/area/engineering/engine)
 "tne" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/wall/r_wall,
@@ -29858,7 +29858,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "tqf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -29900,7 +29900,7 @@
 /area/medical/morgue)
 "trH" = (
 /turf/simulated/wall/r_wall,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "trN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -29908,7 +29908,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "tsf" = (
 /obj/machinery/chem_dispenser,
 /obj/effect/decal/warning_stripes/north,
@@ -30013,7 +30013,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "twj" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/door/firedoor,
@@ -30322,7 +30322,7 @@
 "tFD" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "tFH" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
@@ -30366,7 +30366,7 @@
 /obj/item/wrench,
 /obj/item/crowbar,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "tHf" = (
 /obj/machinery/camera/autoname,
 /obj/machinery/newscaster{
@@ -30381,7 +30381,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "tIa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -30475,7 +30475,7 @@
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "tKo" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/cable{
@@ -30789,7 +30789,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "tTF" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -30939,7 +30939,7 @@
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "tZh" = (
 /obj/machinery/light,
 /obj/machinery/firealarm{
@@ -31035,7 +31035,7 @@
 	dir = 4;
 	icon_state = "rampbottom"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "ubZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -31054,7 +31054,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "ucF" = (
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
@@ -31102,7 +31102,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "uer" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/chips,
@@ -31212,7 +31212,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "uiE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -31372,7 +31372,7 @@
 /obj/item/rpd,
 /obj/machinery/camera/autoname,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "unG" = (
 /obj/machinery/light{
 	dir = 1
@@ -31585,7 +31585,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "uuY" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
@@ -31636,7 +31636,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/break_room)
+/area/engineering/break_room)
 "uvu" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/machinery/firealarm{
@@ -31707,7 +31707,7 @@
 	pixel_y = -2
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "uyQ" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -31736,7 +31736,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "uzj" = (
 /obj/structure/table/reinforced,
 /obj/item/lighter/zippo/rd,
@@ -31873,7 +31873,7 @@
 /area/hallway/secondary/exit)
 "uDj" = (
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "uDq" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -31893,7 +31893,7 @@
 /area/toxins/test_chamber)
 "uDH" = (
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "uDM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -31914,7 +31914,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "uEt" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 5
@@ -31978,7 +31978,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "uHe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -31998,7 +31998,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "uHC" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -32115,7 +32115,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "uLd" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
@@ -32138,7 +32138,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "uLt" = (
 /obj/machinery/atmospherics/trinary/mixer{
 	desc = "Смешивает кислород и азот, создавая смесь для дыхания на станции";
@@ -32213,7 +32213,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "uNp" = (
 /turf/simulated/floor/carpet/black,
 /area/crew_quarters/heads/hos)
@@ -32291,7 +32291,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "uQq" = (
 /obj/structure/sign/poster/random{
 	pixel_y = -32
@@ -32428,7 +32428,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "uTX" = (
 /obj/machinery/chem_dispenser/botanical,
 /obj/effect/decal/warning_stripes/yellow,
@@ -32462,7 +32462,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "uUA" = (
 /obj/machinery/atmospherics/pipe/multiz,
 /turf/simulated/floor/plasteel,
@@ -32473,7 +32473,7 @@
 /area/crew_quarters/dorms)
 "uXp" = (
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "uYt" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel/dark,
@@ -32635,7 +32635,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/break_room)
+/area/engineering/break_room)
 "vdr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -32675,7 +32675,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "vdX" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -32796,7 +32796,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/effect/landmark/start/trainee_engineer,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "viw" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
@@ -32961,7 +32961,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "vlb" = (
 /turf/simulated/floor/plating,
 /area/space)
@@ -32971,7 +32971,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "vly" = (
 /obj/structure/window/reinforced,
 /obj/structure/flora/ausbushes/genericbush,
@@ -33032,7 +33032,7 @@
 	dir = 4;
 	icon_state = "rampbottom"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "vol" = (
 /obj/machinery/porta_turret,
 /obj/machinery/light,
@@ -33197,7 +33197,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "vud" = (
 /obj/machinery/chem_master/condimaster{
 	name = "HoochMaster 2000"
@@ -33408,7 +33408,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "vAH" = (
 /mob/living/simple_animal/crab/Coffee{
 	desc = "Master of the GYM";
@@ -33425,7 +33425,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "vAU" = (
 /obj/effect/landmark/start/chaplain,
 /obj/structure/chair/office{
@@ -33454,7 +33454,7 @@
 /obj/machinery/camera/autoname,
 /obj/effect/landmark/start/civilian,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "vCL" = (
 /obj/structure/curtain,
 /obj/machinery/shower{
@@ -33475,7 +33475,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "vCV" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -33515,7 +33515,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "vDD" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -33690,14 +33690,14 @@
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "vIz" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/radiation,
 /obj/item/clothing/glasses/meson,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "vID" = (
 /turf/simulated/floor/plasteel/grimy,
 /area/hallway/primary/central)
@@ -33760,7 +33760,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "vLQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -33799,7 +33799,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "vMi" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -33812,7 +33812,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "vMx" = (
 /obj/machinery/door/airlock/research{
 	name = "Xenobiology Lab";
@@ -33885,7 +33885,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "vNR" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -33951,7 +33951,7 @@
 /obj/structure/chair/comfy/black,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "vON" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -34016,7 +34016,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "vRu" = (
 /obj/effect/landmark/start/security_pod_pilot,
 /obj/structure/chair/office/dark,
@@ -34049,11 +34049,11 @@
 	dir = 1;
 	icon_state = "rampbottom"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "vTb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "vTq" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -34071,7 +34071,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "vUc" = (
 /obj/effect/turf_decal/bot,
 /turf/simulated/floor/plasteel{
@@ -34092,7 +34092,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "vVo" = (
 /obj/machinery/light{
 	dir = 1
@@ -34325,7 +34325,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "rampbottom"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "wbp" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -34340,7 +34340,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "wbF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -34431,7 +34431,7 @@
 	dir = 6;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "wfd" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -35127,7 +35127,7 @@
 /obj/structure/ladder,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "wzD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -35177,7 +35177,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "wBl" = (
 /obj/machinery/light{
 	dir = 1
@@ -35335,7 +35335,7 @@
 	dir = 4;
 	icon_state = "rampbottom"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "wFa" = (
 /obj/structure/table,
 /obj/item/stack/medical/ointment,
@@ -35462,7 +35462,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "wJu" = (
 /turf/simulated/floor/wood,
 /area/lawoffice)
@@ -35521,7 +35521,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "wLn" = (
 /obj/item/radio/intercom{
 	pixel_x = -32
@@ -35533,7 +35533,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "wLN" = (
 /obj/structure/ladder,
 /obj/machinery/light{
@@ -35671,7 +35671,7 @@
 "wQo" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "wQB" = (
 /obj/structure/spacepoddoor{
 	luminosity = 3
@@ -35679,7 +35679,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "wQE" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/machinery/door/airlock/public/glass,
@@ -35818,7 +35818,7 @@
 "wUx" = (
 /obj/machinery/camera/autoname,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "wUG" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/coffee{
@@ -35956,7 +35956,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "wXd" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/delivery,
@@ -36004,7 +36004,7 @@
 	dir = 8;
 	icon_state = "rampbottom"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "wYd" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -36037,7 +36037,7 @@
 	dir = 1;
 	icon_state = "rampbottom"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "wZj" = (
 /obj/structure/stairs{
 	dir = 1
@@ -36102,7 +36102,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xaz" = (
 /obj/machinery/door_control{
 	id = "hosprivacy";
@@ -36137,7 +36137,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "xdd" = (
 /obj/item/radio/intercom{
 	pixel_y = -32
@@ -36162,7 +36162,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "xef" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -36441,7 +36441,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xmH" = (
 /obj/structure/table,
 /obj/item/clothing/under/color/orange/prison{
@@ -36609,7 +36609,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "xrg" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Experimentor";
@@ -36651,7 +36651,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "xsr" = (
 /obj/effect/landmark/start/scientist,
 /obj/effect/turf_decal/stripes/line,
@@ -36808,7 +36808,7 @@
 /obj/structure/closet/radiation,
 /obj/item/clothing/glasses/meson,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "xvv" = (
 /obj/machinery/newscaster{
 	pixel_y = -32
@@ -36884,7 +36884,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "xyq" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/masks,
@@ -37143,7 +37143,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/break_room)
+/area/engineering/break_room)
 "xIA" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -37347,7 +37347,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "xQQ" = (
 /obj/structure/sign/science{
 	icon_state = "xenobio2";
@@ -37480,7 +37480,7 @@
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "xWt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -37509,7 +37509,7 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/turf_decal/bot_red,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engineering/engine)
 "xXV" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -37705,7 +37705,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/engine,
-/area/engine/engineering)
+/area/engineering/engine)
 "ydG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -37729,7 +37729,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "ydP" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -37784,7 +37784,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engineering/break_room)
 "ygg" = (
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/bar)

--- a/_maps/map_files/nova/nova.dmm
+++ b/_maps/map_files/nova/nova.dmm
@@ -113,7 +113,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "aaW" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -121,11 +121,11 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aaZ" = (
 /obj/structure/railing,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "abb" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
@@ -196,7 +196,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "abF" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -301,7 +301,7 @@
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/structure/cable,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "acN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -457,7 +457,7 @@
 	in_use = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "adU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -508,7 +508,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aek" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -594,7 +594,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "aeF" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -954,7 +954,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ahn" = (
 /obj/structure/sign/directions/evac,
 /turf/simulated/wall,
@@ -1098,7 +1098,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "ain" = (
 /obj/structure/railing{
 	dir = 4
@@ -1139,7 +1139,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "podfloor_dark"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aiz" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -1260,7 +1260,7 @@
 	id_tag = "engineering_west_pump"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "ajt" = (
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1520,7 +1520,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "als" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -25
@@ -1584,7 +1584,7 @@
 	req_access = list(18,48,70,71)
 	},
 /turf/simulated/wall,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "alJ" = (
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating/airless,
@@ -1717,7 +1717,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "amA" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -1776,7 +1776,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "amV" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -2091,7 +2091,7 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "apj" = (
 /obj/item/radio/intercom/custom{
 	pixel_y = 25
@@ -2342,7 +2342,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "arV" = (
 /obj/effect/turf_decal/arrows/white{
 	dir = 8
@@ -2510,7 +2510,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ati" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -2872,7 +2872,7 @@
 /area/maintenance/asmaint)
 "aww" = (
 /turf/simulated/wall/r_wall,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "awz" = (
 /turf/simulated/wall,
 /area/security/checkpoint)
@@ -3016,7 +3016,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "aye" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -3135,7 +3135,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ayZ" = (
 /obj/machinery/status_display,
 /turf/simulated/wall,
@@ -3230,7 +3230,7 @@
 "azB" = (
 /obj/machinery/computer/atmos_alert,
 /turf/simulated/floor/redgrid,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "azG" = (
 /obj/item/stock_parts/scanning_module{
 	pixel_x = 1;
@@ -3265,7 +3265,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "azN" = (
 /obj/machinery/light{
 	dir = 8
@@ -3318,7 +3318,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "azW" = (
 /obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/light/small{
@@ -3514,7 +3514,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "aBQ" = (
 /obj/machinery/door/airlock/medical{
 	name = "Brig Medical Bay";
@@ -3964,7 +3964,7 @@
 "aED" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "aEK" = (
 /obj/structure/bed,
 /obj/item/bedsheet/captain,
@@ -4036,7 +4036,7 @@
 /obj/effect/decal/warning_stripes/southeastcorner,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aFk" = (
 /obj/item/radio/intercom{
 	pixel_x = -28
@@ -4501,7 +4501,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "aHY" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4514,7 +4514,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "aIf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -4543,7 +4543,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aIo" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -4610,7 +4610,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "aII" = (
 /obj/structure/dispenser/oxygen,
 /obj/effect/decal/warning_stripes/yellow,
@@ -5010,7 +5010,7 @@
 	security_level = 6
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "aLb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5041,7 +5041,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aLJ" = (
 /obj/structure/chair{
 	dir = 8
@@ -5213,7 +5213,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "aNn" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/power/apc{
@@ -5537,7 +5537,7 @@
 	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "aPH" = (
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -5551,7 +5551,7 @@
 	dir = 6;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "aPL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6117,7 +6117,7 @@
 	},
 /obj/item/clothing/head/welding/flamedecal,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aSW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -6274,7 +6274,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "aUs" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
@@ -6331,7 +6331,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "aUG" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -6459,7 +6459,7 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "aVt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6517,7 +6517,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aVU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/autolathe,
@@ -6565,7 +6565,7 @@
 /obj/structure/closet/firecloset,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "aWu" = (
 /obj/machinery/computer/monitor{
 	name = "Engineering Power Monitoring Console"
@@ -6577,7 +6577,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "aWy" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/food/snacks/sliceable/chocolatecake,
@@ -6742,7 +6742,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aYk" = (
 /obj/structure/sign/security,
 /turf/simulated/wall/r_wall,
@@ -6851,7 +6851,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "aZq" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -6936,7 +6936,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ban" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -7113,7 +7113,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bbI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip{
@@ -7134,7 +7134,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bbR" = (
 /obj/machinery/light{
 	dir = 4
@@ -7263,7 +7263,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/aienter)
+/area/engineering/aienter)
 "bcM" = (
 /obj/effect/spawner/random_spawners/wall_rusted_70,
 /turf/simulated/wall,
@@ -7281,7 +7281,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bcT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7333,7 +7333,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bdq" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -7341,7 +7341,7 @@
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bdr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
@@ -7397,7 +7397,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bee" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -7649,7 +7649,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "bfN" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -7673,7 +7673,7 @@
 	dir = 10;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bfS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7719,7 +7719,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bgg" = (
 /obj/machinery/door/airlock/command{
 	name = "Blueshield's Office";
@@ -7815,7 +7815,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bgJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8015,7 +8015,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "bil" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -8145,7 +8145,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bjp" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -8495,7 +8495,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "blU" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -8560,11 +8560,11 @@
 	dir = 4
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bmD" = (
 /obj/structure/sign/fire,
 /turf/simulated/wall/r_wall,
-/area/engine/break_room)
+/area/engineering/break_room)
 "bmE" = (
 /obj/structure/chair/comfy/teal{
 	dir = 8
@@ -8666,7 +8666,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bnq" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger{
@@ -9068,7 +9068,7 @@
 	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "bqa" = (
 /obj/machinery/camera{
 	c_tag = "Chapel West";
@@ -9577,7 +9577,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "bts" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -9690,7 +9690,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bua" = (
 /turf/simulated/wall,
 /area/quartermaster/sorting)
@@ -9721,7 +9721,7 @@
 	},
 /obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bup" = (
 /obj/structure/table/glass,
 /obj/item/hand_labeler{
@@ -9827,7 +9827,7 @@
 "buQ" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall,
-/area/engine/break_room)
+/area/engineering/break_room)
 "buU" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -9975,7 +9975,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bvE" = (
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -10175,7 +10175,7 @@
 "bwU" = (
 /obj/structure/sign/radiation,
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bwZ" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -10392,7 +10392,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "byL" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -10449,7 +10449,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "byY" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/plasteel{
@@ -10593,7 +10593,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bAt" = (
 /obj/structure/grille,
 /obj/effect/decal/warning_stripes/east,
@@ -10657,7 +10657,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bAQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10698,7 +10698,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bBe" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -10905,7 +10905,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "bCw" = (
 /obj/structure/sign/directions/evac{
 	pixel_y = -8
@@ -11071,7 +11071,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bDr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -11155,7 +11155,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bDT" = (
 /obj/structure/curtain/black,
 /turf/simulated/floor/plating,
@@ -11211,7 +11211,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bEk" = (
 /obj/machinery/libraryscanner,
 /turf/simulated/floor/plasteel,
@@ -11238,7 +11238,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bEK" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/syringe{
@@ -11304,7 +11304,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "bFc" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -11431,7 +11431,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "bFQ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -11683,7 +11683,7 @@
 "bHl" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "bHv" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11759,7 +11759,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "bIi" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
@@ -11777,7 +11777,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "bIm" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=A34";
@@ -11856,7 +11856,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bIK" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
@@ -11914,7 +11914,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bJa" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11923,7 +11923,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "bJd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -12108,7 +12108,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "bKU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12278,7 +12278,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bMf" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/structure/sign/poster/official/random{
@@ -12354,7 +12354,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "bMP" = (
 /obj/machinery/photocopier,
 /obj/machinery/alarm{
@@ -12419,7 +12419,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bNo" = (
 /obj/machinery/computer/area_atmos/area,
 /turf/simulated/floor/plasteel,
@@ -12706,7 +12706,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "bPA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12846,7 +12846,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bQv" = (
 /obj/machinery/conveyor/inverted{
 	id = "garbage";
@@ -12979,7 +12979,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "bRt" = (
 /obj/structure/closet/secure_closet,
 /obj/item/storage/secure/briefcase,
@@ -13096,7 +13096,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bRU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -13154,7 +13154,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "bSD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -13258,7 +13258,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "bTl" = (
 /obj/item/radio/intercom/locked/prison{
 	pixel_x = 28
@@ -13447,7 +13447,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "bUt" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13470,7 +13470,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "bUP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -14036,7 +14036,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/aienter)
+/area/engineering/aienter)
 "bYF" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -14607,7 +14607,7 @@
 	req_access = list(10,24)
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "cdj" = (
 /obj/structure/curtain/open/shower,
 /obj/machinery/shower{
@@ -14738,7 +14738,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cdQ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -14757,7 +14757,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "cee" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
@@ -14894,7 +14894,7 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cfx" = (
 /obj/machinery/conveyor{
 	id = "packageSort1"
@@ -15044,7 +15044,7 @@
 	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cgP" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel{
@@ -15113,7 +15113,7 @@
 	network = list("SS13","Engineering")
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "chA" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/warning_stripes/red/hollow,
@@ -15494,7 +15494,7 @@
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ckm" = (
 /obj/machinery/light{
 	dir = 4
@@ -15540,7 +15540,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ckW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
@@ -15560,7 +15560,7 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "clc" = (
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/wood{
@@ -15574,7 +15574,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "clm" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/carpet/black,
@@ -16161,7 +16161,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "cpp" = (
 /obj/item/mounted/frame/alarm_frame,
 /turf/simulated/floor/plating,
@@ -16177,7 +16177,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "cpz" = (
 /obj/structure/table/wood/poker,
 /obj/effect/decal/cleanable/dust,
@@ -16403,7 +16403,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "cqN" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -16489,7 +16489,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "cry" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16802,7 +16802,7 @@
 	pixel_y = 25
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "ctQ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -16954,7 +16954,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cuM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -17155,7 +17155,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "cwm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -17271,7 +17271,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cwW" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/kitchen/knife{
@@ -17342,7 +17342,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "cxT" = (
 /obj/structure/railing{
 	dir = 9
@@ -17464,7 +17464,7 @@
 	dir = 8;
 	icon_state = "darkyellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cze" = (
 /obj/structure/table/reinforced,
 /obj/item/tank/internals/emergency_oxygen,
@@ -17512,7 +17512,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "czx" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/ids{
@@ -17563,7 +17563,7 @@
 "czJ" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "czK" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/brflowers,
@@ -17715,7 +17715,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cBf" = (
 /obj/structure/barricade/wooden{
 	layer = 3.5
@@ -17756,7 +17756,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cBC" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/reagent_containers/food/drinks/bottle/fernet,
@@ -17958,7 +17958,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cCL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random_spawners/rodent,
@@ -17996,7 +17996,7 @@
 	dir = 7;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cDq" = (
 /obj/machinery/computer/atmos_alert,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -18254,7 +18254,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cFs" = (
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plating/airless,
@@ -18264,7 +18264,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "podfloor_dark"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cFA" = (
 /obj/item/folder/yellow,
 /obj/item/folder/blue{
@@ -18284,7 +18284,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "cFD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -18535,7 +18535,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cHb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -18895,7 +18895,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cKt" = (
 /obj/machinery/light{
 	dir = 4
@@ -18934,7 +18934,7 @@
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/structure/cable,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cKF" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
@@ -19341,7 +19341,7 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "cNJ" = (
 /obj/structure/sign/poster/official/religious{
 	pixel_x = 32
@@ -19358,7 +19358,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "cNM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -19418,7 +19418,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cOo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/hemostat,
@@ -19602,7 +19602,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "cPC" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light{
@@ -19646,7 +19646,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/aienter)
+/area/engineering/aienter)
 "cPS" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/beakers,
@@ -19691,7 +19691,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "cQj" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -19794,7 +19794,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "cQN" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -19804,7 +19804,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "podfloor_dark"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "cQO" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -19926,7 +19926,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/aienter)
+/area/engineering/aienter)
 "cRz" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -20124,7 +20124,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "cTb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -20261,7 +20261,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "cUl" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -20852,7 +20852,7 @@
 	dir = 7;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cYx" = (
 /obj/item/reagent_containers/spray/plantbgone{
 	pixel_x = 5;
@@ -20910,7 +20910,7 @@
 	dir = 7;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "cYR" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/decal/warning_stripes/yellow,
@@ -21109,7 +21109,7 @@
 	},
 /obj/structure/railing/corner,
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "daQ" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/double,
@@ -21287,7 +21287,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "dcJ" = (
 /obj/machinery/atmospherics/unary/outlet_injector/on{
 	dir = 4;
@@ -21511,7 +21511,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "dfm" = (
 /obj/effect/spawner/random_spawners/oil_5,
 /turf/simulated/floor/plating,
@@ -21531,7 +21531,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/aienter)
+/area/engineering/aienter)
 "dfF" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plating,
@@ -21792,7 +21792,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dho" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -21819,7 +21819,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "dhu" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -21851,7 +21851,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "dhG" = (
 /obj/effect/spawner/window/reinforced/polarized{
 	id = "Morgue"
@@ -21936,7 +21936,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "dif" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -21980,7 +21980,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "diF" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -22083,7 +22083,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "djz" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -22158,7 +22158,7 @@
 	charge = 2e+006
 	},
 /turf/simulated/floor/redgrid,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "djY" = (
 /obj/item/radio/intercom{
 	pixel_x = 28
@@ -22279,7 +22279,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "dlf" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -22684,7 +22684,7 @@
 	req_access = list(10,13)
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "dov" = (
 /obj/structure/sign/security,
 /turf/simulated/wall/r_wall,
@@ -23025,7 +23025,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "podfloor_dark"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "dqM" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -23104,7 +23104,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "drx" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -23118,7 +23118,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "drz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -23829,7 +23829,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "dwM" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance";
@@ -24233,7 +24233,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dzM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -24396,7 +24396,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "dAM" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -24599,7 +24599,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "dCr" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -24649,7 +24649,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "dCG" = (
 /obj/structure/bed,
 /obj/item/bedsheet/mime{
@@ -24745,7 +24745,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "dDE" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -25313,7 +25313,7 @@
 "dIH" = (
 /obj/item/wrench,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "dIJ" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -25421,7 +25421,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "dJu" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop,
@@ -25587,7 +25587,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "dKV" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8;
@@ -25722,7 +25722,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "dMm" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/warning_stripes/yellow,
@@ -25753,7 +25753,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "dMq" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -25794,7 +25794,7 @@
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "dMD" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -25884,7 +25884,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "dNk" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
@@ -25934,7 +25934,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "dNK" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/glass/beaker/large,
@@ -26297,7 +26297,7 @@
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "dQd" = (
 /obj/machinery/kitchen_machine/microwave{
 	pixel_x = -3;
@@ -26468,7 +26468,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "dRn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26717,7 +26717,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "dTb" = (
 /obj/structure/railing,
 /obj/structure/flora/ausbushes/grassybush,
@@ -26737,7 +26737,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "dTd" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26790,7 +26790,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "dTs" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -26965,7 +26965,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "dVP" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/metal{
@@ -27073,7 +27073,7 @@
 "dWp" = (
 /obj/item/screwdriver,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "dWz" = (
 /obj/machinery/light/small,
 /obj/item/twohanded/required/kirbyplants/dead,
@@ -27420,7 +27420,7 @@
 	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "dZD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27459,7 +27459,7 @@
 	dir = 6;
 	icon_state = "yellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "dZL" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -27484,7 +27484,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "dZV" = (
 /obj/structure/sign/poster/contraband/commando{
 	pixel_y = -32
@@ -27649,7 +27649,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ebe" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -27835,7 +27835,7 @@
 "eck" = (
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ecl" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -27922,7 +27922,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "ecX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -28097,7 +28097,7 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "eeb" = (
 /obj/machinery/camera{
 	c_tag = "Prisoners Lockers";
@@ -28223,14 +28223,14 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "eeY" = (
 /obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/engine/hull/reinforced,
 /area/space)
 "efd" = (
 /turf/simulated/wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "efl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -28252,7 +28252,7 @@
 	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "efu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -28328,7 +28328,7 @@
 /area/toxins/test_area)
 "efT" = (
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "efX" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -28413,7 +28413,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "egz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plasteel,
@@ -28512,7 +28512,7 @@
 /area/security/seceqstorage)
 "eha" = (
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "ehb" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Walkway"
@@ -29059,7 +29059,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "ekT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29282,7 +29282,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "eme" = (
 /obj/structure/table/wood,
 /obj/item/deck/cards,
@@ -29686,7 +29686,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/redgrid,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "eps" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29804,7 +29804,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "eqk" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
@@ -29969,7 +29969,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "erR" = (
 /obj/item/shard{
 	icon_state = "medium";
@@ -30159,7 +30159,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "etD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -30217,7 +30217,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "eun" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
@@ -30288,14 +30288,14 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "euC" = (
 /obj/machinery/atmospherics/unary/outlet_injector/on{
 	dir = 8
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "euI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/east,
@@ -30319,7 +30319,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "euP" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -30327,7 +30327,7 @@
 /obj/machinery/atmospherics/meter,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "euT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30392,7 +30392,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "evv" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -30530,7 +30530,7 @@
 /mob/living/simple_animal/possum/Poppy,
 /obj/structure/bed/dogbed/pet,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "ewG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30731,7 +30731,7 @@
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "exP" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -30749,7 +30749,7 @@
 "exR" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "exS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30771,7 +30771,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "exT" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -30900,7 +30900,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "eyD" = (
 /obj/item/radio/intercom{
 	pixel_x = 28
@@ -31086,7 +31086,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ezK" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
@@ -31632,7 +31632,7 @@
 	},
 /obj/machinery/power/emitter,
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "eDP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -31652,7 +31652,7 @@
 "eEd" = (
 /obj/structure/sign/electricshock,
 /turf/simulated/wall/r_wall,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "eEq" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -31678,7 +31678,7 @@
 /obj/machinery/hologram/holopad,
 /obj/effect/turf_decal/box,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "eEw" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -31700,7 +31700,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "eEO" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -31869,7 +31869,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "eGl" = (
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/plasteel{
@@ -31878,7 +31878,7 @@
 /area/storage/eva)
 "eGq" = (
 /turf/simulated/wall/r_wall,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "eGw" = (
 /obj/machinery/ai_status_display{
 	pixel_y = 32;
@@ -32054,7 +32054,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "eHy" = (
 /obj/effect/decal/warning_stripes/red/partial{
 	dir = 8
@@ -32409,7 +32409,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "eKi" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -32543,7 +32543,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "eLA" = (
 /obj/effect/decal/cleanable/dust,
 /obj/effect/decal/cleanable/vomit,
@@ -32700,7 +32700,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "eLZ" = (
 /obj/structure/table/wood,
 /obj/structure/extinguisher_cabinet{
@@ -32845,7 +32845,7 @@
 	dir = 6;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "eNa" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
@@ -32936,7 +32936,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "eNM" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -32960,7 +32960,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "eOe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -33341,7 +33341,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "eRG" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
@@ -33507,7 +33507,7 @@
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "eTm" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -33551,7 +33551,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "eTw" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -33571,7 +33571,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "eTx" = (
 /obj/machinery/computer/teleporter,
 /turf/simulated/floor/plasteel/white,
@@ -33604,7 +33604,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "eTX" = (
 /obj/machinery/door_control{
 	desiredstate = 1;
@@ -33689,7 +33689,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "eUH" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -33912,7 +33912,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "eWL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -33941,7 +33941,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "eXp" = (
 /turf/simulated/wall,
 /area/maintenance/backstage)
@@ -34156,7 +34156,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "eYC" = (
 /obj/effect/landmark/start/security_officer,
 /obj/structure/chair{
@@ -34344,7 +34344,7 @@
 /area/atmos)
 "eZG" = (
 /turf/simulated/wall,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "eZJ" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Laser Room";
@@ -34352,7 +34352,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "eZN" = (
 /mob/living/simple_animal/bot/secbot/beepsky{
 	name = "Officer Rightsky";
@@ -34864,7 +34864,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "fdu" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	name = "standard air scrubber";
@@ -35076,7 +35076,7 @@
 /area/crew_quarters/theatre)
 "ffg" = (
 /turf/simulated/wall/r_wall,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "ffh" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/structure/cable{
@@ -35094,7 +35094,7 @@
 	dir = 6;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ffB" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
@@ -35232,7 +35232,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "fgq" = (
 /obj/structure/table/glass,
 /obj/item/storage/fancy/vials{
@@ -35382,7 +35382,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "fhk" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/structure/cable{
@@ -35393,7 +35393,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "fho" = (
 /obj/structure/table,
 /obj/item/storage/bag/plants/portaseeder,
@@ -35548,7 +35548,7 @@
 	name = "Shield power storage unit"
 	},
 /turf/simulated/floor/redgrid,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "fio" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/arrows/white,
@@ -36284,7 +36284,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "podfloor_dark"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "foj" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -36344,7 +36344,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "fou" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -36369,7 +36369,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "foy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/holotable,
@@ -36577,7 +36577,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "fqf" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -36989,7 +36989,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "fsV" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -37024,7 +37024,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "ftl" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/warning_stripes/west{
@@ -37130,7 +37130,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "fuk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line{
@@ -37154,7 +37154,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "fuE" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -37315,7 +37315,7 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "fvO" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm{
@@ -37335,7 +37335,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "fwa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -37372,7 +37372,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "fwh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -37525,7 +37525,7 @@
 	dir = 6
 	},
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "fxj" = (
 /obj/machinery/camera{
 	c_tag = "Bridge East";
@@ -37568,7 +37568,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "fxC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
@@ -37619,7 +37619,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "fxR" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -37824,7 +37824,7 @@
 	on = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "fzh" = (
 /obj/structure/sink{
 	dir = 4;
@@ -37852,7 +37852,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "fzp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -37994,7 +37994,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "fAy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/comfy,
@@ -38159,7 +38159,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "fBw" = (
 /obj/machinery/power/emitter,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -38472,7 +38472,7 @@
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "fEn" = (
 /turf/simulated/floor/wood/dark,
 /area/crew_quarters/bar/atrium)
@@ -38531,7 +38531,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "fEA" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 2;
@@ -38607,7 +38607,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "fES" = (
 /obj/effect/turf_decal/number/number_2{
 	dir = 1;
@@ -38618,7 +38618,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "fET" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed,
@@ -38660,7 +38660,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "fFf" = (
 /obj/machinery/atmospherics/unary/outlet_injector,
 /turf/simulated/floor/engine,
@@ -38693,7 +38693,7 @@
 	dir = 10;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "fFw" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -38873,7 +38873,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "fHe" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/spray/cleaner/medical{
@@ -39034,7 +39034,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "fIM" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -39202,7 +39202,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "fJI" = (
 /obj/structure/computerframe,
 /turf/simulated/floor/shuttle,
@@ -39311,7 +39311,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "fKG" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -39461,7 +39461,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "fLX" = (
 /obj/machinery/camera{
 	c_tag = "Mining Furnace";
@@ -39783,7 +39783,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "fOk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -39984,7 +39984,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "fQd" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -40189,7 +40189,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "fRt" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	name = "standard air scrubber";
@@ -40818,7 +40818,7 @@
 	dir = 10;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "fVY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -40831,7 +40831,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "fWb" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/stripes/line,
@@ -40870,7 +40870,7 @@
 "fWp" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/engine,
-/area/engine/aienter)
+/area/engineering/aienter)
 "fWq" = (
 /obj/machinery/computer/prisoner{
 	req_access = list(2)
@@ -40962,7 +40962,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "fXe" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -41008,7 +41008,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "fXQ" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -41082,7 +41082,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "fYi" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
@@ -41102,7 +41102,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "fYq" = (
 /obj/structure/window/plasmareinforced{
 	color = "#FF0000";
@@ -41545,7 +41545,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "gbl" = (
 /obj/machinery/gateway{
 	density = 0
@@ -41635,7 +41635,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/aienter)
+/area/engineering/aienter)
 "gbU" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -42048,7 +42048,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "geJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -42366,7 +42366,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ghK" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/siding/wood{
@@ -42404,7 +42404,7 @@
 	dir = 10
 	},
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "ghU" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -42419,7 +42419,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "gib" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -42676,7 +42676,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "gjD" = (
 /turf/simulated/floor/greengrid,
 /area/toxins/xenobiology)
@@ -42780,7 +42780,7 @@
 	dir = 0;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "gjW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -42939,7 +42939,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "gle" = (
 /turf/simulated/floor/engine,
 /area/toxins/test_chamber)
@@ -42988,7 +42988,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "glU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -43315,7 +43315,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "gnY" = (
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
@@ -43387,7 +43387,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "goy" = (
 /obj/effect/decal/warning_stripes/northwestsouth,
 /obj/machinery/power/emitter{
@@ -43400,7 +43400,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "goz" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/primary/command/west)
@@ -43424,7 +43424,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "goL" = (
 /obj/effect/turf_decal/stripes/gold{
 	dir = 1
@@ -43463,7 +43463,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "gpg" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -43935,7 +43935,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "gsI" = (
 /obj/structure/disposalpipe/junction/reversed{
 	dir = 2
@@ -43970,7 +43970,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "gsM" = (
 /obj/machinery/atmospherics/air_sensor{
 	id_tag = "o2_sensor"
@@ -44303,7 +44303,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "gvK" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -44340,7 +44340,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "gvT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -44421,7 +44421,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "gwD" = (
 /obj/structure/bed,
 /obj/item/bedsheet/mime,
@@ -44494,7 +44494,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "gxi" = (
 /obj/item/radio/intercom{
 	pixel_x = 30
@@ -44628,7 +44628,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "podfloor_dark"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "gyE" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
@@ -44638,7 +44638,7 @@
 /obj/item/clothing/glasses/meson,
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "gyK" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -44655,7 +44655,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "gyN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -44703,7 +44703,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "gzl" = (
 /obj/structure/table/wood,
 /obj/machinery/light,
@@ -44790,7 +44790,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "gzU" = (
 /obj/structure/closet/radiation,
 /obj/machinery/camera{
@@ -44890,7 +44890,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "gBb" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -45035,7 +45035,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "gCK" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -45316,7 +45316,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "gFf" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/recharge_station,
@@ -45415,7 +45415,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "gGf" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -45705,7 +45705,7 @@
 	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "gHF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -45796,7 +45796,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "gIq" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -45954,7 +45954,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "gJw" = (
 /turf/simulated/wall/r_wall,
 /area/storage/eva)
@@ -45991,7 +45991,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/aienter)
+/area/engineering/aienter)
 "gJZ" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -46005,7 +46005,7 @@
 	},
 /obj/structure/railing/corner,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "gKd" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -46439,7 +46439,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/aienter)
+/area/engineering/aienter)
 "gNQ" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/effect/landmark/start/scientist,
@@ -46465,7 +46465,7 @@
 "gNZ" = (
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "gOa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -46671,13 +46671,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "gPX" = (
 /obj/structure/stairs{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "gPY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -46821,7 +46821,7 @@
 /area/hallway/primary/central/second/north)
 "gRG" = (
 /turf/simulated/wall,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "gRH" = (
 /obj/structure/spacepoddoor{
 	dir = 4;
@@ -46834,7 +46834,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "gRM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -47011,7 +47011,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "gSU" = (
 /turf/simulated/wall/r_wall,
 /area/medical/research/nhallway)
@@ -47519,7 +47519,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "gXb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -47819,7 +47819,7 @@
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "gYK" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -48069,7 +48069,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "hac" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -48152,12 +48152,12 @@
 	dir = 8;
 	icon_state = "darkyellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "haM" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "haY" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -48437,7 +48437,7 @@
 "hcT" = (
 /obj/structure/railing,
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "hcX" = (
 /turf/simulated/floor/plasteel{
 	dir = 1
@@ -48687,7 +48687,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "hes" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
@@ -48831,7 +48831,7 @@
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "hfz" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
@@ -48956,7 +48956,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "hgq" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = 32
@@ -49119,7 +49119,7 @@
 "hht" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "hhx" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -49320,7 +49320,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "hjA" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -49333,7 +49333,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "hjC" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -49916,7 +49916,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "hnU" = (
 /obj/machinery/light_construct,
 /obj/effect/spawner/lootdrop/maintenance/double,
@@ -49969,7 +49969,7 @@
 	dir = 6;
 	icon_state = "podfloor"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "hov" = (
 /obj/machinery/disposal,
 /obj/effect/decal/warning_stripes/red,
@@ -50320,7 +50320,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "hrI" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -50381,7 +50381,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "hrZ" = (
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken6"
@@ -50413,7 +50413,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "hsD" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -50527,7 +50527,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "htA" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
@@ -50548,7 +50548,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "htO" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -50568,7 +50568,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "htU" = (
 /obj/machinery/conveyor/inverted{
 	id = "QMLoad2";
@@ -50677,7 +50677,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "huw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -50831,7 +50831,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "hvS" = (
 /obj/structure/sign/cargo{
 	pixel_x = 32;
@@ -51180,7 +51180,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "hzo" = (
 /turf/simulated/wall/shuttle/onlyselfsmooth,
 /area/shuttle/arrival/station)
@@ -51196,7 +51196,7 @@
 	},
 /obj/item/stock_parts/cell/high,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "hzN" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/effect/decal/cleanable/dirt,
@@ -51221,7 +51221,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "hzT" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 1
@@ -51705,7 +51705,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "hDV" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Mechanic Workshop";
@@ -51713,7 +51713,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "hEf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -51733,7 +51733,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "hEv" = (
 /obj/structure/table,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -51934,7 +51934,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/glass/reinforced,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "hGp" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -51948,7 +51948,7 @@
 	pixel_x = 26
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "hGs" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
@@ -52331,7 +52331,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "hKh" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/genericbush,
@@ -52547,7 +52547,7 @@
 	dir = 6;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "hMD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/official/random{
@@ -52759,7 +52759,7 @@
 	dir = 7;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "hOY" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -52776,7 +52776,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "hPc" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -53322,7 +53322,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "hSZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/toolbox,
@@ -53639,7 +53639,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "hUV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -53825,7 +53825,7 @@
 /obj/effect/decal/cleanable/blood/gibs/robot,
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "hXd" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
@@ -53909,7 +53909,7 @@
 /obj/machinery/recharger,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "hXD" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -53943,7 +53943,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "hXW" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -54377,7 +54377,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "ibl" = (
 /obj/item/c_tube,
 /obj/effect/decal/cleanable/blood,
@@ -54444,7 +54444,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ibB" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
@@ -54505,7 +54505,7 @@
 /area/crew_quarters/captain/bedroom)
 "ibU" = (
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ibW" = (
 /obj/structure/fireplace,
 /obj/machinery/firealarm{
@@ -54742,7 +54742,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "idr" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -55123,7 +55123,7 @@
 	dir = 6;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "ign" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -55217,7 +55217,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "igT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -55574,7 +55574,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ijm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -56134,12 +56134,12 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "imV" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "inc" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/camera{
@@ -56189,7 +56189,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "inl" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
@@ -56575,7 +56575,7 @@
 "iqk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "iql" = (
 /obj/machinery/power/apc{
 	cell_type = 15000;
@@ -56745,7 +56745,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "irp" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -56840,7 +56840,7 @@
 	dir = 8;
 	icon_state = "darkyellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ist" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -57011,7 +57011,7 @@
 "itD" = (
 /obj/structure/sign/nosmoking_2,
 /turf/simulated/wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "itG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -57203,7 +57203,7 @@
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "iuU" = (
 /obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/r_n_d/protolathe{
@@ -57259,7 +57259,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "ivm" = (
 /turf/simulated/wall,
 /area/medical/cryo)
@@ -57725,7 +57725,7 @@
 	network = list("SS13","Singularity","Engineering")
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "iyY" = (
 /obj/item/radio/intercom{
 	pixel_y = 26
@@ -57935,7 +57935,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "izU" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/robot_parts/l_leg,
@@ -57983,7 +57983,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "iAe" = (
 /obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plasteel,
@@ -58050,7 +58050,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "iAN" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -58421,7 +58421,7 @@
 	dir = 8;
 	icon_state = "darkyellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "iEP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -58455,7 +58455,7 @@
 	dir = 4;
 	icon_state = "yellowcorner"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "iET" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -58842,7 +58842,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "iIv" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 5
@@ -58925,7 +58925,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "iIW" = (
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
@@ -58982,7 +58982,7 @@
 	dir = 9
 	},
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "iJP" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/bodybags{
@@ -59200,7 +59200,7 @@
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "iLu" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -59215,7 +59215,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "iLA" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluecornersalt"
@@ -59223,7 +59223,7 @@
 /area/hallway/primary/central/second/north)
 "iLB" = (
 /turf/simulated/floor/plasteel,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "iLD" = (
 /obj/machinery/smartfridge/medbay,
 /obj/machinery/door/window/eastright{
@@ -59356,7 +59356,7 @@
 	location = "Engineering"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "iMO" = (
 /obj/structure/cable/multiz{
 	color = "#dd1010"
@@ -59390,7 +59390,7 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "iNh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/firecloset,
@@ -59469,7 +59469,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "iNO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -59581,7 +59581,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/aienter)
+/area/engineering/aienter)
 "iON" = (
 /obj/machinery/button/windowtint{
 	dir = 1;
@@ -60001,7 +60001,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "iTs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -60096,7 +60096,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "iTO" = (
 /obj/machinery/light,
 /obj/machinery/firealarm{
@@ -60170,7 +60170,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "iUx" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plasteel{
@@ -60223,7 +60223,7 @@
 	dir = 8;
 	icon_state = "darkyellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "iUX" = (
 /obj/structure/table/wood,
 /obj/item/stack/packageWrap,
@@ -60259,7 +60259,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "iVc" = (
 /obj/structure/closet/secure_closet/RD,
 /obj/effect/decal/warning_stripes/east,
@@ -60281,12 +60281,12 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "iVt" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/computer/station_alert,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "iVu" = (
 /obj/structure/table/reinforced,
 /obj/machinery/keycard_auth{
@@ -60360,7 +60360,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "iVX" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -60724,7 +60724,7 @@
 "iYy" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/engine,
-/area/engine/aienter)
+/area/engineering/aienter)
 "iYD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -60735,7 +60735,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "iYF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -60787,7 +60787,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "iZj" = (
 /turf/simulated/wall,
 /area/hallway/primary/central/north)
@@ -60848,7 +60848,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "iZJ" = (
 /obj/structure/closet/walllocker/emerglocker/north,
 /turf/simulated/floor/plasteel{
@@ -61240,7 +61240,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "jcN" = (
 /obj/effect/turf_decal/stripes/gold{
 	dir = 10
@@ -61280,7 +61280,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "jcX" = (
 /obj/structure/table/reinforced,
 /obj/item/key/janitor,
@@ -61333,7 +61333,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "jds" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/carpet/black,
@@ -61346,7 +61346,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "jdH" = (
 /obj/structure/chair/comfy/red{
 	dir = 8
@@ -61376,7 +61376,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "jdN" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/grass/jungle/b,
@@ -61509,7 +61509,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "jeG" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -61861,13 +61861,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "podfloor_dark"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "jhj" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable,
 /obj/machinery/light,
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "jhn" = (
 /obj/machinery/door/airlock/silver{
 	name = "Bathroom"
@@ -61945,7 +61945,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "jhA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool/bar,
@@ -61972,7 +61972,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "jhG" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -61981,7 +61981,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "jhN" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall,
@@ -62004,7 +62004,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "jhW" = (
 /obj/machinery/hydroponics/soil,
 /turf/simulated/floor/grass,
@@ -62037,7 +62037,7 @@
 "jio" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "jiv" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -62259,7 +62259,7 @@
 	dir = 8;
 	icon_state = "darkyellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "jjP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62339,7 +62339,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "jkf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -62559,7 +62559,7 @@
 	pixel_y = 26
 	},
 /turf/simulated/floor/engine,
-/area/engine/aienter)
+/area/engineering/aienter)
 "jmu" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/light,
@@ -62622,7 +62622,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "jmO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -62652,7 +62652,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "jmU" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/structure/cable{
@@ -62858,7 +62858,7 @@
 	dir = 5;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "joi" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=SatteliteSouth";
@@ -62897,7 +62897,7 @@
 	anchored = 1
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "jov" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -62915,7 +62915,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "jow" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/wood{
@@ -63000,7 +63000,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "jph" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -63093,7 +63093,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "jqb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -63209,7 +63209,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "jqS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -63274,7 +63274,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "jrk" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -63438,7 +63438,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "jsA" = (
 /turf/simulated/wall/r_wall,
 /area/security/range)
@@ -63523,7 +63523,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "jtl" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -63553,7 +63553,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "jtr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/crowbar,
@@ -63731,7 +63731,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "jvk" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
@@ -63864,7 +63864,7 @@
 	dir = 1;
 	icon_state = "yellowcorner"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "jvX" = (
 /obj/machinery/light{
 	dir = 4
@@ -63885,7 +63885,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "jwb" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -64003,7 +64003,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "jxq" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Walkway"
@@ -64291,7 +64291,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "jzQ" = (
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -64350,7 +64350,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "jAn" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluecornersalt"
@@ -64376,7 +64376,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "jAz" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
@@ -64575,7 +64575,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "jBT" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/engine/hull/reinforced,
@@ -64930,7 +64930,7 @@
 	dir = 6;
 	icon_state = "podfloor"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "jFb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -64963,7 +64963,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "jFq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random_spawners/cobweb_right_frequent,
@@ -65152,7 +65152,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "jGo" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -65167,7 +65167,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "jGt" = (
 /obj/machinery/light{
 	dir = 4
@@ -65527,7 +65527,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "jJk" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -65553,7 +65553,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "jJo" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -65589,7 +65589,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "jJu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance{
@@ -65652,13 +65652,13 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "jKf" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "jKh" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -65929,7 +65929,7 @@
 /area/atmos)
 "jLB" = (
 /turf/simulated/openspace,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "jLG" = (
 /obj/machinery/camera{
 	c_tag = "HoS Bedroom";
@@ -66102,7 +66102,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "jMP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -66569,7 +66569,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "jQQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -66599,7 +66599,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "jQU" = (
 /turf/simulated/floor/carpet/royalblue,
 /area/crew_quarters/captain)
@@ -66692,7 +66692,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "jRw" = (
 /obj/structure/sign/restroom,
 /turf/simulated/wall,
@@ -67173,7 +67173,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "jVN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	name = "standard air scrubber";
@@ -67485,7 +67485,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "jYF" = (
 /turf/simulated/floor/plasteel{
 	dir = 1
@@ -67675,7 +67675,7 @@
 "kaK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "kaP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -67744,7 +67744,7 @@
 	dir = 4;
 	icon_state = "yellowcorner"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "kbo" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -67938,7 +67938,7 @@
 	dir = 0;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "kcN" = (
 /obj/effect/decal/remains/mouse,
 /turf/simulated/floor/wood,
@@ -67988,7 +67988,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "kdm" = (
 /obj/effect/spawner/random_spawners/wall_rusted_70,
 /turf/simulated/wall/r_wall,
@@ -68121,7 +68121,7 @@
 	in_use = 1
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "keE" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 8
@@ -68198,7 +68198,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "kfl" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -68627,7 +68627,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "kio" = (
 /obj/machinery/door/airlock{
 	id_tag = "toilet8";
@@ -68764,7 +68764,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "kjg" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Oxygen Tank";
@@ -68810,7 +68810,7 @@
 /area/bridge)
 "kkc" = (
 /turf/simulated/floor/greengrid,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "kkf" = (
 /obj/structure/table/wood,
 /obj/structure/railing,
@@ -68926,7 +68926,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "kkU" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/camera{
@@ -68964,7 +68964,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "klo" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/structure/cable/yellow{
@@ -68978,7 +68978,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "klz" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -69010,7 +69010,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "klB" = (
 /obj/item/radio/intercom{
 	pixel_y = 24
@@ -69108,7 +69108,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "kmb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
@@ -69164,7 +69164,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "kmy" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -69254,7 +69254,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "kna" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -69328,7 +69328,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "kns" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -69661,7 +69661,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "kqD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -69752,7 +69752,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "krx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -69846,7 +69846,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "ksB" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -70103,7 +70103,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "kux" = (
 /obj/machinery/door/airlock/silver{
 	name = "Bathroom"
@@ -70226,7 +70226,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "podfloor_dark"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "kvE" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -70499,7 +70499,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "kxx" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/starboardsolar)
@@ -70535,7 +70535,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "kxH" = (
 /obj/machinery/light,
 /obj/machinery/camera{
@@ -70576,7 +70576,7 @@
 "kxV" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "kxZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dust,
@@ -70624,7 +70624,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/aienter)
+/area/engineering/aienter)
 "kyi" = (
 /obj/machinery/computer/security/mining,
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -70816,7 +70816,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "kAq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -70901,7 +70901,7 @@
 /obj/effect/decal/warning_stripes/east,
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "kBd" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
@@ -70959,7 +70959,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "kBz" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -70989,7 +70989,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "kBI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -71031,7 +71031,7 @@
 	network = list("SS13","Singularity","Engineering")
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "kCo" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -71260,7 +71260,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "kDY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -71446,7 +71446,7 @@
 	},
 /obj/effect/landmark/start/trainee_engineer,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "kGh" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -71484,7 +71484,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "kGm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -71531,7 +71531,7 @@
 /obj/structure/closet/radiation,
 /obj/item/clothing/glasses/meson,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "kGy" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/structure/chair/office/light{
@@ -71765,7 +71765,7 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "kIi" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
@@ -71774,7 +71774,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "kIk" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -72302,7 +72302,7 @@
 	network = list("SS13","Singularity","Engineering")
 	},
 /turf/space,
-/area/engine/engineering)
+/area/engineering/engine)
 "kNb" = (
 /turf/simulated/wall,
 /area/hallway/primary/central/nw)
@@ -72368,7 +72368,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "kNt" = (
 /obj/machinery/camera{
 	c_tag = "Hangar Second Floor North";
@@ -72376,7 +72376,7 @@
 	},
 /obj/structure/railing,
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "kNC" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor{
@@ -72542,7 +72542,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "kOZ" = (
 /obj/structure/table/wood{
 	color = "#996633"
@@ -72660,7 +72660,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "kPy" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/disposalpipe/segment,
@@ -72825,7 +72825,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "kQW" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -72898,7 +72898,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "kRP" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -72945,7 +72945,7 @@
 /area/crew_quarters/theatre)
 "kRZ" = (
 /turf/simulated/wall/r_wall,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "kSp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -73005,7 +73005,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "kSL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -73225,7 +73225,7 @@
 	dir = 6;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "kUD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -73475,7 +73475,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "kWo" = (
 /obj/machinery/recharger{
 	pixel_x = 1;
@@ -73620,7 +73620,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "kXh" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 28;
@@ -73630,7 +73630,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowcorner"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "kXl" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -73657,7 +73657,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "kXs" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -73714,7 +73714,7 @@
 "kXM" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall/r_wall,
-/area/engine/break_room)
+/area/engineering/break_room)
 "kXN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random_spawners/rodent,
@@ -73726,7 +73726,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "kXU" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -73745,10 +73745,10 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "kYb" = (
 /turf/simulated/floor/engine,
-/area/engine/aienter)
+/area/engineering/aienter)
 "kYh" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -73828,7 +73828,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "kYL" = (
 /obj/structure/railing{
 	dir = 8
@@ -74085,7 +74085,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "laB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -74137,7 +74137,7 @@
 /area/civilian/barber)
 "laS" = (
 /turf/simulated/wall/r_wall,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "laV" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -74205,7 +74205,7 @@
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "lbq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -74336,7 +74336,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "lbR" = (
 /obj/machinery/light,
 /obj/structure/railing/corner{
@@ -74354,7 +74354,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "lbT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
@@ -74479,11 +74479,11 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "lde" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "ldl" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -74593,7 +74593,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "leo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -74739,7 +74739,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "lfC" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -74797,7 +74797,7 @@
 	network = list("SS13","Engineering")
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "lgr" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -74831,7 +74831,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "lgu" = (
 /obj/structure/railing{
 	dir = 4;
@@ -75009,7 +75009,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "lhF" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -75266,7 +75266,7 @@
 /obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/light,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "lkf" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -75361,7 +75361,7 @@
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "lkT" = (
 /obj/machinery/vending/clothing/departament/science,
 /turf/simulated/floor/plasteel{
@@ -75386,7 +75386,7 @@
 /area/quartermaster/qm)
 "lkX" = (
 /turf/simulated/floor/plasteel,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "lkY" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall,
@@ -75403,7 +75403,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "llg" = (
 /obj/structure/window/reinforced{
 	color = "red"
@@ -75454,7 +75454,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "llp" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/effect/decal/warning_stripes/blue/partial{
@@ -75510,7 +75510,7 @@
 	dir = 8;
 	icon_state = "darkyellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "llW" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
@@ -75622,7 +75622,7 @@
 	dir = 10;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "lni" = (
 /obj/machinery/recharge_station,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -75673,7 +75673,7 @@
 "lnL" = (
 /obj/structure/sign/nosmoking_2,
 /turf/simulated/wall/r_wall,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "lnQ" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -75833,7 +75833,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "lpw" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -75943,7 +75943,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "lpY" = (
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 8
@@ -75967,7 +75967,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "lqu" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -76234,7 +76234,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "lsv" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -76318,7 +76318,7 @@
 /area/security/hos)
 "lto" = (
 /turf/simulated/wall,
-/area/engine/break_room)
+/area/engineering/break_room)
 "ltp" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -76408,7 +76408,7 @@
 "ltL" = (
 /obj/effect/landmark/start/trainee_engineer,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "ltM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -76436,7 +76436,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "lur" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -76815,7 +76815,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "lxJ" = (
 /obj/structure/table/reinforced,
 /obj/item/weldingtool,
@@ -76823,7 +76823,7 @@
 	dir = 9;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "lxT" = (
 /obj/structure/closet/wardrobe/grey,
 /turf/simulated/floor/shuttle,
@@ -76840,7 +76840,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "lya" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -76859,7 +76859,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "lyd" = (
 /obj/machinery/atmospherics/trinary/filter/flipped{
 	desc = "Отфильтровывает азот из трубы и отправляет их в камеру хранения";
@@ -76960,7 +76960,7 @@
 /obj/structure/cable,
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "lyS" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
@@ -77339,7 +77339,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "lBU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -77587,7 +77587,7 @@
 "lDu" = (
 /obj/structure/sign/pods,
 /turf/simulated/wall,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "lDx" = (
 /obj/structure/bookcase,
 /turf/simulated/floor/wood,
@@ -77613,7 +77613,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "lDS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -77628,7 +77628,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "lDX" = (
 /obj/structure/closet/bombcloset,
 /turf/simulated/floor/plasteel{
@@ -77750,7 +77750,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "lET" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -77876,7 +77876,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "lFI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/wirecutters,
@@ -77948,7 +77948,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/redgrid,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "lGf" = (
 /turf/simulated/wall,
 /area/hallway/secondary/entry/commercial)
@@ -78132,7 +78132,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "lHU" = (
 /obj/item/shard,
 /obj/effect/decal/cleanable/dust,
@@ -78213,7 +78213,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "lIO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -78473,7 +78473,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "lLh" = (
 /obj/effect/decal/cleanable/dust,
 /obj/effect/turf_decal/siding/wood,
@@ -78494,7 +78494,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "lLD" = (
 /obj/machinery/light/small,
 /obj/machinery/camera{
@@ -78677,7 +78677,7 @@
 /obj/structure/closet/radiation,
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "lNh" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -78750,7 +78750,7 @@
 /area/maintenance/apmaint)
 "lNR" = (
 /turf/simulated/wall,
-/area/engine/aienter)
+/area/engineering/aienter)
 "lNW" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
@@ -78783,7 +78783,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "lOa" = (
 /turf/simulated/wall/r_wall,
 /area/atmos/control)
@@ -78947,7 +78947,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowcorner"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "lPv" = (
 /turf/simulated/openspace,
 /area/maintenance/starboard)
@@ -79038,7 +79038,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "lPZ" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -79062,7 +79062,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "lQb" = (
 /obj/machinery/vending/dinnerware,
 /turf/simulated/floor/plasteel{
@@ -79785,7 +79785,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "lVM" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -79835,7 +79835,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "lVZ" = (
 /turf/simulated/floor/wood/dark,
 /area/ntrep)
@@ -79858,7 +79858,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "lWl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -79965,7 +79965,7 @@
 "lWJ" = (
 /obj/structure/window/full/plasmareinforced,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "lWN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -80179,7 +80179,7 @@
 	charge = 2e+006
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "lYF" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -80291,7 +80291,7 @@
 /obj/effect/decal/warning_stripes/south,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "lZA" = (
 /turf/simulated/floor/plating,
 /area/teleporter/abandoned)
@@ -80367,7 +80367,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/aienter)
+/area/engineering/aienter)
 "maf" = (
 /obj/structure/railing{
 	dir = 10
@@ -80621,7 +80621,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "mce" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -80710,7 +80710,7 @@
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "mct" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
@@ -80737,7 +80737,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "mcA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -80783,7 +80783,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "mcO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -80910,7 +80910,7 @@
 	dir = 6;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "mdt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -81313,7 +81313,7 @@
 	network = list("Engineering","SS13")
 	},
 /turf/simulated/floor/engine,
-/area/engine/aienter)
+/area/engineering/aienter)
 "mfJ" = (
 /obj/structure/chair/sofa/right{
 	dir = 4
@@ -81453,7 +81453,7 @@
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "mgH" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -81518,7 +81518,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "mhy" = (
 /obj/machinery/recharge_station,
 /obj/effect/decal/warning_stripes/yellow,
@@ -81546,7 +81546,7 @@
 "mhM" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "mhT" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -81707,7 +81707,7 @@
 "mjd" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "mjg" = (
 /obj/effect/turf_decal/siding/wideplating/light{
 	dir = 1
@@ -81889,7 +81889,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "mkl" = (
 /obj/machinery/recharge_station,
 /obj/effect/decal/warning_stripes/yellow,
@@ -82154,7 +82154,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "mlV" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
@@ -82392,7 +82392,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "mnw" = (
 /obj/structure/chair{
 	dir = 8
@@ -82836,7 +82836,7 @@
 	dir = 6;
 	icon_state = "podfloor"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "msv" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -82897,7 +82897,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "mto" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -82937,7 +82937,7 @@
 	dir = 4;
 	icon_state = "yellowcorner"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "mtC" = (
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -83019,7 +83019,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "muq" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -83235,7 +83235,7 @@
 /obj/item/paper/gravity_gen,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "mwr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -83351,7 +83351,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "mxe" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -83395,7 +83395,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "mxu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -83577,7 +83577,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "myJ" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
@@ -83597,7 +83597,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "myO" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
@@ -83678,7 +83678,7 @@
 	},
 /obj/machinery/power/port_gen/pacman,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "mzG" = (
 /obj/machinery/computer/general_air_control{
 	frequency = 1443;
@@ -83690,7 +83690,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "mzM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
@@ -83730,7 +83730,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "mAp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -83782,7 +83782,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "mAK" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -83807,7 +83807,7 @@
 /obj/machinery/power/port_gen/pacman,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "mBi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -83976,7 +83976,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/redgrid,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "mCf" = (
 /obj/machinery/atmospherics/pipe/multiz{
 	dir = 8
@@ -83984,7 +83984,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "mCB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/trinary/filter{
@@ -84066,7 +84066,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/landmark/start/engineer,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "mDf" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel{
@@ -84128,7 +84128,7 @@
 	network = list("SS13","Singularity","Engineering")
 	},
 /turf/space,
-/area/engine/engineering)
+/area/engineering/engine)
 "mDC" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -84574,7 +84574,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "mHg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -84614,7 +84614,7 @@
 "mHw" = (
 /obj/effect/landmark/start/engineer,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "mHA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -84684,7 +84684,7 @@
 /area/crew_quarters/arcade)
 "mIb" = (
 /turf/simulated/floor/glass,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "mIf" = (
 /turf/simulated/wall/rust,
 /area/maintenance/library)
@@ -84750,7 +84750,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "mIB" = (
 /obj/machinery/light/small,
 /obj/structure/closet/walllocker/emerglocker/north{
@@ -84774,7 +84774,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "mIM" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Cloning";
@@ -84812,7 +84812,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "mJo" = (
 /obj/effect/turf_decal/siding/wideplating/light/corner,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -84854,7 +84854,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/engine/break_room)
+/area/engineering/break_room)
 "mJF" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/reagent_dispensers/watertank/high,
@@ -84892,7 +84892,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "mJM" = (
 /obj/machinery/door/airlock{
 	id_tag = "cabin3";
@@ -85061,7 +85061,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "mKM" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -85082,12 +85082,12 @@
 "mKP" = (
 /obj/structure/lattice,
 /turf/space,
-/area/engine/engineering)
+/area/engineering/engine)
 "mKR" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "mKV" = (
 /obj/item/radio/intercom{
 	name = "north station intercom (General)";
@@ -85156,7 +85156,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "mLs" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -85168,7 +85168,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "mLv" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -85353,7 +85353,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "mMl" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/effect/landmark/start/scientist,
@@ -85494,7 +85494,7 @@
 /obj/structure/closet/secure_closet/engineering_welding,
 /obj/item/clothing/glasses/welding,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "mNh" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -85691,7 +85691,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "mOe" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/storage/belt/medical,
@@ -86025,7 +86025,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "mQO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
@@ -86082,7 +86082,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "mRu" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/apple,
@@ -86117,7 +86117,7 @@
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "mRE" = (
 /obj/structure/barricade/wooden{
 	layer = 3.5
@@ -86427,7 +86427,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "mTA" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/hologram/holopad,
@@ -86475,7 +86475,7 @@
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "mTJ" = (
 /turf/simulated/floor/plasteel{
 	dir = 8
@@ -86564,7 +86564,7 @@
 "mUw" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "mUD" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/bush,
@@ -86868,7 +86868,7 @@
 	network = list("Engineering","SS13")
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "mWV" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 8
@@ -87094,7 +87094,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "mYV" = (
 /obj/effect/decal/warning_stripes/west{
 	icon = 'icons/turf/floors.dmi';
@@ -87303,7 +87303,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "nan" = (
 /obj/effect/decal/cleanable/dust,
 /obj/effect/spawner/lootdrop/crate_spawner,
@@ -87577,7 +87577,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "nbI" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 4
@@ -87627,7 +87627,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "nbM" = (
 /obj/structure/table/glass,
 /obj/machinery/recharger,
@@ -87643,7 +87643,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "nbR" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 8
@@ -87953,7 +87953,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "ner" = (
 /obj/machinery/power/apc{
 	cell_type = 5000;
@@ -87975,7 +87975,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "neC" = (
 /obj/machinery/requests_console{
 	department = "Internal Affairs Office";
@@ -88095,7 +88095,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "nfs" = (
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -88111,7 +88111,7 @@
 	network = list("SS13","Engineering")
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "nft" = (
 /obj/machinery/newscaster{
 	pixel_x = -32
@@ -88160,7 +88160,7 @@
 	anchored = 1
 	},
 /turf/simulated/floor/redgrid,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "nfB" = (
 /obj/machinery/door/airlock{
 	name = "Hydroponic airlock"
@@ -88233,7 +88233,7 @@
 /area/quartermaster/lobby)
 "ngx" = (
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "ngz" = (
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -88312,7 +88312,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "nhp" = (
 /obj/machinery/door_control{
 	id = "janitorshutters";
@@ -88758,7 +88758,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/aienter)
+/area/engineering/aienter)
 "njQ" = (
 /obj/effect/landmark/start/doctor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -88855,7 +88855,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "nkH" = (
 /obj/structure/table/wood,
 /obj/item/stack/cable_coil,
@@ -88977,7 +88977,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "nlM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -89019,7 +89019,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "nmq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/access_button{
@@ -89068,7 +89068,7 @@
 	req_access = list(11)
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/aienter)
+/area/engineering/aienter)
 "nmy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -89099,7 +89099,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "nmH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -89115,7 +89115,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "nmO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -89150,7 +89150,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "nmT" = (
 /obj/machinery/camera{
 	c_tag = "Xeno Containment 4";
@@ -89166,7 +89166,7 @@
 	dir = 10;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "nmW" = (
 /obj/machinery/door/airlock/medical{
 	autoclose = 0;
@@ -89252,7 +89252,7 @@
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "nnt" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Checkpoint Maintenance";
@@ -89424,7 +89424,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "npv" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -89751,7 +89751,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "nsO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
@@ -89920,7 +89920,7 @@
 "ntS" = (
 /obj/machinery/computer/sm_monitor,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ntX" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor{
@@ -89934,7 +89934,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "ntY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -90398,7 +90398,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "nxU" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -90932,7 +90932,7 @@
 	},
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "nBl" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -91066,7 +91066,7 @@
 /area/maintenance/library)
 "nCj" = (
 /turf/simulated/openspace,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "nCl" = (
 /obj/structure/closet/wardrobe/black,
 /obj/item/clothing/under/fluff/soviet_casual_uniform,
@@ -91134,7 +91134,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "nCw" = (
 /obj/machinery/conveyor{
 	id = "QMLoad"
@@ -91168,7 +91168,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "nCG" = (
 /obj/machinery/vending/artvend,
 /turf/simulated/floor/plasteel,
@@ -91205,7 +91205,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "nCX" = (
 /obj/structure/railing{
 	dir = 8
@@ -91214,7 +91214,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "nCY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/east,
@@ -91333,7 +91333,7 @@
 	dir = 7;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "nEb" = (
 /obj/machinery/computer/secure_data{
 	dir = 8
@@ -91393,7 +91393,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "nEG" = (
 /obj/effect/spawner/window/reinforced/polarized{
 	id = "cloninglab"
@@ -91408,7 +91408,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "nEJ" = (
 /obj/structure/railing,
 /turf/simulated/floor/plasteel{
@@ -91732,7 +91732,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "nHK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	name = "standard air scrubber";
@@ -92029,7 +92029,7 @@
 	pixel_x = -29
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "nKm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb2,
@@ -92232,7 +92232,7 @@
 "nLv" = (
 /obj/structure/lattice/catwalk/fireproof,
 /turf/simulated/openspace,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "nLx" = (
 /obj/structure/table/wood,
 /obj/item/stack/tape_roll,
@@ -92276,7 +92276,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "nLM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -92361,7 +92361,7 @@
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "nMl" = (
 /obj/machinery/vending/clothing,
 /turf/simulated/floor/plasteel{
@@ -92521,7 +92521,7 @@
 "nNn" = (
 /obj/structure/sign/fire,
 /turf/simulated/wall,
-/area/engine/break_room)
+/area/engineering/break_room)
 "nNo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -92674,7 +92674,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "nOu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -92858,7 +92858,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "nPz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -92912,7 +92912,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "nPZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -92998,7 +92998,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "nQP" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -93115,7 +93115,7 @@
 	dir = 10;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "nSd" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -93133,7 +93133,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "nSi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -93205,7 +93205,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "nSN" = (
 /obj/machinery/light{
 	dir = 8
@@ -93380,7 +93380,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "nUv" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -93554,7 +93554,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "nVC" = (
 /turf/simulated/wall,
 /area/maintenance/fsmaint)
@@ -93698,7 +93698,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "nWA" = (
 /obj/structure/table,
 /obj/item/tank/internals/emergency_oxygen,
@@ -94205,7 +94205,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "obo" = (
 /obj/item/radio/intercom{
 	pixel_x = -30
@@ -94436,7 +94436,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "ocM" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/food/drinks/britcup,
@@ -94504,7 +94504,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "odd" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/light{
@@ -94571,7 +94571,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "odD" = (
 /turf/simulated/floor/plating,
 /area/toxins/launch)
@@ -94883,7 +94883,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "podfloor_dark"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ogl" = (
 /obj/machinery/disposal,
 /obj/effect/decal/warning_stripes/yellow,
@@ -95067,7 +95067,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "oif" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -95075,14 +95075,14 @@
 	},
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "oin" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "oip" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/decal/cleanable/dirt,
@@ -95353,7 +95353,7 @@
 	layer = 2.9
 	},
 /turf/simulated/floor/engine,
-/area/engine/aienter)
+/area/engineering/aienter)
 "okL" = (
 /turf/simulated/floor/plasteel,
 /area/quartermaster/sorting)
@@ -95403,7 +95403,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "oli" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -95416,7 +95416,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/engine,
-/area/engine/aienter)
+/area/engineering/aienter)
 "oll" = (
 /obj/structure/chair{
 	dir = 1
@@ -95473,7 +95473,7 @@
 	dir = 6;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "olG" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
@@ -95485,7 +95485,7 @@
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "olI" = (
 /obj/structure/computerframe,
 /obj/effect/decal/cleanable/dirt,
@@ -95715,7 +95715,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "onM" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/decal/cleanable/blood/oil,
@@ -95769,7 +95769,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ooc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -95795,7 +95795,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "ooI" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -96173,7 +96173,7 @@
 /obj/structure/cable,
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "osd" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer{
 	dir = 4
@@ -96183,7 +96183,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "osg" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
@@ -96336,7 +96336,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "oth" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -96391,7 +96391,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "otI" = (
 /obj/structure/window/reinforced{
 	color = "red"
@@ -96450,7 +96450,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "otY" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -96735,7 +96735,7 @@
 "ovK" = (
 /obj/structure/sign/fire,
 /turf/simulated/wall/r_wall,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ovO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -97169,7 +97169,7 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ozf" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin{
@@ -97371,7 +97371,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "oAW" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/item/radio/intercom{
@@ -97387,7 +97387,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "oAX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -97854,7 +97854,7 @@
 	dir = 5;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "oEW" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
@@ -98134,7 +98134,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "oHv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -98246,7 +98246,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "oIb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -98273,7 +98273,7 @@
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "oIl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
@@ -98494,7 +98494,7 @@
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "oKb" = (
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel{
@@ -98779,7 +98779,7 @@
 	},
 /obj/structure/railing,
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "oMo" = (
 /obj/machinery/vending/wallmed{
 	pixel_y = -30
@@ -98933,7 +98933,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "oNu" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -98991,7 +98991,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "oNN" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -99047,7 +99047,7 @@
 	pixel_y = 26
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "oOg" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -99673,7 +99673,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "oSO" = (
 /obj/structure/railing{
 	dir = 8
@@ -99752,7 +99752,7 @@
 /area/maintenance/starboard)
 "oTg" = (
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "oTl" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -99766,7 +99766,7 @@
 "oTn" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/glass/reinforced,
-/area/engine/aienter)
+/area/engineering/aienter)
 "oTw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -99801,7 +99801,7 @@
 	dir = 5
 	},
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "oTR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/fueltank,
@@ -99938,7 +99938,7 @@
 	},
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "oUq" = (
 /obj/structure/chair/comfy/red{
 	dir = 4
@@ -100577,7 +100577,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "oZe" = (
 /obj/structure/girder,
 /obj/effect/decal/cleanable/dirt,
@@ -101068,7 +101068,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "pcy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -101516,7 +101516,7 @@
 	dir = 6;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "pgp" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -101721,7 +101721,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "phm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -101786,7 +101786,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "phJ" = (
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/heads/hop)
@@ -102036,7 +102036,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "pjC" = (
 /obj/structure/chair{
 	dir = 1
@@ -102310,7 +102310,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "podfloor_dark"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "plk" = (
 /obj/structure/window/reinforced/polarized,
 /obj/structure/closet/crate/trashcart,
@@ -102407,7 +102407,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "pmc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -102608,7 +102608,7 @@
 "pnG" = (
 /obj/effect/landmark/start/mechanic,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "pnH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip{
@@ -102810,7 +102810,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ppG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shard{
@@ -103086,7 +103086,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "prY" = (
 /obj/effect/landmark/tiles/damageturf,
 /turf/simulated/floor/plating,
@@ -103188,7 +103188,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "psV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -103512,7 +103512,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "pvA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
@@ -103595,7 +103595,7 @@
 /obj/structure/closet/radiation,
 /obj/item/clothing/glasses/meson,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "pvR" = (
 /obj/machinery/ai_status_display{
 	pixel_x = -32
@@ -103630,7 +103630,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/aienter)
+/area/engineering/aienter)
 "pwa" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -103744,7 +103744,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "pxb" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -103789,7 +103789,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "pxx" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -103940,7 +103940,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "pyE" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -103963,7 +103963,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "pyG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -103981,7 +103981,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "pyI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/navbeacon{
@@ -104102,7 +104102,7 @@
 "pzr" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "pzA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -104170,7 +104170,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "pzZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -104240,7 +104240,7 @@
 /area/security/detectives_office)
 "pAn" = (
 /turf/simulated/wall/r_wall,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "pAr" = (
 /obj/effect/decal/cleanable/flour,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -104384,7 +104384,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "pBl" = (
 /turf/simulated/openspace,
 /area/hallway/primary/command/east)
@@ -104533,7 +104533,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "pCC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -104567,7 +104567,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "pCO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -104758,7 +104758,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "pEs" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/food/condiment/peppermill{
@@ -104821,7 +104821,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "pFq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -105184,7 +105184,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/aienter)
+/area/engineering/aienter)
 "pHr" = (
 /obj/machinery/computer/secure_data,
 /turf/simulated/floor/plasteel{
@@ -105375,7 +105375,7 @@
 /area/maintenance/apmaint)
 "pJc" = (
 /turf/simulated/wall,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "pJe" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall/r_wall,
@@ -105679,7 +105679,7 @@
 	on = 1
 	},
 /turf/simulated/floor/grass,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "pLC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -105749,7 +105749,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "pMn" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -105826,7 +105826,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/glass/reinforced,
-/area/engine/aienter)
+/area/engineering/aienter)
 "pMX" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
@@ -105946,7 +105946,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/redgrid,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "pNs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance{
@@ -105994,7 +105994,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "pNE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -106051,7 +106051,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "pNX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -106102,7 +106102,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "pOo" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -106153,10 +106153,10 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "pOQ" = (
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "pOS" = (
 /obj/structure/cable{
 	icon_state = "1-2";
@@ -106207,7 +106207,7 @@
 "pPq" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "pPv" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -106568,7 +106568,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "pSb" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/tripple,
@@ -106611,7 +106611,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "pSN" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -106632,7 +106632,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "pSU" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -106707,7 +106707,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "pTu" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -107015,7 +107015,7 @@
 	dir = 10;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "pVv" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -107158,7 +107158,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "pWa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -107443,7 +107443,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "pXI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -107641,7 +107641,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "pYS" = (
 /obj/structure/window/reinforced,
 /obj/item/flag/nt,
@@ -107791,7 +107791,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "qad" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -108097,7 +108097,7 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
 /turf/simulated/floor/redgrid,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "qcq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -108198,7 +108198,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "qcT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -108240,7 +108240,7 @@
 	req_access = list(32)
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "qdt" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -108322,7 +108322,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "qeC" = (
 /obj/machinery/vending/hydroseeds,
 /obj/machinery/alarm{
@@ -108514,11 +108514,11 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "qfW" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "qgc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -108702,7 +108702,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "qhm" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/siding/wideplating/light,
@@ -108808,7 +108808,7 @@
 /area/quartermaster/lobby)
 "qhK" = (
 /turf/simulated/wall/r_wall,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "qhT" = (
 /obj/machinery/camera{
 	c_tag = "Central Ring Hallway East 3";
@@ -108880,12 +108880,12 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "qiK" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "qiO" = (
 /obj/structure/railing{
 	dir = 10
@@ -108909,7 +108909,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "qiS" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -108947,7 +108947,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "qje" = (
 /turf/simulated/wall,
 /area/crew_quarters/mrchangs)
@@ -109032,7 +109032,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "qki" = (
 /obj/item/radio/intercom{
 	dir = 1;
@@ -109201,11 +109201,11 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "qlC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "qlG" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
@@ -109218,7 +109218,7 @@
 	on = 1
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "qlS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -109242,7 +109242,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "qlX" = (
 /obj/effect/turf_decal/siding/wideplating/dark,
 /turf/simulated/floor/plasteel{
@@ -109258,7 +109258,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "qmd" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "blue";
@@ -109426,7 +109426,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "qnH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -109530,7 +109530,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "qog" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -109835,7 +109835,7 @@
 	pixel_y = -26
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "qrH" = (
 /obj/structure/table/reinforced,
 /obj/item/assembly/igniter,
@@ -109950,7 +109950,7 @@
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "qst" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -110234,7 +110234,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "qtV" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
@@ -110284,7 +110284,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "quj" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowcorner";
@@ -110418,7 +110418,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "qvq" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -110490,7 +110490,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "qvO" = (
 /obj/machinery/light{
 	dir = 4
@@ -110599,7 +110599,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "qwq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/turf_decal/siding/wood{
@@ -110652,7 +110652,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "qwO" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -110716,7 +110716,7 @@
 	dir = 1;
 	icon_state = "yellowcorner"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "qxA" = (
 /obj/machinery/vending/coffee/free,
 /turf/simulated/floor/plasteel{
@@ -110743,7 +110743,7 @@
 	on = 1
 	},
 /turf/simulated/floor/grass,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "qxL" = (
 /obj/machinery/disposal,
 /obj/structure/sign/poster/official/random{
@@ -110901,7 +110901,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "qyP" = (
 /obj/machinery/shower{
 	dir = 1;
@@ -111102,7 +111102,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "qAv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -111274,7 +111274,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "qBq" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/structure/closet/walllocker/emerglocker/north{
@@ -111286,7 +111286,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "qBu" = (
 /obj/structure/computerframe,
 /turf/simulated/floor/plating,
@@ -111332,7 +111332,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qBJ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/multiz{
@@ -111470,7 +111470,7 @@
 	req_access = list(10,13)
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "qCC" = (
 /obj/item/stock_parts/matter_bin,
 /turf/simulated/floor/plasteel{
@@ -111485,7 +111485,7 @@
 	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "qCF" = (
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/captain)
@@ -111539,7 +111539,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "qDa" = (
 /turf/simulated/wall,
 /area/crew_quarters/chief)
@@ -111594,7 +111594,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "qDR" = (
 /turf/simulated/wall,
 /area/hallway/primary/central/east)
@@ -111635,7 +111635,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "qEh" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
@@ -111793,7 +111793,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qFd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -112536,7 +112536,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "qMw" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
@@ -112705,7 +112705,7 @@
 "qNk" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "qNs" = (
 /obj/structure/sign/comand{
 	pixel_y = 32
@@ -112725,7 +112725,7 @@
 	dir = 8;
 	icon_state = "darkyellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "qNF" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -113221,7 +113221,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "qQt" = (
 /obj/structure/railing{
 	dir = 9
@@ -113255,7 +113255,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "qQJ" = (
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -113402,7 +113402,7 @@
 	network = list("Engineering","SS13")
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "qRU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -114011,7 +114011,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "qWW" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -114155,7 +114155,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "qYs" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -114578,7 +114578,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "rcb" = (
 /obj/structure/closet/boxinggloves,
 /turf/simulated/floor/plasteel,
@@ -114645,7 +114645,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "rcS" = (
 /obj/structure/chair/sofa/left,
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -114927,7 +114927,7 @@
 	dir = 7;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "rfB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -115054,7 +115054,7 @@
 /obj/effect/decal/warning_stripes/northwest,
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "rgA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -115468,7 +115468,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "rjd" = (
 /obj/machinery/constructable_frame/machine_frame,
 /obj/item/stock_parts/cell/high,
@@ -115780,7 +115780,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "rlE" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -116143,7 +116143,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "rnH" = (
 /obj/structure/table,
 /obj/item/mmi/robotic_brain,
@@ -116546,7 +116546,7 @@
 	req_access = list(10,13)
 	},
 /turf/simulated/floor/engine,
-/area/engine/aienter)
+/area/engineering/aienter)
 "rre" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
@@ -116612,7 +116612,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "podfloor_dark"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "rsu" = (
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -116994,7 +116994,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "rvs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/secure/loot,
@@ -117121,7 +117121,7 @@
 	security_level = 6
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "rwn" = (
 /obj/machinery/door/window/brigdoor{
 	base_state = "rightsecure";
@@ -117153,7 +117153,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "rwv" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/effect/decal/warning_stripes/east,
@@ -117167,7 +117167,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "rww" = (
 /obj/structure/chair/stool,
 /obj/structure/cable{
@@ -117185,7 +117185,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "rwA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -117197,7 +117197,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "rwC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -117329,7 +117329,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "rwT" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -117406,7 +117406,7 @@
 	},
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "rxF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -117487,7 +117487,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ryq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -117928,7 +117928,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "rBG" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -118119,7 +118119,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "rDi" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/disposalpipe/segment,
@@ -118365,7 +118365,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "rEX" = (
 /obj/machinery/computer/operating/old_frame,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -118431,7 +118431,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "rFy" = (
 /obj/machinery/suit_storage_unit/security/pod_pilot,
 /obj/structure/window/reinforced,
@@ -118566,7 +118566,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "rGe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/critter,
@@ -118912,7 +118912,7 @@
 	dir = 6;
 	icon_state = "podfloor"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "rIV" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -118997,7 +118997,7 @@
 	on = 1
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "rJy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -119268,7 +119268,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "rLA" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -119416,7 +119416,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "rMv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -119477,7 +119477,7 @@
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "rMU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -119833,7 +119833,7 @@
 	dir = 8;
 	icon_state = "darkyellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "rOT" = (
 /obj/machinery/door/airlock{
 	name = "Chapel Morgue";
@@ -119925,7 +119925,7 @@
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "rPp" = (
 /obj/structure/table,
 /obj/machinery/cell_charger{
@@ -120119,7 +120119,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "rQM" = (
 /obj/structure/railing,
 /turf/simulated/floor/plasteel{
@@ -120479,14 +120479,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "rTQ" = (
 /obj/structure/grille,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "rTU" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -120709,7 +120709,7 @@
 /obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "rVE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -120828,7 +120828,7 @@
 "rWN" = (
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "rWS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -120946,7 +120946,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "rXR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -120961,7 +120961,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "rXY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
@@ -121165,7 +121165,7 @@
 /obj/item/clothing/glasses/meson,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "rYY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -121334,7 +121334,7 @@
 "saw" = (
 /obj/machinery/light,
 /turf/simulated/floor/engine,
-/area/engine/aienter)
+/area/engineering/aienter)
 "saA" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/papersack,
@@ -121369,7 +121369,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "saR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -121542,7 +121542,7 @@
 	security_level = 6
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "sbO" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/light{
@@ -121651,7 +121651,7 @@
 "scs" = (
 /obj/item/stack/cable_coil/random,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "scv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -121830,7 +121830,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "sdE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -121977,7 +121977,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "sex" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -122442,7 +122442,7 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "shV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -122927,7 +122927,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "smx" = (
 /obj/machinery/suit_storage_unit/ce,
 /obj/effect/decal/warning_stripes/northwest,
@@ -122940,7 +122940,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "smD" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -123186,7 +123186,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "son" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/bananalamp{
@@ -123395,7 +123395,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "spP" = (
 /obj/machinery/light{
 	dir = 1;
@@ -123432,7 +123432,7 @@
 	dir = 10;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "sqm" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -123585,7 +123585,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "srx" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/red/line,
@@ -123671,7 +123671,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "ssB" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/monkeycubes,
@@ -123764,7 +123764,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "sta" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/firedoor,
@@ -124029,7 +124029,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "suK" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -124080,7 +124080,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "svl" = (
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
@@ -124564,7 +124564,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "szj" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -124828,7 +124828,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "sAP" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -124879,7 +124879,7 @@
 	},
 /obj/machinery/computer/station_alert,
 /turf/simulated/floor/redgrid,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "sBd" = (
 /obj/structure/chair/office,
 /obj/machinery/camera{
@@ -125233,7 +125233,7 @@
 /area/security/interrogation)
 "sDV" = (
 /turf/simulated/openspace,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "sEb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -125269,7 +125269,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "sEH" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin{
@@ -125543,7 +125543,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "sGp" = (
 /obj/structure/flora/rock/pile,
 /obj/structure/flora/ausbushes/sparsegrass/hell,
@@ -126115,7 +126115,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "sKv" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -126152,7 +126152,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "sKL" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -126576,7 +126576,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/aienter)
+/area/engineering/aienter)
 "sOp" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -126655,7 +126655,7 @@
 /obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/light,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "sOP" = (
 /obj/structure/closet/secure_closet/personal/mining,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -126721,7 +126721,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "sPq" = (
 /obj/structure/railing{
 	dir = 10
@@ -126876,7 +126876,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
-/area/engine/aienter)
+/area/engineering/aienter)
 "sRf" = (
 /obj/machinery/sleeper{
 	pixel_x = 3
@@ -126954,11 +126954,11 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "sRO" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "sSb" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -126976,7 +126976,7 @@
 	dir = 6;
 	icon_state = "podfloor"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "sSd" = (
 /obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -126986,7 +126986,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "sSh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -127113,13 +127113,13 @@
 	network = list("Engineering","SS13")
 	},
 /turf/simulated/floor/engine,
-/area/engine/aienter)
+/area/engineering/aienter)
 "sSC" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "sSD" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -127129,7 +127129,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "sSJ" = (
 /obj/effect/decal/cleanable/dust,
 /obj/effect/decal/ants,
@@ -127546,7 +127546,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "sVz" = (
 /obj/machinery/field/generator{
 	anchored = 1;
@@ -128142,7 +128142,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "sZQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/glass,
@@ -128337,7 +128337,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "taP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -128396,7 +128396,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "tba" = (
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/chair{
@@ -128416,7 +128416,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "tbi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -128760,7 +128760,7 @@
 	network = list("SS13","Engineering")
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "tdz" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
@@ -128794,7 +128794,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "tdL" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -129056,7 +129056,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "tfm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/west,
@@ -129152,7 +129152,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/portable_atmospherics/canister,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "tfL" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/cable{
@@ -129209,7 +129209,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "tfW" = (
 /obj/machinery/vending/coffee,
 /obj/effect/decal/warning_stripes/red/hollow,
@@ -129238,7 +129238,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "tgk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -129323,7 +129323,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "tgQ" = (
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel{
@@ -129343,7 +129343,7 @@
 	dir = 6;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "tgX" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -129645,7 +129645,7 @@
 	pixel_y = -22
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "tjq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -129877,7 +129877,7 @@
 	on = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "tkP" = (
 /obj/effect/turf_decal/siding/white/end{
 	dir = 1
@@ -130226,7 +130226,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "tpa" = (
 /obj/effect/decal/ants,
 /obj/effect/landmark/ninja_teleport,
@@ -130354,7 +130354,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "tqe" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -130436,7 +130436,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/aienter)
+/area/engineering/aienter)
 "tqE" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -130701,7 +130701,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "tsn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -130933,7 +130933,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ttD" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "blue"
@@ -131000,7 +131000,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "ttU" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/tripple,
@@ -131037,7 +131037,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "tul" = (
 /obj/structure/railing,
 /turf/simulated/floor/grass,
@@ -131077,7 +131077,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "tuB" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 8
@@ -131158,7 +131158,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "tvk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -131193,7 +131193,7 @@
 	},
 /obj/structure/railing/corner,
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "tvu" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -131333,7 +131333,7 @@
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "twd" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -131508,7 +131508,7 @@
 	dir = 1;
 	icon_state = "yellowcorner"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "twP" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "bluecorner"
@@ -131605,7 +131605,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "txA" = (
 /obj/structure/table/reinforced,
 /obj/item/stamp/hos{
@@ -131640,7 +131640,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "txG" = (
 /obj/structure/stairs{
 	dir = 8
@@ -131683,7 +131683,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "tyf" = (
 /obj/structure/railing{
 	dir = 1
@@ -131744,7 +131744,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "tyE" = (
 /obj/structure/table/wood,
 /obj/item/folder{
@@ -131896,7 +131896,7 @@
 	amount = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "tzy" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
@@ -132049,7 +132049,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/redgrid,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "tBi" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -132058,7 +132058,7 @@
 	},
 /obj/structure/window/full/plasmareinforced,
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "tBj" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical{
@@ -132082,7 +132082,7 @@
 "tBq" = (
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "tBs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -132363,7 +132363,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "tDQ" = (
 /obj/machinery/light{
 	dir = 1;
@@ -132423,7 +132423,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "tEp" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
@@ -132464,7 +132464,7 @@
 	pixel_y = -3
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "tEB" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -132534,7 +132534,7 @@
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "tEV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -132878,7 +132878,7 @@
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "tHc" = (
 /obj/structure/chair/sofa/right,
 /turf/simulated/floor/plasteel{
@@ -133101,7 +133101,7 @@
 	dir = 6;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "tIf" = (
 /obj/machinery/computer/security{
 	network = list("SS13","Research Outpost","Mining Outpost")
@@ -133131,7 +133131,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "tIG" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/effect/decal/warning_stripes/north,
@@ -133140,7 +133140,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "tIW" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -133263,7 +133263,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "tJP" = (
 /obj/structure/railing{
 	dir = 9
@@ -133278,7 +133278,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "tJS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
@@ -133509,7 +133509,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "tLN" = (
 /obj/machinery/light{
 	dir = 1
@@ -133615,7 +133615,7 @@
 /obj/effect/turf_decal/box,
 /obj/effect/landmark/event/lightsout,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "tNi" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -133723,7 +133723,7 @@
 /area/security/processing)
 "tNK" = (
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "tNR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -133774,7 +133774,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "tOf" = (
 /obj/structure/closet/crate{
 	name = "solar pack crate"
@@ -133833,7 +133833,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/engine,
-/area/engine/aienter)
+/area/engineering/aienter)
 "tOz" = (
 /obj/machinery/atmospherics/air_sensor{
 	id_tag = "air_sensor"
@@ -134081,7 +134081,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "tQp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -134106,7 +134106,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "tQA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -134473,7 +134473,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "tSQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -134556,7 +134556,7 @@
 	layer = 4
 	},
 /turf/simulated/wall/r_wall,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "tTq" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -134601,7 +134601,7 @@
 	dir = 8
 	},
 /turf/space,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "tTF" = (
 /obj/item/chair,
 /turf/simulated/floor/plasteel{
@@ -134910,7 +134910,7 @@
 	network = list("SS13","Engineering")
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "tVV" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -135083,7 +135083,7 @@
 	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "tXa" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
@@ -135200,7 +135200,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "tXL" = (
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai)
@@ -135276,7 +135276,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "podfloor_dark"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "tYx" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Walkway"
@@ -135351,7 +135351,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "tYL" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -135507,7 +135507,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "uap" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 4
@@ -135934,7 +135934,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "udq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -136037,7 +136037,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "ueo" = (
 /obj/machinery/door_control{
 	id = "engstorage";
@@ -136052,7 +136052,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "uet" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -136331,7 +136331,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "ugG" = (
 /obj/structure/sign/directions/security{
 	dir = 8;
@@ -136415,7 +136415,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "uhg" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -136439,7 +136439,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "uhk" = (
 /obj/structure/girder,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -136508,7 +136508,7 @@
 "uhJ" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "uhK" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -136703,7 +136703,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "ujr" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -136902,7 +136902,7 @@
 /area/bridge/checkpoint/south)
 "ulx" = (
 /turf/simulated/wall/r_wall,
-/area/engine/break_room)
+/area/engineering/break_room)
 "ulI" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/coffee,
@@ -137193,7 +137193,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "unQ" = (
 /obj/effect/spawner/random_spawners/oil_5,
 /turf/simulated/floor/mech_bay_recharge_floor,
@@ -137416,7 +137416,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "uqh" = (
 /obj/machinery/door/window/southright{
 	dir = 4;
@@ -137497,7 +137497,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "uqM" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -137688,7 +137688,7 @@
 	dir = 6;
 	icon_state = "podfloor"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "usi" = (
 /obj/effect/decal/warning_stripes/yellow/partial,
 /obj/effect/decal/warning_stripes/arrow,
@@ -137808,7 +137808,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "utj" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -137892,7 +137892,7 @@
 "utG" = (
 /obj/structure/railing/corner,
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "utO" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -137922,7 +137922,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "utY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -138256,7 +138256,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "uwJ" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -138283,7 +138283,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "uwS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
@@ -138387,7 +138387,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "uxE" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -138427,7 +138427,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "uxN" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -138528,7 +138528,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "uyM" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 2;
@@ -138591,7 +138591,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "uzh" = (
 /obj/structure/weightmachine/weightlifter,
 /turf/simulated/floor/plasteel{
@@ -138714,7 +138714,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "uAm" = (
 /obj/structure/table,
 /obj/item/flash{
@@ -138790,7 +138790,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "uAO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
@@ -139061,7 +139061,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "uCK" = (
 /obj/effect/decal/cleanable/dust,
 /obj/machinery/light_construct{
@@ -139286,7 +139286,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "uEA" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -139320,7 +139320,7 @@
 	charge = 2e+006
 	},
 /turf/simulated/floor/redgrid,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "uES" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -139500,7 +139500,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "uGp" = (
 /obj/effect/decal/warning_stripes/northeast,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -139628,7 +139628,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/aienter)
+/area/engineering/aienter)
 "uHr" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -140376,7 +140376,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "uNw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -140392,7 +140392,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "uNF" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
@@ -140402,7 +140402,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/glass/reinforced/plasma,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "uNI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -140795,7 +140795,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "uRu" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
@@ -141027,7 +141027,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/aienter)
+/area/engineering/aienter)
 "uSX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -141055,7 +141055,7 @@
 	network = list("Engineering","SS13")
 	},
 /turf/simulated/floor/engine,
-/area/engine/aienter)
+/area/engineering/aienter)
 "uTt" = (
 /obj/item/radio/intercom{
 	pixel_x = 32;
@@ -141377,7 +141377,7 @@
 "uVO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "uVQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
@@ -141527,7 +141527,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "uWR" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/decal/cleanable/dirt,
@@ -141916,7 +141916,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "uZp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dust,
@@ -142064,7 +142064,7 @@
 	dir = 1;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "vat" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom{
@@ -142162,7 +142162,7 @@
 	network = list("Engineering","SS13")
 	},
 /turf/simulated/floor/engine,
-/area/engine/aienter)
+/area/engineering/aienter)
 "vbj" = (
 /obj/machinery/door/poddoor/multi_tile/two_tile_hor{
 	id_tag = "ComEVA2";
@@ -142312,7 +142312,7 @@
 	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "vce" = (
 /turf/simulated/floor/engine/plasma,
 /area/atmos)
@@ -142443,7 +142443,7 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "vcE" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -142508,7 +142508,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "vdh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -142557,7 +142557,7 @@
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
 /turf/simulated/floor/plating/airless,
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "vdL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -142965,7 +142965,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "vhs" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -143219,7 +143219,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "vjH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
@@ -143240,7 +143240,7 @@
 /area/maintenance/apmaint)
 "vjO" = (
 /turf/simulated/wall/r_wall,
-/area/engine/mechanic_workshop)
+/area/engineering/mechanic_workshop)
 "vjQ" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/structure/cable{
@@ -143359,7 +143359,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "podfloor_dark"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "vkH" = (
 /obj/machinery/power/emitter,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -143422,7 +143422,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "vlr" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/camera{
@@ -143730,7 +143730,7 @@
 	dir = 6;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "vnM" = (
 /obj/structure/stairs{
 	dir = 4
@@ -143932,7 +143932,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "vpX" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/number/number_1{
@@ -143982,7 +143982,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "vqy" = (
 /obj/structure/table/wood,
 /obj/machinery/photocopier/faxmachine/longrange{
@@ -144097,7 +144097,7 @@
 /obj/item/radio,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "vrN" = (
 /obj/effect/turf_decal/siding/wideplating/light{
 	dir = 9
@@ -144127,7 +144127,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "vsn" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
@@ -144140,7 +144140,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "podfloor_dark"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "vsz" = (
 /obj/effect/spawner/window/reinforced/polarized{
 	id = "blueshieldofficewindows"
@@ -144428,7 +144428,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "vuT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -144489,7 +144489,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "vvd" = (
 /turf/simulated/wall/r_wall,
 /area/security/medbay)
@@ -144530,7 +144530,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "vvy" = (
 /obj/machinery/vending/cola/free,
 /turf/simulated/floor/wood,
@@ -144857,7 +144857,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "vxM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random_barrier/possibly_welded_airlock,
@@ -145031,7 +145031,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/aienter)
+/area/engineering/aienter)
 "vyY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -145417,7 +145417,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "vCT" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/toxin{
@@ -145839,7 +145839,7 @@
 /obj/structure/cable,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "vGc" = (
 /turf/simulated/wall,
 /area/crew_quarters/bar/atrium)
@@ -145877,7 +145877,7 @@
 /area/maintenance/atmospherics)
 "vGz" = (
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "vGA" = (
 /obj/structure/railing{
 	dir = 9
@@ -145916,7 +145916,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "vGQ" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
@@ -145971,7 +145971,7 @@
 	zap_sound_extrarange = -6
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "vHp" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -145987,7 +145987,7 @@
 /obj/effect/decal/warning_stripes/southwestcorner,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "vHq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -146132,7 +146132,7 @@
 /area/maintenance/chapel)
 "vID" = (
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "vIG" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/storage/belt/medical,
@@ -146417,7 +146417,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "vKz" = (
 /obj/effect/turf_decal/siding/wideplating/light{
 	dir = 10
@@ -146594,7 +146594,7 @@
 	dir = 9;
 	icon_state = "neutral"
 	},
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "vMa" = (
 /obj/structure/chair{
 	dir = 4
@@ -146661,7 +146661,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "vMl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random_spawners/rodent,
@@ -147194,7 +147194,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "vQL" = (
 /obj/machinery/door/airlock/command/glass{
 	id = "conferenceroomwindows";
@@ -147424,7 +147424,7 @@
 "vSW" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall/r_wall,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "vSY" = (
 /obj/machinery/light{
 	dir = 4
@@ -147766,7 +147766,7 @@
 	},
 /obj/structure/railing,
 /turf/simulated/floor/glass/reinforced,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "vUX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -147957,7 +147957,7 @@
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "vWt" = (
 /obj/structure/girder,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -148086,7 +148086,7 @@
 /area/crew_quarters/fitness)
 "vWZ" = (
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "vXb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -148147,7 +148147,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "vXs" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -148172,7 +148172,7 @@
 	dir = 6;
 	icon_state = "podfloor"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "vXu" = (
 /obj/effect/decal/cleanable/vomit,
 /turf/simulated/floor/plating,
@@ -148334,7 +148334,7 @@
 "vYJ" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "vYP" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -148384,7 +148384,7 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/aienter)
+/area/engineering/aienter)
 "vZb" = (
 /obj/structure/closet/secure_closet/atmos_personal,
 /obj/effect/decal/warning_stripes/northeast,
@@ -148401,7 +148401,7 @@
 /obj/structure/closet/radiation,
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "vZe" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 2;
@@ -148410,7 +148410,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "vZi" = (
 /obj/structure/sink{
 	dir = 8;
@@ -148730,7 +148730,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "wbN" = (
 /obj/machinery/camera{
 	c_tag = "Second Floor Central Ring West Hallway 3";
@@ -148886,7 +148886,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "wdu" = (
 /obj/item/grenade/clusterbuster/honk,
 /turf/simulated/floor/plating,
@@ -149032,7 +149032,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "wes" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -149133,7 +149133,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "wfo" = (
 /obj/machinery/door/airlock/security{
 	name = "Evidence Storage";
@@ -149319,7 +149319,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "wgY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing{
@@ -149591,7 +149591,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "wjs" = (
 /obj/item/radio/intercom{
 	name = "west station intercom (General)";
@@ -150218,7 +150218,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/hardsuitstorage)
+/area/engineering/hardsuitstorage)
 "wnr" = (
 /obj/structure/table,
 /obj/item/storage/photo_album,
@@ -150390,7 +150390,7 @@
 "wox" = (
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engineering/break_room)
 "woz" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -150502,7 +150502,7 @@
 /obj/item/analyzer,
 /obj/item/analyzer,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "wpz" = (
 /obj/structure/table,
 /obj/item/storage/box,
@@ -150609,7 +150609,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "wqd" = (
 /obj/machinery/vending/cola,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -150617,7 +150617,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "wqf" = (
 /obj/machinery/power/apc{
 	cell_type = 5000;
@@ -150780,7 +150780,7 @@
 	network = list("SS13","Engineering")
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "wqO" = (
 /obj/structure/chair,
 /obj/machinery/camera{
@@ -150923,7 +150923,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/aienter)
+/area/engineering/aienter)
 "wrO" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Broom Closet"
@@ -151475,7 +151475,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "wvQ" = (
 /obj/machinery/requests_console{
 	department = "Crew Quarters";
@@ -151804,7 +151804,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "wyq" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -151878,7 +151878,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "wyJ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
@@ -151988,7 +151988,7 @@
 "wzG" = (
 /obj/structure/sign/vacuum,
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "wzO" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/structure/morgue{
@@ -152043,7 +152043,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "wAm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -152342,7 +152342,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "wCI" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -152376,7 +152376,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "wCV" = (
 /obj/structure/sign/med{
 	pixel_y = 32
@@ -152675,7 +152675,7 @@
 	dir = 8;
 	icon_state = "darkyellow"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "wGd" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -152835,7 +152835,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "wHB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -152899,7 +152899,7 @@
 	charge = 2e+006
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "wIl" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -152920,7 +152920,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "wIN" = (
 /obj/structure/table,
 /obj/item/storage/bag/trash/cyborg,
@@ -152946,7 +152946,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "wJn" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -153279,7 +153279,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "wKY" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 26
@@ -153455,7 +153455,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "wMQ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -154096,7 +154096,7 @@
 /area/maintenance/casino)
 "wRr" = (
 /turf/simulated/wall/r_wall,
-/area/engine/aienter)
+/area/engineering/aienter)
 "wRx" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/orange,
@@ -154232,7 +154232,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "wSK" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -154435,7 +154435,7 @@
 	dir = 8;
 	icon_state = "darkyellowfull"
 	},
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "wUd" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/packageWrap,
@@ -154757,7 +154757,7 @@
 /obj/structure/table/reinforced,
 /obj/item/tank/internals/plasma,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "wXa" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/firedoor,
@@ -155126,7 +155126,7 @@
 	network = list("SS13","Engineering")
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "wZS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -156114,7 +156114,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "xia" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -156195,7 +156195,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "xiy" = (
 /obj/machinery/camera{
 	c_tag = "Central Ring Hallway South 5";
@@ -156354,7 +156354,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "xjC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -156369,7 +156369,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engineering/engine)
 "xjJ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -156377,7 +156377,7 @@
 /area/medical/virology/lab)
 "xjL" = (
 /turf/simulated/floor/glass/reinforced,
-/area/engine/aienter)
+/area/engineering/aienter)
 "xjP" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -156423,7 +156423,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "xke" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/civilian,
@@ -157063,7 +157063,7 @@
 	layer = 2.9
 	},
 /turf/simulated/floor/engine,
-/area/engine/aienter)
+/area/engineering/aienter)
 "xpD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -157561,7 +157561,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "xto" = (
 /obj/machinery/the_singularitygen,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -157775,7 +157775,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop/expedition)
+/area/engineering/mechanic_workshop/expedition)
 "xvj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -158002,7 +158002,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xwT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/extinguisher_cabinet{
@@ -158199,7 +158199,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "xyr" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -158535,7 +158535,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xAH" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/structure/table,
@@ -158753,7 +158753,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xCr" = (
 /obj/structure/filingcabinet/filingcabinet,
 /obj/machinery/light{
@@ -158800,7 +158800,7 @@
 	dir = 7;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "xCN" = (
 /obj/machinery/light_switch{
 	pixel_x = 24;
@@ -158835,7 +158835,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/engine/gravitygenerator)
+/area/engineering/gravitygenerator)
 "xCY" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/item/radio/intercom{
@@ -159245,7 +159245,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "xGC" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -159336,7 +159336,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "xHE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -159358,7 +159358,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "xHK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -159398,10 +159398,10 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "xHU" = (
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "xHX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -159591,7 +159591,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xJh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -160111,7 +160111,7 @@
 "xMA" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "xMF" = (
 /obj/structure/grille,
 /obj/structure/window/plasmareinforced{
@@ -160156,7 +160156,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xNp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -160226,7 +160226,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xNU" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Walkway"
@@ -160277,7 +160277,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/engine/engineering/monitor)
+/area/engineering/engine/monitor)
 "xOe" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -160929,7 +160929,7 @@
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating/airless,
-/area/engine/engineering)
+/area/engineering/engine)
 "xSV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance,
@@ -161203,7 +161203,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xUn" = (
 /obj/machinery/light{
 	dir = 4
@@ -161217,7 +161217,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "xUp" = (
 /obj/effect/decal/cleanable/dust,
 /obj/structure/chair/wood/wings,
@@ -161234,7 +161234,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "xUu" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -161242,7 +161242,7 @@
 	dir = 10;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xUA" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -161259,7 +161259,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/engine/engineering)
+/area/engineering/engine)
 "xUC" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/cable{
@@ -161361,7 +161361,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/aienter)
+/area/engineering/aienter)
 "xVf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -161408,7 +161408,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "xVI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/filingcabinet/chestdrawer,
@@ -161503,7 +161503,7 @@
 /obj/structure/closet/radiation,
 /obj/item/clothing/glasses/meson,
 /turf/simulated/floor/plasteel,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "xWx" = (
 /obj/item/flag/nt,
 /obj/machinery/light{
@@ -162023,7 +162023,7 @@
 "yan" = (
 /obj/structure/sign/fire,
 /turf/simulated/wall/r_wall/coated,
-/area/engine/supermatter)
+/area/engineering/supermatter)
 "yas" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	name = "standard air scrubber";
@@ -162094,7 +162094,7 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "yaD" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -162333,7 +162333,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ycg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random_spawners/rodent,
@@ -162359,7 +162359,7 @@
 	dir = 10;
 	icon_state = "yellow"
 	},
-/area/engine/engine_smes)
+/area/engineering/engine/smes)
 "ycs" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -162442,7 +162442,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ycP" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -162659,7 +162659,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
 	},
-/area/engine/mechanic_workshop/hangar)
+/area/engineering/mechanic_workshop/hangar)
 "ydX" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -162885,7 +162885,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/engine/break_room)
+/area/engineering/break_room)
 "yfJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -163147,7 +163147,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
+/area/engineering/engine)
 "yhw" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -163326,7 +163326,7 @@
 /area/maintenance/fore2)
 "yiU" = (
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engineering/engine)
 "yiX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -163430,7 +163430,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/engine/controlroom)
+/area/engineering/controlroom)
 "ykg" = (
 /obj/structure/cable{
 	icon_state = "2-8"

--- a/code/game/area/ss13_areas.dm
+++ b/code/game/area/ss13_areas.dm
@@ -1633,65 +1633,65 @@ This applies to all STANDARD station areas
 
 
 //Engineering
-/area/engine
+/area/engineering
 	ambientsounds = ENGINEERING_SOUNDS
 	sound_environment = SOUND_AREA_LARGE_ENCLOSED
 
-/area/engine/engine_smes
+/area/engineering/engine/smes
 	name = "Engineering SMES"
 	icon_state = "engine_smes"
 
-/area/engine/engineering
+/area/engineering/engine
 	name = "Engineering"
 	icon_state = "engine_smes"
 
-/area/engine/engineering/monitor
+/area/engineering/engine/monitor
 	name = "Engineering Monitoring Room"
 	icon_state = "engine_control"
 
-/area/engine/break_room
+/area/engineering/break_room
 	name = "Engineering Foyer"
 	icon_state = "engine"
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
 
-/area/engine/aienter
+/area/engineering/aienter
 	name = "AI Sattelit Access Point"
 	icon_state = "engine"
 
-/area/engine/equipmentstorage
+/area/engineering/equipmentstorage
 	name = "Engineering Equipment Storage"
 	icon_state = "storage"
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
 
-/area/engine/hardsuitstorage
+/area/engineering/hardsuitstorage
 	name = "Engineering Hardsuit Storage"
 	icon_state = "storage"
 
-/area/engine/controlroom
+/area/engineering/controlroom
 	name = "Engineering Control Room"
 	icon_state = "engine_control"
 
-/area/engine/gravitygenerator
+/area/engineering/gravitygenerator
 	name = "Gravity Generator"
 	icon_state = "engine"
 
-/area/engine/chiefs_office
+/area/engineering/chiefs_office
 	name = "Chief Engineer's Office"
 	icon_state = "engine_control"
 
-/area/engine/mechanic_workshop
+/area/engineering/mechanic_workshop
 	name = "Mechanic Workshop"
 	icon_state = "engine"
 
-/area/engine/mechanic_workshop/expedition
+/area/engineering/mechanic_workshop/expedition
 	name = "Hangar Expedition"
 	icon_state = "engine"
 
-/area/engine/mechanic_workshop/hangar
+/area/engineering/mechanic_workshop/hangar
 	name = "Hangаr Bay"
 	icon_state = "engine"
 
-/area/engine/supermatter
+/area/engineering/supermatter
 	name = "Supermatter Engine"
 	icon_state = "engine"
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED

--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -278,7 +278,7 @@
 			to_chat(S, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
 			S.GiveTarget(null)
 			return FALSE
-		else if(istype(A, /area/engine/supermatter))
+		else if(istype(A, /area/engineering/supermatter))
 			to_chat(S, "<span class='warning'>Disrupting the containment of a supermatter crystal would not be to our benefit. Aborting.</span>")
 			S.GiveTarget(null)
 			return FALSE
@@ -393,7 +393,7 @@
 			to_chat(S, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
 			S.GiveTarget(null)
 			return TRUE
-		else if(istype(A, /area/engine/supermatter))
+		else if(istype(A, /area/engineering/supermatter))
 			to_chat(S, "<span class='warning'>Disrupting the containment of a supermatter crystal would not be to our benefit. Aborting.</span>")
 			S.GiveTarget(null)
 			return TRUE
@@ -418,7 +418,7 @@
 			to_chat(S, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
 			S.GiveTarget(null)
 			return TRUE
-		else if(istype(A, /area/engine/supermatter))
+		else if(istype(A, /area/engineering/supermatter))
 			to_chat(S, "<span class='warning'>Disrupting the containment of a supermatter crystal would not be to our benefit. Aborting.</span>")
 			S.GiveTarget(null)
 			return TRUE
@@ -432,7 +432,7 @@
 			to_chat(S, "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>")
 			S.GiveTarget(null)
 			return TRUE
-		else if(istype(A, /area/engine/supermatter))
+		else if(istype(A, /area/engineering/supermatter))
 			to_chat(S, "<span class='warning'>Disrupting the containment of a supermatter crystal would not be to our benefit. Aborting.</span>")
 			S.GiveTarget(null)
 			return TRUE

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -442,7 +442,7 @@
 		else if(is_type_in_list(A, fiftythousand_penalty))
 			scoreboard.nuked_penalty = 50000
 
-		else if(istype(A, /area/engine))
+		else if(istype(A, /area/engineering))
 			scoreboard.nuked_penalty = 100000
 
 		else

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1404,7 +1404,7 @@ GLOBAL_LIST_EMPTY(admin_objective_list)
 	///Where we should KABOOM
 	var/area/detonation_location
 	var/list/area_blacklist = list(
-		/area/engine/engineering, /area/engine/supermatter,
+		/area/engineering/engine, /area/engineering/supermatter,
 		/area/toxins/test_area, /area/turret_protected/ai)
 	needs_target = FALSE
 

--- a/code/modules/antagonists/space_ninja/drain_act/apc.dm
+++ b/code/modules/antagonists/space_ninja/drain_act/apc.dm
@@ -7,7 +7,7 @@
 	var/drain_total = 0
 	add_game_logs("draining energy from [src] [COORD(src)]", ninja)
 	var/area/area = get_area(src)
-	if(area && (istype(area, /area/engine/engineering) || istype(area, /area/engine/supermatter)))
+	if(area && (istype(area, /area/engineering/engine) || istype(area, /area/engineering/supermatter)))
 		//На русском чтобы даже полному идиоту было ясно, почему им не даётся сосать ток из этого АПЦ
 		to_chat(ninja, span_danger("Внимание: Высасывание энергии из АПЦ в этой зоне потенциально может привести к неконтролируемым разрушениям. Процесс отменён."))
 		return INVALID_DRAIN

--- a/code/modules/events/apc_overload.dm
+++ b/code/modules/events/apc_overload.dm
@@ -28,11 +28,11 @@
 	return TRUE
 
 /proc/apc_overload_failure(announce=TRUE)
-	var/list/skipped_areas_apc = list(
+	var/static/list/skipped_areas_apc = typecacheof(list(
 		/area/engineering/engine,
 		/area/engineering/supermatter,
 		/area/turret_protected/ai,
-	)
+	))
 
 	if(announce)
 		GLOB.event_announcement.Announce("Зафиксирована перегрузка энергосети станции [station_name()]. Инженерному отделу надлежит проверить все терминалы ЛКП под напольным покрытием.", "ВНИМАНИЕ: КРИТИЧЕСКИЙ СБОЙ СИСТЕМЫ ПИТАНИЯ.", new_sound = 'sound/AI/attention.ogg')
@@ -43,7 +43,7 @@
 		var/obj/machinery/power/apc/C = thing
 		// skip any APCs that are too critical to break
 		var/area/current_area = get_area(C)
-		if((current_area.type in skipped_areas_apc) || !is_station_level(C.z))
+		if(is_type_in_typecache(current_area, skipped_areas_apc) || !is_station_level(C.z))
 			continue
 		// if we are going to break this one
 		if(prob(APC_BREAK_PROBABILITY))

--- a/code/modules/events/apc_overload.dm
+++ b/code/modules/events/apc_overload.dm
@@ -29,8 +29,10 @@
 
 /proc/apc_overload_failure(announce=TRUE)
 	var/list/skipped_areas_apc = list(
-		/area/engine/engineering,
-		/area/turret_protected/ai)
+		/area/engineering/engine,
+		/area/engineering/supermatter,
+		/area/turret_protected/ai,
+	)
 
 	if(announce)
 		GLOB.event_announcement.Announce("Зафиксирована перегрузка энергосети станции [station_name()]. Инженерному отделу надлежит проверить все терминалы ЛКП под напольным покрытием.", "ВНИМАНИЕ: КРИТИЧЕСКИЙ СБОЙ СИСТЕМЫ ПИТАНИЯ.", new_sound = 'sound/AI/attention.ogg')

--- a/code/modules/events/apc_short.dm
+++ b/code/modules/events/apc_short.dm
@@ -28,8 +28,10 @@
 
 /proc/power_failure(announce=TRUE)
 	var/list/skipped_areas_apc = list(
-		/area/engine/engineering,
-		/area/turret_protected/ai)
+		/area/engineering/engine,
+		/area/engineering/supermatter,
+		/area/turret_protected/ai,
+	)
 
 	if(announce)
 		GLOB.event_announcement.Announce("Зафиксирована перегрузка энергосети станции [station_name()]. Инженерному отделу надлежит проверить все замкнувшие ЛКП.", "ВНИМАНИЕ: СБОЙ СИСТЕМЫ ПИТАНИЯ.", new_sound = 'sound/AI/attention.ogg')

--- a/code/modules/events/apc_short.dm
+++ b/code/modules/events/apc_short.dm
@@ -27,11 +27,11 @@
 	return TRUE
 
 /proc/power_failure(announce=TRUE)
-	var/list/skipped_areas_apc = list(
+	var/static/list/skipped_areas_apc = typecacheof(list(
 		/area/engineering/engine,
 		/area/engineering/supermatter,
 		/area/turret_protected/ai,
-	)
+	))
 
 	if(announce)
 		GLOB.event_announcement.Announce("Зафиксирована перегрузка энергосети станции [station_name()]. Инженерному отделу надлежит проверить все замкнувшие ЛКП.", "ВНИМАНИЕ: СБОЙ СИСТЕМЫ ПИТАНИЯ.", new_sound = 'sound/AI/attention.ogg')
@@ -42,7 +42,7 @@
 		var/obj/machinery/power/apc/C = thing
 		// skip any APCs that are too critical to disable
 		var/area/current_area = get_area(C)
-		if((current_area.type in skipped_areas_apc) || !is_station_level(C.z))
+		if(is_type_in_typecache(current_area, skipped_areas_apc) || !is_station_level(C.z))
 			continue
 		// if we are going to break this one
 		if(prob(APC_BREAK_PROBABILITY))

--- a/code/modules/events/event_procs.dm
+++ b/code/modules/events/event_procs.dm
@@ -25,7 +25,7 @@
 		var/list/safe_areas = typecacheof(list(
 			/area/turret_protected/ai,
 			/area/turret_protected/ai_upload,
-			/area/engine,
+			/area/engineering,
 			/area/holodeck,
 			/area/shuttle,
 			/area/maintenance,
@@ -36,11 +36,11 @@
 
 		//These are needed because /area/station/engineering has to be removed from the list, but we still want these areas to get fucked up.
 		var/list/allowed_areas = list(
-			/area/engine/break_room,
-			/area/engine/equipmentstorage,
-			/area/engine/chiefs_office,
-			/area/engine/controlroom,
-			/area/engine/mechanic_workshop
+			/area/engineering/break_room,
+			/area/engineering/equipmentstorage,
+			/area/engineering/chiefs_office,
+			/area/engineering/controlroom,
+			/area/engineering/mechanic_workshop
 		)
 
 		var/list/remove_these_areas = safe_areas - allowed_areas

--- a/code/modules/power/singularity/investigate.dm
+++ b/code/modules/power/singularity/investigate.dm
@@ -1,4 +1,4 @@
-/area/engine/engineering/poweralert(state, obj/source)
+/area/engineering/engine/poweralert(state, obj/source)
 	if(state != poweralm)
 		source.investigate_log("has a power alarm!", INVESTIGATE_ENGINE)
 	..()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
- Превращает тип зоны `engine ` в `engineering` и делает тоже самое с зоной движка, но в другую сторону.
- Зона "СМЕСы движка" стала подзоной движка.
- Зона суперматерии, попала к зонам движка в исключения для ивентов выбивания АПЦ.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР
#5992 , а если конкретнее, то ошибка в локализации проблемного места от Пиро заставила меня обратить внимание на то, что прилепленные на Фаррагусе каким-то ННом @aeternaclose (или не им, но он всё равно виноват) **неиспользуемые** подзоны двигателя не являются подзонами двигателя.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
`Ctrl+Alt+Enter`
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->

## Тесты
Da.
<!-- Как вы тестировали свой код. Ревьеюру будет проще, если он будет знать какие действия вы совершали, проверяя свой ПР. -->
