### PR TITLE
tweak: Теперь все мобы-антаги, которые могут залезть в венты, спавнятся сразу внутри

### DIFF
--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -179,18 +179,19 @@
 	for(var/i in 1 to count)
 		if (length(candidates))
 			var/obj/vent = pick(vents)
-			var/mob/living/simple_animal/mouse/B = new(vent.loc)
-			var/mob/M = pick(candidates)
-			candidates.Remove(M)
-			B.key = M.key
-			var/datum_type = B.mind.get_blob_infected_type()
+			var/mob/living/simple_animal/mouse/blob = new(vent.loc)
+			blob.move_into_vent(vent, FALSE)
+			var/mob/ghost = pick(candidates)
+			candidates.Remove(ghost)
+			blob.key = ghost.key
+			var/datum_type = blob.mind.get_blob_infected_type()
 			var/datum/antagonist/blob_infected/blob_datum = new datum_type()
 			blob_datum.time_to_burst_hight = TIME_TO_BURST_MOUSE_HIGHT
 			blob_datum.time_to_burst_low = TIME_TO_BURST_MOUSE_LOW
-			B.mind.add_antag_datum(blob_datum)
-			to_chat(B, span_userdanger("Теперь вы мышь, заражённая спорами Блоба. Найдите какое-нибудь укромное место до того, как вы взорветесь и станете Блобом! Вы можете перемещаться по вентиляции, нажав Alt+ЛКМ на вентиляционном отверстии."))
-			log_game("[B.key] has become blob infested mouse.")
-			notify_ghosts("Заражённая мышь появилась в [get_area(B)].", source = B, action = NOTIFY_FOLLOW)
+			blob.mind.add_antag_datum(blob_datum)
+			to_chat(blob, span_userdanger("Теперь вы мышь, заражённая спорами Блоба. Найдите какое-нибудь укромное место до того, как вы взорветесь и станете Блобом! Вы можете перемещаться по вентиляции, нажав Alt+ЛКМ на вентиляционном отверстии."))
+			log_game("[blob.key] has become blob infested mouse.")
+			notify_ghosts("Заражённая мышь появилась в [get_area(blob)].", source = blob, action = NOTIFY_FOLLOW)
 	return TRUE
 
 

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -181,8 +181,7 @@
 			var/obj/vent = pick(vents)
 			var/mob/living/simple_animal/mouse/blob = new(vent.loc)
 			blob.move_into_vent(vent, FALSE)
-			var/mob/ghost = pick(candidates)
-			candidates.Remove(ghost)
+			var/mob/ghost = pick_n_take(candidates)
 			blob.key = ghost.key
 			var/datum_type = blob.mind.get_blob_infected_type()
 			var/datum/antagonist/blob_infected/blob_datum = new datum_type()

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -182,7 +182,7 @@
 			var/mob/living/simple_animal/mouse/blob = new(vent.loc)
 			blob.move_into_vent(vent, FALSE)
 			var/mob/ghost = pick_n_take(candidates)
-			blob.key = ghost.key
+			blob.set_key(ghost.key)
 			var/datum_type = blob.mind.get_blob_infected_type()
 			var/datum/antagonist/blob_infected/blob_datum = new datum_type()
 			blob_datum.time_to_burst_hight = TIME_TO_BURST_MOUSE_HIGHT
@@ -191,6 +191,7 @@
 			to_chat(blob, span_userdanger("Теперь вы мышь, заражённая спорами Блоба. Найдите какое-нибудь укромное место до того, как вы взорветесь и станете Блобом! Вы можете перемещаться по вентиляции, нажав Alt+ЛКМ на вентиляционном отверстии."))
 			log_game("[blob.key] has become blob infested mouse.")
 			notify_ghosts("Заражённая мышь появилась в [get_area(blob)].", source = blob, action = NOTIFY_FOLLOW)
+
 	return TRUE
 
 

