### PR TITLE
map: Удаление ламп со всех газовых  камер на всех мапах

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -31549,12 +31549,6 @@
 	},
 /turf/simulated/floor/engine/air,
 /area/atmos)
-"doB" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/engine/air,
-/area/atmos)
 "doJ" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -34882,12 +34876,6 @@
 	icon_state = "whiteyellow"
 	},
 /area/medical/chemistry)
-"dEq" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/engine/o2,
-/area/atmos)
 "dEt" = (
 /turf/simulated/wall,
 /area/maintenance/banya)
@@ -37866,12 +37854,6 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/atmos)
-"dRE" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/engine/n2,
 /area/atmos)
 "dRG" = (
 /obj/machinery/status_display/supply_display,
@@ -47235,12 +47217,6 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/space)
-"fIS" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/engine/co2,
-/area/atmos)
 "fJh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -57547,12 +57523,6 @@
 	icon_state = "whitebluecorner"
 	},
 /area/medical/biostorage)
-"igL" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/engine/plasma,
-/area/atmos)
 "igP" = (
 /obj/structure/sign/nosmoking_2{
 	pixel_y = 32
@@ -70086,12 +70056,6 @@
 	icon_state = "whitered"
 	},
 /area/security/medbay)
-"lmV" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/engine/n20,
-/area/atmos)
 "lnn" = (
 /obj/structure/grille,
 /obj/effect/decal/warning_stripes/east,
@@ -81455,12 +81419,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/range)
-"nRt" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/atmos)
 "nRC" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -147163,19 +147121,19 @@ aWR
 djg
 uYk
 fmO
-fIS
+fmO
 fmO
 uYk
 hwu
-igL
+hwu
 hwu
 uYk
 klw
-lmV
+klw
 klw
 uYk
 mHd
-nRt
+mHd
 mHd
 uYk
 coE
@@ -155128,15 +155086,15 @@ oJx
 coE
 uYk
 cuq
-doB
+cuq
 cuq
 uYk
 dHQ
-dEq
+dHQ
 dHQ
 uYk
 cge
-dRE
+cge
 cge
 uYk
 qfp

--- a/_maps/map_files/celestation/celestation.dmm
+++ b/_maps/map_files/celestation/celestation.dmm
@@ -13063,12 +13063,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/arcade)
-"bOh" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/engine/n2,
-/area/atmos)
 "bOk" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plasteel,
@@ -13768,12 +13762,6 @@
 "bSa" = (
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
-"bSm" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/engine/o2,
-/area/atmos)
 "bSp" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/light,
@@ -14958,10 +14946,6 @@
 	icon_state = "redcorner"
 	},
 /area/security/permahallway)
-"bXx" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/engine/co2,
-/area/atmos)
 "bXy" = (
 /obj/effect/spawner/window/reinforced/polarized{
 	id = "Magistrate"
@@ -69747,10 +69731,6 @@
 	icon_state = "dark"
 	},
 /area/atmos)
-"maC" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/engine/n20,
-/area/atmos)
 "maK" = (
 /obj/item/twohanded/required/kirbyplants/dead,
 /turf/simulated/floor/plasteel{
@@ -79452,12 +79432,6 @@
 	icon_state = "blue"
 	},
 /area/hallway/primary/fore)
-"nVQ" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/engine/air,
-/area/atmos)
 "nVW" = (
 /obj/machinery/alarm{
 	pixel_y = 26
@@ -108808,10 +108782,6 @@
 	icon_state = "neutralfull"
 	},
 /area/crew_quarters/bar/atrium)
-"tCg" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/engine/plasma,
-/area/atmos)
 "tCk" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
@@ -130590,10 +130560,6 @@
 /obj/item/flag/command,
 /turf/simulated/floor/glass,
 /area/hallway/primary/fore)
-"xJa" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/engine/insulated/vacuum,
-/area/atmos)
 "xJl" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -226437,15 +226403,15 @@ bMk
 wla
 wPH
 bNl
-bOh
+bNl
 bNl
 wPH
 bRq
-bSm
+bRq
 bRq
 wPH
 cUI
-nVQ
+cUI
 cUI
 wPH
 vFt
@@ -228764,7 +228730,7 @@ bJF
 oyz
 ghX
 izo
-bXx
+xZB
 wPH
 rrM
 xtC
@@ -229792,7 +229758,7 @@ gIv
 waW
 bQL
 irM
-tCg
+ijc
 wPH
 amX
 vvT
@@ -230820,7 +230786,7 @@ bJF
 oyz
 tpf
 ayp
-maC
+uIs
 wPH
 rrM
 vvT
@@ -231848,7 +231814,7 @@ cbc
 oyz
 jFZ
 xcj
-xJa
+xcj
 wLj
 bnZ
 vvT

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -13489,12 +13489,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior)
-"bOh" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/engine/n2,
-/area/atmos)
 "bOj" = (
 /turf/simulated/mineral/ancient,
 /area/engineering/mechanic_workshop/hangar)
@@ -14317,12 +14311,6 @@
 	},
 /turf/space,
 /area/space/nearstation)
-"bSm" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/engine/o2,
-/area/atmos)
 "bSo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -15002,12 +14990,6 @@
 "bUN" = (
 /turf/simulated/wall,
 /area/chapel/main)
-"bUQ" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/engine/air,
-/area/atmos)
 "bUR" = (
 /obj/effect/turf_decal/siding/brown/corner{
 	dir = 1
@@ -15767,22 +15749,6 @@
 	icon_state = "dark"
 	},
 /area/hydroponics)
