### PR TITLE
bugfix: request conole in pda spam

### DIFF
--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -195,6 +195,7 @@
 
 	if(COOLDOWN_FINISHED(src, messages_cooldown) && !message_sent)
 		SStgui.update_uis(src)
+		COOLDOWN_RESET(src, messages_cooldown)
 		send_console_message()
 		message_sent = TRUE
 

--- a/code/modules/pda/pda_tgui.dm
+++ b/code/modules/pda/pda_tgui.dm
@@ -115,6 +115,7 @@
 				for(var/datum/data/pda/P in notifying_programs)
 					if(P in C.programs)
 						P.unnotify()
+				request_cartridge.update_programs(null)
 				request_cartridge = null
 				update_shortcuts()
 		if("Authenticate")//Checks for ID


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Исправляет 2 бага картриджей с реквест консолями. Первый: спам сообщениями при кидании по 1 рудинке( не обновлялся кулдаун). Второй: сообщения приходили даже при вынимании картриджа(не было отвязки от пда при вынимании).
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР / Почему это хорошо для игры
багфикс
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Запустил, вытащил картридж, кинул рудинку, сообщения не приходят. Вставил, кинул, приходят. Попытался покидать по 1 рудинке в печь, спама нет.
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
