### PR TITLE
bugfix: lamp attack cd

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -442,7 +442,7 @@
 
 /obj/machinery/light/attackby(obj/item/I, mob/living/user, params)
 	if(user.a_intent == INTENT_HARM)
-		if(light_hit_check(I, user))
+		if(!light_hit_check(I, user))
 			return ATTACK_CHAIN_BLOCKED_ALL
 		return ..()
 
@@ -482,7 +482,7 @@
 			explode()
 		return ATTACK_CHAIN_BLOCKED_ALL
 
-	if(light_hit_check(I, user))
+	if(!light_hit_check(I, user))
 		return ATTACK_CHAIN_BLOCKED_ALL
 
 	return ..()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Ну, у атаки ламп небыло КД. Возвращаю КД. Ошибка была в том, что звей сделал функцию атаки лампы (тип шанс на удар током, все такое) возвращающую то, прошла ли атака, а потом запускал КД удара когда она не прошла, вместо запуска когда она прошла.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР
Ну, это бага. Баги надо фиксить.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Подолбил лампы до и после своих изменений. С ними кд есть.
<!-- Как вы тестировали свой код. Ревьеюру будет проще, если он будет знать какие действия вы совершали, проверяя свой ПР. -->
