### PR TITLE
spellcheck: изменение названий алкоголя

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -105,13 +105,13 @@
 	//Display an attack message.
 	if(target != user)
 		target.visible_message(
-			span_danger("[user] ударил[genderize_ru(user.gender,"","а","о","и")] [target][head_attack_message] бутылкой [name.declent_ru(INSTRUMENTAL)]!"),
-			span_userdanger("[user] ударил[genderize_ru(user.gender,"","а","о","и")] [target][head_attack_message] бутылкой [name.declent_ru(INSTRUMENTAL)]!"),
+			span_danger("[user] ударил[genderize_ru(user.gender,"","а","о","и")] [target][head_attack_message] бутылкой [declent_ru(INSTRUMENTAL)]!"),
+			span_userdanger("[user] ударил[genderize_ru(user.gender,"","а","о","и")] [target][head_attack_message] бутылкой [declent_ru(INSTRUMENTAL)]!"),
 		)
 	else
 		user.visible_message(
-			span_danger("[target] ударил[genderize_ru(target.gender,"","а","о","и")] себя [name.declent_ru(INSTRUMENTAL)][head_attack_message]!"),
-			span_userdanger("[target] ударил[genderize_ru(target.gender,"","а","о","и")] себя [name.declent_ru(INSTRUMENTAL)][head_attack_message]!"),
+			span_danger("[target] ударил[genderize_ru(target.gender,"","а","о","и")] себя [declent_ru(INSTRUMENTAL)][head_attack_message]!"),
+			span_userdanger("[target] ударил[genderize_ru(target.gender,"","а","о","и")] себя [declent_ru(INSTRUMENTAL)][head_attack_message]!"),
 		)
 
 	//Attack logs
@@ -722,7 +722,7 @@
 
 	add_fingerprint(user)
 	if(active)
-		to_chat(user, span_warning("[capitalize(name.declent_ru(NOMINATIVE))] уже горит."))
+		to_chat(user, span_warning("[capitalize(declent_ru(NOMINATIVE))] уже горит."))
 		return .
 	. |= ATTACK_CHAIN_SUCCESS
 	active = TRUE

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -48,7 +48,7 @@
 		return ..()
 
 	if(HAS_TRAIT(user, TRAIT_PACIFISM) || GLOB.pacifism_after_gt)
-		to_chat(user, span_warning("Вы же не хотите навредить [target]!"))
+		to_chat(user, span_warning("Вы не хотите навредить [target]!"))
 		return ATTACK_CHAIN_PROCEED
 
 	. = ATTACK_CHAIN_BLOCKED_ALL
