### PR TITLE
bugfix: Fixing Space in keybinding

### DIFF
--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -714,7 +714,7 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 			var/static/list/pref_toggles_by_category
 			if(!pref_toggles_by_category)
 				pref_toggles_by_category = list()
-				
+
 				for(var/path in GLOB.preference_toggles)
 					var/datum/preference_toggle/toggle = GLOB.preference_toggles[path]
 					pref_toggles_by_category["[toggle.preftoggle_category]"] += list(toggle)
@@ -734,7 +734,7 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 					switch(toggle.preftoggle_toggle)
 						if(PREFTOGGLE_SPECIAL)
 							dat += "<td style='width: 20%'><a href='byond://?_src_=prefs;preference=preference_toggles;toggle=[toggle.UID()];'>Adjust</a></td>"
-							
+
 						if(PREFTOGGLE_TOGGLE1)
 							dat += "<td style='width: 20%'><a href='byond://?_src_=prefs;preference=preference_toggles;toggle=[toggle.UID()];'>[(toggles & toggle.preftoggle_bitflag) ? "<span class='good'>Enabled</span>" : "<span class='bad'>Disabled</span>"]</a></td>"
 
@@ -2663,7 +2663,7 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 									"DEL" = "Delete",
 									"END" = "Southwest",
 									"PAGEDOWN" = "Southeast",
-									"SPACEBAR" = "Space",
+									" " = "Space",
 									"ALT" = "Alt",
 									"SHIFT" = "Shift",
 									"CONTROL" = "Ctrl",


### PR DESCRIPTION
## Описание

Пробел снова можно использовать в кейбиндах

## Причина создания ПР / Почему это хорошо для игры

Раньше пробел можно было использовать в кейбиндах, а сейчас нет. Данный ПР исправляет данную проблему.

## Демонстрация изменений

Теперь можно настроить хоткей на пробел

## Тесты

1. Запущена игра с изменениями.
2. Изменён хоткей на пробел(удачно).
3. Запущен раунд с изменениями.
3. В раунде изменён хоткей на пробел(удачно)
4. Использование пробела при диалогах не вызывает сробатывания хоткея.
