### PR TITLE
bugfix: Доставание ядер аномалий из предметов + прыжок гравбутсов

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -224,7 +224,7 @@
 	var/border_dir = get_dir(src, mover)
 	var/can_pass_self = CanPass(mover, border_dir)
 	if(!can_pass_self)
-		return TRUE
+		return FALSE
 
 	for(var/atom/movable/obstacle as anything in contents)
 		// Multi tile objects and moving out of other objects.

--- a/code/modules/anomalies/items/anomaly_beacon.dm
+++ b/code/modules/anomalies/items/anomaly_beacon.dm
@@ -44,7 +44,8 @@
 	var/msg = "ядро вставлено"
 	if(core)
 		msg = "ядро заменено"
-		user.put_in_hands(core)
+		if(!user.put_in_hands(core))
+			core.forceMove(get_turf(user))
 
 	core = possible_core
 	user.balloon_alert(user, msg)
@@ -55,7 +56,9 @@
 		user.balloon_alert(user, "нет ядра")
 		return
 
-	user.put_in_hands(core)
+	if(!user.put_in_hands(core))
+		core.forceMove(get_turf(user))
+
 	core = null
 	user.balloon_alert(user, "ядро извлечено")
 

--- a/code/modules/anomalies/items/bsg.dm
+++ b/code/modules/anomalies/items/bsg.dm
@@ -82,9 +82,12 @@
 		user.balloon_alert(user, "нет ядра")
 		return
 
-	user.put_in_active_hand(core)
+	if(!user.put_in_hands(core))
+		core.forceMove(get_turf(user))
+
 	core = null
 	user.balloon_alert(user, "ядро извлечено")
+	update_icon(UPDATE_ICON_STATE)
 
 /obj/item/gun/energy/bsg/process_fire(atom/target, mob/living/user, message = TRUE, params, zone_override, bonus_spread = 0)
 	if(!has_bluespace_crystal)

--- a/code/modules/anomalies/items/experimental_syringe_gun.dm
+++ b/code/modules/anomalies/items/experimental_syringe_gun.dm
@@ -46,6 +46,7 @@
 /obj/item/gun/syringe/rapidsyringe/experimental/proc/update_core()
 	if(!core)
 		synth_speed = 0
+		return
 
 	synth_speed = core.get_strenght() / 30
 
@@ -54,7 +55,9 @@
 		add_fingerprint(user)
 		var/msg = "ядро вставлено"
 		if(core)
-			user.put_in_hands(core)
+			if(!user.put_in_hands(core))
+				core.forceMove(get_turf(user))
+
 			msg = "ядро заменено"
 
 		if(!user.drop_transfer_item_to_loc(item, src))
@@ -114,7 +117,9 @@
 	if(!user.contains(src))
 		return
 
-	user.put_in_active_hand(core)
+	if(!user.put_in_hands(core))
+		core.forceMove(get_turf(user))
+
 	core = null
 	user.balloon_alert(user, "ядро извлечено")
 	update_core()

--- a/code/modules/anomalies/items/gravitational_boots.dm
+++ b/code/modules/anomalies/items/gravitational_boots.dm
@@ -103,7 +103,9 @@
 		return
 
 	cell.forceMove_turf()
-	user.put_in_hands(cell, ignore_anim = FALSE)
+	if(!user.put_in_hands(core))
+		core.forceMove(get_turf(user))
+
 	to_chat(user, span_notice("Вы достали [cell.declent_ru(ACCUSATIVE)] из [declent_ru(GENITIVE)]."))
 	cell.update_icon()
 	cell = null
@@ -149,7 +151,9 @@
 		user.balloon_alert(user, "нет ядра")
 		return
 
-	user.put_in_active_hand(core)
+	if(!user.put_in_hands(core))
+		core.forceMove(get_turf(user))
+
 	core = null
 	user.balloon_alert(user, "ядро извлечено")
 

--- a/code/modules/anomalies/items/pyro_claws.dm
+++ b/code/modules/anomalies/items/pyro_claws.dm
@@ -162,7 +162,9 @@
 	add_fingerprint(user)
 	var/msg = "ядро вставлено"
 	if(core)
-		user.put_in_hands(core)
+		if(!user.put_in_hands(core))
+			core.forceMove(get_turf(user))
+
 		msg = "ядро заменено"
 
 	if(!user.drop_transfer_item_to_loc(item, src))
@@ -183,7 +185,9 @@
 		user.balloon_alert(user, "нет ядра")
 		return
 
-	user.put_in_active_hand(core)
+	if(!user.put_in_hands(core))
+		core.forceMove(get_turf(user))
+
 	core = null
 	user.balloon_alert(user, "ядро извлечено")
 

--- a/code/modules/anomalies/items/tuned_anomalous_teleporter.dm
+++ b/code/modules/anomalies/items/tuned_anomalous_teleporter.dm
@@ -131,7 +131,9 @@
 		user.balloon_alert(user, "нет ядра")
 		return
 
-	user.put_in_active_hand(core)
+	if(!user.put_in_hands(core))
+		core.forceMove(get_turf(user))
+
 	core = null
 	user.balloon_alert(user, "ядро извлечено")
 	update_core()
@@ -143,8 +145,9 @@
 	add_fingerprint(user)
 	var/msg = "ядро вставлено"
 	if(core)
-		user.put_in_hands(core)
 		msg = "ядро заменено"
+		if(!user.put_in_hands(core))
+			core.forceMove(get_turf(user))
 
 	if(!user.drop_transfer_item_to_loc(item, src))
 		balloon_alert(user, "отпустить невозможно!")


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
При доставании ядер из предметов, при провале доставания (например занятая рука) предметы оставались внутри, но ссылка на них в предмете затиралась. Сделал чтоб при провале взятия в руку, предмет оказывался на полу под доставающим.

Также у гравбутсов немного коряво считалось может ли игрок войти в плитку со стеной.
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