@@ -105,8 +105,8 @@
 	//Display an attack message.
 	if(target != user)
 		target.visible_message(
-			span_danger("[user] ударил[genderize_ru(user.gender,"","а","о","и")] [target][head_attack_message] бутылкой [declent_ru(INSTRUMENTAL)]!"),
-			span_userdanger("[user] ударил[genderize_ru(user.gender,"","а","о","и")] [target][head_attack_message] бутылкой [declent_ru(INSTRUMENTAL)]!"),
+			span_danger("[user] ударил[genderize_ru(user.gender,"","а","о","и")] [target][head_attack_message] [declent_ru(INSTRUMENTAL)]!"),
+			span_userdanger("[user] ударил[genderize_ru(user.gender,"","а","о","и")] [target][head_attack_message] [declent_ru(INSTRUMENTAL)]!"),
 		)
 	else
 		user.visible_message(
@@ -126,7 +126,7 @@
 
 /obj/item/reagent_containers/food/drinks/bottle/proc/SplashReagents(mob/M)
 	if(reagents && reagents.total_volume)
-		M.visible_message(span_danger("Содержимое [src.declent_ru(GENITIVE)] разбрызгивается по всему [M.declent_ru(DATIVE)]!"))
+		M.visible_message(span_danger("Содержимое [src.declent_ru(GENITIVE)] разбрызгивается по [M.declent_ru(PREPOSITIONAL)]!"))
 		reagents.reaction(M, REAGENT_TOUCH)
 		reagents.clear_reagents()
 
@@ -730,8 +730,8 @@
 	message_admins("[ADMIN_LOOKUP(user)] has primed a [name] for detonation at [ADMIN_COORDJMP(bombturf)].")
 	add_game_logs("has primed a [name] for detonation at [AREACOORD(bombturf)].", user)
 	user.visible_message(
-		span_danger("[user] поджигает [src.declent_ru(GENITIVE)]!"),
-		span_notice("Вы поджигаете [src.declent_ru(GENITIVE)]."),
+		span_danger("[user] поджигает [src.declent_ru(ACCUSATIVE)]!"),
+		span_notice("Вы поджигаете [src.declent_ru(ACCUSATIVE)]."),
 	)
 	add_overlay(GLOB.fire_overlay)
 	if(!isGlass)
@@ -756,8 +756,8 @@
 /obj/item/reagent_containers/food/drinks/bottle/molotov/attack_self(mob/user)
 	if(active)
 		if(!isGlass)
-			to_chat(user, span_danger("Пламя распространилось слишком далеко!"))
+			to_chat(user, span_danger("Пламя распространилось уже слишком далеко!"))
 			return
-		to_chat(user, span_info("Вы гасите пламя на [src.declent_ru(PREPOSITIONAL)]."))
+		to_chat(user, span_info("Вы гасите пламя у [src.declent_ru(GENITIVE)]."))
 		active = FALSE
 		update_icon(UPDATE_OVERLAYS)

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -37,7 +37,7 @@
 		B.name = "broken carton"
 		B.force = 0
 		B.throwforce = 0
-		B.desc = "A carton with the bottom half burst open. Might give you a papercut."
+		B.desc = "Картонная упаковка с разорванным дном. Можно порезаться."
 	transfer_fingerprints_to(B)
 
 	qdel(src)
@@ -48,7 +48,7 @@
 		return ..()
 
 	if(HAS_TRAIT(user, TRAIT_PACIFISM) || GLOB.pacifism_after_gt)
-		to_chat(user, span_warning("You don't want to harm [target]!"))
+		to_chat(user, span_warning("Вы же не хотите навредить [target]!"))
 		return ATTACK_CHAIN_PROCEED
 
 	. = ATTACK_CHAIN_BLOCKED_ALL
@@ -96,7 +96,7 @@
 	// You are going to knock someone out for longer if they are not wearing a helmet.
 	var/head_attack_message = ""
 	if(affecting == BODY_ZONE_HEAD && iscarbon(target))
-		head_attack_message = " on the head"
+		head_attack_message = " по голове"
 		//Knockdown the target for the duration that we calculated and divide it by 5.
 		if(armor_duration)
 			var/knock_time = (min(armor_duration, 10)) STATUS_EFFECT_CONSTANT
@@ -105,13 +105,13 @@
 	//Display an attack message.
 	if(target != user)
 		target.visible_message(
-			span_danger("[user] has hit [target][head_attack_message] with a bottle of [name]!"),
-			span_userdanger("[user] has hit [target][head_attack_message] with a bottle of [name]!"),
+			span_danger("[user] ударил[genderize_ru(user.gender,"","а","о","и")] [target][head_attack_message] бутылкой [name.declent_ru(INSTRUMENTAL)]!"),
+			span_userdanger("[user] ударил[genderize_ru(user.gender,"","а","о","и")] [target][head_attack_message] бутылкой [name.declent_ru(INSTRUMENTAL)]!"),
 		)
 	else
 		user.visible_message(
-			span_danger("[target] hits [target.p_them()]self with a bottle of [name][head_attack_message]!"),
-			span_userdanger("[target] hits [target.p_them()]self with a bottle of [name][head_attack_message]!"),
+			span_danger("[target] ударил[genderize_ru(target.gender,"","а","о","и")] себя [name.declent_ru(INSTRUMENTAL)][head_attack_message]!"),
+			span_userdanger("[target] ударил[genderize_ru(target.gender,"","а","о","и")] себя [name.declent_ru(INSTRUMENTAL)][head_attack_message]!"),
 		)
 
 	//Attack logs
@@ -126,7 +126,7 @@
 
 /obj/item/reagent_containers/food/drinks/bottle/proc/SplashReagents(mob/M)
 	if(reagents && reagents.total_volume)
-		M.visible_message("<span class='danger'>The contents of \the [src] splashes all over [M]!</span>")
+		M.visible_message(span_danger("Содержимое [src.declent_ru(GENITIVE)] разбрызгивается по всему [M.declent_ru(DATIVE)]!"))
 		reagents.reaction(M, REAGENT_TOUCH)
 		reagents.clear_reagents()
 
@@ -173,27 +173,27 @@
 	name = "Griffeater Gin"
 	desc = "Бутылка высококачественного джина, произведённого в Новом Лондоне."
 	ru_names = list(
-		NOMINATIVE = "бутылка джина \"Гриффитер\"",
-		GENITIVE = "бутылки джина \"Гриффитер\"",
-		DATIVE = "бутылке джина \"Гриффитер\"",
-		ACCUSATIVE = "бутылку джина \"Гриффитер\"",
-		INSTRUMENTAL = "бутылкой джина \"Гриффитер\"",
-		PREPOSITIONAL = "бутылке джина \"Гриффитер\""
- 	)
+		NOMINATIVE = "джин \"Гриффитер\"",
+		GENITIVE = "джина \"Гриффитер\"",
+		DATIVE = "джину \"Гриффитер\"",
+		ACCUSATIVE = "джина \"Гриффитер\"",
+		INSTRUMENTAL = "джином \"Гриффитер\"",
+		PREPOSITIONAL = "джине \"Гриффитер\""
+	)
 	icon_state = "ginbottle"
 	list_reagents = list("gin" = 100)
 
 /obj/item/reagent_containers/food/drinks/bottle/whiskey
 	name = "Uncle Git's Special Reserve"
-	desc = "Односолодовый виски премиум-класса, бережно выдержанный в туннелях ядерного бомбоубежища. ТУННЕЛЬНЫЙ ВИСКИ РУЛИТ."
+	desc = "Односолодовый виски премиум-класса, бережно выдержанный в туннелях ядерного бомбоубежища. ТУННЕЛЬНЫЙ ВИСКИ РУЛИТ!"
 	ru_names = list(
-		NOMINATIVE = "бутылка виски \"Особые Запасы Дяди Гита\"",
-		GENITIVE = "бутылки виски \"Особые Запасы Дяди Гита\"",
-		DATIVE = "бутылке виски \"Особые Запасы Дяди Гита\"",
-		ACCUSATIVE = "бутылку виски \"Особые Запасы Дяди Гита\"",
-		INSTRUMENTAL = "бутылкой виски \"Особые Запасы Дяди Гита\"",
-		PREPOSITIONAL = "бутылке виски \"Особые Запасы Дяди Гита\""
- 	)
+		NOMINATIVE = "виски \"Особые Запасы Дяди Гита\"",
+		GENITIVE = "виски \"Особые Запасы Дяди Гита\"",
+		DATIVE = "виски \"Особые Запасы Дяди Гита\"",
+		ACCUSATIVE = "виски \"Особые Запасы Дяди Гита\"",
+		INSTRUMENTAL = "виски \"Особые Запасы Дяди Гита\"",
+		PREPOSITIONAL = "виски \"Особые Запасы Дяди Гита\""
+	)
 	icon_state = "whiskeybottle"
 	list_reagents = list("whiskey" = 100)
 
