### PR TITLE
tweak: contractor portal can't take buckled mobs anymore

### DIFF
--- a/code/modules/antagonists/traitor/contractor/items/extraction_items.dm
+++ b/code/modules/antagonists/traitor/contractor/items/extraction_items.dm
@@ -46,6 +46,10 @@
 	var/mob/living/M = A
 	if(!istype(M))
 		return FALSE
+	if(M.buckled)
+		if(!silent)
+			to_chat(M, span_warning("You can't teleport while buckled to something!"))
+		return FALSE
 	if(M == usr && M.mind == contractor_mind)
 		if(!silent)
 			to_chat(M, "<span class='warning'>The portal is here to extract the contract target, not you!</span>")


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Теперь портал контрактника не может телепортировать цели в случае, если они на чем-то или ком-то сидят.
Решает проблему с телепортацией других людей или симплмобов в случае, если цельсидела на них в момент телепортации.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1296029102016430080 - временное костыльное решение.
![image](https://github.com/user-attachments/assets/4cbcf339-2257-4c06-ac52-d6298ad102a6)
ЭТОТ СКРИН - К РАЗГОВОРУ НИЖЕ

<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
>запустил локалку
>попробовал пройти через портал с целью в хвате пожарного
>попробовал провести через портал цель на стуле, тоже не дало.
<!-- Как вы тестировали свой код. Ревьюеру будет проще, если он будет знать какие действия вы совершали, проверяя свой ПР. -->
