### PR TITLE
bugfix: исправлена ошибка с консолью массдрайверов

### DIFF
--- a/code/game/machinery/computer/pod.dm
+++ b/code/game/machinery/computer/pod.dm
@@ -23,7 +23,6 @@
 
 /obj/machinery/computer/pod/proc/driver_sync()
 	initial_set = TRUE
-	id_tags = list()
 	door_only_tags = list()
 	synced = list()
 	timings = list()


### PR DESCRIPTION
## Описание

Убирает лишнюю строку

## Причина создания ПР / Почему это хорошо для игры

Эта строка пересоздает список тегов, из-за чего они не вносятся в консоль при создании, и приходится вручную привязывать массдрайвера к консоли (к примеру, дедовские драйвера на ЦК)