### PR TITLE
bugfix: shuttle now wait 3 minutes after deny lockdown

### DIFF
--- a/code/game/gamemodes/emergency_shuttle_lockdown.dm
+++ b/code/game/gamemodes/emergency_shuttle_lockdown.dm
@@ -5,5 +5,5 @@
 	emergencyNoEscape = FALSE
 	if(emergency.mode == SHUTTLE_STRANDED)
 		emergency.mode = SHUTTLE_DOCKED
-		emergency.timer = world.time
+		emergency.timer = world.time + 3 MINUTES
 		GLOB.priority_announcement.Announce("Угроза устранена. У вас есть 3 минуты, чтобы подняться на борт эвакуационного шаттла.", "Приоритетное оповещение.")

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -276,10 +276,10 @@
 
 /obj/machinery/doomsday_device/Destroy()
 	STOP_PROCESSING(SSfastprocess, src)
-	SSshuttle.emergencyNoEscape = 0
+	SSshuttle.emergencyNoEscape = FALSE
 	if(SSshuttle.emergency.mode == SHUTTLE_STRANDED)
 		SSshuttle.emergency.mode = SHUTTLE_DOCKED
-		SSshuttle.emergency.timer = world.time
+		SSshuttle.emergency.timer = world.time + 3 MINUTES
 		GLOB.priority_announcement.Announce("Вредоносное окружение устранено. У вас есть 3 минуты, чтобы подняться на борт эвакуационного шаттла.", "Приоритетное оповещение.", 'sound/AI/shuttledock.ogg')
 	return ..()
 
@@ -287,7 +287,7 @@
 	detonation_timer = world.time + default_timer
 	timing = 1
 	START_PROCESSING(SSfastprocess, src)
-	SSshuttle.emergencyNoEscape = 1
+	SSshuttle.emergencyNoEscape = TRUE
 
 /obj/machinery/doomsday_device/proc/seconds_remaining()
 	. = max(0, (round(detonation_timer - world.time) / 10))
@@ -296,10 +296,10 @@
 	var/turf/T = get_turf(src)
 	if(!T || !is_station_level(T.z))
 		GLOB.minor_announcement.Announce("УСТРОЙСТВО СУДНОГО ДНЯ ВНЕ ЗОНЫ ДЕЙСТВИЯ СТАНЦИИ, ОСТАНОВКА.", "ОШИБКА ОШИБКА $0ШБК$!А41.%%!!(%$^^__+ @#Ш0E4", 'sound/misc/notice1.ogg')
-		SSshuttle.emergencyNoEscape = 0
+		SSshuttle.emergencyNoEscape = FALSE
 		if(SSshuttle.emergency.mode == SHUTTLE_STRANDED)
 			SSshuttle.emergency.mode = SHUTTLE_DOCKED
-			SSshuttle.emergency.timer = world.time
+			SSshuttle.emergency.timer = world.time + 3 MINUTES
 			GLOB.priority_announcement.Announce("Вредоносное окружение устранено. У вас есть 3 минуты, чтобы подняться на борт эвакуационного шаттла.", "Приоритетное оповещение.", 'sound/AI/shuttledock.ogg')
 		qdel(src)
 	if(!timing)

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -26,10 +26,10 @@
 
 	if(doomsday_device)
 		doomsday_device.timing = 0
-		SSshuttle.emergencyNoEscape = 0
+		SSshuttle.emergencyNoEscape = FALSE
 		if(SSshuttle.emergency.mode == SHUTTLE_STRANDED)
 			SSshuttle.emergency.mode = SHUTTLE_DOCKED
-			SSshuttle.emergency.timer = world.time
+			SSshuttle.emergency.timer = world.time + 3 MINUTES
 			GLOB.priority_announcement.Announce("Вредоносное окружение устранено. У вас есть 3 минуты, чтобы подняться на борт эвакуационного шаттла.", "Приоритетное оповещение.", 'sound/AI/shuttledock.ogg')
 		qdel(doomsday_device)
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Исправляет недавно появившийся баг с тем, что после снятия сработавшего локдауна шаттл не ждал 3 минуты, а сразу стартовал. Когда функция вводилась это работало и так, но видимо что-то поменяли и теперь нужно указывать время ручками.
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР / Почему это хорошо для игры
багфикс
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
На локалке довел шаттл до локдауна. Снял локдаун. Шаттл ждет 3 минуты, как и полагается.
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
