### PR TITLE
map: Ремап пермобрига

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -30377,7 +30377,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
 "djZ" = (
-/obj/structure/table,
 /obj/item/storage/firstaid/regular,
 /obj/machinery/camera{
 	c_tag = "Permabrig West";
@@ -30389,6 +30388,7 @@
 /obj/item/stack/rods{
 	amount = 2
 	},
+/obj/structure/table,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -35512,10 +35512,12 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "dHs" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/space,
-/area/space)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/permabrig)
 "dHt" = (
 /obj/structure/bookcase,
 /turf/simulated/floor/wood,
@@ -36645,12 +36647,12 @@
 /turf/simulated/floor/carpet,
 /area/medical/psych)
 "dLZ" = (
-/obj/structure/table,
 /obj/machinery/reagentgrinder{
 	pixel_x = -1;
 	pixel_y = 9
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -55098,9 +55100,9 @@
 	},
 /area/hallway/primary/central/south)
 "hzJ" = (
-/obj/structure/table,
 /obj/structure/bedsheetbin,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -65611,11 +65613,10 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/courtroom)
 "kaO" = (
-/obj/structure/table,
-/obj/structure/table,
 /obj/item/clothing/under/color/orange/prison,
 /obj/item/melee/bigiron,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -76609,7 +76610,8 @@
 /area/toxins/mixing)
 "mLC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/recharge_station,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -81566,9 +81568,9 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
+/obj/structure/table,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -81942,7 +81944,6 @@
 	},
 /area/storage/tech)
 "nUO" = (
-/obj/structure/table,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -81954,6 +81955,7 @@
 	},
 /obj/item/storage/photo_album,
 /obj/item/camera,
+/obj/structure/table,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -94631,7 +94633,6 @@
 	},
 /area/security/permabrig)
 "qJM" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -114032,13 +114033,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/lawoffice)
-"vhX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/permabrig)
 "vib" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -180729,7 +180723,7 @@ aaq
 aaq
 aaq
 aaq
-aaq
+coE
 dZq
 coE
 coE
@@ -180986,7 +180980,7 @@ aaq
 aaq
 aaq
 aaq
-aaq
+coE
 aru
 dCr
 dCr
@@ -181497,10 +181491,10 @@ aaq
 aaq
 aaq
 aaq
-bCI
-bCI
-bCI
 aaq
+dZq
+aaq
+coE
 aru
 fgI
 mWu
@@ -181752,9 +181746,9 @@ aaq
 aaq
 aaq
 aaq
-aaq
-bCI
-coE
+dZq
+dZq
+dZq
 coE
 coE
 coE
@@ -182005,10 +181999,10 @@ aaq
 aaq
 aaq
 aaq
-bqc
-bqc
-bqc
-bqc
+dZq
+dZq
+dZq
+aaq
 coE
 coE
 coE
@@ -182516,7 +182510,7 @@ aaq
 aaq
 aaq
 aaq
-bCI
+bqc
 coE
 coE
 aru
@@ -183029,7 +183023,7 @@ aaq
 aaq
 aaq
 aaq
-aaq
+dZq
 coE
 jXK
 aru
@@ -183286,7 +183280,7 @@ aaq
 aaq
 aaq
 aaq
-bCI
+dZq
 coE
 aru
 lMA
@@ -183543,7 +183537,7 @@ aaq
 aaq
 aaq
 aaq
-bCI
+dZq
 coE
 dlr
 hzJ
@@ -183552,10 +183546,10 @@ jrZ
 tqn
 uHx
 dlJ
-vhX
-vhX
 qJM
 qJM
+mLC
+mLC
 xLJ
 acU
 bkl
@@ -183800,7 +183794,7 @@ aaq
 aaq
 aaq
 aaq
-bCI
+dZq
 coE
 aru
 kaO
@@ -184057,7 +184051,7 @@ aaq
 aaq
 aaq
 aaq
-bCI
+aaq
 coE
 jXK
 aru
@@ -184314,8 +184308,8 @@ aaq
 aaq
 aaq
 aaq
-aaq
-dHs
+bqc
+coE
 coE
 aru
 aru
@@ -184572,7 +184566,7 @@ aaq
 aaq
 aaq
 aaq
-bCI
+bqc
 coE
 coE
 aru
@@ -184829,7 +184823,7 @@ aaq
 aaq
 aaq
 aaq
-bCI
+aaq
 aaq
 coE
 aru
@@ -184850,7 +184844,7 @@ xan
 vIm
 vGv
 kTh
-mLC
+dHs
 iCu
 jqn
 rEC
@@ -185087,7 +185081,7 @@ aaq
 aaq
 aaq
 aaq
-bCI
+dZq
 coE
 aru
 aru
@@ -185344,10 +185338,10 @@ aaq
 aaq
 aaq
 aaq
-bCI
-aaq
+dZq
 coE
-dHs
+coE
+coE
 coE
 coE
 aru
@@ -185602,11 +185596,11 @@ aaq
 aaq
 aaq
 aaq
+dZq
+dZq
+dZq
 aaq
-bqc
-bqc
-aaq
-aaq
+coE
 coE
 coE
 coE
@@ -185863,8 +185857,8 @@ aaq
 aaq
 aaq
 aaq
-bqc
-bqc
+aaq
+aaq
 aaq
 coE
 coE
@@ -186123,7 +186117,7 @@ aaq
 aaq
 aaq
 aaq
-bCI
+aaq
 coE
 coE
 coE
@@ -186380,9 +186374,9 @@ aaq
 aaq
 aaq
 aaq
-bCI
-bCI
-bCI
+aaq
+aaq
+aaq
 coE
 coE
 coE
@@ -186640,12 +186634,12 @@ aaq
 aaq
 aaq
 aaq
+dZq
+dZq
+dZq
 aaq
 aaq
-bCI
-bCI
-bCI
-aaq
+dZq
 coE
 dZq
 dZq

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -173,12 +173,6 @@
 /area/space)
 "aat" = (
 /obj/structure/bed/dogbed,
-/obj/machinery/flasher_button{
-	id = "visiting room flash";
-	name = "visiting room flasher button";
-	pixel_x = 24;
-	pixel_y = -24
-	},
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/pet/dog/security,
 /turf/simulated/floor/plasteel{
@@ -441,6 +435,15 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
+"acU" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/permabrig)
 "ads" = (
 /obj/structure/closet/wardrobe/red,
 /obj/item/clothing/suit/tracksuit/red,
@@ -456,13 +459,11 @@
 	},
 /area/security/checkpoint/south)
 "adR" = (
-/obj/machinery/computer/cryopod{
-	layer = 4;
-	pixel_y = 32
-	},
+/obj/structure/table/wood,
+/obj/item/stack/tape_roll,
+/obj/item/stack/packageWrap,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkred"
+	icon_state = "dark"
 	},
 /area/security/permabrig)
 "aee" = (
@@ -4058,6 +4059,10 @@
 	icon_state = "dark"
 	},
 /area/engineering/mechanic_workshop/hangar)
+"aHh" = (
+/obj/structure/sign/poster/contraband/eat,
+/turf/simulated/wall/r_wall,
+/area/security/permabrig)
 "aHo" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4698,6 +4703,13 @@
 	icon_state = "dark"
 	},
 /area/engineering/mechanic_workshop/hangar)
+"aLh" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "darkred"
+	},
+/area/security/visiting_room)
 "aLi" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable{
@@ -5418,6 +5430,17 @@
 	icon_state = "solarpanel"
 	},
 /area/solar/auxstarboard)
+"aPw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/chair/stool{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/permabrig)
 "aPx" = (
 /obj/structure/bookcase,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -7368,11 +7391,15 @@
 	},
 /area/engineering/mechanic_workshop/hangar)
 "bda" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/item/twohanded/required/kirbyplants,
+/obj/machinery/light{
+	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weaponcrafting/receiver,
 /turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
+	dir = 4;
+	icon_state = "darkyellow"
 	},
 /area/security/permabrig)
 "bdd" = (
@@ -8590,6 +8617,14 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/fore)
+"bkl" = (
+/obj/structure/holohoop,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/security/permabrig)
 "bko" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -11461,9 +11496,7 @@
 	req_access = list(63)
 	},
 /obj/structure/table/reinforced,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/plating,
 /area/security/visiting_room)
 "bzy" = (
 /obj/effect/spawner/window/reinforced/plasma,
@@ -17992,10 +18025,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "ceT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
+	icon_state = "dark"
 	},
 /area/security/permabrig)
 "ceY" = (
@@ -21309,17 +21346,22 @@
 /turf/simulated/wall,
 /area/crew_quarters/locker/locker_toilet)
 "cxr" = (
-/obj/structure/table,
-/obj/item/storage/fancy/rollingpapers,
-/obj/item/seeds/tobacco,
-/obj/item/seeds/tobacco,
-/obj/item/seeds/tobacco,
-/obj/item/storage/box/matches,
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "darkred"
 	},
 /area/security/permabrig)
 "cxz" = (
@@ -21841,9 +21883,17 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "czx" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = -28
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkredcorners"
+	dir = 9;
+	icon_state = "darkred"
 	},
 /area/security/permabrig)
 "czy" = (
@@ -21882,6 +21932,13 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
+"czK" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/security/permabrig)
 "czL" = (
 /obj/structure/closet/crate,
 /obj/item/stack/rods{
@@ -25519,6 +25576,13 @@
 /obj/structure/table,
 /obj/item/clipboard,
 /obj/item/paper,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -30314,27 +30378,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
 "djZ" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/obj/machinery/camera{
+	c_tag = "Permabrig West";
+	network = list("Prison","SS13")
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/flasher_button{
-	id = "permacell2";
-	name = "Perma cell 2 flasher button";
-	pixel_x = -38;
-	pixel_y = -4
-	},
-/obj/machinery/flasher_button{
-	id = "permacell1";
-	name = "Perma cell 1 flasher button";
-	pixel_x = -38;
-	pixel_y = 6
+/obj/item/stack/rods{
+	amount = 2
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkred"
+	icon_state = "dark"
 	},
 /area/security/permabrig)
 "dka" = (
@@ -30634,14 +30691,8 @@
 	},
 /area/medical/biostorage)
 "dlr" = (
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	pixel_y = 22
-	},
-/obj/effect/decal/warning_stripes/blue/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
+/obj/structure/sign/poster/contraband/pinup_syn,
+/turf/simulated/wall/r_wall,
 /area/security/permabrig)
 "dlu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -30709,12 +30760,13 @@
 	},
 /area/engineering/engine)
 "dlJ" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock{
+	id_tag = "PermaBath";
+	name = "Restroom"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
+/turf/simulated/floor/plating,
 /area/security/permabrig)
 "dlK" = (
 /obj/structure/window/reinforced{
@@ -31423,8 +31475,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "darkred"
+	dir = 4;
+	icon_state = "darkyellowcorners"
 	},
 /area/security/permabrig)
 "dor" = (
@@ -32182,6 +32236,7 @@
 /obj/item/radio/intercom/locked/prison{
 	pixel_x = -28
 	},
+/obj/item/bedsheet/orange,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "darkred"
@@ -32197,14 +32252,10 @@
 	},
 /area/security/securehallway)
 "drX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
+	dir = 4;
+	icon_state = "darkyellow"
 	},
 /area/security/permabrig)
 "dse" = (
@@ -33444,16 +33495,13 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/fitness)
 "dxN" = (
-/obj/machinery/door/window,
-/obj/structure/window/reinforced{
+/obj/effect/decal/warning_stripes/blue/hollow,
+/obj/structure/chair/stool{
 	dir = 1
 	},
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/blue/hollow,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
+	icon_state = "dark"
 	},
 /area/security/permabrig)
 "dxO" = (
@@ -34158,23 +34206,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "dBo" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkred"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Brig_lockdown";
-	name = "Brig Lockdown"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "PermaLockdown";
-	name = "Perma Lockdown"
-	},
-/turf/simulated/floor/plating,
-/area/security/permabrig)
+/area/security/visiting_room)
 "dBr" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -34324,10 +34361,9 @@
 	},
 /area/medical/morgue)
 "dCj" = (
-/obj/machinery/cryopod{
-	dir = 8
+/obj/structure/chair/stool{
+	dir = 1
 	},
-/obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -34377,10 +34413,17 @@
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "dCw" = (
-/obj/structure/table,
-/obj/machinery/computer/library/public,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = -8;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -8;
+	pixel_y = 11
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "bar"
 	},
 /area/security/permabrig)
 "dCy" = (
@@ -35470,26 +35513,10 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "dHs" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Brig_lockdown";
-	name = "Brig Lockdown"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "PermaLockdown";
-	name = "Perma Lockdown"
-	},
-/turf/simulated/floor/plating,
-/area/security/permabrig)
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/space,
+/area/space)
 "dHt" = (
 /obj/structure/bookcase,
 /turf/simulated/floor/wood,
@@ -35545,11 +35572,25 @@
 	},
 /area/medical/research/restroom)
 "dHH" = (
-/obj/machinery/computer/arcade/battle,
-/obj/effect/decal/warning_stripes/red/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Brig_lockdown";
+	name = "Brig Lockdown"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "PermaLockdown";
+	name = "Perma Lockdown"
+	},
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
 /area/security/permabrig)
 "dHJ" = (
 /obj/structure/disposalpipe/segment{
@@ -35586,13 +35627,12 @@
 	},
 /area/hallway/secondary/exit)
 "dHO" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/item/stack/rods{
-	amount = 10
+/obj/structure/chair/stool{
+	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkred"
+	icon_state = "dark"
 	},
 /area/security/permabrig)
 "dHP" = (
@@ -35609,10 +35649,9 @@
 /turf/simulated/floor/engine/o2,
 /area/atmos)
 "dHR" = (
-/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkred"
+	dir = 4;
+	icon_state = "darkyellow"
 	},
 /area/security/permabrig)
 "dHS" = (
@@ -35751,12 +35790,16 @@
 	},
 /area/security/securearmory)
 "dIk" = (
-/obj/machinery/newscaster{
-	pixel_y = 30
+/obj/machinery/shower{
+	dir = 4
 	},
+/obj/structure/curtain/open/shower{
+	anchored = 1
+	},
+/obj/item/soap/homemade_banana,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkred"
+	dir = 8;
+	icon_state = "cmo"
 	},
 /area/security/permabrig)
 "dIm" = (
@@ -35784,12 +35827,20 @@
 	},
 /area/medical/virology/lab)
 "dIo" = (
-/obj/effect/decal/warning_stripes/red,
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/item/reagent_containers/glass/bucket,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
+/obj/machinery/flasher{
+	desc = "A floor-mounted flashbulb device.";
+	id = "permacell2";
+	layer = 5;
+	pixel_y = -24;
+	range = 3
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
 /area/security/permabrig)
 "dIs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -36169,6 +36220,13 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
+"dKw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/security/permabrig)
 "dKx" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/bodybags{
@@ -36586,6 +36644,17 @@
 	},
 /turf/simulated/floor/carpet,
 /area/medical/psych)
