### PR TITLE
balance: добавлена возможность заточки колоды карты синдиката

### DIFF
--- a/code/modules/games/52card.dm
+++ b/code/modules/games/52card.dm
@@ -113,6 +113,14 @@
 	card_throw_speed = 3
 	card_attack_verb = list("атаковал", "полоснул", "порезал")
 	card_resistance_flags = NONE
+	sharp = TRUE
+
+/obj/item/deck/cards/syndicate/sharpen_act(obj/item/whetstone/whetstone, mob/user)
+	name = "[whetstone.prefix] [name]"
+	card_force = clamp(card_force + whetstone.increment, 0, whetstone.max)
+	card_throwforce = clamp(card_throwforce + whetstone.increment, 0, whetstone.max)
+	set_sharpness(TRUE)
+	return TRUE
 
 
 /obj/item/deck/cards/black


### PR DESCRIPTION
## Описание

Дает возможность заточить колоду карт синдиката с помощью камней.
При заточке колоды затачиваются все его карты. Отдельно карты нельзя затачивать как и раньше.

## Причина создания ПР / Почему это хорошо для игры

Предложка прошла
https://discord.com/channels/617003227182792704/755125334097133628/1391862317423132845

## Тесты

Проверил на локалке, заточенная карта наносит больше урона.
