### PR TITLE
bugfix: no prothesis heal from food and etc

### DIFF
--- a/code/modules/mob/living/carbon/human/species/diona.dm
+++ b/code/modules/mob/living/carbon/human/species/diona.dm
@@ -109,8 +109,8 @@
 			return FALSE
 		if("salglu_solution")
 			if(prob(33))
-				H.adjustBruteLoss(-1)
-				H.adjustFireLoss(-1)
+				H.adjustBruteLoss(-1, FALSE, affect_robotic = FALSE)
+				H.adjustFireLoss(-1, affect_robotic = FALSE)
 			H.reagents.remove_reagent(R.id, R.metabolization_rate * H.metabolism_efficiency * H.digestion_ratio)
 			return FALSE
 

--- a/code/modules/reagents/chemistry/reagents/alcohol.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol.dm
@@ -138,8 +138,8 @@
 /datum/reagent/consumable/ethanol/hooch/on_mob_life(mob/living/carbon/M)
 	if(M.mind && M.mind.assigned_role == JOB_TITLE_CIVILIAN)
 		var/update_flags = STATUS_UPDATE_NONE
-		update_flags |= M.adjustBruteLoss(-1, FALSE)
-		update_flags |= M.adjustFireLoss(-1, FALSE)
+		update_flags |= M.adjustBruteLoss(-1, FALSE, affect_robotic = FALSE)
+		update_flags |= M.adjustFireLoss(-1, FALSE, affect_robotic = FALSE)
 		return ..() | update_flags
 
 /datum/reagent/consumable/ethanol/rum
@@ -1468,8 +1468,8 @@
 
 /datum/reagent/consumable/ethanol/rainbow_sky/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	update_flags |= M.adjustBruteLoss(-1, FALSE)
-	update_flags |= M.adjustFireLoss(-1, FALSE)
+	update_flags |= M.adjustBruteLoss(-1, FALSE, affect_robotic = FALSE)
+	update_flags |= M.adjustFireLoss(-1, FALSE, affect_robotic = FALSE)
 	M.Druggy(30 SECONDS)
 	M.Jitter(10 SECONDS)
 	M.AdjustHallucinate(10 SECONDS)
@@ -1711,13 +1711,13 @@
 
 /datum/reagent/consumable/ethanol/alcomender/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	update_flags |= M.adjustFireLoss(-0.7, FALSE)
+	update_flags |= M.adjustFireLoss(-0.7, FALSE, affect_robotic = FALSE)
 	return ..() | update_flags
 
 /datum/reagent/consumable/ethanol/alcomender/reaction_mob(mob/living/M, method=REAGENT_TOUCH, volume) // It is alcohol after all, so don't try to pour it on someone who's on fire ... please.
 	if(iscarbon(M))
 		if(method == REAGENT_TOUCH)
-			M.adjustFireLoss(-volume * 0.7)
+			M.adjustFireLoss(-volume * 0.7, affect_robotic = FALSE)
 			to_chat(M, "<span class='notice'>The diluted silver sulfadiazine soothes your burns.</span>")
 	return STATUS_UPDATE_NONE
 

--- a/code/modules/reagents/chemistry/reagents/drink_cold.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_cold.dm
@@ -265,8 +265,8 @@
 /datum/reagent/consumable/drink/cold/zaza/on_mob_life(mob/living/user)
 	var/update_flags = STATUS_UPDATE_NONE
 	if(ishuman(user) && prob(40))
-		update_flags |= user.adjustBruteLoss(-healamount, FALSE)
-		update_flags |= user.adjustFireLoss(-healamount, FALSE)
+		update_flags |= user.adjustBruteLoss(-healamount, FALSE, affect_robotic = FALSE)
+		update_flags |= user.adjustFireLoss(-healamount, FALSE, affect_robotic = FALSE)
 	return ..() | update_flags
 
 

--- a/code/modules/reagents/chemistry/reagents/drinks.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks.dm
@@ -37,7 +37,7 @@
 /datum/reagent/consumable/drink/tomatojuice/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	if(prob(20))
-		update_flags |= M.adjustFireLoss(-1, FALSE)
+		update_flags |= M.adjustFireLoss(-1, FALSE, affect_robotic = FALSE)
 	return ..() | update_flags
 
 /datum/reagent/consumable/drink/limejuice
