### PR TITLE
bugfix: теперь после деактивации боеголовки шаттл улетает

### DIFF
--- a/code/datums/wires/nuclearbomb.dm
+++ b/code/datums/wires/nuclearbomb.dm
@@ -50,6 +50,8 @@
 				N.explode()
 
 		if(WIRE_BOMB_TIMING)
+			if(!N.is_syndicate)
+				set_security_level(previous_level)
 			N.timing = FALSE
 			N.update_icon()
 			GLOB.bomb_set = FALSE

--- a/code/datums/wires/nuclearbomb.dm
+++ b/code/datums/wires/nuclearbomb.dm
@@ -51,7 +51,7 @@
 
 		if(WIRE_BOMB_TIMING)
 			if(!N.is_syndicate)
-				set_security_level(previous_level)
+				set_security_level(N.previous_level)
 			N.timing = FALSE
 			N.update_icon()
 			GLOB.bomb_set = FALSE

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -501,6 +501,7 @@ GLOBAL_VAR(bomb_set)
 				if(!is_syndicate)
 					set_security_level(previous_level)
 				GLOB.bomb_set = FALSE
+				SSshuttle?.remove_hostile_environment(src)
 
 
 /obj/machinery/nuclearbomb/blob_act(obj/structure/blob/B)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Исправляет ошибку, из-за которой деактивация бомбы не убирала ее из списка угроз и шаттл не мог улететь. Так же исправляет маловероятный баг, из-за которого при обезвреживании станционной боеголовки через провода код дельта не снимется.
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР / Почему это хорошо для игры
багфикс
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Не нужны
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
