### PR TITLE
bugfix: Spacepod hear_talk

### DIFF
--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -601,7 +601,7 @@
 	equipment_system.vars[slot] = null
 
 
-/obj/spacepod/hear_talk/hear_talk(mob/M, list/message_pieces)
+/obj/spacepod/hear_talk(mob/M, list/message_pieces)
 	cargo_hold.hear_talk(M, message_pieces)
 	..()
 


### PR DESCRIPTION

## Описание
Убрал очепятку, из-за которой hear_talk() у подов никогда не вызывался