+"dLZ" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_x = -1;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/security/permabrig)
 "dMc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -36844,22 +36913,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "dNo" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
+/obj/structure/toilet{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	pixel_x = 26
+/obj/item/wirecutters,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes/blue/hollow,
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "red"
+	icon_state = "freezerfloor"
 	},
-/area/security/visiting_room)
+/area/security/permabrig)
 "dNr" = (
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
@@ -36916,21 +36982,19 @@
 	},
 /area/quartermaster/miningdock)
 "dNy" = (
-/obj/structure/table,
-/obj/machinery/kitchen_machine/microwave{
-	pixel_x = -1;
-	pixel_y = 7
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Brig_lockdown";
+	name = "Brig Lockdown"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "PermaLockdown";
+	name = "Perma Lockdown"
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-4"
 	},
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = -28
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
 /area/security/permabrig)
 "dNz" = (
 /obj/structure/cable{
@@ -37800,19 +37864,9 @@
 /turf/simulated/wall,
 /area/quartermaster/qm)
 "dRJ" = (
-/obj/structure/table,
-/obj/item/storage/box/donkpockets,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/item/radio/intercom/locked/prison{
-	pixel_x = -28
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkred"
 	},
 /area/security/permabrig)
 "dRK" = (
@@ -37870,6 +37924,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -39147,25 +39202,27 @@
 	},
 /area/maintenance/fsmaint)
 "dWV" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/obj/machinery/camera{
-	c_tag = "Permabrig West";
-	network = list("Prison","SS13")
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/security/permabrig)
 "dWW" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
+/obj/structure/table,
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "darkred"
+	dir = 1;
+	icon_state = "red"
 	},
-/area/security/permabrig)
+/area/security/visiting_room)
 "dWY" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -39313,12 +39370,11 @@
 /turf/simulated/floor/plasteel,
 /area/bridge/checkpoint/south)
 "dXz" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/flour,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkred"
+	icon_state = "bar"
 	},
 /area/security/permabrig)
 "dXB" = (
@@ -39343,12 +39399,7 @@
 	},
 /area/engineering/engine)
 "dXG" = (
-/obj/structure/table,
-/obj/item/reagent_containers/spray/cleaner/brig,
-/obj/machinery/camera{
-	c_tag = "Permabrig East";
-	network = list("Prison","SS13")
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -41771,12 +41822,16 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/commercial)
 "etR" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
 /area/security/permabrig)
 "etT" = (
 /obj/machinery/status_display{
@@ -41822,6 +41877,12 @@
 "euA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
+	},
+/obj/structure/chair/stool{
+	dir = 1
+	},
+/obj/structure/chair/stool{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -41985,13 +42046,12 @@
 	},
 /area/medical/surgery/south)
 "exv" = (
-/obj/effect/decal/cleanable/cobweb2,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	dir = 1;
 	icon_state = "darkred"
 	},
 /area/security/visiting_room)
@@ -42275,6 +42335,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
+"eAN" = (
+/obj/structure/weightmachine/stacklifter,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkred"
+	},
+/area/security/permabrig)
+"eAP" = (
+/obj/structure/cable,
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/security/visiting_room)
 "eAS" = (
 /obj/machinery/status_display{
 	pixel_y = 32
@@ -42559,19 +42631,9 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/medical/psych)
 "eEj" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/window{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/blue/hollow,
-/obj/item/stack/cable_coil,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
+	icon_state = "bar"
 	},
 /area/security/permabrig)
 "eEu" = (
@@ -44065,6 +44127,13 @@
 	icon_state = "dark"
 	},
 /area/maintenance/asmaint4)
+"eUL" = (
+/obj/machinery/kitchen_machine/oven,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/security/permabrig)
 "eVa" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating/airless,
@@ -44833,21 +44902,8 @@
 	},
 /area/quartermaster/qm)
 "fdX" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Brig_lockdown";
-	name = "Brig Lockdown"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "PermaLockdown";
-	name = "Perma Lockdown"
-	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/cable_coil,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "feb" = (
@@ -44971,16 +45027,16 @@
 /turf/simulated/floor/engine,
 /area/maintenance/incinerator)
 "ffs" = (
-/obj/structure/closet/wardrobe/pjs,
-/obj/effect/decal/warning_stripes/red,
+/obj/structure/table/wood,
+/obj/item/stack/spacechips/c5000,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/security/permabrig)
 "ffK" = (
-/obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/warning_stripes/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -45029,6 +45085,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
 	},
@@ -45064,55 +45121,34 @@
 	},
 /area/hallway/primary/central/south)
 "fgI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/camera{
+	c_tag = "Prison Solitary Confinement 2";
+	dir = 6;
+	network = list("Prison","SS13")
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door_control{
-	desiredstate = 1;
-	id = "Perma11";
-	name = "First Cell Brig Bolts";
-	normaldoorcontrol = 1;
-	pixel_x = -38;
+/obj/machinery/flasher{
+	desc = "A floor-mounted flashbulb device.";
+	id = "permacell1";
+	layer = 5;
 	pixel_y = 24;
-	req_access = list(2);
-	specialfunctions = 4
+	range = 3
 	},
-/obj/machinery/door_control{
-	desiredstate = 1;
-	id = "Perma12";
-	name = "First Cell Perma Bolts";
-	normaldoorcontrol = 1;
-	pixel_x = -26;
-	pixel_y = 24;
-	req_access = list(2);
-	specialfunctions = 4
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/obj/machinery/flasher_button{
-	id = "Perma1";
-	layer = 4;
-	name = "Prison Flasher";
-	pixel_x = -32;
-	pixel_y = 32
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkred"
-	},
+/turf/simulated/floor/plating,
 /area/security/permabrig)
 "fgQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain)
 "fhd" = (
-/obj/structure/bed,
-/obj/item/bedsheet/syndie,
-/obj/effect/decal/warning_stripes/red/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "fhP" = (
 /obj/structure/table/wood,
@@ -45460,6 +45496,11 @@
 	icon_state = "grimy"
 	},
 /area/hallway/secondary/entry/lounge)
+"fmb" = (
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/security/permabrig)
 "fme" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -45915,8 +45956,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "darkyellow"
 	},
 /area/security/permabrig)
 "fsw" = (
@@ -46482,32 +46525,36 @@
 	},
 /area/security/processing)
 "fAB" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Prison Solitary Confinement 1";
+	dir = 6;
+	network = list("Prison","SS13")
 	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Brig_lockdown";
-	name = "Brig Lockdown"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "PermaLockdown";
-	name = "Perma Lockdown"
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "fAM" = (
-/obj/structure/table,
-/obj/item/camera,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/plating,
 /area/security/permabrig)
 "fAR" = (
 /obj/structure/table,
@@ -46532,7 +46579,6 @@
 /area/tcommsat/chamber)
 "fBo" = (
 /obj/structure/table,
-/obj/item/reagent_containers/glass/beaker/waterbottle,
 /obj/item/reagent_containers/food/drinks/drinkingglass{
 	pixel_x = -5
 	},
@@ -46542,6 +46588,13 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/drinks/zaza,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -46922,6 +46975,13 @@
 	},
 /turf/space,
 /area/turret_protected/ai)
+"fFp" = (
+/obj/structure/table/wood,
+/obj/item/deck/cards,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/permabrig)
 "fFv" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -47931,6 +47991,13 @@
 	icon_state = "fancy-wood-birch-broken3"
 	},
 /area/maintenance/fsmaint)
+"fTe" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/security/permabrig)
 "fTk" = (
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
@@ -49570,20 +49637,22 @@
 	},
 /area/security/medbay)
 "gnI" = (
-/obj/structure/table,
-/obj/item/storage/fancy/crayons,
-/obj/item/storage/fancy/crayons{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/effect/decal/warning_stripes/red/hollow,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
+/obj/machinery/hydroponics/constructable{
+	desc = "These are connected with an irrigation tube. You see a little pipe connecting the trays.";
+	name = "Prison hydroponics tray";
+	using_irrigation = 1
 	},
-/obj/item/radio/intercom/locked/prison{
-	pixel_y = -28
-	},
+/obj/item/seeds/nymph,
+/obj/item/seeds/nymph,
+/obj/item/seeds/nymph,
+/obj/item/seeds/nymph,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "bar"
 	},
 /area/security/permabrig)
 "gnK" = (
@@ -49870,6 +49939,16 @@
 	icon_state = "dark"
 	},
 /area/engineering/hardsuitstorage)
+"gqu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/freezer/fridge/open,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/security/permabrig)
 "gqz" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Vacant Office"
@@ -50142,6 +50221,25 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/space)
+"guG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/security/permabrig)
 "guW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -51354,6 +51452,13 @@
 	},
 /turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
+"gIy" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "cmo"
+	},
+/area/security/permabrig)
 "gIA" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
@@ -51438,9 +51543,12 @@
 	},
 /area/atmos)
 "gJJ" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "darkred"
+	icon_state = "bar"
 	},
 /area/security/permabrig)
 "gJN" = (
@@ -51476,14 +51584,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/brig)
 "gKa" = (
-/obj/machinery/newscaster{
-	pixel_y = -30
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
 	},
-/obj/structure/weightmachine/weightlifter,
-/obj/effect/decal/warning_stripes/red/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "gKc" = (
 /obj/structure/cable{
@@ -51506,6 +51611,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -51671,12 +51777,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -51950,9 +52055,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -51960,13 +52062,10 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/hologram/holopad,
-/obj/machinery/camera{
-	c_tag = "Permabrig South";
-	network = list("Prison","SS13")
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
 	},
+/obj/structure/punching_bag,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -54866,6 +54965,13 @@
 	icon_state = "dark"
 	},
 /area/chapel/office)
+"hyu" = (
+/obj/machinery/kitchen_machine/grill,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/security/permabrig)
 "hyv" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow{
@@ -54982,6 +55088,14 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/central/south)
+"hzJ" = (
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/security/permabrig)
 "hzN" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -55818,6 +55932,14 @@
 /obj/machinery/chem_dispenser,
 /turf/simulated/floor/engine,
 /area/toxins/misc_lab)
+"hKy" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/security/permabrig)
 "hKB" = (
 /turf/simulated/floor/plating,
 /area/maintenance/casino)
@@ -56471,8 +56593,8 @@
 	},
 /area/security/prison/cell_block/A)
 "hRI" = (
-/obj/item/stack/cable_coil,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/maintenance/perma)
 "hRL" = (
@@ -56910,6 +57032,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
+"hXR" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig East";
+	network = list("Prison","SS13")
+	},
+/obj/structure/janitorialcart,
+/obj/item/mop,
+/obj/item/caution,
+/obj/item/reagent_containers/glass/bucket,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/permabrig)
 "hYi" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
@@ -58106,6 +58241,21 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/central/west)
+"inJ" = (
+/obj/structure/table,
+/obj/item/storage/fancy/rollingpapers,
+/obj/item/seeds/tobacco,
+/obj/item/seeds/tobacco,
+/obj/item/seeds/tobacco,
+/obj/item/storage/box/matches,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/item/seeds/tower,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/permabrig)
 "inN" = (
 /obj/structure/girder/reinforced,
 /turf/simulated/floor/plating/airless,
@@ -58839,8 +58989,8 @@
 	},
 /area/security/podbay)
 "iwv" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "darkredcorners"
 	},
 /area/security/permabrig)
@@ -60788,7 +60938,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar/atrium)
 "iWk" = (
-/obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/warning_stripes/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -60801,6 +60950,12 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/crew_quarters/hor)
+"iWm" = (
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "cmo"
+	},
+/area/security/permabrig)
 "iWq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -62508,6 +62663,7 @@
 /obj/item/radio/intercom/locked/prison{
 	pixel_x = 28
 	},
+/obj/item/bedsheet/patriot,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkred"
@@ -62526,6 +62682,16 @@
 	icon_state = "dark"
 	},
 /area/turret_protected/ai)
