### PR TITLE
bugfix: БСГ в турелях не требовало ядра

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -83,6 +83,10 @@
 	///Targets that are currently processed by turret. Used by process()
 	var/list/processing_targets = list()
 
+	/// List of some inserted gun data. Used to setup new gun.
+	var/list/old_gun_data = list()
+
+
 /obj/machinery/porta_turret/Initialize(mapload)
 	. = ..()
 
@@ -93,6 +97,7 @@
 
 	AddComponent(/datum/component/proximity_monitor, scan_range, TRUE)
 	setup()
+
 
 /obj/machinery/porta_turret/HasProximity(atom/movable/AM)
 	handleInterloper(AM)
@@ -116,7 +121,7 @@
 /obj/machinery/porta_turret/proc/setup()
 	var/obj/item/gun/energy/egun = new installation	//All energy-based weapons are applicable
 	var/obj/item/ammo_casing/shottype = egun.ammo_type[1]
-	egun.setup_gun_for_turret(old_gun_data)
+	egun.setup_gun_for_turret(old_gun_data, src)
 
 	projectile = shottype.projectile_type
 	eprojectile = projectile
@@ -338,8 +343,8 @@ GLOBAL_LIST_EMPTY(turret_icons)
 		to_chat(user, span_notice("You remove the turret and salvage some components."))
 		if(installation)
 			var/obj/item/gun/energy/Gun = new installation(loc)
-			Gun.cell.charge = gun_charge
 			Gun.turret_deconstruct(old_gun_data)
+			Gun.cell.charge = gun_charge
 			Gun.update_icon()
 		if(prob(50))
 			new /obj/item/stack/sheet/metal(loc, rand(1,4))
@@ -819,11 +824,6 @@ GLOBAL_LIST_EMPTY(turret_icons)
 	var/list/old_gun_data = list()
 
 
-/obj/machinery/porta_turret_construct/Destroy()
-	QDEL_LAZYLIST(old_gun_data)
-	. = ..()
-
-
 /obj/machinery/porta_turret_construct/update_icon_state()
 	icon_state = "turret_frame[build_step >= TURRET_BUILD_ARMORED ? "2" : ""]"
 
@@ -986,6 +986,7 @@ GLOBAL_LIST_EMPTY(turret_icons)
 			var/obj/machinery/porta_turret/turret = new target_type(loc)
 			turret.name = finish_name
 			turret.installation = installation
+			turret.old_gun_data = old_gun_data
 			turret.gun_charge = gun_charge
 			turret.enabled = FALSE
 			turret.add_fingerprint(user)
@@ -998,11 +999,12 @@ GLOBAL_LIST_EMPTY(turret_icons)
 		if(TURRET_BUILD_GUN)
 			if(!installation)
 				return ..()
+
 			add_fingerprint(user)
 			build_step = TURRET_BUILD_ARMOR_SECURED
 			var/obj/item/gun/energy/removed_gun = new installation(loc)
-			removed_gun.cell.charge = gun_charge
 			removed_gun.turret_deconstruct(old_gun_data)
+			removed_gun.cell.charge = gun_charge
 			removed_gun.update_icon()
 			to_chat(user, span_notice("You remove [removed_gun] from the turret frame."))
 			installation = null

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -114,8 +114,9 @@
 	return ..()
 
 /obj/machinery/porta_turret/proc/setup()
-	var/obj/item/gun/energy/E = new installation	//All energy-based weapons are applicable
-	var/obj/item/ammo_casing/shottype = E.ammo_type[1]
+	var/obj/item/gun/energy/egun = new installation	//All energy-based weapons are applicable
+	var/obj/item/ammo_casing/shottype = egun.ammo_type[1]
+	egun.setup_gun_for_turret(old_gun_data)
 
 	projectile = shottype.projectile_type
 	eprojectile = projectile
@@ -338,7 +339,7 @@ GLOBAL_LIST_EMPTY(turret_icons)
 		if(installation)
 			var/obj/item/gun/energy/Gun = new installation(loc)
 			Gun.cell.charge = gun_charge
-			Gun.turret_deconstruct()
+			Gun.turret_deconstruct(old_gun_data)
 			Gun.update_icon()
 		if(prob(50))
 			new /obj/item/stack/sheet/metal(loc, rand(1,4))
@@ -814,6 +815,13 @@ GLOBAL_LIST_EMPTY(turret_icons)
 	var/finish_name="turret"	//the name applied to the product turret
 	var/installation = null		//the gun type installed
 	var/gun_charge = 0			//the gun charge of the gun type installed
