### PR TITLE
bugfix: syndie drone wrong path

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -234,7 +234,7 @@
 /mob/living/simple_animal/bot/ed209/combat_drone/setup_access()
 	return
 
-/mob/living/simple_animal/bot/ed209/syndicate/set_weapon()
+/mob/living/simple_animal/bot/ed209/combat_drone/set_weapon()
 	projectile = /obj/item/projectile/beam/immolator/weak
 
 /mob/living/simple_animal/bot/ed209/combat_drone/turn_on()


### PR DESCRIPTION
## Описание

Исправляет некорректный путь

## Причина создания ПР / Почему это хорошо для игры

У охранного бота, охраняющего депо синдиката, гранатомет заменяется на слабый лазер, а боевому дрону выдается обычный тазер