### PR TITLE
bugfix: Исправление бага со спрайтами шахтерских зарядов

### DIFF
--- a/code/modules/mining/equipment/mining_charges.dm
+++ b/code/modules/mining/equipment/mining_charges.dm
@@ -133,6 +133,9 @@
 		M.gib()
 	qdel(src)
 
+/obj/item/grenade/plastic/update_icon_state()
+	return //Remove plastic icon_state change logic override
+
 
 /obj/item/grenade/plastic/miningcharge/proc/override_safety()
 	hacked = TRUE


### PR DESCRIPTION

## Описание

Баг возникал из-за переопределения прока `update_icon_state` в `obj/item/grenade/plastic`, там к `icon_state` добавлялся суффикс 0/1 в зависимости от некоторого состояния. Таких спрайтов для miningcharge не существует, и сомневаюсь что такая логика нужна для зарядов. Переопределил прок чтобы убрать ненужную логику.

## Причина создания ПР / Почему это хорошо для игры
Багрепорт
<img width="789" height="558" alt="image" src="https://github.com/user-attachments/assets/934de2de-32a3-4966-865a-af3b749d0382" />

## Тесты

Заряды при броске не теряют свои спрайты, при закладке работает все хорошо - спрайт меняется на активированную через оверлеи.
