### PR TITLE
balance: Добавление размера еде

### DIFF
--- a/code/modules/food_and_drinks/food/foods/baked_goods.dm
+++ b/code/modules/food_and_drinks/food/foods/baked_goods.dm
@@ -6,6 +6,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/carrotcake
 	name = "carrot cake"
 	desc = "A favorite desert of a certain wascally wabbit. Not a lie."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "carrotcake"
 	slice_path = /obj/item/reagent_containers/food/snacks/carrotcakeslice
 	slices_num = 5
@@ -18,6 +19,7 @@
 /obj/item/reagent_containers/food/snacks/carrotcakeslice
 	name = "carrot cake slice"
 	desc = "Carrotty slice of Carrot Cake, carrots are good for your eyes! Also not a lie."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "carrotcake_slice"
 	trash = /obj/item/trash/plate
 	filling_color = "#FFD675"
@@ -28,6 +30,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/braincake
 	name = "brain cake"
 	desc = "A squishy cake-thing."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "braincake"
 	slice_path = /obj/item/reagent_containers/food/snacks/braincakeslice
 	slices_num = 5
@@ -40,6 +43,7 @@
 /obj/item/reagent_containers/food/snacks/braincakeslice
 	name = "brain cake slice"
 	desc = "Lemme tell you something about brains. THEY'RE DELICIOUS."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "braincakeslice"
 	trash = /obj/item/trash/plate
 	filling_color = "#E6AEDB"
@@ -49,6 +53,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/cheesecake
 	name = "cheese cake"
 	desc = "DANGEROUSLY cheesy."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "cheesecake"
 	slice_path = /obj/item/reagent_containers/food/snacks/cheesecakeslice
 	slices_num = 5
@@ -61,6 +66,7 @@
 /obj/item/reagent_containers/food/snacks/cheesecakeslice
 	name = "cheese cake slice"
 	desc = "Slice of pure cheestisfaction."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "cheesecake_slice"
 	trash = /obj/item/trash/plate
 	filling_color = "#FAF7AF"
@@ -70,6 +76,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/plaincake
 	name = "vanilla cake"
 	desc = "A plain cake, not a lie."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "plaincake"
 	slice_path = /obj/item/reagent_containers/food/snacks/plaincakeslice
 	slices_num = 5
@@ -82,6 +89,7 @@
 /obj/item/reagent_containers/food/snacks/plaincakeslice
 	name = "vanilla cake slice"
 	desc = "Just a slice of cake, it is enough for everyone."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "plaincake_slice"
 	trash = /obj/item/trash/plate
 	filling_color = "#F7EDD5"
@@ -91,6 +99,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/orangecake
 	name = "orange cake"
 	desc = "A cake with added orange."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "orangecake"
 	slice_path = /obj/item/reagent_containers/food/snacks/orangecakeslice
 	slices_num = 5
@@ -103,6 +112,7 @@
 /obj/item/reagent_containers/food/snacks/orangecakeslice
 	name = "orange cake slice"
 	desc = "Just a slice of cake, it is enough for everyone."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "orangecake_slice"
 	trash = /obj/item/trash/plate
 	filling_color = "#FADA8E"
@@ -112,6 +122,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/bananacake
 	name = "banana cake"
 	desc = "A cake with added bananas."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "bananacake"
 	slice_path = /obj/item/reagent_containers/food/snacks/bananacakeslice
 	slices_num = 5
@@ -124,6 +135,7 @@
 /obj/item/reagent_containers/food/snacks/bananacakeslice
 	name = "banana cake slice"
 	desc = "Just a slice of cake, it is enough for everyone."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "bananacake_slice"
 	trash = /obj/item/trash/plate
 	filling_color = "#FADA8E"
@@ -133,6 +145,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/limecake
 	name = "lime cake"
 	desc = "A cake with added lime."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "limecake"
 	bitesize = 3
 	slice_path = /obj/item/reagent_containers/food/snacks/limecakeslice
@@ -145,6 +158,7 @@
 /obj/item/reagent_containers/food/snacks/limecakeslice
 	name = "lime cake slice"
 	desc = "Just a slice of cake, it is enough for everyone."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "limecake_slice"
 	trash = /obj/item/trash/plate
 	filling_color = "#CBFA8E"
@@ -154,6 +168,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/lemoncake
 	name = "lemon cake"
 	desc = "A cake with added lemon."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "lemoncake"
 	slice_path = /obj/item/reagent_containers/food/snacks/lemoncakeslice
 	slices_num = 5
@@ -166,6 +181,7 @@
 /obj/item/reagent_containers/food/snacks/lemoncakeslice
 	name = "lemon cake slice"
 	desc = "Just a slice of cake, it is enough for everyone."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "lemoncake_slice"
 	trash = /obj/item/trash/plate
 	filling_color = "#FAFA8E"
@@ -175,6 +191,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/chocolatecake
 	name = "chocolate cake"
 	desc = "A cake with added chocolate."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "chocolatecake"
 	slice_path = /obj/item/reagent_containers/food/snacks/chocolatecakeslice
 	slices_num = 5
@@ -187,6 +204,7 @@
 /obj/item/reagent_containers/food/snacks/chocolatecakeslice
 	name = "chocolate cake slice"
 	desc = "Just a slice of cake, it is enough for everyone."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "chocolatecake_slice"
 	trash = /obj/item/trash/plate
 	filling_color = "#805930"
@@ -196,6 +214,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/birthdaycake
 	name = "birthday cake"
 	desc = "Happy Birthday..."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "birthdaycake"
 	slice_path = /obj/item/reagent_containers/food/snacks/birthdaycakeslice
 	slices_num = 5
@@ -208,6 +227,7 @@
 /obj/item/reagent_containers/food/snacks/birthdaycakeslice
 	name = "birthday cake slice"
 	desc = "A slice of your birthday"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "birthdaycakeslice"
 	trash = /obj/item/trash/plate
 	filling_color = "#FFD6D6"
@@ -217,6 +237,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/applecake
 	name = "apple cake"
 	desc = "A cake centered with Apple."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "applecake"
 	slice_path = /obj/item/reagent_containers/food/snacks/applecakeslice
 	slices_num = 5
@@ -229,6 +250,7 @@
 /obj/item/reagent_containers/food/snacks/applecakeslice
 	name = "apple cake slice"
 	desc = "A slice of heavenly cake."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "applecakeslice"
 	trash = /obj/item/trash/plate
 	filling_color = "#EBF5B8"
@@ -238,6 +260,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/slimepie
 	name = "slime pie"
 	desc = "Blurp blob blup blep blop. Slicable."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "slimepie"
 	slice_path = /obj/item/reagent_containers/food/snacks/slimepieslice
 	slices_num = 5
@@ -250,6 +273,7 @@
 /obj/item/reagent_containers/food/snacks/slimepieslice
 	name = "slime pie slice"
 	desc = "Blurp blob blup blep blop."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "slimepieslice"
 	trash = /obj/item/trash/plate
 	filling_color = "#00d9ff"
@@ -259,6 +283,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/choccherrycake
 	name = "Chocolate - cherry cake"
 	desc = "Another cake. However."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "choccherrycake"
 	slice_path = /obj/item/reagent_containers/food/snacks/choccherrycakeslice
 	slices_num = 6
@@ -271,6 +296,7 @@
 /obj/item/reagent_containers/food/snacks/choccherrycakeslice
 	name = "Chocolate - cherry cake's slice"
 	desc = "Slice of another cake. Wait, what?"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "choccherrycake_s"
 	trash = /obj/item/trash/plate
 	filling_color = "#5e1706"
@@ -279,6 +305,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/noel
 	name = "Buche de Noel"
 	desc = "What?"
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "noel"
 	trash = /obj/item/trash/tray
 	slice_path = /obj/item/reagent_containers/food/snacks/noelslice
@@ -362,6 +389,7 @@
 /obj/item/reagent_containers/food/snacks/pie
 	name = "banana cream pie"
 	desc = "Just like back home, on clown planet! HONK!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "pie"
 	trash = /obj/item/trash/plate
 	filling_color = "#FBFFB8"
@@ -380,6 +408,7 @@
 	name = "meat-pie"
 	icon_state = "meatpie"
 	desc = "An old barber recipe, very delicious!"
+	w_class = WEIGHT_CLASS_SMALL
 	trash = /obj/item/trash/plate
 	filling_color = "#948051"
 	bitesize = 3
@@ -465,6 +494,7 @@
 /obj/item/reagent_containers/food/snacks/tofupie
 	name = "tofu-pie"
 	icon_state = "meatpie"
+	w_class = WEIGHT_CLASS_SMALL
 	desc = "A delicious tofu pie."
 	trash = /obj/item/trash/plate
 	filling_color = "#FFFEE0"
@@ -504,6 +534,7 @@
 /obj/item/reagent_containers/food/snacks/xemeatpie
 	name = "xeno-pie"
 	icon_state = "xenomeatpie"
+	w_class = WEIGHT_CLASS_SMALL
 	desc = "A delicious meatpie. Probably heretical."
 	trash = /obj/item/trash/plate
 	filling_color = "#43DE18"
