### PR TITLE
tweak: Меняем цвет у базового спрайта для перчаток

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -340,7 +340,7 @@ BLIND     // can't see anything
 	gender = PLURAL //Carn: for grammarically correct text-parsing
 	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/clothing/gloves.dmi'
-	item_state = "lgloves" //For gloves withoit their own item_state
+	item_state = "bgloves" //For gloves withoit their own item_state
 	belt_icon = "bgloves"
 	siemens_coefficient = 0.50
 	body_parts_covered = HANDS


### PR DESCRIPTION
## Причина создания ПР / Почему это хорошо для игры
Брать спрайт белого цвета для базового у перчаток было ошибкой
![image](https://github.com/user-attachments/assets/2f7e26f2-f1b1-424f-b48e-d181275fda52)
