### PR TITLE
bugfix: наклонение на стены шаттла при отлёте выкидывало в гиперкосмос

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -529,6 +529,9 @@
 		/* TAKEOFF */
 		var/should_transit = !is_turf_blacklisted_for_transit(oldT)
 		if(should_transit) // Only move over stuff if the transfer actually happened
+			for(var/mob/living/mob in oldT) //check for people leaned on anything
+				if(mob.leaned_object)
+					mob.stop_leaning()
 			oldT.copyTurf(newT)
 
 			//copy over air


### PR DESCRIPTION
## Описание

Добавил доп проверку и убирание наклонения при инициализации отлёта.

## Причина создания ПР / Почему это хорошо для игры

https://discord.com/channels/617003227182792704/1368274760831733852

## Демонстрация изменений
<table>
  <tr>
    <td align="center" style="color: #2c3e50; font-weight: bold; font-size: 20px;">
       До
    </td>
    <td align="center" style="color: #27ae60; font-weight: bold; font-size: 20px;">
      После
    </td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/99a7b1e7-bc53-4f99-bb5e-fffad2ac1a88" width="370"></td>
    <td><img src="https://github.com/user-attachments/assets/1c544e4b-d282-4de8-9a19-07b99e0dcabf" width="370"></td>
  </tr>
</table>

