### PR TITLE
bugfix: dupe of materials

### DIFF
--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -168,11 +168,11 @@
 			qdel(src)
 			return ATTACK_CHAIN_BLOCKED_ALL
 
-		if(glass.get_amount() < 1)
-			to_chat(user, span_warning("You need at least one pile of [glass] to finalize the wall!"))
+		if(glass.get_amount() < 2)
+			to_chat(user, span_warning("You need at least two piles of [glass] to finalize the wall!"))
 			return .
 		to_chat(user, span_notice("You start adding [glass]..."))
-		if(!do_after(user, 4 SECONDS * glass.toolspeed, src, category = DA_CAT_TOOL) || state == GIRDER_DISPLACED || !isfloorturf(loc) || QDELETED(glass) || !glass.use(1))
+		if(!do_after(user, 4 SECONDS * glass.toolspeed, src, category = DA_CAT_TOOL) || state == GIRDER_DISPLACED || !isfloorturf(loc) || QDELETED(glass) || !glass.use(2))
 			return .
 		to_chat(user, span_notice("You have finalized basalt wall."))
 		var/turf/floor = loc
@@ -203,11 +203,11 @@
 			qdel(src)
 			return ATTACK_CHAIN_BLOCKED_ALL
 
-		if(wood.get_amount() < 1)
-			to_chat(user, span_warning("You need at least one plank of wood to finalize the wall!"))
+		if(wood.get_amount() < 2)
+			to_chat(user, span_warning("You need at least two planks of wood to finalize the wall!"))
 			return .
 		to_chat(user, span_notice("You start adding plating..."))
-		if(!do_after(user, 4 SECONDS * wood.toolspeed, src, category = DA_CAT_TOOL) || state == GIRDER_DISPLACED || !isfloorturf(loc) || QDELETED(wood) || !wood.use(1))
+		if(!do_after(user, 4 SECONDS * wood.toolspeed, src, category = DA_CAT_TOOL) || state == GIRDER_DISPLACED || !isfloorturf(loc) || QDELETED(wood) || !wood.use(2))
 			return .
 		to_chat(user, span_notice("You have finalized the wooden wall."))
 		var/turf/floor = loc
@@ -233,11 +233,11 @@
 			qdel(src)
 			return ATTACK_CHAIN_BLOCKED_ALL
 
-		if(metal.get_amount() < 1)
-			to_chat(user, span_warning("You need at least one sheet of metal to finalize the wall!"))
+		if(metal.get_amount() < 2)
+			to_chat(user, span_warning("You need at least two sheets of metal to finalize the wall!"))
 			return .
 		to_chat(user, span_notice("You start adding plating..."))
-		if(!do_after(user, 4 SECONDS * metal.toolspeed, src, category = DA_CAT_TOOL) || state == GIRDER_DISPLACED || !isfloorturf(loc) || QDELETED(metal) || !metal.use(1))
+		if(!do_after(user, 4 SECONDS * metal.toolspeed, src, category = DA_CAT_TOOL) || state == GIRDER_DISPLACED || !isfloorturf(loc) || QDELETED(metal) || !metal.use(2))
 			return .
 		to_chat(user, span_notice("You have finalized the wall."))
 		var/turf/floor = loc
@@ -265,11 +265,11 @@
 				return ATTACK_CHAIN_BLOCKED_ALL
 
 			if(GIRDER_REINF)
-				if(plasteel.get_amount() < 1)
-					to_chat(user, span_warning("You need at least one sheet of plasteel to finalize the reinforced wall!"))
+				if(plasteel.get_amount() < 2)
+					to_chat(user, span_warning("You need at least two sheets of plasteel to finalize the reinforced wall!"))
 					return .
 				to_chat(user, span_notice("You start finalizing the reinforced wall..."))
-				if(!do_after(user, 2 SECONDS * plasteel.toolspeed, src, category = DA_CAT_TOOL) || state != GIRDER_REINF || !isfloorturf(loc) || QDELETED(plasteel) || !plasteel.use(1))
+				if(!do_after(user, 2 SECONDS * plasteel.toolspeed, src, category = DA_CAT_TOOL) || state != GIRDER_REINF || !isfloorturf(loc) || QDELETED(plasteel) || !plasteel.use(2))
 					return .
 				to_chat(user, span_notice("You have finalized the reinforced wall."))
 				var/turf/floor = loc
@@ -280,11 +280,11 @@
 				return ATTACK_CHAIN_BLOCKED_ALL
 
 			else
-				if(plasteel.get_amount() < 1)
-					to_chat(user, span_warning("You need at least one sheet of plasteel to reinforce the girder!"))
+				if(plasteel.get_amount() < 2)
+					to_chat(user, span_warning("You need at least two sheets of plasteel to reinforce the girder!"))
 					return .
 				to_chat(user, span_notice("You start reinforcing the girder..."))
-				if(!do_after(user, 6 SECONDS * plasteel.toolspeed, src, category = DA_CAT_TOOL) || state == GIRDER_DISPLACED || state == GIRDER_REINF || QDELETED(plasteel) || !plasteel.use(1))
+				if(!do_after(user, 6 SECONDS * plasteel.toolspeed, src, category = DA_CAT_TOOL) || state == GIRDER_DISPLACED || state == GIRDER_REINF || QDELETED(plasteel) || !plasteel.use(2))
 					return .
 				to_chat(user, span_notice("You reinforce the girder."))
 				var/obj/structure/girder/reinforced/girder = new(loc)
@@ -313,11 +313,11 @@
 		qdel(src)
 		return ATTACK_CHAIN_BLOCKED_ALL
 
-	if(sheet.get_amount() < 1)
-		to_chat(user, span_warning("You need at least one sheet of [cached_sheet_type] to add plating!"))
+	if(sheet.get_amount() < 2)
+		to_chat(user, span_warning("You need at least two sheets of [cached_sheet_type] to add plating!"))
 		return .
 	to_chat(user, span_notice("You start adding plating..."))
-	if(!do_after(user, 4 SECONDS * sheet.toolspeed, src, category = DA_CAT_TOOL) || state == GIRDER_DISPLACED || !isfloorturf(loc) || QDELETED(sheet) || !sheet.use(1))
+	if(!do_after(user, 4 SECONDS * sheet.toolspeed, src, category = DA_CAT_TOOL) || state == GIRDER_DISPLACED || !isfloorturf(loc) || QDELETED(sheet) || !sheet.use(2))
 		return .
 	to_chat(user, span_notice("You have finalized the [cached_sheet_type] wall."))
 	var/turf/floor = loc


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
После реворка атак чейна некоторые стены, стали тратить меньше материалов на постройку. При разборке дается все то же количество материалов, из-за чего возникла возможность бесконечно дюпать почти любой материал строя и разбирая стену + на это небыло предложки, поэтому ставлю как было.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР
Баг репорт:
https://discord.com/channels/617003227182792704/1285212270623854632/1285212270623854632
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Попробовал построить стены из разных материалов до и после багфикса. До - материалов падало больше чем тратилось. После - и падает и тратится одинаковое количество материалов.
<!-- Как вы тестировали свой код. Ревьеюру будет проще, если он будет знать какие действия вы совершали, проверяя свой ПР. -->
