### PR TITLE
bugfix: Фиксы лицехватов и гринтекста биоугроз

### DIFF
--- a/code/__DEFINES/dcs/signals_object.dm
+++ b/code/__DEFINES/dcs/signals_object.dm
@@ -35,3 +35,6 @@
 
 /// from  /datum/surgery_step/proc/initiate() : (&time)
 #define COMSIG_SURGERY_STEP_INIT "surgery_step_init"
+
+
+#define COMSIG_DISPOSAL_INJECT "disposal_inject"

--- a/code/modules/antagonists/terror_spiders/spider_team.dm
+++ b/code/modules/antagonists/terror_spiders/spider_team.dm
@@ -207,19 +207,19 @@ GLOBAL_VAR_INIT(global_degenerate, FALSE)
 		to_chat(world, "<b>Пауки Ужаса не были истреблены.</b>")
 	to_chat(world, "<b>Целями Пауков Ужаса было:</b>")
 	if(prince_target)
-		to_chat(world, "<br/>Цель Принца: [prince_target.explanation_text] [prince_target.completed?"<font color='green'><b>Успех!</b></font>": "<font color='red'>Провал.</font>"]")
-		SSblackbox.record_feedback("nested tally", "traitor_objective", 1, list("[prince_target.type]", prince_target.completed? "SUCCESS" : "FAIL"))
+		to_chat(world, "<br/>Цель Принца: [prince_target.explanation_text] [prince_target.check_completion()?"<font color='green'><b>Успех!</b></font>": "<font color='red'>Провал.</font>"]")
+		SSblackbox.record_feedback("nested tally", "traitor_objective", 1, list("[prince_target.type]", prince_target.check_completion()? "SUCCESS" : "FAIL"))
 	if(infect_target)
-		to_chat(world, "<br/>Цель Осквернителя: [infect_target.explanation_text] [infect_target.completed?"<font color='green'><b>Успех!</b></font>": "<font color='red'>Провал.</font>"]")
-		SSblackbox.record_feedback("nested tally", "traitor_objective", 1, list("[infect_target.type]", infect_target.completed? "SUCCESS" : "FAIL"))
+		to_chat(world, "<br/>Цель Осквернителя: [infect_target.explanation_text] [infect_target.check_completion()?"<font color='green'><b>Успех!</b></font>": "<font color='red'>Провал.</font>"]")
+		SSblackbox.record_feedback("nested tally", "traitor_objective", 1, list("[infect_target.type]", infect_target.check_completion()? "SUCCESS" : "FAIL"))
 	if(lay_eggs_target)
-		to_chat(world, "<br/>Цель Принцессы/Королевы: [lay_eggs_target.explanation_text] [lay_eggs_target.completed?"<font color='green'><b>Успех!</b></font>": "<font color='red'>Провал.</font>"]")
-		SSblackbox.record_feedback("nested tally", "traitor_objective", 1, list("[lay_eggs_target.type]", lay_eggs_target.completed? "SUCCESS" : "FAIL"))
+		to_chat(world, "<br/>Цель Принцессы/Королевы: [lay_eggs_target.explanation_text] [lay_eggs_target.check_completion()?"<font color='green'><b>Успех!</b></font>": "<font color='red'>Провал.</font>"]")
+		SSblackbox.record_feedback("nested tally", "traitor_objective", 1, list("[lay_eggs_target.type]", lay_eggs_target.check_completion()? "SUCCESS" : "FAIL"))
 	if(other_target)
-		to_chat(world, "<br/>Цель Пауков Ужаса: [other_target.explanation_text] [other_target.completed?"<font color='green'><b>Успех!</b></font>": "<font color='red'>Провал.</font>"]")
-		SSblackbox.record_feedback("nested tally", "traitor_objective", 1, list("[other_target.type]", other_target.completed? "SUCCESS" : "FAIL"))
+		to_chat(world, "<br/>Цель Пауков Ужаса: [other_target.explanation_text] [other_target.check_completion()?"<font color='green'><b>Успех!</b></font>": "<font color='red'>Провал.</font>"]")
+		SSblackbox.record_feedback("nested tally", "traitor_objective", 1, list("[other_target.type]", other_target.check_completion()? "SUCCESS" : "FAIL"))
 	if(protect_egg)
-		var/completed = protect_egg.completed && (!SSticker?.mode?.station_was_nuked || terror_stage == TERROR_STAGE_POST_END)
+		var/completed = protect_egg.check_completion() && (!SSticker?.mode?.station_was_nuked || terror_stage == TERROR_STAGE_POST_END)
 		to_chat(world, "<br/>Защита яйца: [protect_egg.explanation_text] [completed ?"<font color='green'><b>Успех!</b></font>": "<font color='red'>Провал.</font>"]")
 		SSblackbox.record_feedback("nested tally", "traitor_objective", 1, list("[protect_egg.type]", completed ? "SUCCESS" : "FAIL"))
 	return TRUE
