### PR TITLE
bugfix: мульти-режимные очки

### DIFF
--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -659,6 +659,8 @@ SKILLS
 		else
 			HUDType = DATA_HUD_SECURITY_ADVANCED
 			examine_extensions = EXAMINE_HUD_SECURITY_READ | EXAMINE_HUD_SECURITY_WRITE
+	var/datum/atom_hud/newH = GLOB.huds[HUDType]
+	newH.add_hud_to(user)
 	balloon_alert(user, "режим переключён")
 	return
 


### PR DESCRIPTION
## Описание
Не работает переключение режимов. В очках Синего Щита есть три режима: здоровье, криминальный статус, изменения должности (skills). При переключении через кнопку действия в левом верхнем углу пропадает отображение чего-либо.

## Причина создания ПР / Почему это хорошо для игры
bugfix

## Тесты
всё проверил, всё работает как надо теперь