@@ -201,13 +201,13 @@
 	name = "Tunguska Triple Distilled"
 	desc = "Высококачественная водка тройной перегонки, импортированная прямо из СССП."
 	ru_names = list(
-		NOMINATIVE = "бутылка водки \"Тунгуска Тройной Перегонки\"",
-		GENITIVE = "бутылки водки \"Тунгуска Тройной Перегонки\"",
-		DATIVE = "бутылке водки \"Тунгуска Тройной Перегонки\"",
-		ACCUSATIVE = "бутылку водки \"Тунгуска Тройной Перегонки\"",
-		INSTRUMENTAL = "бутылкой водки \"Тунгуска Тройной Перегонки\"",
-		PREPOSITIONAL = "бутылке водки \"Тунгуска Тройной Перегонки\""
- 	)
+		NOMINATIVE = "водка \"Тунгуска Тройной Перегонки\"",
+		GENITIVE = "водки \"Тунгуска Тройной Перегонки\"",
+		DATIVE = "водке \"Тунгуска Тройной Перегонки\"",
+		ACCUSATIVE = "водку \"Тунгуска Тройной Перегонки\"",
+		INSTRUMENTAL = "водкой \"Тунгуска Тройной Перегонки\"",
+		PREPOSITIONAL = "водке \"Тунгуска Тройной Перегонки\""
+	)
 	icon_state = "vodkabottle"
 	list_reagents = list("vodka" = 100)
 
@@ -215,13 +215,13 @@
 	name = "Badminka Vodka"
 	desc = "Может и не самая дорогая, но всё ещё пригодная для употребления водка, производимая на окраинах СССП. Чёрт возьми, водка есть водка!"
 	ru_names = list(
-		NOMINATIVE = "бутылка водки \"Бадминка\"",
-		GENITIVE = "бутылки водки \"Бадминка\"",
-		DATIVE = "бутылке водки \"Бадминка\"",
-		ACCUSATIVE = "бутылку водки \"Бадминка\"",
-		INSTRUMENTAL = "бутылкой водки \"Бадминка\"",
-		PREPOSITIONAL = "бутылке водки \"Бадминка\""
- 	)
+		NOMINATIVE = "водка \"Бадминка\"",
+		GENITIVE = "водки \"Бадминка\"",
+		DATIVE = "водке \"Бадминка\"",
+		ACCUSATIVE = "водку \"Бадминка\"",
+		INSTRUMENTAL = "водкой \"Бадминка\"",
+		PREPOSITIONAL = "водке \"Бадминка\""
+	)
 	icon_state = "badminka"
 	list_reagents = list("vodka" = 100)
 
@@ -229,19 +229,19 @@
 	name = "Caccavo Guaranteed Quality Tequila"
 	desc = "Изготовлена из высококачественных нефтяных дистиллятов, чистого талидомида и других высококачественных ингредиентов!"
 	ru_names = list(
-		NOMINATIVE = "бутылка текилы \"Гарантированно Качественная Текила Каккаво\"",
-		GENITIVE = "бутылки текилы \"Гарантированно Качественная Текила Каккаво\"",
-		DATIVE = "бутылке текилы \"Гарантированно Качественная Текила Каккаво\"",
-		ACCUSATIVE = "бутылку текилы \"Гарантированно Качественная Текила Каккаво\"",
-		INSTRUMENTAL = "бутылкой текилы \"Гарантированно Качественная Текила Каккаво\"",
-		PREPOSITIONAL = "бутылке текилы \"Гарантированно Качественная Текила Каккаво\""
- 	)
+		NOMINATIVE = "текила \"Гарантированно Качественная Каккаво\"",
+		GENITIVE = "текилы \"Гарантированно Качественная Каккаво\"",
+		DATIVE = "текиле \"Гарантированно Качественная Каккаво\"",
+		ACCUSATIVE = "текилу \"Гарантированно Качественная Каккаво\"",
+		INSTRUMENTAL = "текилой \"Гарантированно Качественная Каккаво\"",
+		PREPOSITIONAL = "текиле \"Гарантированно Качественная Каккаво\""
+	)
 	icon_state = "tequilabottle"
 	list_reagents = list("tequila" = 100)
 
 /obj/item/reagent_containers/food/drinks/bottle/bottleofnothing
 	name = "Bottle of Nothing"
-	desc = "Бутылка, наполненная ничем."
+	desc = "Бутылка, наполненная Ничем."
 	ru_names = list(
 		NOMINATIVE = "бутылка \"Ничего\"",
 		GENITIVE = "бутылки \"Ничего\"",
@@ -271,13 +271,13 @@
 	name = "Roca Patron Silver"
 	desc = "Премиальная текила с серебряным отливом, которую подают в ночных клубах по всей галактике."
 	ru_names = list(
-		NOMINATIVE = "бутылка текилы \"Рока Патрон Сильвер\"",
-		GENITIVE = "бутылки текилы \"Рока Патрон Сильвер\"",
-		DATIVE = "бутылке текилы \"Рока Патрон Сильвер\"",
-		ACCUSATIVE = "бутылку текилы \"Рока Патрон Сильвер\"",
-		INSTRUMENTAL = "бутылкой текилы \"Рока Патрон Сильвер\"",
-		PREPOSITIONAL = "бутылке текилы \"Рока Патрон Сильвер\""
- 	)
+		NOMINATIVE = "текила \"Рока Патрон Сильвер\"",
+		GENITIVE = "текилы \"Рока Патрон Сильвер\"",
+		DATIVE = "текиле \"Рока Патрон Сильвер\"",
+		ACCUSATIVE = "текилу \"Рока Патрон Сильвер\"",
+		INSTRUMENTAL = "текилой \"Рока Патрон Сильвер\"",
+		PREPOSITIONAL = "текиле \"Рока Патрон Сильвер\""
+	)
 	icon_state = "patronbottle"
 	list_reagents = list("patron" = 100)
 
