### PR TITLE
bugfix: Теперь датум контрактора выдается после принятия предложения

### DIFF
--- a/code/__DEFINES/contractors.dm
+++ b/code/__DEFINES/contractors.dm
@@ -27,4 +27,8 @@
 
 #define CONTRACTOR_MAX_ACCEPTED 2
 
+#define CONTRACTOR_COST 100
+
+#define CONRACTOR_OFFER_DURATION 10 MINUTES
+
 GLOBAL_DATUM(prisoner_belongings, /obj/structure/closet/secure_closet/contractor)

--- a/code/__DEFINES/span.dm
+++ b/code/__DEFINES/span.dm
@@ -182,3 +182,4 @@
 #define span_fontsize5(str) ("<span style='font-size: 24px;'>" + str + "</span>")
 #define span_fontsize6(str) ("<span style='font-size: 32px;'>" + str + "</span>")
 #define span_fontsize7(str) ("<span style='font-size: 48px;'>" + str + "</span>")
+#define span_fontcolor_red(str) ("<span style='color: red;'>" + str + "</span>")

--- a/code/game/gamemodes/antag_paradise/antag_paradise.dm
+++ b/code/game/gamemodes/antag_paradise/antag_paradise.dm
@@ -308,7 +308,7 @@
 			if(ROLE_HIJACKER)
 				var/datum/antagonist/traitor/hijacker_datum = new
 				hijacker_datum.is_hijacker = TRUE
-				hijacker_datum.is_contractor = roundstart
+				hijacker_datum.contractor_pending = roundstart? new(antag) : null
 				antag.add_antag_datum(hijacker_datum)
 
 			if(ROLE_MALF_AI)
@@ -322,9 +322,10 @@
 			if(ROLE_CHANGELING)
 				antag.add_antag_datum(/datum/antagonist/changeling)
 			if(ROLE_TRAITOR)
-				antag.add_antag_datum(/datum/antagonist/traitor)
+				var/datum/antagonist/traitor/datum = new
 				if(roundstart)
-					antag.add_antag_datum(/datum/antagonist/contractor)
+					datum.contractor_pending = new(antag)
+				antag.add_antag_datum(datum)
 			if(ROLE_THIEF)
 				antag.add_antag_datum(/datum/antagonist/thief)
 

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -87,7 +87,7 @@
 /datum/game_mode/traitor/post_setup()
 	for(var/datum/mind/traitor in pre_traitors)
 		var/datum/antagonist/traitor/new_antag = new
-		new_antag.is_contractor = TRUE
+		new_antag.contractor_pending = new(traitor)
 		addtimer(CALLBACK(traitor, TYPE_PROC_REF(/datum/mind, add_antag_datum), new_antag), rand(1 SECONDS, 10 SECONDS))
 	if(pre_malf_AI)
 		addtimer(CALLBACK(pre_malf_AI, TYPE_PROC_REF(/datum/mind, add_antag_datum), /datum/antagonist/malf_ai), rand(1 SECONDS, 10 SECONDS))

--- a/code/modules/antagonists/space_ninja/ninja_datum.dm
+++ b/code/modules/antagonists/space_ninja/ninja_datum.dm
@@ -371,7 +371,7 @@
 	for(var/datum/mind/traitor in pre_antags)
 		var/datum/antagonist/traitor/traitor_datum = new
 		traitor_datum.give_objectives = FALSE
-		traitor_datum.is_contractor = TRUE
+		traitor_datum.contractor_pending = new(traitor)
 		traitor.add_antag_datum(traitor_datum)
 
 		var/objective_amount = protect_objective ? CONFIG_GET(number/traitor_objectives_amount) - 1 : CONFIG_GET(number/traitor_objectives_amount)

--- a/code/modules/antagonists/traitor/contractor/datums/contractor.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/contractor.dm
@@ -14,27 +14,12 @@
 	job_rank = ROLE_TRAITOR
 	special_role = SPECIAL_ROLE_TRAITOR
 	antag_hud_type = ANTAG_HUD_TRAITOR
-	show_in_orbit = FALSE
 	antag_menu_name = "Контрактник"
-	/// How many telecrystals a traitor must forfeit to become a contractor.
-	var/tc_cost = 100
-	/// How long a traitor's chance to become a contractor lasts before going away. In deciseconds.
-	var/offer_duration = 10 MINUTES
-	/// world.time at which the offer will expire.
-	var/offer_deadline = -1
-	/// indicates whether the offer to become a contractor was given to the player by the admin
-	var/is_admin_forced = FALSE
 	/// The associated contractor uplink. Only present if the offer was accepted.
 	var/obj/item/contractor_uplink/contractor_uplink = null
-	/// Show if the offer was accepted.
-	var/offer_accepted = FALSE
 
 
 /datum/antagonist/contractor/Destroy(force)
