### PR TITLE
qol: UI кнопка пояса позволяет вернуть предмет в пояс без проверки карманов и других открытых инвентарей

### DIFF
--- a/code/datums/keybindings/mob.dm
+++ b/code/datums/keybindings/mob.dm
@@ -407,4 +407,4 @@
 		return .
 	if (!istype(belt))
 		return .
-	belt.radial_menu(human)
+	belt.attack_self(human)

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -35,8 +35,17 @@
 		return
 	if (!usr.put_in_any_hand_if_possible(item))
 		return
-	to_chat(usr, span_notice("Вы достаете [item.name] с пояса."))
+	to_chat(usr, span_notice("Вы достаете [item.declent_ru(ACCUSATIVE)] с пояса."))
 	balloon_alert(usr, "снято с пояса")
+
+/obj/item/storage/belt/proc/try_fast_unequip_item_to_belt(obj/item/item)
+	if (item == null)
+		return
+	if (!can_be_inserted(item)) // Detail stop message in check proc
+		balloon_alert(usr, "не помещается в пояс")
+		return
+	if (handle_item_insertion(item))
+		balloon_alert(usr, "повесил на пояс")
 
 /obj/item/storage/belt/proc/find_content_by_name(choice)
 	for(var/obj/item in contents)
@@ -66,6 +75,10 @@
 	try_fast_equip_item_from_belt(selected)
 
 /obj/item/storage/belt/attack_self(mob/user = usr)
+	var/obj/item/hand_item = user.get_active_hand()
+	if (hand_item)
+		try_fast_unequip_item_to_belt(hand_item)
+		return
 	radial_menu(user)
 
 /obj/item/storage/belt/item_action_slot_check(slot, mob/user, datum/action/action)


### PR DESCRIPTION
## Описание
Кнопка (и хоткей) для снятия предмета с пояса теперь позволяет вернуть предмет в пояс.
Быстрый способ позволяющий засунуть предмет за пояс не проверяя остальные хранилища (*обычный хоткей Е засовывает предмет в приоритетное хранилище, которым могут оказаться пустые карманы или другое открытое хранилище*).

## Причина создания ПР / Почему это хорошо для игры

Человек просил реализовать такой функционал для удобства:
https://discord.com/channels/617003227182792704/1390760585150464090/1390760585150464090

## Демонстрация изменений

https://github.com/user-attachments/assets/b5c1034c-c7ab-4c16-b5ee-e02b6aecfb14


## Тесты

Запускал на локалке, все работает, ошибок вроде нету. 
Изменения минимальные.