### PR TITLE
qol: Убрал анимацию появления радиального меню для быстрого доступа с поясов

### DIFF
--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -72,6 +72,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	var/hudfix_method = TRUE //TRUE to change anchor to user, FALSE to shift by py_shift
 	var/py_shift = 0
 	var/entry_animation = TRUE
+	var/anim_speed = ANIM_SPEED
 
 //If we swap to vis_contens inventory these will need a redo
 /datum/radial_menu/proc/check_screen_border(mob/user)
@@ -168,7 +169,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	var/py = round(cos(angle) * radius) + py_shift
 	var/px = round(sin(angle) * radius)
 	if(anim)
-		var/timing = anim_order * ANIM_SPEED
+		var/timing = anim_order * anim_speed
 		var/matrix/starting = matrix()
 		starting.Scale(0.1, 0.1)
 		E.transform = starting
@@ -290,7 +291,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	Choices should be a list where list keys are movables or text used for element names and return value
 	and list values are movables/icons/images used for element icons
 */
-/proc/show_radial_menu(mob/user, atom/anchor, list/choices, uniqueid, radius, datum/callback/custom_check, require_near = FALSE)
+/proc/show_radial_menu(mob/user, atom/anchor, list/choices, uniqueid, radius, datum/callback/custom_check, require_near = FALSE, anim_speed = ANIM_SPEED)
 	if(!user || !anchor || !length(choices))
 		return
 	if(!uniqueid)
@@ -306,6 +307,10 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	if(istype(custom_check))
 		menu.custom_check_callback = custom_check
 	menu.anchor = anchor
+	if(anim_speed > 0)
+		menu.anim_speed = anim_speed
+	else
+		menu.entry_animation = FALSE
 	menu.check_screen_border(user) //Do what's needed to make it look good near borders or on hud
 	menu.set_choices(choices)
 	menu.show_to(user)

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -55,7 +55,7 @@
 	return null
 
 /obj/item/storage/belt/proc/select_item_by_radial_menu(mob/user, list/choices)
-	var/choice = show_radial_menu(user, src, choices, custom_check = CALLBACK(src, PROC_REF(check_menu), user))
+	var/choice = show_radial_menu(user, src, choices, custom_check = CALLBACK(src, PROC_REF(check_menu), user), anim_speed = 0)
 	if(!check_menu(user))
 		return null
 	return find_content_by_name(choice)


### PR DESCRIPTION
## Описание

Убрал анимацию появления радиального меню для быстрого доступа с поясов (*недавно делал QoL на него*).
Добавил параметр anim_speed в прок `show_radial_menu` для управления скоростью показа радиального меню. Если передать значение `0` то анимация будет пропущена.

## Причина создания ПР / Почему это хорошо для игры

Анимация появления довольно продолжительная, и при частой смене инструментов раздражает своей тормознутостью.

## Тесты

Запустил локалку, проверил что для поясов показыввается без анимаций, другие радиальные меню (*проверил рцд и рпед*) не поменялись.