### PR TITLE
bugfix: радикальное решение проблемы с рантаймами на лаве целестанции.

### DIFF
--- a/_maps/map_files/cerestation/Lavaland.dmm
+++ b/_maps/map_files/cerestation/Lavaland.dmm
@@ -204,19 +204,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine/maintenance)
-"aF" = (
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/lattice/catwalk/mapping,
-/turf/simulated/floor/lava/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "aI" = (
 /obj/machinery/vending/boozeomat,
 /turf/simulated/floor/plasteel{
@@ -1272,7 +1259,8 @@
 	icon_state = "2-8"
 	},
 /obj/structure/lattice/catwalk/mapping,
-/turf/simulated/floor/lava/lava_land_surface,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "fj" = (
 /obj/structure/cable{
@@ -3507,7 +3495,8 @@
 	icon_state = "1-4"
 	},
 /obj/structure/lattice/catwalk/mapping,
-/turf/simulated/floor/lava/lava_land_surface,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "rV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -65331,7 +65320,7 @@ aj
 aj
 aj
 aj
-aF
+MT
 aR
 lC
 aR
@@ -65846,7 +65835,7 @@ aj
 aj
 aj
 aj
-aF
+MT
 aj
 aj
 at

--- a/_maps/map_files/cerestation/Lavaland.dmm
+++ b/_maps/map_files/cerestation/Lavaland.dmm
@@ -284,7 +284,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/lattice/catwalk/mapping,
-/turf/simulated/floor/lava/lava_land_surface,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "aR" = (
 /turf/simulated/wall/r_wall,
@@ -674,7 +675,8 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk/mapping,
-/turf/simulated/floor/lava/lava_land_surface,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "cp" = (
 /obj/machinery/shower{
@@ -798,7 +800,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/lattice/catwalk/mapping,
-/turf/simulated/floor/lava/lava_land_surface,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "cW" = (
 /obj/structure/stone_tile/surrounding_tile{
@@ -1046,7 +1049,8 @@
 	icon_state = "2-8"
 	},
 /obj/structure/lattice/catwalk/mapping,
-/turf/simulated/floor/lava/lava_land_surface,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "ef" = (
 /obj/structure/table,
@@ -4053,7 +4057,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk/mapping,
-/turf/simulated/floor/lava/lava_land_surface,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "wD" = (
 /obj/item/flashlight/lantern{
@@ -4344,7 +4349,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk/mapping,
-/turf/simulated/floor/lava/lava_land_surface,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "ze" = (
 /obj/structure/railing{
@@ -4357,7 +4363,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
 /obj/structure/lattice/catwalk/mapping,
-/turf/simulated/floor/lava/lava_land_surface,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "zi" = (
 /obj/structure/stone_tile/slab,
@@ -4409,7 +4416,8 @@
 	icon_state = "2-4"
 	},
 /obj/structure/lattice/catwalk/mapping,
-/turf/simulated/floor/lava/lava_land_surface,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "zt" = (
 /obj/structure/table,
@@ -4658,7 +4666,8 @@
 	icon_state = "1-8"
 	},
 /obj/structure/lattice/catwalk/mapping,
-/turf/simulated/floor/lava/lava_land_surface,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Bm" = (
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion/dwarf{
@@ -6110,6 +6119,20 @@
 /obj/structure/stone_tile/block,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/necropolis)
+"MT" = (
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/lattice/catwalk/mapping,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "Ne" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -6945,7 +6968,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/lattice/catwalk/mapping,
-/turf/simulated/floor/lava/lava_land_surface,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Vw" = (
 /obj/structure/stone_tile/surrounding_tile,
@@ -6973,7 +6996,8 @@
 	icon_state = "2-4"
 	},
 /obj/structure/lattice/catwalk/mapping,
-/turf/simulated/floor/lava/lava_land_surface,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "VE" = (
 /obj/structure/stone_tile/center,
@@ -67362,7 +67386,7 @@ bV
 ol
 bS
 Zf
-aF
+MT
 aj
 aj
 aj
@@ -67619,7 +67643,7 @@ bV
 bV
 aK
 Zf
-aF
+MT
 aj
 aj
 aj
@@ -67876,7 +67900,7 @@ JS
 Lc
 Km
 Zf
-aF
+MT
 aj
 aj
 aj


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
В случае, если при генерации на церестанции выбираются чазмы, то они все на этапе инициализации карты падают в чазм и уничтожаются, активно рантаймя. Этот, простейший багфикс заменяет все тайлы лавы в местах, где идут провода, на тайлы базальта, убирая все рантаймы.

<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР / Почему это хорошо для игры
багфикс
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
