### PR TITLE
qol: управление замком airalarm через Alt-клик

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1123,11 +1123,12 @@
 	add_fingerprint(user)
 	if(stat & (NOPOWER|BROKEN))
 		to_chat(user, span_warning("It does nothing!"))
-	else if(allowed(user) && !wires.is_cut(WIRE_IDSCAN))
+		return
+	if(allowed(user) && !wires.is_cut(WIRE_IDSCAN))
 		locked = !locked
 		to_chat(user, span_notice("You [ locked ? "lock" : "unlock"] the Air Alarm interface."))
-	else
-		to_chat(user, span_warning("Access denied."))
+		return
+	to_chat(user, span_warning("Access denied."))
 
 /obj/machinery/alarm/click_alt(mob/living/carbon/human/user)
 	if(!istype(user))
@@ -1135,7 +1136,6 @@
 	var/obj/item/card/id/card = user.get_id_card()
 	if(!istype(card))
 		return NONE
-	add_fingerprint(user)
 	togglelock(user)
 	return CLICK_ACTION_SUCCESS
 

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -983,17 +983,7 @@
 	switch(buildstage)
 		if(AIR_ALARM_READY)
 			if(I.GetID() || is_pda(I)) // trying to unlock the interface
-				add_fingerprint(user)
-				if(stat & (NOPOWER|BROKEN))
-					to_chat(user, span_warning("It does nothing!"))
-					return ATTACK_CHAIN_PROCEED
-
-				if(allowed(user) && !wires.is_cut(WIRE_IDSCAN))
-					locked = !locked
-					to_chat(user, span_notice("You [ locked ? "lock" : "unlock"] the Air Alarm interface."))
-					SStgui.update_uis(src)
-					return ATTACK_CHAIN_PROCEED
-				to_chat(user, span_warning("Access denied."))
+				togglelock(user)
 				return ATTACK_CHAIN_PROCEED
 
 		if(AIR_ALARM_BUILDING)
@@ -1127,6 +1117,7 @@
 	if(allowed(user) && !wires.is_cut(WIRE_IDSCAN))
 		locked = !locked
 		to_chat(user, span_notice("You [ locked ? "lock" : "unlock"] the Air Alarm interface."))
+		SStgui.update_uis(src)
 		return
 	to_chat(user, span_warning("Access denied."))
 

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1119,6 +1119,28 @@
 			if(wiresexposed)
 				. += span_notice("The wiring could be <i>cut and removed</i> or panel could <b>screwed</b> closed.")
 
+/obj/machinery/alarm/proc/togglelock(mob/living/user)
+	add_fingerprint(user)
+	if(stat & (NOPOWER|BROKEN))
+		to_chat(user, span_warning("It does nothing!"))
+		return
+	if(allowed(user) && !wires.is_cut(WIRE_IDSCAN))
+		locked = !locked
+		to_chat(user, span_notice("You [ locked ? "lock" : "unlock"] the Air Alarm interface."))
+		return
+	to_chat(user, span_warning("Access denied."))
+
+/obj/machinery/alarm/click_alt(mob/living/carbon/human/H)
+	if(!istype(H))
+		return NONE
+	var/obj/item/card/id/card = H.get_id_card()
+	if(!istype(card))
+		return NONE
+
+	add_fingerprint(H)
+	togglelock(H)
+	return CLICK_ACTION_SUCCESS
+
 
 /obj/machinery/alarm/proc/unshort_callback()
 	if(shorted)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1123,22 +1123,20 @@
 	add_fingerprint(user)
 	if(stat & (NOPOWER|BROKEN))
 		to_chat(user, span_warning("It does nothing!"))
-		return
-	if(allowed(user) && !wires.is_cut(WIRE_IDSCAN))
+	else if(allowed(user) && !wires.is_cut(WIRE_IDSCAN))
 		locked = !locked
 		to_chat(user, span_notice("You [ locked ? "lock" : "unlock"] the Air Alarm interface."))
-		return
-	to_chat(user, span_warning("Access denied."))
+	else
+		to_chat(user, span_warning("Access denied."))
 
-/obj/machinery/alarm/click_alt(mob/living/carbon/human/H)
-	if(!istype(H))
+/obj/machinery/alarm/click_alt(mob/living/carbon/human/user)
+	if(!istype(user))
 		return NONE
-	var/obj/item/card/id/card = H.get_id_card()
+	var/obj/item/card/id/card = user.get_id_card()
 	if(!istype(card))
 		return NONE
-
-	add_fingerprint(H)
-	togglelock(H)
+	add_fingerprint(user)
+	togglelock(user)
 	return CLICK_ACTION_SUCCESS
 
 


### PR DESCRIPTION
## Описание

Alt+клик по аир алярму теперь работает также как у АПЦ.

## Причина создания ПР / Почему это хорошо для игры

Удобство атмосам, не надо больше доставать карту из кошелька тратя на это время.