+"jqH" = (
+/obj/item/radio/intercom/locked/prison{
+	pixel_y = 28
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/bed/wicker,
+/turf/simulated/floor/plating,
+/area/security/permabrig)
 "jqR" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -62662,6 +62828,10 @@
 	icon_state = "whitegreen"
 	},
 /area/medical/virology)
+"jrZ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall,
+/area/security/permabrig)
 "jsa" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -63005,6 +63175,12 @@
 	icon_state = "whitehall"
 	},
 /area/maintenance/asmaint3)
+"jvD" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/security/permabrig)
 "jvK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -63017,7 +63193,7 @@
 "jwd" = (
 /obj/structure/table,
 /obj/item/assembly/igniter,
-/obj/item/book/manual/nuclear,
+/obj/item/storage/box/donkpockets,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -63161,16 +63337,21 @@
 	},
 /area/engineering/break_room)
 "jxB" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Solitary Confinement";
+	req_access = list(2)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkred"
-	},
+/turf/simulated/floor/plating,
 /area/security/permabrig)
 "jxE" = (
 /obj/machinery/mass_driver{
@@ -64375,6 +64556,7 @@
 /obj/structure/table,
 /obj/item/multitool,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/glasses/welding,
 /turf/simulated/floor/plating,
 /area/maintenance/perma)
 "jMi" = (
@@ -65206,6 +65388,10 @@
 	icon_state = "red"
 	},
 /area/security/lobby)
+"jXK" = (
+/obj/structure/lattice,
+/turf/simulated/wall/r_wall,
+/area/security/permabrig)
 "jXW" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -65418,6 +65604,16 @@
 	},
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/courtroom)
+"kaO" = (
+/obj/structure/table,
+/obj/structure/table,
+/obj/item/clothing/under/color/orange/prison,
+/obj/item/melee/bigiron,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/security/permabrig)
 "kaX" = (
 /turf/simulated/floor/mech_bay_recharge_floor,
 /area/assembly/chargebay)
@@ -66284,6 +66480,13 @@
 	icon_state = "darkblue"
 	},
 /area/aisat/aihallway)
+"kmV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/security/permabrig)
 "knb" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -66618,6 +66821,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -69394,17 +69598,14 @@
 	},
 /area/medical/virology/lab)
 "lfw" = (
-/obj/machinery/camera{
-	c_tag = "Visiting Room";
-	dir = 8;
-	network = list("SS13","Security")
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
 	icon_state = "darkred"
 	},
 /area/security/visiting_room)
@@ -72051,6 +72252,13 @@
 /obj/item/folder/yellow,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
+"lMA" = (
+/obj/machinery/washing_machine,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/security/permabrig)
 "lMI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -72212,6 +72420,7 @@
 	},
 /area/bridge)
 "lOu" = (
+/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "darkred"
@@ -72308,21 +72517,15 @@
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "lPJ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/camera{
-	c_tag = "Prison Solitary Confinement 2";
-	dir = 6;
-	network = list("Prison","SS13")
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/flasher{
-	desc = "A floor-mounted flashbulb device.";
-	id = "permacell1";
-	layer = 5;
-	pixel_y = 24;
-	range = 3
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkred"
 	},
-/turf/simulated/floor/plating,
-/area/security/permabrig)
+/area/security/visiting_room)
 "lPO" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -74130,17 +74333,27 @@
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "mmA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/chair,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkred"
+	},
+/area/security/visiting_room)
+"mmE" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/security/permabrig)
-"mmE" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -75854,10 +76067,10 @@
 	},
 /area/medical/medbay2)
 "mEu" = (
-/obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/visiting_room)
 "mEA" = (
@@ -76389,6 +76602,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
+"mLC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/permabrig)
 "mLE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -77272,6 +77493,19 @@
 	icon_state = "whitepurple"
 	},
 /area/toxins/explab)
+"mWu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/light/small,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/security/permabrig)
 "mWw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -80063,6 +80297,17 @@
 	icon_state = "darkyellow"
 	},
 /area/maintenance/fpmaint)
+"nCE" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/permabrig)
 "nCH" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes/cigpack_random{
@@ -80754,19 +80999,17 @@
 /turf/simulated/floor/plating,
 /area/security/visiting_room)
 "nKe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/light/small{
+/obj/structure/chair{
 	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Prison Solitary Confinement 1";
-	dir = 6;
-	network = list("Prison","SS13")
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "red"
 	},
-/turf/simulated/floor/plating,
-/area/security/permabrig)
+/area/security/visiting_room)
 "nKi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -80780,14 +81023,19 @@
 	},
 /area/medical/cmo)
 "nKl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/door/window/brigdoor{
+	dir = 2;
+	name = "Visiting Room";
+	req_access = list(63)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	name = "Visiting Room";
+	req_access = list(63)
 	},
+/obj/structure/table/reinforced,
 /turf/simulated/floor/plating,
-/area/security/permabrig)
+/area/security/visiting_room)
 "nKr" = (
 /obj/structure/closet/walllocker/emerglocker/west,
 /turf/simulated/floor/plasteel{
@@ -80874,26 +81122,43 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "nLI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/door_control{
+	desiredstate = 1;
+	id = "Perma11";
+	name = "First Cell Brig Bolts";
+	normaldoorcontrol = 1;
+	pixel_x = -38;
+	pixel_y = 24;
+	req_access = list(2);
+	specialfunctions = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/door_control{
+	desiredstate = 1;
+	id = "Perma12";
+	name = "First Cell Perma Bolts";
+	normaldoorcontrol = 1;
+	pixel_x = -26;
+	pixel_y = 24;
+	req_access = list(2);
+	specialfunctions = 4
+	},
+/obj/machinery/flasher_button{
+	id = "Perma1";
+	layer = 4;
+	name = "Prison Flasher";
+	pixel_x = -32;
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "darkred"
+	icon_state = "dark"
 	},
 /area/security/permabrig)
 "nLY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/turf_decal/stripes/white/line{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "darkred"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "nMi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -81290,6 +81555,20 @@
 /obj/item/crowbar,
 /turf/simulated/floor/plating,
 /area/maintenance/ai)
+"nRk" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/permabrig)
 "nRp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -81658,6 +81937,23 @@
 	icon_state = "neutralfull"
 	},
 /area/storage/tech)
+"nUO" = (
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/radio/intercom/locked/prison{
+	pixel_x = -28
+	},
+/obj/item/storage/photo_album,
+/obj/item/camera,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/permabrig)
 "nUP" = (
 /obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plasteel{
@@ -82720,17 +83016,19 @@
 	},
 /area/medical/medbay2)
 "oij" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/structure/table,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/tomato,
+/obj/item/seeds/tomato,
+/obj/item/seeds/tomato,
+/obj/item/seeds/grass,
+/obj/item/seeds/grass,
+/obj/item/seeds/grass,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/machinery/flasher{
-	desc = "A floor-mounted flashbulb device.";
-	id = "permacell2";
-	layer = 5;
-	pixel_y = -24;
-	range = 3
-	},
-/turf/simulated/floor/plating,
 /area/security/permabrig)
 "oip" = (
 /obj/effect/decal/cleanable/dirt,
@@ -82790,15 +83088,9 @@
 /turf/simulated/floor/plating,
 /area/security/processing)
 "ojw" = (
-/obj/structure/table,
-/obj/item/plant_analyzer,
-/obj/item/cultivator,
-/obj/item/reagent_containers/spray/plantbgone,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "freezerfloor"
 	},
 /area/security/permabrig)
 "ojx" = (
@@ -82833,11 +83125,9 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/garden)
 "ojU" = (
-/obj/structure/bed,
-/obj/item/bedsheet/patriot,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "freezerfloor"
 	},
 /area/security/permabrig)
 "okc" = (
@@ -83310,6 +83600,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior)
+"opJ" = (
+/obj/structure/table,
+/obj/machinery/kitchen_machine/microwave,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/security/permabrig)
 "opP" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/wood{
@@ -87109,6 +87407,18 @@
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/storage)
+"pix" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/security/permabrig)
 "piB" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -87218,12 +87528,13 @@
 	},
 /area/maintenance/fpmaint)
 "pkc" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
-/obj/effect/decal/warning_stripes/red/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "pke" = (
 /obj/machinery/light_switch{
@@ -89413,13 +89724,30 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "pIp" = (
-/obj/machinery/vending/cola/free,
-/obj/effect/decal/warning_stripes/red/hollow,
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -28
+	},
+/obj/machinery/flasher_button{
+	id = "permacell2";
+	name = "Perma cell 2 flasher button";
+	pixel_x = -38;
+	pixel_y = -4
+	},
+/obj/machinery/flasher_button{
+	id = "permacell1";
+	name = "Perma cell 1 flasher button";
+	pixel_x = -38;
+	pixel_y = 6
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "darkred"
 	},
 /area/security/permabrig)
 "pIq" = (
@@ -91228,17 +91556,7 @@
 	},
 /area/hallway/primary/central/nw)
 "qbW" = (
-/obj/machinery/portable_atmospherics/scrubber/huge/stationary,
-/obj/effect/decal/warning_stripes/red/hollow,
-/obj/machinery/camera{
-	c_tag = "Permabrig North";
-	dir = 1;
-	network = list("Prison","SS13")
-	},
-/obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/plating,
 /area/security/permabrig)
 "qbY" = (
 /obj/effect/decal/warning_stripes/west,
@@ -91767,14 +92085,9 @@
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "qie" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/window/reinforced/polarized{
-	id = "visiting room"
-	},
-/turf/simulated/floor/plating,
-/area/security/visiting_room)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/security/permabrig)
 "qih" = (
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -92381,6 +92694,28 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/glass,
 /area/maintenance/consarea_virology)
+"qoZ" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	pixel_x = 26
+	},
+/obj/machinery/camera{
+	c_tag = "Visiting Room";
+	dir = 8;
+	network = list("SS13","Security")
+	},
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "red"
+	},
+/area/security/visiting_room)
 "qpj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -93097,6 +93432,15 @@
 	icon_state = "tranquillite"
 	},
 /area/maintenance/kitchen)
+"quY" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/permabrig)
 "qvg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -94064,15 +94408,14 @@
 	},
 /area/toxins/misc_lab)
 "qGt" = (
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	pixel_y = 22
+/obj/item/radio/intercom/locked/prison{
+	pixel_y = -28
 	},
-/obj/effect/decal/warning_stripes/blue/hollow,
-/mob/living/simple_animal/frog,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
+/obj/structure/bed/wicker,
+/turf/simulated/floor/plating,
 /area/security/permabrig)
 "qGv" = (
 /obj/machinery/light,
@@ -94272,16 +94615,22 @@
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/lawoffice)
-"qJM" = (
-/obj/machinery/door/airlock{
-	id_tag = "PermaBath";
-	name = "Restroom"
+"qJL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkyellow"
+	},
+/area/security/permabrig)
+"qJM" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
+	icon_state = "dark"
 	},
 /area/security/permabrig)
 "qKa" = (
@@ -94672,6 +95021,13 @@
 	icon_state = "white"
 	},
 /area/assembly/robotics)
+"qOi" = (
+/obj/structure/table/wood,
+/obj/item/storage/fancy/crayons,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/permabrig)
 "qOo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
@@ -94767,6 +95123,13 @@
 	icon_state = "white"
 	},
 /area/medical/research/nhallway)
+"qPl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/permabrig)
 "qPr" = (
 /obj/machinery/door/airlock/security/glass{
 	id = "execution";
@@ -94955,6 +95318,20 @@
 	icon_state = "grimy"
 	},
 /area/maintenance/detectives_office)
+"qRG" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/blue/hollow,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/gloves/knuckles,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/security/permabrig)
 "qRN" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/effect/decal/warning_stripes/north,
@@ -94987,6 +95364,15 @@
 	icon_state = "green"
 	},
 /area/hallway/secondary/exit)
+"qSc" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/permabrig)
 "qSE" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -95320,17 +95706,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/structure/chair,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/flasher{
-	desc = "A floor-mounted flashbulb device.";
-	id = "visiting room flash";
-	layer = 5;
-	pixel_x = 56;
-	range = 3
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
@@ -99715,6 +100093,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
+"rXU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink{
+	dir = 1;
+	layer = 5;
+	pixel_y = -5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/security/permabrig)
 "rXZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/confetti,
@@ -102180,6 +102569,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
+"sAG" = (
+/obj/machinery/vending/cola/free,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "darkred"
+	},
+/area/security/permabrig)
 "sAI" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -102935,6 +103331,14 @@
 	icon_state = "dark"
 	},
 /area/engineering/gravitygenerator)
+"sLe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/library,
+/obj/structure/table,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/permabrig)
 "sLl" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -103920,9 +104324,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "darkred"
@@ -104114,6 +104515,14 @@
 	icon_state = "yellowfull"
 	},
 /area/maintenance/asmaint)
