### PR TITLE
Bugfix: Can't pick sec cyborg

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -406,6 +406,9 @@
 		var/count_secborgs = 0
 
 		for(var/mob/living/silicon/robot/R in GLOB.alive_mob_list)
+			if (R==robot)
+			continue
+
 			if(R && R.stat != DEAD && R.module && istype(R.module, /obj/item/robot_module/security))
 				count_secborgs++
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -405,11 +405,11 @@
 	if(!robot.weapons_unlock)
 		var/count_secborgs = 0
 
-		for(var/mob/living/silicon/robot/R in GLOB.alive_mob_list)
-			if (R==robot)
-			continue
+		for(var/mob/living/silicon/robot/silicon in GLOB.alive_mob_list)
+			if(silicon == robot)
+				continue
 
-			if(R && R.stat != DEAD && R.module && istype(R.module, /obj/item/robot_module/security))
+			if(silicon.stat != DEAD && silicon.module && istype(silicon.module, /obj/item/robot_module/security))
 				count_secborgs++
 
 		var/max_secborgs = 2


### PR DESCRIPTION

<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание

Исправление рефактора. Теперь не считает нас самих в списке сб боргов когда мы пытаемся выбрать сб модуль

## Причина создания ПР / Почему это хорошо для игры

Нельзя было выбрать сб борга в зк
Подтираем после рефактора, это хорошо для игры. Вернули сб боргов в игру, это плохо для игры


## Тесты

В зк выбрал сб модуль, все работает. К сожалению больше ничего, по типу спавна больше одного борга, на локалке проверить не вышло
