### PR TITLE
bugfix: спавн камеры абдукторов на ЦК

### DIFF
--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -89,8 +89,7 @@
 		for(var/obj/machinery/camera/C in GLOB.cameranet.cameras)
 			if(!C.can_use())
 				continue
-			var/list/network_overlap = networks & C.network
-			if(length(network_overlap))
+			if(length(networks & C.network))
 				camera_location = get_turf(C)
 				break
 		if(camera_location)

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -89,7 +89,8 @@
 		for(var/obj/machinery/camera/C in GLOB.cameranet.cameras)
 			if(!C.can_use())
 				continue
-			if(C.network&networks)
+			var/list/network_overlap = networks & C.network
+			if(length(network_overlap))
 				camera_location = get_turf(C)
 				break
 		if(camera_location)


### PR DESCRIPTION
## Описание

Изменяет проверку доступа к сети камер для camera/aiEye при первом его появлении

## Причина создания ПР / Почему это хорошо для игры

Без этой проверки "глаз" спавнится по списку на первой камере, которая зачастую находится на шаттле ОБР, предоставляя возможность абдукторам получить доступ к ЦК