-	var/datum/antagonist/traitor/traitor_datum = owner?.has_antag_datum(/datum/antagonist/traitor)
-	if(traitor_datum)
-		traitor_datum.hidden_uplink?.contractor = null
-
 	if(contractor_uplink)
 		contractor_uplink.hub?.owner = null
 		contractor_uplink.hub?.contractor_uplink = null
@@ -59,24 +44,16 @@
 
 	var/obj/item/uplink/hidden/hidden_uplink = traitor_datum.hidden_uplink
 	if(!hidden_uplink)
-		stack_trace("Potential contractor [owner] spawned without a hidden uplink!")
+		stack_trace("Сontractor [owner] spawned without a hidden uplink!")
 		return
-
-	hidden_uplink.contractor = src
-	offer_deadline = world.time + offer_duration
 
 
 /datum/antagonist/contractor/greet()
 	// Greet them with the unique message
 	var/list/messages = list()
-	var/greet_text = "Контрактники отдают [tc_cost] телекристалл[declension_ru(tc_cost, "", "а", "ов")] за возможность выполнять контракты на похищение, получая за это выплаты в виде ТК и кредитов. Это позволяет заработать гораздо больше, чем они имели раньше.<br>" \
-					+ "Если вы заинтересованы, просто зайдите в аплинк и выберите вкладку \"Заключение контракта\" для получения дополнительной информации.<br>"
-	messages.Add("<b><font size=4 color=red>Вам предложили стать Контрактником.</font></b><br>")
-	messages.Add("<font color=red>[greet_text]</font>")
-	if(!is_admin_forced)
-		messages.Add("<b><i><font color=red>Не упустите возможность! Вы не единственный, кто получил это предложение. \
-					Количество доступных предложений ограничено, и если другие агенты примут их раньше вас, то у вас не останется возможности принять участие.</font></i></b>")
-	messages.Add("<b><i><font color=red>Срок действия этого предложения истекает через 10 минут, начиная с этого момента (время истечения: <u>[station_time_timestamp(time = offer_deadline)]</u>).</font></i></b>")
+	var/greet_text = "Вы приняли предложение. Выполняйте контракты, получайте теллекристаллы и докажите, что ваши наниматели в вас не ошиблись."
+	messages.Add(span_fontsize4(span_fontcolor_red("<b>Вы Контрактник.</b><br>")))
+	messages.Add(span_fontcolor_red("[greet_text]"))
 	return messages
 
 /datum/antagonist/contractor/on_gain()
@@ -88,7 +65,7 @@
 	var/list/messages = list()
 	messages.Add(greet())
 	apply_innate_effects()
-	messages.Add(finalize_antag())
+	finalize_antag()
 	messages.Add(span_motd("С полной информацией вы можете ознакомиться на вики: <a href=\"[CONFIG_GET(string/wikiurl)]/index.php/Contractor\">Контрактор"))
 	to_chat(owner.current, chat_box_red(messages.Join("<br>")))
 	if(is_banned(owner.current) && replace_banned)
@@ -96,41 +73,3 @@
 	owner.current.create_log(MISC_LOG, "[owner.current] was made into \an [special_role]")
 	return TRUE
 
-/**
-  * Accepts the offer to be a contractor if possible.
-  */
-/datum/antagonist/contractor/proc/become_contractor(mob/living/carbon/human/user, obj/item/uplink/uplink)
-	if(contractor_uplink || !istype(user))
-		return
-
-	var/offers_availability_check = !(SSticker?.mode?.contractor_accepted < CONTRACTOR_MAX_ACCEPTED || is_admin_forced)
-	if(uplink.uses < tc_cost || world.time >= offer_deadline || offers_availability_check)
-		var/reason = (uplink.uses < tc_cost) ? \
-			"у вас недостаточно телекристаллов (всего требуется [tc_cost])" : \
-			(offers_availability_check) ? \
-			"все предложения уже приняты другими агентами": \
-			"срок предложения истёк"
-		to_chat(user, span_warning("Вы больше не можете стать Контрактником, потому что [reason]."))
-		return
-
-	// Give the kit
-	var/obj/item/storage/box/syndie_kit/contractor/contractor_kit = new(user)
-	user.put_in_hands(contractor_kit)
-	contractor_uplink = locate(/obj/item/contractor_uplink, contractor_kit)
-	contractor_uplink.hub = new(user.mind, contractor_uplink)
-
-	// Update AntagHUD icon
-	remove_antag_hud(owner.current)
-	add_antag_hud(owner.current)
-
-	// Remove the TC
-	uplink.uses -= tc_cost
-
-	show_in_orbit = TRUE
-	offer_accepted = TRUE
-
-	if(!is_admin_forced)
-		SSticker?.mode?.contractor_accepted++
-
-/datum/antagonist/contractor/check_anatag_menu_ability()
-	return offer_accepted