@@ -179,8 +179,8 @@
 /datum/reagent/consumable/drink/banana/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	if(HAS_TRAIT(M, TRAIT_COMIC) || is_monkeybasic(M))
-		update_flags |= M.adjustBruteLoss(-1, FALSE)
-		update_flags |= M.adjustFireLoss(-1, FALSE)
+		update_flags |= M.adjustBruteLoss(-1, FALSE, affect_robotic = FALSE)
+		update_flags |= M.adjustFireLoss(-1, FALSE, affect_robotic = FALSE)
 	return ..() | update_flags
 
 /datum/reagent/consumable/drink/nothing
@@ -195,8 +195,8 @@
 /datum/reagent/consumable/drink/nothing/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	if(ishuman(M) && M.mind && M.mind.miming)
-		update_flags |= M.adjustBruteLoss(-1, FALSE)
-		update_flags |= M.adjustFireLoss(-1, FALSE)
+		update_flags |= M.adjustBruteLoss(-1, FALSE, affect_robotic = FALSE)
+		update_flags |= M.adjustFireLoss(-1, FALSE, affect_robotic = FALSE)
 	return ..() | update_flags
 
 /datum/reagent/consumable/drink/potato_juice
@@ -223,7 +223,7 @@
 /datum/reagent/consumable/drink/milk/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	if(prob(20))
-		update_flags |= M.adjustBruteLoss(-1, FALSE)
+		update_flags |= M.adjustBruteLoss(-1, FALSE, affect_robotic = FALSE)
 	if(holder.has_reagent("capsaicin"))
 		holder.remove_reagent("capsaicin", 2)
 	return ..() | update_flags
@@ -329,7 +329,7 @@
 	var/update_flags = STATUS_UPDATE_NONE
 	M.SetSleeping(0)
 	if(prob(20))
-		update_flags |= M.adjustBruteLoss(-1, FALSE)
+		update_flags |= M.adjustBruteLoss(-1, FALSE, affect_robotic = FALSE)
 	return ..() | update_flags
 
 /datum/reagent/consumable/drink/coffee/cafe_latte
@@ -348,7 +348,7 @@
 	var/update_flags = STATUS_UPDATE_NONE
 	M.SetSleeping(0)
 	if(prob(20))
-		update_flags |= M.adjustBruteLoss(-1, FALSE)
+		update_flags |= M.adjustBruteLoss(-1, FALSE, affect_robotic = FALSE)
 	return ..() | update_flags
 
 /datum/reagent/consumable/drink/coffee/cafe_latte/cafe_mocha
@@ -414,8 +414,8 @@
 /datum/reagent/consumable/drink/bananahonk/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	if(HAS_TRAIT(src, TRAIT_COMIC) || is_monkeybasic(M))
-		update_flags |= M.adjustBruteLoss(-1, FALSE)
-		update_flags |= M.adjustFireLoss(-1, FALSE)
+		update_flags |= M.adjustBruteLoss(-1, FALSE, affect_robotic = FALSE)
+		update_flags |= M.adjustFireLoss(-1, FALSE, affect_robotic = FALSE)
 	return ..() | update_flags
 
 /datum/reagent/consumable/drink/silencer
@@ -431,8 +431,8 @@
 /datum/reagent/consumable/drink/silencer/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	if(ishuman(M) && (M.job in list(JOB_TITLE_MIME)))
-		update_flags |= M.adjustBruteLoss(-1, FALSE)
-		update_flags |= M.adjustFireLoss(-1, FALSE)
+		update_flags |= M.adjustBruteLoss(-1, FALSE, affect_robotic = FALSE)
+		update_flags |= M.adjustFireLoss(-1, FALSE, affect_robotic = FALSE)
 	return ..() | update_flags
 
 /datum/reagent/consumable/drink/chocolatepudding

--- a/code/modules/reagents/chemistry/reagents/drugs.dm
+++ b/code/modules/reagents/chemistry/reagents/drugs.dm
@@ -612,8 +612,8 @@
 		if(M.reagents.get_reagent_amount("thc") <= 20)
 			M.Drowsy(20 SECONDS)
 	if(prob(25))