--- a/code/game/gamemodes/miniantags/changeling_slug/changeling_slug_event.dm
+++ b/code/game/gamemodes/miniantags/changeling_slug/changeling_slug_event.dm
@@ -22,7 +22,7 @@
 	// It is necessary to wrap this to avoid the event triggering repeatedly.
 
 /datum/event/headslug_infestation/proc/wrappedstart()
-	var/list/vents = get_valid_vent_spawns(exclude_mobs_nearby = TRUE, exclude_visible_by_mobs = TRUE) //check for amount of people
+	var/list/vents = get_valid_vent_spawns(exclude_visible_by_mobs = TRUE) //check for amount of people
 	if(eventcheck())
 		var/datum/event_container/EC = SSevents.event_containers[EVENT_LEVEL_MODERATE]
 		EC.next_event_time = world.time + (60 * 10)
@@ -38,6 +38,7 @@
 			var/mob/living/simple_animal/hostile/headslug/evented/new_slug = new(vent.loc)
 			new_slug.key = C.key
 			new_slug.make_slug_antag() //give objective and plays coolsound
+			new_slug.move_into_vent(vent, FALSE)
 			spawncount--
 			successSpawn = TRUE
 			log_game("[new_slug.key] has become Changeling Headslug.")

--- a/code/game/gamemodes/miniantags/morph/morph_event.dm
+++ b/code/game/gamemodes/miniantags/morph/morph_event.dm
@@ -18,7 +18,7 @@
 
 		var/datum/mind/player_mind = new /datum/mind(key_of_morph)
 		player_mind.active = 1
-		var/vent = pick(get_valid_vent_spawns(exclude_visible_by_mobs = TRUE))
+		var/obj/machinery/atmospherics/unary/vent_pump/vent = pick(get_valid_vent_spawns(exclude_visible_by_mobs = TRUE))
 		if(!vent)
 			kill()
 			return

--- a/code/game/gamemodes/miniantags/morph/morph_event.dm
+++ b/code/game/gamemodes/miniantags/morph/morph_event.dm
@@ -22,7 +22,7 @@
 		if(!vent)
 			kill()
 			return
-		var/mob/living/simple_animal/hostile/morph/morph = new (pick(GLOB.xeno_spawn))
+		var/mob/living/simple_animal/hostile/morph/morph = new(vent.loc)
 		player_mind.transfer_to(morph)
 		morph.make_morph_antag()
 		morph.move_into_vent(vent, FALSE)

--- a/code/game/gamemodes/miniantags/morph/morph_event.dm
+++ b/code/game/gamemodes/miniantags/morph/morph_event.dm
@@ -18,13 +18,14 @@
 
 		var/datum/mind/player_mind = new /datum/mind(key_of_morph)
 		player_mind.active = 1
-		if(!GLOB.xeno_spawn)
+		var/vent = pick(get_valid_vent_spawns(exclude_visible_by_mobs = TRUE))
+		if(!vent)
 			kill()
 			return
-
-		var/mob/living/simple_animal/hostile/morph/morph = new /mob/living/simple_animal/hostile/morph(pick(GLOB.xeno_spawn))
+		var/mob/living/simple_animal/hostile/morph/morph = new (pick(GLOB.xeno_spawn))
 		player_mind.transfer_to(morph)
 		morph.make_morph_antag()
+		morph.move_into_vent(vent, FALSE)
 		message_admins("[key_name_admin(morph)] has been made into morph by an event.")
 		add_game_logs("was spawned as a morph by an event.", morph)
 

--- a/code/modules/antagonists/terror_spiders/spider_team.dm
+++ b/code/modules/antagonists/terror_spiders/spider_team.dm
@@ -316,11 +316,16 @@ GLOBAL_VAR_INIT(global_degenerate, FALSE)
 		if(spider_type.ventcrawler_trait)
 			var/vent = pick(get_valid_vent_spawns(exclude_visible_by_mobs = TRUE))
 			spider = new spider_type(vent)
