### PR TITLE
bugfix: Hardmode grenades do not work on enemies with less than 80% HP

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
@@ -172,6 +172,9 @@ Difficulty: Very Hard
 
 /mob/living/simple_animal/hostile/megafauna/ancient_robot/enrage()
 	. = ..()
+	if(!.)
+		return
+
 	armour_penetration = 66
 	TL.armour_penetration = 66
 	TR.armour_penetration = 66

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -288,6 +288,9 @@ Difficulty: Medium
 
 /mob/living/simple_animal/hostile/megafauna/blood_drunk_miner/enrage()
 	. = ..()
+	if(!.)
+		return
+
 	miner_saw = new /obj/item/melee/energy/cleaving_saw(src) //Real saw for real men.
 	dash_cooldown_to_use = 0.5 SECONDS //Becomes a teleporting shit.
 	ranged_cooldown_time = 5 //They got some cooldown mods.

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -125,6 +125,9 @@ Difficulty: Hard
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/enrage()
 	. = ..()
+	if(!.)
+		return
+
 	maxHealth = 2000 //Less health, as a phase 2
 	health = 2000
 	rapid_melee = 12 //Don't stand still

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -108,6 +108,9 @@ Difficulty: Very Hard
 
 /mob/living/simple_animal/hostile/megafauna/colossus/enrage()
 	. = ..()
+	if(!.)
+		return
+
 	move_to_delay = 5
 
 /mob/living/simple_animal/hostile/megafauna/colossus/unrage()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -123,6 +123,9 @@ Difficulty: Hard
 
 /mob/living/simple_animal/hostile/megafauna/hierophant/enrage()
 	. = ..()
+	if(!.)
+		return
+
 	move_to_delay = 5
 
 /mob/living/simple_animal/hostile/megafauna/hierophant/unrage()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -222,6 +222,7 @@
 		return FALSE
 
 	enraged = TRUE
+	return TRUE
 
 /mob/living/simple_animal/hostile/megafauna/proc/unrage()
 	enraged = FALSE

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -219,7 +219,8 @@
 /// This proc is called by the HRD-MDE grenade to enrage the megafauna. This should increase the megafaunas attack speed if possible, give it new moves, or disable weak moves. This should be reverseable, and reverses on zlvl change.
 /mob/living/simple_animal/hostile/megafauna/proc/enrage()
 	if(enraged || ((health / maxHealth) * 100 <= 80))
-		return
+		return FALSE
+
 	enraged = TRUE
 
 /mob/living/simple_animal/hostile/megafauna/proc/unrage()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание

<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Исправление ошибки с неработающей хардмод гранатой на поврежденных врагов.
## Ссылка на предложение/Причина создания ПР

<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Репорт https://discord.com/channels/617003227182792704/1299685204667011072/1299685204667011072