-		update_flags |= M.adjustBruteLoss(-2, FALSE)
-		update_flags |= M.adjustFireLoss(-2, FALSE)
+		update_flags |= M.adjustBruteLoss(-2, FALSE, affect_robotic = FALSE)
+		update_flags |= M.adjustFireLoss(-2, FALSE, affect_robotic = FALSE)
 	return ..() | update_flags
 
 

--- a/code/modules/reagents/chemistry/reagents/food.dm
+++ b/code/modules/reagents/chemistry/reagents/food.dm
@@ -29,8 +29,8 @@
 /datum/reagent/consumable/nutriment/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	if(!isvampire(M))
-		update_flags |= M.adjustBruteLoss(-brute_heal, FALSE)
-		update_flags |= M.adjustFireLoss(-burn_heal, FALSE)
+		update_flags |= M.adjustBruteLoss(-brute_heal, FALSE, affect_robotic = FALSE)
+		update_flags |= M.adjustFireLoss(-burn_heal, FALSE, affect_robotic = FALSE)
 	return ..() | update_flags
 
 /datum/reagent/consumable/nutriment/on_new(list/supplied_data)
@@ -490,8 +490,8 @@
 		else
 			if(H.job == JOB_TITLE_CHEF)
 				if(prob(20)) //stays in the system much longer than sprinkles/banana juice, so heals slower to partially compensate
-					update_flags |= H.adjustBruteLoss(-1, FALSE)
-					update_flags |= H.adjustFireLoss(-1, FALSE)
+					update_flags |= H.adjustBruteLoss(-1, FALSE, affect_robotic = FALSE)
+					update_flags |= H.adjustFireLoss(-1, FALSE, affect_robotic = FALSE)
 	return ..() | update_flags
 
 /datum/reagent/consumable/sprinkles
@@ -504,8 +504,8 @@
 /datum/reagent/consumable/sprinkles/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	if(ishuman(M) && (M.job in list(JOB_TITLE_OFFICER, JOB_TITLE_PILOT, JOB_TITLE_DETECTIVE, JOB_TITLE_WARDEN, JOB_TITLE_HOS, JOB_TITLE_BRIGDOC, JOB_TITLE_LAWYER, JOB_TITLE_JUDGE)))
-		update_flags |= M.adjustBruteLoss(-1, FALSE)
-		update_flags |= M.adjustFireLoss(-1, FALSE)
+		update_flags |= M.adjustBruteLoss(-1, FALSE, affect_robotic = FALSE)
+		update_flags |= M.adjustFireLoss(-1, FALSE, affect_robotic = FALSE)
 	return ..() | update_flags
 
 /datum/reagent/consumable/cornoil
@@ -686,8 +686,8 @@
 	var/update_flags = STATUS_UPDATE_NONE
 	M.reagents.add_reagent("sugar", 3)
 	if(prob(20))
-		update_flags |= M.adjustBruteLoss(-3, FALSE)
-		update_flags |= M.adjustFireLoss(-1, FALSE)
+		update_flags |= M.adjustBruteLoss(-3, FALSE, affect_robotic = FALSE)
+		update_flags |= M.adjustFireLoss(-1, FALSE, affect_robotic = FALSE)
 	return ..() | update_flags
 
 /datum/reagent/consumable/onion
@@ -743,8 +743,8 @@
 		if(M.mind.special_role == SPECIAL_ROLE_WIZARD || M.mind.special_role == SPECIAL_ROLE_WIZARD_APPRENTICE)
 			update_flags |= M.adjustToxLoss(-0.5, FALSE)
 			update_flags |= M.adjustOxyLoss(-0.5, FALSE)
-			update_flags |= M.adjustBruteLoss(-0.5, FALSE)
-			update_flags |= M.adjustFireLoss(-0.5, FALSE)
+			update_flags |= M.adjustBruteLoss(-0.5, FALSE, affect_robotic = FALSE)
+			update_flags |= M.adjustFireLoss(-0.5, FALSE, affect_robotic = FALSE)
 	return ..() | update_flags
 
 /datum/reagent/consumable/porktonium
@@ -962,8 +962,8 @@
 /datum/reagent/msg/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	if(istype(M.mind?.martial_art, /datum/martial_art/mr_chang))
