### PR TITLE
tweak: Correct calculation of acids protection

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -611,8 +611,8 @@
 						protection = L.get_permeability_protection()
 					if(protection && show_message)
 						to_chat(L, span_alert("Your clothes protects you from the reaction."))
-
-				R.reaction_mob(A, method, R.volume * volume_modifier * (1 - protection), show_message)
+				var/reacting_volume = R.volume * volume_modifier * clamp(1 - protection + R.clothing_penetration, 0, 1)
+				R.reaction_mob(A, method, reacting_volume, show_message)
 
 			if("TURF")
 				R.reaction_turf(A, R.volume * volume_modifier, R.color)

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -13,6 +13,8 @@
 	var/heart_rate_decrease = 0
 	var/heart_rate_stop = 0
 	var/penetrates_skin = FALSE //Whether or not a reagent penetrates the skin
+	/// Shows how the reagent penetrates the protection from clothing in TOUCH reactions. Should be [0-1]. 0 by default, 1 - full penetration.
+	var/clothing_penetration = 0
 	//Processing flags, defines the type of mobs the reagent will affect
 	//By default, all reagents will ONLY affect organics, not synthetics. Re-define in the reagent's definition if the reagent is meant to affect synths
 	var/process_flags = ORGANIC

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -353,6 +353,8 @@
 	color = "#00FF32"
 	process_flags = ORGANIC | SYNTHETIC
 	taste_description = "<span class='userdanger'>ACID</span>"
+	//acid is not using permeability_coefficient to calculate protection, but armour["acid"]
+	clothing_penetration = 1
 	var/acidpwr = 10 //the amount of protection removed from the armour
 
 /datum/reagent/acid/on_mob_life(mob/living/M)
@@ -364,30 +366,34 @@
 	if(ishuman(M) && !isgrey(M))
 		var/mob/living/carbon/human/H = M
 		if(method == REAGENT_TOUCH)
-			if(volume > 25)
-				if(H.wear_mask)
-					to_chat(H, "<span class='danger'>Your [H.wear_mask] protects you from the acid!</span>")
-					return
+			to_chat(H, span_warning("The greenish acidic substance stings[volume < 1 ? " you, but isn't concentrated enough to harm you" : null]!"))
+			if(volume < 1)
+				return
 
-				if(H.head)
-					to_chat(H, "<span class='danger'>Your [H.wear_mask] protects you from the acid!</span>")
-					return
+			var/damage_coef = 0
+			var/should_scream = TRUE
+			for(var/obj/item/organ/external/bodypart as anything in H.bodyparts)
+				if(istype(bodypart, /obj/item/organ/external/head) && !H.wear_mask && !H.head && volume > 25)
+					bodypart.disfigure()
+					if(H.has_pain() && should_scream)
+						H.emote("scream")
+						should_scream = FALSE
 
-				if(prob(75))
-					H.take_organ_damage(5, 10)
+				damage_coef = (100 - clamp(H.getarmor_organ(bodypart, "acid"), 0, 100))/100
+				if(damage_coef > 0 && should_scream)
+					should_scream = FALSE
+					if(H.has_pain())
+						H.emote("scream")
+				H.apply_damage(clamp(volume - 1, 2, 20) * damage_coef / length(H.bodyparts), BURN, def_zone = bodypart)
+				H.apply_damage(clamp((volume - 1)/2, 1, 10) * damage_coef / length(H.bodyparts), BRUTE, def_zone = bodypart)
+			return
+
+		if(method == REAGENT_INGEST)
+			to_chat(H, span_warning("The greenish acidic substance stings[volume < 1 ? " you, but isn't concentrated enough to harm you" : null]!"))
+			if(volume >= 1)
+				H.adjustFireLoss(clamp((volume - 1) * 2, 0, 30))
+				if(H.has_pain())
 					H.emote("scream")
-					var/obj/item/organ/external/affecting = H.get_organ(BODY_ZONE_HEAD)
-					if(affecting)
-						affecting.disfigure()
-				else
-					H.take_organ_damage(5, 10)
-			else
-				H.take_organ_damage(5, 10)
-		else
-			to_chat(H, "<span class='warning'>The greenish acidic substance stings[volume < 10 ? " you, but isn't concentrated enough to harm you" : null]!</span>")
-			if(volume >= 10)
-				H.adjustFireLoss(min(max(4, (volume - 10) * 2), 20))
-				H.emote("scream")
 
 /datum/reagent/acid/reaction_obj(obj/O, volume)
 	if(ismob(O.loc)) //handled in human acid_act()
@@ -407,6 +413,8 @@
 	description = "Fluorosulfuric acid is a an extremely corrosive super-acid."
 	color = "#5050FF"
 	acidpwr = 42
+	//acid is not using permeability_coefficient to calculate protection, but armour["acid"]
+	clothing_penetration = 1
 
 /datum/reagent/acid/facid/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -419,11 +427,11 @@
 		if(method == REAGENT_TOUCH)
 			if(volume >= 5)
 				var/damage_coef = 0
-				var/isDamaged = FALSE
+				var/should_scream = TRUE
 				for(var/obj/item/organ/external/bodypart as anything in H.bodyparts)
 					damage_coef = (100 - clamp(H.getarmor_organ(bodypart, "acid"), 0, 100))/100
-					if(damage_coef > 0 && !isDamaged)
-						isDamaged = TRUE
+					if(damage_coef > 0 && should_scream)
+						should_scream = FALSE
 						if(H.has_pain())
 							H.emote("scream")
 					H.apply_damage(clamp((volume - 5) * 3, 8, 75) * damage_coef / length(H.bodyparts), BURN, def_zone = bodypart)
@@ -440,7 +448,8 @@
 				return
 		else
 			if(volume >= 5)
-				H.emote("scream")
+				if(H.has_pain())
+					H.emote("scream")
 				H.adjustFireLoss(clamp((volume - 5) * 3, 8, 75));
 		to_chat(H, "<span class='warning'>The blueish acidic substance stings[volume < 5 ? " you, but isn't concentrated enough to harm you" : null]!</span>")
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Серная и фторсерная кислоты теперь игнорят пермабилити коэфициент при реакции. Серной добавлен учёт брони от кислоты, как и у фторсерной. Серной теперь дамажит полностью всё тело, каждую конечность с учётом её брони. Убран фиксированный урон для любого объёма, вместо него формула, зависящая от объёма.
Исправлен баг, что большие объёмы кислоты почему то могли полностью задефаться маской, в отличие от маленьких.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Тесты
Обился кислотой, почекал в дебагере, что всё чики пуки
<!-- Как вы тестировали свой код. Ревьюеру будет проще, если он будет знать какие действия вы совершали, проверяя свой ПР. -->