@@ -319,7 +319,7 @@ GLOBAL_VAR_INIT(global_degenerate, FALSE)
 		var/mob/ghost = pick_n_take(candidates)
 		var/obj/machinery/atmospherics/unary/vent_pump/vent = pick(vent_spawns)
 		var/mob/living/simple_animal/hostile/poison/terror_spider/spider = new spider_type(spider_type.ventcrawler_trait ? vent.loc : pick(GLOB.xeno_spawn))
-		
+
 		spider.set_key(ghost.key)
 
 		if(spider_type.ventcrawler_trait)
@@ -330,7 +330,7 @@ GLOBAL_VAR_INIT(global_degenerate, FALSE)
 		count--
 		successSpawn = TRUE
 		log_game("[spider.key] has become [spider].")
-		
+
 	return successSpawn
 
 

--- a/code/modules/antagonists/terror_spiders/terror_spider_actions.dm
+++ b/code/modules/antagonists/terror_spiders/terror_spider_actions.dm
@@ -9,16 +9,25 @@
 /datum/action/innate/terrorspider/lay_empress_egg/Activate()
 	. = ..()
 	var/datum/team/terror_spiders/team = spider_team.resolve()
+
 	if(!team)
 		return
+
 	if(team.empress_egg)
 		to_chat(usr, span_warning("Вы или кто-то из вашего гнезда уже отложили яйцо Императрицы."))
 		return
+
+	if(team.protect_egg.check_completion())
+		to_chat(usr, span_warning("Императрица уже вылупилась. Вы не можете отложить еще одно яйцо."))
+		return
+
 	if(GLOB.global_degenerate)
 		to_chat(usr, span_warning("Яйцо было уничтожено. Отложить новое невозможно."))
 		return
+
 	if(tgui_alert(usr, "Вы действительно готовы отложить яйцо Имератрицы Ужаса?", "", list("Да", "Нет")) != "Да")
 		return
+
 	var/obj/structure/spider/eggcluster/terror_eggcluster/C = new /obj/structure/spider/eggcluster/terror_eggcluster/empress(get_turf(owner))
 	C.spiderling_number = 1
 	C.spider_mymother = owner

--- a/code/modules/antagonists/terror_spiders/terror_spider_objectives.dm
+++ b/code/modules/antagonists/terror_spiders/terror_spider_objectives.dm
@@ -24,7 +24,7 @@
 		return .
 
 	if(spider_team?.infect_target?.completed || \
-	spider_team?.lay_eggs_target?.completed|| \
+	spider_team?.lay_eggs_target?.completed || \
 	spider_team?.prince_target?.completed)
 		completed = TRUE
 		return TRUE

--- a/code/modules/antagonists/xenomorth/xenomorph_team.dm
+++ b/code/modules/antagonists/xenomorth/xenomorph_team.dm
@@ -177,17 +177,17 @@
 	to_chat(world, "<b>Целями Ксеноморфов было:</b>")
 
 	if(xeno_power_objective)
-		to_chat(world, "<br/>Цель Королевы: [xeno_power_objective.explanation_text] [xeno_power_objective.completed?"<font color='green'><b>Успех!</b></font>": "<font color='red'>Провал.</font>"]")
-		SSblackbox.record_feedback("nested tally", "traitor_objective", 1, list("[xeno_power_objective.type]", xeno_power_objective.completed? "SUCCESS" : "FAIL"))
+		to_chat(world, "<br/>Цель Королевы: [xeno_power_objective.explanation_text] [xeno_power_objective.check_completion()?"<font color='green'><b>Успех!</b></font>": "<font color='red'>Провал.</font>"]")
+		SSblackbox.record_feedback("nested tally", "traitor_objective", 1, list("[xeno_power_objective.type]", xeno_power_objective.check_completion()? "SUCCESS" : "FAIL"))
 	if(create_queen)
-		to_chat(world, "<br/>Создание королевы: [create_queen.explanation_text] [create_queen.completed?"<font color='green'><b>Успех!</b></font>": "<font color='red'>Провал.</font>"]")
-		SSblackbox.record_feedback("nested tally", "traitor_objective", 1, list("[create_queen.type]", create_queen.completed? "SUCCESS" : "FAIL"))
+		to_chat(world, "<br/>Создание королевы: [create_queen.explanation_text] [create_queen.check_completion()?"<font color='green'><b>Успех!</b></font>": "<font color='red'>Провал.</font>"]")
+		SSblackbox.record_feedback("nested tally", "traitor_objective", 1, list("[create_queen.type]", create_queen.check_completion()? "SUCCESS" : "FAIL"))
 	if(protect_queen)
-		to_chat(world, "<br/>Защита королевы: [protect_queen.explanation_text] [protect_queen.completed?"<font color='green'><b>Успех!</b></font>": "<font color='red'>Провал.</font>"]")
-		SSblackbox.record_feedback("nested tally", "traitor_objective", 1, list("[protect_queen.type]", protect_queen.completed? "SUCCESS" : "FAIL"))
+		to_chat(world, "<br/>Защита королевы: [protect_queen.explanation_text] [protect_queen.check_completion()?"<font color='green'><b>Успех!</b></font>": "<font color='red'>Провал.</font>"]")
+		SSblackbox.record_feedback("nested tally", "traitor_objective", 1, list("[protect_queen.type]", protect_queen.check_completion()? "SUCCESS" : "FAIL"))
 	if(protect_cocon)