-		update_flags |= M.adjustBruteLoss(-0.75)
-		update_flags |= M.adjustFireLoss(-0.75)
+		update_flags |= M.adjustBruteLoss(-0.75, affect_robotic = FALSE)
+		update_flags |= M.adjustFireLoss(-0.75, affect_robotic = FALSE)
 	else
 		if(prob(5))
 			if(prob(10))
@@ -1138,8 +1138,8 @@
 /datum/reagent/consumable/vitfro/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	if(prob(80))
-		update_flags |= M.adjustBruteLoss(-0.5, FALSE)
-		update_flags |= M.adjustFireLoss(-0.5, FALSE)
+		update_flags |= M.adjustBruteLoss(-0.5, FALSE, affect_robotic = FALSE)
+		update_flags |= M.adjustFireLoss(-0.5, FALSE, affect_robotic = FALSE)
 	return ..() | update_flags
 
 /datum/reagent/consumable/animal_feed
@@ -1153,8 +1153,8 @@
 /datum/reagent/consumable/animal_feed/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	if(isvulpkanin(M) || istajaran(M))
-		update_flags |= M.adjustBruteLoss(-0.25, FALSE)
-		update_flags |= M.adjustFireLoss(-0.25, FALSE)
+		update_flags |= M.adjustBruteLoss(-0.25, FALSE, affect_robotic = FALSE)
+		update_flags |= M.adjustFireLoss(-0.25, FALSE, affect_robotic = FALSE)
 		M.AdjustDisgust(-5 SECONDS)
 		if(prob(2))
 			to_chat(M, span_notice("You feel delicious yummy snack taste!"))

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -150,8 +150,8 @@
 		update_flags |= M.adjustCloneLoss(-1, FALSE)
 		update_flags |= M.adjustOxyLoss(-2, FALSE)
 		update_flags |= M.adjustToxLoss(-0.5, FALSE)
-		update_flags |= M.adjustBruteLoss(-2, FALSE)
-		update_flags |= M.adjustFireLoss(-4, FALSE)
+		update_flags |= M.adjustBruteLoss(-2, FALSE, affect_robotic = FALSE)
+		update_flags |= M.adjustFireLoss(-4, FALSE, affect_robotic = FALSE)
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			var/obj/item/organ/external/head/head = H.get_organ(BODY_ZONE_HEAD)
@@ -180,8 +180,8 @@
 /datum/reagent/medicine/rezadone/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	update_flags |= M.adjustCloneLoss(-5, FALSE) //What? We just set cloneloss to 0. Why? Simple; this is so external organs properly unmutate. // why don't you fix the code instead // i fix the code dont worry
-	update_flags |= M.adjustBruteLoss(-1, FALSE)
-	update_flags |= M.adjustFireLoss(-1, FALSE)
+	update_flags |= M.adjustBruteLoss(-1, FALSE, affect_robotic = FALSE)
+	update_flags |= M.adjustFireLoss(-1, FALSE, affect_robotic = FALSE)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/head/head = H.get_organ(BODY_ZONE_HEAD)
@@ -289,8 +289,8 @@
 /datum/reagent/medicine/salglu_solution/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	if(prob(33))
-		update_flags |= M.adjustBruteLoss(-1, FALSE)
-		update_flags |= M.adjustFireLoss(-1, FALSE)
+		update_flags |= M.adjustBruteLoss(-1, FALSE, affect_robotic = FALSE)
+		update_flags |= M.adjustFireLoss(-1, FALSE, affect_robotic = FALSE)
 	if(ishuman(M) && prob(33))
 		var/mob/living/carbon/human/H = M
 		//do not restore blood on things with no blood by nature.
@@ -333,7 +333,7 @@
 /datum/reagent/medicine/ab_stimulant/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	to_chat(M, "<span class='notice'>Вы чуствуете чесотку.</span>")
-	update_flags |= M.adjustFireLoss(-1.5, FALSE)
+	update_flags |= M.adjustFireLoss(-1.5, FALSE, affect_robotic = FALSE)
 	if(volume > 1.9)
 		if(HAS_TRAIT(M, TRAIT_HUSK))
 			var/mob/living/carbon/human/H = M