+"sZL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/weightmachine/weightlifter,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkred"
+	},
+/area/security/permabrig)
 "sZN" = (
 /obj/structure/chair/sofa/pew/left,
 /turf/simulated/floor/plasteel{
@@ -105556,6 +105965,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
+"tqn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/screwdriver,
+/turf/simulated/floor/plating,
+/area/security/permabrig)
 "tqo" = (
 /obj/structure/cable,
 /obj/effect/spawner/window/reinforced/polarized{
@@ -106332,6 +106755,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
+"tAg" = (
+/obj/structure/sign/poster/contraband/bad_guy,
+/turf/simulated/wall/r_wall,
+/area/security/permabrig)
 "tAh" = (
 /obj/structure/delta_statue/e,
 /turf/simulated/floor/plasteel{
@@ -106547,6 +106974,7 @@
 	dir = 1;
 	pixel_y = -26
 	},
+/obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
 	},
@@ -108691,7 +109119,6 @@
 /obj/structure/table,
 /obj/item/clothing/under/color/orange/prison,
 /obj/item/clothing/shoes/orange,
-/obj/item/wrench,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/perma)
@@ -110048,6 +110475,13 @@
 	icon_state = "red"
 	},
 /area/security/checkpoint/south)
+"uoU" = (
+/obj/structure/weightmachine/stacklifter,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/security/permabrig)
 "uoW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -110084,6 +110518,14 @@
 	icon_state = "neutral"
 	},
 /area/toxins/mixing)
+"ups" = (
+/obj/structure/table/wood,
+/obj/item/storage/belt/chef,
+/obj/item/clothing/head/chefhat,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/security/permabrig)
 "upx" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -110587,6 +111029,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/brig)
+"uvM" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/cheesewedge,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/security/permabrig)
 "uvT" = (
 /obj/structure/bookcase,
 /turf/simulated/floor/plasteel{
@@ -111454,6 +111904,13 @@
 	icon_state = "dark"
 	},
 /area/crew_quarters/chief)
+"uHx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/security/permabrig)
 "uHy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -112986,7 +113443,7 @@
 /area/medical/virology/lab)
 "val" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -113039,14 +113496,20 @@
 	},
 /area/maintenance/starboard)
 "vbh" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/item/pen,
-/turf/simulated/floor/plating,
-/area/security/permabrig)
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkred"
+	},
+/area/security/visiting_room)
 "vbq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -113492,12 +113955,13 @@
 	},
 /area/crew_quarters/locker)
 "vhp" = (
-/obj/structure/bed,
-/obj/item/radio/intercom/locked/prison{
-	pixel_y = -28
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/security/permabrig)
+/turf/simulated/floor/plasteel{
+	icon_state = "red"
+	},
+/area/security/visiting_room)
 "vhD" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -114629,12 +115093,16 @@
 	},
 /area/assembly/robotics)
 "vvh" = (
-/obj/structure/bed,
-/obj/item/radio/intercom/locked/prison{
-	pixel_y = 28
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
 	},
-/turf/simulated/floor/plating,
-/area/security/permabrig)
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkred"
+	},
+/area/security/visiting_room)
 "vvn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -115635,6 +116103,14 @@
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/storage)
+"vEB" = (
+/obj/effect/decal/warning_stripes/red,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/coffee/free,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/security/permabrig)
 "vEU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/engineering,
@@ -116730,6 +117206,7 @@
 	pixel_y = -3;
 	req_access = list(2)
 	},
+/obj/item/megaphone,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -117090,6 +117567,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/warden)
+"vXq" = (
+/obj/machinery/door/airlock{
+	id_tag = "PermaBath";
+	name = "Restroom"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/security/permabrig)
 "vXH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -117392,7 +117878,7 @@
 	},
 /area/medical/surgery/south)
 "wbO" = (
-/obj/item/wirecutters,
+/obj/item/storage/toolbox/mechanical/old,
 /turf/simulated/floor/plating,
 /area/maintenance/perma)
 "wbP" = (
@@ -118024,12 +118510,18 @@
 /area/security/warden)
 "wkn" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkred"
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Brig_lockdown";
+	name = "Brig Lockdown"
 	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "PermaLockdown";
+	name = "Perma Lockdown"
+	},
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
 /area/security/permabrig)
 "wkt" = (
 /obj/effect/decal/warning_stripes/south,
@@ -118273,6 +118765,15 @@
 	icon_state = "whiteblue"
 	},
 /area/assembly/robotics)
+"wnn" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/breadslice,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kitchen/knife/plastic,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/security/permabrig)
 "wnq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -119455,6 +119956,21 @@
 	color = "orange"
 	},
 /area/crew_quarters/courtroom)
+"wAI" = (
+/obj/structure/table,
+/obj/item/plant_analyzer,
+/obj/item/cultivator,
+/obj/item/reagent_containers/spray/plantbgone,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/permabrig)
 "wAK" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -119705,19 +120221,13 @@
 /turf/simulated/wall,
 /area/medical/medbay)
 "wDS" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Solitary Confinement";
-	req_access = list(2)
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/security/permabrig)
+/area/security/visiting_room)
 "wDT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -119953,6 +120463,19 @@
 	icon_state = "freezerfloor"
 	},
 /area/security/brigstaff)
+"wGg" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/curtain/open/shower{
+	anchored = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "cmo"
+	},
+/area/security/permabrig)
 "wGp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -120022,6 +120545,17 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
+"wGV" = (
+/obj/machinery/computer/cryopod{
+	layer = 4;
+	pixel_y = 32
+	},
+/obj/machinery/cryopod,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkred"
+	},
+/area/security/permabrig)
 "wGW" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -120296,6 +120830,14 @@
 	icon_state = "neutral"
 	},
 /area/crew_quarters/fitness)
+"wLc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/weightmachine/weightlifter,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/security/permabrig)
 "wLd" = (
 /obj/effect/spawner/random_spawners/wall_rusted_70,
 /turf/simulated/wall,
@@ -120903,20 +121445,10 @@
 /turf/simulated/floor/light,
 /area/maintenance/kitchen)
 "wSo" = (
-/obj/machinery/hydroponics/constructable{
-	desc = "These are connected with an irrigation tube. You see a little pipe connecting the trays.";
-	name = "Prison hydroponics tray";
-	using_irrigation = 1
-	},
-/obj/item/seeds/nymph,
-/obj/item/seeds/nymph,
-/obj/item/seeds/nymph,
-/obj/effect/decal/warning_stripes/red/hollow,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "darkyellow"
 	},
 /area/security/permabrig)
 "wSJ" = (
@@ -120986,9 +121518,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "wTJ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "darkred"
+	icon_state = "dark"
 	},
 /area/security/permabrig)
 "wTS" = (
@@ -121546,15 +122081,32 @@
 	icon_state = "grimy"
 	},
 /area/chapel/main)
-"xbO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+"xbL" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/cryopod,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkred"
 	},
-/turf/simulated/floor/plating,
 /area/security/permabrig)
+"xbO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "darkred"
+	},
+/area/security/visiting_room)
 "xbS" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -122258,6 +122810,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
+"xja" = (
+/obj/item/stack/cable_coil,
+/turf/simulated/floor/plating,
+/area/maintenance/perma)
 "xji" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/comfy/beige{
@@ -123685,10 +124241,9 @@
 	},
 /area/security/podbay)
 "xxG" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/obj/item/beach_ball/holoball,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "xxH" = (
 /obj/effect/decal/warning_stripes/blue,
@@ -125156,6 +125711,17 @@
 	icon_state = "green"
 	},
 /area/medical/virology/lab)
+"xNE" = (
+/obj/machinery/light,
+/obj/machinery/camera{
+	c_tag = "Quartermaster's Office";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkred"
+	},
+/area/security/permabrig)
 "xNO" = (
 /obj/item/shard{
 	icon_state = "medium";
@@ -127167,6 +127733,19 @@
 	},
 /turf/simulated/floor/wood,
 /area/security/hos)
