### PR TITLE
bugfix: Меняем местами бластдуры и кнопки для карго шаттла

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -22236,7 +22236,7 @@
 /area/maintenance/banya)
 "cBq" = (
 /obj/machinery/door/poddoor{
-	id_tag = "QMLoaddoor";
+	id_tag = "QMLoaddoor2";
 	name = "supply dock loading door"
 	},
 /obj/machinery/conveyor{
@@ -27774,14 +27774,14 @@
 /area/crew_quarters/bar/atrium)
 "cYX" = (
 /obj/machinery/door_control{
-	id = "QMLoaddoor2";
+	id = "QMLoaddoor";
 	layer = 4;
 	name = "Loading Doors";
 	pixel_x = 24;
 	pixel_y = 8
 	},
 /obj/machinery/door_control{
-	id = "QMLoaddoor";
+	id = "QMLoaddoor2";
 	layer = 4;
 	name = "Loading Doors";
 	pixel_x = 24;
@@ -41470,7 +41470,7 @@
 /area/security/podbay)
 "eqQ" = (
 /obj/machinery/door/poddoor{
-	id_tag = "QMLoaddoor2";
+	id_tag = "QMLoaddoor";
 	name = "supply dock loading door"
 	},
 /obj/machinery/conveyor{


### PR DESCRIPTION
## Причина создания ПР / Почему это хорошо для игры
Верхняя кнопка на шаттле открывает нижний шлюз, а нижняя наоборот верхний, меняем

![image](https://github.com/user-attachments/assets/a92a4667-47b1-4862-86ea-2bcf142c0baa)
