### PR TITLE
qol: Деревянные баррикады можно снимать с помощью монтировки

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -112,6 +112,7 @@
 	if(obj_flags & NODECONSTRUCT)
 		return
 	. = TRUE
+
 	if(!I.tool_use_check(user, 0))
 		return
 	TOOL_ATTEMPT_DISMANTLE_MESSAGE

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -107,6 +107,17 @@
 
 	return ..()
 
+/obj/structure/barricade/wooden/crowbar_act(mob/living/user, obj/item/I)
+	. = ..()
+	if(obj_flags & NODECONSTRUCT)
+		return
+	. = TRUE
+	if(!I.tool_use_check(user, 0))
+		return
+	TOOL_ATTEMPT_DISMANTLE_MESSAGE
+	if(I.use_tool(src, user, 4 SECONDS, volume = I.tool_volume))
+		deconstruct(TRUE)
+		TOOL_DISMANTLE_SUCCESS_MESSAGE
 
 /obj/structure/barricade/wooden/crude
 	name = "crude plank barricade"

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -116,9 +116,10 @@
 	if(!I.tool_use_check(user, 0))
 		return
 	TOOL_ATTEMPT_DISMANTLE_MESSAGE
-	if(I.use_tool(src, user, 4 SECONDS, volume = I.tool_volume))
-		deconstruct(TRUE)
-		TOOL_DISMANTLE_SUCCESS_MESSAGE
+	if(!I.use_tool(src, user, 4 SECONDS, volume = I.tool_volume))
+		return
+	deconstruct(TRUE)
+	TOOL_DISMANTLE_SUCCESS_MESSAGE
 
 /obj/structure/barricade/wooden/crude
 	name = "crude plank barricade"


### PR DESCRIPTION
## Описание

Добавлен прок crobar_act для деревянной баррикады, после 4 секундного прогрессбара разбирает с помощью стандартного прока deconstruct, даст столько же дерева как если бы ломали сваркой (*у деревянных баррикад нет прока для нормального разбора*). В отличие от ударов разборка будет чуточку быстрее (*примерно на секунды две, так что баланс не пострадает*).
<img width="369" height="373" alt="image" src="https://github.com/user-attachments/assets/8576fc1b-3b13-4249-b61a-0cb656d6cba9" />

## Причина создания ПР / Почему это хорошо для игры

1. QoL
2. Логика: мы можем разбирать деревянные столы/стулья одним инструментом, а заколоченные доски не можем снять монтировкой, нехорошо.

## Тесты

Тест на локалке показал что монтировка снимает деревянные баррикады как надо.