+"yhN" = (
+/obj/machinery/shower{
+	pixel_y = 22
+	},
+/obj/structure/curtain/open/shower{
+	anchored = 1
+	},
+/mob/living/simple_animal/frog,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "cmo"
+	},
+/area/security/permabrig)
 "yhO" = (
 /obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -179378,8 +179957,8 @@ ubg
 dsj
 jXk
 nwj
-uSY
-qie
+nwj
+nwj
 nwj
 nKc
 lCu
@@ -180152,8 +180731,8 @@ nwj
 exv
 lfw
 mEu
-jdU
-dNo
+dWW
+vhp
 wMw
 nRT
 tLv
@@ -180393,12 +180972,12 @@ aaq
 aaq
 aaq
 aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-coE
+aru
+dCr
+dCr
+aru
+dCr
+dCr
 vyi
 jRh
 skC
@@ -180406,12 +180985,12 @@ qfc
 wLq
 kfc
 nwj
-nwj
-nwj
-nwj
-nwj
-nwj
-nwj
+dBo
+mmA
+nKl
+nKe
+vhp
+wMw
 hdu
 pLB
 bzC
@@ -180650,27 +181229,27 @@ bCI
 bCI
 bCI
 coE
-coE
-coE
-coE
-coE
-coE
-coE
+aru
+jqH
+pix
+aru
+pix
+qGt
 vyi
 jch
 tFf
 iBE
 joq
 keE
-aru
+nwj
 vvh
 vbh
-aru
-vbh
+eAP
+dWW
 vhp
-aru
+wMw
 oIn
-qug
+mqz
 mml
 lhS
 uou
@@ -180904,29 +181483,29 @@ aaq
 aaq
 aaq
 bCI
-coE
-coE
-coE
+aaq
+aaq
+aaq
 aru
+fgI
+mWu
 aru
-mAr
-fdX
 fAB
-aru
+dIo
 vyi
 hsI
 hZW
 ucB
 nnG
 kfc
-aru
+nwj
 lPJ
 mmA
-aru
+nKl
 nKe
-oij
-aru
-pbM
+vhp
+wMw
+pcc
 mqz
 iUI
 lhS
@@ -181162,28 +181741,28 @@ aaq
 aaq
 coE
 coE
-dCr
+coE
+coE
 aru
-aru
-dWV
+lSM
 etR
-ffs
+aru
 fAM
-gnI
+kmJ
 aru
 vyi
 dgo
 iCk
 cfs
 cJM
-aru
-lSM
+nwj
+aLh
 xbO
-aru
-nKl
-kmJ
-aru
-pcc
+eAP
+jdU
+qoZ
+wMw
+oIn
 qug
 mfd
 lhS
@@ -181408,38 +181987,38 @@ aaq
 aaq
 aaq
 aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
 bCI
 coE
+aaq
+bqc
+bqc
+bqc
+bqc
+aaq
 coE
-dBo
-dHs
+coE
+coE
+dCr
 dNy
-dRJ
-dWW
-wkn
-wkn
+aru
+aru
 jxB
-wTJ
-gKa
+aru
+jxB
+aru
+dAb
 aru
 aru
 aru
 aru
 aru
-aru
-aru
+nwj
+uSY
 wDS
-aru
-wDS
-aru
-aru
+nwj
+nwj
+nwj
+nwj
 pdt
 onq
 ioU
@@ -181665,35 +182244,35 @@ aaq
 aaq
 aaq
 aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-bCI
-bCI
-bCI
+coE
+coE
+coE
+coE
+coE
+coE
+coE
 coE
 aru
-anZ
+aru
+wkn
 dHH
-fzL
-uPb
+nRk
+nUO
 czx
-xan
+cxr
 pIp
-vIm
-qDW
+guG
 uPb
-wTJ
-dAb
+uPb
+uPb
+sAG
 qbt
 drU
 cfz
 ult
+xan
+xan
 lTH
-fgI
-djZ
 nLI
 otM
 aru
@@ -181922,27 +182501,27 @@ aaq
 aaq
 aaq
 aaq
-aaq
-aaq
-aaq
-aaq
-aaq
 bCI
 coE
 coE
-coE
 aru
+aru
+aru
+aru
+aru
+tAg
+sLe
 dCj
-fzL
-czx
-fLm
+dHO
 xan
+fLm
+acU
 cPu
 tLD
 fBo
-val
+wTJ
 gKm
-xan
+dXG
 xan
 nfZ
 joA
@@ -181950,8 +182529,8 @@ kfn
 lga
 chy
 mmE
-dcs
-nLY
+xan
+xan
 ojL
 xxI
 oIn
@@ -182179,25 +182758,25 @@ aaq
 aaq
 aaq
 aaq
-aaq
-aaq
-aaq
-aaq
-aaq
 coE
 coE
 aru
 aru
+yhN
+dIk
+wGg
 aru
-aru
+wGV
+dHO
+fFp
 adR
 euA
 dRZ
 jQW
-jQW
+dWV
 ffK
-jQW
-jQW
+nCE
+dcs
 gLN
 wxD
 iLK
@@ -182208,7 +182787,7 @@ wSO
 fxR
 kaJ
 xan
-wxD
+xan
 jnU
 wyT
 pee
@@ -182436,27 +183015,27 @@ aaq
 aaq
 aaq
 aaq
-aaq
-aaq
-aaq
-aaq
-bCI
 coE
+jXK
 aru
+gIy
+gIy
+gIy
+iWm
 aru
-aOn
+xbL
 dxN
-aru
-dXz
-xmf
+ffs
+qOi
+aPw
 vGv
 vGv
-vGv
+eAN
 gIs
-kNh
+sZL
 kNh
 vjr
-wxD
+xNE
 aru
 xwO
 qic
@@ -182466,7 +183045,7 @@ vTG
 kaJ
 nHp
 qDW
-wTJ
+jnU
 ugN
 pfE
 pLF
@@ -182692,28 +183271,28 @@ aaq
 aaq
 aaq
 aaq
-aaq
-aaq
-aaq
-aaq
-aaq
 bCI
 coE
 aru
-qGt
+lMA
+ojU
+ojU
 drT
-mdB
+qbW
 aru
+djZ
+dXG
+dCj
 dHO
 fgv
 jwd
-xxG
-ojU
+fTe
+fhd
 fhd
 pkc
-xxG
+gKa
 gLR
-wxD
+dRJ
 yeN
 fWz
 fgj
@@ -182949,26 +183528,26 @@ aaq
 aaq
 aaq
 aaq
-aaq
-aaq
-aaq
-aaq
-aaq
 bCI
 coE
-aru
+dlr
+hzJ
+ojw
+jrZ
+tqn
+uHx
 dlJ
-drX
-ceT
-qJM
 dcs
+dcs
+qJM
+mLC
 xLJ
-qbW
-tLD
+iLK
+bkl
+qie
 xxG
-xxG
-xxG
-tLD
+qie
+fmb
 gOi
 lme
 ibF
@@ -183206,28 +183785,28 @@ aaq
 aaq
 aaq
 aaq
-aaq
-aaq
-aaq
-aaq
-aaq
 bCI
 coE
 aru
-dlr
-bda
-mdB
+kaO
+ojU
+ojU
+jvD
+fdX
 aru
+bda
+drX
+drX
 dHR
 don
 qMN
-xxG
-duN
-iRA
-jEA
-xxG
+czK
+hKy
+hKy
+hKy
+nLY
 gLR
-wxD
+dRJ
 ice
 eKe
 qqA
@@ -183463,25 +184042,25 @@ aaq
 aaq
 aaq
 aaq
-aaq
-aaq
-aaq
-aaq
-aaq
 bCI
 coE
+jXK
 aru
+dKw
+qbW
+mdB
+ojU
 aru
-aOn
+gqu
 eEj
-aru
+eEj
 dXz
-wUT
+qJL
+dXG
 uPb
-uPb
-uPb
+uoU
 fiU
-fCQ
+wLc
 fCQ
 gOj
 tCR
@@ -183721,25 +184300,25 @@ aaq
 aaq
 aaq
 aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-coE
+dHs
 coE
 aru
 aru
+vXq
 aru
+vXq
 aru
-dIk
+dLZ
+kmV
+uvM
+gJJ
 fsu
 gLB
 juW
 juW
 iWk
 juW
-juW
+qPl
 gPM
 wxD
 iLK
@@ -183978,27 +184557,27 @@ aaq
 aaq
 aaq
 aaq
-aaq
-aaq
-aaq
-aaq
-aaq
 bCI
 coE
 coE
-coE
 aru
+rXU
+aru
+aOn
+aru
+eUL
+dXz
 dCw
 gJJ
-iwv
+wSo
 vsn
-xan
-eue
-tLD
-cxr
+qSc
+duN
+iRA
+jEA
 val
 gQC
-val
+wTJ
 srM
 iDp
 jqd
@@ -184235,28 +184814,28 @@ aaq
 aaq
 aaq
 aaq
-aaq
-aaq
-aaq
-aaq
-aaq
 bCI
-bCI
-bCI
+aaq
 coE
 aru
-dCr
-dIo
+dNo
+aru
+qRG
+aHh
+hyu
+eEj
+ups
 gJJ
-vGv
-iwv
+wSo
 xan
-ojw
+dXG
+dXG
+xan
+xan
 vIm
-cqf
 vGv
 kTh
-vIm
+quY
 iCu
 jqn
 rEC
@@ -184493,24 +185072,24 @@ aaq
 aaq
 aaq
 aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
 bCI
 coE
-coE
-dCA
-ekp
+aru
+aru
+aru
+aru
+aru
+opJ
+kmV
+wnn
+gJJ
 wSo
-fFB
-kdO
-iZf
-iZf
-fCT
-kTh
+xan
+xan
+oij
+tLD
+inJ
+ceT
 gQN
 dZF
 uUT
@@ -184750,24 +185329,24 @@ aaq
 aaq
 aaq
 aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
+bCI
 aaq
 coE
+dHs
 coE
-anZ
+coE
 aru
 aru
+aru
+dCr
+vEB
+wSo
+xan
 dXG
-eur
-fkB
-kti
-gof
+eue
+wAI
+vIm
+iwv
 dZF
 dZF
 oWU
@@ -185009,27 +185588,27 @@ aaq
 aaq
 aaq
 aaq
+bqc
+bqc
 aaq
 aaq
-aaq
-aaq
-aaq
-aaq
-bCI
 coE
 coE
 coE
-aru
-aru
-mAr
-nos
-fEI
-aru
+dCA
+ekp
+gnI
+fFB
+kdO
+iZf
+iZf
+fCT
+kTh
 dZF
 pbV
 gue
 pzY
-pzY
+xja
 mIv
 wyD
 dZu
@@ -185269,19 +185848,19 @@ aaq
 aaq
 aaq
 aaq
+bqc
+bqc
 aaq
-aaq
-aaq
-bCI
-bCI
-bCI
 coE
 coE
-coE
-coE
-coE
-coE
-coE
+anZ
+aru
+aru
+hXR
+eur
+fkB
+kti
+gof
 dZF
 luL
 msW
@@ -185529,16 +186108,16 @@ aaq
 aaq
 aaq
 aaq
-aaq
-aaq
-aaq
-aaq
-aaq
 bCI
-bCI
-bCI
-aaq
 coE
+coE
+coE
+aru
+aru
+mAr
+nos
+fEI
+aru
 dZF
 dZF
 dZF
@@ -185786,15 +186365,15 @@ aaq
 aaq
 aaq
 aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
+bCI
+bCI
+bCI
+coE
+coE
+coE
+coE
+coE
+coE
 coE
 coE
 coE
@@ -186048,11 +186627,11 @@ aaq
 aaq
 aaq
 aaq
+bCI
+bCI
+bCI
 aaq
-aaq
-aaq
-aaq
-dZq
+coE
 dZq
 dZq
 aaq

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -30759,13 +30759,13 @@
 	},
 /area/engineering/engine)
 "dlJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock{
 	id_tag = "PermaBath";
 	name = "Restroom"
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "dlK" = (
@@ -45028,6 +45028,7 @@
 "ffs" = (
 /obj/structure/table/wood,
 /obj/item/stack/spacechips/c5000,
+/obj/item/deck/cards/doublecards,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -46985,7 +46986,7 @@
 /area/turret_protected/ai)
 "fFp" = (
 /obj/structure/table/wood,
-/obj/item/deck/cards,
+/obj/item/deck/unum,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -72913,6 +72914,13 @@
 	icon_state = "dark"
 	},
 /area/bridge)
+"lVs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/permabrig)
 "lVE" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -76607,9 +76615,8 @@
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
 "mLC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -94632,8 +94639,8 @@
 /area/security/permabrig)
 "qJM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -111910,7 +111917,6 @@
 "uHx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "uHy" = (
@@ -183546,10 +183552,10 @@ jrZ
 tqn
 uHx
 dlJ
-dcs
-dcs
-qJM
 mLC
+mLC
+qJM
+qJM
 xLJ
 acU
 bkl
@@ -184844,7 +184850,7 @@ xan
 vIm
 vGv
 kTh
-dXG
+lVs
 iCu
 jqn
 rEC

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -435,6 +435,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
+"acU" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkredcorners"
+	},
+/area/security/permabrig)
 "ads" = (
 /obj/structure/closet/wardrobe/red,
 /obj/item/clothing/suit/tracksuit/red,
@@ -30758,6 +30765,7 @@
 	id_tag = "PermaBath";
 	name = "Restroom"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "dlK" = (
@@ -33487,13 +33495,11 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/fitness)
 "dxN" = (
-/obj/effect/decal/warning_stripes/blue/hollow,
-/obj/structure/chair/stool{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/wardrobe/pjs,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "cmo"
 	},
 /area/security/permabrig)
 "dxO" = (
@@ -36215,6 +36221,7 @@
 "dKw" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/dresser,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -45025,9 +45032,13 @@
 	},
 /area/security/permabrig)
 "ffK" = (
-/obj/effect/decal/warning_stripes/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -45078,7 +45089,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "darkred"
+	icon_state = "dark"
 	},
 /area/security/permabrig)
 "fgB" = (
@@ -45231,6 +45242,7 @@
 /area/security/detectives_office)
 "fiU" = (
 /obj/machinery/atmospherics/unary/outlet_injector/on,
+/obj/effect/decal/warning_stripes/red,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkred"
@@ -46364,9 +46376,7 @@
 	pixel_x = -4;
 	pixel_y = 2
 	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 7
-	},
+/obj/item/melee/baton,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -47020,7 +47030,8 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 4;
+	icon_state = "darkred"
 	},
 /area/security/permabrig)
 "fFC" = (
@@ -49643,10 +49654,10 @@
 /obj/item/seeds/nymph,
 /obj/item/seeds/nymph,
 /obj/item/seeds/nymph,
-/obj/item/seeds/nymph,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 5;
+	icon_state = "darkyellow"
 	},
 /area/security/permabrig)
 "gnK" = (
@@ -51427,6 +51438,7 @@
 /area/atmos)
 "gIs" = (
 /obj/machinery/atmospherics/unary/outlet_injector/on,
+/obj/effect/decal/warning_stripes/red,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkred"
@@ -52055,7 +52067,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
 	},
@@ -52079,7 +52090,8 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "darkredcorners"
 	},
 /area/security/permabrig)
 "gOq" = (
@@ -57035,6 +57047,7 @@
 /obj/item/mop,
 /obj/item/caution,
 /obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -60935,10 +60948,10 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar/atrium)
 "iWk" = (
-/obj/effect/decal/warning_stripes/red,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/portable_atmospherics/scrubber/huge/stationary,
+/obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkred"
 	},
 /area/security/permabrig)
 "iWl" = (
@@ -63192,7 +63205,7 @@
 /obj/item/assembly/igniter,
 /obj/item/storage/box/donkpockets,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkred"
 	},
 /area/security/permabrig)
 "jwe" = (
@@ -65740,15 +65753,6 @@
 	icon_state = "neutralfull"
 	},
 /area/atmos/control)
-"kdO" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "darkred"
-	},
-/area/security/permabrig)
 "kdP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood/fancy/black,
@@ -94875,7 +94879,7 @@
 	freeplay = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkred"
 	},
 /area/security/permabrig)
 "qMV" = (
@@ -111906,7 +111910,6 @@
 "uHx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
@@ -114136,7 +114139,8 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 4;
+	icon_state = "darkredcorners"
 	},
 /area/security/permabrig)
 "vjx" = (
@@ -118770,6 +118774,7 @@
 /obj/item/reagent_containers/food/snacks/breadslice,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kitchen/knife/plastic,
+/obj/item/kitchen/rollingpin,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -120551,6 +120556,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/cryopod,
+/obj/effect/decal/warning_stripes/green,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -122086,6 +122092,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/cryopod,
+/obj/effect/decal/warning_stripes/green,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -125526,7 +125533,7 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	icon_state = "darkred"
+	icon_state = "dark"
 	},
 /area/security/permabrig)
 "xLL" = (
@@ -181225,9 +181232,9 @@ aaq
 aaq
 aaq
 aaq
-bCI
-bCI
-bCI
+aaq
+aaq
+aaq
 coE
 aru
 jqH
@@ -181483,8 +181490,8 @@ aaq
 aaq
 aaq
 bCI
-aaq
-aaq
+bCI
+bCI
 aaq
 aru
 fgI
@@ -181738,7 +181745,7 @@ aaq
 aaq
 aaq
 aaq
-aaq
+bCI
 coE
 coE
 coE
@@ -181987,14 +181994,14 @@ aaq
 aaq
 aaq
 aaq
-bCI
+aaq
+aaq
+aaq
+bqc
+bqc
+bqc
+bqc
 coE
-aaq
-bqc
-bqc
-bqc
-bqc
-aaq
 coE
 coE
 coE
@@ -182244,8 +182251,8 @@ aaq
 aaq
 aaq
 aaq
-coE
-coE
+aaq
+bqc
 coE
 coE
 coE
@@ -182774,7 +182781,7 @@ euA
 dRZ
 jQW
 dWV
-ffK
+dcs
 nCE
 dcs
 gLN
@@ -183018,17 +183025,17 @@ aaq
 coE
 jXK
 aru
-gIy
+dxN
 gIy
 gIy
 iWm
 aru
 xbL
-dxN
+dHO
 ffs
 qOi
 aPw
-vGv
+cqf
 vGv
 eAN
 gIs
@@ -183542,14 +183549,14 @@ dcs
 qJM
 mLC
 xLJ
-iLK
+iWk
 bkl
 qie
 xxG
 qie
 fmb
 gOi
-lme
+ffK
 ibF
 lme
 fjL
@@ -184056,7 +184063,7 @@ eEj
 eEj
 dXz
 qJL
-dXG
+acU
 uPb
 uoU
 fiU
@@ -184316,7 +184323,7 @@ fsu
 gLB
 juW
 juW
-iWk
+juW
 juW
 qPl
 gPM
@@ -185599,7 +185606,7 @@ dCA
 ekp
 gnI
 fFB
-kdO
+iZf
 iZf
 iZf
 fCT

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -435,15 +435,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
-"acU" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/permabrig)
 "ads" = (
 /obj/structure/closet/wardrobe/red,
 /obj/item/clothing/suit/tracksuit/red,
@@ -182515,7 +182506,7 @@ dCj
 dHO
 xan
 fLm
-acU
+dXG
 cPu
 tLD
 fBo

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -72914,13 +72914,6 @@
 	icon_state = "dark"
 	},
 /area/bridge)
