### PR TITLE
tweak: Path Gear Tweak больше не пересчитывает base64icon

### DIFF
--- a/code/modules/client/preference/loadout/loadout.dm
+++ b/code/modules/client/preference/loadout/loadout.dm
@@ -38,7 +38,7 @@ GLOBAL_LIST_EMPTY(gear_datums)
 	icon = path::icon
 	if(!initial(description))
 		description = path::desc
-	if(!icon || !icon_state)
+	if(!icon || !icon_state || !color)
 		return
 	var/icon/new_icon = icon(icon, icon_state, SOUTH, 1, FALSE)
 	if(color)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Убирает ненужный пересчет base64icon при выборе подтипа объекта лодаута.
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР / Почему это хорошо для игры
Убирает ненужную трату ресурсов
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Не нужны
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