-		to_chat(world, "<br/>Защита кокона: [protect_cocon.explanation_text] [protect_cocon.completed?"<font color='green'><b>Успех!</b></font>": "<font color='red'>Провал.</font>"]")
-		SSblackbox.record_feedback("nested tally", "traitor_objective", 1, list("[protect_cocon.type]", protect_cocon.completed? "SUCCESS" : "FAIL"))
+		to_chat(world, "<br/>Защита кокона: [protect_cocon.explanation_text] [protect_cocon.check_completion()?"<font color='green'><b>Успех!</b></font>": "<font color='red'>Провал.</font>"]")
+		SSblackbox.record_feedback("nested tally", "traitor_objective", 1, list("[protect_cocon.type]", protect_cocon.check_completion()? "SUCCESS" : "FAIL"))
 	return TRUE
 
 

--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -82,6 +82,10 @@
 
 /mob/living/simple_animal/MouseDrop(atom/over_object)
 	var/mob/living/carbon/human_to_ask = over_object
+
+	if(!istype(human_to_ask))
+		return ..()
+
 	if(holder_type)
 		var/obj/item/holder = holder_type
 		var/holder_flags = holder.holder_flags
@@ -91,6 +95,7 @@
 
 	if(human_to_ask.incapacitated() || HAS_TRAIT(human_to_ask, TRAIT_HANDS_BLOCKED) || !Adjacent(human_to_ask) || !holder_type)
 		return ..()
+
 	if(usr == src)
 		switch(tgui_alert(human_to_ask, "[src] wants you to pick [p_them()] up. Do it?",,list("Yes","No")))
 			if("Yes")

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -55,9 +55,11 @@
 	. = ..()
 	holdered_mob = hugger
 	hugger?.forceMove(src)
+	RegisterSignal(src, COMSIG_DISPOSAL_INJECT, PROC_REF(on_disposal_inject))
 
 /obj/item/clothing/mask/facehugger/Destroy()
 	holdered_mob = null
+	UnregisterSignal(src, COMSIG_DISPOSAL_INJECT)
 	. = ..()
 
 /obj/item/clothing/mask/facehugger/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
@@ -171,6 +173,13 @@
 /obj/item/clothing/mask/facehugger/proc/check_mob_inside()
 	if(holdered_mob && isturf(loc))
 		holdered_mob.forceMove(loc)
+		holdered_mob.hugger_holder = null
+		qdel(src)
+
+/obj/item/clothing/mask/facehugger/proc/on_disposal_inject(datum/source, obj/machinery/disposal/disposal)
+	SIGNAL_HANDLER
+	if(holdered_mob && istype(disposal))
+		holdered_mob.forceMove(disposal)
 		holdered_mob.hugger_holder = null
 		qdel(src)
 

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -325,7 +325,7 @@
 /obj/item/clothing/mask/facehugger/container_resist(mob/living/L)
 	var/mob/living/mob = src.loc
 
-	if(istype(mob))
+	if(istype(mob) || isstorage(loc))
 		mob.drop_item_ground(src)
 	else if(isitem(loc))
 		to_chat(L, "Вы выбираетесь из [loc].")

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -172,6 +172,8 @@
 	if(!can_be_inserted(I) || !user.drop_transfer_item_to_loc(I, src))
 		return ..()
 
+	SEND_SIGNAL(I, COMSIG_DISPOSAL_INJECT, src)
+
 	user.visible_message(
 		span_notice("[user] has placed [I] into [src]."),
 		span_notice("You have placed [I] into [src]."),
@@ -603,6 +605,7 @@
 	if((isitem(mover) && !isprojectile(mover)) && mover.throwing && mover.pass_flags != PASSEVERYTHING)
 		if((prob(75)  || mover.throwing.thrower && HAS_TRAIT(mover.throwing.thrower, TRAIT_BADASS)) && can_be_inserted(mover, TRUE))
 			mover.forceMove(src)
+			SEND_SIGNAL(mover, COMSIG_DISPOSAL_INJECT, src)
 			visible_message("[mover] lands in [src].")
 			update()
 		else


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Исправляет баг, из-за которого пауки могли отложить второе яйцо императрицы после вылупления первого.
Исправляет баг, из-за которого MouseDrop рантаймил.
Исправляет баг, из-за которого целька пауков ужаса отображалась проваленой даже при полной победе
Исправляет баг, из-за которого лицехваты, засунутые в мусорку в форме маски оставались в ней до тех пор, пока их кто-то не возьмет в руки.
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР / Почему это хорошо для игры
багфиксы
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Заспавнил ламарр, засунул её в мусорку, из мусорки она извлеклась в форме моба.
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