@@ -387,8 +387,8 @@
 	var/update_flags = STATUS_UPDATE_NONE
 	update_flags |= M.adjustToxLoss(-0.5, FALSE)
 	update_flags |= M.adjustOxyLoss(-0.5, FALSE)
-	update_flags |= M.adjustBruteLoss(-1, FALSE)
-	update_flags |= M.adjustFireLoss(-1, FALSE)
+	update_flags |= M.adjustBruteLoss(-1, FALSE, affect_robotic = FALSE)
+	update_flags |= M.adjustFireLoss(-1, FALSE, affect_robotic = FALSE)
 	if(prob(50))
 		M.AdjustLoseBreath(-2 SECONDS)
 	return ..() | update_flags
@@ -506,7 +506,7 @@
 /datum/reagent/medicine/sal_acid/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	if(prob(55))
-		update_flags |= M.adjustBruteLoss(-1, FALSE)
+		update_flags |= M.adjustBruteLoss(-1, FALSE, affect_robotic = FALSE)
 	if(M.bodytemperature > BODYTEMP_NORMAL)
 		M.adjust_bodytemperature(-10)
 	return ..() | update_flags
@@ -523,7 +523,7 @@
 /datum/reagent/medicine/menthol/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	if(prob(55))
-		update_flags |= M.adjustFireLoss(-1, FALSE)
+		update_flags |= M.adjustFireLoss(-1, FALSE, affect_robotic = FALSE)
 	if(M.bodytemperature > 280)
 		M.adjust_bodytemperature(-10)
 	return ..() | update_flags
@@ -561,8 +561,8 @@
 	if(volume >= 4)
 		M.LoseBreath(12 SECONDS)
 	if(prob(33))
-		update_flags |= M.adjustBruteLoss(-0.5, FALSE)
-		update_flags |= M.adjustFireLoss(-0.5, FALSE)
+		update_flags |= M.adjustBruteLoss(-0.5, FALSE, affect_robotic = FALSE)
+		update_flags |= M.adjustFireLoss(-0.5, FALSE, affect_robotic = FALSE)
 	return ..() | update_flags
 
 /datum/reagent/medicine/ephedrine
@@ -591,8 +591,8 @@
 		update_flags |= M.adjustOxyLoss(-1, FALSE)
 	if(M.health < 0 || M.health > 0 && prob(33))
 		update_flags |= M.adjustToxLoss(-1, FALSE)
-		update_flags |= M.adjustBruteLoss(-1, FALSE)
-		update_flags |= M.adjustFireLoss(-1, FALSE)
+		update_flags |= M.adjustBruteLoss(-1, FALSE, affect_robotic = FALSE)
+		update_flags |= M.adjustFireLoss(-1, FALSE, affect_robotic = FALSE)
 	return ..() | update_flags
 
 /datum/reagent/medicine/ephedrine/overdose_process(mob/living/M, severity)
@@ -732,8 +732,8 @@
 		update_flags |= M.adjustOxyLoss(-5, FALSE)
 	if(M.health < -25)
 		update_flags |= M.adjustToxLoss(-1, FALSE)
-		update_flags |= M.adjustBruteLoss(-1.5, FALSE)
-		update_flags |= M.adjustFireLoss(-1.5, FALSE)
+		update_flags |= M.adjustBruteLoss(-1.5, FALSE, affect_robotic = FALSE)
+		update_flags |= M.adjustFireLoss(-1.5, FALSE, affect_robotic = FALSE)
 	else if(M.health > -60)
 		update_flags |= M.adjustToxLoss(1, FALSE)
 	M.reagents.remove_reagent("sarin", 20)
@@ -769,8 +769,8 @@
 		update_flags |= M.adjustOxyLoss(-5, FALSE)
 	if(M.health < -10 && M.health > -65)
 		update_flags |= M.adjustToxLoss(-0.5, FALSE)
-		update_flags |= M.adjustBruteLoss(-0.5, FALSE)
-		update_flags |= M.adjustFireLoss(-0.5, FALSE)
+		update_flags |= M.adjustBruteLoss(-0.5, FALSE, affect_robotic = FALSE)
+		update_flags |= M.adjustFireLoss(-0.5, FALSE, affect_robotic = FALSE)
 	return ..() | update_flags
 
 /datum/reagent/medicine/epinephrine/overdose_process(mob/living/M, severity)
