### PR TITLE
bugfix: Теперь в турель нельзя установить БСП без ядра и БС кристаллов

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -338,6 +338,7 @@ GLOBAL_LIST_EMPTY(turret_icons)
 		if(installation)
 			var/obj/item/gun/energy/Gun = new installation(loc)
 			Gun.cell.charge = gun_charge
+			Gun.turret_deconstruct()
 			Gun.update_icon()
 		if(prob(50))
 			new /obj/item/stack/sheet/metal(loc, rand(1,4))
@@ -903,12 +904,12 @@ GLOBAL_LIST_EMPTY(turret_icons)
 
 		if(TURRET_BUILD_ARMOR_SECURED)
 			if(istype(I, /obj/item/gun/energy)) //the gun installation part
-				if(isrobot(user))
+				var/obj/item/gun/energy/new_gun = I
+				if(isrobot(user) || !new_gun.turret_check())
 					return ATTACK_CHAIN_PROCEED
 				add_fingerprint(user)
 				if(!user.drop_transfer_item_to_loc(I, src))
 					return ..()
-				var/obj/item/gun/energy/new_gun = I
 				installation = new_gun.type	//installation becomes new_gun.type
 				gun_charge = new_gun.cell.charge	//the gun's charge is stored in gun_charge
 				to_chat(user, span_notice("You add [I] to the turret."))
@@ -991,6 +992,7 @@ GLOBAL_LIST_EMPTY(turret_icons)
 			build_step = TURRET_BUILD_ARMOR_SECURED
 			var/obj/item/gun/energy/removed_gun = new installation(loc)
 			removed_gun.cell.charge = gun_charge
+			removed_gun.turret_deconstruct()
 			removed_gun.update_icon()
 			to_chat(user, span_notice("You remove [removed_gun] from the turret frame."))
 			installation = null

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -390,3 +390,9 @@
 			var/obj/item/ammo_casing/energy/shot = ammo_type[select] //Necessary to find cost of shot
 			if(R.cell.use(shot.e_cost)) 		//Take power from the borg...
 				cell.give(shot.e_cost)	//... to recharge the shot
+
+/obj/item/gun/energy/proc/turret_check()
+	return TRUE
+
+/obj/item/gun/energy/proc/turret_deconstruct()
+	return

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -515,6 +515,13 @@
 	has_bluespace_crystal = FALSE
 	update_icon(UPDATE_ICON_STATE)
 
+/obj/item/gun/energy/bsg/turret_check()
+	return has_bluespace_crystal && has_core
+
+/obj/item/gun/energy/bsg/turret_deconstruct()
+	has_bluespace_crystal = TRUE
+	has_bluespace_crystal = TRUE
+
 /obj/item/gun/energy/bsg/prebuilt
 	icon_state = "bsg_finished"
 	has_bluespace_crystal = TRUE


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Теперь для установки в турель нужна полностью собранная БСП. При этом при разборе турели с бсп будет возвращаться так же версия с ядром и кристаллами.
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР / Почему это хорошо для игры
багфикс + закрытие абуза с кучей мощных бесплатных турелек
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
не нужны
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