@@ -285,13 +285,13 @@
 	name = "Captain Pete's Cuban Spiced Rum"
 	desc = "Как сказал однажды мой шкипер: \"Если бледная смерть с трепетным ужасом сделает космическую пустоту нашим последним пристанищем, Бог, слышащий, как клубится тьма космоса, соизволит спасти нашу молящуюся душу\"."
 	ru_names = list(
-		NOMINATIVE = "бутылка рома \"Кубинский Пряный Ром Капитана Пита\"",
-		GENITIVE = "бутылки рома \"Кубинский Пряный Ром Капитана Пита\"",
-		DATIVE = "бутылке рома \"Кубинский Пряный Ром Капитана Пита\"",
-		ACCUSATIVE = "бутылку рома \"Кубинский Пряный Ром Капитана Пита\"",
-		INSTRUMENTAL = "бутылкой рома \"Кубинский Пряный Ром Капитана Пита\"",
-		PREPOSITIONAL = "бутылке рома\"Кубинский Пряный Ром Капитана Пита\""
- 	)
+		NOMINATIVE = "ром \"Кубинский Пряный Капитана Пита\"",
+		GENITIVE = "рома \"Кубинский Пряный Капитана Пита\"",
+		DATIVE = "рому \"Кубинский Пряный Капитана Пита\"",
+		ACCUSATIVE = "ром \"Кубинский Пряный Капитана Пита\"",
+		INSTRUMENTAL = "ромом \"Кубинский Пряный Капитана Пита\"",
+		PREPOSITIONAL = "роме \"Кубинский Пряный Капитана Пита\""
+	)
 	icon_state = "rumbottle"
 	list_reagents = list("rum" = 100)
 
@@ -317,27 +317,27 @@
 	name = "Goldeneye Vermouth"
 	desc = "Сладкая, сладкая сухость..."
 	ru_names = list(
-		NOMINATIVE = "бутылка вермута \"Золотой Глаз\"",
-		GENITIVE = "бутылки вермута \"Золотой Глаз\"",
-		DATIVE = "бутылке вермута \"Золотой Глаз\"",
-		ACCUSATIVE = "бутылку вермута \"Золотой Глаз\"",
-		INSTRUMENTAL = "бутылкой вермута \"Золотой Глаз\"",
-		PREPOSITIONAL = "бутылке вермута \"Золотой Глаз\""
- 	)
+		NOMINATIVE = "вермут \"Золотой Глаз\"",
+		GENITIVE = "вермута \"Золотой Глаз\"",
+		DATIVE = "вермуту \"Золотой Глаз\"",
+		ACCUSATIVE = "вермут \"Золотой Глаз\"",
+		INSTRUMENTAL = "вермутом \"Золотой Глаз\"",
+		PREPOSITIONAL = "вермуте \"Золотой Глаз\""
+	)
 	icon_state = "vermouthbottle"
 	list_reagents = list("vermouth" = 100)
 
 /obj/item/reagent_containers/food/drinks/bottle/kahlua
 	name = "Robert Robust's Coffee Liqueur"
-	desc = "Широко известный мексиканский ликёр со вкусом кофе. Производится с 1936 года."
+	desc = "Широко известный мексиканский ликёр \"Калуа\" со вкусом кофе. Производится с 1936 года."
 	ru_names = list(
-		NOMINATIVE = "бутылка ликёра Калуа \"Кофейный ликёр Роберта Робаста\"",
-		GENITIVE = "бутылки ликёра Калуа \"Кофейный ликёр Роберта Робаста\"",
-		DATIVE = "бутылке ликёра Калуа \"Кофейный ликёр Роберта Робаста\"",
-		ACCUSATIVE = "бутылку ликёра Калуа \"Кофейный ликёр Роберта Робаста\"",
-		INSTRUMENTAL = "бутылкой ликёра Калуа \"Кофейный ликёр Роберта Робаста\"",
-		PREPOSITIONAL = "бутылке ликёра Калуа \"Кофейный ликёр Роберта Робаста\""
- 	)
+		NOMINATIVE = "ликёр \"Роберт Робаст\"",
+		GENITIVE = "ликёра \"Роберт Робаст\"",
+		DATIVE = "ликёру \"Роберт Робаст\"",
+		ACCUSATIVE = "ликёр \"Роберт Робаст\"",
+		INSTRUMENTAL = "ликёром \"Роберт Робаст\"",
+		PREPOSITIONAL = "ликёре \"Роберт Робаст\""
+	)
 	icon_state = "kahluabottle"
 	list_reagents = list("kahlua" = 100)
 
@@ -345,13 +345,13 @@
 	name = "College Girl Goldschlager"
 	desc = "Потому что они единственные, кто будет пить шнапс с корицей 100%-ой пробы."
 	ru_names = list(
-		NOMINATIVE = "бутылка шнапса \"Голдшлягер Студенческий\"",
-		GENITIVE = "бутылки шнапса \"Голдшлягер Студенческий\"",
-		DATIVE = "бутылке шнапса \"Голдшлягер Студенческий\"",
-		ACCUSATIVE = "бутылку шнапса \"Голдшлягер Студенческий\"",
-		INSTRUMENTAL = "бутылкой шнапса \"Голдшлягер Студенческий\"",
-		PREPOSITIONAL = "бутылке шнапса \"Голдшлягер Студенческий\""
- 	)
+		NOMINATIVE = "шнапс \"Голдшлягер Студенческий\"",
+		GENITIVE = "шнапса \"Голдшлягер Студенческий\"",
+		DATIVE = "шнапсу \"Голдшлягер Студенческий\"",
+		ACCUSATIVE = "шнапс \"Голдшлягер Студенческий\"",
+		INSTRUMENTAL = "шнапсом \"Голдшлягер Студенческий\"",
+		PREPOSITIONAL = "шнапсе \"Голдшлягер Студенческий\""
+	)
 	icon_state = "goldschlagerbottle"
 	list_reagents = list("goldschlager" = 100)
 
