### PR TITLE
bugfix: Хранилища сьютов теперь могут хранить предметы для которых были предназначены

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -346,7 +346,7 @@
 	. = FALSE
 	if(panel_open)
 		return .
-	if(istype(I, /obj/item/clothing/suit/space) && !suit)
+	if((istype(I, /obj/item/clothing/suit/space) || istype(I, suit_type)) && !suit)
 		. = user.drop_transfer_item_to_loc(I, src)
 		if(.)
 			suit = I
@@ -362,7 +362,7 @@
 		. = user.drop_transfer_item_to_loc(I, src)
 		if(.)
 			magboots = I
-	else if((istype(I, /obj/item/tank)) && !storage)
+	else if((istype(I, /obj/item/tank) || istype(I, storage_type)) && !storage)
 		. = user.drop_transfer_item_to_loc(I, src)
 		if(.)
 			storage = I


### PR DESCRIPTION
## Описание

Хранилища сьютов при инициализации создают suit согласно полю `suit_type`, а для того чтобы засунуть обратно используется тип `/obj/item/clothing/suit/space`, поэтому для хранилищ шахтеров, сьюты которых не являются наследниками данного типа, засунуть обратно никак не получится.
Добавил дополнительную проверку на то что предмет является типом `suit_type` при попытке засунуть предмет.
Теперь специализированные хранилища сьютов позволят засунуть обратно предметы для которых создавались.

## Причина создания ПР / Почему это хорошо для игры
<img width="1179" height="563" alt="image" src="https://github.com/user-attachments/assets/4ac5b441-ba54-4262-a01b-08a7420f185e" />


## Демонстрация изменений

https://github.com/user-attachments/assets/18ac9d61-deb5-4f2d-874c-8e965fca8852



