### PR TITLE
bugfix: Fixed phazon noclip on teleport forbidden areas

### DIFF
--- a/code/game/mecha/combat/phazon.dm
+++ b/code/game/mecha/combat/phazon.dm
@@ -37,6 +37,23 @@
 	ME = new /obj/item/mecha_parts/mecha_equipment/gravcatapult
 	ME.attach(src)
 
+
+/obj/mecha/combat/phazon/on_changed_z_level(turf/old_turf, turf/new_turf, same_z_layer, notify_contents)
+	. = ..()
+
+	if(!phasing || is_teleport_allowed(new_turf.z))
+		return
+
+	phasing = FALSE
+	occupant_message("<font color='#f00'>Phasing is malfunctioning.</font>")
+
+	if(!phasing_action.owner)
+		return
+
+	phasing_action.button_icon_state = "mech_phasing_off"
+	phasing_action.UpdateButtonIcon()
+
+
 /obj/mecha/combat/phazon/get_commands()
 	var/output = {"<div class='wr'>
 						<div class='header'>Special</div>

--- a/code/game/mecha/combat/phazon.dm
+++ b/code/game/mecha/combat/phazon.dm
@@ -37,23 +37,6 @@
 	ME = new /obj/item/mecha_parts/mecha_equipment/gravcatapult
 	ME.attach(src)
 
-
-/obj/mecha/combat/phazon/on_changed_z_level(turf/old_turf, turf/new_turf, same_z_layer, notify_contents)
-	. = ..()
-
-	if(!phasing || is_teleport_allowed(new_turf.z))
-		return
-
-	phasing = FALSE
-	occupant_message("<font color='#f00'>Phasing is malfunctioning.</font>")
-
-	if(!phasing_action.owner)
-		return
-
-	phasing_action.button_icon_state = "mech_phasing_off"
-	phasing_action.UpdateButtonIcon()
-
-
 /obj/mecha/combat/phazon/get_commands()
 	var/output = {"<div class='wr'>
 						<div class='header'>Special</div>

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1745,4 +1745,20 @@
 	icon_state = occupant ? init_icon_state : "[init_icon_state]-open"
 
 
+/obj/mecha/on_changed_z_level(turf/old_turf, turf/new_turf, same_z_layer, notify_contents)
+	. = ..()
+
+	if(!phasing || is_teleport_allowed(new_turf.z))
+		return
+
+	phasing = FALSE
+	occupant_message("<font color='#f00'>Phasing is malfunctioning.</font>")
+
+	if(!phasing_action.owner)
+		return
+
+	phasing_action.button_icon_state = "mech_phasing_off"
+	phasing_action.UpdateButtonIcon()
+
+
 #undef OCCUPANT_LOGGING

--- a/code/game/mecha/mecha_actions.dm
+++ b/code/game/mecha/mecha_actions.dm
@@ -210,7 +210,7 @@
 	button_icon_state = "mech_phasing_off"
 
 /datum/action/innate/mecha/mech_toggle_phasing/Activate()
-	if(!owner || !chassis || chassis.occupant != owner)
+	if(!owner || !chassis || chassis.occupant != owner || !is_teleport_allowed(chassis.z))
 		return
 	chassis.phasing = !chassis.phasing
 	button_icon_state = "mech_phasing_[chassis.phasing ? "on" : "off"]"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
У фазона (или меха, которому щитспавном дали фазирование) отрубается беганье между стенками, если он попадает на уровень с запрещённой телепортацией (а-ля нарушающее работу БС устройств место).
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР
Жалобы и не жалобы на фазонов там, где их быть не должно, по типу за-индестрактибле-стеновье гейтов.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Да. Полетал на гамме.
<!-- Как вы тестировали свой код. Ревьюеру будет проще, если он будет знать какие действия вы совершали, проверяя свой ПР. -->
