### PR TITLE
add: Titlescreen optimization for dreamseeker debug mode

### DIFF
--- a/code/controllers/configuration/entries/testing.dm
+++ b/code/controllers/configuration/entries/testing.dm
@@ -4,3 +4,6 @@
 
 ///Enables bombarda crafting on server.
 /datum/config_entry/flag/enable_bombarda_craft
+
+///Enables loading titlescreen only after master has been loaded.
+/datum/config_entry/flag/enable_titlescreen_lateload

--- a/code/controllers/subsystem/non-firing/titlescreen.dm
+++ b/code/controllers/subsystem/non-firing/titlescreen.dm
@@ -18,8 +18,13 @@ SUBSYSTEM_DEF(title)
 	import_html()
 	fill_title_images_pool()
 	current_title_screen = new(title_html = base_html, screen_image_file = pick_title_image())
-	show_title_screen_to_all_new_players()
+	if(!CONFIG_GET(flag/enable_titlescreen_lateload))
+		show_title_screen_to_all_new_players()
 	return SS_INIT_SUCCESS
+
+/datum/controller/subsystem/title/OnMasterLoad()
+	if(CONFIG_GET(flag/enable_titlescreen_lateload))
+		show_title_screen_to_all_new_players()
 
 /datum/controller/subsystem/title/Recover()
 	current_title_screen = SStitle.current_title_screen

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -473,12 +473,6 @@ PLAYER_REROUTE_CAP 0
 ## Server to reroute to
 #TUTORIAL_SERVER_URL byond://example.org:1111
 
-## Minimum number of space ruins levels to generate
-EXTRA_SPACE_RUIN_LEVELS_MIN 4
-
-## Maximum number of space ruins levels to generate
-EXTRA_SPACE_RUIN_LEVELS_MAX 8
-
 ## Uncomment to disable the OOC/LOOC channel by default.
 #DISABLE_OOC
 
@@ -642,7 +636,6 @@ TOPIC_FILTERING_WHITELIST 127.0.0.1
 # Number of players required for automatic gamemode change to extended. Doesn't work if set to zero or commented
 #AUTO_EXTENDED_PLAYERS_NUM 10
 
-
 ## CPU Affinity for FFmpeg. Check out taskset man page.
 ## Example valid values: "0-3" or "1,4-7"
 #FFMPEG_CPUAFFINITY 0-3
@@ -659,12 +652,6 @@ MAP_ROTATE none
 ## nodoubles - current map can't be selected as next
 ## notriples - current map can't be selected as next if played twice in a row
 MAP_VOTE_MODE all
-
-## Default server map
-DEFAULT_MAP /datum/map/cyberiad
-
-## Override server map by specified, uncomment to apply
-# OVERRIDE_MAP /datum/map/delta
 
 ## Enable animations on item pickup and drop down
 # ITEM_ANIMATIONS_ENABLED
@@ -739,5 +726,17 @@ CACHE_ASSETS 0
 
 ## Disable the loading of space ruins
 #DISABLE_SPACE_RUINS
+
+## Default server map
+DEFAULT_MAP /datum/map/cyberiad
+
+## Override server map by specified, uncomment to apply
+# OVERRIDE_MAP /datum/map/delta
+
+## Minimum number of space ruins levels to generate
+EXTRA_SPACE_RUIN_LEVELS_MIN 4
+
+## Maximum number of space ruins levels to generate
+EXTRA_SPACE_RUIN_LEVELS_MAX 8
 
 ### INITIALIZATION SETTINGS END ###

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -473,12 +473,6 @@ PLAYER_REROUTE_CAP 0
 ## Server to reroute to
 #TUTORIAL_SERVER_URL byond://example.org:1111
 
-## Disable the loading of away missions
-#DISABLE_AWAY_MISSIONS
-
-## Disable the loading of space ruins
-#DISABLE_SPACE_RUINS
-
 ## Minimum number of space ruins levels to generate
 EXTRA_SPACE_RUIN_LEVELS_MIN 4
 
@@ -675,12 +669,6 @@ DEFAULT_MAP /datum/map/cyberiad
 ## Enable animations on item pickup and drop down
 # ITEM_ANIMATIONS_ENABLED
 
-## Disable the loading of "Taipan"
-# DISABLE_TAIPAN
-
-## Disable the loading of Lavaland
-# DISABLE_LAVALAND
-
 ## If the number of players is more or same than this, then we apply the highpop jobs config.
 JOBS_HIGH_POP_MODE_AMOUNT 80
 
@@ -734,6 +722,22 @@ CACHE_ASSETS 0
 ## Enable the replay demo recording subsystem
 #DEMOS_ENABLED
 
+### INITIALIZATION SETTINGS ###
+## This section contains settings directly affecting initializing progress. Uncomment these to make your world load faster.
+
 ## Enables loading titlescreen only after master has been loaded. Recommended to be used on local server for faster loading.
 #ENABLE_TITLESCREEN_LATELOAD
  
+## Disable the loading of "Taipan"
+#DISABLE_TAIPAN
+
+## Disable the loading of Lavaland
+#DISABLE_LAVALAND
+
+## Disable the loading of away missions
+#DISABLE_AWAY_MISSIONS
+
+## Disable the loading of space ruins
+#DISABLE_SPACE_RUINS
+
+### INITIALIZATION SETTINGS END ###

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -733,3 +733,7 @@ CACHE_ASSETS 0
 
 ## Enable the replay demo recording subsystem
 #DEMOS_ENABLED
+
+## Enables loading titlescreen only after master has been loaded. Recommended to be used on local server for faster loading.
+#ENABLE_TITLESCREEN_LATELOAD
+ 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание

<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Добавляет оптимизацию загрузки локальных тестовых сред посредством включения загрузки HTML тайтлскрина только после загрузки мастер-контроллера.

Для активации раскомментить строчку в конфиге под названием ENABLE_TITLESCREEN_LATELOAD

## Демонстрация изменений

<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
Кибериада, без лаваленда, руин и авейки.
До
![изображение](https://github.com/user-attachments/assets/61116c8e-c001-4e89-a09e-6a8d41e5888d)
После
![изображение](https://github.com/user-attachments/assets/e529adde-5bc0-4473-aef2-7e022389214e)
