### PR TITLE
bugfix: Hesphiastos Titan Enforcer IPC monitor fix

### DIFF
--- a/code/modules/mob/new_player/sprite_accessories/ipc/ipc_face.dm
+++ b/code/modules/mob/new_player/sprite_accessories/ipc/ipc_face.dm
@@ -104,32 +104,32 @@
 /datum/sprite_accessory/hair/ipc/hesphiastos_alt_pink
 	name = "Pink Hesphiastos Screen"
 	icon_state = "pink_hesp_alt"
-	models_allowed = list("Industrial Revolution")
+	models_allowed = list("Titan Enforcer")
 
 /datum/sprite_accessory/hair/ipc/hesphiastos_alt_orange
 	name = "Orange Hesphiastos Screen"
 	icon_state = "orange_hesp_alt"
-	models_allowed = list("Industrial Revolution")
+	models_allowed = list("Titan Enforcer")
 
 /datum/sprite_accessory/hair/ipc/hesphiastos_alt_goggle
 	name = "Goggles Hesphiastos Screen"
 	icon_state = "goggles_hesp_alt"
-	models_allowed = list("Industrial Revolution")
+	models_allowed = list("Titan Enforcer")
 
 /datum/sprite_accessory/hair/ipc/hesphiastos_alt_scroll
 	name = "Scrolling Hesphiastos Screen"
 	icon_state = "scroll_hesp_alt"
-	models_allowed = list("Industrial Revolution")
+	models_allowed = list("Titan Enforcer")
 
 /datum/sprite_accessory/hair/ipc/hesphiastos_alt_rgb
 	name = "RGB Hesphiastos Screen"
 	icon_state = "rgb_hesp_alt"
-	models_allowed = list("Industrial Revolution")
+	models_allowed = list("Titan Enforcer")
 
 /datum/sprite_accessory/hair/ipc/hesphiastos_alt_rainbow
 	name = "Rainbow Hesphiastos Screen"
 	icon_state = "rainbow_hesp_alt"
-	models_allowed = list("Industrial Revolution")
+	models_allowed = list("Titan Enforcer")
 
 //Fluff
 /datum/sprite_accessory/hair/ipc/fluff


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
PR делает так, что-бы спрайты монитора созданные под голову Titan Enforcer были доступны только при выборе головы Titan Enforcer, а не Industrial Revolution, где им не место.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
До добавления кучи оболочек 7 месяцев всё воркало как нужно. Давно заметил, хочу пофиксить.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Потыкал на лолкалке, всё работает как нужно.
<!-- Как вы тестировали свой код. Ревьюеру будет проще, если он будет знать какие действия вы совершали, проверяя свой ПР. -->
