### PR TITLE
tweak: Стабилизация flick_overlay

### DIFF
--- a/code/__DEFINES/qdel.dm
+++ b/code/__DEFINES/qdel.dm
@@ -40,7 +40,11 @@
 #define QDEL_ITEM_ADMINS_WARNED (1<<0) //! Set when admins are told about lag causing qdels in this type.
 #define QDEL_ITEM_SUSPENDED_FOR_LAG (1<<1) //! Set when a type can no longer be hard deleted on failure because of lag it causes while this happens.
 
-#define QDEL_IN(item, time) addtimer(CALLBACK(GLOBAL_PROC, /proc/qdel, item), time, TIMER_STOPPABLE)
+// This is a bit hacky, we do it to avoid people relying on a return value for the macro
+// If you need that you should use QDEL_IN_STOPPABLE instead
+#define QDEL_IN(item, time) ; \
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(qdel), (time) > GC_FILTER_QUEUE ? WEAKREF(item) : item), time);
+#define QDEL_IN_STOPPABLE(item, time) addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(qdel), (time) > GC_FILTER_QUEUE ? WEAKREF(item) : item), time, TIMER_STOPPABLE)
 #define QDEL_IN_CLIENT_TIME(item, time) addtimer(CALLBACK(GLOBAL_PROC, /proc/qdel, item), time, TIMER_STOPPABLE | TIMER_CLIENT_TIME)
 #define QDEL_NULL(item) if(item) { qdel(item); item = null }
 #define QDEL_LIST(L) if(L) { for(var/___I in L) qdel(___I); if(L) { L.Cut() }; }

--- a/code/__DEFINES/qdel.dm
+++ b/code/__DEFINES/qdel.dm
@@ -40,6 +40,14 @@
 #define QDEL_ITEM_ADMINS_WARNED (1<<0) //! Set when admins are told about lag causing qdels in this type.
 #define QDEL_ITEM_SUSPENDED_FOR_LAG (1<<1) //! Set when a type can no longer be hard deleted on failure because of lag it causes while this happens.
 
+#define QDEL_IN(item, time) addtimer(CALLBACK(GLOBAL_PROC, /proc/qdel, item), time, TIMER_STOPPABLE)
+#define QDEL_IN_CLIENT_TIME(item, time) addtimer(CALLBACK(GLOBAL_PROC, /proc/qdel, item), time, TIMER_STOPPABLE | TIMER_CLIENT_TIME)
+#define QDEL_NULL(item) if(item) { qdel(item); item = null }
+#define QDEL_LIST(L) if(L) { for(var/___I in L) qdel(___I); if(L) { L.Cut() }; }
+#define QDEL_LIST_IN(L, time) addtimer(CALLBACK(GLOBAL_PROC, /proc/______qdel_list_wrapper, L), time, TIMER_STOPPABLE)
+#define QDEL_LIST_ASSOC(L) if(L) { for(var/___I in L) { qdel(L[___I]); qdel(___I); } L.Cut(); }
+#define QDEL_LIST_ASSOC_VAL(L) if(L) { for(var/___I in L) qdel(L[___I]); L.Cut(); }
+
 #define GC_QUEUED_FOR_QUEUING -1
 #define GC_CURRENTLY_BEING_QDELETED -2
 

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -382,14 +382,37 @@
 		add_to.images += image_to_show
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(remove_image_from_clients), image_to_show, show_to), duration, TIMER_CLIENT_TIME)
 
-/// Flicks an overlay to anyone who can view this atom
-/atom/proc/flick_overlay_view(image_to_show, duration)
-	var/list/viewing = list()
-	for(var/mob/viewer as anything in viewers(src))
-		if(viewer.client)
-			viewing += viewer.client
-	flick_overlay(image_to_show, viewing, duration)
+/**
+ * Helper atom that copies an appearance and exists for a period
+*/
+/atom/movable/flick_visual
 
+/// Takes the passed in MA/icon_state, mirrors it onto ourselves, and displays that in world for duration seconds
+/// Returns the displayed object, you can animate it and all, but you don't own it, we'll delete it after the duration
+/atom/proc/flick_overlay_view(mutable_appearance/display, duration)
+	if(!display)
+		return null
+
+	var/mutable_appearance/passed_appearance = \
+		istext(display) \
+			? mutable_appearance(icon, display, layer) \
+			: display
+
+	// If you don't give it a layer, we assume you want it to layer on top of this atom
+	// Because this is vis_contents, we need to set the layer manually (you can just set it as you want on return if this is a problem)
+	if(passed_appearance.layer == FLOAT_LAYER)
+		passed_appearance.layer = layer + 0.1
+	// This is faster then pooling. I promise
+	var/atom/movable/flick_visual/visual = new()
+	visual.appearance = passed_appearance
+	// I hate /area
+	var/atom/movable/lies_to_children = src
+	lies_to_children.vis_contents += visual
+	QDEL_IN_CLIENT_TIME(visual, duration)
+	return visual
+
+/area/flick_overlay_view(mutable_appearance/display, duration)
+	return
 
 /proc/get_active_player_count()
 	// Get active players who are playing in the round