-"lVs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/recharge_station,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/permabrig)
 "lVE" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -76615,8 +76608,8 @@
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
 "mLC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -114039,6 +114032,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/lawoffice)
+"vhX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/permabrig)
 "vib" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -183552,8 +183552,8 @@ jrZ
 tqn
 uHx
 dlJ
-mLC
-mLC
+vhX
+vhX
 qJM
 qJM
 xLJ
@@ -184850,7 +184850,7 @@ xan
 vIm
 vGv
 kTh
-lVs
+mLC
 iCu
 jqn
 rEC

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -35512,8 +35512,8 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "dHs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/recharge_station,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -49715,11 +49715,11 @@
 /area/maintenance/disposal)
 "gof" = (
 /obj/structure/table,
-/obj/item/instrument/harmonica,
-/obj/item/dice/d20,
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
+/obj/item/dice/d20,
+/obj/item/instrument/piano_synth,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -94633,8 +94633,8 @@
 	},
 /area/security/permabrig)
 "qJM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -119752,6 +119752,14 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/magistrateoffice)
+"wxy" = (
+/obj/structure/table,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/item/instrument/harmonica,
+/turf/simulated/floor/plating,
+/area/security/permabrig)
 "wxC" = (
 /turf/simulated/wall/r_wall,
 /area/security/prisonershuttle)
@@ -181242,7 +181250,7 @@ aru
 jqH
 pix
 aru
-pix
+wxy
 qGt
 vyi
 jch
@@ -183546,8 +183554,8 @@ jrZ
 tqn
 uHx
 dlJ
-qJM
-qJM
+dHs
+dHs
 mLC
 mLC
 xLJ
@@ -184844,7 +184852,7 @@ xan
 vIm
 vGv
 kTh
-dHs
+qJM
 iCu
 jqn
 rEC

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -25574,6 +25574,7 @@
 	dir = 4
 	},
 /obj/item/pen,
+/obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -36212,8 +36213,8 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "dKw" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb2,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -36908,7 +36909,6 @@
 	dir = 8
 	},
 /obj/item/wirecutters,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/blue/hollow,
 /obj/machinery/light/small{
 	dir = 4
@@ -46586,6 +46586,9 @@
 	dir = 4
 	},
 /obj/item/reagent_containers/food/drinks/zaza,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -58243,6 +58246,9 @@
 	icon_state = "2-4"
 	},
 /obj/item/seeds/tower,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -83017,6 +83023,7 @@
 /obj/item/seeds/grass,
 /obj/item/seeds/grass,
 /obj/item/seeds/grass,
+/obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -83080,6 +83087,8 @@
 /area/security/processing)
 "ojw" = (
 /obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -95314,7 +95323,6 @@
 	dir = 8
 	},
 /obj/effect/decal/warning_stripes/blue/hollow,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/gloves/knuckles,
 /obj/machinery/light/small{
 	dir = 4
@@ -100085,12 +100093,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
 "rXU" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/sink{
 	dir = 1;
 	layer = 5;
 	pixel_y = -5
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -117559,6 +117567,7 @@
 /turf/simulated/floor/plating,
 /area/security/warden)
 "vXq" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock{
 	id_tag = "PermaBath";
 	name = "Restroom"
@@ -183266,7 +183275,7 @@ bCI
 coE
 aru
 lMA
-ojU
+mdB
 ojU
 drT
 qbW
@@ -183781,7 +183790,7 @@ coE
 aru
 kaO
 ojU
-ojU
+mdB
 jvD
 fdX
 aru

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -436,10 +436,10 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "acU" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/scrubber/huge/stationary,
+/obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/security/permabrig)
 "ads" = (
@@ -33495,11 +33495,12 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/fitness)
 "dxN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/wardrobe/pjs,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "cmo"
+	dir = 6;
+	icon_state = "darkred"
 	},
 /area/security/permabrig)
 "dxO" = (
@@ -46785,6 +46786,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkred"
@@ -50207,10 +50211,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
 "gue" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/landmark/ninja_teleport,
+/obj/structure/cable{
+	icon_state = "1-4";
+	tag = "90Curve"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/perma)
 "gui" = (
@@ -52289,9 +52294,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -60947,13 +60949,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar/atrium)
-"iWk" = (
-/obj/machinery/portable_atmospherics/scrubber/huge/stationary,
-/obj/effect/decal/warning_stripes/red/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkred"
-	},
-/area/security/permabrig)
 "iWl" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -65753,6 +65748,14 @@
 	icon_state = "neutralfull"
 	},
 /area/atmos/control)
+"kdO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/wardrobe/pjs,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "cmo"
+	},
+/area/security/permabrig)
 "kdP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood/fancy/black,
@@ -86423,9 +86426,7 @@
 	},
 /area/security/prison/cell_block/A)
 "oWU" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/maintenance/perma)
 "oWV" = (
@@ -86831,8 +86832,10 @@
 	},
 /area/library/game_zone)
 "pbV" = (
-/obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/perma)
 "pcb" = (
@@ -93437,12 +93440,10 @@
 	},
 /area/maintenance/kitchen)
 "quY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/can,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "bar"
 	},
 /area/security/permabrig)
 "qvg" = (
@@ -101827,11 +101828,10 @@
 	},
 /area/bridge)
 "srM" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "darkredcorners"
 	},
 /area/security/permabrig)
 "srP" = (
@@ -113029,11 +113029,11 @@
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior)
 "uUT" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(2)
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/perma)
@@ -120226,10 +120226,12 @@
 /turf/simulated/wall,
 /area/medical/medbay)
 "wDS" = (
-/obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "visiting room"
 	},
 /turf/simulated/floor/plating,
 /area/security/visiting_room)
@@ -183025,7 +183027,7 @@ aaq
 coE
 jXK
 aru
-dxN
+kdO
 gIy
 gIy
 iWm
@@ -183549,7 +183551,7 @@ dcs
 qJM
 mLC
 xLJ
-iWk
+acU
 bkl
 qie
 xxG
@@ -184060,10 +184062,10 @@ ojU
 aru
 gqu
 eEj
-eEj
+quY
 dXz
 qJL
-acU
+srM
 uPb
 uoU
 fiU
@@ -184584,8 +184586,8 @@ iRA
 jEA
 val
 gQC
-wTJ
-srM
+dXG
+xan
 iDp
 jqd
 sdz
@@ -184842,7 +184844,7 @@ xan
 vIm
 vGv
 kTh
-quY
+dXG
 iCu
 jqn
 rEC
@@ -185099,7 +185101,7 @@ inJ
 ceT
 gQN
 dZF
-uUT
+dZF
 dZF
 dZF
 dZF
@@ -185610,8 +185612,8 @@ iZf
 iZf
 iZf
 fCT
-kTh
-dZF
+dxN
+uUT
 pbV
 gue
 pzY

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -4703,6 +4703,9 @@
 /area/engineering/mechanic_workshop/hangar)
 "aLh" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkred"
@@ -36219,6 +36222,9 @@
 /obj/effect/decal/cleanable/cobweb2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/dresser,
+/obj/structure/mirror{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -49616,8 +49622,8 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
-/obj/item/dice/d20,
 /obj/item/instrument/piano_synth,
+/obj/item/reagent_containers/food/snacks/grown/lily,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -72335,9 +72341,6 @@
 /area/storage/secure)
 "lPJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -80784,7 +80787,7 @@
 	name = "Brig Lockdown"
 	},
 /obj/effect/spawner/window/reinforced/polarized{
-	id = "Interrogation"
+	id = "vipbar"
 	},
 /turf/simulated/floor/plating,
 /area/security/interrogation)
@@ -83396,7 +83399,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/window/reinforced/polarized{
-	id = "Interrogation"
+	id = "vipbar"
 	},
 /turf/simulated/floor/plating,
 /area/security/interrogation)
@@ -86492,7 +86495,7 @@
 	name = "Brig Lockdown"
 	},
 /obj/effect/spawner/window/reinforced/polarized{
-	id = "Interrogation"
+	id = "vipbar"
 	},
 /turf/simulated/floor/plating,
 /area/security/interrogation)
@@ -93915,7 +93918,7 @@
 	icon_state = "1-4"
 	},
 /obj/effect/spawner/window/reinforced/polarized{
-	id = "Interrogation"
+	id = "vipbar"
 	},
 /turf/simulated/floor/plating,
 /area/security/interrogation)
@@ -94816,6 +94819,7 @@
 /area/assembly/robotics)
 "qOi" = (
 /obj/structure/table/wood,
+/obj/item/dice/d20,
 /obj/item/storage/fancy/crayons,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -105397,8 +105401,9 @@
 "tmw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/button/windowtint{
-	id = "visiting room";
-	pixel_x = 24
+	id = "vipbar";
+	pixel_x = 22;
+	pixel_y = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -114847,7 +114852,7 @@
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/window/reinforced/polarized{
-	id = "Interrogation"
+	id = "vipbar"
 	},
 /turf/simulated/floor/plating,
 /area/security/interrogation)

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -7825,9 +7825,9 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red"
+	icon_state = "darkred"
 	},
-/area/security/holding_cell)
+/area/security/interrogation)
 "bgw" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -10265,8 +10265,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/simulated/floor/plasteel,
-/area/security/holding_cell)
+/obj/structure/table/reinforced,
+/obj/item/taperecorder,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/interrogation)
 "buf" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
@@ -18104,16 +18108,19 @@
 /turf/simulated/floor/engine,
 /area/engineering/supermatter)
 "cfs" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
 /obj/machinery/camera{
-	c_tag = "Interrogation Room";
+	c_tag = "Temporary Holding Cell";
 	dir = 8;
-	network = list("SS13","Security","Interrogation")
+	network = list("SS13","Security")
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkred"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/area/security/interrogation)
+/turf/simulated/floor/plating,
+/area/security/visiting_room)
 "cft" = (
 /obj/machinery/camera{
 	c_tag = "Supermatter Pump Airlock";
@@ -21347,16 +21354,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkred"
@@ -24379,11 +24380,18 @@
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
 "cJM" = (
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "darkred"
+/obj/machinery/flasher{
+	desc = "A floor-mounted flashbulb device.";
+	id = "permacell2";
+	layer = 5;
+	pixel_y = -24;
+	range = 3
 	},
-/area/security/interrogation)
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/security/visiting_room)
 "cJN" = (
 /obj/effect/spawner/window/reinforced/polarized{
 	id = "library_gameroom"
@@ -25574,12 +25582,6 @@
 /obj/structure/table,
 /obj/item/clipboard,
 /obj/item/paper,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/item/pen,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -29514,13 +29516,20 @@
 	},
 /area/medical/research/nhallway)
 "dgo" = (
-/obj/effect/decal/cleanable/cobweb2,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "darkred"
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "PermaLockdown";
+	name = "Perma Lockdown"
 	},
-/area/security/interrogation)
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Brig_lockdown";
+	name = "Brig Lockdown"
+	},
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/security/visiting_room)
 "dgv" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -31725,14 +31734,18 @@
 	},
 /area/medical/medbay)
 "dpk" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkred"
+/obj/machinery/camera{
+	c_tag = "Fore Hallway South 2";
+	dir = 4
 	},
-/area/security/interrogation)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/security/visiting_room)
 "dpn" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -33927,19 +33940,11 @@
 	},
 /area/security/processing)
 "dAb" = (
-/obj/structure/bookcase{
-	name = "Forbidden Knowledge"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -28
 	},
-/obj/item/book/manual/security_space_law,
-/obj/item/book/manual/sop_command,
-/obj/item/book/manual/sop_engineering,
-/obj/item/book/manual/sop_general,
-/obj/item/book/manual/sop_legal,
-/obj/item/book/manual/sop_medical,
-/obj/item/book/manual/sop_science,
-/obj/item/book/manual/sop_security,
-/obj/item/book/manual/sop_service,
-/obj/item/book/manual/sop_supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -34206,6 +34211,11 @@
 /area/maintenance/fpmaint)
 "dBo" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -34728,9 +34738,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
-/area/security/holding_cell)
+/area/security/interrogation)
 "dDH" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
@@ -35827,22 +35837,6 @@
 	icon_state = "whitegreencorner"
 	},
 /area/medical/virology/lab)
-"dIo" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/flasher{
-	desc = "A floor-mounted flashbulb device.";
-	id = "permacell2";
-	layer = 5;
-	pixel_y = -24;
-	range = 3
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/security/permabrig)
 "dIs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/girder,
@@ -37567,8 +37561,13 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel,
-/area/security/holding_cell)
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/interrogation)
 "dQl" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -39202,18 +39201,6 @@
 	icon_state = "fancy-wood-birch-broken"
 	},
 /area/maintenance/fsmaint)
-"dWV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/permabrig)
 "dWW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -41822,18 +41809,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/commercial)
