### PR TITLE
bugfix: Experimentor now uses initial technology of item for duping

### DIFF
--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -163,7 +163,7 @@
 		return ATTACK_CHAIN_PROCEED
 
 	if(clone_next)
-		var/list/temp_tech = ConvertReqString2List(I.origin_tech)
+		var/list/temp_tech = ConvertReqString2List(initial(I.origin_tech))
 		var/techs_sum = 0
 		for(var/T in temp_tech)
 			techs_sum += temp_tech[T]


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание

<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Экспериментор теперь смотрит на изначальные технологии предмета для дюпа.

