### PR TITLE
bugfix: строительство каменной печи и других вещей из камня теперь занимает время

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -24,7 +24,7 @@ GLOBAL_LIST_INIT(sandstone_recipes, list ( \
 	new/datum/stack_recipe("Sandstone Plate", /obj/structure/bed/sandstone, 15, one_per_turf = 1, on_floor = 1), \
 	null, \
 	new/datum/stack_recipe("Breakdown into sand", /obj/item/stack/ore/glass, 1, one_per_turf = 0, on_floor = 1), \
-	new/datum/stack_recipe("tribal oven", /obj/machinery/kitchen_machine/tribal_oven, 20, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("tribal oven", /obj/machinery/kitchen_machine/tribal_oven, 20, time = 4 SECONDS, one_per_turf = 1, on_floor = 1), \
 	))
 
 GLOBAL_LIST_INIT(silver_recipes, list ( \

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -17,11 +17,11 @@ Mineral Sheets
 
 GLOBAL_LIST_INIT(sandstone_recipes, list ( \
 	new/datum/stack_recipe("pile of dirt", /obj/machinery/hydroponics/soil, 3, time = 10, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("sandstone door", /obj/structure/mineral_door/sandstone, 10, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("sandstone door", /obj/structure/mineral_door/sandstone, 10, time = 4 SECONDS, one_per_turf = 1, on_floor = 1), \
 	null, \
-	new/datum/stack_recipe("Assistant Statue", /obj/structure/statue/sandstone/assistant, 5, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("Assistant Statue", /obj/structure/statue/sandstone/assistant, 5, time = 4 SECONDS, one_per_turf = 1, on_floor = 1), \
 	null, \
-	new/datum/stack_recipe("Sandstone Plate", /obj/structure/bed/sandstone, 15, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("Sandstone Plate", /obj/structure/bed/sandstone, 15, time = 4 SECONDS, one_per_turf = 1, on_floor = 1), \
 	null, \
 	new/datum/stack_recipe("Breakdown into sand", /obj/item/stack/ore/glass, 1, one_per_turf = 0, on_floor = 1), \
 	new/datum/stack_recipe("tribal oven", /obj/machinery/kitchen_machine/tribal_oven, 20, time = 4 SECONDS, one_per_turf = 1, on_floor = 1), \


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
ранее не занимало. Эши или шахтеры при погонях начали отстраиваться печками. Пиздец
Ненавижу игроков.
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР / Почему это хорошо для игры
баги плохо
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
