### PR TITLE
bugfix: Запрет на отключение энергии в гейте академии магов

### DIFF
--- a/code/modules/awaymissions/mission_code/academy.dm
+++ b/code/modules/awaymissions/mission_code/academy.dm
@@ -6,6 +6,7 @@
 	report_alerts = FALSE
 	no_teleportlocs = TRUE
 	tele_proof = TRUE
+	requires_power = FALSE
 
 /area/awaymission/academy/headmaster
 	name = "\improper Academy Fore Block"


### PR DESCRIPTION
## Описание

Запрещает установку АПЦ в гейте академии магов.

## Причина создания ПР / Почему это хорошо для игры

Исследователи могут установить стенку, на него АПЦ и выключить энергию в гейте, тем самым получив возможность открыть ворота к кубикам судьбы и пропустить все испытания.