-"etR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/security/permabrig)
 "etT" = (
 /obj/machinery/status_display{
 	pixel_x = 32
@@ -42050,6 +42025,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
 	pixel_y = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -45126,25 +45104,6 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/central/south)
-"fgI" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/camera{
-	c_tag = "Prison Solitary Confinement 2";
-	dir = 6;
-	network = list("Prison","SS13")
-	},
-/obj/machinery/flasher{
-	desc = "A floor-mounted flashbulb device.";
-	id = "permacell1";
-	layer = 5;
-	pixel_y = 24;
-	range = 3
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/security/permabrig)
 "fgQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood/fancy/light,
@@ -45684,26 +45643,15 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "fnM" = (
-/obj/machinery/door/airlock/security/glass{
-	id = "Interrogation";
-	id_tag = "Interrogation";
-	name = "Private Room";
-	req_access = list(63)
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "darkredfull"
+/obj/structure/bed/wicker,
+/obj/item/radio/intercom/locked/prison{
+	pixel_x = 28
 	},
-/area/security/interrogation)
+/turf/simulated/floor/plating,
+/area/security/visiting_room)
 "foa" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/arcade,
@@ -45947,18 +45895,6 @@
 /obj/structure/holosign/barrier,
 /turf/simulated/floor/plating,
 /area/maintenance/tourist)
-"fsq" = (
-/obj/machinery/button/windowtint{
-	id = "Interrogation";
-	pixel_y = 24;
-	req_access = list(63)
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "darkred"
-	},
-/area/security/interrogation)
 "fsu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -46529,38 +46465,6 @@
 	icon_state = "dark"
 	},
 /area/security/processing)
-"fAB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Prison Solitary Confinement 1";
-	dir = 6;
-	network = list("Prison","SS13")
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/security/permabrig)
-"fAM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/security/permabrig)
 "fAR" = (
 /obj/structure/table,
 /obj/item/stack/packageWrap,
@@ -46592,12 +46496,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
 	},
 /obj/item/reagent_containers/food/drinks/zaza,
 /obj/machinery/light{
@@ -47875,7 +47773,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "redfull"
 	},
-/area/security/holding_cell)
+/area/security/interrogation)
 "fRt" = (
 /obj/structure/sign/directions/engineering{
 	dir = 8;
@@ -50236,18 +50134,12 @@
 /area/space)
 "guG" = (
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkred"
@@ -54569,21 +54461,6 @@
 "hsp" = (
 /turf/simulated/wall,
 /area/maintenance/tourist)
-"hsI" = (
-/obj/effect/decal/cleanable/cobweb2,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/obj/item/radio/intercom{
-	pixel_y = 28
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "darkred"
-	},
-/area/security/interrogation)
 "hsQ" = (
 /obj/machinery/light{
 	dir = 8
@@ -57166,15 +57043,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
 "hZW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkredcorners"
+	dir = 8;
+	icon_state = "darkred"
 	},
-/area/security/interrogation)
+/area/security/permabrig)
 "iaa" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/glass/reinforced,
@@ -57647,18 +57523,6 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
-"igZ" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/structure/sign/poster/official/obey{
-	pixel_x = 32
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/security/holding_cell)
 "ihd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -59264,15 +59128,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/courtroom)
-"iAK" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/window/reinforced/polarized{
-	id = "Interrogation"
-	},
-/turf/simulated/floor/plating,
-/area/security/interrogation)
 "iAS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -59316,17 +59171,11 @@
 	},
 /area/crew_quarters/sleep)
 "iBE" = (
-/obj/item/flashlight/lamp{
-	layer = 4;
-	pixel_x = 7;
-	pixel_y = 14
-	},
-/obj/structure/table/reinforced,
-/obj/item/radio/intercom/department/security,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/interrogation)
+/obj/structure/lattice,
+/obj/structure/grille,
+/obj/structure/grille,
+/turf/space,
+/area/space)
 "iBT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -60197,9 +60046,6 @@
 	},
 /area/security/permabrig)
 "iLT" = (
-/obj/structure/chair{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
 	dir = 8;
@@ -60207,9 +60053,9 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
-/area/security/holding_cell)
+/area/security/interrogation)
 "iLV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -61473,14 +61319,32 @@
 	},
 /area/toxins/test_chamber)
 "jch" = (
-/obj/machinery/alarm{
-	pixel_y = 22
+/obj/machinery/door/airlock/security/glass{
+	name = "Solitary Confinement";
+	req_access = list(2)
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/flasher_button{
+	id = "permacell2";
+	name = "Perma cell 2 flasher button";
+	pixel_x = -38;
+	pixel_y = -4
+	},
+/obj/machinery/flasher_button{
+	id = "permacell1";
+	name = "Perma cell 1 flasher button";
+	pixel_x = -38;
+	pixel_y = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkred"
+	icon_state = "dark"
 	},
-/area/security/interrogation)
+/area/security/visiting_room)
 "jcq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -62013,7 +61877,6 @@
 "jiX" = (
 /obj/structure/closet,
 /obj/item/storage/box/handcuffs,
-/obj/item/clothing/suit/straight_jacket,
 /obj/item/clothing/mask/muzzle,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/stack/tape_roll,
@@ -62382,21 +62245,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
-"jnn" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/window/reinforced/polarized{
-	id = "Interrogation"
-	},
-/turf/simulated/floor/plating,
-/area/security/interrogation)
 "jnr" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light_switch{
@@ -62451,14 +62299,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/medical/research/nhallway)
-"joq" = (
-/obj/item/taperecorder,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/interrogation)
 "jox" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -62690,16 +62530,6 @@
 	icon_state = "dark"
 	},
 /area/turret_protected/ai)
-"jqH" = (
-/obj/item/radio/intercom/locked/prison{
-	pixel_y = 28
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/bed/wicker,
-/turf/simulated/floor/plating,
-/area/security/permabrig)
 "jqR" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -62836,10 +62666,6 @@
 	icon_state = "whitegreen"
 	},
 /area/medical/virology)
-"jrZ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall,
-/area/security/permabrig)
 "jsa" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -63345,19 +63171,17 @@
 	},
 /area/engineering/break_room)
 "jxB" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Solitary Confinement";
-	req_access = list(2)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Brig_lockdown";
+	name = "Brig Lockdown"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "PermaLockdown";
+	name = "Perma Lockdown"
 	},
 /turf/simulated/floor/plating,
 /area/security/permabrig)
@@ -64826,19 +64650,6 @@
 	icon_state = "dark"
 	},
 /area/security/evidence)
-"jRh" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 26
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkred"
-	},
-/area/security/interrogation)
 "jRl" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -65631,13 +65442,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
-"kbT" = (
-/obj/structure/cable,
-/obj/effect/spawner/window/reinforced/polarized{
-	id = "Interrogation"
-	},
-/turf/simulated/floor/plating,
-/area/security/interrogation)
 "kbW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -65730,11 +65534,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/tourist)
 "kdd" = (
-/turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "darkred"
+/obj/machinery/flasher{
+	desc = "A floor-mounted flashbulb device.";
+	id = "permacell2";
+	layer = 5;
+	pixel_y = -24;
+	range = 3
 	},
-/area/security/interrogation)
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/security/visiting_room)
 "kdl" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Telescience"
@@ -65814,12 +65625,6 @@
 	icon_state = "red"
 	},
 /area/security/securehallway)
-"keE" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkred"
-	},
-/area/security/interrogation)
 "keL" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
@@ -65845,10 +65650,15 @@
 	},
 /area/hallway/secondary/exit)
 "kfc" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "darkred"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/area/security/interrogation)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/security/visiting_room)
 "kff" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
@@ -66453,12 +66263,6 @@
 	icon_state = "neutralfull"
 	},
 /area/atmos)
-"kmJ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/security/permabrig)
 "kmL" = (
 /obj/machinery/light{
 	dir = 1
@@ -66828,6 +66632,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -71392,11 +71199,9 @@
 	},
 /area/toxins/test_chamber)
 "lBw" = (
-/obj/machinery/flasher/portable,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/item/wrench,
 /obj/machinery/door_control{
 	id = "temporary holding cell";
 	name = "Temporary Holding Cell Privacy Shutters Control";
@@ -71406,11 +71211,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom/department/security,
+/obj/item/flashlight/lamp{
+	pixel_x = -3;
+	pixel_y = 11
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
-/area/security/holding_cell)
+/area/security/interrogation)
 "lBB" = (
 /obj/effect/spawner/window/reinforced/polarized{
 	id = "qm"
@@ -72527,6 +72338,13 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -72686,10 +72504,6 @@
 	icon_state = "darkblue"
 	},
 /area/bridge)
-"lSM" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plating,
-/area/security/permabrig)
 "lTb" = (
 /obj/structure/statue/gold/ce{
 	desc = "Золотая литая статуя, посвящённая великому СЕ - Гарри Оппенгеймеру, который продолжал исполнять свой долг даже в самых тяжелых условиях";
@@ -74344,9 +74158,10 @@
 	icon_state = "4-8"
 	},
 /obj/structure/chair,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
 	},
@@ -77500,18 +77315,15 @@
 	},
 /area/toxins/explab)
 "mWu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/light/small,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/security/permabrig)
+/area/security/visiting_room)
 "mWw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -78985,14 +78797,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "nnG" = (
-/obj/structure/chair{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/area/security/interrogation)
+/turf/simulated/floor/plating,
+/area/security/visiting_room)
 "nnM" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -80303,17 +80115,6 @@
 	icon_state = "darkyellow"
 	},
 /area/maintenance/fpmaint)
-"nCE" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/permabrig)
 "nCH" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes/cigpack_random{
@@ -80982,9 +80783,11 @@
 	id_tag = "Brig_lockdown";
 	name = "Brig Lockdown"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "Interrogation"
+	},
 /turf/simulated/floor/plating,
-/area/security/holding_cell)
+/area/security/interrogation)
 "nJZ" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light{
@@ -83591,10 +83394,12 @@
 	id_tag = "Brig_lockdown";
 	name = "Brig Lockdown"
 	},
-/obj/effect/spawner/window/reinforced,
 /obj/structure/disposalpipe/segment,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "Interrogation"
+	},
 /turf/simulated/floor/plating,
-/area/security/holding_cell)
+/area/security/interrogation)
 "opF" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -83611,8 +83416,11 @@
 /area/turret_protected/aisat_interior)
 "opJ" = (
 /obj/structure/table,
-/obj/machinery/kitchen_machine/microwave,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/kitchen_machine/microwave{
+	pixel_x = -1;
+	pixel_y = 7
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -84834,13 +84642,16 @@
 /area/toxins/mixing)
 "oDN" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkred"
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
 	},
-/area/security/interrogation)
+/obj/item/pen,
+/turf/simulated/floor/plating,
+/area/security/visiting_room)
 "oDO" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/newscaster/security_unit{
@@ -86680,9 +86491,11 @@
 	id_tag = "Brig_lockdown";
 	name = "Brig Lockdown"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "Interrogation"
+	},
 /turf/simulated/floor/plating,
-/area/security/holding_cell)
+/area/security/interrogation)
 "pal" = (
 /obj/structure/rack{
 	dir = 8;
@@ -87416,18 +87229,6 @@
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/storage)
-"pix" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/security/permabrig)
 "piB" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -89733,26 +89534,11 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "pIp" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
-	},
-/obj/machinery/flasher_button{
-	id = "permacell2";
-	name = "Perma cell 2 flasher button";
-	pixel_x = -38;
-	pixel_y = -4
-	},
-/obj/machinery/flasher_button{
-	id = "permacell1";
-	name = "Perma cell 1 flasher button";
-	pixel_x = -38;
-	pixel_y = 6
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -91802,16 +91588,18 @@
 	},
 /area/medical/sleeper)
 "qfc" = (
-/obj/structure/chair{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/bed/wicker,
+/obj/item/radio/intercom/locked/prison{
+	pixel_x = 28
 	},
-/area/security/interrogation)
+/turf/simulated/floor/plating,
+/area/security/visiting_room)
 "qfe" = (
 /obj/machinery/newscaster{
 	pixel_x = -30
@@ -92423,23 +92211,20 @@
 /turf/simulated/floor/carpet/red,
 /area/maintenance/library)
 "qlW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "PermaLockdown";
+	name = "Perma Lockdown"
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-2"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/effect/spawner/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Brig_lockdown";
+	name = "Brig Lockdown"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/security/interrogation)
+/turf/simulated/floor/plating,
+/area/security/visiting_room)
 "qme" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced{
@@ -92460,9 +92245,6 @@
 	icon_state = "redyellowfull"
 	},
 /area/engineering/break_room)
-"qmr" = (
-/turf/simulated/wall/r_wall,
-/area/security/holding_cell)
 "qmu" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/decal/warning_stripes/yellow,
@@ -94132,9 +93914,11 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "Interrogation"
+	},
 /turf/simulated/floor/plating,
-/area/security/holding_cell)
+/area/security/interrogation)
 "qDz" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -94415,15 +94199,18 @@
 	},
 /area/toxins/misc_lab)
 "qGt" = (
-/obj/item/radio/intercom/locked/prison{
-	pixel_y = -28
-	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/structure/bed/wicker,
+/obj/machinery/door/airlock/security/glass{
+	name = "Solitary Confinement";
+	req_access = list(2)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/security/permabrig)
+/area/security/visiting_room)
 "qGv" = (
 /obj/machinery/light,
 /obj/structure/table/reinforced,
@@ -95329,10 +95116,10 @@
 	dir = 8
 	},
 /obj/effect/decal/warning_stripes/blue/hollow,
-/obj/item/clothing/gloves/knuckles,
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/item/clothing/ears/earmuffs,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -95708,12 +95495,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/structure/chair,
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
@@ -96707,18 +96494,16 @@
 	dir = 8;
 	network = list("SS13","Security")
 	},
-/obj/structure/chair{
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 26
 	},
