### PR TITLE
bugfix: firemanned people are can no longer be teleported when buckled

### DIFF
--- a/code/datums/elements/ridable.dm
+++ b/code/datums/elements/ridable.dm
@@ -195,7 +195,7 @@
 		return
 	return rider
 
-/obj/item/riding_offhand/afterattack(atom/movable/interacting_with, mob/living/user, list/modifiers)
+/obj/item/riding_offhand/afterattack(atom/movable/interacting_with, mob/living/user, proximity, list/modifiers)
 	if(!istype(interacting_with) || !interacting_with.can_buckle || !proximity)
 		return NONE
 	if(rider == user) // Piggyback user

--- a/code/datums/elements/ridable.dm
+++ b/code/datums/elements/ridable.dm
@@ -196,7 +196,7 @@
 	return rider
 
 /obj/item/riding_offhand/afterattack(atom/movable/interacting_with, mob/living/user, list/modifiers)
-	if(!istype(interacting_with) || !interacting_with.can_buckle)
+	if(!istype(interacting_with) || !interacting_with.can_buckle || !proximity)
 		return NONE
 	if(rider == user) // Piggyback user
 		return

--- a/code/datums/elements/ridable.dm
+++ b/code/datums/elements/ridable.dm
@@ -195,7 +195,7 @@
 		return
 	return rider
 
-/obj/item/riding_offhand/afterattack(atom/movable/interacting_with, mob/living/user, proximity, list/modifiers)
+/obj/item/riding_offhand/afterattack(atom/movable/interacting_with, mob/living/user, proximity, list/modifiers, status)
 	if(!istype(interacting_with) || !interacting_with.can_buckle || !proximity)
 		return NONE
 	if(rider == user) // Piggyback user


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет пропущенную проверку на проксимити, без которой людей в хвате пожарного можно было буквально телепортировать.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1297867255001911296/1297867255001911296
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
