### PR TITLE
bugfix: Исправление отсутствия кнопок в пачке бумаг с фото

### DIFF
--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -207,7 +207,7 @@
 		usr << browse_rsc(P.img, "tmp_photo.png")
 		var/datum/browser/popup = new(usr, "PaperBundle[UID()]", P.name, P.photo_size, P.photo_size)
 		popup.include_default_stylesheet = FALSE
-		popup.set_content("<div> <img src='tmp_photo.png' width = '180'" \
+		popup.set_content(dat + "<div><img src='tmp_photo.png' width = '180'" \
 		+ "[P.scribble ? "<div><br> Written on the back:<br><i>[P.scribble]</i>" : ""]")
 		popup.add_stylesheet("paper_bundle", 'html/css/paper_bundle.css')
 		popup.open(FALSE)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
При переводе на datum/browser потерял dat и из-за этого нельзя было листать бандл если дошел до фото. Этот пр это исправляет
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР / Почему это хорошо для игры
багфикс
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Запустил, прикрепил фото к бумаге, смог полистать
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
