### PR TITLE
add: подсумки в SechTech СБ

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -2156,6 +2156,7 @@
 		/obj/item/storage/box/fingerprints = 6,
 		/obj/item/eftpos/sec = 4,
 		/obj/item/storage/belt/security/webbing = 2,
+		/obj/item/storage/pouch/fast = 2,
 		/obj/item/clothing/mask/gas/sechailer/tactical = 5,
 		/obj/item/flashlight/sectaclight = 2,
 		/obj/item/grenade/smokebomb = 8,
@@ -2169,6 +2170,7 @@
 	prices = list(
 		/obj/item/storage/belt/security/judobelt = 499,
 		/obj/item/storage/belt/security/webbing = 999,
+		/obj/item/storage/pouch/fast = 999,
 		/obj/item/clothing/mask/gas/sechailer/tactical = 299,
 		/obj/item/flashlight/sectaclight = 299,
 		/obj/item/grenade/smokebomb = 249


### PR DESCRIPTION
## Описание

Добавляет в SecTech СБ вендорматы два подсумка под магазины. 

## Причина создания ПР / Почему это хорошо для игры
https://discord.com/channels/617003227182792704/755125334097133628/1387297463018455163

## Тесты

Проверил на локальном сервере, ошибок не было. 
