### PR TITLE
bugfix: anomalies bugfix

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -29,7 +29,7 @@
 	START_PROCESSING(SSobj, src)
 	impact_area = get_area(src)
 
-	if(!impact_area)
+	if(!impact_area || impact_area.outdoors)
 		return INITIALIZE_HINT_QDEL
 
 	drops_core = _drops_core
@@ -254,7 +254,7 @@
 		investigate_log("teleported [key_name_log(moving_atom)] to [COORD(moving_atom)]", INVESTIGATE_TELEPORTATION)
 
 /obj/effect/anomaly/bluespace/detonate()
-	if(!mass_teleporting)
+	if(!mass_teleporting || impact_area.outdoors)
 		return
 	var/turf/T = pick(get_area_turfs(impact_area))
 	if(T)

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -55,7 +55,8 @@
 	GLOB.poi_list.Remove(src)
 	STOP_PROCESSING(SSobj, src)
 	QDEL_NULL(countdown)
-	QDEL_NULL(aSignal)
+	if(!ispath(aSignal))
+		QDEL_NULL(aSignal)
 	return ..()
 
 /obj/effect/anomaly/process()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Теперь аномалии не могут заспавниться там, где им не место. Так же дополнительно блюспейс аномалия не может сработать в неподходящей зоне. Неподходящие зоны -- космос, лава и тд. Все, что не помещение.
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР / Почему это хорошо для игры
аномалия, сработавшая в зонах, которые не являются помещениями(и в особенности космос) телепортируют все свое содержимое. При этом находиться они могут в разных, совершенно далеких друг от друга местах.
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Запустил, заспавнил аномалию в космосе -- она не заспавнилась.
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