@@ -947,8 +947,8 @@
 	if(volume > 5)
 		update_flags |= M.adjustOxyLoss(-2.5, FALSE)
 		update_flags |= M.adjustToxLoss(-2.5, FALSE)
-		update_flags |= M.adjustBruteLoss(-5, FALSE)
-		update_flags |= M.adjustFireLoss(-5, FALSE)
+		update_flags |= M.adjustBruteLoss(-5, FALSE, affect_robotic = FALSE)
+		update_flags |= M.adjustFireLoss(-5, FALSE, affect_robotic = FALSE)
 		update_flags |= M.setStaminaLoss(0, FALSE)
 		M.SetSlowed(0)
 		M.AdjustDizzy(-20 SECONDS)
@@ -990,8 +990,8 @@
 	var/update_flags = STATUS_UPDATE_NONE
 	if(user.health < 50 && user.health > 0)
 		update_flags |= user.adjustOxyLoss(-2, FALSE)
-		update_flags |= user.adjustBruteLoss(-2, FALSE)
-		update_flags |= user.adjustFireLoss(-2, FALSE)
+		update_flags |= user.adjustBruteLoss(-2, FALSE, affect_robotic = FALSE)
+		update_flags |= user.adjustFireLoss(-2, FALSE, affect_robotic = FALSE)
 	user.AdjustParalysis(-6 SECONDS)
 	user.AdjustStunned(-6 SECONDS)
 	user.AdjustWeakened(-6 SECONDS)
@@ -1154,8 +1154,8 @@
 
 /datum/reagent/medicine/syndicate_nanites/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	update_flags |= M.adjustBruteLoss(-2.5, FALSE) //A ton of healing - this is a 50 telecrystal investment.
-	update_flags |= M.adjustFireLoss(-2.5, FALSE)
+	update_flags |= M.adjustBruteLoss(-2.5, FALSE, affect_robotic = FALSE) //A ton of healing - this is a 50 telecrystal investment.
+	update_flags |= M.adjustFireLoss(-2.5, FALSE, affect_robotic = FALSE)
 	update_flags |= M.adjustOxyLoss(-7.5, FALSE)
 	update_flags |= M.adjustToxLoss(-2.5, FALSE)
 	update_flags |= M.adjustBrainLoss(-7.5, FALSE)
@@ -1183,8 +1183,8 @@
 	var/update_flags = STATUS_UPDATE_NONE
 	update_flags |= M.adjustToxLoss(-0.25, FALSE)
 	update_flags |= M.adjustOxyLoss(-0.25, FALSE)
-	update_flags |= M.adjustBruteLoss(-0.25, FALSE)
-	update_flags |= M.adjustFireLoss(-0.25, FALSE)
+	update_flags |= M.adjustBruteLoss(-0.25, FALSE, affect_robotic = FALSE)
+	update_flags |= M.adjustFireLoss(-0.25, FALSE, affect_robotic = FALSE)
 	return ..() | update_flags
 
 /datum/reagent/medicine/omnizine_diluted/overdose_process(mob/living/M, severity)
@@ -1275,7 +1275,7 @@
 
 /datum/reagent/medicine/bicaridine/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	update_flags |= M.adjustBruteLoss(-1, FALSE)
+	update_flags |= M.adjustBruteLoss(-1, FALSE, affect_robotic = FALSE)
 	return ..() | update_flags
 
 /datum/reagent/medicine/bicaridine/overdose_process(mob/living/M)
@@ -1295,7 +1295,7 @@
 
 /datum/reagent/medicine/kelotane/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	update_flags |= M.adjustFireLoss(-1, FALSE)
+	update_flags |= M.adjustFireLoss(-1, FALSE, affect_robotic = FALSE)
 	return ..() | update_flags
 
 /datum/reagent/medicine/kelotane/overdose_process(mob/living/M)
@@ -1315,8 +1315,8 @@
 
 /datum/reagent/medicine/earthsblood/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	update_flags |= M.adjustBruteLoss(-1.5, FALSE)
