### PR TITLE
balance: картонная коробка пропускает урон тем кто лежит внутри

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -278,13 +278,3 @@
 		max_weight_of_contents = A_is_item.w_class
 	folding_bodybag.w_class = max_weight_of_contents
 	the_folder.put_in_hands(folding_bodybag)
-
-/obj/structure/closet/body_bag/bullet_act(obj/projectile/P)
-	. = ..()
-	var/list/carbons = list()
-	for(var/mob/living/carbon/C in contents)
-		if (istype(C))
-			carbons += C
-	if (length(carbons) > 0)
-		var/mob/living/carbon/randomCarbon = pick(carbons)
-		randomCarbon.bullet_act(P)

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -278,3 +278,13 @@
 		max_weight_of_contents = A_is_item.w_class
 	folding_bodybag.w_class = max_weight_of_contents
 	the_folder.put_in_hands(folding_bodybag)
+
+/obj/structure/closet/body_bag/bullet_act(obj/projectile/P)
+	. = ..()
+	var/list/carbons = list()
+	for(var/mob/living/carbon/C in contents)
+		if (istype(C))
+			carbons += C
+	if (length(carbons) > 0)
+		var/mob/living/carbon/randomCarbon = pick(carbons)
+		randomCarbon.bullet_act(P)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -623,3 +623,12 @@ GLOBAL_LIST_EMPTY(closets)
 	if(loc)
 		UpdateTransparency()
 
+/obj/structure/closet/bullet_act(obj/projectile/P)
+	. = ..()
+	var/list/carbons = list()
+	for(var/mob/living/carbon/C in contents)
+		if (istype(C))
+			carbons += C
+	if (length(carbons) > 0)
+		var/mob/living/carbon/randomCarbon = pick(carbons)
+		randomCarbon.bullet_act(P)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -622,13 +622,3 @@ GLOBAL_LIST_EMPTY(closets)
 	. = ..()
 	if(loc)
 		UpdateTransparency()
-
-/obj/structure/closet/bullet_act(obj/projectile/P)
-	. = ..()
-	var/list/carbons = list()
-	for(var/mob/living/carbon/C in contents)
-		if (istype(C))
-			carbons += C
-	if (length(carbons) > 0)
-		var/mob/living/carbon/randomCarbon = pick(carbons)
-		randomCarbon.bullet_act(P)

--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -185,5 +185,16 @@
 	animate(alpha = 0, time = 0.3 SECONDS)
 
 
+/obj/structure/closet/cardboard/bullet_act(obj/projectile/P)
+	. = ..()
+	var/list/carbons = list()
+	for(var/mob/living/carbon/C in contents)
+		if (istype(C))
+			carbons += C
+	if (length(carbons) > 0)
+		var/mob/living/carbon/randomCarbon = pick(carbons)
+		randomCarbon.bullet_act(P)
+
+
 #undef SNAKE_ALERT_COOLDOWN
 

--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -184,16 +184,19 @@
 	animate(image, pixel_z = 32, alpha = 255, time = 0.5 SECONDS, easing = ELASTIC_EASING)
 	animate(alpha = 0, time = 0.3 SECONDS)
 
-
-/obj/structure/closet/cardboard/bullet_act(obj/projectile/P)
+/obj/structure/closet/cardboard/take_damage(damage_amount, damage_type = BRUTE, damage_flag = "", sound_effect = TRUE, attack_dir, armour_penetration = 0)
 	. = ..()
-	var/list/carbons = list()
-	for(var/mob/living/carbon/C in contents)
-		if (istype(C))
-			carbons += C
-	if (length(carbons) > 0)
-		var/mob/living/carbon/randomCarbon = pick(carbons)
-		randomCarbon.bullet_act(P)
+	if (damage_flag == MELEE)
+		return
+	var/list/humans = list()
+	for(var/mob/living/carbon/human/human in contents)
+		if (istype(human))
+			humans += human
+	if (length(humans) <= 0)
+		return
+	var/mob/living/carbon/human/target = pick(humans)
+	var/armor = target.run_armor_check(BODY_ZONE_CHEST, damage_flag, armour_penetration)
+	target.apply_damage(damage_amount, damage_type, BODY_ZONE_CHEST, armor)
 
 
 #undef SNAKE_ALERT_COOLDOWN


### PR DESCRIPTION
## Описание

При попадании любого вида урона по коробке, урон проходит внутрь (*в того кто лежит внутри*).
Если внутри лежит не один чел, то рандомно выбирается один из них (*живой/мертвый - не влияет*)
Пропускает все виды урона кроме мили. 

По сути нерф абуза коробки.

Хотел сделать сначала через bullet_act, но там возникает баг с двойным взрывом ракет (*при попадании в коробку и при попадании в того кто внутри*). 
Реализовал через `take_damage`, поэтому попадания внутри будут только в туловище.

Влияет на имплант коробки синдиката, она также пропускает урон (*маленький нерф предмета с аплинка, раньше оно впитывало одно попадание прежде чем исчезнуть, теперь будет исчезать без впитывания урона*)

## Причина создания ПР / Почему это хорошо для игры

*Автор предложки умер от коробки*

Надо подождать завершения голосования
https://discord.com/channels/617003227182792704/1219014729742159952/1390363321542246470

## Демонстрация изменений


https://github.com/user-attachments/assets/1870afbc-9aa2-43e1-9202-ce1f3e806098


## Тесты

Протестировано, работает. Багов не нашел.
