### PR TITLE
tweak: Разделение QDEL_IN на обычный и останавливаемый

### DIFF
--- a/code/__HELPERS/qdel.dm
+++ b/code/__HELPERS/qdel.dm
@@ -1,4 +1,8 @@
-#define QDEL_IN(item, time) addtimer(CALLBACK(GLOBAL_PROC, /proc/qdel, item), time, TIMER_STOPPABLE)
+// This is a bit hacky, we do it to avoid people relying on a return value for the macro
+// If you need that you should use QDEL_IN_STOPPABLE instead
+#define QDEL_IN(item, time) ; \
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(qdel), (time) > GC_FILTER_QUEUE ? WEAKREF(item) : item), time);
+#define QDEL_IN_STOPPABLE(item, time) addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(qdel), (time) > GC_FILTER_QUEUE ? WEAKREF(item) : item), time, TIMER_STOPPABLE)
 #define QDEL_IN_CLIENT_TIME(item, time) addtimer(CALLBACK(GLOBAL_PROC, /proc/qdel, item), time, TIMER_STOPPABLE | TIMER_CLIENT_TIME)
 #define QDEL_NULL(item) if(item) { qdel(item); item = null }
 #define QDEL_LIST(L) if(L) { for(var/___I in L) qdel(___I); if(L) { L.Cut() }; }

--- a/code/game/objects/effects/temporary_visuals/temporary_visual.dm
+++ b/code/game/objects/effects/temporary_visuals/temporary_visual.dm
@@ -13,7 +13,7 @@
 	if(randomdir)
 		setDir(pick(GLOB.cardinal))
 
-	timerid = QDEL_IN(src, duration)
+	timerid = QDEL_IN_STOPPABLE(src, duration)
 
 /obj/effect/temp_visual/Destroy()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/mining/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/goliath.dm
@@ -337,4 +337,4 @@
 /obj/effect/temp_visual/goliath_tentacle/proc/retract()
 	icon_state = "Goliath_tentacle_retract"
 	deltimer(timerid)
-	timerid = QDEL_IN(src, 7)
+	timerid = QDEL_IN_STOPPABLE(src, 7)

--- a/code/modules/tgui/tgui_input/alert_input.dm
+++ b/code/modules/tgui/tgui_input/alert_input.dm
@@ -81,7 +81,7 @@
 	if(timeout)
 		src.timeout = timeout
 		start_time = world.time
-		deletion_timer = QDEL_IN(src, timeout)
+		deletion_timer = QDEL_IN_STOPPABLE(src, timeout)
 
 /datum/tgui_alert/Destroy(force)
 	SStgui.close_uis(src)

--- a/code/modules/tgui/tgui_input/color_input.dm
+++ b/code/modules/tgui/tgui_input/color_input.dm
@@ -68,7 +68,7 @@
 	if(timeout)
 		src.timeout = timeout
 		start_time = world.time
-		deletion_timer = QDEL_IN(src, timeout)
+		deletion_timer = QDEL_IN_STOPPABLE(src, timeout)
 
 /datum/tgui_input_color/Destroy(force, ...)
 	SStgui.close_uis(src)

--- a/code/modules/tgui/tgui_input/keycombo_input.dm
+++ b/code/modules/tgui/tgui_input/keycombo_input.dm
@@ -72,7 +72,7 @@
 	if(timeout)
 		src.timeout = timeout
 		start_time = world.time
-		deletion_timer = QDEL_IN(src, timeout)
+		deletion_timer = QDEL_IN_STOPPABLE(src, timeout)
 
 /datum/tgui_input_keycombo/Destroy(force)
 	SStgui.close_uis(src)

--- a/code/modules/tgui/tgui_input/list_input.dm
+++ b/code/modules/tgui/tgui_input/list_input.dm
@@ -92,7 +92,7 @@
 	if(timeout)
 		src.timeout = timeout
 		start_time = world.time
-		deletion_timer = QDEL_IN(src, timeout)
+		deletion_timer = QDEL_IN_STOPPABLE(src, timeout)
 
 /datum/tgui_list_input/Destroy(force)
 	SStgui.close_uis(src)

--- a/code/modules/tgui/tgui_input/number_input.dm
+++ b/code/modules/tgui/tgui_input/number_input.dm
@@ -86,7 +86,7 @@
 	if(timeout)
 		src.timeout = timeout
 		start_time = world.time
-		deletion_timer = QDEL_IN(src, timeout)
+		deletion_timer = QDEL_IN_STOPPABLE(src, timeout)
 
 	/// Checks for empty numbers - bank accounts, etc.
 	if(max_value == 0)

--- a/code/modules/tgui/tgui_input/text_input.dm
+++ b/code/modules/tgui/tgui_input/text_input.dm
@@ -96,7 +96,7 @@
 	if(timeout)
 		src.timeout = timeout
 		start_time = world.time
-		deletion_timer = QDEL_IN(src, timeout)
+		deletion_timer = QDEL_IN_STOPPABLE(src, timeout)
 
 /datum/tgui_input_text/Destroy(force)
 	SStgui.close_uis(src)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Разделяет QDEL_IN на QDEL_IN(без STOPPABLE флага)  и QDEL_IN_STOPPABLE(с флагом). Заменяет QDEL_IN на QDEL_IN_STOPPABLE там, где это необходимо.
Взято отсюда:
https://github.com/tgstation/tgstation/pull/76214
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР / Почему это хорошо для игры
Останавливаемый таймер будет подороже. Нет причин создавать такой таймер там, где это не нужно.
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Не нужны.
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
