### PR TITLE
server: 'Has Approve' Label Manager

### DIFF
--- a/.github/workflows/approve label manager.yml
+++ b/.github/workflows/approve label manager.yml
@@ -1,0 +1,41 @@
+name: Approve Label Manager
+
+on:
+  pull_request:
+    types: [submitted, dismissed]
+
+env:
+  APPROVE_LABEL: 'Has Approve'
+
+jobs:
+  manage-approve-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for ${{ env.APPROVE_LABEL }} label
+        id: check_approve_label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            return context.payload.pull_request.labels?
+            .some(label => label.name === process.env.APPROVE_LABEL);
+
+      - name: Add label
+        uses: jburgess/AddRemovePrLabels@v1.0.4
+        if: |
+          github.event.action === 'submitted' &&
+          github.event.review.state === 'approved' &&
+          !steps.check_approve_label.outputs.result
+        with:
+          githubToken: '${{ secrets.GITHUB_TOKEN }}'
+          labelsToAdd: ${{ env.APPROVE_LABEL }}
+
+      - name: Remove label
+        uses: jburgess/AddRemovePrLabels@v1.0.4
+        if: |
+          (github.event.action === 'dismissed' || 
+          (github.event.action === 'submitted' && 
+          github.event.review.state !== 'approved')) && 
+          steps.check_approve_label.outputs.result
+        with:
+          githubToken: '${{ secrets.GITHUB_TOKEN }}'
+          labelsToRemove: ${{ env.APPROVE_LABEL }}

--- a/.github/workflows/approve_label_manager.yml
+++ b/.github/workflows/approve_label_manager.yml
@@ -1,7 +1,7 @@
 name: Approve Label Manager
 
 on:
-  pull_request:
+  pull_request_review:
     types: [submitted, dismissed]
 
 env:
@@ -16,26 +16,25 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            return context.payload.pull_request.labels?
-            .some(label => label.name === process.env.APPROVE_LABEL);
+            return context.payload.pull_request.labels?.some(label => label.name == '${{ env.APPROVE_LABEL }}');
 
       - name: Add label
         uses: jburgess/AddRemovePrLabels@v1.0.4
         if: |
-          github.event.action === 'submitted' &&
-          github.event.review.state === 'approved' &&
-          !steps.check_approve_label.outputs.result
+          (github.event.action == 'submitted' &&
+          github.event.review.state == 'approved') &&
+          steps.check_approve_label.outputs.result == 'false'
         with:
           githubToken: '${{ secrets.GITHUB_TOKEN }}'
-          labelsToAdd: ${{ env.APPROVE_LABEL }}
+          labelsToAdd: '${{ env.APPROVE_LABEL }}'
 
       - name: Remove label
         uses: jburgess/AddRemovePrLabels@v1.0.4
         if: |
-          (github.event.action === 'dismissed' || 
-          (github.event.action === 'submitted' && 
-          github.event.review.state !== 'approved')) && 
-          steps.check_approve_label.outputs.result
+          github.event.action == 'dismissed' || 
+          (github.event.action == 'submitted' && 
+          github.event.review.state != 'approved') && 
+          steps.check_approve_label.outputs.result == 'true'
         with:
           githubToken: '${{ secrets.GITHUB_TOKEN }}'
-          labelsToRemove: ${{ env.APPROVE_LABEL }}
+          labelsToRemove: '${{ env.APPROVE_LABEL }}'


### PR DESCRIPTION
## Описание
На PR теперь вешается плашка Has Approve, если ревью было сабмитнуто и аппрувнуто, если плашки на пре нет.
Плашка убирается, если ревью дисмисается
Фича: Также если ревьювер случайно апрувнул, а потом запросил изменения - плашка также сбросится.

Также у меня есть 2 версия - с улучшенной логикой в remove плашки, где она  еще получает данные о защите бранча и необходимое количество ревью и убирает плашку Has Approve, если условия апрувов для мержа пра удовлетворено - если такое нужно будет, то обновлю файл catsmile

## Ссылка на предложение/Причина создания ПР
автоматизация

## Тесты
Тестировал логику, по логике все работает нормально, но была проблема - не добавлялся/убирался лабель возможно из-за ошибки прав ( Error removing label Has Approve: Resource not accessible by integration), но библиотеку я использую такую же, как в тестмерж лабелере - а он у нас работает.