@@ -515,6 +546,7 @@
 /obj/item/reagent_containers/food/snacks/applepie
 	name = "apple pie"
 	desc = "A pie containing sweet sweet love... or apple."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "applepie"
 	filling_color = "#E0EDC5"
 	bitesize = 3
@@ -526,6 +558,7 @@
 /obj/item/reagent_containers/food/snacks/cherrypie
 	name = "cherry pie"
 	desc = "Taste so good, make a grown man cry."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "cherrypie"
 	filling_color = "#FF525A"
 	bitesize = 3
@@ -536,6 +569,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/pumpkinpie
 	name = "pumpkin pie"
 	desc = "A delicious treat for the autumn months."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "pumpkinpie"
 	slice_path = /obj/item/reagent_containers/food/snacks/pumpkinpieslice
 	slices_num = 5
@@ -548,6 +582,7 @@
 /obj/item/reagent_containers/food/snacks/pumpkinpieslice
 	name = "pumpkin pie slice"
 	desc = "A slice of pumpkin pie, with whipped cream on top. Perfection."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "pumpkinpieslice"
 	trash = /obj/item/trash/plate
 	filling_color = "#F5B951"
@@ -734,6 +769,7 @@
 /obj/item/reagent_containers/food/snacks/pancake
 	name = "pancake"
 	desc = "A plain pancake."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "pancake"
 	filling_color = "#E7D8AB"
 	bitesize = 2
@@ -743,6 +779,7 @@
 /obj/item/reagent_containers/food/snacks/pancake/berry_pancake
 	name = "berry pancake"
 	desc = "A pancake loaded with berries."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "berry_pancake"
 	list_reagents = list("nutriment" = 3, "sugar" = 10, "berryjuice" = 3)
 	foodtype = GRAIN | SUGAR | FRUIT
@@ -750,6 +787,7 @@
 /obj/item/reagent_containers/food/snacks/pancake/choc_chip_pancake
 	name = "choc-chip pancake"
 	desc = "A pancake loaded with chocolate chips."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "choc_chip_pancake"
 	list_reagents = list("nutriment" = 3, "sugar" = 10, "cocoa" = 3)
 
@@ -769,6 +807,7 @@
 /obj/item/reagent_containers/food/snacks/berryclafoutis
 	name = "berry clafoutis"
 	desc = "No black birds, this is a good sign."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "berryclafoutis"
 	trash = /obj/item/trash/plate
 	bitesize = 3
@@ -805,6 +844,7 @@
 /obj/item/reagent_containers/food/snacks/appletart
 	name = "golden apple streusel tart"
 	desc = "A tasty dessert that won't make it through a metal detector."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "gappletart"
 	trash = /obj/item/trash/plate
 	filling_color = "#FFFF00"

--- a/code/modules/food_and_drinks/food/foods/bread.dm
+++ b/code/modules/food_and_drinks/food/foods/bread.dm
@@ -6,6 +6,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/bread/meat
 	name = "meatbread loaf"
 	desc = "The culinary base of every self-respecting eloquen/tg/entleman."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "meatbread"
 	slice_path = /obj/item/reagent_containers/food/snacks/meatbreadslice
 	slices_num = 5
@@ -17,6 +18,7 @@
 /obj/item/reagent_containers/food/snacks/meatbreadslice
 	name = "meatbread slice"
 	desc = "A slice of delicious meatbread."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "meatbreadslice"
 	trash = /obj/item/trash/plate
 	filling_color = "#FF7575"
@@ -25,6 +27,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/bread/xeno
 	name = "xenomeatbread loaf"
 	desc = "The culinary base of every self-respecting eloquent gentleman. Extra Heretical."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "xenomeatbread"
 	slice_path = /obj/item/reagent_containers/food/snacks/xenomeatbreadslice
 	slices_num = 5
@@ -36,6 +39,7 @@
 /obj/item/reagent_containers/food/snacks/xenomeatbreadslice
 	name = "xenomeatbread slice"
 	desc = "A slice of delicious meatbread. Extra Heretical."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "xenobreadslice"
 	trash = /obj/item/trash/plate
 	filling_color = "#8AFF75"
@@ -44,6 +48,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/bread/spider
 	name = "spider meat loaf"
 	desc = "Reassuringly green meatloaf made from spider meat."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "spidermeatbread"
 	slice_path = /obj/item/reagent_containers/food/snacks/spidermeatbreadslice
 	slices_num = 5
@@ -54,6 +59,7 @@
 /obj/item/reagent_containers/food/snacks/spidermeatbreadslice
 	name = "spider meat bread slice"
 	desc = "A slice of meatloaf made from an animal that most likely still wants you dead."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "xenobreadslice"
 	trash = /obj/item/trash/plate
 	list_reagents = list("toxin" = 2)
@@ -62,6 +68,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/bread/banana
 	name = "banana-nut bread"
 	desc = "A heavenly and filling treat."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "bananabread"
 	slice_path = /obj/item/reagent_containers/food/snacks/bananabreadslice
 	slices_num = 5
@@ -73,6 +80,7 @@
 /obj/item/reagent_containers/food/snacks/bananabreadslice
 	name = "banana-nut bread slice"
 	desc = "A slice of delicious banana bread."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "bananabreadslice"
 	trash = /obj/item/trash/plate
 	filling_color = "#EDE5AD"
@@ -82,6 +90,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/bread/tofu
 	name = "tofubread"
 	icon_state = "Like meatbread but for vegetarians. Not guaranteed to give superpowers."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "tofubread"
 	slice_path = /obj/item/reagent_containers/food/snacks/tofubreadslice
 	slices_num = 5
@@ -93,6 +102,7 @@
 /obj/item/reagent_containers/food/snacks/tofubreadslice
 	name = "tofubread slice"
 	desc = "A slice of delicious tofubread."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "tofubreadslice"
 	trash = /obj/item/trash/plate
 	filling_color = "#F7FFE0"
@@ -100,7 +110,8 @@
 
 /obj/item/reagent_containers/food/snacks/sliceable/bread
 	name = "bread"
-	icon_state = "Some plain old Earthen bread."
+	desc =  "Some plain old Earthen bread."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "bread"
 	slice_path = /obj/item/reagent_containers/food/snacks/breadslice
 	slices_num = 6
@@ -118,6 +129,7 @@
 /obj/item/reagent_containers/food/snacks/breadslice
 	name = "bread slice"
 	desc = "A slice of home."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "breadslice"
 	trash = /obj/item/trash/plate
 	filling_color = "#D27332"
@@ -128,6 +140,7 @@
 /obj/item/reagent_containers/food/snacks/breadslice/burned
 	name = "burned bread slice"
 	desc = "A slice of slightly burned bread. Probably it's not the best idea to eat this..."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "breadslice"
 	trash = /obj/item/trash/plate
 	filling_color = "#D27332"
@@ -138,6 +151,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/creamcheesebread
 	name = "cream cheese bread"
 	desc = "Yum yum yum!"
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "creamcheesebread"
 	slice_path = /obj/item/reagent_containers/food/snacks/creamcheesebreadslice
 	slices_num = 5
@@ -149,6 +163,7 @@
 /obj/item/reagent_containers/food/snacks/creamcheesebreadslice
 	name = "cream cheese bread slice"
 	desc = "A slice of yum!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "creamcheesebreadslice"
 	trash = /obj/item/trash/plate
 	filling_color = "#FFF896"
@@ -182,6 +197,7 @@
 /obj/item/reagent_containers/food/snacks/flatbread
 	name = "flatbread"
 	desc = "Bland but filling."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon = 'icons/obj/food/food_ingredients.dmi'
 	icon_state = "flatbread"
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
@@ -191,6 +207,7 @@
 /obj/item/reagent_containers/food/snacks/baguette
 	name = "baguette"
 	desc = "Bon appetit!"
