### PR TITLE
add: Добавление настольного звонка к инвалидной коляске

### DIFF
--- a/code/modules/vehicle/wheelchair.dm
+++ b/code/modules/vehicle/wheelchair.dm
@@ -19,6 +19,9 @@
 	var/material_type = /obj/item/stack/sheet/metal
 	var/decon_speed = 3
 	var/kit_applied = FALSE
+	var/exists_bell = FALSE
+	//Actions
+	var/datum/action/innate/wheelchair/bell_action = new
 
 /obj/vehicle/ridden/wheelchair/Initialize(mapload)
 	. = ..()
@@ -74,3 +77,49 @@
 /obj/vehicle/ridden/wheelchair/update_desc(updates = ALL)
 	. = ..()
 	desc = applied_skin ? initial(applied_skin.new_desc) : initial(desc)
+	if (exists_bell)
+		desc += " К подлокотнику зачем-то прикреплен звонок."
+
+/obj/vehicle/ridden/wheelchair/attackby(obj/item/item, mob/user, params)
+	if(!istype(item, /obj/item/desk_bell))
+		. = ..()
+		return
+	if(exists_bell)
+		return ATTACK_CHAIN_PROCEED
+	to_chat(user, span_notice("Вы начинаете прикреплять [item.declent_ru(ACCUSATIVE)] к [declent_ru(PREPOSITIONAL)]..."))
+	if (!do_after(user, 2 SECONDS, src))
+		return ATTACK_CHAIN_PROCEED
+	user.balloon_alert(user, "прикреплено")
+	exists_bell = TRUE
+	update_desc()
+	qdel(item)
+	return ATTACK_CHAIN_PROCEED
+
+/obj/vehicle/ridden/wheelchair/post_unbuckle_mob(mob/living/user)
+	if (exists_bell)
+		bell_action.Remove(user)
+	return ..()
+
+/obj/vehicle/ridden/wheelchair/post_buckle_mob(mob/living/user)
+	if (exists_bell)
+		bell_action.Grant(user, src)
+	return ..()
+
+/datum/action/innate/wheelchair
+	check_flags = AB_CHECK_HANDS_BLOCKED|AB_CHECK_CONSCIOUS|AB_CHECK_INCAPACITATED
+	icon_icon = 'icons/obj/bureaucracy.dmi'
+	button_icon_state = "desk_bell"
+	name = "Звонок"
+	var/obj/vehicle/ridden/wheelchair/wheelchair
+
+/datum/action/innate/wheelchair/Grant(mob/living/L, obj/vehicle/ridden/wheelchair/W)
+	if(W)
+		wheelchair = W
+	. = ..()
+
+/datum/action/innate/wheelchair/Destroy()
+	wheelchair = null
+	return ..()
+
+/datum/action/innate/wheelchair/Activate()
+	playsound(wheelchair, "sound/machines/bell.ogg", 70, extrarange = SHORT_RANGE_SOUND_EXTRARANGE)

--- a/code/modules/vehicle/wheelchair.dm
+++ b/code/modules/vehicle/wheelchair.dm
@@ -20,7 +20,7 @@
 	var/decon_speed = 3
 	var/kit_applied = FALSE
 	var/exists_bell = FALSE
-	//Actions
+	///Actions
 	var/datum/action/innate/wheelchair/bell_action = new
 
 /obj/vehicle/ridden/wheelchair/Initialize(mapload)
@@ -78,7 +78,7 @@
 	. = ..()
 	desc = applied_skin ? initial(applied_skin.new_desc) : initial(desc)
 	if (exists_bell)
-		desc += " К подлокотнику зачем-то прикреплен звонок."
+		desc += " К подлокотнику зачем-то прикреплён звонок."
 
 /obj/vehicle/ridden/wheelchair/attackby(obj/item/item, mob/user, params)
 	if(!istype(item, /obj/item/desk_bell))
@@ -106,10 +106,10 @@
 	return ..()
 
 /datum/action/innate/wheelchair
-	check_flags = AB_CHECK_HANDS_BLOCKED|AB_CHECK_CONSCIOUS|AB_CHECK_INCAPACITATED
+	name = "Звонок"
 	icon_icon = 'icons/obj/bureaucracy.dmi'
 	button_icon_state = "desk_bell"
-	name = "Звонок"
+	check_flags = AB_CHECK_HANDS_BLOCKED|AB_CHECK_CONSCIOUS|AB_CHECK_INCAPACITATED
 	var/obj/vehicle/ridden/wheelchair/wheelchair
 
 /datum/action/innate/wheelchair/Grant(mob/living/L, obj/vehicle/ridden/wheelchair/W)

--- a/code/modules/vehicle/wheelchair.dm
+++ b/code/modules/vehicle/wheelchair.dm
@@ -32,6 +32,7 @@
 /obj/vehicle/ridden/wheelchair/Destroy()
 	chair_overlay = null
 	applied_skin = null
+	QDEL_NULL(bell_action)
 	return ..()
 
 /obj/vehicle/ridden/wheelchair/proc/on_skin_apply(obj/item/fluff/rapid_wheelchair_kit/kit, mob/user)


### PR DESCRIPTION
## Описание

Позволяет крепить настольный звонок к инвалидной коляске. Крепление происходит ударом колокольчика в руках по коляске. Процесс занимает 2 секунды.
После прикрепления немного меняется описание самой коляски.
Звонок происходит через дополнительную UI кнопку справа-сверху.

## Причина создания ПР / Почему это хорошо для игры

Предложка
https://discord.com/channels/617003227182792704/618952559607939072/1392039566344720485

*Надо подождать пока предложка пройдет, а пока можно поменять если что не так*

## Тесты
Проверил на локалке, все работает, багов никаких не обнаружено. Ни на что другое кроме коляски никак не влияет.