### PR TITLE
tweak: Бога больше не надо кормить после призыва

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -726,9 +726,6 @@
 	set_antag_hud(mob_mind.current, null)
 
 /datum/game_mode/proc/apocalypse_cinema(obj/singularity/god/god, inevitable = FALSE)
-	if(god.soul_devoured <= 17 && !inevitable)
-		return FALSE
-
 	if(istype(god, /obj/singularity/god/narsie))
 		return SSticker.cultdat.apocalypse_cinema
 


### PR DESCRIPTION
## Описание
Кормление бога после призыва больше не влияет на выбор синематика

## Причина создания ПР / Почему это хорошо для игры
[Предложка](https://discord.com/channels/617003227182792704/755125334097133628/1335144016416739348)

## Тесты
Локалка