### PR TITLE
tweak: M90 instead riot shotguns in ERT armory

### DIFF
--- a/_maps/map_files/generic/CentComm.dmm
+++ b/_maps/map_files/generic/CentComm.dmm
@@ -2454,36 +2454,6 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/bridge)
 "beG" = (
-/obj/item/gun/energy/gun/advtaser{
-	pixel_y = -2
-	},
-/obj/item/gun/energy/gun/advtaser{
-	pixel_y = -2
-	},
-/obj/item/gun/energy/gun/advtaser{
-	pixel_y = -2
-	},
-/obj/item/gun/energy/gun/advtaser{
-	pixel_y = -2
-	},
-/obj/item/gun/energy/gun/advtaser{
-	pixel_y = -2
-	},
-/obj/item/gun/energy/gun/advtaser{
-	pixel_y = 7
-	},
-/obj/item/gun/energy/gun/advtaser{
-	pixel_y = 7
-	},
-/obj/item/gun/energy/gun/advtaser{
-	pixel_y = 7
-	},
-/obj/item/gun/energy/gun/advtaser{
-	pixel_y = 7
-	},
-/obj/item/gun/energy/gun/advtaser{
-	pixel_y = 7
-	},
 /obj/structure/rack/gunrack,
 /obj/machinery/recharger/wallcharger{
 	pixel_x = -24;
@@ -2498,6 +2468,36 @@
 	pixel_y = -11
 	},
 /obj/effect/decal/warning_stripes/white,
+/obj/item/gun/energy/gun/advtaser{
+	pixel_x = -6
+	},
+/obj/item/gun/energy/gun/advtaser{
+	pixel_x = -6
+	},
+/obj/item/gun/energy/gun/advtaser{
+	pixel_x = -6
+	},
+/obj/item/gun/energy/gun/advtaser{
+	pixel_x = -6
+	},
+/obj/item/gun/energy/gun/advtaser{
+	pixel_x = -6
+	},
+/obj/item/gun/energy/gun/advtaser{
+	pixel_x = 6
+	},
+/obj/item/gun/energy/gun/advtaser{
+	pixel_x = 6
+	},
+/obj/item/gun/energy/gun/advtaser{
+	pixel_x = 6
+	},
+/obj/item/gun/energy/gun/advtaser{
+	pixel_x = 6
+	},
+/obj/item/gun/energy/gun/advtaser{
+	pixel_x = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -4756,24 +4756,24 @@
 /obj/structure/rack/gunrack,
 /obj/effect/decal/warning_stripes/green/hollow,
 /obj/item/gun/projectile/automatic/m90{
-	pixel_y = -4;
-	name = "\improper DAE 5.56 Compact GL"
+	name = "\improper DAE 5.56 Compact GL";
+	pixel_x = -6
 	},
 /obj/item/gun/projectile/automatic/m90{
-	pixel_y = 8;
-	name = "\improper DAE 5.56 Compact GL"
+	name = "\improper DAE 5.56 Compact GL";
+	pixel_x = -6
 	},
 /obj/item/gun/projectile/automatic/m90{
-	pixel_y = -4;
-	name = "\improper DAE 5.56 Compact GL"
+	name = "\improper DAE 5.56 Compact GL";
+	pixel_x = 6
 	},
 /obj/item/gun/projectile/automatic/m90{
-	pixel_y = 8;
-	name = "\improper DAE 5.56 Compact GL"
+	name = "\improper DAE 5.56 Compact GL";
+	pixel_x = 6
 	},
 /obj/item/gun/projectile/automatic/m90{
-	pixel_y = 8;
-	name = "\improper DAE 5.56 Compact GL"
+	name = "\improper DAE 5.56 Compact GL";
+	pixel_x = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -10466,53 +10466,48 @@
 	},
 /area/syndicate_mothership)
 "eTs" = (
-/obj/item/gun/projectile/automatic/pistol/enforcer{
-	icon_state = "enforcer_black";
-	pixel_x = 2
-	},
-/obj/item/gun/projectile/automatic/pistol/enforcer{
-	icon_state = "enforcer_black";
-	pixel_x = 2
-	},
-/obj/item/gun/projectile/automatic/pistol/enforcer{
-	icon_state = "enforcer_black";
-	pixel_x = 2
-	},
-/obj/item/gun/projectile/automatic/pistol/enforcer{
-	icon_state = "enforcer_black";
-	pixel_x = 2
-	},
-/obj/item/gun/projectile/automatic/pistol/enforcer{
-	icon_state = "enforcer_black";
-	pixel_x = 2
-	},
-/obj/item/gun/projectile/automatic/pistol/enforcer{
-	icon_state = "enforcer_black";
-	pixel_x = -2;
-	pixel_y = 7
-	},
-/obj/item/gun/projectile/automatic/pistol/enforcer{
-	icon_state = "enforcer_black";
-	pixel_x = -2;
-	pixel_y = 7
-	},
-/obj/item/gun/projectile/automatic/pistol/enforcer{
-	icon_state = "enforcer_black";
-	pixel_x = -2;
-	pixel_y = 7
-	},
-/obj/item/gun/projectile/automatic/pistol/enforcer{
-	icon_state = "enforcer_black";
-	pixel_x = -2;
-	pixel_y = 7
-	},
-/obj/item/gun/projectile/automatic/pistol/enforcer{
-	icon_state = "enforcer_black";
-	pixel_x = -2;
-	pixel_y = 7
-	},
 /obj/structure/rack/gunrack,
 /obj/effect/decal/warning_stripes/white,
+/obj/item/gun/projectile/automatic/pistol/enforcer{
+	icon_state = "enforcer_black";
+	pixel_x = -6
+	},
+/obj/item/gun/projectile/automatic/pistol/enforcer{
+	icon_state = "enforcer_black";
+	pixel_x = -6
+	},
+/obj/item/gun/projectile/automatic/pistol/enforcer{
+	icon_state = "enforcer_black";
+	pixel_x = -6
+	},
+/obj/item/gun/projectile/automatic/pistol/enforcer{
+	icon_state = "enforcer_black";
+	pixel_x = -6
+	},
+/obj/item/gun/projectile/automatic/pistol/enforcer{
+	icon_state = "enforcer_black";
+	pixel_x = -6
+	},
+/obj/item/gun/projectile/automatic/pistol/enforcer{
+	icon_state = "enforcer_black";
+	pixel_x = 6
+	},
+/obj/item/gun/projectile/automatic/pistol/enforcer{
+	icon_state = "enforcer_black";
+	pixel_x = 6
+	},
+/obj/item/gun/projectile/automatic/pistol/enforcer{
+	icon_state = "enforcer_black";
+	pixel_x = 6
+	},
+/obj/item/gun/projectile/automatic/pistol/enforcer{
+	icon_state = "enforcer_black";
+	pixel_x = 6
+	},
+/obj/item/gun/projectile/automatic/pistol/enforcer{
+	icon_state = "enforcer_black";
+	pixel_x = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -13022,17 +13017,37 @@
 /area/centcom/jail)
 "gcn" = (
 /obj/structure/rack/gunrack,
-/obj/item/gun/projectile/automatic/sfg,
-/obj/item/gun/projectile/automatic/sfg,
-/obj/item/gun/projectile/automatic/sfg,
-/obj/item/gun/projectile/automatic/sfg,
-/obj/item/gun/projectile/automatic/sfg,
-/obj/item/gun/projectile/automatic/sfg,
-/obj/item/gun/projectile/automatic/sfg,
-/obj/item/gun/projectile/automatic/sfg,
-/obj/item/gun/projectile/automatic/sfg,
-/obj/item/gun/projectile/automatic/sfg,
 /obj/effect/decal/warning_stripes/red/hollow,
+/obj/item/gun/projectile/automatic/sfg{
+	pixel_x = -6
+	},
+/obj/item/gun/projectile/automatic/sfg{
+	pixel_x = -6
+	},
+/obj/item/gun/projectile/automatic/sfg{
+	pixel_x = -6
+	},
+/obj/item/gun/projectile/automatic/sfg{
+	pixel_x = -6
+	},
+/obj/item/gun/projectile/automatic/sfg{
+	pixel_x = -6
+	},
+/obj/item/gun/projectile/automatic/sfg{
+	pixel_x = 6
+	},
+/obj/item/gun/projectile/automatic/sfg{
+	pixel_x = 6
+	},
+/obj/item/gun/projectile/automatic/sfg{
+	pixel_x = 6
+	},
+/obj/item/gun/projectile/automatic/sfg{
+	pixel_x = 6
+	},
+/obj/item/gun/projectile/automatic/sfg{
+	pixel_x = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -21060,6 +21075,36 @@
 /obj/item/ammo_box/magazine/sfg9mm,
 /obj/item/ammo_box/magazine/sfg9mm,
 /obj/effect/decal/warning_stripes/red/hollow,
+/obj/item/ammo_box/magazine/sfg9mm{
+	pixel_x = 8
+	},
+/obj/item/ammo_box/magazine/sfg9mm{
+	pixel_x = 8
+	},
+/obj/item/ammo_box/magazine/sfg9mm{
+	pixel_x = 8
+	},
+/obj/item/ammo_box/magazine/sfg9mm{
+	pixel_x = 8
+	},
+/obj/item/ammo_box/magazine/sfg9mm{
+	pixel_x = 8
+	},
+/obj/item/ammo_box/magazine/sfg9mm{
+	pixel_x = 8
+	},
+/obj/item/ammo_box/magazine/sfg9mm{
+	pixel_x = 8
+	},
+/obj/item/ammo_box/magazine/sfg9mm{
+	pixel_x = 8
+	},
+/obj/item/ammo_box/magazine/sfg9mm{
+	pixel_x = 8
+	},
+/obj/item/ammo_box/magazine/sfg9mm{
+	pixel_x = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -31353,17 +31398,35 @@
 	},
 /area/centcom/specops)
 "ozP" = (
-/obj/item/gun/projectile/automatic/lasercarbine,
-/obj/item/gun/projectile/automatic/lasercarbine,
-/obj/item/gun/projectile/automatic/lasercarbine,
-/obj/item/gun/projectile/automatic/lasercarbine,
-/obj/item/gun/projectile/automatic/lasercarbine,
-/obj/item/gun/projectile/automatic/lasercarbine,
-/obj/item/gun/projectile/automatic/lasercarbine,
-/obj/item/gun/projectile/automatic/lasercarbine,
-/obj/item/gun/projectile/automatic/lasercarbine,
 /obj/structure/rack/gunrack,
 /obj/effect/decal/warning_stripes/blue/hollow,
+/obj/item/gun/projectile/automatic/lasercarbine{
+	pixel_x = -6
+	},
+/obj/item/gun/projectile/automatic/lasercarbine{
+	pixel_x = -6
+	},
+/obj/item/gun/projectile/automatic/lasercarbine{
+	pixel_x = -6
+	},
+/obj/item/gun/projectile/automatic/lasercarbine{
+	pixel_x = -6
+	},
+/obj/item/gun/projectile/automatic/lasercarbine{
+	pixel_x = -6
+	},
+/obj/item/gun/projectile/automatic/lasercarbine{
+	pixel_x = 6
+	},
+/obj/item/gun/projectile/automatic/lasercarbine{
+	pixel_x = 6
+	},
+/obj/item/gun/projectile/automatic/lasercarbine{
+	pixel_x = 6
+	},
+/obj/item/gun/projectile/automatic/lasercarbine{
+	pixel_x = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -31511,23 +31574,26 @@
 	},
 /area/syndicate_mothership)
 "oEt" = (
-/obj/item/gun/energy/gun/pdw9{
-	pixel_x = 4;
-	pixel_y = 8
-	},
-/obj/item/gun/energy/gun/pdw9,
-/obj/item/gun/energy/gun/pdw9{
-	pixel_x = 4;
-	pixel_y = 8
-	},
-/obj/item/gun/energy/gun/pdw9{
-	pixel_x = 4;
-	pixel_y = 8
-	},
-/obj/item/gun/energy/gun/pdw9,
-/obj/item/gun/energy/gun/pdw9,
 /obj/structure/rack/gunrack,
 /obj/effect/decal/warning_stripes/green/hollow,
+/obj/item/gun/energy/gun/pdw9{
+	pixel_x = -6
+	},
+/obj/item/gun/energy/gun/pdw9{
+	pixel_x = -6
+	},
+/obj/item/gun/energy/gun/pdw9{
+	pixel_x = -6
+	},
+/obj/item/gun/energy/gun/pdw9{
+	pixel_x = 6
+	},
+/obj/item/gun/energy/gun/pdw9{
+	pixel_x = 6
+	},
+/obj/item/gun/energy/gun/pdw9{
+	pixel_x = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -33626,26 +33692,26 @@
 /turf/simulated/floor/wood,
 /area/centcom/zone1)
 "pDr" = (
-/obj/item/gun/energy/gun/nuclear{
-	pixel_y = 8
-	},
-/obj/item/gun/energy/gun/nuclear{
-	pixel_y = -2
-	},
-/obj/item/gun/energy/gun/nuclear{
-	pixel_y = -2
-	},
-/obj/item/gun/energy/gun/nuclear{
-	pixel_y = 8
-	},
 /obj/structure/rack/gunrack,
-/obj/item/gun/energy/gun/nuclear{
-	pixel_y = -2
-	},
-/obj/item/gun/energy/gun/nuclear{
-	pixel_y = 8
-	},
 /obj/effect/decal/warning_stripes/red/hollow,
+/obj/item/gun/energy/gun/nuclear{
+	pixel_x = -6
+	},
+/obj/item/gun/energy/gun/nuclear{
+	pixel_x = -6
+	},
+/obj/item/gun/energy/gun/nuclear{
+	pixel_x = -6
+	},
+/obj/item/gun/energy/gun/nuclear{
+	pixel_x = 6
+	},
+/obj/item/gun/energy/gun/nuclear{
+	pixel_x = 6
+	},
+/obj/item/gun/energy/gun/nuclear{
+	pixel_x = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -39716,12 +39782,10 @@
 /area/centcom/supply)
 "sqO" = (
 /obj/item/gun/energy/sniperrifle{
-	pixel_x = 3;
-	pixel_y = 8
+	pixel_x = -6
 	},
 /obj/item/gun/energy/sniperrifle{
-	pixel_x = 3;
-	pixel_y = -3
+	pixel_x = 6
 	},
 /obj/structure/rack/gunrack,
 /obj/effect/decal/warning_stripes/red/hollow,
@@ -39912,13 +39976,23 @@
 /turf/simulated/floor/carpet/arcade,
 /area/centcom/zone1)
 "svw" = (
-/obj/item/gun/projectile/automatic/ar,
-/obj/item/gun/projectile/automatic/ar,
-/obj/item/gun/projectile/automatic/ar,
-/obj/item/gun/projectile/automatic/ar,
-/obj/item/gun/projectile/automatic/ar,
 /obj/structure/rack/gunrack,
 /obj/effect/decal/warning_stripes/red/hollow,
+/obj/item/gun/projectile/automatic/ar{
+	pixel_x = -6
+	},
+/obj/item/gun/projectile/automatic/ar{
+	pixel_x = -6
+	},
+/obj/item/gun/projectile/automatic/ar{
+	pixel_x = -6
+	},
+/obj/item/gun/projectile/automatic/ar{
+	pixel_x = 6
+	},
+/obj/item/gun/projectile/automatic/ar{
+	pixel_x = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -50598,32 +50672,26 @@
 	},
 /area/syndicate_mothership)
 "xjB" = (
-/obj/item/gun/projectile/shotgun/automatic/combat{
-	pixel_x = 3;
-	pixel_y = 8
-	},
-/obj/item/gun/projectile/shotgun/automatic/combat{
-	pixel_x = 3;
-	pixel_y = -2
-	},
-/obj/item/gun/projectile/shotgun/automatic/combat{
-	pixel_x = 3;
-	pixel_y = 8
-	},
-/obj/item/gun/projectile/shotgun/automatic/combat{
-	pixel_x = 3;
-	pixel_y = 8
-	},
-/obj/item/gun/projectile/shotgun/automatic/combat{
-	pixel_x = 3;
-	pixel_y = -2
-	},
-/obj/item/gun/projectile/shotgun/automatic/combat{
-	pixel_x = 3;
-	pixel_y = -2
-	},
 /obj/structure/rack/gunrack,
 /obj/effect/decal/warning_stripes/blue/hollow,
+/obj/item/gun/projectile/shotgun/automatic/combat{
+	pixel_x = -6
+	},
+/obj/item/gun/projectile/shotgun/automatic/combat{
+	pixel_x = -6
+	},
+/obj/item/gun/projectile/shotgun/automatic/combat{
+	pixel_x = -6
+	},
+/obj/item/gun/projectile/shotgun/automatic/combat{
+	pixel_x = 6
+	},
+/obj/item/gun/projectile/shotgun/automatic/combat{
+	pixel_x = 6
+	},
+/obj/item/gun/projectile/shotgun/automatic/combat{
+	pixel_x = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},

--- a/_maps/map_files/generic/CentComm.dmm
+++ b/_maps/map_files/generic/CentComm.dmm
@@ -4637,9 +4637,8 @@
 "cgX" = (
 /obj/machinery/door/poddoor/shutters/invincible{
 	dir = 2;
-	id_tag = "CC_Armory_shotgun"
+	id_tag = "CC_Armory_DAE"
 	},
-/obj/effect/decal/warning_stripes/red,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -4756,19 +4755,25 @@
 "cjN" = (
 /obj/structure/rack/gunrack,
 /obj/effect/decal/warning_stripes/green/hollow,
-/obj/item/gun/projectile/automatic/m90,
-/obj/item/gun/projectile/automatic/m90,
 /obj/item/gun/projectile/automatic/m90{
-	pixel_x = -3;
-	pixel_y = 3
+	pixel_y = -4;
+	name = "\improper DAE 5.56 Compact GL"
 	},
 /obj/item/gun/projectile/automatic/m90{
-	pixel_x = -3;
-	pixel_y = 3
+	pixel_y = 8;
+	name = "\improper DAE 5.56 Compact GL"
 	},
 /obj/item/gun/projectile/automatic/m90{
-	pixel_x = -3;
-	pixel_y = 3
+	pixel_y = -4;
+	name = "\improper DAE 5.56 Compact GL"
+	},
+/obj/item/gun/projectile/automatic/m90{
+	pixel_y = 8;
+	name = "\improper DAE 5.56 Compact GL"
+	},
+/obj/item/gun/projectile/automatic/m90{
+	pixel_y = 8;
+	name = "\improper DAE 5.56 Compact GL"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -10573,10 +10578,6 @@
 	icon_state = "dark"
 	},
 /area/centcom/evac)
-"eWz" = (
-/obj/structure/lattice,
-/turf/space,
-/area/centcom/specops)
 "eWA" = (
 /turf/space{
 	icon_state = "black"
@@ -11883,8 +11884,8 @@
 /area/centcom/zone3)
 "fBu" = (
 /obj/machinery/door_control/secure{
-	id = "CC_Armory_shotgun";
-	name = "Shotguns";
+	id = "CC_Armory_DAE";
+	name = "DAE";
 	pixel_x = -24;
 	pixel_y = 24;
 	req_access = list(114)
@@ -16144,16 +16145,6 @@
 	icon_state = "grimy"
 	},
 /area/syndicate_mothership)
-"hDk" = (
-/obj/effect/decal/warning_stripes/red,
-/obj/machinery/door/poddoor/shutters/invincible{
-	dir = 2;
-	id_tag = "CC_Armory_shotgun"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/centcom/specops)
 "hDO" = (
 /obj/structure/toilet,
 /turf/simulated/floor/plasteel{
@@ -20444,7 +20435,6 @@
 	dir = 2;
 	id_tag = "CC_Armory_NG"
 	},
-/obj/effect/decal/warning_stripes/red,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -39323,7 +39313,6 @@
 	},
 /area/syndicate_mothership/cargo)
 "seQ" = (
-/obj/effect/decal/warning_stripes/red,
 /obj/machinery/door/poddoor/shutters/invincible{
 	dir = 2;
 	id_tag = "CC_Armory_PDW"
@@ -43369,16 +43358,18 @@
 "tYP" = (
 /obj/structure/rack,
 /obj/effect/decal/warning_stripes/green/hollow,
-/obj/item/ammo_box/magazine/m556,
-/obj/item/ammo_box/magazine/m556,
-/obj/item/ammo_box/magazine/m556,
-/obj/item/ammo_box/magazine/m556,
-/obj/item/ammo_box/magazine/m556,
-/obj/item/ammo_box/magazine/m556,
-/obj/item/ammo_box/magazine/m556,
-/obj/item/ammo_box/magazine/m556,
 /obj/item/ammo_box/a40mm,
 /obj/item/ammo_box/a40mm,
+/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/m556,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -98785,7 +98776,7 @@ nAN
 nAN
 nAN
 nAN
-fID
+mVX
 mVX
 mVX
 mVX
@@ -106227,7 +106218,7 @@ cAo
 iGP
 nAN
 cjN
-hDk
+cgX
 rTJ
 hBW
 lYK
@@ -109810,8 +109801,8 @@ tgn
 nFb
 uSN
 uSN
-eWz
-eWz
+jMD
+jMD
 nAN
 eHW
 eHW
@@ -110066,10 +110057,10 @@ nAN
 uSN
 uSN
 uSN
-eWz
+jMD
 mVX
 mVX
-eWz
+jMD
 eHW
 eHW
 eHW

--- a/_maps/map_files/generic/CentComm.dmm
+++ b/_maps/map_files/generic/CentComm.dmm
@@ -4754,26 +4754,13 @@
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/syndicate_mothership/control)
 "cjN" = (
-/obj/item/gun/projectile/shotgun/riot{
-	pixel_x = 3;
-	pixel_y = 8
-	},
-/obj/item/gun/projectile/shotgun/riot{
-	pixel_x = 3;
-	pixel_y = 8
-	},
-/obj/item/gun/projectile/shotgun/riot/short,
-/obj/item/gun/projectile/shotgun/riot/short,
-/obj/item/gun/projectile/shotgun/riot{
-	pixel_x = 3;
-	pixel_y = 8
-	},
-/obj/item/gun/projectile/shotgun/riot{
-	pixel_x = 3;
-	pixel_y = 8
-	},
 /obj/structure/rack/gunrack,
 /obj/effect/decal/warning_stripes/green/hollow,
+/obj/item/gun/projectile/automatic/m90,
+/obj/item/gun/projectile/automatic/m90,
+/obj/item/gun/projectile/automatic/m90,
+/obj/item/gun/projectile/automatic/m90,
+/obj/item/gun/projectile/automatic/m90,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -43372,10 +43359,17 @@
 /area/centcom/specops)
 "tYP" = (
 /obj/structure/rack,
-/obj/item/ammo_box/shotgun/rubbershot,
-/obj/item/ammo_box/shotgun/rubbershot,
-/obj/item/ammo_box/shotgun/rubbershot,
 /obj/effect/decal/warning_stripes/green/hollow,
+/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/a40mm,
+/obj/item/ammo_box/a40mm,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},

--- a/_maps/map_files/generic/CentComm.dmm
+++ b/_maps/map_files/generic/CentComm.dmm
@@ -4758,9 +4758,18 @@
 /obj/effect/decal/warning_stripes/green/hollow,
 /obj/item/gun/projectile/automatic/m90,
 /obj/item/gun/projectile/automatic/m90,
-/obj/item/gun/projectile/automatic/m90,
-/obj/item/gun/projectile/automatic/m90,
-/obj/item/gun/projectile/automatic/m90,
+/obj/item/gun/projectile/automatic/m90{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/projectile/automatic/m90{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/projectile/automatic/m90{
+	pixel_x = -3;
+	pixel_y = 3
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Меняет служебные дробовики на М90 в оружейной ЕРТ
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
https://discord.com/channels/617003227182792704/1269912125606723594/1271068409404063866
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
![image](https://github.com/user-attachments/assets/5a6d2151-3eb7-4700-b37d-37a779b58911)

## Тесты
Все работает.
<!-- Как вы тестировали свой код. Ревьюеру будет проще, если он будет знать какие действия вы совершали, проверяя свой ПР. -->
