### PR TITLE
bugfix: Исправление ошибки 404 при отправке больших текстов через tgui на 516

### DIFF
--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -117,14 +117,14 @@
     }
 
     // Perform a standard call via location.href
-    if (url.length < 2048) {
+    if (url.length < 2048 || Byond.BLINK !== null) {
       location.href = 'byond://' + url;
       return;
     }
     // Send an HTTP request to DreamSeeker's HTTP server.
     // Allows sending much bigger payloads.
     var xhr = new XMLHttpRequest();
-    xhr.open('GET', 'http://' + window.location.host + url);
+    xhr.open('GET', url);
     xhr.send();
   };
 

--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -124,7 +124,7 @@
     // Send an HTTP request to DreamSeeker's HTTP server.
     // Allows sending much bigger payloads.
     var xhr = new XMLHttpRequest();
-    xhr.open('GET', url);
+    xhr.open('GET', 'http://' + window.location.host + url);
     xhr.send();
   };
 

--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -117,10 +117,12 @@
     }
 
     // Perform a standard call via location.href
+    // Remove condition with 516
     if (url.length < 2048 || Byond.BLINK !== null) {
       location.href = 'byond://' + url;
       return;
     }
+      // Remove with 516
     // Send an HTTP request to DreamSeeker's HTTP server.
     // Allows sending much bigger payloads.
     var xhr = new XMLHttpRequest();


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Прочитав доки и форумы, а так же сделав несколько тестов ингейм с помощью девтулов эджа, доступных на 516 я пришел к выводу, что   ``
var xhr = new XMLHttpRequest();
    xhr.open('GET', url);
    xhr.send();
`` абсолютно бесполезный кусок кода для byond >= 516. В byond 516+ ограничение на длину url увеличено до сопоставимых с XMLHttpRequest размеров. При этом из-за необходимости byond:// перед запросом для того, чтобы все работало корректно код с  XMLHttpRequest выдает 404. Поэтому в пр-ре убрано ограничение на размер для 516+ клиентов и все call будут идти через `location.href = 'byond://' + url;`, либо через cef_to_byond, если та когда-нибудь появится. До 516 все остается как было.
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР / Почему это хорошо для игры
фикс
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Тесты не локалке, ингейм тесты с помощью замены кода с помощью консоли в dev tools.
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
