### PR TITLE
bugfix: no more multiple tipping

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1250,13 +1250,15 @@
 			"[user] begins to right [src].",
 			"You begin to right [src]."
 		)
-		if(!do_after(user, 7 SECONDS, src))
+		if(!do_after(user, 7 SECONDS, src, max_interact_count = 1, cancel_on_max = TRUE))
 			return
 		user.visible_message(
 			span_notice("[user] rights [src]."),
 			span_notice("You right [src]."),
 			span_notice(">You hear a loud clang.")
 		)
+	if(!tilted) //Sanity check
+		return
 
 	unbuckle_all_mobs(TRUE)
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет две простейшие проверки на максимальное количество вызовов "попытки перевернуть" вендомат и на то, перевернут ли вендомат после do_after
Первое нужно для того, чтобы не вызывать через альтклик сотню "begin to right [src]" и не заставлять вендор вертеться по оси, а второе - чтобы несколько человек одновременно не заставляли тот же вендор вертеться по оси.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
багфикс
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