+/obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
-/area/security/holding_cell)
+/area/security/interrogation)
 "rhQ" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -97680,11 +97465,14 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/chair{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
-/area/security/holding_cell)
+/area/security/interrogation)
 "rtB" = (
 /obj/structure/sign/biohazard,
 /turf/simulated/wall,
@@ -101152,20 +100940,6 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/central/nw)
-"skC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/interrogation)
 "skZ" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -104205,9 +103979,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
-/area/security/holding_cell)
+/area/security/interrogation)
 "sVt" = (
 /obj/effect/decal/cleanable/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -105621,18 +105395,16 @@
 	},
 /area/medical/virology/lab)
 "tmw" = (
-/obj/structure/chair{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_switch{
+/obj/machinery/button/windowtint{
+	id = "visiting room";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
-/area/security/holding_cell)
+/area/security/interrogation)
 "tmB" = (
 /obj/effect/decal/warning_stripes/blue,
 /obj/structure/rack{
@@ -107202,14 +106974,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
-"tFf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/interrogation)
 "tFj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -109388,13 +109152,16 @@
 	},
 /area/chapel/main)
 "ucB" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/area/security/interrogation)
+/obj/structure/table,
+/obj/item/instrument/harmonica,
+/turf/simulated/floor/plating,
+/area/security/visiting_room)
 "ucJ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
@@ -115076,12 +114843,14 @@
 	},
 /area/security/hos)
 "vuq" = (
-/obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "Interrogation"
+	},
 /turf/simulated/floor/plating,
-/area/security/holding_cell)
+/area/security/interrogation)
 "vur" = (
 /obj/structure/closet/walllocker/emerglocker/east,
 /turf/simulated/floor/plasteel{
@@ -115098,8 +114867,8 @@
 "vvh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -118773,7 +118542,7 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/breadslice,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/kitchen/knife/plastic,
+/obj/item/kitchen/knife,
 /obj/item/kitchen/rollingpin,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
@@ -119752,14 +119521,6 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/magistrateoffice)
-"wxy" = (
-/obj/structure/table,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/item/instrument/harmonica,
-/turf/simulated/floor/plating,
-/area/security/permabrig)
 "wxC" = (
 /turf/simulated/wall/r_wall,
 /area/security/prisonershuttle)
@@ -120612,17 +120373,16 @@
 	},
 /area/maintenance/starboard)
 "wHu" = (
-/obj/structure/table,
-/obj/item/storage/fancy/donut_box,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom{
 	pixel_x = -28
 	},
+/obj/structure/chair,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
-/area/security/holding_cell)
+/area/security/interrogation)
 "wHz" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/tripple,
@@ -120859,13 +120619,14 @@
 /turf/simulated/wall,
 /area/crew_quarters/theatre)
 "wLq" = (
-/obj/structure/chair{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/area/security/interrogation)
+/turf/simulated/floor/plating,
+/area/security/visiting_room)
 "wLr" = (
 /obj/machinery/light{
 	dir = 8
@@ -179449,12 +179210,12 @@ aaq
 dZq
 coE
 coE
-qmr
-qmr
-qmr
-qmr
-qmr
-qmr
+vyi
+vyi
+vyi
+vyi
+vyi
+vyi
 qHb
 ubg
 ubg
@@ -180222,7 +179983,7 @@ coE
 acF
 paa
 rhG
-igZ
+iCk
 tmw
 iLT
 vuq
@@ -180477,16 +180238,16 @@ aaq
 aaq
 bCI
 coE
-qmr
-qmr
-qmr
-qmr
 vyi
 vyi
-fnM
-iAK
-jnn
-kbT
+vyi
+vyi
+vyi
+vyi
+nwj
+nwj
+nwj
+nwj
 nwj
 krM
 qWg
@@ -180731,15 +180492,15 @@ aaq
 aaq
 aaq
 aaq
-coE
+aaq
 dZq
 coE
 coE
 coE
 coE
 coE
-vyi
-fsq
+coE
+coE
 qlW
 oDN
 dpk
@@ -180988,20 +180749,20 @@ aaq
 aaq
 aaq
 aaq
+aaq
+aaq
+aaq
+aaq
+iBE
+dZq
+aaq
+aaq
 coE
-aru
-dCr
-dCr
-aru
-dCr
-dCr
-vyi
-jRh
-skC
+qlW
 qfc
 wLq
 kfc
-nwj
+qGt
 dBo
 mmA
 nKl
@@ -181245,19 +181006,19 @@ aaq
 aaq
 aaq
 aaq
+aaq
+aaq
+aaq
+aaq
+aaq
+aaq
+aaq
+dZq
 coE
-aru
-jqH
-pix
-aru
-wxy
-qGt
-vyi
-jch
-tFf
-iBE
-joq
-keE
+nwj
+nwj
+nwj
+nwj
 nwj
 vvh
 vbh
@@ -181502,20 +181263,20 @@ aaq
 aaq
 dZq
 aaq
+dZq
+dZq
+dZq
+aaq
+aaq
+aaq
+dZq
+dZq
 coE
-aru
-fgI
-mWu
-aru
-fAB
-dIo
-vyi
-hsI
-hZW
+dgo
 ucB
 nnG
-kfc
-nwj
+mWu
+jch
 lPJ
 mmA
 nKl
@@ -181760,16 +181521,16 @@ dZq
 coE
 coE
 coE
-aru
-lSM
-etR
-aru
-fAM
-kmJ
-aru
-vyi
+coE
+coE
+coE
+coE
+coE
+coE
+coE
+coE
 dgo
-iCk
+fnM
 cfs
 cJM
 nwj
@@ -182020,10 +181781,10 @@ dNy
 aru
 aru
 jxB
-aru
+jxB
 jxB
 aru
-dAb
+aru
 aru
 aru
 aru
@@ -182280,7 +182041,7 @@ cxr
 pIp
 guG
 uPb
-uPb
+hZW
 uPb
 sAG
 qbt
@@ -182790,9 +182551,9 @@ adR
 euA
 dRZ
 jQW
-dWV
-dcs
-nCE
+dXG
+dAb
+xan
 dcs
 gLN
 wxD
@@ -183550,7 +183311,7 @@ coE
 dlr
 hzJ
 ojw
-jrZ
+tLD
 tqn
 uHx
 dlJ

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -28573,10 +28573,9 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/sorting)
 "dcs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/chair/office/dark,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkred"
 	},
 /area/security/permabrig)
 "dcz" = (
@@ -33949,7 +33948,6 @@
 /area/security/processing)
 "dAb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
 	},
@@ -51695,8 +51693,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -70058,14 +70058,6 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating/airless,
 /area/space)
-"lnr" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "darkred"
-	},
-/area/security/permabrig)
 "lnt" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/cable{
@@ -71054,6 +71046,14 @@
 /obj/item/lighter/zippo/rd,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
+"lzs" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkred"
+	},
+/area/security/permabrig)
 "lzu" = (
 /obj/effect/spawner/window/reinforced/polarized{
 	id = "qm"
@@ -72907,6 +72907,22 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/surgery/north)
+"lXk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkred"
+	},
+/area/security/permabrig)
 "lXr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -83090,12 +83106,6 @@
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
-	},
-/area/security/permabrig)
-"oln" = (
-/obj/structure/chair/office/dark,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkred"
 	},
 /area/security/permabrig)
 "olA" = (
@@ -102010,6 +102020,13 @@
 	icon_state = "neutralcorner"
 	},
 /area/maintenance/starboard)
+"sxa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/permabrig)
 "sxc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/gibs/xeno,
@@ -113493,22 +113510,6 @@
 	icon_state = "whitebluefull"
 	},
 /area/medical/paramedic)
-"vei" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkred"
-	},
-/area/security/permabrig)
 "veO" = (
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "RnDChem";
@@ -182578,10 +182579,10 @@ adR
 euA
 dRZ
 jQW
-dXG
+sxa
 dAb
-xan
-dcs
+jQW
+jQW
 gLN
 wxD
 iLK
@@ -182590,7 +182591,7 @@ fda
 riX
 wSO
 fxR
-vei
+lXk
 tLD
 jnU
 ojL
@@ -184132,9 +184133,9 @@ qEP
 xvh
 ult
 wNO
-vei
+lXk
 tLD
-lnr
+lzs
 omz
 wyT
 pee
@@ -184391,7 +184392,7 @@ lgH
 chy
 xgm
 xan
-oln
+dcs
 pPW
 ugN
 oIn

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -459,6 +459,7 @@
 "adR" = (
 /obj/structure/table/wood,
 /obj/item/stack/tape_roll,
+/obj/item/stack/wrapping_paper,
 /obj/item/stack/packageWrap,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -7824,8 +7825,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
@@ -10262,14 +10266,15 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/table/reinforced,
 /obj/item/taperecorder,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -34723,14 +34728,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
 "dDE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -34739,6 +34740,12 @@
 	pixel_x = -26
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "darkred"
@@ -37566,10 +37573,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/hologram/holopad,
 /obj/structure/chair{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -46931,9 +46939,6 @@
 /obj/item/seeds/chili,
 /obj/item/seeds/chili,
 /obj/effect/decal/warning_stripes/red/hollow,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -51455,10 +51460,8 @@
 	},
 /area/atmos)
 "gJJ" = (
-/obj/structure/chair{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/wooden,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -62262,9 +62265,9 @@
 	},
 /area/chapel/main)
 "jnU" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/effect/decal/warning_stripes/red/hollow,
-/obj/machinery/light,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -70055,6 +70058,14 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating/airless,
 /area/space)
+"lnr" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkred"
+	},
+/area/security/permabrig)
 "lnt" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/cable{
@@ -71205,9 +71216,6 @@
 	},
 /area/toxins/test_chamber)
 "lBw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/machinery/door_control{
 	id = "temporary holding cell";
 	name = "Temporary Holding Cell Privacy Shutters Control";
@@ -71217,12 +71225,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/table/reinforced,
 /obj/item/radio/intercom/department/security,
 /obj/item/flashlight/lamp{
 	pixel_x = -3;
 	pixel_y = 11
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkred"
@@ -83081,6 +83092,12 @@
 	icon_state = "dark"
 	},
 /area/security/permabrig)
+"oln" = (
+/obj/structure/chair/office/dark,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkred"
+	},
+/area/security/permabrig)
 "olA" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -83175,7 +83192,6 @@
 /area/medical/virology/lab)
 "omz" = (
 /obj/machinery/computer/area_atmos/area,
-/obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -97464,7 +97480,6 @@
 	},
 /area/security/prison/cell_block/A)
 "rtu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -113478,6 +113493,22 @@
 	icon_state = "whitebluefull"
 	},
 /area/medical/paramedic)
+"vei" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkred"
+	},
+/area/security/permabrig)
 "veO" = (
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "RnDChem";
@@ -116957,9 +116988,6 @@
 /turf/simulated/floor/plating,
 /area/security/reception)
 "vTG" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/table/reinforced,
 /obj/structure/sign/poster/official/random{
@@ -117685,9 +117713,6 @@
 	dir = 2;
 	name = "Riot Control";
 	req_access = list(2)
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /obj/item/wrench,
 /obj/structure/sign/poster/official/random{
@@ -119740,9 +119765,6 @@
 /obj/item/plant_analyzer,
 /obj/item/cultivator,
 /obj/item/reagent_containers/spray/plantbgone,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/item/reagent_containers/glass/bottle/nutrient/ez,
 /obj/item/reagent_containers/glass/bottle/nutrient/ez,
 /obj/item/reagent_containers/glass/bottle/nutrient/ez,
@@ -181032,7 +181054,7 @@ dWW
 vhp
 wMw
 oIn
-mqz
+qug
 mml
 lhS
 uou
@@ -182568,10 +182590,10 @@ fda
 riX
 wSO
 fxR
-kaJ
-xan
-xan
+vei
+tLD
 jnU
+ojL
 wyT
 pee
 gBH
@@ -182828,7 +182850,7 @@ vTG
 kaJ
 nHp
 qDW
-jnU
+ojL
 ugN
 pfE
 pLF
@@ -184110,9 +184132,9 @@ qEP
 xvh
 ult
 wNO
-kaJ
-xan
-wxD
+vei
+tLD
+lnr
 omz
 wyT
 pee
@@ -184369,7 +184391,7 @@ lgH
 chy
 xgm
 xan
-wxD
+oln
 pPW
 ugN
 oIn


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание

РЕмап пермы.
Пермач это петля на шее антагов, слишком сложно сбежать и слишком нехуй делать если решил не сбегать.
Так что сделано много изменений.
1. Карцеры перенесены внутрь пермы и в них добавлено окошко для теоретического спасение другим антагонистом.
2. Комната встреч в процедуре переделана под комнату встреч для пермовцев.
3. Сам пермобриг расширен процентов на 20
4. Куча новых активностей для ботаников, возможность готовить еду и много прикольных фич для досуга.
5. Добавлено +- 4 новых вида побега, и парочку новых оружий ближнего боя, а так же предметы для карафта.

## Причина создания ПР / Почему это хорошо для игры

Хорошо потому что описано выше, предлога в процессе, но если мержанете без нее я только за
## Демонстрация изменений

![image](https://github.com/user-attachments/assets/30f7aa41-0b8d-4380-aa64-213e6c9c3eda)


## Тесты

Запустил локалку, проверил кислород, проверил свет, проверил работу локдаунов, проверил доступы у шлюзов. ВСЕ ПАШЕТ КАК НАДО
