### PR TITLE
bugfix: очистка комбо после удаления боевого искусства

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -173,6 +173,7 @@
 
 	if(martial_art)
 		for(var/datum/martial_art/MA in known_martial_arts)
+			MA.reset_combos(old_current)
 			MA.remove(current)
 			if(old_current)
 				MA.remove_martial_art_verbs(old_current)

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -92,10 +92,14 @@
 			return check_combos(step, user, target, could_start_new_combo)
 	return FALSE
 
-/datum/martial_art/proc/reset_combos()
+/datum/martial_art/proc/reset_combos(mob/living/carbon/human/H)
 	current_combos.Cut()
 	streak = ""
-	var/mob/living/carbon/human/owner = locateUID(owner_UID)
+	var/mob/living/carbon/human/owner
+	if(H)
+		owner = H
+	else
+		owner = locateUID(owner_UID)
 	if(istype(owner) && !QDELETED(owner))
 		owner.hud_used.combo_display.update_icon(ALL, streak)
 	for(var/combo_type in combos)
@@ -224,6 +228,8 @@
 	var/datum/martial_art/MA = src
 	if(!H.mind)
 		return FALSE
+	if(H.hud_used)
+		reset_combos()
 	deltimer(combo_timer)
 	H.mind.known_martial_arts.Remove(MA)
 	H.mind.martial_art = get_highest_weight(H)


### PR DESCRIPTION
## Описание
исправление комбо, что остаются после обезглавливания или удалении боевого искусства

## Причина создания ПР / Почему это хорошо для игры
bugfix
