### PR TITLE
bugfix: blob overminds in nullspace

### DIFF
--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -91,9 +91,6 @@ GLOBAL_LIST_EMPTY(overminds)
 
 
 /mob/camera/blob/process()
-	if(!blob_core)
-		qdel(src)
-		return
 	if(!free_strain_rerolls && (last_reroll_time + BLOB_POWER_REROLL_FREE_TIME < world.time))
 		to_chat(src, span_boldnotice("Вы получили еще одну бесплатную смену штамма."))
 		free_strain_rerolls = TRUE

--- a/code/modules/antagonists/blob/structures/core.dm
+++ b/code/modules/antagonists/blob/structures/core.dm
@@ -46,7 +46,7 @@
 	GLOB.blob_cores -= src
 	if(overmind)
 		overmind.blob_core = null
-		overmind = null
+		QDEL_NULL(overmind.blob_core)
 	SSticker?.mode?.blob_died()
 	STOP_PROCESSING(SSobj, src)
 	GLOB.poi_list.Remove(src)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Исправляет неудаление овермайнда при уничтожении ядра. Теперь удаление прямое, что должно помочь.
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР / Почему это хорошо для игры
багфикс
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Запустил, заспвнил ядро, зашел за майнд, убил ядро, майнд удалился.
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
