### PR TITLE
bugfix: Исправление багов подсистем дыма и пены

### DIFF
--- a/code/datums/status_effects/wet_stacks.dm
+++ b/code/datums/status_effects/wet_stacks.dm
@@ -48,10 +48,11 @@
 
 
 /datum/status_effect/stacking/wet/proc/DryMob()
-	if(stacks > 0)
-		qdel(owner.GetComponent(/datum/component/slippery))
-		stacks = 0
-		update_wet()
+	var/slippery = owner.GetComponent(/datum/component/slippery)
+	if(slippery)
+		qdel(slippery)
+	stacks = 0
+	update_wet()
 
 /datum/status_effect/stacking/wet/stack_decay_effect()
 	. = ..()

--- a/code/game/objects/effects/effect_system/fluid_spread/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_smoke.dm
@@ -477,6 +477,7 @@
 /datum/effect_system/fluid_spread/smoke/chem/set_up(range = 1, amount = DIAMOND_AREA(range), atom/holder, atom/location = null, datum/reagents/carry = null, silent = FALSE)
 	. = ..()
 	carry?.copy_to(chemholder, carry.total_volume)
+	carry?.clear_reagents()
 
 	if(silent)
 		return


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Реакция химдыма теперь очищает хранилище реагентов
Скользкость от эффекта мокроты теперь снимается при окончании эффекта
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР / Почему это хорошо для игры
багфикс
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Не нужны
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