@@ -359,13 +359,13 @@
 	name = "Chateau De Baton Premium Cognac"
 	desc = "Коньяк премиального качества, изготовленный путём многочисленных дистилляций и многолетней выдержки."
 	ru_names = list(
-		NOMINATIVE = "бутылка коньяка \"Шато Дэ Батон\"",
-		GENITIVE = "бутылки коньяка \"Шато Дэ Батон\"",
-		DATIVE = "бутылке коньяка \"Шато Дэ Батон\"",
-		ACCUSATIVE = "бутылку коньяка \"Шато Дэ Батон\"",
-		INSTRUMENTAL = "бутылкой коньяка \"Шато Дэ Батон\"",
-		PREPOSITIONAL = "бутылке коньяка \"Шато Дэ Батон\""
- 	)
+		NOMINATIVE = "коньяк \"Шато Дэ Батон\"",
+		GENITIVE = "коньяка \"Шато Дэ Батон\"",
+		DATIVE = "коньяку \"Шато Дэ Батон\"",
+		ACCUSATIVE = "коньяк \"Шато Дэ Батон\"",
+		INSTRUMENTAL = "коньяком \"Шато Дэ Батон\"",
+		PREPOSITIONAL = "коньяке \"Шато Дэ Батон\""
+	)
 	icon_state = "cognacbottle"
 	list_reagents = list("cognac" = 100)
 
@@ -373,13 +373,13 @@
 	name = "Doublebeard Bearded Special Wine"
 	desc = "Слабая аура беспокойства и боли в заднице окружает эту бутылку."
 	ru_names = list(
-		NOMINATIVE = "бутылка вина \"Особое Двухбородое\"",
-		GENITIVE = "бутылки вина \"Особое Двухбородое\"",
-		DATIVE = "бутылке вина \"Особое Двухбородое\"",
-		ACCUSATIVE = "бутылку вина \"Особое Двухбородое\"",
-		INSTRUMENTAL = "бутылкой вина \"Особое Двухбородое\"",
-		PREPOSITIONAL = "бутылке вина \"Особое Двухбородое\""
- 	)
+		NOMINATIVE = "вино \"Особое Двухбородое\"",
+		GENITIVE = "вина \"Особое Двухбородое\"",
+		DATIVE = "вину \"Особое Двухбородое\"",
+		ACCUSATIVE = "вино \"Особое Двухбородое\"",
+		INSTRUMENTAL = "вином \"Особое Двухбородое\"",
+		PREPOSITIONAL = "вине \"Особое Двухбородое\""
+	)
 	icon_state = "winebottle"
 	list_reagents = list("wine" = 100)
 
@@ -387,13 +387,13 @@
 	name = "Yellow Marquee Absinthe"
 	desc = "Крепкий алкогольный напиток, сваренный и распространяемый компанией \"Жёлтый Шатёр\"."
 	ru_names = list(
-		NOMINATIVE = "бутылка абсента \"Жёлтый Шатёр\"",
-		GENITIVE = "бутылки абсента \"Жёлтый Шатёр\"",
-		DATIVE = "бутылке абсента \"Жёлтый Шатёр\"",
-		ACCUSATIVE = "бутылку абсента \"Жёлтый Шатёр\"",
-		INSTRUMENTAL = "бутылкой абсента \"Жёлтый Шатёр\"",
-		PREPOSITIONAL = "бутылке абсента \"Жёлтый Шатёр\""
- 	)
+		NOMINATIVE = "абсент \"Жёлтый Шахтёр\"",
+		GENITIVE = "абсента \"Жёлтый Шахтёр\"",
+		DATIVE = "абсенту \"Жёлтый Шахтёр\"",
+		ACCUSATIVE = "абсент \"Жёлтый Шахтёр\"",
+		INSTRUMENTAL = "абсентом \"Жёлтый Шахтёр\"",
+		PREPOSITIONAL = "абсенте \"Жёлтый Шахтёр\""
+	)
 	icon_state = "absinthebottle"
 	list_reagents = list("absinthe" = 100)
 
@@ -401,26 +401,26 @@
 	name = "Gwyn's Premium Absinthe"
 	desc = "Крепкий алкогольный напиток, почти заставляющий забыть о пепле в лёгких."
 	ru_names = list(
-		NOMINATIVE = "бутылка абсента \"Премиальный Абсент Гвена\"",
-		GENITIVE = "бутылки абсента \"Премиальный Абсент Гвена\"",
-		DATIVE = "бутылке абсента \"Премиальный Абсент Гвена\"",
-		ACCUSATIVE = "бутылку абсента \"Премиальный Абсент Гвена\"",
-		INSTRUMENTAL = "бутылкой абсента \"Премиальный Абсент Гвена\"",
-		PREPOSITIONAL = "бутылке абсента \"Премиальный Абсент Гвена\""
- 	)
+		NOMINATIVE = "абсент \"Премиальный от Гвена\"",
+		GENITIVE = "абсента \"Премиальный от Гвена\"",
+		DATIVE = "абсенту \"Премиальный от Гвена\"",
+		ACCUSATIVE = "абсент \"Премиальный от Гвена\"",
+		INSTRUMENTAL = "абсентом \"Премиальный от Гвена\"",
+		PREPOSITIONAL = "абсенте \"Премиальный от Гвена\""
+	)
 	icon_state = "absinthepremium"
 
 /obj/item/reagent_containers/food/drinks/bottle/hcider
 	name = "Jian Hard Cider"
 	desc = "Яблочный сок для взрослых."
 	ru_names = list(
-		NOMINATIVE = "бутылка сидра \"Цзянь Крепкий\"",
-		GENITIVE = "бутылки сидра \"Цзянь Крепкий\"",
-		DATIVE = "бутылке сидра \"Цзянь Крепкий\"",
-		ACCUSATIVE = "бутылку сидра \"Цзянь Крепкий\"",
-		INSTRUMENTAL = "бутылкой сидра \"Цзянь Крепкий\"",
-		PREPOSITIONAL = "бутылке сидра \"Цзянь Крепкий\""
- 	)
+		NOMINATIVE = "сидр \"Цзянь Крепкий\"",
+		GENITIVE = "сидра \"Цзянь Крепкий\"",
+		DATIVE = "сидру \"Цзянь Крепкий\"",
+		ACCUSATIVE = "сидр \"Цзянь Крепкий\"",
+		INSTRUMENTAL = "сидром \"Цзянь Крепкий\"",
+		PREPOSITIONAL = "сидре \"Цзянь Крепкий\""
+	)
 	icon_state = "hcider"
 	volume = 50
 	list_reagents = list("suicider" = 50)
