### PR TITLE
tweak: Делаем мёртвых слаймов лужами

### DIFF
--- a/code/datums/spell_targeting/matter_eater_targeting.dm
+++ b/code/datums/spell_targeting/matter_eater_targeting.dm
@@ -5,14 +5,13 @@
 	range = 1
 	var/list/types_allowed = list(
 		/obj/item,
+		/mob/living/carbon/human,
+		/mob/living/carbon/alien/larva,
 		/mob/living/simple_animal/pet,
 		/mob/living/simple_animal/hostile,
 		/mob/living/simple_animal/parrot,
 		/mob/living/simple_animal/crab,
 		/mob/living/simple_animal/mouse,
-		/mob/living/carbon/human,
-		/mob/living/simple_animal/slime,
-		/mob/living/carbon/alien/larva,
 		/mob/living/simple_animal/slime,
 		/mob/living/simple_animal/chick,
 		/mob/living/simple_animal/chicken,

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -15,7 +15,7 @@
 
 	harm_intent_damage = 3
 	icon_living = "grey baby slime"
-	icon_dead = "grey baby slime dead"
+	icon_dead = "grey baby slime dead-nocore"
 	response_help  = "pets"
 	response_disarm = "shoos"
 	response_harm   = "stomps on"
@@ -153,7 +153,7 @@
 	..()
 	var/icon_text = "[colour] [(age_state.age != SLIME_BABY) ? "adult" : "baby"] slime"
 	//icon_dead = "[icon_text] dead"
-	icon_dead = "[colour] baby slime dead" //REMOVE THIS ONLY WHEN THERE WILL BE SPRITES OF ALL SLIME COLOURS AND SIZES!!!
+	icon_dead = "[colour] baby slime dead-nocore" //REMOVE THIS ONLY WHEN THERE WILL BE SPRITES OF ALL SLIME COLOURS AND SIZES!!!
 	if(stat != DEAD)
 		icon_state = icon_text
 		if(mood && !stat)

--- a/code/modules/surgery/core_removal.dm
+++ b/code/modules/surgery/core_removal.dm
@@ -78,7 +78,6 @@
 		new slime.coretype(slime.loc)
 
 		if(slime.cores <= 0)
-			slime.icon_state = "[slime.colour] baby slime dead-nocore"
 			return SURGERY_STEP_CONTINUE
 		else
 			return SURGERY_STEP_INCOMPLETE


### PR DESCRIPTION
## Описание
Меняем спрайт слаймов при смерти
Удаляем смену спрайтов при операции на удаление ядра
Удаляем дублирование в /datum/spell_targeting/matter_eater

## Причина создания ПР / Почему это хорошо для игры
[Предложка](https://discord.com/channels/617003227182792704/755125334097133628/1346325223716290641)
Слайм по стандарту теперь имеет этот спрайт при смерти
Уже есть слаймы в этом листе, а дублировать их смысла нет

## Тесты
Бил, тушил, поливал, множил и снова убивал слаймов