### PR TITLE
bugfix: Металическая пена больше не дублируется в 1 тайле

### DIFF
--- a/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
@@ -287,6 +287,7 @@
 	result_type = /obj/structure/foamedmetal
 	icon_state = "mfoam"
 	slippery_foam = FALSE
+	allow_duplicate_results = FALSE
 	var/make_floor = TRUE
 
 /obj/effect/particle_effect/fluid/foam/metal/make_result() //Smart foam adheres to area borders for walls
@@ -299,20 +300,6 @@
 /obj/effect/particle_effect/fluid/foam/metal/iron
 	name = "iron foam"
 	result_type = /obj/structure/foamedmetal/iron
-
-/// A factory which produces aluminium metal foam.
-/datum/effect_system/fluid_spread/foam/metal
-	effect_type = /obj/effect/particle_effect/fluid/foam/metal
-
-/// A factory which produces smart aluminium metal foam.
-/datum/effect_system/fluid_spread/foam/metal
-	effect_type = /obj/effect/particle_effect/fluid/foam/metal
-
-/datum/effect_system/fluid_spread/foam/metal/iron
-	effect_type = /obj/effect/particle_effect/fluid/foam/metal/iron
-
-/datum/effect_system/fluid_spread/foam/metal/resin
-	effect_type = /obj/effect/particle_effect/fluid/foam/metal/resin
 
 /// A foam variant which produces atmos resin walls.
 /obj/effect/particle_effect/fluid/foam/metal/resin
@@ -328,6 +315,16 @@
 
 /obj/effect/particle_effect/fluid/foam/metal/resin/halon/temperature_expose(datum/gas_mixture/air, exposed_temperature)
 	return // Doesn't dissolve in heat.
+
+/// A factory which produces smart aluminium metal foam.
+/datum/effect_system/fluid_spread/foam/metal
+	effect_type = /obj/effect/particle_effect/fluid/foam/metal
+
+/datum/effect_system/fluid_spread/foam/metal/iron
+	effect_type = /obj/effect/particle_effect/fluid/foam/metal/iron
+
+/datum/effect_system/fluid_spread/foam/metal/resin
+	effect_type = /obj/effect/particle_effect/fluid/foam/metal/resin
 
 /datum/effect_system/fluid_spread/foam/metal/resin/halon
 	effect_type = /obj/effect/particle_effect/fluid/foam/metal/resin/halon


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Забыл выставить параметр, мешающий пене стакаться в одном тайле. Такие стаки вызывают неприятные лаги.
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР / Почему это хорошо для игры
фикс
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
не нужны
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