--- a/code/__HELPERS/qdel.dm
+++ b/code/__HELPERS/qdel.dm
@@ -1,11 +1,3 @@
-#define QDEL_IN(item, time) addtimer(CALLBACK(GLOBAL_PROC, /proc/qdel, item), time, TIMER_STOPPABLE)
-#define QDEL_IN_CLIENT_TIME(item, time) addtimer(CALLBACK(GLOBAL_PROC, /proc/qdel, item), time, TIMER_STOPPABLE | TIMER_CLIENT_TIME)
-#define QDEL_NULL(item) if(item) { qdel(item); item = null }
-#define QDEL_LIST(L) if(L) { for(var/___I in L) qdel(___I); if(L) { L.Cut() }; }
-#define QDEL_LIST_IN(L, time) addtimer(CALLBACK(GLOBAL_PROC, /proc/______qdel_list_wrapper, L), time, TIMER_STOPPABLE)
-#define QDEL_LIST_ASSOC(L) if(L) { for(var/___I in L) { qdel(L[___I]); qdel(___I); } L.Cut(); }
-#define QDEL_LIST_ASSOC_VAL(L) if(L) { for(var/___I in L) qdel(L[___I]); L.Cut(); }
-
 /proc/______qdel_list_wrapper(list/L) //the underscores are to encourage people not to use this directly.
 	QDEL_LIST(L)
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1286,12 +1286,12 @@
 	// we will register on turf to avoid image changes with attacked_atom transforms
 	var/turf/image_loc = get_turf(attacked_atom)
 	if(visual_effect_icon)
-		attack_image = image('icons/effects/effects.dmi', image_loc, visual_effect_icon, attacked_atom.layer + 0.1)
+		attack_image = image(icon = 'icons/effects/effects.dmi', icon_state = visual_effect_icon)
 		if(ismob(src) && ismob(attacked_atom))
 			var/mob/attacker = src
 			attack_image.color = attacker.a_intent == INTENT_HARM ? "#ff0000" : "#ffffff"
 	else if(used_item)
-		attack_image = image(icon = used_item, loc = image_loc, layer = attacked_atom.layer + 0.1)
+		attack_image = image(icon = used_item)
 		// Scale the icon.
 		attack_image.transform *= 0.4
 		// The icon should not rotate.
@@ -1324,10 +1324,10 @@
 		if(viewer.client && (viewer.client.prefs.toggles2 & PREFTOGGLE_2_ITEMATTACK))
 			viewing += viewer.client
 
-	flick_overlay(attack_image, viewing, 0.7 SECONDS)
+	var/atom/movable/flick_visual/attack = attacked_atom.flick_overlay_view(attack_image, 0.7 SECONDS)
 	var/matrix/initial_transform = new(transform)
 	// And animate the attack!
-	animate(attack_image, alpha = 175, transform = initial_transform.Scale(0.75), pixel_x = 0, pixel_y = 0, pixel_z = 0, time = 0.3 SECONDS)
+	animate(attack, alpha = 175, transform = initial_transform.Scale(0.75), pixel_x = 0, pixel_y = 0, pixel_z = 0, time = 0.3 SECONDS)
 	animate(time = 0.1 SECONDS)
 	animate(alpha = 0, time = 0.3 SECONDS, easing = (CIRCULAR_EASING|EASE_OUT))
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1233,7 +1233,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 	if(get_turf(src) == get_turf(target))	// No need for pickup animation if item is on user or on the same turf
 		return
 
-	var/image/transfer_animation = image(icon = src, loc = src.loc, layer = MOB_LAYER + 0.1)
+	var/image/transfer_animation = image(icon = src, layer = ABOVE_MOB_LAYER)
 	SET_PLANE(transfer_animation, GAME_PLANE, loc)
 	transfer_animation.transform.Scale(0.75)
 	transfer_animation.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
@@ -1254,13 +1254,14 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 		target_y += 10
 		transfer_animation.pixel_x += 6 * (prob(50) ? 1 : -1)
 
