### PR TITLE
bugfix: Исправлении возможности захвата ядра блоба

### DIFF
--- a/code/modules/antagonists/blob/structures/core.dm
+++ b/code/modules/antagonists/blob/structures/core.dm
@@ -41,6 +41,9 @@
 		update_blob()
 	return ..()
 
+/obj/structure/blob/special/core/link_to_overmind(mob/camera/blob/owner_overmind)
+	. = ..()
+	owner_overmind.blob_core = src
 
 /obj/structure/blob/special/core/Destroy()
 	GLOB.blob_cores -= src
@@ -132,10 +135,9 @@
 
 	if(C && !QDELETED(src))
 		var/mob/camera/blob/B = new(loc, src)
-		B.blob_core = src
 		B.mind_initialize()
 		B.key = C.key
-		overmind = B
+		link_to_overmind(B)
 		B.is_offspring = is_offspring
 		addtimer(CALLBACK(src, PROC_REF(add_datum_if_not_exist)), TIME_TO_ADD_OM_DATUM)
 		log_game("[B.key] has become Blob [is_offspring ? "offspring" : ""]")

--- a/code/modules/antagonists/blob/structures/special.dm
+++ b/code/modules/antagonists/blob/structures/special.dm
@@ -21,7 +21,7 @@
 		else
 			for(var/obj/structure/blob/normal/B in range(strong_reinforce_range, src))
 				reinforce_tile(B, /obj/structure/blob/shield/core, seconds_per_tick)
-				
+
 	if(reflector_reinforce_range)
 		if(is_there_multiz())
 			for(var/obj/structure/blob/shield/B in urange_multiz(reflector_reinforce_range, src))
@@ -55,7 +55,7 @@
 		var/obj/structure/blob/B = L
 		if(!is_location_within_transition_boundaries(get_turf(B)))
 			continue
-		if(!B.overmind && overmind && prob(30))
+		if(!B.overmind && overmind && prob(30) && !istype(B, /obj/structure/blob/special/core))
 			B.link_to_overmind(pulsing_overmind) //reclaim unclaimed, non-core blobs.
 			B.update_blob()
 		var/distance = get_dist(get_turf(src), get_turf(B))


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Исправление бага из-за которого была возможность захвата блобом пустого ядра, что приводило к наличию фантомного овермайнда и неубиваемости ядра, в случае, если на него не нашелся игрок.
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР / Почему это хорошо для игры
багфикс
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Заспавнил блобов, поделился. Ядро не захватилось, все ядра спокойно убились.
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