-	update_flags |= M.adjustFireLoss(-1.5, FALSE)
+	update_flags |= M.adjustBruteLoss(-1.5, FALSE, affect_robotic = FALSE)
+	update_flags |= M.adjustFireLoss(-1.5, FALSE, affect_robotic = FALSE)
 	update_flags |= M.adjustOxyLoss(-7.5, FALSE)
 	update_flags |= M.adjustToxLoss(-1.5, FALSE)
 	update_flags |= M.adjustBrainLoss(1, FALSE) //This does, after all, come from ambrosia, and the most powerful ambrosia in existence, at that!
@@ -1344,8 +1344,8 @@
 
 /datum/reagent/medicine/syndiezine/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	update_flags |= M.adjustBruteLoss(-0.5, FALSE)
-	update_flags |= M.adjustFireLoss(-0.5, FALSE)
+	update_flags |= M.adjustBruteLoss(-0.5, FALSE, affect_robotic = FALSE)
+	update_flags |= M.adjustFireLoss(-0.5, FALSE, affect_robotic = FALSE)
 	update_flags |= M.adjustOxyLoss(-4.5, FALSE)
 	update_flags |= M.adjustToxLoss(-0.5, FALSE)
 	update_flags |= M.adjustCloneLoss(-0.5, FALSE)
@@ -1434,8 +1434,8 @@
 				if(M.health < 40)
 					update_flags |= M.adjustOxyLoss(-6, FALSE)
 					update_flags |= M.adjustToxLoss(-2, FALSE)
-					update_flags |= M.adjustBruteLoss(-4, FALSE)
-					update_flags |= M.adjustFireLoss(-4, FALSE)
+					update_flags |= M.adjustBruteLoss(-4, FALSE, affect_robotic = FALSE)
+					update_flags |= M.adjustFireLoss(-4, FALSE, affect_robotic = FALSE)
 				else
 					if(prob(50))
 						to_chat(M, span_warning("Your skin feels like it is ripping apart and your veins are on fire!")) //It is experimental and does cause scars, after all.
