### PR TITLE
bugfix: selling one item multiple times

### DIFF
--- a/code/game/machinery/customat.dm
+++ b/code/game/machinery/customat.dm
@@ -408,12 +408,17 @@
 			return
 
 		cost = input_cost
-	if(user && get_dist(get_turf(user), get_turf(src)) > 1)
-		to_chat(user, span_warning("Вы слишком далеко!"))
-		inserting = FALSE
+	if(!user)
 		return
 
-	inserting = FALSE
+	if(!Adjacent(user))
+		to_chat(user, span_warning("Вы слишком далеко!"))
+		return
+
+	if(!user.is_in_hands(I))
+		to_chat(user, span_warning("Нечего положить внутрь!"))
+		return
+
 	insert(user, I, cost)
 
 /obj/machinery/customat/attackby(obj/item/I, mob/user, params)

--- a/code/game/machinery/customat.dm
+++ b/code/game/machinery/customat.dm
@@ -413,8 +413,8 @@
 		inserting = FALSE
 		return
 
-	insert(user, I, cost)
 	inserting = FALSE
+	insert(user, I, cost)
 
 /obj/machinery/customat/attackby(obj/item/I, mob/user, params)
 	if(user.a_intent == INTENT_HARM && COOLDOWN_FINISHED(src, emp_cooldown) && COOLDOWN_FINISHED(src, alarm_cooldown))

--- a/code/game/machinery/customat.dm
+++ b/code/game/machinery/customat.dm
@@ -155,8 +155,6 @@
 	/// Direct ref to the trunk pipe underneath us
 	var/obj/structure/disposalpipe/trunk/trunk
 
-	/// If true, there is somebody who is inserting sth right now.
-	var/inserting = FALSE
 
 /obj/machinery/customat/proc/set_up_components()
 	component_parts = list()
@@ -389,10 +387,6 @@
 	inserted_items_count++
 
 /obj/machinery/customat/proc/try_insert(mob/user, obj/item/I, from_tube = FALSE)
-	if(inserting)
-		return
-
-	inserting = TRUE
 	var/cost = 100
 	if(from_tube)
 		if(I.name in remembered_costs)
@@ -404,10 +398,10 @@
 		var/input_cost = tgui_input_number(user, "Пожалуйста, выберите цену для этого товара. Цена не может быть ниже 0 и выше 1000000 кредитов.", "Выбор цены", 0, 1000000, 0)
 		if(!input_cost)
 			to_chat(user, span_warning("Цена не указанна!"))
-			inserting = FALSE
 			return
 
 		cost = input_cost
+
 	if(!user)
 		return
 

--- a/code/game/machinery/customat.dm
+++ b/code/game/machinery/customat.dm
@@ -402,7 +402,7 @@
 
 		cost = input_cost
 
-	if(!user)
+	if(!user || user.stat)
 		return
 
 	if(!Adjacent(user))

--- a/code/game/machinery/customat.dm
+++ b/code/game/machinery/customat.dm
@@ -155,6 +155,9 @@
 	/// Direct ref to the trunk pipe underneath us
 	var/obj/structure/disposalpipe/trunk/trunk
 
+	/// If true, there is somebody who is inserting sth right now.
+	var/inserting = FALSE
+
 /obj/machinery/customat/proc/set_up_components()
 	component_parts = list()
 	var/obj/item/circuitboard/vendor/V = new
@@ -386,6 +389,10 @@
 	inserted_items_count++
 
 /obj/machinery/customat/proc/try_insert(mob/user, obj/item/I, from_tube = FALSE)
+	if(inserting)
+		return
+
+	inserting = TRUE
 	var/cost = 100
 	if(from_tube)
 		if(I.name in remembered_costs)
@@ -397,14 +404,17 @@
 		var/input_cost = tgui_input_number(user, "Пожалуйста, выберите цену для этого товара. Цена не может быть ниже 0 и выше 1000000 кредитов.", "Выбор цены", 0, 1000000, 0)
 		if(!input_cost)
 			to_chat(user, span_warning("Цена не указанна!"))
+			inserting = FALSE
 			return
 
 		cost = input_cost
 	if(user && get_dist(get_turf(user), get_turf(src)) > 1)
 		to_chat(user, span_warning("Вы слишком далеко!"))
+		inserting = FALSE
 		return
 
 	insert(user, I, cost)
+	inserting = FALSE
 
 /obj/machinery/customat/attackby(obj/item/I, mob/user, params)
 	if(user.a_intent == INTENT_HARM && COOLDOWN_FINISHED(src, emp_cooldown) && COOLDOWN_FINISHED(src, alarm_cooldown))


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Если тыкнуть итемом по кастомату несколько раз, можно было засунуть несколько раз один и тот же итем. При каждой покупке этот итем будет тепаться к новому покупателю.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР
Эпик в лс написал
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Попробовал запихать предмет несколько раз. Не получилось.
<!-- Как вы тестировали свой код. Ревьюеру будет проще, если он будет знать какие действия вы совершали, проверяя свой ПР. -->
