### PR TITLE
bugfix: Lasergun implant doesnt have icon in inventory

### DIFF
--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -208,12 +208,6 @@
 /obj/item/organ/internal/cyberimp/arm/gun/laser/l
 	parent_organ_zone = BODY_ZONE_L_ARM
 
-/obj/item/organ/internal/cyberimp/arm/gun/laser/Initialize(mapload)
-	. = ..()
-	var/obj/item/organ/internal/cyberimp/arm/gun/laser/laserphasergun = locate(/obj/item/gun/energy/laser/mounted) in contents
-	laserphasergun.icon = icon //No invisible laser guns kthx
-	laserphasergun.icon_state = icon_state
-
 /obj/item/organ/internal/cyberimp/arm/gun/taser
 	name = "arm-mounted taser implant"
 	desc = "A variant of the arm cannon implant that fires electrodes and disabler shots. The cannon emerges from the subject's arm and remains inside when not in use."


### PR DESCRIPTION
## Описание

Чинит невидимость импланта лазерной пушки(прошлый фикс теперь является тем что ломает видимость)

## Почему это хорошо для игры
https://discord.com/channels/617003227182792704/1305518301493071893
## Демонстрация изменений
Лазерная пушка снова видима в инвентаре руки

## Тесты
 Установил имплант,  достал пушку,  проверил есть ли текстура
![Screenshot_1431](https://github.com/user-attachments/assets/fcb930fb-8d9b-4f2d-b2d3-03094b0190ce)
