### PR TITLE
bugfix: tgui input text более не обрезает переносы строки в начале ввода

### DIFF
--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -96,12 +96,12 @@ GLOBAL_LIST_INIT(VVpixelmovement, list("step_x", "step_y", "step_size", "bound_h
 
 	switch(.["class"])
 		if(VV_TEXT)
-			.["value"] = tgui_input_text(src, "Введите текст:", "Текст", current_value, encode = FALSE)
+			.["value"] = tgui_input_text(src, "Введите текст:", "Текст", current_value, encode = FALSE, trim = FALSE)
 			if(.["value"] == null)
 				.["class"] = null
 				return
 		if(VV_MESSAGE)
-			.["value"] = tgui_input_text(src, "Введите текст:", "Текст", current_value, multiline = TRUE, encode = FALSE)
+			.["value"] = tgui_input_text(src, "Введите текст:", "Текст", current_value, multiline = TRUE, encode = FALSE, trim = FALSE)
 			if(.["value"] == null)
 				.["class"] = null
 				return
@@ -236,7 +236,7 @@ GLOBAL_LIST_INIT(VVpixelmovement, list("step_x", "step_y", "step_size", "bound_h
 				return
 			.["type"] = type
 			var/list/arguments
-			
+
 			if(tgui_alert(usr, "Вы хотите добавить аргументы?", "Новый атом", list("Да", "Нет")) == "Да")
 				arguments = get_callproc_args(FALSE)
 			else
@@ -252,7 +252,7 @@ GLOBAL_LIST_INIT(VVpixelmovement, list("step_x", "step_y", "step_size", "bound_h
 				return
 			.["type"] = type
 			var/list/arguments
-			
+
 			if(tgui_alert(usr, "Вы хотите добавить аргументы?", "Новый атом", list("Да", "Нет")) == "Да")
 				arguments = get_callproc_args(FALSE)
 			else
@@ -272,7 +272,7 @@ GLOBAL_LIST_INIT(VVpixelmovement, list("step_x", "step_y", "step_size", "bound_h
 
 			.["type"] = type
 			var/list/arguments
-			
+
 			if(tgui_alert(usr, "Вы хотите добавить аргументы?", "Новый атом", list("Да", "Нет")) == "Да")
 				arguments = get_callproc_args(FALSE)
 			else

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -438,7 +438,7 @@
 
 	if(href_list["write"] )
 		var/id = href_list["write"]																			/* Becаuse HTML */
-		var/input_element = tgui_input_text(usr, "Enter what you want to write:", "Write", multiline = TRUE, max_length = 3000, encode = FALSE) //as message
+		var/input_element = tgui_input_text(usr, "Enter what you want to write:", "Write", multiline = TRUE, max_length = 3000, encode = FALSE, trim = FALSE)
 
 		topic_href_write(usr, id, input_element)
 

--- a/code/modules/tgui/tgui_input/text_input.dm
+++ b/code/modules/tgui/tgui_input/text_input.dm
@@ -174,4 +174,4 @@
 		return
 
 	var/converted_entry = encode ? html_encode(entry) : entry
-	src.entry = trim? trim(converted_entry, max_length + 1) : trim_length(converted_entry, max_length + 1)
+	src.entry = trim ? trim(converted_entry, max_length + 1) : trim_length(converted_entry, max_length + 1)

--- a/code/modules/tgui/tgui_input/text_input.dm
+++ b/code/modules/tgui/tgui_input/text_input.dm
@@ -15,7 +15,7 @@
  * * encode - Toggling this determines if input is filtered via html_encode. Setting this to FALSE gives raw input.
  * * timeout - The timeout of the textbox, after which the modal will close and qdel itself. Set to zero for no timeout.
  */
-/proc/tgui_input_text(mob/user, message = "", title = "Text Input", default, max_length = MAX_MESSAGE_LEN, multiline = FALSE, encode = TRUE, timeout = 0, ui_state = GLOB.always_state)
+/proc/tgui_input_text(mob/user, message = "", title = "Text Input", default, max_length = MAX_MESSAGE_LEN, multiline = FALSE, encode = TRUE, trim = TRUE, timeout = 0, ui_state = GLOB.always_state)
 	if(!user)
 		user = usr
 
@@ -32,16 +32,16 @@
 	if(user.client?.prefs?.toggles2 & PREFTOGGLE_2_DISABLE_TGUI_INPUT)
 		if(encode)
 			if(multiline)
-				return stripped_multiline_input(user, message, title, default, max_length)
+				return stripped_multiline_input(user, message, title, default, max_length, !trim)
 			else
-				return stripped_input(user, message, title, default, max_length)
+				return stripped_input(user, message, title, default, max_length, !trim)
 		else
 			if(multiline)
 				return input(user, message, title, default) as message|null
 			else
 				return input(user, message, title, default) as text|null
 
-	var/datum/tgui_input_text/text_input = new(user, message, title, default, max_length, multiline, encode, timeout, ui_state)
+	var/datum/tgui_input_text/text_input = new(user, message, title, default, max_length, multiline, encode, trim, timeout, ui_state)
 
 	text_input.ui_interact(user)
 	text_input.wait()
@@ -62,6 +62,8 @@
 	var/default
 	/// Whether the input should be stripped using html_encode
 	var/encode
+	/// Whether the input should be trimmed from whitespaces
+	var/trim
 	/// The entry that the user has return_typed in.
 	var/entry
 	/// The maximum length for text entry
@@ -81,9 +83,10 @@
 	/// The TGUI UI state that will be returned in ui_state(). Default: always_state
 	var/datum/ui_state/state
 
-/datum/tgui_input_text/New(mob/user, message, title, default, max_length, multiline, encode, timeout, ui_state)
+/datum/tgui_input_text/New(mob/user, message, title, default, max_length, multiline, encode, trim, timeout, ui_state)
 	src.default = default
 	src.encode = encode
+	src.trim = trim
 	src.max_length = max_length
 	src.message = message
 	src.multiline = multiline
@@ -171,4 +174,4 @@
 		return
 
 	var/converted_entry = encode ? html_encode(entry) : entry
-	src.entry = trim(converted_entry, max_length + 1)
+	src.entry = trim? trim(converted_entry, max_length + 1) : trim_length(converted_entry, max_length + 1)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Добавляет новую опцию для tgui_input_text, позволяющую отключить обрезку переносов строк, пробелов и прочего в начале текста, если это не нужно.
Так же эта опция включена в бумагах и в ВВ
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР / Почему это хорошо для игры
багфикс 
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Запустил. Ввел перенос строки в начале в вода в бумеге. перенос сохранился.
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
