### PR TITLE
tweak: mob_suspension now affects mob spawners

### DIFF
--- a/code/datums/components/spawner.dm
+++ b/code/datums/components/spawner.dm
@@ -37,10 +37,13 @@
 
 /datum/component/spawner/proc/try_spawn_mob()
 	var/atom/P = parent
+	var/turf/T = get_turf(P)
+	if(GLOB.mob_suspension && T && !length(SSmobs?.clients_by_zlevel[T.z]))
+		return FALSE
 	if(spawned_mobs.len >= max_mobs)
-		return 0
+		return FALSE
 	if(spawn_delay > world.time)
-		return 0
+		return FALSE
 	spawn_delay = world.time + spawn_time
 	var/chosen_mob_type = pickweight(mob_types)
 	var/mob/living/simple_animal/L = new chosen_mob_type(P.loc)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
У нас есть оптимизация, которая исключает мобов из обработки, если на z уровне. С этим пр-ом она будет и работать так же на спавнеры мобов.
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР / Почему это хорошо для игры
У некоторых спавнеров(например хедкрабов) нет никакого ограничения на количество. Они стоят в руинах, в которые в раунде может никто и не зайти, при этом крабы там будут спавниться до посинения, нагружая все, что работает со списками всех мобов. Данный пр ограничит ненужный спавн в те моменты, в которые в секторе нет хотя бы одиного игрока, на которого эти мобы в теории могут напасть.
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->


## Тесты
Запустил. Поставил спавнер хедкрабов. Спавна не происходит. Зашел за куклу в секторе -- спавн заработал.
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
