### PR TITLE
bugfix: detective and contractor zippo

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -2330,7 +2330,7 @@
 
 /datum/uplink_item/contractor/zippo
 	name = "Contractor Zippo Lighter"
-	desc = "An unique black and gold zippo lighter with no purpose other than showing off. You must complete all your contracts in order to buy this."
+	desc = "An unique black and gold zippo lighter with no purpose other than showing off."
 	item = /obj/item/lighter/zippo/contractor
 	cost = 1
 

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -2330,9 +2330,9 @@
 
 /datum/uplink_item/contractor/zippo
 	name = "Contractor Zippo Lighter"
-	desc = "A kit with your personal assistant. It comes with an increased amount of memory and special programs."
-	item = /obj/item/storage/box/contractor/spai_kit
-	cost = 120
+	desc = "An unique black and gold zippo lighter with no purpose other than showing off. You must complete all your contracts in order to buy this."
+	item = /obj/item/lighter/zippo/contractor
+	cost = 1
 
 /datum/uplink_item/contractor/loadout_box
 	name = "Contractor standard loadout box"

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -150,7 +150,7 @@
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses/aviators
 	id = /obj/item/card/id/security
 	l_pocket = /obj/item/toy/crayon/white
-	r_pocket = /obj/item/lighter/zippo
+	r_pocket = /obj/item/lighter/zippo/detective
 	pda = /obj/item/pda/detective
 	l_hand = /obj/item/storage/briefcase/crimekit
 	backpack_contents = list(

--- a/code/game/objects/items/weapons/lighters.dm
+++ b/code/game/objects/items/weapons/lighters.dm
@@ -283,6 +283,14 @@
 	icon_on = "zippo_dec_on"
 	icon_off = "zippo_dec"
 
+/obj/item/lighter/zippo/contractor
+	name = "contractor zippo lighter"
+	desc = "An unique black and gold zippo commonly carried by elite Syndicate agents."
+	icon_state = "contractorzippo"
+	item_state = "contractorzippo"
+	icon_on = "contractorzippoon"
+	icon_off = "contractorzippo"
+
 //Ninja-Zippo//
 /obj/item/lighter/zippo/ninja
 	name = "\"Shinobi on a rice field\" zippo"

--- a/code/modules/antagonists/traitor/contractor/datums/rep_purchases/zippo.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/rep_purchases/zippo.dm
@@ -19,11 +19,3 @@
 		to_chat(user, "<span class='warning'>All of your contracts must be completed to be eligible for this item.</span>")
 		return FALSE
 	return ..()
-
-/obj/item/lighter/zippo/contractor
-	name = "contractor zippo lighter"
-	desc = "An unique black and gold zippo commonly carried by elite Syndicate agents."
-	icon_state = "contractorzippo"
-	item_state = "contractorzippo"
-	icon_on = "contractorzippoon"
-	icon_off = "contractorzippo"


### PR DESCRIPTION
## Причина создания ПР / Почему это хорошо для игры
Зажигалку детективу добавили, а при спавне не сунули
Чиним аплинк, чтобы покупая зажигалку не выдавался спии
Переносим зажигалку контрактника к остальным зажигалкам, чтобы она не скучала одна