### PR TITLE
bugfix: customat deleting things from pipes

### DIFF
--- a/code/game/machinery/customat.dm
+++ b/code/game/machinery/customat.dm
@@ -395,6 +395,7 @@
 		if(I.name in remembered_costs)
 			cost = remembered_costs[I.name]
 		insert(user, I, cost)
+		return
 
 	else if(fast_insert && (I.name in remembered_costs))
 		cost = remembered_costs[I.name]

--- a/code/game/machinery/customat.dm
+++ b/code/game/machinery/customat.dm
@@ -394,6 +394,7 @@
 	if(from_tube)
 		if(I.name in remembered_costs)
 			cost = remembered_costs[I.name]
+		insert(user, I, cost)
 
 	else if(fast_insert && (I.name in remembered_costs))
 		cost = remembered_costs[I.name]


### PR DESCRIPTION
## Описание

Фиксит баг с удалением вещей через трубу в кастомат.

## Причина создания ПР / Почему это хорошо для игры

До этого предмет не проходил проверки, так как try_insert вызывался с параметром user = null, и вещь позже удалялась. Теперь не удаляется, лезет в кастомат.
