### PR TITLE
bugfix: Keybind "Y" resulted in the use of an item in hand.

### DIFF
--- a/code/datums/keybindings/mob.dm
+++ b/code/datums/keybindings/mob.dm
@@ -5,7 +5,7 @@
 // Hands
 /datum/keybinding/mob/use_held_object
 	name = "Использовать вещь в руке"
-	keys = list("Y", "Z")
+	keys = list("Z")
 
 
 /datum/keybinding/mob/use_held_object/down(client/user)


### PR DESCRIPTION
## Описание

Теперь когда тыкаешь "Y" - предмет в руке не используется.
До этого если в руке че-т держать и нажать на клавишу быстрой рации - активировался предмет, из за чего могли быть проблемы(активация гранаты в руке)