### PR TITLE
bugfix: Исправление проблемы с областью видимости при смене версии бьенда между 515 и 516

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -56,6 +56,10 @@
 	/// Goes from 0 to the max (z level stack size - 1)
 	var/current_plane_offset = 0
 
+	/// The BYOND version of the client that was last logged into this mob.
+	/// Currently used to rebuild all plane master groups when going between 515<->516.
+	var/last_byond_version
+
 /datum/hud/New(mob/owner)
 	mymob = owner
 	hide_actions_toggle = new
@@ -77,6 +81,19 @@
 	update_sightflags(mymob, mymob.sight, NONE)
 
 /datum/hud/proc/client_refresh(datum/source)
+	SIGNAL_HANDLER
+	var/client/client = mymob.canon_client
+	var/new_byond_version = client.byond_version
+	#if MIN_COMPILER_VERSION > 515
+		#warn Fully change default relay_loc to "1,1", rather than changing it based on client version
+	#endif
+	if(!isnull(last_byond_version) && new_byond_version != last_byond_version)
+		var/new_relay_loc = (new_byond_version > 515) ? "1,1" : "CENTER"
+		for(var/group_key as anything in master_groups)
+			var/datum/plane_master_group/group = master_groups[group_key]
+			group.relay_loc = new_relay_loc
+			group.rebuild_hud()
+	last_byond_version = new_byond_version
 	RegisterSignal(mymob.client, COMSIG_CLIENT_SET_EYE, PROC_REF(on_eye_change), TRUE)
 	on_eye_change(null, null, mymob.client.eye)
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Иправляет проблему из-за которой когда у моба был игрок с 515, а затем он сменился на игрока с 516 у последнего весь рендер собирался в 1 тайл в углу.
Код взят отсюда:
https://github.com/tgstation/tgstation/pull/87889
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР / Почему это хорошо для игры
багфикс
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
не нужны. Было проверено на пострадавшем ингейм методами щитспавна.
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
