### PR TITLE
qol: Моментальный ввод ресурсов в машинерию

### DIFF
--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -88,8 +88,6 @@
 		var/atom/current_parent = parent
 		var/obj/item/stack/S = I
 		requested_amount = S.amount
-		if(isnull(requested_amount) || (requested_amount <= 0))
-			return
 		if(QDELETED(I) || QDELETED(user) || QDELETED(src) || parent != current_parent || user.incapacitated() || !in_range(current_parent, user) || user.l_hand != I && user.r_hand != I)
 			return
 	if(!user.drop_transfer_item_to_loc(I, parent))

--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -87,7 +87,7 @@
 	if(isstack(I) && precise_insertion)
 		var/atom/current_parent = parent
 		var/obj/item/stack/S = I
-		requested_amount = tgui_input_number(user, "How much do you want to insert?", "Inserting [S.singular_name]s", max_value = S.amount)
+		requested_amount = S.amount
 		if(isnull(requested_amount) || (requested_amount <= 0))
 			return
 		if(QDELETED(I) || QDELETED(user) || QDELETED(src) || parent != current_parent || user.incapacitated() || !in_range(current_parent, user) || user.l_hand != I && user.r_hand != I)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
[При нажатии минералами в машинерию все ресурсы из руки сразу загрузятся в неё без окна с выбором количества](https://discord.com/channels/617003227182792704/618952559607939072/1352644419614015550)
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР / Почему это хорошо для игры
У нас и так есть разделение пачки ресурсов в руке. В 99% случаев тебе нужно загрузить ВСЁ, а для оставшегося 1% существует вышеописанный способ
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
![dreamseeker_DIK9tMluZl](https://github.com/user-attachments/assets/46c858a9-52e7-4bd7-bebe-8c3b4f857f11)

<!-- В случае наличия изменений, влияющих на игровую часть, опишите их здесь. В случае их отсутствия, этот пункт можно удалить -->

## Тесты
Загрузил все типы ресурсов, ошибок не было
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
