### PR TITLE
balance/bugfix: Закрытие абуза с моментально убивающими дымовыми гранатами/овощами

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drugs.dm
+++ b/code/modules/reagents/chemistry/reagents/drugs.dm
@@ -512,9 +512,9 @@
 		to_chat(M, span_danger("<font face='[pick("Curlz MT", "Comic Sans MS")]' size='[rand(4,6)]'>КАК ЖЕ ЭТО ОХУЕННО!!!</font>"))
 		M << 'sound/effects/singlebeat.ogg'
 		M.emote("faint")
-		M.apply_effect(5, IRRADIATE, negate_armor = 1)
-		M.adjustToxLoss(5)
-		M.adjustBrainLoss(10)
+		M.apply_effect(volume, IRRADIATE, negate_armor = 1)
+		M.adjustToxLoss(volume)
+		M.adjustBrainLoss(volume * 2)
 	else
 		to_chat(M, span_notice("Вы чувствуете себя соленоватым."))
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Дело в том, что у солей для ванн есть реакция ingest, при которой игрок получает 5 радиации, 5 токсинов и 10 урона мозгу при приеме. И все бы ничего, если бы не существовал дым. Дело в том, что каждый тик дым производит реацию ingest c минимальным типом вещества. В результате получается адовая штука, выжигающая мозг за пару секунд, которые игрок проведет в стане в дыму. 
Данный пр делает урон(радиация и токсины) равным количеству вещества,  а уроны мозгу количество * 2
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР / Почему это хорошо для игры
Не логично, что незавивимо от количества принятого вещества получается одинаковый эффект. Вдобавок это позволяет создать абузную некотрибельную аое смерть  в виде овоща/гранаты. Для тех, кто использует соли как стимулятор мало что изменится, а вот смерть гранаты исправит.
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Не нужны
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
