### PR TITLE
bugfix: missing advanced reagent scanner design

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -849,7 +849,7 @@
 	build_path = /obj/item/storage/pill_bottle/bluespace
 	category = list("Medical")
 
-/datum/design/adv_reagent_scanner
+/datum/design/inugami_medical_gloves
 	name = "Inugami medical gloves"
 	id = "medical_gloves_inugami"
 	req_tech = list("materials" = 7, "biotech" = 7, "magnets" = 8, "programming" = 7)


### PR DESCRIPTION

## Причина создания ПР / Почему это хорошо для игры
Отсутствовал дизайн Advanced Reagent Scanner в протолате из-за оверрайда [мед перчатками](https://github.com/ss220-space/Paradise/pull/6462)


## Тесты
Тыкнул протолат на локалке с макс. исследованиями - дизайны на месте