@@ -429,13 +429,13 @@
 	name = "Fernet Bronca"
 	desc = "Бутылка фернета, произведенного на космической станции \"Кордоба\"."
 	ru_names = list(
-		NOMINATIVE = "бутылка фернета \"Фернет Бронка\"",
-		GENITIVE = "бутылки фернета \"Фернет Бронка\"",
-		DATIVE = "бутылке фернета \"Фернет Бронка\"",
-		ACCUSATIVE = "бутылку фернета \"Фернет Бронка\"",
-		INSTRUMENTAL = "бутылкой фернета \"Фернет Бронка\"",
-		PREPOSITIONAL = "бутылке фернета \"Фернет Бронка\""
- 	)
+		NOMINATIVE = "фернет \"Фернет Бронка\"",
+		GENITIVE = "фернета \"Фернет Бронка\"",
+		DATIVE = "фернету \"Фернет Бронка\"",
+		ACCUSATIVE = "фернет \"Фернет Бронка\"",
+		INSTRUMENTAL = "фернетом \"Фернет Бронка\"",
+		PREPOSITIONAL = "фернете \"Фернет Бронка\""
+	)
 	icon_state = "fernetbottle"
 	list_reagents = list("fernet" = 100)
 
@@ -443,13 +443,13 @@
 	name = "Sparkling Sunny Champagne"
 	desc = "Бутылка чистого обжигающего солнца, готовая поразить ваш мозг."
 	ru_names = list(
-		NOMINATIVE = "бутылка шампанского \"Сверкающее Солнце\"",
-		GENITIVE = "бутылки шампанского \"Сверкающее Солнце\"",
-		DATIVE = "бутылке шампанского \"Сверкающее Солнце\"",
-		ACCUSATIVE = "бутылку шампанского \"Сверкающее Солнце\"",
-		INSTRUMENTAL = "бутылкой шампанского \"Сверкающее Солнце\"",
-		PREPOSITIONAL = "бутылке шампанского \"Сверкающее Солнце\""
- 	)
+		NOMINATIVE = "шампанское \"Сверкающее Солнце\"",
+		GENITIVE = "шампанского \"Сверкающее Солнце\"",
+		DATIVE = "шампанскому \"Сверкающее Солнце\"",
+		ACCUSATIVE = "шампанское \"Сверкающее Солнце\"",
+		INSTRUMENTAL = "шампанским \"Сверкающее Солнце\"",
+		PREPOSITIONAL = "шампанском \"Сверкающее Солнце\""
+	)
 	icon_state = "champagnebottle"
 	list_reagents = list("champagne" = 100)
 
@@ -457,13 +457,13 @@
 	name = "Jungle Aperol Aperitivo"
 	desc = "Настоящая засажа для вашей печени."
 	ru_names = list(
-		NOMINATIVE = "бутылка апероля \"Джунгли Аперитив\"",
-		GENITIVE = "бутылки апероля \"Джунгли Аперитив\"",
-		DATIVE = "бутылке апероля \"Джунгли Аперитив\"",
-		ACCUSATIVE = "бутылку апероля \"Джунгли Аперитив\"",
-		INSTRUMENTAL = "бутылкой апероля \"Джунгли Аперитив\"",
-		PREPOSITIONAL = "бутылке апероля \"Джунгли Аперитив\""
- 	)
+		NOMINATIVE = "апероль \"Джунгли Аперитив\"",
+		GENITIVE = "апероля \"Джунгли Аперитив\"",
+		DATIVE = "аперолю \"Джунгли Аперитив\"",
+		ACCUSATIVE = "апероль \"Джунгли Аперитив\"",
+		INSTRUMENTAL = "аперолем \"Джунгли Аперитив\"",
+		PREPOSITIONAL = "апероле \"Джунгли Аперитив\""
+	)
 	icon_state = "aperolbottle"
 	list_reagents = list("aperol" = 100)
 
@@ -471,13 +471,13 @@
 	name = "Infused Space Jaegermeister"
 	desc = "Das ist des Jägers Ehrenschild, daß er beschützt und hegt sein Wild, weidmännisch jagt, wie sich gehört, den Schöpfer im Geschöpfe ehrt."
 	ru_names = list(
-		NOMINATIVE = "бутылка ягермейстера \"Космически Настоенный\"",
-		GENITIVE = "бутылки ягермейстера \"Космически Настоенный\"",
-		DATIVE = "бутылке ягермейстера \"Космически Настоенный\"",
-		ACCUSATIVE = "бутылку ягермейстера \"Космически Настоенный\"",
-		INSTRUMENTAL = "бутылкой ягермейстера \"Космически Настоенный\"",
-		PREPOSITIONAL = "бутылке ягермейстера \"Космически Настоенный\""
- 	)
+		NOMINATIVE = "ягермейстер \"Космически Настоенный\"",
+		GENITIVE = "ягермейстера \"Космически Настоенный\"",
+		DATIVE = "ягермейстеру \"Космически Настоенный\"",
+		ACCUSATIVE = "ягермейстер \"Космически Настоенный\"",
+		INSTRUMENTAL = "ягермейстером \"Космически Настоенный\"",
+		PREPOSITIONAL = "ягермастере \"Космически Настоенный\""
+	)
 	icon_state = "jagermeisterbottle"
 	list_reagents = list("jagermeister" = 100)
 
