### PR TITLE
bugfix: Правки весов БИ

### DIFF
--- a/code/modules/martial_arts/judo.dm
+++ b/code/modules/martial_arts/judo.dm
@@ -10,7 +10,7 @@
 		/datum/martial_combo/judo/wheelthrow,
 		/datum/martial_combo/judo/goldenblast
 	)
-	weight = 5 //takes priority over boxing and drunkneness, less priority than krav or CQC/carp
+	weight = 8
 	no_baton_reason = span_warning("Из-за занятий дзюдо у вас не получается крепко держать дубинку!")
 	can_horizontally_grab = FALSE
 

--- a/code/modules/martial_arts/krav_maga.dm
+++ b/code/modules/martial_arts/krav_maga.dm
@@ -1,7 +1,7 @@
 /datum/martial_art/krav_maga
 	name = "Krav Maga"
 	has_dirslash = FALSE
-	weight = 8 //Higher weight, since you can choose to put on or take off the gloves
+	weight = 9 //Higher weight, since you can choose to put on or take off the gloves
 	var/datum/action/neck_chop/neckchop = new/datum/action/neck_chop()
 	var/datum/action/leg_sweep/legsweep = new/datum/action/leg_sweep()
 	var/datum/action/lung_punch/lungpunch = new/datum/action/lung_punch()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
У дзюдо был вес ниже чем у CQC. Это привело к тому, что при изучении CQC с активным Дзюдо была какая-то бага. Сделал чтобы у дзюдо был больший вес чем у остальных БИ кроме кравмаг. Кравмаги все еще самые верхние.
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
