### PR TITLE
qol: preventing accidental explosion of an abandoned crate

### DIFF
--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -228,7 +228,7 @@
 	if(!istype(user))
 		return
 	if(locked)
-		boom(user)
+		attack_hand(user)
 	else
 		..()
 


### PR DESCRIPTION
## Описание
Заброшенный ящик больше не взрывается, если нажать на него НЕ пустой рукой. Вместо этого откроется панель для ввода кода.
Если сломать/емагнуть ящик, то он всё ещё взрывается.

## Причина создания ПР / Почему это хорошо для игры
Меньше взрывов исследователей, которые случайно тыкают ящик не пустой рукой.
Это уже очень давно реализовано на других билдах.

## Тесты
Зашёл на локалку, потыкал ящик палкой, не взрывается..
