### PR TITLE
balance: тёмная материя и сорий в пене

### DIFF
--- a/code/modules/reagents/chemistry/reagents/pyrotechnic.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic.dm
@@ -277,6 +277,8 @@
 	taste_description = "горького воздуха"
 
 /datum/reagent/sorium/reaction_turf(turf/T, volume) // oh no
+	if(volume < 1)
+		return
 	if(prob(75))
 		return
 	if(isspaceturf(T))
@@ -294,6 +296,8 @@
 	taste_description = "горького вакуума"
 
 /datum/reagent/liquid_dark_matter/reaction_turf(turf/T, volume) //Oh gosh, why
+	if(volume < 4)
+		return
 	if(prob(75))
 		return
 	if(isspaceturf(T))


### PR DESCRIPTION
## Описание

Добавляет требование на опр. кол-во реагента сория и тёмной материи, чтобы при обливании на пол оно там появилось. 

## Причина создания ПР / Почему это хорошо для игры

Так как в пене при распространении уменьшается кол-во реагента, то это значительный фикс. Для того, чтобы оно вообще начало работать, понадобится 25+ юнита реагента в изначальной гранате (чтобы при обливании пеной был 1 юнит). Т.е. для гранаты с материей понадобится 100 юнитов, для сория 25.