-"bYc" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/engine/co2,
-/area/atmos)
-"bYd" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/engine/plasma,
-/area/atmos)
-"bYe" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/engine/n20,
-/area/atmos)
-"bYf" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/engine/insulated/vacuum,
-/area/atmos)
 "bYj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -125323,15 +125289,15 @@ vFg
 mXi
 bDR
 bNl
-bOh
+bNl
 bNl
 bDR
 bRq
-bSm
+bRq
 bRq
 bDR
 bUj
-bUQ
+bUj
 bUj
 bDR
 nIF
@@ -127650,7 +127616,7 @@ bVW
 vsE
 jjg
 oqz
-bYc
+bXv
 bDR
 nIF
 cuZ
@@ -128678,7 +128644,7 @@ bVW
 vsE
 nAi
 vpX
-bYd
+bXx
 bDR
 nIF
 ozT
@@ -129706,7 +129672,7 @@ bVW
 vsE
 gfJ
 dOS
-bYe
+bXz
 bDR
 kgL
 ccS
@@ -130734,7 +130700,7 @@ bWc
 dAk
 kdK
 bXB
-bYf
+bXB
 cIg
 nVW
 mJM

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -15929,10 +15929,6 @@
 	icon_state = "dark"
 	},
 /area/storage/eva)
-"bbM" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/engine/o2,
-/area/atmos)
 "bbN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15941,10 +15937,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
-"bbO" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/engine/air,
-/area/atmos)
 "bbP" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
@@ -47829,12 +47821,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/atmospherics)
-"cUV" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/engine/insulated/vacuum,
-/area/atmos)
 "cUX" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/welding,
@@ -50852,12 +50838,6 @@
 	id_tag = "co2_sensor"
 	},
 /turf/simulated/floor/engine/co2,
-/area/atmos)
-"del" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/engine/plasma,
 /area/atmos)
 "dem" = (
 /obj/structure/table,
@@ -64830,12 +64810,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/permabrig)
-"jID" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/engine/n20,
-/area/atmos)
 "jJj" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -67224,12 +67198,6 @@
 	icon_state = "white"
 	},
 /area/toxins/explab)
-"lqG" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/engine/co2,
-/area/atmos)
 "lrl" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
@@ -87581,10 +87549,6 @@
 /obj/effect/spawner/random_spawners/rodent,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
-"xWY" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/engine/n2,
-/area/atmos)
 "xXc" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -120062,7 +120026,7 @@ lTl
 dej
 hva
 hgn
-xWY
+jxi
 cQZ
 dcq
 deW
@@ -121090,7 +121054,7 @@ lTl
 dej
 cTo
 dkh
-bbM
+dkO
 cQZ
 doE
 lTl
@@ -122118,7 +122082,7 @@ cWL
 dej
 khx
 dkp
-bbO
+dkT
 cQZ
 doE
 lTl
@@ -123895,19 +123859,19 @@ cBP
 cBK
 cQZ
 cVR
-cUV
+cVR
 cVR
 cQZ
 dhI
-jID
+dhI
 dhI
 cQZ
 dbI
-del
+dbI
 dbI
 cQZ
 wDq
-lqG
+wDq
 wDq
 cQZ
 cTP

--- a/_maps/map_files/nova/nova.dmm
+++ b/_maps/map_files/nova/nova.dmm
@@ -6862,12 +6862,6 @@
 	icon_state = "darkyellow"
 	},
 /area/engineering/mechanic_workshop/hangar)
-"aZq" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/engine/air,
-/area/atmos)
 "aZA" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
@@ -14911,12 +14905,6 @@
 	icon_state = "cult"
 	},
 /area/maintenance/chapel)
-"cfq" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/engine/insulated/vacuum,
-/area/atmos)
 "cft" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -26754,12 +26742,6 @@
 	dir = 8
 	},
 /area/medical/cryo)
-"dSL" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/engine/n20,
-/area/atmos)
 "dSM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -129211,12 +129193,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/assembly/showroom)
-"sXd" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/engine/n2,
-/area/atmos)
 "sXg" = (
 /turf/simulated/wall,
 /area/maintenance/electrical)
@@ -154045,12 +154021,6 @@
 	icon_state = "dark"
 	},
 /area/aisat/maintenance)
-"wBV" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/engine/co2,
-/area/atmos)
 "wBY" = (
 /obj/machinery/light,
 /turf/simulated/openspace,
@@ -154854,12 +154824,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
-"wJR" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/engine/o2,
-/area/atmos)
 "wJT" = (
 /obj/machinery/light{
 	dir = 8
@@ -155899,12 +155863,6 @@
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry)
-"wRm" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/engine/plasma,
-/area/atmos)
 "wRn" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/light,
@@ -209250,19 +209208,19 @@ eIe
 eIe
 syE
 ake
-cfq
+ake
 ake
 syE
 jBM
-wBV
+jBM
 jBM
 syE
 vce
-wRm
+vce
 vce
 syE
 cVE
-dSL
+cVE
 cVE
 syE
 eIe
@@ -216446,15 +216404,15 @@ dnj
 eIe
 syE
 xEw
-aZq
+xEw
 xEw
 syE
 avC
-wJR
+avC
 avC
 syE
 ndf
-sXd
+ndf
 ndf
 syE
 eIe


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание

Удаляет лапочки с камер с газом, что бы они случайно не ломались и не поджигали плазму.

## Причина создания ПР / Почему это хорошо для игры

баг фикс
![image](https://github.com/user-attachments/assets/fe481016-0d65-4500-a10b-02803412b716)

