### PR TITLE
bugfix: holoparasites are no longer can be refreshed in colossus crystal

### DIFF
--- a/code/modules/mining/lavaland/loot/colossus_loot.dm
+++ b/code/modules/mining/lavaland/loot/colossus_loot.dm
@@ -322,7 +322,7 @@
 	activation_sound = 'sound/magic/timeparadox2.ogg'
 	var/list/banned_items_typecache = list(/obj/item/storage, /obj/item/implant, /obj/item/implanter, /obj/item/disk/nuclear,
 										   /obj/item/projectile, /obj/item/spellbook, /obj/item/clothing/mask/facehugger, /obj/item/contractor_uplink,
-										   /obj/item/dice/d20/fate, /obj/item/gem)
+										   /obj/item/dice/d20/fate, /obj/item/gem, /obj/item/guardiancreator)
 
 /obj/machinery/anomalous_crystal/refresher/New()
 	..()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет карты таро (и инъектор голопаразита) в список необновляемых предметов для кристалла колосса, не позволяя более его абъюзить.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
![image](https://github.com/user-attachments/assets/536c426f-0e82-4f7c-9e6b-f6c840851f75)
https://discord.com/channels/617003227182792704/1295391571532841030/1295391571532841030
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