-	flick_overlay_view(transfer_animation, 4)
-	var/matrix/animation_matrix = new(transfer_animation.transform)
+	var/atom/movable/flick_visual/pickup = src.loc.flick_overlay_view(transfer_animation, 0.4 SECONDS)
+	var/matrix/animation_matrix = new(pickup.transform)
 	animation_matrix.Turn(pick(-30, 30))
 	animation_matrix.Scale(0.65)
 
-	animate(transfer_animation, alpha = 175, pixel_x = target_x, pixel_y = target_y, time = 3, transform = animation_matrix, easing = CUBIC_EASING)
-	animate(alpha = 0, transform = matrix().Scale(0.7), time = 1)
+
+	animate(pickup, alpha = 175, pixel_x = target_x, pixel_y = target_y, time = 0.3 SECONDS, transform = animation_matrix, easing = CUBIC_EASING)
+	animate(alpha = 0, transform = matrix().Scale(0.7), time = 0.1 SECONDS)
 
 
 /obj/item/proc/do_drop_animation(atom/moving_from)

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -143,16 +143,16 @@
 	is_pointing = TRUE
 	update_icon(UPDATE_ICON_STATE)
 	addtimer(CALLBACK(src, PROC_REF(stop_pointing)), 1 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
-	var/image/I = image('icons/obj/weapons/projectiles.dmi',targloc,pointer_icon_state,10)
+	var/mutable_appearance/laser = mutable_appearance('icons/obj/weapons/projectiles.dmi', pointer_icon_state, target.layer + 0.01)
 	var/list/click_params = params2list(params)
 	if(click_params)
 		if(click_params["icon-x"])
-			I.pixel_x = (text2num(click_params["icon-x"]) - 16)
+			laser.pixel_x = (text2num(click_params["icon-x"]) - 16)
 		if(click_params["icon-y"])
-			I.pixel_y = (text2num(click_params["icon-y"]) - 16)
+			laser.pixel_y = (text2num(click_params["icon-y"]) - 16)
 	else
-		I.pixel_x = target.pixel_x + rand(-5,5)
-		I.pixel_y = target.pixel_y + rand(-5,5)
+		laser.pixel_x = target.pixel_x + rand(-5,5)
+		laser.pixel_y = target.pixel_y + rand(-5,5)
 
 	if(outmsg)
 		to_chat(user, outmsg)
@@ -168,7 +168,7 @@
 			to_chat(user, "<span class='warning'>You've overused the battery of [src], now it needs time to recharge!</span>")
 			recharge_locked = 1
 
-	flick_overlay_view(I, 1 SECONDS)
+	target.flick_overlay_view(laser, 1 SECONDS)
 
 
 /obj/item/laser_pointer/proc/stop_pointing()

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -98,7 +98,6 @@
 
 	. = TRUE
 	var/outmsg
-	var/turf/targloc = get_turf(target)
 
 	//human/alien mobs
 	if(iscarbon(target))

--- a/code/game/objects/items/weapons/implants/implant_stealth.dm
+++ b/code/game/objects/items/weapons/implants/implant_stealth.dm
@@ -57,11 +57,11 @@
 
 /datum/action/item_action/agent_box/proc/spawn_box()
 	// Do the box's fade in spawn animation with an image so it follows the owner.
-	var/image/fake_box = image('icons/obj/cardboard_boxes.dmi', owner, "agentbox", ABOVE_MOB_LAYER)
-	owner.flick_overlay_view(fake_box, 0.4 SECONDS)
+	var/mutable_appearance/fake_box = mutable_appearance('icons/obj/cardboard_boxes.dmi', "agentbox")
 	fake_box.alpha = 200
 	fake_box.pixel_z = 30
-	animate(fake_box, pixel_z = 0, time = 0.3 SECONDS)
+	var/atom/movable/flick_visual/fake_box_visual = owner.flick_overlay_view(fake_box, 0.4 SECONDS)
+	animate(fake_box_visual, pixel_z = 0, time = 0.3 SECONDS)
 	sleep(0.3 SECONDS)
 	if(!isturf(owner.loc))
 		to_chat(owner, span_warning("You need more space to activate this implant!"))
@@ -89,9 +89,9 @@
 
 
 /datum/action/item_action/agent_box/proc/recall_box_animation()
-	var/image/fake_box = image('icons/obj/cardboard_boxes.dmi', owner, "agentbox", ABOVE_MOB_LAYER)
-	owner.flick_overlay_view(fake_box, 0.4 SECONDS)
-	animate(fake_box, pixel_z = fake_box.pixel_z + 30, alpha = fake_box.alpha - 255, time = 3, loop = 1)
+	var/mutable_appearance/fake_box = mutable_appearance('icons/obj/cardboard_boxes.dmi', "agentbox")
+	var/atom/movable/flick_visual/fake_box_visual = owner.flick_overlay_view(fake_box, 0.4 SECONDS)
+	animate(fake_box_visual, pixel_z = fake_box.pixel_z + 30, alpha = fake_box.alpha - 255, time = 3, loop = 1)
 
 
 /datum/action/item_action/agent_box/IsAvailable()

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -104,7 +104,7 @@
 	emagged = TRUE
 	locked = FALSE
 	playsound(loc, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-	flick_overlay_view(image(icon, src, icon_sparking), 1 SECONDS)
+	flick_overlay_view(mutable_appearance(icon, icon_sparking), 1 SECONDS)
 	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, update_icon)), 1 SECONDS)
 
 	if(istype(weapon, /obj/item/melee/energy/blade))

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -36,7 +36,7 @@
 	if(prob(50 / severity))
 		locked = !locked
 		playsound(loc, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-		flick_overlay_view(image(icon, src, overlay_sparking), sparking_duration)
+		flick_overlay_view(mutable_appearance(icon, overlay_sparking), sparking_duration)
 		addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, update_icon)), sparking_duration)
 
 	if(prob(20 / severity))