-			spider.key = ghost.key
+		var/obj/machinery/atmospherics/unary/vent_pump/vent = pick(get_valid_vent_spawns(exclude_visible_by_mobs = TRUE))
+		var/mob/living/simple_animal/hostile/poison/terror_spider/spider = new spider_type(spider_type.ventcrawler_trait ? vent.loc : pick(GLOB.xeno_spawn))
+		
+		spider.set_key(ghost.key)
+
+		if(spider_type.ventcrawler_trait)
 			spider.move_into_vent(vent, FALSE)
-		else
-			spider = new spider_type(pick(GLOB.xeno_spawn))
-			spider.key = ghost.key
+
+		spider.add_datum_if_not_exist()
+
 		spider.add_datum_if_not_exist()
 		count--
 		successSpawn = TRUE

--- a/code/modules/antagonists/terror_spiders/spider_team.dm
+++ b/code/modules/antagonists/terror_spiders/spider_team.dm
@@ -302,17 +302,22 @@ GLOBAL_VAR_INIT(global_degenerate, FALSE)
 
 /proc/create_terror_spiders(type, count)
 	var/mob/living/simple_animal/hostile/poison/terror_spider/spider_type = get_spider_type(type)
+
 	if(!spider_type)
 		to_chat(usr, "Некорректный тип паука Ужаса.")
 		return FALSE
+
 	var/list/candidates = SSghost_spawns.poll_candidates("Вы хотите занять роль Паука Ужаса?", ROLE_TERROR_SPIDER, TRUE, 60 SECONDS, source = spider_type)
 	if(length(candidates) < count)
 		message_admins("Warning: not enough players volunteered to be terrors. Could only spawn [length(candidates)] out of [count]!")
 		return FALSE
+
 	var/successSpawn = FALSE
+	var/vent_spawns = get_valid_vent_spawns(exclude_visible_by_mobs = TRUE)
+
 	while(count && length(candidates))
 		var/mob/ghost = pick_n_take(candidates)
-		var/obj/machinery/atmospherics/unary/vent_pump/vent = pick(get_valid_vent_spawns(exclude_visible_by_mobs = TRUE))
+		var/obj/machinery/atmospherics/unary/vent_pump/vent = pick(vent_spawns)
 		var/mob/living/simple_animal/hostile/poison/terror_spider/spider = new spider_type(spider_type.ventcrawler_trait ? vent.loc : pick(GLOB.xeno_spawn))
 		
 		spider.set_key(ghost.key)

--- a/code/modules/antagonists/terror_spiders/spider_team.dm
+++ b/code/modules/antagonists/terror_spiders/spider_team.dm
@@ -312,10 +312,6 @@ GLOBAL_VAR_INIT(global_degenerate, FALSE)
 	var/successSpawn = FALSE
 	while(count && length(candidates))
 		var/mob/ghost = pick_n_take(candidates)
-		var/mob/living/simple_animal/hostile/poison/terror_spider/spider
-		if(spider_type.ventcrawler_trait)
-			var/vent = pick(get_valid_vent_spawns(exclude_visible_by_mobs = TRUE))
-			spider = new spider_type(vent)
 		var/obj/machinery/atmospherics/unary/vent_pump/vent = pick(get_valid_vent_spawns(exclude_visible_by_mobs = TRUE))
 		var/mob/living/simple_animal/hostile/poison/terror_spider/spider = new spider_type(spider_type.ventcrawler_trait ? vent.loc : pick(GLOB.xeno_spawn))
 		
@@ -326,10 +322,10 @@ GLOBAL_VAR_INIT(global_degenerate, FALSE)
 
 		spider.add_datum_if_not_exist()
 
-		spider.add_datum_if_not_exist()
 		count--
 		successSpawn = TRUE
 		log_game("[spider.key] has become [spider].")
+		
 	return successSpawn
 
 