+	w_class = WEIGHT_CLASS_NORMAL
 	ru_names = list(
 		NOMINATIVE = "багет",
 		GENITIVE = "багета",
@@ -216,6 +233,7 @@
 /obj/item/reagent_containers/food/snacks/twobread
 	name = "two bread"
 	desc = "It is very bitter and winy."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "twobread"
 	filling_color = "#DBCC9A"
 	bitesize = 3
@@ -226,6 +244,7 @@
 /obj/item/reagent_containers/food/snacks/toast
 	name = "toast"
 	desc = "Yeah! Toast!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "toast"
 	filling_color = "#B2580E"
 	bitesize = 3
@@ -236,6 +255,7 @@
 /obj/item/reagent_containers/food/snacks/jelliedtoast
 	name = "jellied toast"
 	desc = "A slice of bread covered with delicious jam."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "jellytoast"
 	trash = /obj/item/trash/plate
 	filling_color = "#B572AB"
@@ -252,6 +272,7 @@
 /obj/item/reagent_containers/food/snacks/rofflewaffles
 	name = "roffle waffles"
 	desc = "Waffles from Roffle. Co."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "rofflewaffles"
 	trash = /obj/item/trash/waffles
 	filling_color = "#FF00F7"
@@ -263,6 +284,7 @@
 /obj/item/reagent_containers/food/snacks/waffles
 	name = "waffles"
 	desc = "Mmm, waffles."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "waffles"
 	trash = /obj/item/trash/waffles
 	filling_color = "#E6DEB5"

--- a/code/modules/food_and_drinks/food/foods/desserts.dm
+++ b/code/modules/food_and_drinks/food/foods/desserts.dm
@@ -48,6 +48,7 @@
 /obj/item/reagent_containers/food/snacks/friedbanana
 	name = "fried banana"
 	desc = "Goreng Pisang, also known as fried bananas."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "friedbanana"
 	list_reagents = list("sugar" = 10, "nutriment" = 8, "cornoil" = 4)
 	foodtype = FRIED | FRUIT | SUGAR
@@ -55,6 +56,7 @@
 /obj/item/reagent_containers/food/snacks/ricepudding
 	name = "rice pudding"
 	desc = "Where's the Jam!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "rpudding"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#FFFBDB"
@@ -65,6 +67,7 @@
 /obj/item/reagent_containers/food/snacks/spacylibertyduff
 	name = "spacy liberty duff"
 	desc = "Jello gelatin, from Alfred Hubbard's cookbook."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "spacylibertyduff"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#42B873"
@@ -76,6 +79,7 @@
 /obj/item/reagent_containers/food/snacks/amanitajelly
 	name = "amanita jelly"
 	desc = "Looks curiously toxic."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "amanitajelly"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#ED0758"

--- a/code/modules/food_and_drinks/food/foods/ethnic.dm
+++ b/code/modules/food_and_drinks/food/foods/ethnic.dm
@@ -6,6 +6,7 @@
 /obj/item/reagent_containers/food/snacks/taco
 	name = "taco"
 	desc = "Take a bite!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "taco"
 	bitesize = 3
 	list_reagents = list("nutriment" = 7, "vitamin" = 1)
@@ -15,6 +16,7 @@
 /obj/item/reagent_containers/food/snacks/burrito
 	name = "burrito"
 	desc = "Meat, beans, cheese, and rice wrapped up as an easy-to-hold meal."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "burrito"
 	trash = /obj/item/trash/plate
 	filling_color = "#A36A1F"
@@ -26,6 +28,7 @@
 /obj/item/reagent_containers/food/snacks/chimichanga
 	name = "chimichanga"
 	desc = "Time to eat a chimi-f***ing-changa."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "chimichanga"
 	trash = /obj/item/trash/plate
 	filling_color = "#A36A1F"
@@ -35,6 +38,7 @@
 /obj/item/reagent_containers/food/snacks/enchiladas
 	name = "enchiladas"
 	desc = "Viva la Mexico!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "enchiladas"
 	trash = /obj/item/trash/tray
 	filling_color = "#A36A1F"
@@ -56,6 +60,7 @@
 /obj/item/reagent_containers/food/snacks/tortilla
 	name = "Tortilla"
 	desc = "Hasta la vista, baby"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "tortilla"
 	trash = /obj/item/trash/plate
 	filling_color = "#E8C31E"
@@ -68,6 +73,7 @@
 	name = "Nachos"
 	desc = "Hola!"
 	icon_state = "nachos"
+	w_class = WEIGHT_CLASS_SMALL
 	trash = /obj/item/trash/plate
 	filling_color = "#E8C31E"
 	list_reagents = list("nutriment" = 5, "salt" = 1)
@@ -78,6 +84,7 @@
 /obj/item/reagent_containers/food/snacks/cheesenachos
 	name = "Cheese nachos"
 	desc = "Cheese hola!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "cheesenachos"
 	trash = /obj/item/trash/plate
 	filling_color = "#f1d65c"
@@ -89,6 +96,7 @@
 /obj/item/reagent_containers/food/snacks/cubannachos
 	name = "Cuban nachos"
 	desc = "Very hot hola!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "cubannachos"
 	trash = /obj/item/trash/plate
 	filling_color = "#ec5c23"
@@ -100,6 +108,7 @@
 /obj/item/reagent_containers/food/snacks/carneburrito
 	name = "Carne de burrito asado"
 	desc = "Like a classical burrito, but with some meat."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "carneburrito"
 	filling_color = "#69250b"
 	list_reagents = list("nutriment" = 8, "protein" = 3, "soysauce" = 1)
@@ -110,6 +119,7 @@
 /obj/item/reagent_containers/food/snacks/cheeseburrito
 	name = "Cheese burrito"
 	desc = "Is it really necessary to say something here?"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "cheeseburrito"
 	filling_color = "#f1d65c"
 	list_reagents = list("nutriment" = 10, "soysauce" = 2)
@@ -120,6 +130,7 @@
 /obj/item/reagent_containers/food/snacks/plasmaburrito
 	name = "Fuego Plasma Burrito"
 	desc = "Very hot, amigos."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "plasmaburrito"
 	filling_color = "#f35a46"
 	list_reagents = list("nutriment" = 4, "plantmatter" = 4, "capsaicin" = 4)
@@ -134,6 +145,7 @@
 /obj/item/reagent_containers/food/snacks/chinese/chowmein
 	name = "chow mein"
 	desc = "What is in this anyways?"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "chinese1"
 	junkiness = 25
 	antable = FALSE
@@ -144,6 +156,7 @@
 /obj/item/reagent_containers/food/snacks/chinese/sweetsourchickenball
 	name = "sweet & sour chicken balls"
 	desc = "Is this chicken cooked? The odds are better than wok paper scissors."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "chickenball"
 	item_state = "chinese3"
 	junkiness = 25
@@ -154,6 +167,7 @@
 /obj/item/reagent_containers/food/snacks/chinese/tao
 	name = "Admiral Yamamoto carp"
 	desc = "Tastes like chicken."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "chinese2"
 	junkiness = 25
 	antable = FALSE
@@ -164,6 +178,7 @@
 /obj/item/reagent_containers/food/snacks/chinese/newdles
 	name = "chinese newdles"
 	desc = "Made fresh, weekly!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "chinese3"
 	junkiness = 25
 	antable = FALSE
@@ -174,6 +189,7 @@
 /obj/item/reagent_containers/food/snacks/chinese/rice
 	name = "fried rice"
 	desc = "A timeless classic."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "chinese4"
 	item_state = "chinese2"
 	junkiness = 20
@@ -200,6 +216,7 @@
 /obj/item/reagent_containers/food/snacks/yakiimo
 	name = "yaki imo"
 	desc = "Made with roasted sweet potatoes!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "yakiimo"
 	trash = /obj/item/trash/plate
 	list_reagents = list("nutriment" = 5, "vitamin" = 4)
@@ -216,6 +233,7 @@
 	name = "-kabob"
 	icon_state = "kabob"
 	desc = "Human meat, on a stick."
+	w_class = WEIGHT_CLASS_SMALL
 	trash = /obj/item/stack/rods
 	filling_color = "#A85340"
 	list_reagents = list("nutriment" = 8)
@@ -225,6 +243,7 @@
 	name = "meat-kabob"
 	icon_state = "kabob"
 	desc = "Delicious meat, on a stick."
+	w_class = WEIGHT_CLASS_SMALL
 	trash = /obj/item/stack/rods
 	filling_color = "#A85340"
 	list_reagents = list("nutriment" = 8)
@@ -234,6 +253,7 @@
 	name = "tofu-kabob"
 	icon_state = "kabob"
 	desc = "Vegan meat, on a stick."
+	w_class = WEIGHT_CLASS_SMALL
 	trash = /obj/item/stack/rods
 	filling_color = "#FFFEE0"
 	list_reagents = list("nutriment" = 8)
@@ -246,6 +266,7 @@
 /obj/item/reagent_containers/food/snacks/shawarma
 	name = "shawarma"
 	desc = "Awesome mix of grilled meat and fresh vegetables. Don't ask about meat."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "shawarma"
 	filling_color = "#c0720c"
 	list_reagents = list("protein" = 4, "nutriment" = 4, "vitamin" = 2, "tomatojuice" = 4)
@@ -255,6 +276,7 @@
 /obj/item/reagent_containers/food/snacks/doner_cheese
 	name = "cheese doner"
 	desc = "Chef's special - grilled meat and fresh vegetables with warm cheese sause. Yummy!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "doner_cheese"
 	filling_color = "#c0720c"
 	list_reagents = list("protein" = 4, "nutriment" = 6, "vitamin" = 2, "tomatojuice" = 4)
@@ -264,6 +286,7 @@
 /obj/item/reagent_containers/food/snacks/doner_mushroom
 	name = "mushroom doner"
 	desc = "Grilled meat and fresh vegetables. You can see some mushrooms too."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "doner_mushroom"
 	filling_color = "#c0720c"
 	list_reagents = list("protein" = 4, "nutriment" = 4, "plantmatter" = 2, "vitamin" = 2, "tomatojuice" = 4)
@@ -273,6 +296,7 @@
 /obj/item/reagent_containers/food/snacks/doner_vegan
 	name = "vegan doner"
 	desc = "Fresh vegetables wrapped in a long roll. No meat included!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "doner_vegan"
 	filling_color = "#c0720c"
 	list_reagents = list("nutriment" = 4, "plantmatter" = 4, "vitamin" = 4, "tomatojuice" = 8)
@@ -296,6 +320,7 @@
 /obj/item/reagent_containers/food/snacks/bruschetta
 	name = "Bruschetta"
 	desc = "..."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "bruschetta"
 	trash = /obj/item/trash/plate
 	filling_color = "#a30e0e"
@@ -307,6 +332,7 @@
 /obj/item/reagent_containers/food/snacks/quiche
 	name = "Quiche"
 	desc = "Makes you feel more intelligent. Give to lower lifeforms!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "quiche"
 	trash = /obj/item/trash/plate
 	filling_color = "#cfae89"

--- a/code/modules/food_and_drinks/food/foods/ingredients.dm
+++ b/code/modules/food_and_drinks/food/foods/ingredients.dm
@@ -41,6 +41,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/cheesewheel
 	name = "cheese wheel"
 	desc = "A big wheel of delicious Cheddar."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "cheesewheel"
 	slice_path = /obj/item/reagent_containers/food/snacks/cheesewedge
 	slices_num = 5
@@ -52,6 +53,7 @@
 /obj/item/reagent_containers/food/snacks/cheesewedge
 	name = "cheese wedge"
 	desc = "A wedge of delicious Cheddar. The cheese wheel it was cut from can't have gone far."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "cheesewedge"
 	filling_color = "#FFF700"
 	tastes = list("cheese" = 1)
@@ -60,6 +62,7 @@
 /obj/item/reagent_containers/food/snacks/weirdcheesewedge
 	name = "weird cheese"
 	desc = "Some kind of... gooey, messy, gloopy thing. Similar to cheese, but only in the broad sense of the word."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "weirdcheesewedge"
 	filling_color = "#00FF33"
 	list_reagents = list("mercury" = 5, "lsd" = 5, "ethanol" = 5, "weird_cheese" = 5)

--- a/code/modules/food_and_drinks/food/foods/junkfood.dm
+++ b/code/modules/food_and_drinks/food/foods/junkfood.dm
@@ -157,6 +157,7 @@
 	)
 	desc = "Специализированный пищевой продукт с высоким содержанием белка. \
 			Разработан филиалом Donk Co расположенным на планете клоунов."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "proteinbar_bananza"
 	filling_color = "#d1a62f"
 	junkiness = 5
