### PR TITLE
bugfix: Fixes ash storm damaging in some lavaland ruins

### DIFF
--- a/code/game/area/areas/ruins/lavaland.dm
+++ b/code/game/area/areas/ruins/lavaland.dm
@@ -101,6 +101,7 @@
 
 // This area exists so that lavaland ruins dont overwrite the baseturfs on regular space ruins
 /area/ruin/unpowered/misc_lavaruin
+	outdoors = FALSE
 
 //'safe' caves
 /area/ruin/unpowered/safe_cave


### PR DESCRIPTION
## Описание
Исправление ошибки, при которых в некоторых руинах лаваленда игрок получал ожоги во время пепельного шторма.
## Ссылка на предложение/Причина создания ПР
Репорт: https://discord.com/channels/617003227182792704/1299423072817774713/1299423072817774713

