### PR TITLE
tweak: Попытка убрать лаги от бури на Лаве

### DIFF
--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -111,7 +111,7 @@
 
 
 /datum/weather/ash_storm/weather_act(mob/living/target)
-	if(!target.mind || !ishuman(target))
+	if(!target.mind && target.stat == DEAD || !ishuman(target))
 		target.adjustFireLoss(4)
 		return
 

--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -111,7 +111,7 @@
 
 
 /datum/weather/ash_storm/weather_act(mob/living/target)
-	if(!target.mind && target.stat == DEAD || !ishuman(target))
+	if(!target.mind && target.stat == DEAD || !ishuman(target)) //mind&stat check for optimization against dead roundstart dolls
 		target.adjustFireLoss(4)
 		return
 

--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -111,7 +111,7 @@
 
 
 /datum/weather/ash_storm/weather_act(mob/living/target)
-	if(!ishuman(target))
+	if(!target.mind || !ishuman(target))
 		target.adjustFireLoss(4)
 		return
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Попытка убрать лаги от бури на лаве. 
Исключает из сложной обработки(урон от бури никуда не девается, просто он будет наносится так же как и по всем не хуманам) бури на Лаве все трупы хуманов, у который нет майнда(по сути те, в которых никогда не было игрока)
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР / Почему это хорошо для игры
Дело в том, что в конце декабря был замерджен пр с более сложным просчетом урона от бури. Все бы ничего, вот только буря действует на всех хуманов на лаве, в том числе на руинные трупы и трупы из легионов. В купе с не особо-то и легким новым просчетом урона получаем потенциальную причину лагов.
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Не нужны.
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
