### PR TITLE
tgs: Обновление revision info

### DIFF
--- a/code/datums/revision.dm
+++ b/code/datums/revision.dm
@@ -11,16 +11,24 @@ GLOBAL_PROTECT(revision_info) // Dont mess with this
 	var/commit_hash
 	/// Date that this commit was made
 	var/commit_date
-	// git rev-parse origin/master220
-	var/originmastercommit
-	// repo name
-	var/repo = "ss220-space/Paradise"
+	/// Origin commit (Only set if running TGS, and will only be different if the server is running testmerges)
+	var/origin_commit
+	/// List of testmerges (If applicable)
+	var/list/testmerges = list()
 
+// Pull info from the rust DLL
 /datum/code_revision/New()
 	commit_hash = rustg_git_revparse("HEAD")
 	if(commit_hash)
 		commit_date = rustg_git_commit_date(commit_hash)
-	originmastercommit = rustg_git_revparse("origin/master220")
+
+// Pull info from TGS
+/datum/code_revision/proc/load_tgs_info()
+	testmerges = world.TgsTestMerges()
+	var/datum/tgs_revision_information/revinfo = world.TgsRevision()
+	if(revinfo)
+		commit_hash = revinfo.commit
+		origin_commit = revinfo.origin_commit
 
 /**
   * Code Revision Logging Helper
@@ -29,16 +37,48 @@ GLOBAL_PROTECT(revision_info) // Dont mess with this
   */
 /datum/code_revision/proc/log_info()
 	// Put revision info in the world log
-	var/logmsg
+	var/list/logmsgs = list()
 	if(commit_hash && commit_date)
-		logmsg = "Running ParaCode commit: [commit_hash] (Date: [commit_date])"
+		logmsgs += "Running ParaCode commit: [commit_hash] (Date: [commit_date])"
 	else
-		logmsg = "Unable to determine revision info! Code may not be running in a git repository."
+		logmsgs += "Unable to determine revision info! Code may not be running in a git repository."
+
+	// Check if we were on TGS
+	if(world.TgsAvailable())
+		if(origin_commit && (commit_hash != origin_commit)) // Commits are different, theres likely a testmerge
+			logmsgs += "Origin commit: [origin_commit]"
+		if(length(testmerges))
+			logmsgs += "The following PRs are testmerged:"
+			for(var/pr in testmerges)
+				var/datum/tgs_revision_information/test_merge/tm = pr
+				logmsgs += "PR #[tm.number] at commit [tm.pull_request_commit]"
+				// Log these in blackbox so they can be attributed to round IDs easier in the future
+				SSblackbox.record_feedback("associative", "testmerged_prs", 1, list("number" = "[tm.number]", "commit" = "[tm.pull_request_commit]", "title" = "[tm.title]", "author" = "[tm.author]"))
+
+	var/logmsg = logmsgs.Join("\n")
 
 	// Log it in all these
 	log_world(logmsg)
 	log_runtime_txt(logmsg)
 	log_runtime_summary(logmsg)
+
+/**
+  * Testmerge Chat Message Helper
+  *
+  * Formats testmerged PRs into a nice message
+  * Arguments:
+  * * header - Should a header be sent too
+  */
+/datum/code_revision/proc/get_testmerge_chatmessage(header = FALSE)
+	var/list/msg = list()
+	if(header)
+		msg += "<span class='notice'>The following PRs are currently testmerged:</span>"
+
+	for(var/pr in GLOB.revision_info.testmerges)
+		var/datum/tgs_revision_information/test_merge/tm = pr
+		msg += "- PR <a href='[tm.url]'>#[tm.number] - [tm.title]</a>"
+
+	return msg.Join("<br>")
 
 /client/verb/get_revision_info()
 	set name = "Информация о сборке"
@@ -53,8 +93,21 @@ GLOBAL_PROTECT(revision_info) // Dont mess with this
 	// Commit info
 	if(GLOB.revision_info.commit_hash && GLOB.revision_info.commit_date)
 		msg += "<b>Server Commit:</b> <a href='[CONFIG_GET(string/githuburl)]/commit/[GLOB.revision_info.commit_hash]'>[GLOB.revision_info.commit_hash]</a> (Date: [GLOB.revision_info.commit_date])"
+		if(GLOB.revision_info.origin_commit && (GLOB.revision_info.commit_hash != GLOB.revision_info.origin_commit))
+			msg += "<b>Origin Commit:</b> <a href='[CONFIG_GET(string/githuburl)]/commit/[GLOB.revision_info.origin_commit]'>[GLOB.revision_info.origin_commit]</a>"
 	else
 		msg += "<b>Server Commit:</b> <i>Unable to determine</i>"
+
+	msg += "<b>RUST-G Build</b>: [rustg_get_version()]"
+
+	if(world.TgsAvailable())
+		var/datum/tgs_version/tgs_ver = world.TgsVersion()
+		var/datum/tgs_version/api_ver = world.TgsApiVersion()
+		msg += "<b>TGS Version</b>: [tgs_ver.deprefixed_parameter] (API: [api_ver.deprefixed_parameter])"
+
+	if(world.TgsAvailable() && length(GLOB.revision_info.testmerges))
+		msg += "<b>Active Testmerges:</b>"
+		msg += GLOB.revision_info.get_testmerge_chatmessage(FALSE)
 
 
 	// Show server BYOND version

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -40,7 +40,7 @@ GLOBAL_DATUM(test_runner, /datum/test_runner)
 	// This needs to happen early, otherwise people can get a null species, nuking their character
 	makeDatumRefLists()
 
-	TgsNew(new /datum/tgs_event_handler/impl, TGS_SECURITY_TRUSTED) // creates a new TGS object
+	InitTGS() // creates a new TGS object
 	log_world("World loaded at [time_stamp()]")
 	log_world("[GLOB.vars.len - GLOB.gvars_datum_in_built_vars.len] global variables")
 	GLOB.revision_info.log_info()
@@ -77,6 +77,10 @@ GLOBAL_DATUM(test_runner, /datum/test_runner)
 	#endif
 
 	return
+
+/world/proc/InitTGS()
+	TgsNew(new /datum/tgs_event_handler/impl, TGS_SECURITY_TRUSTED) // creates a new TGS object
+	GLOB.revision_info.load_tgs_info() // Loads git and TM info from TGS itself
 
 // This is basically a replacement for hook/startup. Please dont shove random bullshit here
 // If it doesnt need to happen IMMEDIATELY on world load, make a subsystem for it

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -397,6 +397,10 @@
 	Master.UpdateTickRate()
 	INVOKE_ASYNC(src, TYPE_PROC_REF(/client, nag_516))
 
+	// Tell clients about active testmerges
+	if(world.TgsAvailable() && length(GLOB.revision_info.testmerges))
+		to_chat(src, GLOB.revision_info.get_testmerge_chatmessage(TRUE))
+
 	// Check total playercount
 	var/playercount = 0
 	for(var/mob/M in GLOB.player_list)


### PR DESCRIPTION
## Описание
Портировал с ОфПары их обновленные revision info. Из-за слегка устаревшего TGS DMAPI, у нас не будет показывать время, но ничего страшного. За то теперь показываются текущие тестмержи и другая важная (нет) информация о сборке.

## Причина создания ПР / Почему это хорошо для игры

## Демонстрация изменений

## Тесты