@@ -178,6 +179,7 @@
 	)
 	desc = "Специализированный пищевой продукт с высоким содержанием белка. \
 			Долгое время существовал миф, будто в его состав входит слизь одной известной слаймолюдки."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "proteinbar_cherry"
 	filling_color = "#d1a62f"
 	junkiness = 5
@@ -199,6 +201,7 @@
 	)
 	desc = "Специализированный пищевой продукт с высоким содержанием белка. \
 			Во время производства ни одна корова не пострадала."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "proteinbar_beef"
 	filling_color = "#d1a62f"
 	junkiness = 5

--- a/code/modules/food_and_drinks/food/foods/meat.dm
+++ b/code/modules/food_and_drinks/food/foods/meat.dm
@@ -6,6 +6,7 @@
 /obj/item/reagent_containers/food/snacks/meat
 	name = "meat"
 	desc = "Кусок сырого мяса. Большинство гуманоидов не стало бы есть его в сыром виде."
+	w_class = WEIGHT_CLASS_SMALL
 	ru_names = list(
 		NOMINATIVE = "кусок мяса",
 		GENITIVE = "куска мяса",
@@ -74,6 +75,7 @@
 /obj/item/reagent_containers/food/snacks/roasted_meat
 	name = "roasted meat"
 	desc = "Хорошо прожаренный стейк. Отличный источник белков и жиров."
+	w_class = WEIGHT_CLASS_SMALL
 	ru_names = list(
 		NOMINATIVE = "жаренное мясо",
 		GENITIVE = "жаренного мяса",
@@ -93,10 +95,12 @@
 
 /obj/item/reagent_containers/food/snacks/meat/syntiflesh
 	name = "synthetic meat"
+	w_class = WEIGHT_CLASS_SMALL
 	desc = "A synthetic slab of flesh."
 
 /obj/item/reagent_containers/food/snacks/meat/humanoid
 	name = "humanoid meat"
+	w_class = WEIGHT_CLASS_SMALL
 	var/subjectname = ""
 	var/subjectjob = null
 	tastes = list("salty meat" = 1)
@@ -412,6 +416,7 @@
 /obj/item/reagent_containers/food/snacks/monstermeat/bearmeat
 	name = "bear meat"
 	desc = "A very manly slab of meat."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "bearmeat"
 	filling_color = "#DB0000"
 	bitesize = 3
@@ -422,6 +427,7 @@
 /obj/item/reagent_containers/food/snacks/monstermeat/xenomeat
 	name = "meat"
 	desc = "A slab of meat. It's green!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "xenomeat"
 	filling_color = "#43DE18"
 	bitesize = 6
@@ -485,6 +491,7 @@
 /obj/item/reagent_containers/food/snacks/monstermeat/goliath
 	name = "goliath meat"
 	desc = "Кусок мяса голиафа. Сейчас не очень съедобно, но в лаве оно готовится отлично."
+	w_class = WEIGHT_CLASS_SMALL
 	ru_names = list(
 		NOMINATIVE = "мясо голиафа",
 		GENITIVE = "мяса голиафа",
@@ -527,6 +534,7 @@
 
 /obj/item/reagent_containers/food/snacks/monstermeat/rotten
 	name = "rotten meat"
+	w_class = WEIGHT_CLASS_SMALL
 	desc = "A slab of rotten meat. Looks really awful, a couple of flies sit on it."
 	icon_state = "rottenmeatslab"
 	list_reagents = list("protein" = 1, "toxin" = 10, "????" = 20)
@@ -540,6 +548,7 @@
 /obj/item/reagent_containers/food/snacks/meatsteak
 	name = "meat steak"
 	desc = "A piece of hot spicy meat."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "meatstake"
 	trash = /obj/item/trash/plate
 	filling_color = "#7A3D11"
@@ -663,6 +672,7 @@
 
 /obj/item/reagent_containers/food/snacks/birdsteak
 	name = "Chicken steak"
+	w_class = WEIGHT_CLASS_SMALL
 	desc = "A piece of hot light bird meat."
 	icon_state = "birdsteak"
 	filling_color = "#7A3D11"
@@ -728,6 +738,7 @@
 /obj/item/reagent_containers/food/snacks/spidereggsham
 	name = "green eggs and ham"
 	desc = "Would you eat them on a train? Would you eat them on a plane? Would you eat them on a state of the art corporate deathtrap floating through space?"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "spidereggsham"
 	trash = /obj/item/trash/plate
 	bitesize = 4
@@ -738,6 +749,7 @@
 /obj/item/reagent_containers/food/snacks/boiledspiderleg
 	name = "boiled spider leg"
 	desc = "A giant spider's leg that's still twitching after being cooked. Gross!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "spiderlegcooked"
 	trash = /obj/item/trash/plate
 	bitesize = 3
@@ -748,6 +760,7 @@
 /obj/item/reagent_containers/food/snacks/wingfangchu
 	name = "wing fang chu"
 	desc = "A savory dish of alien wing wang in soy. Wait, what?"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "wingfangchu"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#43DE18"
@@ -758,6 +771,7 @@
 /obj/item/reagent_containers/food/snacks/goliath_steak
 	name = "goliath steak"
 	desc = "Восхитительный стейк из мяса голиафа, прожаренный прямо в лаве. Так первобытно."
+	w_class = WEIGHT_CLASS_SMALL
 	ru_names = list(
 		NOMINATIVE = "стейк из мяса голиафа",
 		GENITIVE = "стейка из мяса голиафа",
@@ -806,6 +820,7 @@
 /obj/item/reagent_containers/food/snacks/smokedsausage
 	name = "Smoked sausage"
 	desc = "Piece of smoked sausage. Oh, really?"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "smokedsausage"
 	list_reagents = list("protein" = 12)
 	tastes = list("meat" = 3)
@@ -814,6 +829,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/salami
 	name = "Salami"
 	desc = "Not the best for sandwiches."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "salami"
 	slice_path = /obj/item/reagent_containers/food/snacks/slice/salami
 	slices_num = 6
@@ -985,6 +1001,7 @@
 /obj/item/reagent_containers/food/snacks/friedegg
 	name = "fried egg"
 	desc = "A fried egg, with a touch of salt and pepper."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "friedegg"
 	filling_color = "#FFDF78"
 	bitesize = 1
@@ -1011,6 +1028,7 @@
 /obj/item/reagent_containers/food/snacks/omelette
 	name = "omelette du fromage"
 	desc = "That's all you can say!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "omelette"
 	trash = /obj/item/trash/plate
 	filling_color = "#FFF9A8"
@@ -1022,6 +1040,7 @@
 /obj/item/reagent_containers/food/snacks/benedict
 	name = "eggs benedict"
 	desc = "There is only one egg on this, how rude."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "benedict"
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "egg" = 3, "vitamin" = 4)
@@ -1036,6 +1055,7 @@
 /obj/item/reagent_containers/food/snacks/hotdog
 	name = "hotdog"
 	desc = "Not made with actual dogs. Hopefully."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "hotdog"
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "ketchup" = 3, "vitamin" = 3)
@@ -1054,6 +1074,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/turkey
 	name = "turkey"
 	desc = "A traditional turkey served with stuffing."
+	w_class = WEIGHT_CLASS_HUGE
 	icon_state = "turkey"
 	slice_path = /obj/item/reagent_containers/food/snacks/turkeyslice
 	slices_num = 6
@@ -1064,6 +1085,7 @@
 /obj/item/reagent_containers/food/snacks/turkeyslice
 	name = "turkey serving"
 	desc = "A serving of some tender and delicious turkey."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "turkeyslice"
 	trash = /obj/item/trash/plate
 	filling_color = "#B97A57"
@@ -1083,6 +1105,7 @@
 /obj/item/reagent_containers/food/snacks/boiledpelmeni
 	name = "boiled pelmeni"
 	desc = "We don't know what was Siberia, but these tasty pelmeni definitely arrived from there."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "boiledpelmeni"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#d9be29"
@@ -1122,6 +1145,7 @@
 /obj/item/reagent_containers/food/snacks/fried_vox
 	name = "Kentucky Fried Vox"
 	desc = "Bucket of voxxy, yaya!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "fried_vox"
 	trash = /obj/item/trash/fried_vox
 	list_reagents = list("nutriment" = 3, "protein" = 5)
@@ -1131,6 +1155,7 @@
 /obj/item/reagent_containers/food/snacks/kidanragu
 	name = "Spicy chitin ragu"
 	desc = "Stew with very tough chitinous meat and stewed vegetables."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "kidanragu"
 	list_reagents = list("nutriment" = 8, "vitamin" = 4, "protein" = 4)
 	tastes = list("insect" = 3, "vegetable" = 2)
@@ -1139,6 +1164,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/lizard
 	name = "Fried reptile meat"
 	desc = " A Juicy steaks from the tail of a large lizard, makes you want to lie on warm rocks. Slicable"
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "lizard_steak"
 	slice_path = /obj/item/reagent_containers/food/snacks/lizardslice
 	slices_num = 5
@@ -1149,6 +1175,7 @@
 /obj/item/reagent_containers/food/snacks/lizardslice
 	name = "reptile steak"
 	desc = "A serving of unathi meat."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "lizard_slice"
 	trash = /obj/item/trash/plate
 	filling_color = "#a55f3a"
@@ -1158,6 +1185,7 @@
 /obj/item/reagent_containers/food/snacks/tajaroni
 	name = "Tajaroni"
 	desc = "Spicy dried sausage with pepper and... Did it just meow?"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "tajaroni"
 	list_reagents = list("nutriment" = 8, "vitamin" = 4, "protein" = 4)
 	tastes = list("dry meat" = 3, "cat meat" = 2)
@@ -1167,6 +1195,7 @@
 /obj/item/reagent_containers/food/snacks/vulpix
 	name = "Vulpixes"
 	desc = "Appetizing-looking meat balls in the dough.. The main thing is not to think about WHO they are made of!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "vulpix"
 	list_reagents = list("nutriment" = 10, "vitamin" = 4, "protein" = 5)
 	tastes = list("dough" = 2, "dog meat" = 3)
@@ -1175,24 +1204,28 @@
 /obj/item/reagent_containers/food/snacks/vulpix/cheese
 	name = "Cheese vulpixes"
 	desc = "Appetizing-looking meat balls in the dough filled with cheese.. The main thing is not to think about WHO they are made of!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "vulpix_cheese"
 	tastes = list("dough" = 2, "dog meat" = 3, "cheese" = 2)
 
 /obj/item/reagent_containers/food/snacks/vulpix/bacon
 	name = "Bacon and mushroom vulpixes"
 	desc = "Appetizing-looking meat balls in the dough filled with.. The main thing is not to think about WHO they are made of!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "vulpix_bacon"
 	tastes = list("dough" = 2, "dog meat" = 3, "bacon" = 2, "mushroom" = 2)
 
 /obj/item/reagent_containers/food/snacks/vulpix/chilli
 	name = "Chilli vulpixes"
 	desc = "Appetizing-looking meat balls in the dough.. The main thing is not to think about WHO they are made of! Makes your tongue burn."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "vulpix_chillie"
 	tastes = list("dough" = 2, "dog meat" = 3, "chillie" = 2)
 
 /obj/item/reagent_containers/food/snacks/bakedvulp
 	name = "oven-baked vulp"
 	desc = "Oven-baked vulp meat with a juicy apple in the mouth. She was unintelligent... Wasn't she?"
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "bakedvulp"
 	trash = /obj/item/trash/tray
 	list_reagents = list("protein" = 12, "nutriment" = 10, "vitamin" = 5)

--- a/code/modules/food_and_drinks/food/foods/misc.dm
+++ b/code/modules/food_and_drinks/food/foods/misc.dm
@@ -72,6 +72,7 @@
 /obj/item/reagent_containers/food/snacks/aesirsalad
 	name = "aesir salad"
 	desc = "Probably too incredible for mortal men to fully enjoy."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "aesirsalad"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#468C00"
@@ -83,6 +84,7 @@
 /obj/item/reagent_containers/food/snacks/herbsalad
 	name = "herb salad"
 	desc = "A tasty salad with apples on top."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "herbsalad"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#76B87F"
@@ -95,6 +97,7 @@
 	name = "valid salad"
 	desc = "It's just an herb salad with meatballs and fried potato slices. Nothing suspicious about it."
 	icon_state = "validsalad"
+	w_class = WEIGHT_CLASS_SMALL
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#76B87F"
 	bitesize = 3
@@ -105,6 +108,7 @@
 /obj/item/reagent_containers/food/snacks/oliviersalad
 	name = "olivier salad"
 	desc = "Don't touch this, its for the New Year!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "oliviersalad"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#C2CFAB"
@@ -115,6 +119,7 @@
 /obj/item/reagent_containers/food/snacks/vegisalad
 	name = "vegetable salad"
 	desc = "A perfect combination of tomatoes and cucumbers."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "validsalad"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#C2CFAB"
@@ -126,6 +131,7 @@
 /obj/item/reagent_containers/food/snacks/weirdoliviersalad
 	name = "weird olivier salad"
 	desc = "What have you done to this salad, you monster?"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "oliviersalad"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#C2CFAB"
@@ -137,6 +143,7 @@
 /obj/item/reagent_containers/food/snacks/fruitcup
 	name = "Dina's fruit cup"
 	desc = "Single salad with edible plate"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "fruitcup"
 	filling_color = "#C2CFAB"
 	list_reagents = list("nutriment" = 3, "watermelonjuice" = 5, "orangejuice" = 5, "vitamin" = 4)
@@ -147,6 +154,7 @@
 /obj/item/reagent_containers/food/snacks/junglesalad
 	name = "Jungle salad"
 	desc = "From the depths of the jungle."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "junglesalad"
 	filling_color = "#C2CFAB"
 	list_reagents = list("nutriment" = 6, "watermelonjuice" = 3, "vitamin" = 4)
@@ -156,6 +164,7 @@
 /obj/item/reagent_containers/food/snacks/delightsalad
 	name = "Delight salad"
 	desc = "Truly citrus delight."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "delightsalad"
 	filling_color = "#C2CFAB"
 	trash = /obj/item/trash/snack_bowl
@@ -218,9 +227,10 @@
 //  Buckwheat       //
 //////////////////////
 
-/obj/item/reagent_containers/food/snacks/boiledbuckwheat
+/obj/item/reagent_containers/food/snacks/boiledbuckwheat 
 	name = "boiled buckwheat"
 	desc = "'Grechka', or boiled buckwheat. Motherland would be proud of you."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "boiledbuckwheat"
 	trash = /obj/item/trash/plate
 	filling_color = "#8E633C"
@@ -231,6 +241,7 @@
 /obj/item/reagent_containers/food/snacks/buckwheat_merchant
 	name = "merchant's buckwheat porridge"
 	desc = "Hot and steamy, soviet spies are involved. No doubt."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "buckwheat_merchant"
 	trash = /obj/item/trash/plate
 	filling_color = "#8E633C"

--- a/code/modules/food_and_drinks/food/foods/pasta.dm
+++ b/code/modules/food_and_drinks/food/foods/pasta.dm
@@ -6,6 +6,7 @@
 /obj/item/reagent_containers/food/snacks/spaghetti
 	name = "spaghetti"
 	desc = "A bundle of raw spaghetti."
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/pasta.dmi'
 	icon_state = "spaghetti"
 	filling_color = "#EDDD00"
@@ -16,6 +17,7 @@
 /obj/item/reagent_containers/food/snacks/macaroni
 	name = "macaroni twists"
 	desc = "These are little twists of raw macaroni."
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/pasta.dmi'
 	icon_state = "macaroni"
 	filling_color = "#EDDD00"
@@ -31,6 +33,7 @@
 /obj/item/reagent_containers/food/snacks/boiledspaghetti
 	name = "boiled spaghetti"
 	desc = "A plain dish of noodles. This sucks."
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/pasta.dmi'
 	icon_state = "spaghettiboiled"
 	trash = /obj/item/trash/plate
@@ -42,6 +45,7 @@
 /obj/item/reagent_containers/food/snacks/pastatomato
 	name = "spaghetti"
 	desc = "Spaghetti and crushed tomatoes. Just like your abusive father used to make!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/pasta.dmi'
 	icon_state = "pastatomato"
 	trash = /obj/item/trash/plate
@@ -54,6 +58,7 @@
 /obj/item/reagent_containers/food/snacks/meatballspaghetti
 	name = "spaghetti & meatballs"
 	desc = "Now thats a nice'a meatball!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/pasta.dmi'
 	icon_state = "meatballspaghetti"
 	trash = /obj/item/trash/plate
@@ -65,6 +70,7 @@
 /obj/item/reagent_containers/food/snacks/spesslaw
 	name = "spesslaw"
 	desc = "A lawyer's favourite."
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/pasta.dmi'
 	icon_state = "spesslaw"
 	filling_color = "#DE4545"
@@ -76,6 +82,7 @@
 /obj/item/reagent_containers/food/snacks/macncheese
 	name = "mac 'n' cheese"
 	desc = "One of the most comforting foods in the world. Apparently."
+	w_class = WEIGHT_CLASS_SMALL
 	trash = /obj/item/trash/snack_bowl
 	icon = 'icons/obj/food/pasta.dmi'
 	icon_state = "macncheese"
@@ -87,6 +94,7 @@
 /obj/item/reagent_containers/food/snacks/lasagna
 	name = "Lasagna"
 	desc = "Tajara are supposed to love to eat this, but the tomato really doesn't work well."
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/pasta.dmi'
 	icon_state = "lasagna"
 	filling_color = "#E18712"
@@ -97,6 +105,7 @@
 /obj/item/reagent_containers/food/snacks/chowmein
 	name = "Chowmein"
 	desc = "Nihao!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "chowmein"
 	trash = /obj/item/trash/plate
 	list_reagents = list("nutriment" = 6, "protein" = 6)
@@ -107,6 +116,7 @@
 /obj/item/reagent_containers/food/snacks/beefnoodles
 	name = "Beef noodles"
 	desc = "So simple, but so yummy!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "beefnoodles"
 	trash = /obj/item/trash/snack_bowl
 	list_reagents = list("nutriment" = 3, "protein" = 5, "plantmatter" = 3)

--- a/code/modules/food_and_drinks/food/foods/pizza.dm
+++ b/code/modules/food_and_drinks/food/foods/pizza.dm
@@ -13,6 +13,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/pizza/margherita
 	name = "margherita pizza"
 	desc = "The golden standard of pizzas."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "pizzamargherita"
 	slice_path = /obj/item/reagent_containers/food/snacks/margheritaslice
 	list_reagents = list("nutriment" = 30, "tomatojuice" = 6, "vitamin" = 5)
@@ -20,6 +21,7 @@
 /obj/item/reagent_containers/food/snacks/margheritaslice
 	name = "margherita slice"
 	desc = "A slice of the classic pizza."
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/pizza.dmi'
 	icon_state = "pizzamargheritaslice"
 	filling_color = "#BAA14C"
@@ -29,6 +31,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/pizza/meatpizza
 	name = "meat pizza"
 	desc = "A pizza with meat topping."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "meatpizza"
 	slice_path = /obj/item/reagent_containers/food/snacks/meatpizzaslice
 	list_reagents = list("protein" = 30, "tomatojuice" = 6, "vitamin" = 8)
@@ -38,6 +41,7 @@
 /obj/item/reagent_containers/food/snacks/meatpizzaslice
 	name = "meat pizza slice"
 	desc = "A slice of a meaty pizza."
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/pizza.dmi'
 	icon_state = "meatpizzaslice"
 	filling_color = "#BAA14C"
@@ -46,6 +50,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/pizza/mushroompizza
 	name = "mushroom pizza"
 	desc = "Very special pizza."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "mushroompizza"
 	slice_path = /obj/item/reagent_containers/food/snacks/mushroompizzaslice
 	list_reagents = list("plantmatter" = 30, "vitamin" = 5)
@@ -56,6 +61,7 @@
 /obj/item/reagent_containers/food/snacks/mushroompizzaslice
 	name = "mushroom pizza slice"
 	desc = "Maybe it is the last slice of pizza in your life."
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/pizza.dmi'
 	icon_state = "mushroompizzaslice"
 	filling_color = "#BAA14C"
@@ -65,6 +71,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/pizza/vegetablepizza
 	name = "vegetable pizza"
 	desc = "No Tomato Sapiens were harmed during the making of this pizza."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "vegetablepizza"
 	slice_path = /obj/item/reagent_containers/food/snacks/vegetablepizzaslice
 	list_reagents = list("plantmatter" = 25, "tomatojuice" = 6, "oculine" = 12, "vitamin" = 5)
@@ -75,6 +82,7 @@
 /obj/item/reagent_containers/food/snacks/vegetablepizzaslice
 	name = "vegetable pizza slice"
 	desc = "A slice of the most green pizza of all pizzas not containing green ingredients."
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/pizza.dmi'
 	icon_state = "vegetablepizzaslice"
 	filling_color = "#BAA14C"
@@ -84,6 +92,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/pizza/hawaiianpizza
 	name = "hawaiian pizza"
 	desc = "Love it or hate it, this pizza divides opinions. Complete with juicy pineapple."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "hawaiianpizza" //NEEDED
 	slice_path = /obj/item/reagent_containers/food/snacks/hawaiianpizzaslice
 	list_reagents = list("protein" = 15, "tomatojuice" = 6, "plantmatter" = 20, "pineapplejuice" = 6, "vitamin" = 5)
@@ -93,6 +102,7 @@
 /obj/item/reagent_containers/food/snacks/hawaiianpizzaslice
 	name = "hawaiian pizza slice"
 	desc = "A slice of polarising pizza."
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/pizza.dmi'
 	icon_state = "hawaiianpizzaslice"
 	filling_color = "#e5b437"
@@ -102,6 +112,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/pizza/macpizza
 	name = "mac 'n' cheese pizza"
 	desc = "Gastronomists have yet to classify this dish as 'pizza'."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "macpizza"
 	slice_path = /obj/item/reagent_containers/food/snacks/macpizzaslice
 	list_reagents = list("nutriment" = 40, "vitamin" = 5) //More nutriment because carbs, but it's not any more vitaminicious
@@ -112,6 +123,7 @@
 /obj/item/reagent_containers/food/snacks/macpizzaslice
 	name = "mac 'n' cheese pizza slice"
 	desc = "A delicious slice of pizza topped with macaroni & cheese... wait, what the hell? Who would do this?!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/pizza.dmi'
 	icon_state = "macpizzaslice"
 	filling_color = "#ffe45d"
@@ -121,6 +133,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/pizza/seafood
 	name = "seafood pizza"
 	desc = "Gifts of cosmic lakes, cheese and a little sourness."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "fishpizza"
 	slice_path = /obj/item/reagent_containers/food/snacks/seapizzaslice
 	list_reagents = list("nutriment" = 30, "vitamin" = 15, "protein" = 15)
@@ -131,6 +144,7 @@
 /obj/item/reagent_containers/food/snacks/seapizzaslice
 	name = "seafood pizza slice"
 	desc = "A delicious slice of pizza topped with seafood & cheese..."
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/pizza.dmi'
 	icon_state = "fishpizzaslice"
 	filling_color = "#ffe45d"
@@ -140,6 +154,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/pizza/bacon
 	name = "bacon and mushrooms pizza"
 	desc = "A classic pizza, one of the ingredients was replaced with fried bacon"
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "baconpizza"
 	slice_path = /obj/item/reagent_containers/food/snacks/baconpizzaslice
 	list_reagents = list("nutriment" = 40, "vitamin" = 5, "protein" = 15)
@@ -150,6 +165,7 @@
 /obj/item/reagent_containers/food/snacks/baconpizzaslice
 	name = "bacon and mushrooms pizza slice"
 	desc = "A delicious slice of pizza topped with bacon & mushrooms..."
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/pizza.dmi'
 	icon_state = "baconpizzaslice"
 	filling_color = "#ffe45d"
@@ -159,6 +175,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/pizza/tajaroni
 	name = "tajaroni pizza"
 	desc = "Spicy tayaroni sausages covered with cheese, and olives.. Which of these is more terrible has yet to be decided."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "tajarpizza"
 	slice_path = /obj/item/reagent_containers/food/snacks/tajpizzaslice
 	list_reagents = list("nutriment" = 30, "vitamin" = 15, "protein" = 15)
@@ -169,6 +186,7 @@
 /obj/item/reagent_containers/food/snacks/tajpizzaslice
 	name = "tajaroni pizza slice"
 	desc = "A delicious slice of pizza topped with tajaroni & olives..."
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/pizza.dmi'
 	icon_state = "tajarpizzaslice"
 	filling_color = "#ffe45d"
@@ -178,6 +196,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/pizza/diablo
 	name = "diablo pizza"
 	desc = "Incredibly burning pizza with meat pieces, some say it can send you to the redspace."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "diablopizza"
 	slice_path = /obj/item/reagent_containers/food/snacks/diablopizzaslice
 	list_reagents = list("nutriment" = 30, "vitamin" = 15, "protein" = 15, "capsaicin" = 15)
@@ -188,6 +207,7 @@
 /obj/item/reagent_containers/food/snacks/diablopizzaslice
 	name = "diablo pizza slice"
 	desc = "A delicious slice of pizza topped with diablo sauce & meat..."
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/pizza.dmi'
 	icon_state = "diablopizzaslice"
 	filling_color = "#ffe45d"

--- a/code/modules/food_and_drinks/food/foods/sandwiches.dm
+++ b/code/modules/food_and_drinks/food/foods/sandwiches.dm
@@ -6,6 +6,7 @@
 /obj/item/reagent_containers/food/snacks/brainburger
 	name = "brainburger"
 	desc = "A strange looking burger. It appears almost sentient."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "brainburger"
 	filling_color = "#F2B6EA"
 	bitesize = 3
@@ -17,6 +18,7 @@
 /obj/item/reagent_containers/food/snacks/ghostburger
 	name = "ghost burger"
 	desc = "Spooky! It doesn't look very filling."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "ghostburger"
 	filling_color = "#FFF2FF"
 	bitesize = 3
@@ -27,6 +29,7 @@
 /obj/item/reagent_containers/food/snacks/human_burger
 	name = "-burger"
 	desc = "A bloody burger."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "hburger"
 	filling_color = "#D63C3C"
 	bitesize = 3
@@ -37,6 +40,7 @@
 /obj/item/reagent_containers/food/snacks/cheeseburger
 	name = "cheeseburger"
 	desc = "The cheese adds a good flavor."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "cheeseburger"
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
@@ -46,6 +50,7 @@
 /obj/item/reagent_containers/food/snacks/monkeyburger
 	name = "burger"
 	desc = "The cornerstone of every nutritious breakfast."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "hburger"
 	filling_color = "#D63C3C"
 	bitesize = 3
@@ -56,6 +61,7 @@
 /obj/item/reagent_containers/food/snacks/tofuburger
 	name = "tofu burger"
 	desc = "Making this should probably be a criminal offense."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "tofuburger"
 	filling_color = "#FFFEE0"
 	bitesize = 3
@@ -66,6 +72,7 @@
 /obj/item/reagent_containers/food/snacks/roburger
 	name = "roburger"
 	desc = "The lettuce is the only organic component. Beep."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "roburger"
 	filling_color = "#CCCCCC"
 	bitesize = 3
@@ -77,6 +84,7 @@
 /obj/item/reagent_containers/food/snacks/roburgerbig
 	name = "roburger"
 	desc = "This massive patty looks like poison. Beep."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "roburger"
 	filling_color = "#CCCCCC"
 	volume = 120
@@ -89,6 +97,7 @@
 /obj/item/reagent_containers/food/snacks/xenoburger
 	name = "xenoburger"
 	desc = "Smells caustic and tastes like heresy."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "xburger"
 	filling_color = "#43DE18"
 	bitesize = 3
@@ -99,6 +108,7 @@
 /obj/item/reagent_containers/food/snacks/clownburger
 	name = "clown burger"
 	desc = "This tastes funny..."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "clownburger"
 	filling_color = "#FF00FF"
 	bitesize = 3
@@ -109,6 +119,7 @@
 /obj/item/reagent_containers/food/snacks/mimeburger
 	name = "mime burger"
 	desc = "Its taste defies language."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "mimeburger"
 	filling_color = "#FFFFFF"
 	bitesize = 3
@@ -119,6 +130,7 @@
 /obj/item/reagent_containers/food/snacks/baseballburger
 	name = "home run baseball burger"
 	desc = "It's still warm. Batter up!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "baseball"
 	filling_color = "#CD853F"
 	bitesize = 3
@@ -129,6 +141,7 @@
 /obj/item/reagent_containers/food/snacks/spellburger
 	name = "spell burger"
 	desc = "This is absolutely Ei Nath."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "spellburger"
 	filling_color = "#D505FF"
 	bitesize = 3
@@ -139,6 +152,7 @@
 /obj/item/reagent_containers/food/snacks/bigbiteburger
 	name = "BigBite burger"
 	desc = "Forget the Big Mac, THIS is the future!"
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "bigbiteburger"
 	filling_color = "#E3D681"
 	bitesize = 3
@@ -149,6 +163,7 @@
 /obj/item/reagent_containers/food/snacks/superbiteburger
 	name = "SuperBite burger"
 	desc = "This is a mountain of a burger. FOOD!"
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "superbiteburger"
 	filling_color = "#CCA26A"
 	bitesize = 7
@@ -159,6 +174,7 @@
 /obj/item/reagent_containers/food/snacks/jellyburger
 	name = "jelly burger"
 	desc = "Culinary delight...?"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "jellyburger"
 	filling_color = "#B572AB"
 	bitesize = 3
@@ -181,6 +197,7 @@
 	name = "sandwich"
 	desc = "A grand creation of meat, cheese, bread, and several leaves of lettuce! Arthur Dent would be proud."
 	icon_state = "sandwich"
+	w_class = WEIGHT_CLASS_SMALL
 	trash = /obj/item/trash/plate
 	filling_color = "#D9BE29"
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
@@ -190,6 +207,7 @@
 /obj/item/reagent_containers/food/snacks/toastedsandwich
 	name = "toasted sandwich"
 	desc = "Now if you only had a pepper bar."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "toastedsandwich"
 	trash = /obj/item/trash/plate
 	filling_color = "#D9BE29"
@@ -200,6 +218,7 @@
 /obj/item/reagent_containers/food/snacks/grilledcheese
 	name = "grilled cheese sandwich"
 	desc = "Goes great with tomato soup!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "toastedsandwich"
 	trash = /obj/item/trash/plate
 	filling_color = "#D9BE29"
@@ -210,6 +229,7 @@
 /obj/item/reagent_containers/food/snacks/jellysandwich
 	name = "jelly sandwich"
 	desc = "You wish you had some peanut butter to go with this..."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "jellysandwich"
 	trash = /obj/item/trash/plate
 	filling_color = "#9E3A78"
@@ -227,6 +247,7 @@
 /obj/item/reagent_containers/food/snacks/notasandwich
 	name = "not-a-sandwich"
 	desc = "Something seems to be wrong with this, you can't quite figure what. Maybe it's his moustache."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "notasandwich"
 	list_reagents = list("nutriment" = 6, "vitamin" = 6)
 	tastes = list("nothing suspicious" = 1)
@@ -235,6 +256,7 @@
 /obj/item/reagent_containers/food/snacks/wrap
 	name = "egg wrap"
 	desc = "The precursor to Pigs in a Blanket."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "wrap"
 	list_reagents = list("nutriment" = 5)
 	tastes = list("egg" = 1)

--- a/code/modules/food_and_drinks/food/foods/seafood.dm
+++ b/code/modules/food_and_drinks/food/foods/seafood.dm
@@ -157,6 +157,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/Ebi_maki
 	name = "ebi maki roll"
 	desc = "A large unsliced roll of Ebi Sushi."
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "Ebi_maki"
 	slice_path = /obj/item/reagent_containers/food/snacks/sushi_Ebi
@@ -179,6 +180,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/Ikura_maki
 	name = "ikura maki roll"
 	desc = "A large unsliced roll of Ikura Sushi."
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "Ikura_maki"
 	slice_path = /obj/item/reagent_containers/food/snacks/sushi_Ikura
@@ -201,6 +203,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/Sake_maki
 	name = "sake maki roll"
 	desc = "A large unsliced roll of Sake Sushi."
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "Sake_maki"
 	slice_path = /obj/item/reagent_containers/food/snacks/sushi_Sake
@@ -223,6 +226,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/SmokedSalmon_maki
 	name = "smoked salmon maki roll"
 	desc = "A large unsliced roll of Smoked Salmon Sushi."
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "SmokedSalmon_maki"
 	slice_path = /obj/item/reagent_containers/food/snacks/sushi_SmokedSalmon
@@ -245,6 +249,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/Tamago_maki
 	name = "tamago maki roll"
 	desc = "A large unsliced roll of Tamago Sushi."
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "Tamago_maki"
 	slice_path = /obj/item/reagent_containers/food/snacks/sushi_Tamago
@@ -267,6 +272,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/Inari_maki
 	name = "inari maki roll"
 	desc = "A large unsliced roll of Inari Sushi."
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "Inari_maki"
 	slice_path = /obj/item/reagent_containers/food/snacks/sushi_Inari
@@ -289,6 +295,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/Masago_maki
 	name = "masago maki roll"
 	desc = "A large unsliced roll of Masago Sushi."
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "Masago_maki"
 	slice_path = /obj/item/reagent_containers/food/snacks/sushi_Masago
@@ -311,6 +318,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/Tobiko_maki
 	name = "tobiko maki roll"
 	desc = "A large unsliced roll of Tobkio Sushi."
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "Tobiko_maki"
 	slice_path = /obj/item/reagent_containers/food/snacks/sushi_Tobiko
@@ -355,6 +363,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/Tai_maki
 	name = "tai maki roll"
 	desc = "A large unsliced roll of Tai Sushi."
+	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "Tai_maki"
 	slice_path = /obj/item/reagent_containers/food/snacks/sushi_Tai

--- a/code/modules/food_and_drinks/food/foods/side_dishes.dm
+++ b/code/modules/food_and_drinks/food/foods/side_dishes.dm
@@ -20,6 +20,7 @@
 /obj/item/reagent_containers/food/snacks/fries
 	name = "space fries"
 	desc = "AKA: French Fries, Freedom Fries, etc."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "fries"
 	trash = /obj/item/trash/plate
 	filling_color = "#EDDD00"
@@ -30,6 +31,7 @@
 /obj/item/reagent_containers/food/snacks/cheesyfries
 	name = "cheesy fries"
 	desc = "Fries. Covered in cheese. Duh."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "cheesyfries"
 	trash = /obj/item/trash/plate
 	filling_color = "#EDDD00"
@@ -59,6 +61,7 @@
 /obj/item/reagent_containers/food/snacks/carrotfries
 	name = "carrot fries"
 	desc = "Tasty fries from fresh carrots."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "carrotfries"
 	trash = /obj/item/trash/plate
 	filling_color = "#FAA005"
@@ -101,6 +104,7 @@
 /obj/item/reagent_containers/food/snacks/loadedbakedpotato
 	name = "loaded baked potato"
 	desc = "Totally baked."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "loadedbakedpotato"
 	filling_color = "#9C7A68"
 	list_reagents = list("nutriment" = 6)
@@ -110,6 +114,7 @@
 /obj/item/reagent_containers/food/snacks/boiledrice
 	name = "boiled rice"
 	desc = "A boring dish of boring rice."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "boiledrice"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#FFFBDB"
@@ -120,6 +125,7 @@
 /obj/item/reagent_containers/food/snacks/roastparsnip
 	name = "roast parsnip"
 	desc = "Sweet and crunchy."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "roastparsnip"
 	trash = /obj/item/trash/plate
 	list_reagents = list("nutriment" = 3, "vitamin" = 4)
@@ -130,6 +136,7 @@
 /obj/item/reagent_containers/food/snacks/plov
 	name = "Plov"
 	desc = "Mix of rice and vegetables."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "plov"
 	trash = /obj/item/trash/plate
 	list_reagents = list("nutriment" = 6, "protein" = 6, "plantmatter" = 6)

--- a/code/modules/food_and_drinks/food/foods/soups.dm
+++ b/code/modules/food_and_drinks/food/foods/soups.dm
@@ -6,6 +6,7 @@
 /obj/item/reagent_containers/food/snacks/soup
 	name = "impossible soup"
 	desc = "This soup is so good, it shouldn't even exist!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "beans" // If you don't have a sprite, you get beans.
 	consume_sound = 'sound/items/drink.ogg'
 	trash = /obj/item/trash/snack_bowl
@@ -14,6 +15,7 @@
 /obj/item/reagent_containers/food/snacks/soup/meatballsoup
 	name = "meatball soup"
 	desc = "You've got balls kid, BALLS!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "meatballsoup"
 	filling_color = "#785210"
 	list_reagents = list("nutriment" = 8, "water" = 5, "vitamin" = 4)
@@ -23,6 +25,7 @@
 /obj/item/reagent_containers/food/snacks/soup/slimesoup
 	name = "slime soup"
 	desc = "If no water is available, you may substitute tears."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "slimesoup"
 	filling_color = "#C4DBA0"
 	list_reagents = list("nutriment" = 5, "slimejelly" = 5, "water" = 5, "vitamin" = 4)
@@ -32,6 +35,7 @@
 /obj/item/reagent_containers/food/snacks/soup/bloodsoup
 	name = "tomato soup"
 	desc = "Smells like copper."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "tomatosoup"
 	filling_color = "#FF0000"
 	list_reagents = list("nutriment" = 2, "blood" = 10, "water" = 5, "vitamin" = 4)
@@ -41,6 +45,7 @@
 /obj/item/reagent_containers/food/snacks/soup/clownstears
 	name = "clown's tears"
 	desc = "Not very funny."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "clownstears"
 	filling_color = "#C4FBFF"
 	list_reagents = list("nutriment" = 4, "banana" = 5, "water" = 5, "vitamin" = 8)
@@ -49,6 +54,7 @@
 /obj/item/reagent_containers/food/snacks/soup/vegetablesoup
 	name = "vegetable soup"
 	desc = "A true vegan meal."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "vegetablesoup"
 	filling_color = "#AFC4B5"
 	list_reagents = list("nutriment" = 8, "water" = 5, "vitamin" = 4)
@@ -58,6 +64,7 @@
 /obj/item/reagent_containers/food/snacks/soup/nettlesoup
 	name = "nettle soup"
 	desc = "To think, the botanist would've beaten you to death with one of these."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "nettlesoup"
 	filling_color = "#AFC4B5"
 	list_reagents = list("nutriment" = 8, "water" = 5, "vitamin" = 4)
@@ -67,6 +74,7 @@
 /obj/item/reagent_containers/food/snacks/soup/mysterysoup
 	name = "mystery soup"
 	desc = "The mystery is, why aren't you eating it?"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "mysterysoup"
 	var/extra_reagent = null
 	list_reagents = list("nutriment" = 6)
@@ -80,6 +88,7 @@
 /obj/item/reagent_containers/food/snacks/soup/wishsoup
 	name = "wish soup"
 	desc = "I wish this was soup."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "wishsoup"
 	filling_color = "#D1F4FF"
 	list_reagents = list("water" = 10)
@@ -95,6 +104,7 @@
 /obj/item/reagent_containers/food/snacks/soup/tomatosoup
 	name = "tomato soup"
 	desc = "Drinking this feels like being a vampire! A tomato vampire..."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "tomatosoup"
 	filling_color = "#D92929"
 	list_reagents = list("nutriment" = 5, "tomatojuice" = 10, "vitamin" = 3)
@@ -104,6 +114,7 @@
 /obj/item/reagent_containers/food/snacks/soup/misosoup
 	name = "miso soup"
 	desc = "The universe's best soup! Yum!!!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "misosoup"
 	list_reagents = list("nutriment" = 7, "vitamin" = 2)
 	foodtype = VEGETABLES
@@ -112,6 +123,7 @@
 /obj/item/reagent_containers/food/snacks/soup/mushroomsoup
 	name = "chantrelle soup"
 	desc = "A delicious and hearty mushroom soup."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "mushroomsoup"
 	filling_color = "#E386BF"
 	list_reagents = list("nutriment" = 8, "vitamin" = 4)
@@ -121,6 +133,7 @@
 /obj/item/reagent_containers/food/snacks/soup/beetsoup
 	name = "beet soup"
 	desc = "Wait, how do you spell it again..?"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "beetsoup"
 	filling_color = "#FAC9FF"
 	list_reagents = list("nutriment" = 7, "vitamin" = 2)
@@ -134,6 +147,7 @@
 /obj/item/reagent_containers/food/snacks/soup/rassolnik
 	name = "pickle soup"
 	desc = "Quite popular in USSP."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "rassolnik"
 	filling_color = "#F1FC72"
 	list_reagents = list("nutriment" = 6, "kelotane" = 1, "vitamin" = 2)
@@ -143,6 +157,7 @@
 /obj/item/reagent_containers/food/snacks/soup/shavelsoup
 	name = "shavel soup"
 	desc = "Light soup with fresh shavel and vegetables."
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "shavelsoup"
 	filling_color = "#135f13"
 	list_reagents = list("nutriment" = 4, "water" = 5, "vitamin" = 5)
@@ -154,6 +169,7 @@
 /obj/item/reagent_containers/food/snacks/soup/stew
 	name = "stew"
 	desc = "A nice and warm stew. Healthy and strong."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "stew"
 	filling_color = "#9E673A"
 	bitesize = 7
@@ -164,6 +180,7 @@
 /obj/item/reagent_containers/food/snacks/soup/stewedsoymeat
 	name = "stewed soy meat"
 	desc = "Even non-vegetarians will LOVE this!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "stewedsoymeat"
 	trash = /obj/item/trash/plate
 	list_reagents = list("nutriment" = 8)
@@ -177,6 +194,7 @@
 /obj/item/reagent_containers/food/snacks/soup/hotchili
 	name = "hot chili"
 	desc = "A five alarm Texan Chili!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "hotchili"
 	filling_color = "#FF3C00"
 	list_reagents = list("nutriment" = 5, "capsaicin" = 1, "tomatojuice" = 2, "vitamin" = 2)
@@ -186,6 +204,7 @@
 /obj/item/reagent_containers/food/snacks/soup/coldchili
 	name = "cold chili"
 	desc = "This slush is barely a liquid!"
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "coldchili"
 	filling_color = "#2B00FF"
 	list_reagents = list("nutriment" = 5, "frostoil" = 1, "tomatojuice" = 2, "vitamin" = 2)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание

у всей еды теперь есть размер, зависит он от размера спрайта.
Раньше у всей еды был крохотный размер.
Буквально огромный торт имел размер кусочка торта что не правильно на мой взгляд.
## Причина создания ПР / Почему это хорошо для игры

Баланс еды, что бы нельзя было таскать так много хавки.
Предлога точно нужна то?
![image](https://github.com/user-attachments/assets/a2289cdb-5691-4df1-9c8f-182dd265e996)


## Тесты

Запустил локалку, все работает