@@ -485,13 +485,13 @@
 	name = "Grainy Mint Schnapps"
 	desc = "Настоящий ужас для истинного ценителя, высококачественный мятный шнапс."
 	ru_names = list(
-		NOMINATIVE = "бутылка шнапса \"Мятный Зерновой\"",
-		GENITIVE = "бутылки шнапса \"Мятный Зерновой\"",
-		DATIVE = "бутылке шнапса \"Мятный Зерновой\"",
-		ACCUSATIVE = "бутылку шнапса \"Мятный Зерновой\"",
-		INSTRUMENTAL = "бутылкой шнапса \"Мятный Зерновой\"",
-		PREPOSITIONAL = "бутылке шнапса \"Мятный Зерновой\""
- 	)
+		NOMINATIVE = "шнапс \"Мятный Зерновой\"",
+		GENITIVE = "шнапса \"Мятный Зерновой\"",
+		DATIVE = "шнапсу \"Мятный Зерновой\"",
+		ACCUSATIVE = "шнапс \"Мятный Зерновой\"",
+		INSTRUMENTAL = "шнапсом \"Мятный Зерновой\"",
+		PREPOSITIONAL = "шнапсе \"Мятный Зерновой\""
+	)
 	icon_state = "schnapsbottle"
 	list_reagents = list("schnaps" = 100)
 
@@ -499,13 +499,13 @@
 	name = "Sheridan's Coffee Layered"
 	desc = "Двойное чудо с новой инновационной шеей, намного лучше, чем у вас."
 	ru_names = list(
-		NOMINATIVE = "бутылка ликёра \"Шериданс Кофейный\"",
-		GENITIVE = "бутылки ликёра \"Шериданс Кофейный\"",
-		DATIVE = "бутылке ликёра \"Шериданс Кофейный\"",
-		ACCUSATIVE = "бутылку ликёра \"Шериданс Кофейный\"",
-		INSTRUMENTAL = "бутылкой ликёра \"Шериданс Кофейный\"",
-		PREPOSITIONAL = "бутылке ликёра \"Шериданс Кофейный\""
- 	)
+		NOMINATIVE = "ликёр \"Шериданс Кофейный\"",
+		GENITIVE = "ликёра \"Шериданс Кофейный\"",
+		DATIVE = "ликёру \"Шериданс Кофейный\"",
+		ACCUSATIVE = "ликёр \"Шериданс Кофейный\"",
+		INSTRUMENTAL = "ликёром \"Шериданс Кофейный\"",
+		PREPOSITIONAL = "ликёре \"Шериданс Кофейный\""
+	)
 	icon_state = "sheridanbottle"
 	list_reagents = list("sheridan" = 100)
 
@@ -513,13 +513,13 @@
 	name = "Vacuum Cherry Bitter"
 	desc = "Постарайтесь не задохнуться, выпив такую чудесную горечь."
 	ru_names = list(
-		NOMINATIVE = "бутылка битера \"Вауумный Вишнёвый\"",
-		GENITIVE = "бутылки битера \"Вауумный Вишнёвый\"",
-		DATIVE = "бутылке битера \"Вауумный Вишнёвый\"",
-		ACCUSATIVE = "бутылку битера \"Вауумный Вишнёвый\"",
-		INSTRUMENTAL = "бутылкой битера \"Вауумный Вишнёвый\"",
-		PREPOSITIONAL = "бутылке битера \"Вауумный Вишнёвый\""
- 	)
+		NOMINATIVE = "битер \"Вакуумный Вишнёвый\"",
+		GENITIVE = "битера \"Вакуумный Вишнёвый\"",
+		DATIVE = "битеру \"Вакуумный Вишнёвый\"",
+		ACCUSATIVE = "битер \"Вакуумный Вишнёвый\"",
+		INSTRUMENTAL = "битером \"Вакуумный Вишнёвый\"",
+		PREPOSITIONAL = "битере \"Вакуумный Вишнёвый\""
+	)
 	icon_state = "bitterbottle"
 	list_reagents = list("bitter" = 50)
 
@@ -527,13 +527,13 @@
 	name = "Grenadier Blue Curacao"
 	desc = "Взрыв - это искусство, но синий взрыв намного лучше."
 	ru_names = list(
-		NOMINATIVE = "бутылка кюрасао \"Гренадёрский Синий\"",
-		GENITIVE = "бутылки кюрасао \"Гренадёрский Синий\"",
-		DATIVE = "бутылке кюрасао \"Гренадёрский Синий\"",
-		ACCUSATIVE = "бутылку кюрасао \"Гренадёрский Синий\"",
-		INSTRUMENTAL = "бутылкой кюрасао \"Гренадёрский Синий\"",
-		PREPOSITIONAL = "бутылке кюрасао \"Гренадёрский Синий\""
- 	)
+		NOMINATIVE = "кюрасао \"Гренадёрский Синий\"",
+		GENITIVE = "кюрасао \"Гренадёрский Синий\"",
+		DATIVE = "кюрасао \"Гренадёрский Синий\"",
+		ACCUSATIVE = "кюрасао \"Гренадёрский Синий\"",
+		INSTRUMENTAL = "кюрасао \"Гренадёрский Синий\"",
+		PREPOSITIONAL = "кюрасао \"Гренадёрский Синий\""
+	)
 	icon_state = "bluecuracao"
 	list_reagents = list("bluecuracao" = 100)
 
@@ -541,13 +541,13 @@
 	name = "The Headless Horseman's Sambuka"
 	desc = "Я не пил самбуку с тех пор, как мне было двадцать."
 	ru_names = list(
-		NOMINATIVE = "бутылка самбуки \"Безголовый Всадник\"",
-		GENITIVE = "бутылки самбуки \"Безголовый Всадник\"",
-		DATIVE = "бутылке самбуки \"Безголовый Всадник\"",
-		ACCUSATIVE = "бутылку самбуки \"Безголовый Всадник\"",
-		INSTRUMENTAL = "бутылкой самбуки \"Безголовый Всадник\"",
-		PREPOSITIONAL = "бутылке самбуки \"Безголовый Всадник\""
- 	)
+		NOMINATIVE = "самбука \"Безголовый Всадник\"",
+		GENITIVE = "самбуки \"Безголовый Всадник\"",
+		DATIVE = "самбуке \"Безголовый Всадник\"",
+		ACCUSATIVE = "самбуку \"Безголовый Всадник\"",
+		INSTRUMENTAL = "самбукой \"Безголовый Всадник\"",
+		PREPOSITIONAL = "самбуке \"Безголовый Всадник\""
+	)
 	icon_state = "sambukabottle"
 	list_reagents = list("sambuka" = 100)
 
