### PR TITLE
admin: select equipment on ghosts

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -585,6 +585,8 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 	var/delete_pocket
 	var/mob/living/carbon/human/H
 	if(isobserver(M))
+		if(!check_rights(R_SPAWN))
+			return
 		var/mob/dead/observer/ghost = M
 		H = ghost.incarnate_ghost()
 	else

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -557,14 +557,14 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 	for(var/areatype in areas_without_camera)
 		to_chat(world, "* [areatype]")
 
-/client/proc/cmd_admin_dress(mob/living/carbon/human/M in GLOB.human_list)
+/client/proc/cmd_admin_dress(mob/living/carbon/human/M in GLOB.mob_list)
 	set name = "\[Admin\] Select equipment"
 
 	if(!check_rights(R_EVENT))
 		return
 
 	if(!ishuman(M) && !isobserver(M))
-		alert("Invalid mob")
+		tgui_alert(usr, "Неподходящее существо")
 		return
 
 	var/dresscode = robust_dress_shop()
@@ -575,11 +575,12 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 	var/delete_pocket
 	var/mob/living/carbon/human/H
 	if(isobserver(M))
-		H = M.change_mob_type(/mob/living/carbon/human, null, null, TRUE)
+		var/mob/dead/observer/ghost = M
+		H = ghost.incarnate_ghost()
 	else
 		H = M
 		if(H.l_store || H.r_store || H.s_store) //saves a lot of time for admins and coders alike
-			if(alert("Should the items in their pockets be dropped? Selecting \"No\" will delete them.", "Robust quick dress shop", "Yes", "No") == "No")
+			if(tgui_alert(usr, "Нужно ли выбрасывать вещи из карманов? Выбор \"Нет\" удалит их.", "Робастный, быстрый магазин одежды", "Да", "Нет") == "Нет")
 				delete_pocket = TRUE
 
 	for (var/obj/item/I in H.get_equipped_items(delete_pocket))
@@ -588,7 +589,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 		H.equipOutfit(dresscode)
 	else	// We have regenerate_icons() proc in the end of equipOutfit(), so don't need to call it two times.
 		H.regenerate_icons()
-	log_and_message_admins("<span class='notice'>changed the equipment of [key_name_admin(M)] to [dresscode].</span>")
+	log_and_message_admins(span_notice("changed the equipment of [key_name_admin(M)] to [dresscode]."))
 
 /client/proc/robust_dress_shop()
 	var/list/outfits = list(

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -590,7 +590,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 	else
 		H = M
 		if(H.l_store || H.r_store || H.s_store) //saves a lot of time for admins and coders alike
-			if(tgui_alert(usr, "Нужно ли выбрасывать вещи из карманов? Выбор \"Нет\" удалит их.", "Робастный, быстрый магазин одежды", "Да", "Нет") == "Нет")
+			if(tgui_alert(usr, "Нужно ли выбрасывать вещи из карманов? Выбор \"Нет\" удалит их.", "Выбор экипировки существа", "Да", "Нет") == "Нет")
 				delete_pocket = TRUE
 
 	for (var/obj/item/I in H.get_equipped_items(delete_pocket))


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Теперь применение Select equipment по призраку работает и работает так же, как реинкарнейт в Player panel. Применение на призрака требует помимо К_EVENT еще и  R_SPAWN.
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР / Почему это хорошо для игры
Эта кнопка из-за технического аспекта висит на всех мобах, но работает только на хуманах. При этом за такой частой вещью как респавн госта нужно лезть в плеер панель. Раз уж кнопка все равно есть на призраках, то почему бы не расширить ее вполне очевидным и смежным функционалом.
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Запустил, выбрал Select equipment  на призраке -- призрак реинкарнейтнулся в нужной экипировке.
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
