### PR TITLE
bugfix: venus human trap vines should be deleting properly

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -9,7 +9,8 @@
 	opacity = FALSE
 	canSmoothWith = null
 	smooth = NONE
-	var/growth_time = 1200
+	var/growth_time = 120 SECONDS
+	var/list/vines = list()
 
 /obj/structure/alien/resin/flower_bud_enemy/New()
 	..()
@@ -20,13 +21,17 @@
 	anchors += locate(x+2,y-2,z)
 
 	for(var/turf/T in anchors)
-		Beam(T, "vine", time=INFINITY, maxdistance=5, beam_type=/obj/effect/ebeam/reacting/vine)
+		vines += Beam(T, "vine", maxdistance = 5, beam_type = /obj/effect/ebeam/reacting/vine)
 	addtimer(CALLBACK(src, PROC_REF(bear_fruit)), growth_time)
 
 /obj/structure/alien/resin/flower_bud_enemy/proc/bear_fruit()
 	visible_message("<span class='danger'>the plant has borne fruit!</span>")
 	new /mob/living/simple_animal/hostile/venus_human_trap(get_turf(src))
 	qdel(src)
+
+/obj/structure/alien/resin/flower_bud_enemy/Destroy()
+	QDEL_LIST(vines)
+	return ..()
 
 
 /mob/living/simple_animal/hostile/venus_human_trap


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Теперь лоза венериной мухоловки должна нормально удаляться при смерти (рождении) самой мухоловки
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР / Почему это хорошо для игры
https://discord.com/channels/617003227182792704/1346897556634079403/1346897556634079403
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