--- a/code/modules/antagonists/traitor/contractor/datums/contractor_pending.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/contractor_pending.dm
@@ -1,0 +1,62 @@
+/datum/contractor_pending
+	/// world.time at which the offer will expire.
+	var/offer_deadline = -1
+	/// indicates whether the offer to become a contractor was given to the player by the admin
+	var/is_admin_forced = FALSE
+	/// Show if the offer was accepted.
+	var/offer_accepted = FALSE
+
+/datum/contractor_pending/New(datum/mind/mind, is_admin_forced)
+	. = ..()
+	offer_deadline = world.time + CONRACTOR_OFFER_DURATION
+	src.is_admin_forced = is_admin_forced
+	if(!is_admin_forced)
+		return
+	var/list/messages = greet()
+	to_chat(mind.current, chat_box_red(messages.Join("<br>")))
+
+
+/datum/contractor_pending/proc/greet()
+	// Greet them with the unique message
+	var/list/messages = list()
+	var/greet_text = "Контрактники отдают [CONTRACTOR_COST] телекристалл[declension_ru(CONTRACTOR_COST, "", "а", "ов")] за возможность выполнять контракты на похищение, получая за это выплаты в виде ТК и кредитов. Это позволяет заработать гораздо больше, чем они имели раньше.<br>" \
+					+ "Если вы заинтересованы, просто зайдите в аплинк и выберите вкладку \"Заключение контракта\" для получения дополнительной информации.<br>"
+	messages.Add(span_fontsize3(span_fontcolor_red("<b>Вам предложили стать Контрактником.</b><br>")))
+	messages.Add(span_fontcolor_red("[greet_text]"))
+	if(!is_admin_forced)
+		messages.Add(span_fontcolor_red("<b><i>Не упустите возможность! Вы не единственный, кто получил это предложение. \
+					Количество доступных предложений ограничено, и если другие агенты примут их раньше вас, то у вас не останется возможности принять участие.</i></b>"))
+	messages.Add(span_fontcolor_red("<b><i>Срок действия этого предложения истекает через 10 минут, начиная с этого момента (время истечения: <u>[station_time_timestamp(time = offer_deadline)]</u>).</i></b>"))
+	return messages
+
+/**
+  * Accepts the offer to be a contractor if possible.
+  */
+/datum/contractor_pending/proc/become_contractor(mob/living/carbon/human/user, obj/item/uplink/uplink)
+	if(!istype(user))
+		return
+
+	var/offers_availability_check = !(SSticker?.mode?.contractor_accepted < CONTRACTOR_MAX_ACCEPTED || is_admin_forced)
+	if(uplink.uses < CONTRACTOR_COST || world.time >= offer_deadline || offers_availability_check)
+		var/reason = (uplink.uses < CONTRACTOR_COST) ? \
+			"у вас недостаточно телекристаллов (всего требуется [CONTRACTOR_COST])" : \
+			(offers_availability_check) ? \
+			"все предложения уже приняты другими агентами": \
+			"срок предложения истёк"
+		to_chat(user, span_warning("Вы больше не можете стать Контрактником, потому что [reason]."))
+		return
+	var/datum/antagonist/contractor/contractor = user.mind.add_antag_datum(/datum/antagonist/contractor)
+	// Give the kit
+	var/obj/item/storage/box/syndie_kit/contractor/contractor_kit = new(user)
+	user.put_in_hands(contractor_kit)
+	var/obj/item/contractor_uplink/contractor_uplink = locate(/obj/item/contractor_uplink, contractor_kit)
+	contractor.contractor_uplink = contractor_uplink
+	contractor_uplink.hub = new(user.mind, contractor_uplink)
+
+	// Remove the TC
+	uplink.uses -= CONTRACTOR_COST
+
+	offer_accepted = TRUE
+
+	if(!is_admin_forced)
+		SSticker?.mode?.contractor_accepted++

--- a/paradise.dme
+++ b/paradise.dme
@@ -1901,6 +1901,7 @@
 #include "code\modules\antagonists\traitor\contractor\datums\contractor.dm"
 #include "code\modules\antagonists\traitor\contractor\datums\contractor_hub.dm"
 #include "code\modules\antagonists\traitor\contractor\datums\contractor_hub_ui.dm"
+#include "code\modules\antagonists\traitor\contractor\datums\contractor_pending.dm"
 #include "code\modules\antagonists\traitor\contractor\datums\contractor_support.dm"
 #include "code\modules\antagonists\traitor\contractor\datums\objective_contract.dm"
 #include "code\modules\antagonists\traitor\contractor\datums\syndicate_contract.dm"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Теперь за предложения контрактора отвечает отдельный датум, который хранится в датуме трейтора. Датум контрактора же получается только после принятия предложения.
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР / Почему это хорошо для игры

<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений

<!-- В случае наличия изменений, влияющих на игровую часть, опишите их здесь. В случае их отсутствия, этот пункт можно удалить -->

## Тесты

<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