+	/// List of some inserted gun data. Used to setup new gun.
+	var/list/old_gun_data = list()
+
+
+/obj/machinery/porta_turret_construct/Destroy()
+	QDEL_LAZYLIST(old_gun_data)
+	. = ..()
 
 
 /obj/machinery/porta_turret_construct/update_icon_state()
@@ -910,6 +918,8 @@ GLOBAL_LIST_EMPTY(turret_icons)
 				add_fingerprint(user)
 				if(!user.drop_transfer_item_to_loc(I, src))
 					return ..()
+
+				new_gun.prepare_gun_data(old_gun_data)
 				installation = new_gun.type	//installation becomes new_gun.type
 				gun_charge = new_gun.cell.charge	//the gun's charge is stored in gun_charge
 				to_chat(user, span_notice("You add [I] to the turret."))
@@ -992,7 +1002,7 @@ GLOBAL_LIST_EMPTY(turret_icons)
 			build_step = TURRET_BUILD_ARMOR_SECURED
 			var/obj/item/gun/energy/removed_gun = new installation(loc)
 			removed_gun.cell.charge = gun_charge
-			removed_gun.turret_deconstruct()
+			removed_gun.turret_deconstruct(old_gun_data)
 			removed_gun.update_icon()
 			to_chat(user, span_notice("You remove [removed_gun] from the turret frame."))
 			installation = null

--- a/code/modules/anomalies/items/bsg.dm
+++ b/code/modules/anomalies/items/bsg.dm
@@ -154,9 +154,10 @@
 	core.forceMove(src)
 
 
-/obj/item/gun/energy/bsg/setup_gun_for_turret(list/data)
+/obj/item/gun/energy/bsg/setup_gun_for_turret(list/data, turret)
 	core = data["core"]
 	has_bluespace_crystal = TRUE
+	core.forceMove(turret)
 
 
 /obj/item/gun/energy/bsg/prebuilt

--- a/code/modules/anomalies/items/bsg.dm
+++ b/code/modules/anomalies/items/bsg.dm
@@ -18,9 +18,14 @@
 	var/admin_model = FALSE //For the admin gun, prevents crystal shattering, so anyone can use it, and you dont need to carry backup crystals.
 
 /obj/item/gun/energy/bsg/Destroy()
-	core?.forceMove(get_turf(src))
+	if(!ismachinery(loc))
+		core?.forceMove(get_turf(src))
+	else
+		core?.forceMove(loc)
+
 	core = null
 	. = ..()
+
 
 /obj/item/gun/energy/bsg/examine(mob/user)
 	. = ..()
@@ -133,6 +138,26 @@
 	playsound(src, 'sound/effects/pylon_shatter.ogg', 50, TRUE)
 	has_bluespace_crystal = FALSE
 	update_icon(UPDATE_ICON_STATE)
+
+
+/obj/item/gun/energy/bsg/turret_check()
+	return core && has_bluespace_crystal
+
+
+/obj/item/gun/energy/bsg/prepare_gun_data(list/data)
+	data["core"] = core
+
+
+/obj/item/gun/energy/bsg/turret_deconstruct(list/data)
+	has_bluespace_crystal = TRUE
+	core = data["core"]
+	core.forceMove(src)
+
+
+/obj/item/gun/energy/bsg/setup_gun_for_turret(list/data)
+	core = data["core"]
+	has_bluespace_crystal = TRUE
+
 
 /obj/item/gun/energy/bsg/prebuilt
 	icon_state = "bsg_finished"

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -393,8 +393,18 @@
 			if(R.cell.use(shot.e_cost)) 		//Take power from the borg...
 				cell.give(shot.e_cost)	//... to recharge the shot
 
+
 /obj/item/gun/energy/proc/turret_check()
 	return TRUE
 
-/obj/item/gun/energy/proc/turret_deconstruct()
+
+/obj/item/gun/energy/proc/turret_deconstruct(list/data)
+	return
+
+
+/obj/item/gun/energy/proc/prepare_gun_data(list/data)
+	return
+
+
+/obj/item/gun/energy/proc/setup_gun_for_turret(list/data)
 	return


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Из-за корявого решения мердж конфликтов, БСГ при пихании в турельку перестал требовать ядра.
Починил требование, а также сделал чтоб ядро при доставании не пропадало как раньше. Ну и ядро теперь влияет на силу атаки, как и должно.
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Тесты
Запустил, построил турельку, попытался запихать бсг без ядра, запихал бсг с ядром и бс кристаллом, поломал турельку, достал бсг, достял ядро из бсг.
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