@@ -1454,8 +1454,8 @@
 
 /datum/reagent/medicine/lavaland_extract/on_mob_life(mob/living/carbon/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	update_flags |= M.adjustBruteLoss(-2.5, FALSE)
-	update_flags |= M.adjustFireLoss(-2.5, FALSE)
+	update_flags |= M.adjustBruteLoss(-2.5, FALSE, affect_robotic = FALSE)
+	update_flags |= M.adjustFireLoss(-2.5, FALSE, affect_robotic = FALSE)
 	return ..() | update_flags
 
 /datum/reagent/medicine/lavaland_extract/overdose_process(mob/living/M) // This WILL be brutal
@@ -1479,8 +1479,8 @@
 
 /datum/reagent/medicine/zessulblood/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	update_flags |= M.adjustBruteLoss(-1, FALSE)
-	update_flags |= M.adjustFireLoss(-1, FALSE)
+	update_flags |= M.adjustBruteLoss(-1, FALSE, affect_robotic = FALSE)
+	update_flags |= M.adjustFireLoss(-1, FALSE, affect_robotic = FALSE)
 	return ..() | update_flags
 
 /datum/reagent/medicine/pure_plasma   //unique chemical for plasmaman
@@ -1502,8 +1502,8 @@
 			normal_temperature = BODYTEMP_NORMAL
 		if(M.bodytemperature < normal_temperature)
 			M.adjust_bodytemperature(5 * TEMPERATURE_DAMAGE_COEFFICIENT)
-		update_flags |= M.adjustBruteLoss(-0.25, FALSE)
-		update_flags |= M.adjustFireLoss(-0.25, FALSE)
+		update_flags |= M.adjustBruteLoss(-0.25, FALSE, affect_robotic = FALSE)
+		update_flags |= M.adjustFireLoss(-0.25, FALSE, affect_robotic = FALSE)
 	else
 		update_flags |= M.adjustToxLoss(4, FALSE)
 	return ..() | update_flags
@@ -1586,18 +1586,18 @@
 	var/update_flags = STATUS_UPDATE_NONE
 	update_flags |= M.adjustOxyLoss(-3.5, FALSE)
 	update_flags |= M.adjustToxLoss(-2.5, FALSE)
-	update_flags |= M.adjustBruteLoss(-3, FALSE)
-	update_flags |= M.adjustFireLoss(-3, FALSE)
+	update_flags |= M.adjustBruteLoss(-3, FALSE, affect_robotic = FALSE)
+	update_flags |= M.adjustFireLoss(-3, FALSE, affect_robotic = FALSE)
 	if(prob(50))
 		M.AdjustLoseBreath(-2 SECONDS)
 	M.SetConfused(0)
 	M.SetSleeping(0)
 	if(M.getFireLoss() > 35)
-		update_flags |= M.adjustFireLoss(-4, FALSE)
+		update_flags |= M.adjustFireLoss(-4, FALSE, affect_robotic = FALSE)
 	if(M.health < 0)
 		update_flags |= M.adjustToxLoss(-1, FALSE)
-		update_flags |= M.adjustBruteLoss(-1, FALSE)
-		update_flags |= M.adjustFireLoss(-1, FALSE)
+		update_flags |= M.adjustBruteLoss(-1, FALSE, affect_robotic = FALSE)
+		update_flags |= M.adjustFireLoss(-1, FALSE, affect_robotic = FALSE)
 	return ..() | update_flags
 
 /datum/reagent/medicine/adv_lava_extract/overdose_process(mob/living/M, severity)

--- a/code/modules/reagents/chemistry/reagents/misc.dm
+++ b/code/modules/reagents/chemistry/reagents/misc.dm
@@ -473,7 +473,7 @@
 	if(prob(10))
 		M.emote("giggle")
 	if(M?.mind.assigned_role == JOB_TITLE_CLOWN || M?.mind.assigned_role == SPECIAL_ROLE_HONKSQUAD)
-		update_flags |= M.adjustBruteLoss(-0.75) //Screw those pesky clown beatings!
+		update_flags |= M.adjustBruteLoss(-0.75, affect_robotic = FALSE) //Screw those pesky clown beatings!
 	else
 		M.AdjustDizzy(20 SECONDS, 0, 1000 SECONDS)
 		M.Druggy(30 SECONDS)

--- a/code/modules/reagents/chemistry/reagents/ninja.dm
+++ b/code/modules/reagents/chemistry/reagents/ninja.dm
@@ -51,8 +51,8 @@
 			our_mob.AdjustDrunk(-8 SECONDS)
 			our_mob.reagents.remove_all_type(/datum/reagent/consumable/ethanol, 8, 0, 1)
 			//Basic damage types
-			update_flags |= our_mob.adjustBruteLoss(-5, FALSE)
-			update_flags |= our_mob.adjustFireLoss(-5, FALSE)
+			update_flags |= our_mob.adjustBruteLoss(-5, FALSE, affect_robotic = FALSE)
+			update_flags |= our_mob.adjustFireLoss(-5, FALSE, affect_robotic = FALSE)
 			update_flags |= our_mob.adjustOxyLoss(-5, FALSE)
 			update_flags |= our_mob.adjustToxLoss(-5, FALSE)
 			//Eyes and ears

--- a/code/modules/reagents/chemistry/reagents/paradise_pop.dm
+++ b/code/modules/reagents/chemistry/reagents/paradise_pop.dm
@@ -48,9 +48,9 @@
 		var/heal_type = rand(0, 5)		//still prefer the string version
 		switch(heal_type)
 			if(0)
-				update_flags |= M.adjustBruteLoss(-0.25, FALSE)
+				update_flags |= M.adjustBruteLoss(-0.25, FALSE, affect_robotic = FALSE)
 			if(1)
-				update_flags |= M.adjustFireLoss(-0.25, FALSE)
+				update_flags |= M.adjustFireLoss(-0.25, FALSE, affect_robotic = FALSE)
 			if(2)
 				update_flags |= M.adjustToxLoss(-0.25, FALSE)
 			if(3)


### PR DESCRIPTION
## Описание
После рефактора со сменой affect_robotic = FALSE на affect_robotic = TRUE в родительском проке еда и многие другие штуки начали лечить протезы. Пришлось чинить...

## Тесты
На локалке больше не могу захилить протезы от регена унатха/дионы/еды/воды етц