--- a/code/modules/antagonists/terror_spiders/spider_team.dm
+++ b/code/modules/antagonists/terror_spiders/spider_team.dm
@@ -301,7 +301,7 @@ GLOBAL_VAR_INIT(global_degenerate, FALSE)
 
 
 /proc/create_terror_spiders(type, count)
-	var/spider_type = get_spider_type(type)
+	var/mob/living/simple_animal/hostile/poison/terror_spider/spider_type = get_spider_type(type)
 	if(!spider_type)
 		to_chat(usr, "Некорректный тип паука Ужаса.")
 		return FALSE
@@ -311,9 +311,16 @@ GLOBAL_VAR_INIT(global_degenerate, FALSE)
 		return FALSE
 	var/successSpawn = FALSE
 	while(count && length(candidates))
-		var/mob/living/simple_animal/hostile/poison/terror_spider/spider = new spider_type(pick(GLOB.xeno_spawn))
 		var/mob/ghost = pick_n_take(candidates)
-		spider.key = ghost.key
+		var/mob/living/simple_animal/hostile/poison/terror_spider/spider
+		if(spider_type.ventcrawler_trait)
+			var/vent = pick(get_valid_vent_spawns(exclude_visible_by_mobs = TRUE))
+			spider = new spider_type(vent)
+			spider.key = ghost.key
+			spider.move_into_vent(vent, FALSE)
+		else
+			spider = new spider_type(pick(GLOB.xeno_spawn))
+			spider.key = ghost.key
 		spider.add_datum_if_not_exist()
 		count--
 		successSpawn = TRUE

--- a/code/modules/antagonists/xenomorth/xenomorph_team.dm
+++ b/code/modules/antagonists/xenomorth/xenomorph_team.dm
@@ -225,7 +225,7 @@
 
 /proc/spawn_aliens(spawn_count)
 	var/spawn_vectors = tgui_alert(usr, "Какой тип ксеноморфа заспавнить?", "Тип ксеноморфов", list("Вектор", "Грудолом")) == "Вектор"
-	var/list/vents = get_valid_vent_spawns(exclude_mobs_nearby = TRUE, exclude_visible_by_mobs = TRUE)
+	var/list/vents = get_valid_vent_spawns(exclude_visible_by_mobs = TRUE)
 	if(spawn_vectors)
 		spawn_vectors(vents, spawn_count)
 	else
@@ -242,7 +242,7 @@
 			var/mob/living/carbon/alien/larva/new_xeno = new(vent.loc)
 			new_xeno.evolution_points += (0.75 * new_xeno.max_evolution_points)	//event spawned larva start off almost ready to evolve.
 			new_xeno.key = C.key
-
+			new_xeno.move_into_vent(vent, FALSE)
 			if(first_spawn)
 				new_xeno.queen_maximum++
 				first_spawn = FALSE
@@ -262,8 +262,8 @@
 		if(C)
 			GLOB.respawnable_list -= C
 			var/mob/living/carbon/alien/humanoid/hunter/vector/new_xeno = new(vent.loc)
+			new_xeno.move_into_vent(vent, FALSE)
 			new_xeno.key = C.key
-
 			if(first_spawn)
 				new_xeno.queen_maximum++
 				first_spawn = FALSE


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Теперь все мобы-антаги из ивентов(кроме борреров, у них из-за этого ломается рендер до тех пор, пока они не перезалезут в венты, да и спрайты у них маленькие и для них это не так критично) спавнятся сразу в них.
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР / Почему это хорошо для игры
Уже много много раз было так, что условный грудолом спавнятся в условном рнд, через секунду рядом проходит ученый и вот уже вся станция знает, что на станции ксеноморфы, а иногда этот же ученый и забивает грудолома сваркой. Умирать сразу после спавна и палить этим мажора, не имея ни шанса как-то этого избежать выглядит как бред. Этот пр это исправляет.
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Запустил, зафорсил ивенты, заспавнился сразу в вентах.
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