@@ -53,7 +53,7 @@
 		broken = TRUE
 		locked = FALSE
 		playsound(loc, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-		flick_overlay_view(image(icon, src, overlay_sparking), sparking_duration)
+		flick_overlay_view(mutable_appearance(icon, overlay_sparking), sparking_duration)
 		addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, update_appearance), UPDATE_ICON|UPDATE_DESC), sparking_duration)
 		if(user)
 			to_chat(user, span_notice("You break the lock on [src]."))
@@ -160,7 +160,7 @@
 
 	//Well then break it!
 	playsound(loc, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-	flick_overlay_view(image(icon, src, overlay_sparking), sparking_duration)
+	flick_overlay_view(mutable_appearance(icon, overlay_sparking), sparking_duration)
 	broken = TRUE
 	locked = FALSE
 	welded = FALSE

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -264,7 +264,7 @@
 		locked = FALSE
 		broken = TRUE
 		playsound(loc, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-		flick_overlay_view(image(icon, src, overlay_sparking), sparking_duration)
+		flick_overlay_view(mutable_appearance(icon, overlay_sparking), sparking_duration)
 		addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, update_icon)), sparking_duration)
 		if(user)
 			to_chat(user, span_notice("You unlock [src]."))
@@ -280,7 +280,7 @@
 	if(prob(50 / severity))
 		locked = !locked
 		playsound(loc, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-		flick_overlay_view(image(icon, src, overlay_sparking), sparking_duration)
+		flick_overlay_view(mutable_appearance(icon, overlay_sparking), sparking_duration)
 		addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, update_icon)), sparking_duration)
 
 	if(prob(20 / severity))

--- a/code/modules/economy/quests/quest_console.dm
+++ b/code/modules/economy/quests/quest_console.dm
@@ -297,7 +297,7 @@
 
 
 /obj/machinery/computer/supplyquest/workers/proc/print_animation()
-	flick_overlay_view(image(icon, src, "print_quest_overlay", layer + 0.1), 4 SECONDS)
+	flick_overlay_view(mutable_appearance(icon, "print_quest_overlay"), 4 SECONDS)
 
 
 /obj/item/qm_quest_tablet

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -133,7 +133,7 @@
 		var/obj/item/stack/S = type_inserted
 		stack_name = initial(S.name)
 		use_power(min(1000, (amount_inserted / 100)))
-	flick_overlay_view(image(icon, src,"[initial(name)]_[stack_name]", layer + 0.01), 1 SECONDS)
+	flick_overlay_view(mutable_appearance(icon, "[initial(name)]_[stack_name]"), 1 SECONDS)
 
 
 /obj/machinery/r_n_d/proc/check_mat(datum/design/being_built, var/M)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Изменяет способ наложения flick оверлея. Заместо отображения в client.images, создается специальный атом c нужным визуалом, который цепляется к объекту через vis_content.
Так же фиксит отображение лазерной указки на объектах.
Взято отсюда:
https://github.com/tgstation/tgstation/pull/76937
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР / Почему это хорошо для игры
На тг это сделало цену операции стабильнее и при этом оптимальнее даже при одном игроке.
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Запустил, проверил все объекты и действия, в которых ипользуется данный прок. Визуально ничего не изменилось. Лазерная указка отображается нормально.
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
