### PR TITLE
bugfix: Now admins can use VV

### DIFF
--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -96,12 +96,12 @@ GLOBAL_LIST_INIT(VVpixelmovement, list("step_x", "step_y", "step_size", "bound_h
 
 	switch(.["class"])
 		if(VV_TEXT)
-			.["value"] = tgui_input_text(src, "Введите текст:", "Текст", current_value, max_length = INFINITY, encode = FALSE, trim = FALSE)
+			.["value"] = tgui_input_text(src, "Введите текст:", "Текст", current_value, max_length = MAX_BOOK_MESSAGE_LEN, encode = FALSE, trim = FALSE) //TGUI can not comprehend 1eN, don't use scientific notation
 			if(.["value"] == null)
 				.["class"] = null
 				return
 		if(VV_MESSAGE)
-			.["value"] = tgui_input_text(src, "Введите текст:", "Текст", current_value, max_length = INFINITY, multiline = TRUE, encode = FALSE, trim = FALSE)
+			.["value"] = tgui_input_text(src, "Введите текст:", "Текст", current_value, max_length = MAX_BOOK_MESSAGE_LEN, multiline = TRUE, encode = FALSE, trim = FALSE)
 			if(.["value"] == null)
 				.["class"] = null
 				return


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание

Меняет количество символов, которое админ может ввести в окно текста, что поменяли в #6619.
Цифру поменял с `1` (эффективно) на `9216` .

## Причина создания ПР / Почему это хорошо для игры

Зашёл на локалку - не смог набрать больше одного символа в `VV`.

## Тесты

Зашёл на локалку - попытался сменить название у предмета через `VV` - получилось
![image](https://github.com/user-attachments/assets/314b97ed-6563-4fff-b37e-d98ae970d4bb)
