### PR TITLE
add: Allows you to not load station

### DIFF
--- a/code/controllers/configuration/entries/testing.dm
+++ b/code/controllers/configuration/entries/testing.dm
@@ -7,3 +7,6 @@
 
 ///Enables loading titlescreen only after master has been loaded.
 /datum/config_entry/flag/enable_titlescreen_lateload
+
+///Do not load station
+/datum/config_entry/flag/load_no_station

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -709,6 +709,9 @@ CACHE_ASSETS 0
 ### INITIALIZATION SETTINGS ###
 ## This section contains settings directly affecting initializing progress. Uncomment these to make your world load faster.
 
+## Loads only space without anything in station sector. Still makes landmarks for spawnpoints, though.
+#LOAD_NO_STATION
+
 ## Enables loading titlescreen only after master has been loaded. Recommended to be used on local server for faster loading.
 #ENABLE_TITLESCREEN_LATELOAD
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание

<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
ПР позволяет не загружать станцию посредством конфига. Ставит все лендмарки в центре пустого зет уровня для тестирования.
## Ссылка на предложение/Причина создания ПР

<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
Надо было потестить руинки, а это так неудобно...

## Демонстрация изменений

<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
В config.txt раскомментировать или добавить строку `LOAD_NO_STATION`

![изображение](https://github.com/user-attachments/assets/2a728cfd-a487-43fb-b509-9d82d6a5ec98)


## Тесты

<!-- Как вы тестировали свой код. Ревьюеру будет проще, если он будет знать какие действия вы совершали, проверяя свой ПР. -->
Погонял, всё ок, чистый космос с лавалендом на фоне. Разве что неактивный ИИ спавнится 👌 