### PR TITLE
spellcheck: Свои названия органам абдукторов и мясистой массе

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/gland.dm
+++ b/code/game/gamemodes/miniantags/abduction/gland.dm
@@ -1,6 +1,14 @@
 /obj/item/organ/internal/heart/gland
 	name = "fleshy mass"
 	desc = "A nausea-inducing hunk of twisting flesh and metal."
+	ru_names = list(
+		NOMINATIVE = "мясистая масса",
+		GENITIVE = "мясистой массы",
+		DATIVE = "мясистой массе",
+		ACCUSATIVE = "мясистую массу",
+		INSTRUMENTAL = "мясистой массой",
+		PREPOSITIONAL = "мясистой массе"
+	)
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "gland"
 	dead_icon = null

--- a/code/modules/mob/living/carbon/human/species/abductor.dm
+++ b/code/modules/mob/living/carbon/human/species/abductor.dm
@@ -8,12 +8,12 @@
 	default_language = LANGUAGE_HIVE_ABDUCTOR
 	eyes = "blank_eyes"
 	has_organ = list(
-		INTERNAL_ORGAN_HEART = /obj/item/organ/internal/heart,
-		INTERNAL_ORGAN_LIVER = /obj/item/organ/internal/liver,
-		INTERNAL_ORGAN_KIDNEYS = /obj/item/organ/internal/kidneys,
+		INTERNAL_ORGAN_HEART = /obj/item/organ/internal/heart/grey/abductor,
+		INTERNAL_ORGAN_LIVER = /obj/item/organ/internal/liver/grey/abductor,
+		INTERNAL_ORGAN_KIDNEYS = /obj/item/organ/internal/kidneys/grey/abductor,
 		INTERNAL_ORGAN_BRAIN = /obj/item/organ/internal/brain/abductor,
-		INTERNAL_ORGAN_EYES = /obj/item/organ/internal/eyes/abductor, //3 darksight.
-		INTERNAL_ORGAN_EARS = /obj/item/organ/internal/ears,
+		INTERNAL_ORGAN_EYES = /obj/item/organ/internal/eyes/grey/abductor,
+		INTERNAL_ORGAN_EARS = /obj/item/organ/internal/ears/grey/abductor,
 	)
 
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/humanoid/grey

--- a/code/modules/surgery/organs/subtypes/abductor.dm
+++ b/code/modules/surgery/organs/subtypes/abductor.dm
@@ -1,3 +1,43 @@
+/obj/item/organ/internal/heart/grey/abductor
+	species_type = /datum/species/abductor
+	name = "abductor heart"
+	desc = "Орган, качающий кровь или её заменяющую субстанцию по организму гуманоида. Это принадлежало абдуктору."
+	ru_names = list(
+		NOMINATIVE = "сердце абдуктора",
+		GENITIVE = "сердца абдуктора",
+		DATIVE = "сердцу абдуктора",
+		ACCUSATIVE = "сердце абдуктора",
+		INSTRUMENTAL = "сердцем абдуктора",
+		PREPOSITIONAL = "сердце абдуктора"
+	)
+
+/obj/item/organ/internal/liver/grey/abductor
+	species_type = /datum/species/abductor
+	name = "abductor liver"
+	desc = "Маленькая печень серого цвета - орган, выполняющий множество функций, таких как фильтрация кровотока от вредных веществ, синтез необходимых белков и ферментов и удаление токсинов из организма."
+	ru_names = list(
+		NOMINATIVE = "печень абдуктора",
+		GENITIVE = "печени абдуктора",
+		DATIVE = "печени абдуктора",
+		ACCUSATIVE = "печень абдуктора",
+		INSTRUMENTAL = "печенью абдуктора",
+		PREPOSITIONAL = "печени абдуктора"
+	)
+	alcohol_intensity = 1
+
+/obj/item/organ/internal/kidneys/grey/abductor
+	species_type = /datum/species/abductor
+	name = "abductor kidneys"
+	desc = "Парный орган, отвечающий за фильтрацию кровотока и выведение токсинов и отходов из организма. Эти принадлежали абдуктору."
+	ru_names = list(
+		NOMINATIVE = "почки абдуктора",
+		GENITIVE = "почек абдуктора",
+		DATIVE = "почкам абдуктора",
+		ACCUSATIVE = "почки абдуктора",
+		INSTRUMENTAL = "почками абдуктора",
+		PREPOSITIONAL = "почках абдуктора"
+	)
+
 /obj/item/organ/internal/brain/abductor
 	species_type = /datum/species/abductor
 	desc = "Основной орган центральной нервной системы гуманоида. Фактически, именно здесь и находится разум. Этот принадлежал абдуктору."
@@ -10,9 +50,10 @@
 		PREPOSITIONAL = "мозге абдуктора"
 	)
 	icon_state = "brain-x"
+	item_state = "grey_brain"
 	mmi_icon_state = "mmi_alien"
 
-/obj/item/organ/internal/eyes/abductor
+/obj/item/organ/internal/eyes/grey/abductor
 	species_type = /datum/species/abductor
 	name = "abductor eyeballs"
 	ru_names = list(
@@ -23,4 +64,16 @@
 		INSTRUMENTAL = "глазами абдуктора",
 		PREPOSITIONAL = "глазах абдуктора"
 	)
-	see_in_dark = 3
+
+/obj/item/organ/internal/ears/grey/abductor
+	species_type = /datum/species/abductor
+	name = "abductor ears"
+	desc = "Парный орган, отвечающий за аудиальное восприятие окружающей среды и получение информации о положении гуманоида в пространстве. Эти принадлежали абдуктору."
+	ru_names = list(
+		NOMINATIVE = "уши абдуктора",
+		GENITIVE = "ушей абдуктора",
+		DATIVE = "ушам абдуктора",
+		ACCUSATIVE = "уши абдуктора",
+		INSTRUMENTAL = "ушами абдуктора",
+		PREPOSITIONAL = "ушах абдуктора"
+	)


### PR DESCRIPTION
## Причина создания ПР / Почему это хорошо для игры
Локализаторы сделали ранее базовые органы для многих рас человеческими из-за чего fleshy mass и органы абдукторов стали людскими, правим названия обратно, а плюсом ещё натягиваем спрайты органов серых на органы абдукторов, где были человеческие спрайты

## Тесты
Запустил локалку, вшил мясистую масса, посмотрел на сканер, сделал абдуктора, посмотрел на сканере, везде свои названия вместо человеческих