### PR TITLE
Bugfix: Standard guardian phrase length

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/types/standard.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/standard.dm
@@ -23,7 +23,7 @@
 /mob/living/simple_animal/hostile/guardian/punch/AttackingTarget()
 	. = ..()
 	if(iscarbon(target) && target != summoner)
-		if(length(battlecry) > 8)//no more then 8 letters in a battle cry.
+		if(length_char(battlecry) > 8)//no more then 8 letters in a battle cry.
 			visible_message("<span class='danger'>[src] punches [target]!</span>")
 		else
 			say("[battlecry]", TRUE)

--- a/code/modules/tgui/tgui_input/text_input.dm
+++ b/code/modules/tgui/tgui_input/text_input.dm
@@ -171,4 +171,4 @@
 		return
 
 	var/converted_entry = encode ? html_encode(entry) : entry
-	src.entry = trim(converted_entry, max_length)
+	src.entry = trim(converted_entry, max_length + 1)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание

Фикс боевого клича стандартного паразита/стража. Теперь корректно считает количество букв если писать на русском. Так же теперь не обрезает последний, восьмой, символ. Хз чем руководствуется trim но если нам нужна длина 8 и мы пишем длина 8 мы получаем слово длиной 7, вот и думайте головой

## Причина создания ПР / Почему это хорошо для игры

Чинить всегда хорошо
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты

Писал в клич цифры, английские буквы, русские буквы и все вместе