@@ -555,13 +555,13 @@
 	name = "Arrogant Green Rat"
 	desc = "Лучшее вино из райского города, где трава зелёная, а девушки красивые."
 	ru_names = list(
-		NOMINATIVE = "бутылка вина \"Высокомерная Зелёная Крыса\"",
-		GENITIVE = "бутылки вина \"Высокомерная Зелёная Крыса\"",
-		DATIVE = "бутылке вина \"Высокомерная Зелёная Крыса\"",
-		ACCUSATIVE = "бутылку вина \"Высокомерная Зелёная Крыса\"",
-		INSTRUMENTAL = "бутылкой вина \"Высокомерная Зелёная Крыса\"",
-		PREPOSITIONAL = "бутылке вина \"Высокомерная Зелёная Крыса\""
- 	)
+		NOMINATIVE = "вино \"Высокомерная Зелёная Крыса\"",
+		GENITIVE = "вина \"Высокомерная Зелёная Крыса\"",
+		DATIVE = "вину \"Высокомерная Зелёная Крыса\"",
+		ACCUSATIVE = "вино \"Высокомерная Зелёная Крыса\"",
+		INSTRUMENTAL = "вином \"Высокомерная Зелёная Крыса\"",
+		PREPOSITIONAL = "вине \"Высокомерная Зелёная Крыса\""
+	)
 	icon_state = "arrogant_green_rat"
 	list_reagents = list("wine" = 100)
 
@@ -577,7 +577,7 @@
 		ACCUSATIVE = "пачку апельсинового сока",
 		INSTRUMENTAL = "пачкой апельсинового сока",
 		PREPOSITIONAL = "пачке апельсинового сока"
- 	)
+	)
 	icon_state = "orangejuice"
 	item_state = "carton"
 	throwforce = 0
@@ -655,7 +655,15 @@
 ////////////////////////// MOLOTOV ///////////////////////
 /obj/item/reagent_containers/food/drinks/bottle/molotov
 	name = "molotov cocktail"
-	desc = "A throwing weapon used to ignite things, typically filled with an accelerant. Recommended highly by rioters and revolutionaries. Light and toss."
+	desc = "Бутылка с зажигательной смесью. Обязательный элемент экипировки любого бунтаря или революционера. Поджигайте и бросайте."
+		ru_names = list(
+		NOMINATIVE = "коктейль Молотова",
+		GENITIVE = "коктейля Молотова",
+		DATIVE = "коктейлю Молотова",
+		ACCUSATIVE = "коктейль Молотова",
+		INSTRUMENTAL = "коктейлем Молотова",
+		PREPOSITIONAL = "коктейле Молотова"
+	)
 	icon_state = "vodkabottle"
 	list_reagents = list()
 	var/list/accelerants = list(/datum/reagent/consumable/ethanol,/datum/reagent/fuel,/datum/reagent/clf3,/datum/reagent/phlogiston,
@@ -667,7 +675,7 @@
 	. = ..()
 	desc = initial(desc)
 	if(!isGlass)
-		desc += " You're not sure if making this out of a carton was the brightest idea."
+		desc += " Вы не уверены, что сделать это из коробки было самой удачной идеей."
 
 
 /obj/item/reagent_containers/food/drinks/bottle/molotov/update_icon_state()
@@ -714,7 +722,7 @@
 
 	add_fingerprint(user)
 	if(active)
-		to_chat(user, span_warning("The [name] is already lit."))
+		to_chat(user, span_warning("[capitalize(name.declent_ru(NOMINATIVE))] уже горит."))
 		return .
 	. |= ATTACK_CHAIN_SUCCESS
 	active = TRUE
@@ -722,8 +730,8 @@
 	message_admins("[ADMIN_LOOKUP(user)] has primed a [name] for detonation at [ADMIN_COORDJMP(bombturf)].")
 	add_game_logs("has primed a [name] for detonation at [AREACOORD(bombturf)].", user)
 	user.visible_message(
-		span_danger("[user] lights [src] on fire!"),
-		span_notice("You light [src] on fire."),
+		span_danger("[user] поджигает [src.declent_ru(GENITIVE)]!"),
+		span_notice("Вы поджигаете [src.declent_ru(GENITIVE)]."),
 	)
 	add_overlay(GLOB.fire_overlay)
 	if(!isGlass)
@@ -748,8 +756,8 @@
 /obj/item/reagent_containers/food/drinks/bottle/molotov/attack_self(mob/user)
 	if(active)
 		if(!isGlass)
-			to_chat(user, "<span class='danger'>The flame's spread too far on it!</span>")
+			to_chat(user, span_danger("Пламя распространилось слишком далеко!"))
 			return
-		to_chat(user, "<span class='info'>You snuff out the flame on \the [src].</span>")
+		to_chat(user, span_info("Вы гасите пламя на [src.declent_ru(PREPOSITIONAL)]."))
 		active = FALSE
 		update_icon(UPDATE_OVERLAYS)

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -656,7 +656,7 @@
 /obj/item/reagent_containers/food/drinks/bottle/molotov
 	name = "molotov cocktail"
 	desc = "Бутылка с зажигательной смесью. Обязательный элемент экипировки любого бунтаря или революционера. Поджигайте и бросайте."
-		ru_names = list(
+	ru_names = list(
 		NOMINATIVE = "коктейль Молотова",
 		GENITIVE = "коктейля Молотова",
 		DATIVE = "коктейлю Молотова",


### PR DESCRIPTION
## Описание
Названия были слишком длинными и иногда дублировали смысл в имени собственном и вне него. Убрал все слова бутылка, некоторые название сократил ― должно помочь.
До конца перевёл файл.

## Причина создания ПР / Почему это хорошо для игры
![image](https://github.com/user-attachments/assets/efe0fdcc-3a95-4567-a868-00d35001dc31)
