### PR TITLE
bugfix: Таскание и толкание объектов снова замедляет

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -256,12 +256,12 @@
 	return ..()
 
 /mob/living/carbon/human/update_pull_movespeed()
-	if(!HAS_TRAIT(src, TRAIT_STRONG_PULLING))
+	if(!pulling || !HAS_TRAIT(src, TRAIT_STRONG_PULLING))
 		return ..()
 	remove_movespeed_modifier(/datum/movespeed_modifier/bulky_drag)
 
 /mob/living/carbon/human/update_push_movespeed()
-	if(!HAS_TRAIT(src, TRAIT_STRONG_PULLING))
+	if(!now_pushing || !HAS_TRAIT(src, TRAIT_STRONG_PULLING))
 		return ..()
 	remove_movespeed_modifier(/datum/movespeed_modifier/bulky_push)
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -256,12 +256,12 @@
 	return ..()
 
 /mob/living/carbon/human/update_pull_movespeed()
-	if(!pulling && HAS_TRAIT(src, TRAIT_STRONG_PULLING))
+	if(!HAS_TRAIT(src, TRAIT_STRONG_PULLING))
 		return ..()
 	remove_movespeed_modifier(/datum/movespeed_modifier/bulky_drag)
 
 /mob/living/carbon/human/update_push_movespeed()
-	if(!now_pushing && HAS_TRAIT(src, TRAIT_STRONG_PULLING))
+	if(!HAS_TRAIT(src, TRAIT_STRONG_PULLING))
 		return ..()
 	remove_movespeed_modifier(/datum/movespeed_modifier/bulky_push)
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание

Чинит баг, когда при таскании и толкании объектов кукла не замедлялась.

## Причина создания ПР / Почему это хорошо для игры

Баг - плохо.
Багрепорт: https://discord.com/channels/617003227182792704/1379361517715067061

## Тесты

Побегал, потаскал за врина, потаскал за скрелла. У скрелла спидмод выдаётся, врину - нет.