### PR TITLE
bugfix: дым, что не должен заставлять блевать, теперь не заставляет

### DIFF
--- a/code/game/objects/effects/effect_system/fluid_spread/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_smoke.dm
@@ -398,7 +398,7 @@
 	color = "#752424"
 	lifetime = 3 SMOKE_TICK_TO_SECONDS
 
-/obj/effect/particle_effect/fluid/smoke/smoke_mob(mob/living/carbon/victim)
+/obj/effect/particle_effect/fluid/smoke/vomiting/smoke_mob(mob/living/carbon/victim)
 	. = ..()
 	if(!.)
 		return .


### PR DESCRIPTION
## Описание
В проке smoke_mob вомит дыма забыли дописывать путь, из-за чего он оверрайдил прок стандартного дыма. Плохо
