### PR TITLE
bugfix: double megafauna loot

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -324,6 +324,7 @@
 		M.visible_message(span_notice("[M] seems happy with you after exposure to the bouquet!"))
 		M.add_atom_colour("#11c42f", FIXED_COLOUR_PRIORITY)
 		M.drop_loot()
+		M.loot = list()
 		M.faction = user.faction
 		summons |= M
 	..()


### PR DESCRIPTION
## Описание

Убирает список лута у приручённых цветками мобов.

## Причина создания ПР / Почему это хорошо для игры

https://discord.com/channels/617003227182792704/1367518263705075817/1367518263705075817