### PR TITLE
bugfix: Посох асклепия теперь могут активировать только игроки

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -228,7 +228,7 @@
 /obj/item/rod_of_asclepius/attack_self(mob/user)
 	if(activated)
 		return
-	if(!iscarbon(user))
+	if(!iscarbon(user) || !user.client)
 		to_chat(user, span_warning("Резьба змеи, кажется, оживает на мгновение, прежде чем вернуться в свое спящее состояние, словно она находит вас недостойным её клятвы."))
 		return
 	var/mob/living/carbon/itemUser = user

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -228,7 +228,7 @@
 /obj/item/rod_of_asclepius/attack_self(mob/user)
 	if(activated)
 		return
-	if(!iscarbon(user) || !user.client)
+	if(!iscarbon(user) || !user.mind)
 		to_chat(user, span_warning("Резьба змеи, кажется, оживает на мгновение, прежде чем вернуться в свое спящее состояние, словно она находит вас недостойным её клятвы."))
 		return
 	var/mob/living/carbon/itemUser = user


### PR DESCRIPTION
## Описание

Исправлен баг (*абуз*) когда очеловеченная мартышка активировала посох асклепия и игроки получали бесплатный хилл. 

Добавлена проверка на mind при активации посоха асклепия.


## Причина создания ПР / Почему это хорошо для игры

Предмет подразумевает жертвовать возможностью харм действий вообще и дает взамет супер хилл, а этот абуз делает предмет полностью бесплатным для игроков.

Удаляем баг/недоработку возникший с введением ии для монке.

## Тесты
Проверил на локалке с помощью брейкпоинта, проверка успешно блокирует возможность монке активировать посох.