### PR TITLE
bugfix: Тени не боятся осколков стекла

### DIFF
--- a/code/modules/mob/living/carbon/human/species/shadowling.dm
+++ b/code/modules/mob/living/carbon/human/species/shadowling.dm
@@ -21,6 +21,7 @@
 		TRAIT_NO_GUNS,
 		TRAIT_EMBEDIMMUNE,
 		TRAIT_NO_SLIP_ALL,
+		TRAIT_PIERCEIMMUNE,
 	)
 	burn_mod = 1.25
 	heatmod = 1.5
@@ -83,7 +84,7 @@
 			H.clear_alert("lightexposure")
 			var/obj/item/organ/internal/eyes/E = H.get_int_organ(/obj/item/organ/internal/eyes)
 			if(istype(E))
-				E.internal_receive_damage(-1)
+				E.internal_receive_damage(-5)
 			var/update = NONE
 			if(is_species(H, /datum/species/shadow/ling/lesser))
 				update |= H.heal_overall_damage(2, 3, updating_health = FALSE)
@@ -95,7 +96,6 @@
 			H.AdjustEyeBlurry(-2 SECONDS)
 			H.CureNearsighted()
 			H.CureBlind()
-
 			H.SetWeakened(0)
 			H.SetStunned(0)
 			H.SetKnockdown(0)
@@ -110,24 +110,7 @@
 
 /datum/species/shadow/ling/lesser //Empowered thralls. Obvious, but powerful
 	name = SPECIES_LESSER_SHADOWLING
-
 	icobase = 'icons/mob/human_races/r_lshadowling.dmi'
 	deform = 'icons/mob/human_races/r_lshadowling.dmi'
-
-	blood_color = "#CCCCCC"
-	flesh_color = "#AAAAAA"
-
-	inherent_traits = list(
-		TRAIT_NO_BLOOD,
-		TRAIT_NO_BREATH,
-		TRAIT_RADIMMUNE,
-		TRAIT_NO_SPECIES_EXAMINE,
-		TRAIT_NO_HUNGER,
-	)
 	burn_mod = 1.1
 	heatmod = 1.1
-
-/datum/species/shadow/ling/lesser/handle_life(mob/living/carbon/human/H)
-	if(!H.weakeyes)
-		H.weakeyes = 1
-	handle_light(H)

--- a/code/modules/mob/living/carbon/human/species/shadowling.dm
+++ b/code/modules/mob/living/carbon/human/species/shadowling.dm
@@ -84,7 +84,7 @@
 			H.clear_alert("lightexposure")
 			var/obj/item/organ/internal/eyes/E = H.get_int_organ(/obj/item/organ/internal/eyes)
 			if(istype(E))
-				E.internal_receive_damage(-5)
+				E.internal_receive_damage(-1)
 			var/update = NONE
 			if(is_species(H, /datum/species/shadow/ling/lesser))
 				update |= H.heal_overall_damage(2, 3, updating_health = FALSE)


### PR DESCRIPTION
## Описание
Убрал дублирование кода у низших форм теней
Вернул тенелингам защиту от осколков стекла/муравьёв и т.д.

## Причина создания ПР / Почему это хорошо для игры
В [6683](https://github.com/ss220-space/Paradise/pull/6683) я забыл дать теням защиту стоп от осколков стекла/муравьёв и т.д., а низшим теням новые трейты тенелингов

## Тесты
Походил по стеклу
Порегенился в тени на низшей тени