### PR TITLE
bugfix: взаимодействие зеркала гордости и джаунтера

### DIFF
--- a/code/modules/ruins/lavalandruin_code/sin_ruins.dm
+++ b/code/modules/ruins/lavalandruin_code/sin_ruins.dm
@@ -132,7 +132,6 @@
 	user_turf.ChangeTurf(/turf/simulated/floor/chasm)
 	var/turf/simulated/floor/chasm/new_chasm = user_turf
 	new_chasm.set_target(dest)
-	new_chasm.drop(user)
 
 
 // Envy


### PR DESCRIPTION
## Описание
при использовании руин гордыни кукла падала в чазм игнорируя наличие джаунтера

## Причина создания ПР / Почему это хорошо для игры
bugfix

## Тесты
всё проверил, всё работает как надо
