### PR TITLE
qol: Announcements Disabling.

### DIFF
--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -13,7 +13,7 @@ GLOBAL_DATUM_INIT(event_announcement, /datum/announcement/priority/command/event
 	var/announcement_type = "Оповещение"
 	var/admin_announcement = 0 // Admin announcements are received regardless of being in range of a radio, unless you're in the lobby to prevent metagaming
 	var/language = LANGUAGE_GALACTIC_COMMON
-	var/beannounced = 1
+	var/beannounced = TRUE
 
 /datum/announcement/New(var/do_log = 0, var/new_sound = null, var/do_newscast = 0)
 	sound = new_sound

--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -13,6 +13,7 @@ GLOBAL_DATUM_INIT(event_announcement, /datum/announcement/priority/command/event
 	var/announcement_type = "Оповещение"
 	var/admin_announcement = 0 // Admin announcements are received regardless of being in range of a radio, unless you're in the lobby to prevent metagaming
 	var/language = LANGUAGE_GALACTIC_COMMON
+	var/beannounced = 1
 
 /datum/announcement/New(var/do_log = 0, var/new_sound = null, var/do_newscast = 0)
 	sound = new_sound
@@ -46,6 +47,8 @@ GLOBAL_DATUM_INIT(event_announcement, /datum/announcement/priority/command/event
 
 /datum/announcement/proc/Announce(message as text, new_title = "", new_sound = null, do_newscast = newscast, msg_sanitized = 0, from, msg_language)
 	if(!message)
+		return
+	if(!beannounced)
 		return
 
 	var/message_title = new_title ? new_title : title


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Даёт возможность выключить анонсы разных категорий.
От ивентов, до админ анонсов(не ООС) 
Удобная штука только для педалей. 
Позволяет проводить мини ивентики
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР

<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
QOL
## Тесты

<!-- Как вы тестировали свой код. Ревьюеру будет проще, если он будет знать какие действия вы совершали, проверяя свой ПР. -->Зашёл, меня 1 на 0, 0 на 1 в ввшке анонсов. Делал анонсы. При 0, анонсы не работают, при 1 работают.
Есть также одно примечание. У меня не работала ивент панель.
