### PR TITLE
bugfix: Now clock-structure can disguise

### DIFF
--- a/code/game/gamemodes/clockwork/clockwork_structures.dm
+++ b/code/game/gamemodes/clockwork/clockwork_structures.dm
@@ -55,7 +55,7 @@
 		if("girder")
 			desc = "[span_notice("The bolts are <b>lodged</b> in place.")]"
 		if("broken grille")
-			desc = "A flimsy framework of metal rods. [span_notice("It's secured in place with <b>screws</b>. The rods look like they could be <b>cut</b> through.")]"
+			desc = "A flimsy framework of metal rods. <BR>[span_notice("It's secured in place with <b>screws</b>. The rods look like they could be <b>cut</b> through.")]"
 		else //used in case, where objects "examine" text aren't in their desc var (like in proc/examine()) or if you want do something funny
 			desc = choosable_items[hidden_type]::desc
 

--- a/code/game/gamemodes/clockwork/clockwork_structures.dm
+++ b/code/game/gamemodes/clockwork/clockwork_structures.dm
@@ -23,7 +23,7 @@
 	var/canbehidden = FALSE
 	var/hidden = FALSE
 	var/hidden_type
-	var/list/choosable_items = list(
+	var/list/atom/choosable_items = list(
 		"rack" = /obj/structure/rack,
 		"table" = /obj/structure/table,
 		"wooden table" = /obj/structure/table/wood,
@@ -37,19 +37,7 @@
 	if(!hidden)
 		name = initial(name)
 		return
-	switch(hidden_type)
-		if("rack")
-			name = "rack"
-		if("table")
-			name = "table"
-		if("wooden table")
-			name = "wooden table"
-		if("personal closet")
-			name = "personal closet"
-		if("girder")
-			name = "girder"
-		if("bookcase")
-			name = "bookcase"
+	name = choosable_items[hidden_type]::name
 
 
 /obj/structure/clockwork/functional/update_desc(updates = ALL)
@@ -59,17 +47,17 @@
 		return
 	switch(hidden_type)
 		if("rack")
-			desc = "Different from the Middle Ages version. <BR><span class='notice'>It's held together by a couple of <b>bolts</b>.</span>"
+			desc = "Different from the Middle Ages version. <BR>[span_notice("It's held together by a couple of <b>bolts</b>.")]"
 		if("table")
-			desc = "A square piece of metal standing on four metal legs. It can not move. <BR><span class='notice'>The top is <b>screwed</b> on, but the main <b>bolts</b> are also visible.</span>"
+			desc = "A square piece of metal standing on four metal legs. It can not move. <BR>[span_notice("The top is <b>screwed</b> on, but the main <b>bolts</b> are also visible.")]"
 		if("wooden table")
-			desc = "Do not apply fire to this. Rumour says it burns easily. <BR><span class='notice'>The top is <b>screwed</b> on, but the main <b>bolts</b> are also visible.</span>"
-		if("personal closet")
-			desc = "It's a secure locker for personnel. The first card swiped gains control."
+			desc = "Do not apply fire to this. Rumour says it burns easily. <BR>[span_notice("The top is <b>screwed</b> on, but the main <b>bolts</b> are also visible.")]"
 		if("girder")
-			desc = "<span class='notice'>The bolts are <b>lodged</b> in place.</span>"
-		if("bookcase")
-			desc = null
+			desc = "[span_notice("The bolts are <b>lodged</b> in place.")]"
+		if("broken grille")
+			desc = "A flimsy framework of metal rods. [span_notice("It's secured in place with <b>screws</b>. The rods look like they could be <b>cut</b> through.")]"
+		else //used in case, where objects "examine" text aren't in their desc var (like in proc/examine()) or if you want do something funny
+			desc = choosable_items[hidden_type]::desc
 
 
 /obj/structure/clockwork/functional/update_icon_state()
@@ -77,25 +65,8 @@
 		icon = initial(icon)
 		icon_state = anchored ? "[initial(icon_state)]-off" : initial(icon_state)
 		return
-	switch(hidden_type)
-		if("rack")
-			icon = 'icons/obj/objects.dmi'
-			icon_state = "rack"
-		if("table")
-			icon = 'icons/obj/smooth_structures/table.dmi'
-			icon_state = "table"
-		if("wooden table")
-			icon = 'icons/obj/smooth_structures/wood_table.dmi'
-			icon_state = "wood_table"
-		if("personal closet")
-			icon = 'icons/obj/closet.dmi'
-			icon_state = "secureoff"
-		if("girder")
-			icon = 'icons/obj/structures.dmi'
-			icon_state = "girder"
-		if("bookcase")
-			icon = 'icons/obj/library.dmi'
-			icon_state = "book-0"
+	icon = choosable_items[hidden_type]::icon
+	icon_state = choosable_items[hidden_type]::icon_state
 
 
 /obj/structure/clockwork/functional/attackby(obj/item/I, mob/user, params)
@@ -265,38 +236,6 @@
 	return ..()
 
 
-/obj/structure/clockwork/functional/altar/update_name(updates = ALL)
-	. = ..()
-	if(!hidden)
-		name = initial(name)
-		return
-	switch(hidden_type)
-		if("potted plant")
-			name = "potted plant"
-		if("chair")
-			name = "chair"
-		if("stool")
-			name = "stool"
-		if("broken grille")
-			name = "grille"
-
-
-/obj/structure/clockwork/functional/altar/update_desc(updates = ALL)
-	. = ..()
-	if(!hidden)
-		desc = initial(desc)
-		return
-	switch(hidden_type)
-		if("potted plant")
-			desc = null
-		if("chair")
-			desc = "You sit in this. Either by will or force."
-		if("stool")
-			desc = "Apply butt."
-		if("broken grille")
-			desc = "A flimsy framework of metal rods."
-
-
 /obj/structure/clockwork/functional/altar/update_icon_state()
 	if(!hidden)
 		icon = initial(icon)
@@ -305,19 +244,11 @@
 			return
 		icon_state = first_stage ? "[initial(icon_state)]-fast" : initial(icon_state)
 		return
-	switch(hidden_type)
-		if("potted plant")
-			icon = 'icons/obj/flora/plants.dmi'
-			icon_state = "plant-[rand(1,36)]"
-		if("chair")
-			icon = 'icons/obj/chairs.dmi'
-			icon_state = "chair"
-		if("stool")
-			icon = 'icons/obj/chairs.dmi'
-			icon_state = "stool"
-		if("broken grille")
-			icon = 'icons/obj/structures.dmi'
-			icon_state = "brokengrille"
+	icon = choosable_items[hidden_type]::icon
+	if(hidden_type == "potted plant")
+		icon_state = "plant-[rand(1,36)]"
+	else
+		icon_state = choosable_items[hidden_type]::icon_state
 
 
 /obj/structure/clockwork/functional/altar/attackby(obj/item/I, mob/user, params)
@@ -511,8 +442,6 @@
 		. += "<span class='notice'>There's [cog_slots - cogscarab_list.len] cogscarab ready. [timer_fabrictor ? "And it's creating another one now" : "It stopped creating."]."
 
 
-/obj/structure/clockwork/functional/cogscarab_fabricator/update_icon_state()
-	icon_state = anchored ? "[initial(icon_state)]-off" : initial(icon_state)
 
 
 /obj/structure/clockwork/functional/cogscarab_fabricator/Initialize(mapload)

--- a/code/game/gamemodes/clockwork/clockwork_structures.dm
+++ b/code/game/gamemodes/clockwork/clockwork_structures.dm
@@ -45,7 +45,7 @@
 	if(!hidden)
 		desc = initial(desc)
 		return
-	switch(hidden_type)
+	switch(hidden_type) //used in case, where objects "examine" text aren't in their desc var (like in proc/examine()) or if you want do something funny
 		if("rack")
 			desc = "Different from the Middle Ages version. <BR>[span_notice("It's held together by a couple of <b>bolts</b>.")]"
 		if("table")
@@ -56,7 +56,7 @@
 			desc = "[span_notice("The bolts are <b>lodged</b> in place.")]"
 		if("broken grille")
 			desc = "A flimsy framework of metal rods. <BR>[span_notice("It's secured in place with <b>screws</b>. The rods look like they could be <b>cut</b> through.")]"
-		else //used in case, where objects "examine" text aren't in their desc var (like in proc/examine()) or if you want do something funny
+		else
 			desc = choosable_items[hidden_type]::desc
 
 

--- a/code/game/gamemodes/clockwork/clockwork_structures.dm
+++ b/code/game/gamemodes/clockwork/clockwork_structures.dm
@@ -18,7 +18,7 @@
 /obj/structure/clockwork/functional
 	max_integrity = 100
 	var/cooldowntime = 0
-	var/death_message = "<span class='danger'>The structure falls apart.</span>"
+	var/death_message = span_danger("The structure falls apart.")
 	var/death_sound = 'sound/effects/forge_destroy.ogg'
 	var/canbehidden = FALSE
 	var/hidden = FALSE
@@ -110,7 +110,7 @@
 /obj/structure/clockwork/functional/examine(mob/user)
 	. = ..()
 	if(hidden && isclocker(user))
-		. += "<span class='notice'>It's a disguised [initial(name)]!</span>"
+		. += span_notice("It's a disguised [initial(name)]!")
 
 // returns TRUE if hidden, if unhidden FALSE
 /obj/structure/clockwork/functional/proc/toggle_hide(chosen_type)
@@ -129,7 +129,7 @@
 	desc = "An imposing spire formed of brass. It somewhat pulsates."
 	icon_state = "beacon"
 	max_integrity = 250 // A very important one
-	death_message = "<span class='danger'>The beacon crumbles and falls in parts to the ground relaesing it's power!</span>"
+	death_message = span_danger("The beacon crumbles and falls in parts to the ground relaesing it's power!")
 	death_sound = 'sound/effects/creepyshriek.ogg'
 	var/heal_delay = 6 SECONDS
 	var/last_heal = 0
@@ -157,7 +157,7 @@
 			if(!isclocker(L))
 				continue
 			if(L.reagents?.has_reagent("holywater"))
-				to_chat(L, "<span class='warning'>You feel a terrible liquid disappearing from your body.</span>")
+				to_chat(L, span_warning("You feel a terrible liquid disappearing from your body."))
 				L.reagents.del_reagent("holywater")
 			if(iscogscarab(L))
 				var/mob/living/silicon/robot/cogscarab/C = L
@@ -184,7 +184,7 @@
 	GLOB.clockwork_beacons -= src
 	STOP_PROCESSING(SSobj, src)
 	for(var/datum/mind/M in SSticker.mode.clockwork_cult)
-		to_chat(M.current, "<span class='danger'>You get the feeling that one of the beacons have been destroyed! The source comes from [areabeacon.name]</span>")
+		to_chat(M.current, span_danger("You get the feeling that one of the beacons have been destroyed! The source comes from [areabeacon.name]"))
 	return ..()
 
 /obj/structure/clockwork/functional/beacon/attackby(obj/item/I, mob/user, params)
@@ -199,7 +199,7 @@
 	desc = "A strange brass platform with spinning cogs inside. It demands something in exchange for goods..."
 	icon_state = "altar"
 	density = FALSE
-	death_message = "<span class='danger'>The credence breaks in pieces as it dusts into nothing!</span>"
+	death_message = span_danger("The credence breaks in pieces as it dusts into nothing!")
 	canbehidden = TRUE
 	choosable_items = list(
 		"potted plant" = /obj/item/twohanded/required/kirbyplants,
@@ -339,7 +339,7 @@
 
 /obj/structure/clockwork/functional/altar/proc/first_stage_check(var/mob/living/carbon/human/target)
 	first_stage = TRUE
-	target.visible_message("<span class='warning'>[src] begins to glow a piercing amber!</span>", "<span class='clock'>You feel something start to invade your mind...</span>")
+	target.visible_message(span_warning("[src] begins to glow a piercing amber!"), span_clock("You feel something start to invade your mind..."))
 	glow = new (get_turf(src))
 	animate(glow, alpha = 255, time = 8 SECONDS)
 	update_icon(UPDATE_ICON_STATE)
@@ -347,11 +347,11 @@
 /obj/structure/clockwork/functional/altar/proc/second_stage_check(var/mob/living/carbon/human/target)
 	second_stage = TRUE
 	if(!is_convertable_to_clocker(target.mind) || target.stat == DEAD) // mindshield or holy or mindless monkey. or dead guy
-		target.visible_message("<span class='warning'>[src] in glowing manner starts corrupting [target]!</span>", \
-		"<span class='danger'>You feel as your body starts to corrupt by [src] underneath!</span>")
+		target.visible_message(span_warning("[src] in glowing manner starts corrupting [target]!"), \
+		span_danger("You feel as your body starts to corrupt by [src] underneath!"))
 		target.Weaken(20 SECONDS)
 	else // just a living non-clocker civil
-		to_chat(target, "<span class='clocklarge'><b>\"You belong to me now.\"</b></span>")
+		to_chat(target, span_clocklarge("<b>\"You belong to me now.\"</b>"))
 		target.heal_overall_damage(50, 50)
 		if(isgolem(target))
 			target.mind.wipe_memory()
@@ -369,7 +369,7 @@
 	converting = null
 	update_icon(UPDATE_ICON_STATE)
 	if(!silent)
-		visible_message("<span class='warning'>[src] slowly stops glowing!</span>")
+		visible_message(span_warning("[src] slowly stops glowing!"))
 
 
 /obj/structure/clockwork/functional/altar/attackby(obj/item/I, mob/user, params)
@@ -398,30 +398,30 @@
 	var/datum/game_mode/gamemode = SSticker.mode
 
 	if(GLOB.ark_of_the_clockwork_justiciar)
-		to_chat(user, "<span class='clockitalic'>There is already Gateway somewhere!</span>")
+		to_chat(user, span_clockitalic("There is already Gateway somewhere!"))
 		return FALSE
 
 	if(gamemode.clocker_objs.clock_status < RATVAR_NEEDS_SUMMONING)
-		to_chat(user, "<span class='clockitalic'><b>Ratvar</b> is not ready to be summoned yet!</span>")
+		to_chat(user, span_clockitalic("<b>Ratvar</b> is not ready to be summoned yet!"))
 		return FALSE
 	if(gamemode.clocker_objs.clock_status == RATVAR_HAS_RISEN)
-		to_chat(user, "<span class='clocklarge'>\"My fellow. There is no need for it anymore.\"</span>")
+		to_chat(user, span_clockitalic("\"My fellow. There is no need for it anymore.\""))
 		return FALSE
 
 	var/list/summon_areas = gamemode.clocker_objs.obj_summon.ritual_spots
 	if(!(A in summon_areas))
-		to_chat(user, "<span class='cultlarge'>Ratvar can only be summoned where the veil is weak - in [english_list(summon_areas)]!</span>")
+		to_chat(user, span_cultlarge("Ratvar can only be summoned where the veil is weak - in [english_list(summon_areas)]!"))
 		return FALSE
 	var/confirm_final = tgui_alert(user, "This is the FINAL step to summon, the crew will be alerted to your presence AND your location!",
 	"The power comes...", list("Let Ratvar shine ones more!", "No"))
 	if(user)
 		if(confirm_final != "Let Ratvar shine ones more!")
-			to_chat(user, "<span class='clockitalic'><b>You decide to prepare further before pincing the shard.</b></span>")
+			to_chat(user, span_clockitalic("<b>You decide to prepare further before pincing the shard.</b>"))
 			return FALSE
 		return TRUE
 
 /obj/structure/clockwork/functional/altar/proc/begin_the_ritual()
-	visible_message("<span class='danger'>The [src] expands itself revealing into the great Ark!</span>")
+	visible_message(span_danger("The [src] expands itself revealing into the great Ark!"))
 	new /obj/structure/clockwork/functional/celestial_gateway(get_turf(src))
 	qdel(src)
 	return
@@ -430,7 +430,7 @@
 	name = "cogscarab fabricator"
 	desc = "House for a tons of little cogscarabs, self-producing and maintaining itself."
 	icon_state = "fabricator"
-	death_message = "<span class='danger'>Fabricator crumbles and dusts, leaving nothing behind!</span>"
+	death_message = span_danger("Fabricator crumbles and dusts, leaving nothing behind!")
 	var/list/cogscarab_list = list()
 	canbehidden = TRUE
 	var/cog_slots = 0
@@ -439,9 +439,7 @@
 /obj/structure/clockwork/functional/cogscarab_fabricator/examine(mob/user)
 	. = ..()
 	if(!hidden && (isclocker(user) || isobserver(user)))
-		. += "<span class='notice'>There's [cog_slots - cogscarab_list.len] cogscarab ready. [timer_fabrictor ? "And it's creating another one now" : "It stopped creating."]."
-
-
+		. += span_notice("There's [cog_slots - cogscarab_list.len] cogscarab ready. [timer_fabrictor ? "And it's creating another one now" : "It stopped creating."].")
 
 
 /obj/structure/clockwork/functional/cogscarab_fabricator/Initialize(mapload)
@@ -506,17 +504,17 @@
 
 /obj/structure/clockwork/functional/cogscarab_fabricator/attack_ghost(mob/dead/observer/user)
 	if(hidden)
-		to_chat(user, "<span class='warning'>It's hidden and cannot produce you at this state!</span>")
+		to_chat(user, span_warning("It's hidden and cannot produce you at this state!"))
 		return FALSE
 	if(!anchored)
-		to_chat(user, "<span class='warning'>It seems to be non-functional to produce a new shell!</span>")
+		to_chat(user, span_warning("It seems to be non-functional to produce a new shell!"))
 		return FALSE
 	if(cogscarab_list.len >= cog_slots)
-		to_chat(user, "<span class='notice'>There's no empty shells to take!</span>")
+		to_chat(user, span_notice("There's no empty shells to take!"))
 		return FALSE
 	if(alert(user, "Do you wish to become cogscarab?",,"Yes","No") == "Yes")
 		if(cogscarab_list.len >= cog_slots) //Double check. No duplications
-			to_chat(user, "<span class='notice'>There's no empty shells to take!</span>")
+			to_chat(user, span_notice("There's no empty shells to take!"))
 			return FALSE
 		var/mob/living/silicon/robot/cogscarab/cog = new(loc)
 		cog.key = user.key


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание

Меняет работу как предметы культа маскируются, чтобы имя и описания подходили и после перевода к предметам.
Меняет все `span class` на соответствующий дефайн.

## Ссылка на предложение/Причина создания ПР

[Ссылка на баг-репорт.](https://discord.com/channels/617003227182792704/1305255658265772184/1305255658265772184)
Фабрикатор культа не мог менять свой скин.

## Демонстрация изменений

https://github.com/user-attachments/assets/2cf62f62-33e1-4e84-b0c6-b40f6bc30725

## Тесты

Зашёл на локалку - нажал часами по фабрикатору.
