### PR TITLE
bugfix: Исправлен баг со спрайтом инвалидной коляски

### DIFF
--- a/code/modules/vehicle/wheelchair.dm
+++ b/code/modules/vehicle/wheelchair.dm
@@ -11,6 +11,7 @@
 	)
 	icon = 'icons/obj/chairs.dmi'
 	icon_state = "wheelchair"
+	base_icon_state = "wheelchair"
 	/// Overlay used to overlap buckled mob.
 	var/mutable_appearance/chair_overlay
 	/// Currently applied skin, it contains path, not an instance.


### PR DESCRIPTION

## Описание
Исправлен баг возникающий со спрайтом инвалидной коляски.
баг был добавлен во время рефактора или во время добавления золотого скина на коляску, забыли назначит переменную base_icon_state, из-за этого там был null и в переопределенном локе `update_icon_state` исчезал спрайт коляски без скина и оставался лишь оверлей ручек.

## Причина создания ПР / Почему это хорошо для игры

Багрепорт
<img width="770" height="456" alt="image" src="https://github.com/user-attachments/assets/dd672093-78fd-4885-a3e3-eca1c6ab388e" />

## Тесты
Проверил все работает, ничего дополнительно не сломал, честно.