### PR TITLE
bugfix: fix sql query

### DIFF
--- a/code/modules/client/preference/preference_info.dm
+++ b/code/modules/client/preference/preference_info.dm
@@ -275,5 +275,5 @@ GLOBAL_LIST_INIT(preferences_info, list())
 /datum/preference_info/auto_dnr/proc/set_dnr_status(mob/source, gibbed)
     SIGNAL_HANDLER
 
-    var/mob/dead/observer/ghost = source.ghostize(NONE)
-    ghost.apply_dnr() // we prevented re-entering earlier, but we need to update hud and send signal
+    var/mob/dead/observer/ghost = source.ghostize()
+    ghost.apply_dnr()

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -734,12 +734,19 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 					switch(toggle.preftoggle_toggle)
 						if(PREFTOGGLE_SPECIAL)
 							dat += "<td style='width: 20%'><a href='byond://?_src_=prefs;preference=preference_toggles;toggle=[toggle.UID()];'>Adjust</a></td>"
+							
 						if(PREFTOGGLE_TOGGLE1)
 							dat += "<td style='width: 20%'><a href='byond://?_src_=prefs;preference=preference_toggles;toggle=[toggle.UID()];'>[(toggles & toggle.preftoggle_bitflag) ? "<span class='good'>Enabled</span>" : "<span class='bad'>Disabled</span>"]</a></td>"
+
 						if(PREFTOGGLE_TOGGLE2)
 							dat += "<td style='width: 20%'><a href='byond://?_src_=prefs;preference=preference_toggles;toggle=[toggle.UID()];'>[(toggles2 & toggle.preftoggle_bitflag) ? "<span class='good'>Enabled</span>" : "<span class='bad'>Disabled</span>"]</a></td>"
+
+						if(PREFTOGGLE_TOGGLE3)
+							dat += "<td style='width: 20%'><a href='byond://?_src_=prefs;preference=preference_toggles;toggle=[toggle.UID()];'>[(toggles3 & toggle.preftoggle_bitflag) ? "<span class='good'>Enabled</span>" : "<span class='bad'>Disabled</span>"]</a></td>"
+
 						if(PREFTOGGLE_SOUND)
 							dat += "<td style='width: 20%'><a href='byond://?_src_=prefs;preference=preference_toggles;toggle=[toggle.UID()];'>[(sound & toggle.preftoggle_bitflag) ? "<span class='good'>Enabled</span>" : "<span class='bad'>Disabled</span>"]</a></td>"
+
 					dat += "</tr>"
 				dat += "<tr><td colspan=4><br></td></tr>"
 

--- a/code/modules/client/preference/preferences_mysql.dm
+++ b/code/modules/client/preference/preferences_mysql.dm
@@ -112,7 +112,7 @@
 					keybindings=:keybindings,
 					viewrange=:viewrange,
 					ghost_darkness_level=:ghost_darkness_level,
-					toggles_3=:toggles3,
+					toggles_3=:toggles3
 					WHERE ckey=:ckey"}, list(
 						// OH GOD THE PARAMETERS
 						"ooccolour" = ooccolor,


### PR DESCRIPTION
## Описание
была еще 1 ошибка с запятой, на этот раз лишней перед where. Это финальный фикс запросов
гостайз от автоднра теперь вызывается с дефолтным битфлагом прока, что бы не отбирался респавн

## Причина создания ПР / Почему это хорошо для игры

## Тесты
дб коннект есть
![image](https://github.com/user-attachments/assets/f7810746-fab7-443a-a259-8b8fef6a35e6)
преф подгрузился и отобразился
![image](https://github.com/user-attachments/assets/f1d51bd3-5f33-4ee4-ab69-5324bb63e173)

Также префы сохраняются и подгружаются без ошибок
![image](https://github.com/user-attachments/assets/8bc66f53-74d1-472d-b978-01b64399bbd2)
